### PR TITLE
Add TLS backend selection facade

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use std::sync::{LazyLock, Mutex};
 #[cfg(not(test))]
 use std::sync::{RwLock, RwLockReadGuard};
 
@@ -97,7 +99,10 @@ pub fn get_config() -> Result<RwLockReadGuard<'static, AppConfig>, ApiError> {
 }
 
 #[cfg(test)]
-pub fn get_config() -> Result<AppConfig, ApiError> {
+static TEST_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+#[cfg(test)]
+fn get_config_from_env() -> Result<AppConfig, ApiError> {
     use std::env;
 
     // Helper function to read an environment variable or return a default value
@@ -138,18 +143,18 @@ pub fn get_config() -> Result<AppConfig, ApiError> {
 }
 
 #[cfg(test)]
+pub fn get_config() -> Result<AppConfig, ApiError> {
+    let _lock = TEST_ENV_LOCK.lock().unwrap();
+    get_config_from_env()
+}
+
+#[cfg(test)]
 mod tests {
-    use std::{
-        env,
-        ffi::OsString,
-        sync::{LazyLock, Mutex},
-    };
+    use std::{env, ffi::OsString};
 
     use clap::Parser;
 
-    use super::{get_config, AppConfig, TlsBackend};
-
-    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    use super::{get_config_from_env, AppConfig, TlsBackend, TEST_ENV_LOCK};
 
     struct EnvVarGuard {
         key: &'static str,
@@ -180,11 +185,11 @@ mod tests {
 
     #[test]
     fn tls_backend_env_var_is_parsed_by_clap_and_test_config_loader() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _guard = EnvVarGuard::set("HUBUUM_TLS_BACKEND", Some("OpEnSsL"));
 
         let parsed = AppConfig::try_parse_from(["hubuum-server"]).unwrap();
-        let loaded = get_config().unwrap();
+        let loaded = get_config_from_env().unwrap();
 
         assert_eq!(parsed.tls_backend, Some(TlsBackend::Openssl));
         assert_eq!(loaded.tls_backend, Some(TlsBackend::Openssl));
@@ -192,11 +197,11 @@ mod tests {
 
     #[test]
     fn tls_backend_defaults_to_none_when_env_var_is_unset() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _guard = EnvVarGuard::set("HUBUUM_TLS_BACKEND", None);
 
         let parsed = AppConfig::try_parse_from(["hubuum-server"]).unwrap();
-        let loaded = get_config().unwrap();
+        let loaded = get_config_from_env().unwrap();
 
         assert_eq!(parsed.tls_backend, None);
         assert_eq!(loaded.tls_backend, None);
@@ -204,7 +209,7 @@ mod tests {
 
     #[test]
     fn tls_backend_invalid_env_var_is_rejected_by_clap_parser() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _guard = EnvVarGuard::set("HUBUUM_TLS_BACKEND", Some("bogus"));
 
         let error = AppConfig::try_parse_from(["hubuum-server"]).unwrap_err();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,33 @@
 #[cfg(not(test))]
 use std::sync::{RwLock, RwLockReadGuard};
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 #[cfg(not(test))]
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
 use crate::errors::ApiError;
+
+#[derive(ValueEnum, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TlsBackend {
+    Rustls,
+    Openssl,
+}
+
+impl TlsBackend {
+    #[cfg(any(
+        not(any(feature = "tls-rustls", feature = "tls-openssl")),
+        all(feature = "tls-rustls", not(feature = "tls-openssl")),
+        all(feature = "tls-openssl", not(feature = "tls-rustls"))
+    ))]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Rustls => "rustls",
+            Self::Openssl => "openssl",
+        }
+    }
+}
 
 #[derive(Parser, Debug, Deserialize, Serialize, Clone)]
 pub struct AppConfig {
@@ -53,6 +74,16 @@ pub struct AppConfig {
     /// Optional passphrase to decrypt an encrypted PEM key
     #[clap(long, env = "HUBUUM_TLS_KEY_PASSPHRASE", default_value = None)]
     pub tls_key_passphrase: Option<String>,
+
+    /// Preferred TLS backend when TLS is enabled
+    #[clap(
+        long,
+        env = "HUBUUM_TLS_BACKEND",
+        value_enum,
+        ignore_case = true,
+        default_value = None
+    )]
+    pub tls_backend: Option<TlsBackend>,
 }
 
 #[cfg(not(test))]
@@ -78,6 +109,13 @@ pub fn get_config() -> Result<AppConfig, ApiError> {
         env::var(key).ok().or(default.map(String::from))
     }
 
+    fn env_or_default_tls_backend(key: &str) -> Option<TlsBackend> {
+        env::var(key).ok().map(|value| {
+            TlsBackend::from_str(&value, true)
+                .unwrap_or_else(|err| panic!("Invalid TLS backend in {key}: {value} ({err})"))
+        })
+    }
+
     Ok(AppConfig {
         bind_ip: env_or_default("HUBUUM_BIND_IP", "127.0.0.1"),
         port: env_or_default("HUBUUM_BIND_PORT", "8080")
@@ -95,5 +133,85 @@ pub fn get_config() -> Result<AppConfig, ApiError> {
         tls_cert_path: env_or_default_opt("HUBUUM_TLS_CERT_PATH", None),
         tls_key_path: env_or_default_opt("HUBUUM_TLS_KEY_PATH", None),
         tls_key_passphrase: env_or_default_opt("HUBUUM_TLS_KEY_PASSPHRASE", None),
+        tls_backend: env_or_default_tls_backend("HUBUUM_TLS_BACKEND"),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        env,
+        ffi::OsString,
+        sync::{LazyLock, Mutex},
+    };
+
+    use clap::Parser;
+
+    use super::{get_config, AppConfig, TlsBackend};
+
+    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let original = env::var_os(key);
+
+            match value {
+                Some(value) => unsafe { env::set_var(key, value) },
+                None => unsafe { env::remove_var(key) },
+            }
+
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => unsafe { env::set_var(self.key, value) },
+                None => unsafe { env::remove_var(self.key) },
+            }
+        }
+    }
+
+    #[test]
+    fn tls_backend_env_var_is_parsed_by_clap_and_test_config_loader() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvVarGuard::set("HUBUUM_TLS_BACKEND", Some("OpEnSsL"));
+
+        let parsed = AppConfig::try_parse_from(["hubuum-server"]).unwrap();
+        let loaded = get_config().unwrap();
+
+        assert_eq!(parsed.tls_backend, Some(TlsBackend::Openssl));
+        assert_eq!(loaded.tls_backend, Some(TlsBackend::Openssl));
+    }
+
+    #[test]
+    fn tls_backend_defaults_to_none_when_env_var_is_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvVarGuard::set("HUBUUM_TLS_BACKEND", None);
+
+        let parsed = AppConfig::try_parse_from(["hubuum-server"]).unwrap();
+        let loaded = get_config().unwrap();
+
+        assert_eq!(parsed.tls_backend, None);
+        assert_eq!(loaded.tls_backend, None);
+    }
+
+    #[test]
+    fn tls_backend_invalid_env_var_is_rejected_by_clap_parser() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvVarGuard::set("HUBUUM_TLS_BACKEND", Some("bogus"));
+
+        let error = AppConfig::try_parse_from(["hubuum-server"]).unwrap_err();
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::InvalidValue);
+        assert!(error.to_string().contains("bogus"));
+        assert!(error.to_string().contains("rustls"));
+        assert!(error.to_string().contains("openssl"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod middlewares;
 mod models;
 mod schema;
 mod tests;
+mod tls;
 mod traits;
 mod utilities;
 
@@ -24,16 +25,13 @@ use tracing_subscriber::{
     filter::EnvFilter, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
 };
 
+use crate::api::openapi::openapi_json as openapi_json_handler;
 use crate::config::get_config;
 use crate::errors::{
     fatal_error, json_error_handler, EXIT_CODE_CONFIG_ERROR, EXIT_CODE_INIT_ERROR,
     EXIT_CODE_TLS_ERROR,
 };
 use crate::utilities::is_valid_log_level;
-use crate::api::openapi::openapi_json as openapi_json_handler;
-
-#[cfg(all(feature = "tls-openssl", feature = "tls-rustls"))]
-compile_error!("Features `tls-openssl` and `tls-rustls` are mutually exclusive");
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -115,6 +113,7 @@ async fn main() -> std::io::Result<()> {
             cert,
             key,
             config.tls_key_passphrase.as_deref(),
+            config.tls_backend,
         ) {
             Ok(srv) => srv,
             Err(e) => fatal_error(
@@ -137,193 +136,4 @@ async fn main() -> std::io::Result<()> {
     };
 
     server.workers(config.actix_workers).run().await
-}
-
-// TLS module if neither tls-rustls or tls-openssl are set.
-#[cfg(not(any(feature = "tls-rustls", feature = "tls-openssl")))]
-mod tls {
-    use actix_http::{Request, Response};
-    use actix_service::{IntoServiceFactory, ServiceFactory};
-    use actix_web::{body::MessageBody, dev::AppConfig, Error, HttpServer};
-    pub fn configure_server<F, I, S, B>(
-        _: HttpServer<F, I, S, B>,
-        _: &str,
-        _: &str,
-        _: &str,
-        _: Option<&str>,
-    ) -> std::io::Result<HttpServer<F, I, S, B>>
-    where
-        F: Fn() -> I + Send + Clone + 'static,
-        I: IntoServiceFactory<S, Request>,
-        S: ServiceFactory<Request, Config = AppConfig> + 'static,
-        S::Error: Into<Error>,
-        S::InitError: std::fmt::Debug,
-        S::Response: Into<Response<B>>,
-        B: MessageBody + 'static,
-    {
-        Err(std::io::Error::other(
-            "TLS certificate and key offered, but no TLS feature enabled during build. Please enable either `tls-rustls` or `tls-openssl` during build to use TLS"
-        ))
-    }
-}
-
-#[cfg(feature = "tls-rustls")]
-mod tls {
-    use actix_http::{Request, Response};
-    use actix_service::{IntoServiceFactory, ServiceFactory};
-    use actix_web::{body::MessageBody, dev::AppConfig, Error, HttpServer};
-    use rustls::{
-        pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer},
-        ServerConfig,
-    };
-    use tracing::info;
-
-    pub fn configure_server<F, I, S, B>(
-        server: HttpServer<F, I, S, B>,
-        bind_address: &str,
-        cert: &str,
-        key: &str,
-        pass: Option<&str>,
-    ) -> std::io::Result<HttpServer<F, I, S, B>>
-    where
-        F: Fn() -> I + Send + Clone + 'static,
-        I: IntoServiceFactory<S, Request>,
-        S: ServiceFactory<Request, Config = AppConfig> + 'static,
-        S::Error: Into<Error>,
-        S::InitError: std::fmt::Debug,
-        S::Response: Into<Response<B>>,
-        B: MessageBody + 'static,
-    {
-        if pass.is_some() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Using encrypted TLS key with passphrase is not supported with rustls feature",
-            ));
-        }
-
-        rustls::crypto::aws_lc_rs::default_provider()
-            .install_default()
-            .map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("Failed to install crypto provider: {:?}", e),
-                )
-            })?;
-
-        let cert_chain = CertificateDer::pem_file_iter(cert)
-            .map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("Failed to read certificate file: {}", e),
-                )
-            })?
-            .flatten()
-            .collect();
-
-        let key_der = PrivateKeyDer::from_pem_file(key).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("Failed to read key file: {}", e),
-            )
-        })?;
-
-        let rustls_config = ServerConfig::builder()
-            .with_no_client_auth()
-            .with_single_cert(cert_chain, key_der)
-            .map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("Failed to configure TLS: {}", e),
-                )
-            })?;
-
-        info!("Server binding with rustls to https://{}", bind_address);
-        server
-            .bind_rustls_0_23(bind_address, rustls_config)
-            .map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("Failed to bind server: {}", e),
-                )
-            })
-    }
-}
-
-#[cfg(feature = "tls-openssl")]
-mod tls {
-    use actix_http::{Request, Response};
-    use actix_service::{IntoServiceFactory, ServiceFactory};
-    use actix_web::{body::MessageBody, dev::AppConfig, Error, HttpServer};
-    use openssl::{
-        pkey::PKey,
-        ssl::{SslAcceptor, SslFiletype, SslMethod},
-    };
-    use std::{fs::File, io::Read};
-    use tracing::info;
-
-    pub fn configure_server<F, I, S, B>(
-        server: HttpServer<F, I, S, B>,
-        bind_address: &str,
-        cert: &str,
-        key: &str,
-        pass: Option<&str>,
-    ) -> std::io::Result<HttpServer<F, I, S, B>>
-    where
-        F: Fn() -> I + Send + Clone + 'static,
-        I: IntoServiceFactory<S, Request>,
-        S: ServiceFactory<Request, Config = AppConfig> + 'static,
-        S::Error: Into<Error>,
-        S::InitError: std::fmt::Debug,
-        S::Response: Into<Response<B>>,
-        B: MessageBody + 'static,
-    {
-        let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls()).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("unable to create SSL acceptor: {}", e),
-            )
-        })?;
-
-        if let Some(pass) = pass {
-            let mut buf = Vec::new();
-            File::open(key)?.read_to_end(&mut buf)?;
-            let pkey =
-                PKey::private_key_from_pem_passphrase(&buf, pass.as_bytes()).map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("unable to decrypt private key: {}", e),
-                    )
-                })?;
-            builder.set_private_key(&pkey).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("unable to set private key: {}", e),
-                )
-            })?;
-        } else {
-            builder
-                .set_private_key_file(key, SslFiletype::PEM)
-                .map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::NotFound,
-                        format!("unable to load private key file: {}", e),
-                    )
-                })?;
-        }
-
-        builder.set_certificate_chain_file(cert).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("unable to load certificate chain: {}", e),
-            )
-        })?;
-
-        info!("Server binding with openssl to https://{}", bind_address);
-        server.bind_openssl(bind_address, builder).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Failed to bind server: {}", e),
-            )
-        })
-    }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,328 @@
+use actix_http::{Request, Response};
+use actix_service::{IntoServiceFactory, ServiceFactory};
+use actix_web::{body::MessageBody, dev::AppConfig, Error, HttpServer};
+
+use crate::config::TlsBackend;
+
+type ServerResult<F, I, S, B> = std::io::Result<HttpServer<F, I, S, B>>;
+
+#[cfg(not(any(feature = "tls-rustls", feature = "tls-openssl")))]
+fn no_tls_backend_error(requested_backend: Option<TlsBackend>) -> std::io::Error {
+    let message = match requested_backend {
+        Some(backend) => format!(
+            "TLS backend `{}` was requested, but no TLS backend was enabled during build. Please enable either `tls-rustls` or `tls-openssl` during build to use TLS",
+            backend.as_str()
+        ),
+        None => "TLS certificate and key offered, but no TLS backend was enabled during build. Please enable either `tls-rustls` or `tls-openssl` during build to use TLS".to_string(),
+    };
+
+    std::io::Error::other(message)
+}
+
+#[cfg(any(
+    all(feature = "tls-rustls", not(feature = "tls-openssl")),
+    all(feature = "tls-openssl", not(feature = "tls-rustls"))
+))]
+fn unavailable_backend_error(
+    requested_backend: TlsBackend,
+    available_feature: &'static str,
+) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!(
+            "TLS backend `{}` was requested, but this build only includes `{}`",
+            requested_backend.as_str(),
+            available_feature
+        ),
+    )
+}
+
+fn resolve_backend(requested_backend: Option<TlsBackend>) -> std::io::Result<TlsBackend> {
+    #[cfg(all(feature = "tls-rustls", feature = "tls-openssl"))]
+    {
+        Ok(requested_backend.unwrap_or(TlsBackend::Rustls))
+    }
+
+    #[cfg(all(feature = "tls-rustls", not(feature = "tls-openssl")))]
+    {
+        match requested_backend {
+            Some(TlsBackend::Openssl) => {
+                Err(unavailable_backend_error(TlsBackend::Openssl, "tls-rustls"))
+            }
+            _ => Ok(TlsBackend::Rustls),
+        }
+    }
+
+    #[cfg(all(feature = "tls-openssl", not(feature = "tls-rustls")))]
+    {
+        match requested_backend {
+            Some(TlsBackend::Rustls) => {
+                Err(unavailable_backend_error(TlsBackend::Rustls, "tls-openssl"))
+            }
+            _ => Ok(TlsBackend::Openssl),
+        }
+    }
+
+    #[cfg(not(any(feature = "tls-rustls", feature = "tls-openssl")))]
+    {
+        Err(no_tls_backend_error(requested_backend))
+    }
+}
+
+pub fn configure_server<F, I, S, B>(
+    server: HttpServer<F, I, S, B>,
+    bind_address: &str,
+    cert: &str,
+    key: &str,
+    pass: Option<&str>,
+    backend: Option<TlsBackend>,
+) -> ServerResult<F, I, S, B>
+where
+    F: Fn() -> I + Send + Clone + 'static,
+    I: IntoServiceFactory<S, Request>,
+    S: ServiceFactory<Request, Config = AppConfig> + 'static,
+    S::Error: Into<Error>,
+    S::InitError: std::fmt::Debug,
+    S::Response: Into<Response<B>>,
+    B: MessageBody + 'static,
+{
+    let selected_backend = resolve_backend(backend)?;
+
+    #[cfg(feature = "tls-rustls")]
+    if selected_backend == TlsBackend::Rustls {
+        return tls_rustls::configure_server(server, bind_address, cert, key, pass);
+    }
+
+    #[cfg(feature = "tls-openssl")]
+    if selected_backend == TlsBackend::Openssl {
+        return tls_openssl::configure_server(server, bind_address, cert, key, pass);
+    }
+
+    let _ = (server, bind_address, cert, key, pass, selected_backend);
+    unreachable!("resolved TLS backend without a compiled implementation")
+}
+
+#[cfg(feature = "tls-rustls")]
+mod tls_rustls {
+    use super::*;
+    use rustls::{
+        pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer},
+        ServerConfig,
+    };
+    use tracing::info;
+
+    pub fn configure_server<F, I, S, B>(
+        server: HttpServer<F, I, S, B>,
+        bind_address: &str,
+        cert: &str,
+        key: &str,
+        pass: Option<&str>,
+    ) -> ServerResult<F, I, S, B>
+    where
+        F: Fn() -> I + Send + Clone + 'static,
+        I: IntoServiceFactory<S, Request>,
+        S: ServiceFactory<Request, Config = AppConfig> + 'static,
+        S::Error: Into<Error>,
+        S::InitError: std::fmt::Debug,
+        S::Response: Into<Response<B>>,
+        B: MessageBody + 'static,
+    {
+        if pass.is_some() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Using encrypted TLS key with passphrase is not supported with rustls feature",
+            ));
+        }
+
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .map_err(|e| {
+                std::io::Error::other(format!("Failed to install crypto provider: {e:?}"))
+            })?;
+
+        let cert_chain = CertificateDer::pem_file_iter(cert)
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Failed to read certificate file: {e}"),
+                )
+            })?
+            .flatten()
+            .collect();
+
+        let key_der = PrivateKeyDer::from_pem_file(key).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Failed to read key file: {e}"),
+            )
+        })?;
+
+        let rustls_config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(cert_chain, key_der)
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Failed to configure TLS: {e}"),
+                )
+            })?;
+
+        info!("Server binding with rustls to https://{}", bind_address);
+        server
+            .bind_rustls_0_23(bind_address, rustls_config)
+            .map_err(|e| std::io::Error::other(format!("Failed to bind server: {e}")))
+    }
+}
+
+#[cfg(feature = "tls-openssl")]
+mod tls_openssl {
+    use super::*;
+    use openssl::{
+        pkey::PKey,
+        ssl::{SslAcceptor, SslFiletype, SslMethod},
+    };
+    use std::{fs::File, io::Read};
+    use tracing::info;
+
+    pub fn configure_server<F, I, S, B>(
+        server: HttpServer<F, I, S, B>,
+        bind_address: &str,
+        cert: &str,
+        key: &str,
+        pass: Option<&str>,
+    ) -> ServerResult<F, I, S, B>
+    where
+        F: Fn() -> I + Send + Clone + 'static,
+        I: IntoServiceFactory<S, Request>,
+        S: ServiceFactory<Request, Config = AppConfig> + 'static,
+        S::Error: Into<Error>,
+        S::InitError: std::fmt::Debug,
+        S::Response: Into<Response<B>>,
+        B: MessageBody + 'static,
+    {
+        let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls())
+            .map_err(|e| std::io::Error::other(format!("unable to create SSL acceptor: {e}")))?;
+
+        if let Some(pass) = pass {
+            let mut buf = Vec::new();
+            File::open(key)?.read_to_end(&mut buf)?;
+            let pkey =
+                PKey::private_key_from_pem_passphrase(&buf, pass.as_bytes()).map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("unable to decrypt private key: {e}"),
+                    )
+                })?;
+            builder.set_private_key(&pkey).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unable to set private key: {e}"),
+                )
+            })?;
+        } else {
+            builder
+                .set_private_key_file(key, SslFiletype::PEM)
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("unable to load private key file: {e}"),
+                    )
+                })?;
+        }
+
+        builder.set_certificate_chain_file(cert).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("unable to load certificate chain: {e}"),
+            )
+        })?;
+
+        info!("Server binding with openssl to https://{}", bind_address);
+        server
+            .bind_openssl(bind_address, builder)
+            .map_err(|e| std::io::Error::other(format!("Failed to bind server: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_backend;
+    use crate::config::TlsBackend;
+
+    #[cfg(all(feature = "tls-rustls", feature = "tls-openssl"))]
+    #[test]
+    fn backend_selection_defaults_to_rustls_when_both_backends_are_enabled() {
+        assert_eq!(resolve_backend(None).unwrap(), TlsBackend::Rustls);
+    }
+
+    #[cfg(all(feature = "tls-rustls", feature = "tls-openssl"))]
+    #[test]
+    fn backend_selection_honors_explicit_backend_when_both_backends_are_enabled() {
+        assert_eq!(
+            resolve_backend(Some(TlsBackend::Rustls)).unwrap(),
+            TlsBackend::Rustls
+        );
+        assert_eq!(
+            resolve_backend(Some(TlsBackend::Openssl)).unwrap(),
+            TlsBackend::Openssl
+        );
+    }
+
+    #[cfg(all(feature = "tls-rustls", not(feature = "tls-openssl")))]
+    #[test]
+    fn backend_selection_defaults_to_rustls_when_only_rustls_is_enabled() {
+        assert_eq!(resolve_backend(None).unwrap(), TlsBackend::Rustls);
+        assert_eq!(
+            resolve_backend(Some(TlsBackend::Rustls)).unwrap(),
+            TlsBackend::Rustls
+        );
+    }
+
+    #[cfg(all(feature = "tls-rustls", not(feature = "tls-openssl")))]
+    #[test]
+    fn backend_selection_rejects_openssl_when_only_rustls_is_enabled() {
+        let error = resolve_backend(Some(TlsBackend::Openssl)).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains(
+            "TLS backend `openssl` was requested, but this build only includes `tls-rustls`"
+        ));
+    }
+
+    #[cfg(all(feature = "tls-openssl", not(feature = "tls-rustls")))]
+    #[test]
+    fn backend_selection_defaults_to_openssl_when_only_openssl_is_enabled() {
+        assert_eq!(resolve_backend(None).unwrap(), TlsBackend::Openssl);
+        assert_eq!(
+            resolve_backend(Some(TlsBackend::Openssl)).unwrap(),
+            TlsBackend::Openssl
+        );
+    }
+
+    #[cfg(all(feature = "tls-openssl", not(feature = "tls-rustls")))]
+    #[test]
+    fn backend_selection_rejects_rustls_when_only_openssl_is_enabled() {
+        let error = resolve_backend(Some(TlsBackend::Rustls)).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains(
+            "TLS backend `rustls` was requested, but this build only includes `tls-openssl`"
+        ));
+    }
+
+    #[cfg(not(any(feature = "tls-rustls", feature = "tls-openssl")))]
+    #[test]
+    fn backend_selection_rejects_tls_requests_when_no_backend_is_enabled() {
+        let implicit_backend_error = resolve_backend(None).unwrap_err();
+        assert_eq!(implicit_backend_error.kind(), std::io::ErrorKind::Other);
+        assert!(implicit_backend_error
+            .to_string()
+            .contains("no TLS backend was enabled during build"));
+
+        let explicit_backend_error = resolve_backend(Some(TlsBackend::Rustls)).unwrap_err();
+        assert_eq!(explicit_backend_error.kind(), std::io::ErrorKind::Other);
+        assert!(explicit_backend_error
+            .to_string()
+            .contains("TLS backend `rustls` was requested"));
+    }
+}


### PR DESCRIPTION
Summary
- add TLS backend selection logic and config parsing for HUBUUM_TLS_BACKEND
- replace mutual TLS modules in `src/main.rs` with a unified facade and dedicated backend modules
- include tests covering backend parsing and validation errors
