### PR TITLE
Replace buildx with native builders, generally improve CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Rust build artifacts
+target/
+**/target/
+
+# Git
+.git/
+.gitignore
+
+# CI/CD
+.github/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Documentation
+docs/
+*.md
+!README.md
+
+# Test and development files
+**/test/
+# **/tests/
+*.log
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Misc
+*.tar.gz
+*.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: CI
 
-# Copied from https://github.com/houseabsolute/precious/blob/master/.github/workflows/ci.yml
-
 on:
   push:
     branches:
@@ -9,6 +7,10 @@ on:
     tags:
       - "v*"
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CRATE_NAME: hubuum
@@ -211,7 +213,10 @@ jobs:
           sudo apt-get install --yes libsqlite3-dev libmysqlclient-dev libpq-dev libssl-dev
       - name: Set up database
         run: |
-          cargo install diesel_cli --no-default-features --features postgres
+          # Install cargo-binstall for faster binary installation
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          # Use binstall to get prebuilt diesel_cli binary
+          cargo binstall --no-confirm diesel_cli --no-default-features --features postgres
           echo "Creating database"
           PGPASSWORD=postgres createdb -U postgres -h localhost -p 5432 hubuum_rust_test
           echo "Running database setup and migrations"
@@ -351,7 +356,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Set up database
         run: |
-          cargo install diesel_cli --no-default-features --features postgres
+          # Install cargo-binstall for faster binary installation
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          # Use binstall to get prebuilt diesel_cli binary
+          cargo binstall --no-confirm diesel_cli --no-default-features --features postgres
           echo "Creating database"
           PGPASSWORD=postgres createdb -U postgres -h localhost -p 5432 hubuum_rust_test
           echo "Running database setup and migrations"
@@ -362,13 +370,14 @@ jobs:
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-      - name: Install musl-tools on Linux
-        run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
-        if: contains(matrix.platform.name, 'musl')
-      - name: Install database libraries on Linux
+      - name: Install Linux dependencies
         run: |
           sudo apt-get update --yes
-          sudo apt-get install --yes libsqlite3-dev libmysqlclient-dev libpq-dev
+          packages=(libsqlite3-dev libmysqlclient-dev libpq-dev)
+          if [[ "${{ matrix.platform.name }}" == *"musl"* ]]; then
+            packages+=(musl-tools)
+          fi
+          sudo apt-get install --yes "${packages[@]}"
         if: contains(matrix.platform.os, 'ubuntu')
       - name: Build binary with rustls feature enabled
         uses: houseabsolute/actions-rust-cross@v0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,8 +215,8 @@ jobs:
         run: |
           # Install cargo-binstall for faster binary installation
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          # Use binstall to get prebuilt diesel_cli binary
-          cargo binstall --no-confirm diesel_cli -- --no-default-features --features postgres
+          # Use binstall to get prebuilt diesel_cli binary (includes postgres support)
+          cargo binstall --no-confirm diesel_cli
           echo "Creating database"
           PGPASSWORD=postgres createdb -U postgres -h localhost -p 5432 hubuum_rust_test
           echo "Running database setup and migrations"
@@ -358,8 +358,8 @@ jobs:
         run: |
           # Install cargo-binstall for faster binary installation
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          # Use binstall to get prebuilt diesel_cli binary
-          cargo binstall --no-confirm diesel_cli -- --no-default-features --features postgres
+          # Use binstall to get prebuilt diesel_cli binary (includes postgres support)
+          cargo binstall --no-confirm diesel_cli
           echo "Creating database"
           PGPASSWORD=postgres createdb -U postgres -h localhost -p 5432 hubuum_rust_test
           echo "Running database setup and migrations"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   RUST_BACKTRACE: 1
   DATABASE_URL: postgres://postgres:postgres@localhost:5432/hubuum_rust_test
   HUBUUM_DATABASE_URL: postgres://postgres:postgres@localhost:5432/hubuum_rust_test
