### PR TITLE
Extend sorting and limits to users, groups, relations, and permissions

### DIFF
--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -238,12 +238,14 @@ async fn get_class_permissions(
     pool: web::Data<DbPool>,
     requestor: UserAccess,
     class_id: web::Path<HubuumClassID>,
+    req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     use crate::models::groups_on;
     use crate::traits::NamespaceAccessors;
 
     let user = requestor.user;
     let class_id = class_id.into_inner();
+    let query_options = parse_query_parameter(req.query_string())?;
 
     debug!(
         message = "Getting class permissions",
@@ -264,6 +266,7 @@ async fn get_class_permissions(
             Permissions::ReadClass,
             Permissions::DeleteClass,
         ],
+        query_options,
     )
     .await?;
 

--- a/src/api/v1/handlers/namespaces.rs
+++ b/src/api/v1/handlers/namespaces.rs
@@ -233,6 +233,7 @@ pub async fn get_namespace_permissions(
     pool: web::Data<DbPool>,
     requestor: UserAccess,
     namespace_id: web::Path<NamespaceID>,
+    req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     use crate::models::namespace::groups_on;
 
@@ -250,7 +251,8 @@ pub async fn get_namespace_permissions(
         namespace
     );
 
-    let permissions = groups_on(&pool, namespace, vec![]).await?;
+    let query_options = parse_query_parameter(req.query_string())?;
+    let permissions = groups_on(&pool, namespace, vec![], query_options).await?;
     Ok(json_response(permissions, StatusCode::OK))
 }
 

--- a/src/db/traits/mod.rs
+++ b/src/db/traits/mod.rs
@@ -178,6 +178,47 @@ where
             }
         }
 
+        for order in query_options.sort.iter() {
+            match (&order.field, &order.descending) {
+                (FilterField::Id, false) => base_query = base_query.order_by(id.asc()),
+                (FilterField::Id, true) => base_query = base_query.order_by(id.desc()),
+                (FilterField::ClassFrom, false) => {
+                    base_query = base_query.order_by(from_hubuum_class_id.asc())
+                }
+                (FilterField::ClassFrom, true) => {
+                    base_query = base_query.order_by(from_hubuum_class_id.desc())
+                }
+                (FilterField::ClassTo, false) => {
+                    base_query = base_query.order_by(to_hubuum_class_id.asc())
+                }
+                (FilterField::ClassTo, true) => {
+                    base_query = base_query.order_by(to_hubuum_class_id.desc())
+                }
+                (FilterField::CreatedAt, false) => {
+                    base_query = base_query.order_by(created_at.asc())
+                }
+                (FilterField::CreatedAt, true) => {
+                    base_query = base_query.order_by(created_at.desc())
+                }
+                (FilterField::UpdatedAt, false) => {
+                    base_query = base_query.order_by(updated_at.asc())
+                }
+                (FilterField::UpdatedAt, true) => {
+                    base_query = base_query.order_by(updated_at.desc())
+                }
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't orderable (or does not exist) for class relations",
+                        order.field
+                    )))
+                }
+            }
+        }
+
+        if let Some(limit) = query_options.limit {
+            base_query = base_query.limit(limit as i64);
+        }
+
         trace_query!(base_query, "Searching relations");
 
         with_connection(pool, |conn| {

--- a/src/db/traits/user.rs
+++ b/src/db/traits/user.rs
@@ -4,8 +4,8 @@ use std::iter::IntoIterator;
 use tracing::{debug, trace};
 
 use crate::models::{Group, Permissions, User, UserID};
-use crate::utilities::auth::hash_password;
 use crate::traits::{GroupAccessors, NamespaceAccessors, SelfAccessors};
+use crate::utilities::auth::hash_password;
 
 use crate::db::{with_connection, DbPool};
 use crate::errors::ApiError;
@@ -19,26 +19,23 @@ impl User {
         use crate::schema::users::dsl::*;
 
         with_connection(pool, |conn| {
-            users
-                .filter(username.eq(username_arg))
-                .first::<User>(conn)
+            users.filter(username.eq(username_arg)).first::<User>(conn)
         })
     }
 
     /// Set a new password for a user
-    /// 
+    ///
     /// The password will be hashed before storing it in the database, so the input should be the
     /// desired plaintext password.
-    pub async fn set_password(&self, pool: &DbPool, new_password: &str) -> Result<(), ApiError> {        
+    pub async fn set_password(&self, pool: &DbPool, new_password: &str) -> Result<(), ApiError> {
         use crate::schema::users::dsl::*;
         debug!(
             message = "Setting new password",
             id = self.id(),
             username = self.username,
         );
-        let new_password = hash_password(new_password).map_err(|e| {
-            ApiError::HashError(format!("Failed to hash password: {e}"))
-        })?;
+        let new_password = hash_password(new_password)
+            .map_err(|e| ApiError::HashError(format!("Failed to hash password: {e}")))?;
 
         with_connection(pool, |conn| {
             diesel::update(users.filter(id.eq(self.id)))
@@ -52,7 +49,7 @@ impl User {
 
 pub trait UserPermissions: SelfAccessors<User> + GroupAccessors + GroupMemberships {
     /// ## Check if a user has a set of permissions in a set of namespaces
-    /// 
+    ///
     /// All permissions must be present in all namespaces for the function to return true.
     ///
     /// ### Parameters
@@ -63,7 +60,7 @@ pub trait UserPermissions: SelfAccessors<User> + GroupAccessors + GroupMembershi
     ///
     /// ### Returns
     ///
-    /// * Nothing if the user has the required permissions, or an ApiError::Forbidden if they do not.    
+    /// * Nothing if the user has the required permissions, or an ApiError::Forbidden if they do not.
     async fn can<P, N, I>(
         &self,
         pool: &DbPool,
@@ -75,10 +72,10 @@ pub trait UserPermissions: SelfAccessors<User> + GroupAccessors + GroupMembershi
         I: IntoIterator<Item = N>,
         N: NamespaceAccessors,
     {
-        use futures::stream::{self, StreamExt, TryStreamExt};
-        use diesel::{dsl::sql, sql_types::BigInt};
-        use std::collections::HashSet;
         use crate::models::PermissionFilter;
+        use diesel::{dsl::sql, sql_types::BigInt};
+        use futures::stream::{self, StreamExt, TryStreamExt};
+        use std::collections::HashSet;
 
         if self.is_admin(pool).await? {
             return Ok(());
@@ -87,7 +84,7 @@ pub trait UserPermissions: SelfAccessors<User> + GroupAccessors + GroupMembershi
         let lookup_table = crate::schema::permissions::dsl::permissions;
         let group_id_field = crate::schema::permissions::dsl::group_id;
         let namespace_id_field = crate::schema::permissions::dsl::namespace_id;
-    
+
         let group_id_subquery = self.group_ids_subquery();
 
         let namespace_ids: HashSet<i32> = stream::iter(namespaces)
@@ -101,24 +98,26 @@ pub trait UserPermissions: SelfAccessors<User> + GroupAccessors + GroupMembershi
             .into_boxed()
             .filter(namespace_id_field.eq_any(&namespace_ids))
             .filter(group_id_field.eq_any(group_id_subquery));
-    
+
         // Apply all permission filters
         for perm in permissions {
             base_query = perm.create_boxed_filter(base_query, true);
         }
-    
+
         // Count the number of distinct namespaces that match all criteria
         let matching_namespaces_count = with_connection(pool, |conn| {
             base_query
                 .select(sql::<BigInt>("COUNT(DISTINCT namespace_id)"))
                 .first::<i64>(conn)
         })?;
-    
+
         // Check if the count of matching namespaces equals the number of input namespaces
         if matching_namespaces_count as usize == namespace_ids.len() {
             Ok(())
         } else {
-            Err(ApiError::Forbidden("User does not have the required permissions".to_string()))
+            Err(ApiError::Forbidden(
+                "User does not have the required permissions".to_string(),
+            ))
         }
     }
 }
@@ -133,9 +132,9 @@ pub trait GroupMemberships: SelfAccessors<User> {
     }
 
     /// Check if the user is in a group by name
-    /// 
+    ///
     /// This function checks if the user is a member of a group with the specified name.
-    /// 
+    ///
     /// ## Parameters
     ///
     /// * `groupname_queried` - The name of the group to check for membership.
@@ -146,17 +145,21 @@ pub trait GroupMemberships: SelfAccessors<User> {
     /// * Ok(true) if the user is in the group
     /// * Ok(false) if the user is not in the group
     /// * Err(ApiError) if something failed.
-    async fn is_in_group_by_name(&self, groupname_queried: &str, pool: &DbPool) -> Result<bool, ApiError> {
-        use diesel::dsl::{exists, select};
+    async fn is_in_group_by_name(
+        &self,
+        groupname_queried: &str,
+        pool: &DbPool,
+    ) -> Result<bool, ApiError> {
         use crate::schema::groups::dsl::{groupname, groups};
-        use crate::schema::user_groups::dsl::{user_id as ug_user_id,user_groups};
+        use crate::schema::user_groups::dsl::{user_groups, user_id as ug_user_id};
+        use diesel::dsl::{exists, select};
 
         let is_in_group = with_connection(pool, |conn| {
             select(exists(
                 user_groups
                     .inner_join(groups)
                     .filter(ug_user_id.eq(self.id()))
-                    .filter(groupname.eq(groupname_queried))
+                    .filter(groupname.eq(groupname_queried)),
             ))
             .get_result(conn)
         })?;
@@ -172,11 +175,13 @@ pub trait GroupMemberships: SelfAccessors<User> {
     }
 
     /// Check if the user is an admin
-    /// 
+    ///
     /// This function checks the user's admin status in the database, but checking if they are
     /// a member of the group with the name "admin".
     async fn is_admin(&self, pool: &DbPool) -> Result<bool, ApiError> {
-        let is_admin = self.is_in_group_by_name(&self.admin_groupname().await?, pool).await?;
+        let is_admin = self
+            .is_in_group_by_name(&self.admin_groupname().await?, pool)
+            .await?;
 
         trace!(
             message = "Admin check result",
@@ -195,9 +200,9 @@ impl User {
     pub async fn search_users(
         &self,
         pool: &DbPool,
-        query_options: QueryOptions
+        query_options: QueryOptions,
     ) -> Result<Vec<User>, ApiError> {
-        use crate::schema::users::dsl::*;
+        use crate::schema::users::dsl::{created_at, email, id, updated_at, username, users};
 
         let query_params = query_options.filters;
 
@@ -228,12 +233,51 @@ impl User {
             }
         }
 
+        for order in query_options.sort.iter() {
+            match (&order.field, &order.descending) {
+                (FilterField::Id, false) => base_query = base_query.order_by(id.asc()),
+                (FilterField::Id, true) => base_query = base_query.order_by(id.desc()),
+                (FilterField::Name, false) | (FilterField::Username, false) => {
+                    base_query = base_query.order_by(username.asc())
+                }
+                (FilterField::Name, true) | (FilterField::Username, true) => {
+                    base_query = base_query.order_by(username.desc())
+                }
+                (FilterField::Email, false) => base_query = base_query.order_by(email.asc()),
+                (FilterField::Email, true) => base_query = base_query.order_by(email.desc()),
+                (FilterField::CreatedAt, false) => {
+                    base_query = base_query.order_by(created_at.asc())
+                }
+                (FilterField::CreatedAt, true) => {
+                    base_query = base_query.order_by(created_at.desc())
+                }
+                (FilterField::UpdatedAt, false) => {
+                    base_query = base_query.order_by(updated_at.asc())
+                }
+                (FilterField::UpdatedAt, true) => {
+                    base_query = base_query.order_by(updated_at.desc())
+                }
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't orderable (or does not exist) for users",
+                        order.field
+                    )))
+                }
+            }
+        }
+
+        if let Some(limit) = query_options.limit {
+            base_query = base_query.limit(limit as i64);
+        }
+
         trace_query!(base_query, "Searching users");
 
-        let result = with_connection(pool, |conn| base_query
-            .select(users::all_columns())
-            .distinct() // TODO: Is it the joins that makes this required?
-            .load::<User>(conn))?;
+        let result = with_connection(pool, |conn| {
+            base_query
+                .select(users::all_columns())
+                .distinct() // TODO: Is it the joins that makes this required?
+                .load::<User>(conn)
+        })?;
 
         Ok(result)
     }
@@ -241,9 +285,11 @@ impl User {
     pub async fn search_groups(
         &self,
         pool: &DbPool,
-        query_options: QueryOptions
+        query_options: QueryOptions,
     ) -> Result<Vec<Group>, ApiError> {
-        use crate::schema::groups::dsl::{id, created_at, updated_at, groupname, description, groups};
+        use crate::schema::groups::dsl::{
+            created_at, description, groupname, groups, id, updated_at,
+        };
 
         let query_params = query_options.filters;
 
@@ -261,8 +307,10 @@ impl User {
             match param.field {
                 FilterField::Id => numeric_search!(base_query, param, operator, id),
                 FilterField::Name => string_search!(base_query, param, operator, groupname),
-                FilterField::Groupname => string_search!(base_query, param, operator, groupname),                
-                FilterField::Description => string_search!(base_query, param, operator, description),
+                FilterField::Groupname => string_search!(base_query, param, operator, groupname),
+                FilterField::Description => {
+                    string_search!(base_query, param, operator, description)
+                }
                 FilterField::CreatedAt => date_search!(base_query, param, operator, created_at),
                 FilterField::UpdatedAt => date_search!(base_query, param, operator, updated_at),
                 _ => {
@@ -274,16 +322,58 @@ impl User {
             }
         }
 
+        for order in query_options.sort.iter() {
+            match (&order.field, &order.descending) {
+                (FilterField::Id, false) => base_query = base_query.order_by(id.asc()),
+                (FilterField::Id, true) => base_query = base_query.order_by(id.desc()),
+                (FilterField::Name, false) | (FilterField::Groupname, false) => {
+                    base_query = base_query.order_by(groupname.asc())
+                }
+                (FilterField::Name, true) | (FilterField::Groupname, true) => {
+                    base_query = base_query.order_by(groupname.desc())
+                }
+                (FilterField::Description, false) => {
+                    base_query = base_query.order_by(description.asc())
+                }
+                (FilterField::Description, true) => {
+                    base_query = base_query.order_by(description.desc())
+                }
+                (FilterField::CreatedAt, false) => {
+                    base_query = base_query.order_by(created_at.asc())
+                }
+                (FilterField::CreatedAt, true) => {
+                    base_query = base_query.order_by(created_at.desc())
+                }
+                (FilterField::UpdatedAt, false) => {
+                    base_query = base_query.order_by(updated_at.asc())
+                }
+                (FilterField::UpdatedAt, true) => {
+                    base_query = base_query.order_by(updated_at.desc())
+                }
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't orderable (or does not exist) for groups",
+                        order.field
+                    )))
+                }
+            }
+        }
+
+        if let Some(limit) = query_options.limit {
+            base_query = base_query.limit(limit as i64);
+        }
+
         trace_query!(base_query, "Searching groups");
 
-        let result = with_connection(pool, |conn| base_query
-            .select(groups::all_columns())
-            .distinct() 
-            .load::<Group>(conn))?;
+        let result = with_connection(pool, |conn| {
+            base_query
+                .select(groups::all_columns())
+                .distinct()
+                .load::<Group>(conn)
+        })?;
 
         Ok(result)
     }
-
 }
 
 #[cfg(test)]
@@ -304,13 +394,13 @@ mod tests {
         u1_ns1_classreadcreate_true = { 0, vec![0], vec![P::ReadClass, P::CreateClass], true },
         u1_ns2_classdelete_true = { 0, vec![1], vec![P::DeleteClass], true },
         u1_ns2_classcreate_true = { 0, vec![1], vec![P::CreateClass], true },
-        u1_ns2_classcreatedelete_true = { 0, vec![1], vec![P::CreateClass, P::DeleteClass], true },        
+        u1_ns2_classcreatedelete_true = { 0, vec![1], vec![P::CreateClass, P::DeleteClass], true },
         u1_ns12_classcreate_true = { 0, vec![0,1], vec![P::CreateClass], true },
 
         u1_ns1_objectread_false = { 0, vec![0], vec![P::ReadObject], false },
         u1_ns1_namespacecreate_false = { 0, vec![0], vec![P::ReadCollection], false },
         u1_ns12_classreadcreate_false = { 0, vec![0,1], vec![P::CreateClass, P::ReadClass], false },
-        u1_ns12_classreadcreatedelete_false = { 0, vec![0,1], vec![P::CreateClass, P::ReadClass, P::DeleteClass], false }, 
+        u1_ns12_classreadcreatedelete_false = { 0, vec![0,1], vec![P::CreateClass, P::ReadClass, P::DeleteClass], false },
 
         u2_ns1_objectread_true = { 1, vec![0], vec![P::ReadObject], true },
         u2_ns1_objectcreate_true = { 1, vec![0], vec![P::CreateObject], true },
@@ -318,7 +408,7 @@ mod tests {
         u2_ns2_objectdelete_true = { 1, vec![1], vec![P::DeleteObject], true },
         u2_ns2_objectcreate_true = { 1, vec![1], vec![P::CreateObject], true },
         u2_ns2_objectcreatedelete_true = { 1, vec![1], vec![P::CreateObject, P::DeleteObject], true },
-        
+
 
     )]
     #[test_macro(actix_web::test)]
@@ -345,14 +435,18 @@ mod tests {
             expected
         );
 
-        let namespaces = [create_namespace(&pool, &format!("test_user_can_ns1_{suffix}"))
+        let namespaces = [
+            create_namespace(&pool, &format!("test_user_can_ns1_{suffix}"))
                 .await
                 .unwrap(),
             create_namespace(&pool, &format!("test_user_can_ns2_{suffix}"))
                 .await
-                .unwrap()];
-        let groups = [create_test_group(&pool).await,
-            create_test_group(&pool).await];
+                .unwrap(),
+        ];
+        let groups = [
+            create_test_group(&pool).await,
+            create_test_group(&pool).await,
+        ];
         let users = [
             create_user_with_params(&pool, &format!("test_user_can_u1_{suffix}"), "foo").await,
             create_user_with_params(&pool, &format!("test_user_can_u2_{suffix}"), "foo").await,
@@ -406,23 +500,23 @@ mod tests {
         match (result, expected) {
             (Ok(()), true) => {
                 // Success case: We expected permission and got it
-            },
+            }
             (Err(ApiError::Forbidden(_)), false) => {
                 // Expected failure case: We expected no permission and got Forbidden error
-            },
+            }
             (Ok(()), false) => {
                 if user.is_admin(&pool).await.unwrap() {
                     panic!("Expected permission check to fail, but it succeeded (user is admin)");
                 } else {
                     panic!("Expected permission check to fail, but it succeeded");
                 }
-            },
+            }
             (Err(ApiError::Forbidden(msg)), true) => {
                 panic!("Expected permission check to succeed, but got Forbidden error: {msg}");
-            },
+            }
             (Err(e), _) => {
                 panic!("Unexpected error occurred: {e:?}");
-            },
+            }
         }
     }
 }

--- a/src/models/namespace.rs
+++ b/src/models/namespace.rs
@@ -16,6 +16,7 @@ use crate::schema::namespaces;
 use crate::errors::ApiError;
 
 use crate::models::output::GroupPermission;
+use crate::models::search::{FilterField, QueryOptions, QueryParamsExt};
 use crate::models::{Permission, Permissions};
 
 use crate::db::traits::user::GroupMemberships;
@@ -281,22 +282,80 @@ pub async fn groups_on<T: NamespaceAccessors>(
     pool: &DbPool,
     namespace_ref: T,
     permissions_filter: Vec<Permissions>,
+    query_options: QueryOptions,
 ) -> Result<Vec<GroupPermission>, ApiError> {
     use crate::models::traits::output::FromTuple;
     use crate::models::PermissionFilter;
     use crate::schema::groups::dsl::{groups, id as group_table_id};
-    use crate::schema::permissions::dsl::*;
+    use crate::schema::permissions::dsl::{
+        created_at as permission_created_at, group_id, id as permission_id, namespace_id,
+        permissions, updated_at as permission_updated_at,
+    };
+    use crate::{date_search, numeric_search};
     use diesel::prelude::*;
 
     let mut conn = pool.get()?;
     let namespace_target_id = namespace_ref.namespace_id(pool).await?;
+    let query_params = query_options.filters;
+
+    let mut permission_filters = query_params.permissions()?;
+    permission_filters.ensure_contains(&permissions_filter);
 
     let mut base_query = permissions
         .filter(namespace_id.eq(namespace_target_id))
         .into_boxed();
 
-    for perm in permissions_filter.into_iter() {
+    for perm in permission_filters.iter().cloned() {
         base_query = perm.create_boxed_filter(base_query, true);
+    }
+
+    for param in query_params {
+        let operator = param.operator.clone();
+        match param.field {
+            FilterField::Id => numeric_search!(base_query, param, operator, permission_id),
+            FilterField::CreatedAt => {
+                date_search!(base_query, param, operator, permission_created_at)
+            }
+            FilterField::UpdatedAt => {
+                date_search!(base_query, param, operator, permission_updated_at)
+            }
+            FilterField::Permissions => {} // handled above
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' isn't searchable (or does not exist) for permissions",
+                    param.field
+                )))
+            }
+        }
+    }
+
+    for order in query_options.sort.iter() {
+        match (&order.field, &order.descending) {
+            (FilterField::Id, false) => base_query = base_query.order_by(permission_id.asc()),
+            (FilterField::Id, true) => base_query = base_query.order_by(permission_id.desc()),
+            (FilterField::CreatedAt, false) => {
+                base_query = base_query.order_by(permission_created_at.asc())
+            }
+            (FilterField::CreatedAt, true) => {
+                base_query = base_query.order_by(permission_created_at.desc())
+            }
+            (FilterField::UpdatedAt, false) => {
+                base_query = base_query.order_by(permission_updated_at.asc())
+            }
+            (FilterField::UpdatedAt, true) => {
+                base_query = base_query.order_by(permission_updated_at.desc())
+            }
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' isn't orderable (or does not exist) for permissions",
+                    order.field
+                )))
+            }
+        }
+    }
+
+    if let Some(limit) = query_options.limit {
+        base_query = base_query.limit(limit as i64);
     }
 
     let query = base_query
@@ -453,7 +512,18 @@ mod tests {
         groups_can_on_count(&pool, namespace.id, NP::CreateClass, 1).await;
         groups_can_on_count(&pool, namespace.id, NP::CreateObject, 1).await;
 
-        let all_on = groups_on(&pool, namespace.clone(), vec![]).await.unwrap();
+        let all_on = groups_on(
+            &pool,
+            namespace.clone(),
+            vec![],
+            QueryOptions {
+                filters: vec![],
+                sort: vec![],
+                limit: None,
+            },
+        )
+        .await
+        .unwrap();
         assert_eq!(all_on.len(), 5);
 
         namespace.delete(&pool).await.unwrap();

--- a/src/models/traits/user.rs
+++ b/src/models/traits/user.rs
@@ -719,6 +719,55 @@ pub trait Search: SelfAccessors<User> + GroupAccessors + UserNamespaceAccessors 
             }
         }
 
+        for order in query_options.sort.iter() {
+            match (&order.field, &order.descending) {
+                (FilterField::Id, false) => {
+                    base_query = base_query.order_by(hubuum_class_relation_id.asc())
+                }
+                (FilterField::Id, true) => {
+                    base_query = base_query.order_by(hubuum_class_relation_id.desc())
+                }
+                (FilterField::ClassFrom, false) => {
+                    base_query = base_query.order_by(from_hubuum_class_id.asc())
+                }
+                (FilterField::ClassFrom, true) => {
+                    base_query = base_query.order_by(from_hubuum_class_id.desc())
+                }
+                (FilterField::ClassTo, false) => {
+                    base_query = base_query.order_by(to_hubuum_class_id.asc())
+                }
+                (FilterField::ClassTo, true) => {
+                    base_query = base_query.order_by(to_hubuum_class_id.desc())
+                }
+                (FilterField::CreatedAt, false) => {
+                    base_query = base_query
+                        .order_by(crate::schema::hubuumclass_relation::dsl::created_at.asc())
+                }
+                (FilterField::CreatedAt, true) => {
+                    base_query = base_query
+                        .order_by(crate::schema::hubuumclass_relation::dsl::created_at.desc())
+                }
+                (FilterField::UpdatedAt, false) => {
+                    base_query = base_query
+                        .order_by(crate::schema::hubuumclass_relation::dsl::updated_at.asc())
+                }
+                (FilterField::UpdatedAt, true) => {
+                    base_query = base_query
+                        .order_by(crate::schema::hubuumclass_relation::dsl::updated_at.desc())
+                }
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't orderable (or does not exist) for class relations",
+                        order.field
+                    )))
+                }
+            }
+        }
+
+        if let Some(limit) = query_options.limit {
+            base_query = base_query.limit(limit as i64);
+        }
+
         trace_query!(base_query, "Searching class relations");
 
         let result = with_connection(pool, |conn| {
@@ -853,6 +902,61 @@ pub trait Search: SelfAccessors<User> + GroupAccessors + UserNamespaceAccessors 
                     )))
                 }
             }
+        }
+
+        for order in query_options.sort.iter() {
+            match (&order.field, &order.descending) {
+                (FilterField::Id, false) => {
+                    base_query = base_query.order_by(hubuum_object_relation_id.asc())
+                }
+                (FilterField::Id, true) => {
+                    base_query = base_query.order_by(hubuum_object_relation_id.desc())
+                }
+                (FilterField::ClassRelation, false) => {
+                    base_query = base_query.order_by(class_relation_id.asc())
+                }
+                (FilterField::ClassRelation, true) => {
+                    base_query = base_query.order_by(class_relation_id.desc())
+                }
+                (FilterField::ObjectFrom, false) => {
+                    base_query = base_query.order_by(from_hubuum_object_id.asc())
+                }
+                (FilterField::ObjectFrom, true) => {
+                    base_query = base_query.order_by(from_hubuum_object_id.desc())
+                }
+                (FilterField::ObjectTo, false) => {
+                    base_query = base_query.order_by(to_hubuum_object_id.asc())
+                }
+                (FilterField::ObjectTo, true) => {
+                    base_query = base_query.order_by(to_hubuum_object_id.desc())
+                }
+                (FilterField::CreatedAt, false) => {
+                    base_query = base_query
+                        .order_by(crate::schema::hubuumobject_relation::dsl::created_at.asc())
+                }
+                (FilterField::CreatedAt, true) => {
+                    base_query = base_query
+                        .order_by(crate::schema::hubuumobject_relation::dsl::created_at.desc())
+                }
+                (FilterField::UpdatedAt, false) => {
+                    base_query = base_query
+                        .order_by(crate::schema::hubuumobject_relation::dsl::updated_at.asc())
+                }
+                (FilterField::UpdatedAt, true) => {
+                    base_query = base_query
+                        .order_by(crate::schema::hubuumobject_relation::dsl::updated_at.desc())
+                }
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't orderable (or does not exist) for object relations",
+                        order.field
+                    )))
+                }
+            }
+        }
+
+        if let Some(limit) = query_options.limit {
+            base_query = base_query.limit(limit as i64);
         }
 
         trace_query!(base_query, "Searching object relations");
@@ -1027,6 +1131,107 @@ pub trait Search: SelfAccessors<User> + GroupAccessors + UserNamespaceAccessors 
                     )))
                 }
             }
+        }
+
+        for order in query_options.sort.iter() {
+            match (&order.field, &order.descending) {
+                (FilterField::ObjectFrom, false) => {
+                    base_query = base_query.order_by(obj::ancestor_object_id.asc())
+                }
+                (FilterField::ObjectFrom, true) => {
+                    base_query = base_query.order_by(obj::ancestor_object_id.desc())
+                }
+                (FilterField::ObjectTo, false) => {
+                    base_query = base_query.order_by(obj::descendant_object_id.asc())
+                }
+                (FilterField::ObjectTo, true) => {
+                    base_query = base_query.order_by(obj::descendant_object_id.desc())
+                }
+                (FilterField::ClassFrom, false) => {
+                    base_query = base_query.order_by(obj::ancestor_class_id.asc())
+                }
+                (FilterField::ClassFrom, true) => {
+                    base_query = base_query.order_by(obj::ancestor_class_id.desc())
+                }
+                (FilterField::ClassTo, false) => {
+                    base_query = base_query.order_by(obj::descendant_class_id.asc())
+                }
+                (FilterField::ClassTo, true) => {
+                    base_query = base_query.order_by(obj::descendant_class_id.desc())
+                }
+                (FilterField::NamespacesFrom, false) => {
+                    base_query = base_query.order_by(obj::ancestor_namespace_id.asc())
+                }
+                (FilterField::NamespacesFrom, true) => {
+                    base_query = base_query.order_by(obj::ancestor_namespace_id.desc())
+                }
+                (FilterField::NamespacesTo, false) => {
+                    base_query = base_query.order_by(obj::descendant_namespace_id.asc())
+                }
+                (FilterField::NamespacesTo, true) => {
+                    base_query = base_query.order_by(obj::descendant_namespace_id.desc())
+                }
+                (FilterField::NameFrom, false) => {
+                    base_query = base_query.order_by(obj::ancestor_name.asc())
+                }
+                (FilterField::NameFrom, true) => {
+                    base_query = base_query.order_by(obj::ancestor_name.desc())
+                }
+                (FilterField::NameTo, false) => {
+                    base_query = base_query.order_by(obj::descendant_name.asc())
+                }
+                (FilterField::NameTo, true) => {
+                    base_query = base_query.order_by(obj::descendant_name.desc())
+                }
+                (FilterField::DescriptionFrom, false) => {
+                    base_query = base_query.order_by(obj::ancestor_description.asc())
+                }
+                (FilterField::DescriptionFrom, true) => {
+                    base_query = base_query.order_by(obj::ancestor_description.desc())
+                }
+                (FilterField::DescriptionTo, false) => {
+                    base_query = base_query.order_by(obj::descendant_description.asc())
+                }
+                (FilterField::DescriptionTo, true) => {
+                    base_query = base_query.order_by(obj::descendant_description.desc())
+                }
+                (FilterField::CreatedAtFrom, false) => {
+                    base_query = base_query.order_by(obj::ancestor_created_at.asc())
+                }
+                (FilterField::CreatedAtFrom, true) => {
+                    base_query = base_query.order_by(obj::ancestor_created_at.desc())
+                }
+                (FilterField::CreatedAtTo, false) => {
+                    base_query = base_query.order_by(obj::descendant_created_at.asc())
+                }
+                (FilterField::CreatedAtTo, true) => {
+                    base_query = base_query.order_by(obj::descendant_created_at.desc())
+                }
+                (FilterField::UpdatedAtFrom, false) => {
+                    base_query = base_query.order_by(obj::ancestor_updated_at.asc())
+                }
+                (FilterField::UpdatedAtFrom, true) => {
+                    base_query = base_query.order_by(obj::ancestor_updated_at.desc())
+                }
+                (FilterField::UpdatedAtTo, false) => {
+                    base_query = base_query.order_by(obj::descendant_updated_at.asc())
+                }
+                (FilterField::UpdatedAtTo, true) => {
+                    base_query = base_query.order_by(obj::descendant_updated_at.desc())
+                }
+                (FilterField::Depth, false) => base_query = base_query.order_by(obj::depth.asc()),
+                (FilterField::Depth, true) => base_query = base_query.order_by(obj::depth.desc()),
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't orderable (or does not exist) for related objects",
+                        order.field
+                    )))
+                }
+            }
+        }
+
+        if let Some(limit) = query_options.limit {
+            base_query = base_query.limit(limit as i64);
         }
 
         trace_query!(base_query, "Searching object relations");

--- a/src/tests/api/v1/groups.rs
+++ b/src/tests/api/v1/groups.rs
@@ -203,4 +203,75 @@ mod tests {
         user.delete(&pool).await.unwrap();
         group.delete(&pool).await.unwrap();
     }
+
+    #[parameterized(
+        id_asc = { "id.asc", &[0, 1, 2] },
+        id_desc = { "id.desc", &[2, 1, 0] },
+        name_asc = { "name.asc", &[0, 1, 2] },
+        name_desc = { "name.desc", &[2, 1, 0] },
+    )]
+    #[test_macro(actix_web::test)]
+    async fn test_list_groups_sorted(sort_order: &str, expected_order: &[usize]) {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let prefix = format!("test_list_groups_sorted_{}", sort_order.replace('.', "_"));
+
+        let mut created_groups = Vec::new();
+        for i in 0..3 {
+            let group = NewGroup {
+                groupname: format!("{prefix}_{i}"),
+                description: Some(format!("{prefix}_description_{i}")),
+            }
+            .save(&pool)
+            .await
+            .unwrap();
+            created_groups.push(group);
+        }
+
+        let url = format!("{GROUPS_ENDPOINT}?groupname__contains={prefix}&sort={sort_order}");
+        let resp = get_request(&pool, &admin_token, &url).await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let groups: Vec<Group> = test::read_body_json(resp).await;
+
+        assert_eq!(groups.len(), created_groups.len());
+        assert_eq!(groups[0].id, created_groups[expected_order[0]].id);
+        assert_eq!(groups[1].id, created_groups[expected_order[1]].id);
+        assert_eq!(groups[2].id, created_groups[expected_order[2]].id);
+
+        for group in created_groups {
+            group.delete(&pool).await.unwrap();
+        }
+    }
+
+    #[parameterized(
+        limit_1 = { 1 },
+        limit_2 = { 2 },
+        limit_5 = { 3 },
+    )]
+    #[test_macro(actix_web::test)]
+    async fn test_list_groups_limit(limit: usize) {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let prefix = format!("test_list_groups_limit_{limit}");
+
+        let mut created_groups = Vec::new();
+        for i in 0..3 {
+            let group = NewGroup {
+                groupname: format!("{prefix}_{i}"),
+                description: Some(format!("{prefix}_description_{i}")),
+            }
+            .save(&pool)
+            .await
+            .unwrap();
+            created_groups.push(group);
+        }
+
+        let url = format!("{GROUPS_ENDPOINT}?groupname__contains={prefix}&sort=id&limit={limit}");
+        let resp = get_request(&pool, &admin_token, &url).await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let groups: Vec<Group> = test::read_body_json(resp).await;
+        assert_eq!(groups.len(), limit);
+
+        for group in created_groups {
+            group.delete(&pool).await.unwrap();
+        }
+    }
 }

--- a/src/tests/api/v1/namespaces.rs
+++ b/src/tests/api/v1/namespaces.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::models::{
-        GroupPermission, Namespace, NewNamespaceWithAssignee, Permission, Permissions,
+        GroupPermission, Namespace, NewGroup, NewNamespaceWithAssignee, Permission, Permissions,
         UpdateNamespace,
     };
 
@@ -408,6 +408,68 @@ mod tests {
 
         test_group.delete(&pool).await.unwrap();
         test_user.delete(&pool).await.unwrap();
+    }
+
+    #[actix_web::test]
+    async fn test_api_namespace_permissions_sorted_and_limited() {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let ns = create_namespace(&pool, "test_namespace_permissions_sorted_and_limited")
+            .await
+            .unwrap();
+
+        let group_one = NewGroup {
+            groupname: format!("test_namespace_permissions_sorted_{}_a", ns.id),
+            description: Some(format!(
+                "test_namespace_permissions_sorted_{}_description_a",
+                ns.id
+            )),
+        }
+        .save(&pool)
+        .await
+        .unwrap();
+        let group_two = NewGroup {
+            groupname: format!("test_namespace_permissions_sorted_{}_b", ns.id),
+            description: Some(format!(
+                "test_namespace_permissions_sorted_{}_description_b",
+                ns.id
+            )),
+        }
+        .save(&pool)
+        .await
+        .unwrap();
+
+        ns.grant_one(&pool, group_one.id, Permissions::ReadCollection)
+            .await
+            .unwrap();
+        ns.grant_one(&pool, group_two.id, Permissions::ReadCollection)
+            .await
+            .unwrap();
+
+        let sorted_endpoint = format!(
+            "{NAMESPACE_ENDPOINT}/{}/permissions?permissions=ReadCollection&sort=id.desc",
+            ns.id
+        );
+        let resp = get_request(&pool, &admin_token, &sorted_endpoint).await;
+        let resp = assert_response_status(resp, http::StatusCode::OK).await;
+        let permissions: Vec<GroupPermission> = test::read_body_json(resp).await;
+
+        assert!(permissions.len() >= 2);
+        assert!(permissions[0].permission.id > permissions[1].permission.id);
+        assert!(permissions.iter().any(|p| p.group.id == group_one.id));
+        assert!(permissions.iter().any(|p| p.group.id == group_two.id));
+
+        let limited_endpoint = format!(
+            "{NAMESPACE_ENDPOINT}/{}/permissions?permissions=ReadCollection&sort=id&limit=1",
+            ns.id
+        );
+        let resp = get_request(&pool, &admin_token, &limited_endpoint).await;
+        let resp = assert_response_status(resp, http::StatusCode::OK).await;
+        let limited_permissions: Vec<GroupPermission> = test::read_body_json(resp).await;
+        assert_eq!(limited_permissions.len(), 1);
+
+        group_one.delete(&pool).await.unwrap();
+        group_two.delete(&pool).await.unwrap();
+        ns.delete(&pool).await.unwrap();
     }
 
     #[parameterized(

--- a/src/tests/api/v1/relations.rs
+++ b/src/tests/api/v1/relations.rs
@@ -3,8 +3,10 @@ mod tests {
     use actix_web::{http::StatusCode, test};
     use yare::parameterized;
 
-    use crate::models::{        
-        HubuumClass, HubuumClassRelation, HubuumClassRelationTransitive, HubuumObject, HubuumObjectRelation, HubuumObjectWithPath, NamespaceID, NewHubuumClassRelation, NewHubuumClassRelationFromClass, NewHubuumObject, NewHubuumObjectRelation, Permissions
+    use crate::models::{
+        HubuumClass, HubuumClassRelation, HubuumClassRelationTransitive, HubuumObject,
+        HubuumObjectRelation, HubuumObjectWithPath, NamespaceID, NewHubuumClassRelation,
+        NewHubuumClassRelationFromClass, NewHubuumObject, NewHubuumObjectRelation, Permissions,
     };
     use crate::traits::{CanSave, PermissionController, SelfAccessors};
     use crate::{assert_contains_all, assert_contains_same_ids};
@@ -111,6 +113,42 @@ mod tests {
 
         assert_contains_same_ids!(&relations, &relations_in_namespace);
         assert_contains_all!(&relations, &relations_in_namespace);
+
+        cleanup(&classes).await;
+    }
+
+    #[actix_web::test]
+    async fn test_get_class_relations_sorted_and_limited() {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let (classes, relations) =
+            create_classes_and_relations(&pool, "get_class_relations_sorted_and_limited").await;
+
+        let class_ids = classes
+            .iter()
+            .map(|class| class.id.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let sorted_url =
+            format!("{CLASS_RELATIONS_ENDPOINT}?from_classes={class_ids}&sort=id.desc");
+        let resp = get_request(&pool, &admin_token, &sorted_url).await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let sorted_relations: Vec<HubuumClassRelation> = test::read_body_json(resp).await;
+
+        assert_eq!(sorted_relations.len(), relations.len());
+        assert_eq!(sorted_relations[0].id, relations[4].id);
+        assert_eq!(sorted_relations[1].id, relations[3].id);
+        assert_eq!(sorted_relations[2].id, relations[2].id);
+
+        let limited_url =
+            format!("{CLASS_RELATIONS_ENDPOINT}?from_classes={class_ids}&sort=id&limit=2");
+        let resp = get_request(&pool, &admin_token, &limited_url).await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let limited_relations: Vec<HubuumClassRelation> = test::read_body_json(resp).await;
+
+        assert_eq!(limited_relations.len(), 2);
+        assert_eq!(limited_relations[0].id, relations[0].id);
+        assert_eq!(limited_relations[1].id, relations[1].id);
 
         cleanup(&classes).await;
     }
@@ -315,7 +353,7 @@ mod tests {
 
     // classidx of obj1, obj1_idx, obj2_idx, relation_idx, exists
     #[parameterized(
-        relation_12_rel_true = { 0, 0, 1, 0, true },        
+        relation_12_rel_true = { 0, 0, 1, 0, true },
         relation_12_rel_false_c1 = { 1, 0, 1, 0, false }, // Gets the wrong class
         relation_21_rel_true = { 1, 1, 0, 0, true }, // This is the same as relation_12_true, relations are bidirectional
         relation_32_true = { 2, 2, 1, 1, true },
@@ -334,9 +372,8 @@ mod tests {
         relation_index: usize,
         exists: bool,
     ) {
-        let unique = format!(
-            "get_object_relation_param_{from_index}_{to_index}_{relation_index}_{exists}"
-        );
+        let unique =
+            format!("get_object_relation_param_{from_index}_{to_index}_{relation_index}_{exists}");
         let (pool, admin_token, _) = setup_pool_and_tokens().await;
         let (classes, relations) = create_classes_and_relations(&pool, &unique).await;
         let objects = create_objects_in_classes(&pool, &classes).await;
@@ -354,7 +391,10 @@ mod tests {
 
         let endpoint = format!(
             "/api/v1/classes/{}/{}/relations/{}/{}",
-            classes[class_index].id, objects[from_index].id, objects[to_index].hubuum_class_id, objects[to_index].id
+            classes[class_index].id,
+            objects[from_index].id,
+            objects[to_index].hubuum_class_id,
+            objects[to_index].id
         );
 
         let resp = get_request(&pool, &admin_token, &endpoint).await;
@@ -380,9 +420,60 @@ mod tests {
                 );
                 assert_eq!(relation_response.to_hubuum_object_id, objects[to_index].id);
             }
-        } else if !(resp.status() == StatusCode::NOT_FOUND || resp.status() == StatusCode::BAD_REQUEST) {
-            panic!("Expected NOT_FOUND/BAD_REQUEST from {}, got {:?} ({:?})", endpoint, resp.status(), test::read_body(resp).await);  
+        } else if !(resp.status() == StatusCode::NOT_FOUND
+            || resp.status() == StatusCode::BAD_REQUEST)
+        {
+            panic!(
+                "Expected NOT_FOUND/BAD_REQUEST from {}, got {:?} ({:?})",
+                endpoint,
+                resp.status(),
+                test::read_body(resp).await
+            );
         }
+
+        cleanup(&classes).await;
+    }
+
+    #[actix_web::test]
+    async fn test_get_object_relations_sorted_and_limited() {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let (classes, class_relations) =
+            create_classes_and_relations(&pool, "get_object_relations_sorted_and_limited").await;
+        let objects = create_objects_in_classes(&pool, &classes).await;
+
+        let rel_1 =
+            create_object_relation(&pool, &objects[0], &objects[1], &class_relations[0]).await;
+        let rel_2 =
+            create_object_relation(&pool, &objects[1], &objects[2], &class_relations[1]).await;
+        let rel_3 =
+            create_object_relation(&pool, &objects[2], &objects[3], &class_relations[2]).await;
+        let object_relations = [rel_1, rel_2, rel_3];
+
+        let class_relation_ids = class_relations[0..3]
+            .iter()
+            .map(|relation| relation.id.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let sorted_url =
+            format!("{OBJECT_RELATIONS_ENDPOINT}?class_relation={class_relation_ids}&sort=id.desc");
+        let resp = get_request(&pool, &admin_token, &sorted_url).await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let sorted_relations: Vec<HubuumObjectRelation> = test::read_body_json(resp).await;
+        assert_eq!(sorted_relations.len(), object_relations.len());
+        assert_eq!(sorted_relations[0].id, object_relations[2].id);
+        assert_eq!(sorted_relations[1].id, object_relations[1].id);
+        assert_eq!(sorted_relations[2].id, object_relations[0].id);
+
+        let limited_url = format!(
+            "{OBJECT_RELATIONS_ENDPOINT}?class_relation={class_relation_ids}&sort=id&limit=2"
+        );
+        let resp = get_request(&pool, &admin_token, &limited_url).await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let limited_relations: Vec<HubuumObjectRelation> = test::read_body_json(resp).await;
+        assert_eq!(limited_relations.len(), 2);
+        assert_eq!(limited_relations[0].id, object_relations[0].id);
+        assert_eq!(limited_relations[1].id, object_relations[1].id);
 
         cleanup(&classes).await;
     }
@@ -399,19 +490,27 @@ mod tests {
         rel_0_0_depth_gt = { 0, 0, StatusCode::OK, "?depth__gt=1", vec![4]},
         rel_0_0_depth_lt = { 0, 0, StatusCode::OK, "?depth__lt=1", vec![]},
         rel_0_0_path_equals_0_1 = { 0, 0, StatusCode::OK, "?path=<0>,<1>", vec![1]},
-        rel_0_0_path_equals_0_2 = { 0, 0, StatusCode::OK, "?path=<0>,<1>,<2>", vec![2]}, 
+        rel_0_0_path_equals_0_2 = { 0, 0, StatusCode::OK, "?path=<0>,<1>,<2>", vec![2]},
         rel_0_0_path_contains = { 0, 0, StatusCode::OK, "?path__contains=<1>", vec![1,2]},
         rel_1_2_empty = { 1, 1, StatusCode::OK, "", vec![2]},
         rel_0_0_invalid_key = { 0, 0, StatusCode::BAD_REQUEST, "?nosuchkey=foo", vec![]},
-        
-        rel_0_0_invalid_op = { 0, 0, StatusCode::BAD_REQUEST, "?from_name__foo=bar", vec![]},         
+
+        rel_0_0_invalid_op = { 0, 0, StatusCode::BAD_REQUEST, "?from_name__foo=bar", vec![]},
         rel_0_1_wrong_class = { 0, 1, StatusCode::NOT_FOUND, "", vec![]},
     )]
     #[test_macro(actix_web::test)]
-    async fn test_filter_related_objects(class_index: usize, object_index: usize, status: StatusCode, filter: &str, expected_object_ids: Vec<usize>) {
+    async fn test_filter_related_objects(
+        class_index: usize,
+        object_index: usize,
+        status: StatusCode,
+        filter: &str,
+        expected_object_ids: Vec<usize>,
+    ) {
         use regex::Regex;
 
-        let unique = format!("filter_related_objects_{class_index}_{object_index}_{status}_{filter}").replace(&['=', '&', '?', ' ', '<', '>', ][..], "_");
+        let unique =
+            format!("filter_related_objects_{class_index}_{object_index}_{status}_{filter}")
+                .replace(&['=', '&', '?', ' ', '<', '>'][..], "_");
         let (pool, admin_token, _) = setup_pool_and_tokens().await;
         let (classes, relations) = create_classes_and_relations(&pool, &unique).await;
         let objects = create_objects_in_classes(&pool, &classes).await;
@@ -428,24 +527,32 @@ mod tests {
             objects[index].id.to_string()
         });
 
-        let endpoint = format!( "/api/v1/classes/{}/{}/relations/{}", classes[class_index].id, objects[object_index].id, filter);
+        let endpoint = format!(
+            "/api/v1/classes/{}/{}/relations/{}",
+            classes[class_index].id, objects[object_index].id, filter
+        );
 
         let resp = get_request(&pool, &admin_token, &endpoint).await;
-        let resp = assert_response_status(resp, status).await;        
+        let resp = assert_response_status(resp, status).await;
 
         if status == StatusCode::OK {
             let body = test::read_body(resp).await;
             let objects_fetched: Vec<HubuumObjectWithPath> = serde_json::from_slice(&body).unwrap();
 
-            assert_eq!(objects_fetched.len(), expected_object_ids.len(), "{} -> Expected: {:?}, got: {:?}\nAll objects: {:?}",
+            assert_eq!(
+                objects_fetched.len(),
+                expected_object_ids.len(),
+                "{} -> Expected: {:?}, got: {:?}\nAll objects: {:?}",
                 endpoint,
-                expected_object_ids.iter().map(|i| objects[*i].id).collect::<Vec<_>>(),
+                expected_object_ids
+                    .iter()
+                    .map(|i| objects[*i].id)
+                    .collect::<Vec<_>>(),
                 objects_fetched.iter().map(|o| o.id).collect::<Vec<_>>(),
                 objects
             );
         }
 
         cleanup(&classes).await;
-        
     }
 }

--- a/src/tests/api/v1/users.rs
+++ b/src/tests/api/v1/users.rs
@@ -2,6 +2,7 @@
 mod tests {
     use crate::models::user::{NewUser, UpdateUser, User};
     use actix_web::{http::StatusCode, test};
+    use yare::parameterized;
 
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
     use crate::tests::asserts::assert_response_status;
@@ -121,5 +122,79 @@ mod tests {
         assert_eq!(patched_user.username, test_user.username);
         assert_ne!(patched_user.password, test_user.password);
         assert_eq!(patched_user.email, test_user.email);
+    }
+
+    #[parameterized(
+        id_asc = { "id.asc", &[0, 1, 2] },
+        id_desc = { "id.desc", &[2, 1, 0] },
+        name_asc = { "name.asc", &[0, 1, 2] },
+        name_desc = { "name.desc", &[2, 1, 0] },
+    )]
+    #[test_macro(actix_web::test)]
+    async fn test_list_users_sorted(sort_order: &str, expected_order: &[usize]) {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let prefix = format!("test_list_users_sorted_{}", sort_order.replace('.', "_"));
+
+        let mut created_users = Vec::new();
+        for i in 0..3 {
+            let user = NewUser {
+                username: format!("{prefix}_{i}"),
+                password: "testpassword".to_string(),
+                email: Some(format!("{prefix}_{i}@example.com")),
+            }
+            .save(&pool)
+            .await
+            .unwrap();
+            created_users.push(user);
+        }
+
+        let url = format!("{USERS_ENDPOINT}?username__contains={prefix}&sort={sort_order}");
+        let resp = get_request(&pool, &admin_token, &url).await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let users: Vec<User> = test::read_body_json(resp).await;
+
+        assert_eq!(users.len(), created_users.len());
+        assert_eq!(users[0].id, created_users[expected_order[0]].id);
+        assert_eq!(users[1].id, created_users[expected_order[1]].id);
+        assert_eq!(users[2].id, created_users[expected_order[2]].id);
+
+        for user in created_users {
+            user.delete(&pool).await.unwrap();
+        }
+    }
+
+    #[parameterized(
+        limit_1 = { 1 },
+        limit_2 = { 2 },
+        limit_5 = { 3 },
+    )]
+    #[test_macro(actix_web::test)]
+    async fn test_list_users_limit(limit: usize) {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let prefix = format!("test_list_users_limit_{limit}");
+
+        let mut created_users = Vec::new();
+        for i in 0..3 {
+            let user = NewUser {
+                username: format!("{prefix}_{i}"),
+                password: "testpassword".to_string(),
+                email: Some(format!("{prefix}_{i}@example.com")),
+            }
+            .save(&pool)
+            .await
+            .unwrap();
+            created_users.push(user);
+        }
+
+        let url = format!("{USERS_ENDPOINT}?username__contains={prefix}&sort=id&limit={limit}");
+        let resp = get_request(&pool, &admin_token, &url).await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let users: Vec<User> = test::read_body_json(resp).await;
+
+        assert_eq!(users.len(), limit);
+
+        for user in created_users {
+            user.delete(&pool).await.unwrap();
+        }
     }
 }


### PR DESCRIPTION
Summary:
- Add sort and limit support to user and group search queries.
- Add sort and limit support to class/object relation searches (global and contextual relation searches).
- Add query parsing to namespace/class permissions list handlers and apply sorting/limits in groups_on.
- Add API tests for users, groups, relations, and permissions sorting/limits.

Testing:
- cargo test --no-run
- source .env && ./run_tests.sh (233 passed, 1 flaky pre-existing failure on test_api_namespaces_sorted::unsorted; isolated rerun passed)
- source .env && ./run_tests.sh test_api_namespaces_sorted::unsorted

Closes #3