### PR TITLE
Ensure docs/openapi.json rebuilds before commit

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -16,12 +16,14 @@ That's it! Git will automatically run hooks from the `hooks/` directory from now
 
 ## Pre-commit Hook
 
-The `hooks/pre-commit` hook automatically runs `cargo clippy` before each commit. If clippy finds any warnings or errors, the commit will be prevented until they are fixed.
+The `hooks/pre-commit` hook automatically runs `cargo clippy` and rebuilds `docs/openapi.json` before each commit. If clippy fails or the OpenAPI document cannot be regenerated, the commit is prevented.
 
 ### Features
 
 - ✅ Runs clippy with `-D warnings` to treat all warnings as errors
+- ✅ Rebuilds and stages `docs/openapi.json` from the current code
 - ✅ Prevents commits that fail clippy checks
+- ✅ Prevents commits if OpenAPI generation fails
 - ✅ Clear error messages guide developers on how to fix issues
 - ✅ Stored in version control and shared with the team
 - ✅ No installation script needed - git handles it automatically via `core.hooksPath`
@@ -36,6 +38,9 @@ cargo clippy --all-targets
 
 # Fix clippy issues with automatic suggestions
 cargo clippy --all-targets --fix
+
+# Rebuild the committed OpenAPI spec
+cargo run --quiet --bin hubuum-openapi > docs/openapi.json
 ```
 
 ## Architecture Overview

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,17 +1,38 @@
 #!/bin/bash
-# Pre-commit hook to enforce clippy checks
-# This prevents commits if clippy finds any warnings
+# Pre-commit hook to enforce generated docs and clippy checks.
 
-set -e
+set -euo pipefail
 
 echo "Running clippy checks before commit..."
 
 if ! cargo clippy --all-targets -- -D warnings; then
     echo ""
-    echo "❌ Clippy found warnings or errors. Please fix them before committing."
+    echo "Clippy found warnings or errors. Please fix them before committing."
     echo "You can run 'cargo clippy --all-targets -- -D warnings' to see all issues."
     exit 1
 fi
 
-echo "✅ Clippy checks passed!"
-exit 0
+echo "Rebuilding docs/openapi.json before commit..."
+
+tmp_openapi="$(mktemp)"
+cleanup() {
+    rm -f "$tmp_openapi"
+}
+trap cleanup EXIT
+
+if ! cargo run --quiet --bin hubuum-openapi >"$tmp_openapi"; then
+    echo ""
+    echo "Failed to rebuild docs/openapi.json."
+    echo "You can run 'cargo run --quiet --bin hubuum-openapi > docs/openapi.json' to inspect the error."
+    exit 1
+fi
+
+if ! cmp -s "$tmp_openapi" docs/openapi.json; then
+    mv "$tmp_openapi" docs/openapi.json
+    git add docs/openapi.json
+    echo "Updated docs/openapi.json and staged it."
+else
+    echo "docs/openapi.json is already up to date."
+fi
+
+echo "Pre-commit checks passed."


### PR DESCRIPTION
Summary
- add docs/development guidance and a hook so docs/openapi.json is regenerated prior to commits
- wire up the pre-commit hook to run the rebuild script and ensure new output is tracked
Testing