-  HUBUU_DB_TEST_PASSWORD: postgres
+  HUBUUM_DB_TEST_PASSWORD: postgres
 
 jobs:
   lint:
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install clippy
         run: rustup component add clippy
       - name: Run clippy
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
       - name: Generate OpenAPI JSON
@@ -114,7 +114,7 @@ jobs:
       matrix: ${{ steps.detect.outputs.matrix }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
       - name: Install feature build dependencies
@@ -202,7 +202,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
       - name: Install database libraries on Linux
@@ -211,7 +211,7 @@ jobs:
           sudo apt-get install --yes libsqlite3-dev libmysqlclient-dev libpq-dev libssl-dev
       - name: Set up database
         run: |
-          cargo install diesel_cli --no-default-features --features postgres --force
+          cargo install diesel_cli --no-default-features --features postgres
           echo "Creating database"
           PGPASSWORD=postgres createdb -U postgres -h localhost -p 5432 hubuum_rust_test
           echo "Running database setup and migrations"
@@ -345,17 +345,13 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - name: Docker debugging
-        run: |
-          docker ps -a
-          docker container ls
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
       - name: Set up database
         run: |
-          cargo install diesel_cli --no-default-features --features postgres --force
+          cargo install diesel_cli --no-default-features --features postgres
           echo "Creating database"
           PGPASSWORD=postgres createdb -U postgres -h localhost -p 5432 hubuum_rust_test
           echo "Running database setup and migrations"
@@ -364,8 +360,8 @@ jobs:
           PGPASSWORD=postgres psql -U postgres -h localhost -p 5432 -d hubuum_rust_test -c "select * from users;"
       - name: Configure Git
         run: |
-          git config --global user.email "terje@kvernes.no"
-          git config --global user.name "Terje Kvernes"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
       - name: Install musl-tools on Linux
         run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
         if: contains(matrix.platform.name, 'musl')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
           # Install cargo-binstall for faster binary installation
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           # Use binstall to get prebuilt diesel_cli binary
-          cargo binstall --no-confirm diesel_cli --no-default-features --features postgres
+          cargo binstall --no-confirm diesel_cli -- --no-default-features --features postgres
           echo "Creating database"
           PGPASSWORD=postgres createdb -U postgres -h localhost -p 5432 hubuum_rust_test
           echo "Running database setup and migrations"
@@ -359,7 +359,7 @@ jobs:
           # Install cargo-binstall for faster binary installation
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           # Use binstall to get prebuilt diesel_cli binary
-          cargo binstall --no-confirm diesel_cli --no-default-features --features postgres
+          cargo binstall --no-confirm diesel_cli -- --no-default-features --features postgres
           echo "Creating database"
           PGPASSWORD=postgres createdb -U postgres -h localhost -p 5432 hubuum_rust_test
           echo "Running database setup and migrations"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,8 +607,8 @@ jobs:
           prerelease: false
           files: dist/*
 
-  publish-main-containers:
-    name: Publish main containers (${{ matrix.variant.name }})
+  publish-main-container-images:
+    name: Build main container (${{ matrix.variant.name }}, ${{ matrix.platform.arch }})
     if: github.ref == 'refs/heads/main'
     needs:
       - lint
@@ -616,7 +616,7 @@ jobs:
       - openapi-contract
       - feature-permutations
       - test
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
       packages: write
@@ -628,11 +628,14 @@ jobs:
             build_args: "-F tls-rustls -F tls-openssl"
           - name: rustls-only
             build_args: "-F tls-rustls"
+        platform:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
@@ -641,47 +644,70 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Compute image tags
-        id: tags
-        shell: bash
-        run: |
-          owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
-          image="ghcr.io/${owner}/hubuum-server"
-          variant="${{ matrix.variant.name }}"
-          tags=()
-
-          if [[ "$variant" == "full" ]]; then
-            tags+=("${image}:main")
-            tags+=("${image}:main-full")
-          else
-            tags+=("${image}:main-${variant}")
-          fi
-
-          {
-            echo "tags<<EOF"
-            printf '%s\n' "${tags[@]}"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - name: Build and push image
+      - name: Build and push platform-specific image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.platform.arch }}
           push: true
-          tags: ${{ steps.tags.outputs.tags }}
+          tags: ghcr.io/${{ github.repository_owner }}/hubuum-server:main-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ github.ref_name }}
           build-args: |
             CARGO_BUILD_FLAGS=${{ matrix.variant.build_args }} --locked --release
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-  publish-tag-containers:
-    name: Publish release containers (${{ matrix.variant.name }})
+  publish-main-container-manifests:
+    name: Create main multi-arch manifest (${{ matrix.variant.name }})
+    if: github.ref == 'refs/heads/main'
+    needs: publish-main-container-images
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - name: full
+          - name: rustls-only
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
+        shell: bash
+        run: |
+          owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          image="ghcr.io/${owner}/hubuum-server"
+          variant="${{ matrix.variant.name }}"
+          
+          # Determine final tags
+          if [[ "$variant" == "full" ]]; then
+            final_tags=("${image}:main" "${image}:main-full")
+          else
+            final_tags=("${image}:main-${variant}")
+          fi
+          
+          # Create and push manifest for each tag
+          for tag in "${final_tags[@]}"; do
+            docker buildx imagetools create -t "$tag" \
+              "${image}:main-${variant}-amd64" \
+              "${image}:main-${variant}-arm64"
+          done
+
+  publish-tag-container-images:
+    name: Build release container (${{ matrix.variant.name }}, ${{ matrix.platform.arch }})
     if: startsWith(github.ref, 'refs/tags/v')
     needs: validate-tag-release
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
       packages: write
@@ -693,6 +719,11 @@ jobs:
             build_args: "-F tls-rustls -F tls-openssl"
           - name: rustls-only
             build_args: "-F tls-rustls"
+        platform:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -700,8 +731,6 @@ jobs:
         run: chmod +x scripts/*.sh
       - name: Check tagged release metadata
         run: ./scripts/check-release-readiness.sh "${GITHUB_REF_NAME}"
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
@@ -710,8 +739,45 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Compute image tags
-        id: tags
+      - name: Build and push platform-specific image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/${{ matrix.platform.arch }}
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/hubuum-server:${{ github.ref_name }}-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}
+          build-args: |
+            CARGO_BUILD_FLAGS=${{ matrix.variant.build_args }} --locked --release
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  publish-tag-container-manifests:
+    name: Create release multi-arch manifest (${{ matrix.variant.name }})
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: publish-tag-container-images
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - name: full
+          - name: rustls-only
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
         shell: bash
         run: |
           owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
@@ -719,34 +785,27 @@ jobs:
           version_tag="${GITHUB_REF_NAME}"
           version="${version_tag#v}"
           variant="${{ matrix.variant.name }}"
-          tags=()
-
+          
+          # Determine final tags
           if [[ "$variant" == "full" ]]; then
-            tags+=("${image}:${version_tag}")
-            tags+=("${image}:${version}")
-            tags+=("${image}:${version_tag}-full")
-            tags+=("${image}:${version}-full")
+            final_tags=(
+              "${image}:${version_tag}"
+              "${image}:${version}"
+              "${image}:${version_tag}-full"
+              "${image}:${version}-full"
+            )
           else
-            tags+=("${image}:${version_tag}-${variant}")
-            tags+=("${image}:${version}-${variant}")
+            final_tags=(
+              "${image}:${version_tag}-${variant}"
+              "${image}:${version}-${variant}"
+            )
           fi
-
-          {
-            echo "tags<<EOF"
-            printf '%s\n' "${tags[@]}"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - name: Build and push image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.tags.outputs.tags }}
-          labels: |
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ github.ref_name }}
+          
+          # Create and push manifest for each tag
+          for tag in "${final_tags[@]}"; do
+            docker buildx imagetools create -t "$tag" \
+              "${image}:${version_tag}-${variant}-amd64" \
+              "${image}:${version_tag}-${variant}-arm64"
+          done
           build-args: |
             CARGO_BUILD_FLAGS=${{ matrix.variant.build_args }} --locked --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 on:
   push:
     branches:
-      - "**"
+      - main
     tags:
       - "v*"
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,52 @@
-FROM rust:bookworm AS builder
+# syntax=docker/dockerfile:1
+FROM rust:slim-trixie AS builder
 
 ARG CARGO_BUILD_FLAGS="--locked --release"
 
 WORKDIR /usr/src/hubuum
 
-# Install diesel CLI
-RUN cargo install diesel_cli --no-default-features --features postgres
+# Install system dependencies and cargo-binstall in one layer
+RUN apt-get update && \
+    apt-get install -y libpq-dev libpq5 libssl3 libssl-dev curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
-# Copy the project files
+# Install diesel CLI using binstall (much faster)
+RUN cargo binstall --no-confirm diesel_cli
+
+# Copy manifests first for better layer caching
+COPY Cargo.toml Cargo.lock ./
+COPY migrations ./migrations
+
+# Build dependencies only (creates dummy project)
+# Use cache mounts to persist cargo registry/git between builds
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    mkdir -p src/bin && \
+    echo "fn main() {}" > src/main.rs && \
+    echo "pub fn dummy() {}" > src/lib.rs && \
+    echo "fn main() {}" > src/bin/admin.rs && \
+    echo "fn main() {}" > src/bin/openapi.rs && \
+    cargo build ${CARGO_BUILD_FLAGS} --bin hubuum-server --bin hubuum-admin && \
+    rm -rf src
+
+# Copy the actual source code
 COPY . .
 
-# Build the application
-RUN cargo build ${CARGO_BUILD_FLAGS} --bin hubuum-server --bin hubuum-admin
+# Build the real application (dependencies are cached)
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/src/hubuum/target \
+    cargo build ${CARGO_BUILD_FLAGS} --bin hubuum-server --bin hubuum-admin && \
+    cp target/release/hubuum-server /tmp/ && \
+    cp target/release/hubuum-admin /tmp/
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y libpq5 libssl3 && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/src/hubuum/target/release/hubuum-server /usr/local/bin/hubuum-server
-COPY --from=builder /usr/src/hubuum/target/release/hubuum-admin /usr/local/bin/hubuum-admin
+COPY --from=builder /tmp/hubuum-server /usr/local/bin/hubuum-server
+COPY --from=builder /tmp/hubuum-admin /usr/local/bin/hubuum-admin
 COPY --from=builder /usr/local/cargo/bin/diesel /usr/local/bin/diesel
 COPY --from=builder /usr/src/hubuum/migrations /migrations
 


### PR DESCRIPTION
## Native ARM64 Builds 

- Replaced QEMU-emulated ARM builds with native ubuntu-24.04-arm runners for faster container builds.
- Split container jobs into platform-specific builds (run in parallel on native hardware)
- Added manifest jobs to combine platform images into multi-arch tags

Affects: publish-main-container-images/manifests and publish-tag-container-images/manifests

## Additional improvements

- Auto-cancel outdated PR runs when new commits are pushed (concurrency control)
- Fast diesel_cli - Use cargo-binstall for prebuilt binaries (~5-10 min → ~30 sec)
- Fixed duplicate runs - Only trigger on main, not all branches
- Consolidated apt updates - Single call per job

## Cleanup 

- Updated actions/checkout to v4
- Fixed typos and hardcoding
- Removed unnecessary Docker debugging step
- Generic git config instead of hardcoded email

## Note

Requires GitHub-hosted ARM64 runners (ubuntu-24.04-arm), available on [standard plans.](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories)