### PR TITLE
Refactor paginated total counts

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -472,7 +472,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes",
-        "description": "Auto-generated documentation for GET /api/v1/classes. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1Classes",
         "parameters": [
           {
@@ -505,13 +505,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Classes matching optional query filters The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Classes matching optional query filters The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -810,7 +816,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id Trailing",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdTrailing",
         "parameters": [
           {
@@ -853,13 +859,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Objects in class The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Objects in class The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -1073,7 +1085,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id Objects By Object Id Related Objects",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/objects/{object_id}/related/objects. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/objects/{object_id}/related/objects. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdObjectsByObjectIdRelatedObjects",
         "parameters": [
           {
@@ -1144,13 +1156,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Objects connected to the object The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Objects connected to the object The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -1208,7 +1226,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id Objects By Object Id Related Relations",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/objects/{object_id}/related/relations. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/objects/{object_id}/related/relations. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdObjectsByObjectIdRelatedRelations",
         "parameters": [
           {
@@ -1261,13 +1279,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Direct relations touching the object The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Direct relations touching the object The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -1325,7 +1349,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id Permissions",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/permissions. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/permissions. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdPermissions",
         "parameters": [
           {
@@ -1368,13 +1392,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Namespace-group permission mappings for class namespace The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Namespace-group permission mappings for class namespace The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -1422,7 +1452,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id Related Classes",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/related/classes. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/related/classes. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdRelatedClasses",
         "parameters": [
           {
@@ -1465,13 +1495,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Classes connected to the class The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Classes connected to the class The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -1598,7 +1634,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id Related Relations",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/related/relations. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/related/relations. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdRelatedRelations",
         "parameters": [
           {
@@ -1641,13 +1677,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Direct relations touching the class The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Direct relations touching the class The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -2348,7 +2390,7 @@
           "groups"
         ],
         "summary": "Get Api V1 Iam Groups",
-        "description": "Auto-generated documentation for GET /api/v1/iam/groups. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/iam/groups. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1IamGroups",
         "parameters": [
           {
@@ -2381,13 +2423,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Groups matching optional query filters The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Groups matching optional query filters The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -2686,7 +2734,7 @@
           "groups"
         ],
         "summary": "Get Api V1 Iam Groups By Group Id Members",
-        "description": "Auto-generated documentation for GET /api/v1/iam/groups/{group_id}/members. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/iam/groups/{group_id}/members. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1IamGroupsByGroupIdMembers",
         "parameters": [
           {
@@ -2729,13 +2777,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Members of group The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Members of group The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -2905,7 +2959,7 @@
           "users"
         ],
         "summary": "Get Api V1 Iam Users",
-        "description": "Auto-generated documentation for GET /api/v1/iam/users. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/iam/users. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1IamUsers",
         "parameters": [
           {
@@ -2938,13 +2992,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Users matching optional query filters The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Users matching optional query filters The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -3243,7 +3303,7 @@
           "users"
         ],
         "summary": "Get Api V1 Iam Users By User Id Groups",
-        "description": "Auto-generated documentation for GET /api/v1/iam/users/{user_id}/groups. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/iam/users/{user_id}/groups. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1IamUsersByUserIdGroups",
         "parameters": [
           {
@@ -3286,13 +3346,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Groups of user The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Groups of user The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -3340,7 +3406,7 @@
           "users"
         ],
         "summary": "Get Api V1 Iam Users By User Id Tokens",
-        "description": "Auto-generated documentation for GET /api/v1/iam/users/{user_id}/tokens. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/iam/users/{user_id}/tokens. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1IamUsersByUserIdTokens",
         "parameters": [
           {
@@ -3383,13 +3449,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Active token metadata for user The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Active token metadata for user The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -3645,7 +3717,7 @@
           "namespaces"
         ],
         "summary": "Get Api V1 Namespaces",
-        "description": "Auto-generated documentation for GET /api/v1/namespaces. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/namespaces. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1Namespaces",
         "parameters": [
           {
@@ -3678,13 +3750,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Namespaces matching optional query filters The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Namespaces matching optional query filters The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -3983,7 +4061,7 @@
           "namespaces"
         ],
         "summary": "List all groups that have any permissions on a namespace",
-        "description": "Auto-generated documentation for GET /api/v1/namespaces/{namespace_id}/has_permissions/{permission}. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/namespaces/{namespace_id}/has_permissions/{permission}. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1NamespacesByNamespaceIdHasPermissionsByPermission",
         "parameters": [
           {
@@ -4035,13 +4113,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Groups with permission The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Groups with permission The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -4089,7 +4173,7 @@
           "namespaces"
         ],
         "summary": "List all groups who have permissions for a namespace",
-        "description": "Auto-generated documentation for GET /api/v1/namespaces/{namespace_id}/permissions. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/namespaces/{namespace_id}/permissions. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1NamespacesByNamespaceIdPermissions",
         "parameters": [
           {
@@ -4132,13 +4216,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Group permissions on namespace The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Group permissions on namespace The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -4680,7 +4770,7 @@
           "namespaces"
         ],
         "summary": "List all permissions for a user on a namespace",
-        "description": "Auto-generated documentation for GET /api/v1/namespaces/{namespace_id}/permissions/user/{user_id}. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/namespaces/{namespace_id}/permissions/user/{user_id}. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1NamespacesByNamespaceIdPermissionsUserByUserId",
         "parameters": [
           {
@@ -4733,13 +4823,19 @@
         ],
         "responses": {
           "200": {
-            "description": "User permissions via group memberships The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "User permissions via group memberships The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -4787,7 +4883,7 @@
           "relations"
         ],
         "summary": "Get Api V1 Relations Classes",
-        "description": "Auto-generated documentation for GET /api/v1/relations/classes. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/relations/classes. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1RelationsClasses",
         "parameters": [
           {
@@ -4820,13 +4916,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Class relations matching optional query filters The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Class relations matching optional query filters The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -5048,7 +5150,7 @@
           "relations"
         ],
         "summary": "Get Api V1 Relations Objects",
-        "description": "Auto-generated documentation for GET /api/v1/relations/objects. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/relations/objects. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1RelationsObjects",
         "parameters": [
           {
@@ -5081,13 +5183,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Object relations matching optional query filters The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Object relations matching optional query filters The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -5638,7 +5746,7 @@
           "tasks"
         ],
         "summary": "Get Api V1 Tasks",
-        "description": "Auto-generated documentation for GET /api/v1/tasks. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/tasks. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1Tasks",
         "parameters": [
           {
@@ -5700,13 +5808,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Visible tasks The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Visible tasks The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {
@@ -5895,7 +6009,7 @@
           "templates"
         ],
         "summary": "Get Api V1 Templates",
-        "description": "Auto-generated documentation for GET /api/v1/templates. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/templates. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1Templates",
         "parameters": [
           {
@@ -5928,13 +6042,19 @@
         ],
         "responses": {
           "200": {
-            "description": "Templates visible to caller The response body contains the current page items as a JSON array. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "description": "Templates visible to caller The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
             "headers": {
               "X-Next-Cursor": {
                 "schema": {
                   "type": "string"
                 },
                 "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
               }
             },
             "content": {

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -2,7 +2,7 @@
 
 Hubuum list endpoints share a common query interface for filtering, sorting, and cursor pagination. These query options are applied in the database, not by loading a full result set into memory first.
 
-The response body for list endpoints remains a plain JSON array. Pagination state is returned in the `X-Next-Cursor` response header.
+The response body for list endpoints remains a plain JSON array. Pagination metadata is returned in response headers.
 
 For endpoint-specific field support, see [query_support_matrix.md](query_support_matrix.md).
 
@@ -101,9 +101,11 @@ Limits:
 Behavior:
 
 - the current page is returned as a JSON array
+- every paginated response includes `X-Total-Count` with the exact number of matching results
 - if another page exists, the response includes `X-Next-Cursor`
 - send that cursor back unchanged to fetch the next page
 - if `X-Next-Cursor` is absent, there is no next page
+- total pages can be derived client-side as `ceil(X-Total-Count / limit)`
 
 Example:
 
@@ -114,6 +116,7 @@ GET /api/v1/classes?namespaces=12&limit=2&sort=id.asc
 Example response header:
 
 ```text
+X-Total-Count: 6
 X-Next-Cursor: eyJzb3J0cyI6W3siZmllbGQiOiJpZCIsImRlc2NlbmRpbmciOmZhbHNlfV0sInZhbHVlcyI6W3sidHlwZSI6ImludGVnZXIiLCJ2YWx1ZSI6Mn1dfQ
 ```
 

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -21,7 +21,7 @@ use crate::models::{
     UpdateHubuumObject, UpdateNamespace, UpdateReportTemplate, UpdateUser, User, UserToken,
     UserTokenMetadata,
 };
-use crate::pagination::{NEXT_CURSOR_HEADER, page_limits_or_defaults};
+use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER, page_limits_or_defaults};
 use actix_web::{HttpResponse, Responder};
 use serde::Serialize;
 use utoipa::openapi::OpenApi as OpenApiDoc;
@@ -401,7 +401,7 @@ fn add_cursor_pagination_docs(operation: &mut Operation) {
 
     if let Some(description) = operation.description.as_mut() {
         let pagination_text = format!(
-            " Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The next page cursor is returned in the `{NEXT_CURSOR_HEADER}` response header."
+            " Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `{TOTAL_COUNT_HEADER}` response header, and the next page cursor is returned in the `{NEXT_CURSOR_HEADER}` response header."
         );
         if !description.contains(NEXT_CURSOR_HEADER) {
             description.push_str(&pagination_text);
@@ -409,6 +409,7 @@ fn add_cursor_pagination_docs(operation: &mut Operation) {
     }
 
     if let Some(response) = operation.responses.responses.get_mut("200") {
+        add_total_count_header(response);
         add_next_cursor_header(response);
     }
 }
@@ -455,9 +456,27 @@ fn add_next_cursor_header(response: &mut RefOr<utoipa::openapi::response::Respon
 
     if !response.description.contains(NEXT_CURSOR_HEADER) {
         response.description.push_str(&format!(
-            " The response body contains the current page items as a JSON array. Use the `{NEXT_CURSOR_HEADER}` header, when present, to request the next page."
+            " The response body contains the current page items as a JSON array. Use the `{TOTAL_COUNT_HEADER}` header for the exact number of matching results. Use the `{NEXT_CURSOR_HEADER}` header, when present, to request the next page."
         ));
     }
+}
+
+fn add_total_count_header(response: &mut RefOr<utoipa::openapi::response::Response>) {
+    let RefOr::T(response) = response else {
+        return;
+    };
+
+    response
+        .headers
+        .entry(TOTAL_COUNT_HEADER.to_string())
+        .or_insert_with(|| {
+            let mut header = Header::default();
+            header.description = Some(
+                "Exact total number of results matching the current filter set, independent of cursor pagination."
+                    .to_string(),
+            );
+            header
+        });
 }
 
 fn for_each_operation_mut(
@@ -742,10 +761,19 @@ mod tests {
                 "/paths/~1api~1v1~1classes/get/responses/200/headers/X-Next-Cursor/description",
             )
             .and_then(Value::as_str);
+        let total_count_description = json
+            .pointer(
+                "/paths/~1api~1v1~1classes/get/responses/200/headers/X-Total-Count/description",
+            )
+            .and_then(Value::as_str);
 
         assert!(
             header_description.is_some(),
             "X-Next-Cursor header must be documented for paginated list responses"
+        );
+        assert!(
+            total_count_description.is_some(),
+            "X-Total-Count header must be documented for paginated list responses"
         );
     }
 

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -9,7 +9,7 @@ use crate::db::traits::{ClassRelation, ObjectRelationMemberships, UserPermission
 use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::traits::{ExpandNamespace, ToHubuumObjects};
-use crate::pagination::prepare_db_pagination;
+use crate::pagination::{count_query_options, prepare_db_pagination};
 use crate::utilities::response::{
     json_response, json_response_created, paginated_json_mapped_response, paginated_json_response,
 };
@@ -128,10 +128,13 @@ async fn get_classes(
 
     debug!(message = "Listing classes", user_id = user.id());
 
+    let total_count = user
+        .count_classes(&pool, count_query_options(&params))
+        .await?;
     let search_params = prepare_db_pagination::<HubuumClassExpanded>(&params)?;
     let classes = user.search_classes(&pool, search_params).await?;
 
-    paginated_json_response(classes, StatusCode::OK, &params)
+    paginated_json_response(classes, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(
@@ -333,6 +336,19 @@ async fn get_class_permissions(
     can!(&pool, user, [Permissions::ReadClass], class);
 
     let nid = class.namespace_id(&pool).await?;
+    let count_params = count_query_options(&params);
+    let total_count = crate::models::namespace::count_groups_on_paginated(
+        &pool,
+        NamespaceID(nid),
+        vec![
+            Permissions::CreateClass,
+            Permissions::UpdateClass,
+            Permissions::ReadClass,
+            Permissions::DeleteClass,
+        ],
+        &count_params,
+    )
+    .await?;
     let search_params = prepare_db_pagination::<GroupPermission>(&params)?;
     let permissions = groups_on_paginated(
         &pool,
@@ -347,7 +363,7 @@ async fn get_class_permissions(
     )
     .await?;
 
-    paginated_json_response(permissions, StatusCode::OK, &params)
+    paginated_json_response(permissions, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(
@@ -381,11 +397,11 @@ async fn get_related_classes(
     can!(&pool, user, [Permissions::ReadClass], class);
 
     let search_params = prepare_db_pagination::<ClassClosureRow>(&params)?;
-    let classes = user
-        .search_classes_related_to(&pool, class, search_params)
+    let (classes, total_count) = user
+        .classes_related_to_page(&pool, class, search_params)
         .await?;
 
-    paginated_json_mapped_response(classes, StatusCode::OK, &params, |page| {
+    paginated_json_mapped_response(classes, total_count, StatusCode::OK, &params, |page| {
         page.to_descendant_classes_with_path()
     })
 }
@@ -568,10 +584,10 @@ async fn get_related_class_relations(
     );
 
     let search_params = prepare_db_pagination::<HubuumClassRelation>(&params)?;
-    let relations = user
-        .search_class_relations_touching(&pool, class, search_params)
+    let (relations, total_count) = user
+        .class_relations_touching_page(&pool, class, search_params)
         .await?;
-    paginated_json_response(relations, StatusCode::OK, &params)
+    paginated_json_response(relations, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(
@@ -672,10 +688,13 @@ async fn get_objects_in_class(
         query = query_string
     );
 
+    let total_count = user
+        .count_objects(&pool, count_query_options(&params))
+        .await?;
     let search_params = prepare_db_pagination::<HubuumObject>(&params)?;
     let objects = user.search_objects(&pool, search_params).await?;
 
-    paginated_json_response(objects, StatusCode::OK, &params)
+    paginated_json_response(objects, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(
@@ -912,11 +931,11 @@ async fn get_related_objects(
     );
 
     let search_params = prepare_db_pagination::<RelatedObjectClosureRow>(&params)?;
-    let hits = user
-        .search_objects_related_to(&pool, object, search_params)
+    let (hits, total_count) = user
+        .objects_related_to_page(&pool, object, search_params)
         .await?;
 
-    paginated_json_mapped_response(hits, StatusCode::OK, &params, |page| {
+    paginated_json_mapped_response(hits, total_count, StatusCode::OK, &params, |page| {
         page.to_descendant_objects_with_path()
     })
 }
@@ -963,11 +982,11 @@ async fn get_related_object_relations(
     );
 
     let search_params = prepare_db_pagination::<HubuumObjectRelation>(&params)?;
-    let relations = user
-        .search_object_relations_touching(&pool, object, search_params)
+    let (relations, total_count) = user
+        .object_relations_touching_page(&pool, object, search_params)
         .await?;
 
-    paginated_json_response(relations, StatusCode::OK, &params)
+    paginated_json_response(relations, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(

--- a/src/api/v1/handlers/groups.rs
+++ b/src/api/v1/handlers/groups.rs
@@ -5,7 +5,7 @@ use crate::extractors::{AdminAccess, UserAccess};
 use crate::models::group::{GroupID, NewGroup, UpdateGroup};
 use crate::models::search::parse_query_parameter;
 use crate::models::{Group, User, UserID};
-use crate::pagination::prepare_db_pagination;
+use crate::pagination::{count_query_options, prepare_db_pagination};
 use crate::utilities::response::{json_response, json_response_created, paginated_json_response};
 use actix_web::{HttpRequest, Responder, delete, get, http::StatusCode, patch, post, routes, web};
 use serde::{Deserialize, Serialize};
@@ -51,10 +51,13 @@ pub async fn get_groups(
         params = ?params
     );
 
+    let total_count = user
+        .count_groups(&pool, count_query_options(&params))
+        .await?;
     let search_params = prepare_db_pagination::<Group>(&params)?;
     let result = user.search_groups(&pool, search_params).await?;
 
-    paginated_json_response(result, StatusCode::OK, &params)
+    paginated_json_response(result, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(
@@ -219,10 +222,12 @@ pub async fn get_group_members(
         requestor = requestor.user.id
     );
 
+    let count_params = count_query_options(&params);
+    let total_count = group.count_members_paginated(&pool, &count_params).await?;
     let search_params = prepare_db_pagination::<User>(&params)?;
     let members = group.members_paginated(&pool, &search_params).await?;
 
-    paginated_json_response(members, StatusCode::OK, &params)
+    paginated_json_response(members, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(

--- a/src/api/v1/handlers/imports.rs
+++ b/src/api/v1/handlers/imports.rs
@@ -6,7 +6,7 @@ use crate::api::openapi::ApiErrorResponse;
 use crate::db::DbPool;
 use crate::db::traits::task::{
     TaskCreateRequest, create_generic_task, find_task_by_idempotency, find_task_record,
-    list_import_results,
+    list_import_results_with_total_count,
 };
 use crate::errors::ApiError;
 use crate::extractors::UserAccess;
@@ -212,10 +212,11 @@ pub async fn get_import_results(
     load_authorized_import_task(&pool, &requestor.user, task_id).await?;
     let params = parse_query_parameter(req.query_string())?;
     let search_params = prepare_db_pagination::<ImportTaskResultResponse>(&params)?;
-    let results = list_import_results(&pool, task_id, &search_params)
-        .await?
+    let (results, total_count) =
+        list_import_results_with_total_count(&pool, task_id, &search_params).await?;
+    let results = results
         .into_iter()
         .map(ImportTaskResultResponse::from)
         .collect::<Vec<_>>();
-    paginated_json_response(results, StatusCode::OK, &params)
+    paginated_json_response(results, total_count, StatusCode::OK, &params)
 }

--- a/src/api/v1/handlers/namespaces.rs
+++ b/src/api/v1/handlers/namespaces.rs
@@ -8,7 +8,7 @@ use crate::models::{
 };
 
 use crate::models::search::parse_query_parameter;
-use crate::pagination::prepare_db_pagination;
+use crate::pagination::{count_query_options, prepare_db_pagination};
 
 use crate::utilities::response::{json_response, json_response_created, paginated_json_response};
 use actix_web::{
@@ -56,9 +56,12 @@ pub async fn get_namespaces(
         Err(e) => return Err(e),
     };
 
+    let total_count = user
+        .count_namespaces(&pool, count_query_options(&params))
+        .await?;
     let search_params = prepare_db_pagination::<Namespace>(&params)?;
     let result = user.search_namespaces(&pool, search_params).await?;
-    paginated_json_response(result, StatusCode::OK, &params)
+    paginated_json_response(result, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(
@@ -254,10 +257,15 @@ pub async fn get_namespace_permissions(
     );
 
     let search_params = prepare_db_pagination::<GroupPermission>(&params)?;
-    let permissions =
-        crate::models::namespace::groups_on_paginated(&pool, namespace, vec![], &search_params)
-            .await?;
-    paginated_json_response(permissions, StatusCode::OK, &params)
+    let (permissions, total_count) =
+        crate::models::namespace::groups_on_paginated_with_total_count(
+            &pool,
+            namespace.clone(),
+            vec![],
+            &search_params,
+        )
+        .await?;
+    paginated_json_response(permissions, total_count, StatusCode::OK, &params)
 }
 
 /// List all permissions for a given group on a namespace
@@ -655,15 +663,19 @@ pub async fn get_namespace_user_permissions(
     );
 
     let search_params = prepare_db_pagination::<GroupPermission>(&query_options)?;
-    let permissions: Vec<GroupPermission> =
-        crate::models::namespace::user_on_paginated(&pool, user_id, namespace, &search_params)
-            .await?;
+    let (permissions, total_count) = crate::models::namespace::user_on_paginated_with_total_count(
+        &pool,
+        user_id.clone(),
+        namespace.clone(),
+        &search_params,
+    )
+    .await?;
 
-    if permissions.is_empty() {
+    if total_count == 0 {
         return Ok(json_response((), StatusCode::NOT_FOUND));
     }
 
-    paginated_json_response(permissions, StatusCode::OK, &query_options)
+    paginated_json_response(permissions, total_count, StatusCode::OK, &query_options)
 }
 
 /// List all groups that have any permissions on a namespace
@@ -708,7 +720,7 @@ pub async fn get_namespace_groups_with_permission(
     );
 
     let search_params = prepare_db_pagination::<Group>(&query_options)?;
-    let groups = crate::models::namespace::groups_can_on_paginated(
+    let (groups, total_count) = crate::models::namespace::groups_can_on_paginated_with_total_count(
         &pool,
         namespace.id,
         permission,
@@ -716,5 +728,5 @@ pub async fn get_namespace_groups_with_permission(
     )
     .await?;
 
-    paginated_json_response(groups, StatusCode::OK, &query_options)
+    paginated_json_response(groups, total_count, StatusCode::OK, &query_options)
 }

--- a/src/api/v1/handlers/relations.rs
+++ b/src/api/v1/handlers/relations.rs
@@ -51,9 +51,9 @@ async fn get_class_relations(
     debug!(message = "Listing class relations", user_id = user.id());
 
     let search_params = prepare_db_pagination::<HubuumClassRelation>(&params)?;
-    let classes = user.search_class_relations(&pool, search_params).await?;
+    let (classes, total_count) = user.class_relations_page(&pool, search_params).await?;
 
-    paginated_json_response(classes, StatusCode::OK, &params)
+    paginated_json_response(classes, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(
@@ -217,9 +217,9 @@ async fn get_object_relations(
     debug!(message = "Listing object relations", user_id = user.id());
 
     let search_params = prepare_db_pagination::<HubuumObjectRelation>(&params)?;
-    let object_relations = user.search_object_relations(&pool, search_params).await?;
+    let (object_relations, total_count) = user.object_relations_page(&pool, search_params).await?;
 
-    paginated_json_response(object_relations, StatusCode::OK, &params)
+    paginated_json_response(object_relations, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(

--- a/src/api/v1/handlers/tasks.rs
+++ b/src/api/v1/handlers/tasks.rs
@@ -2,7 +2,9 @@ use actix_web::{HttpRequest, Responder, get, http::StatusCode, routes, web};
 
 use crate::api::openapi::ApiErrorResponse;
 use crate::db::DbPool;
-use crate::db::traits::task::{find_task_record, list_task_events, list_tasks};
+use crate::db::traits::task::{
+    find_task_record, list_task_events_with_total_count, list_tasks_with_total_count,
+};
 use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::search::parse_query_parameter_with_passthrough;
@@ -120,20 +122,20 @@ pub async fn get_tasks(
     } else {
         Some(requestor.user.id)
     };
-
-    let tasks = list_tasks(
+    let (tasks, total_count) = list_tasks_with_total_count(
         &pool,
         submitted_by_filter,
         filters.kind.map(TaskKind::as_str),
         filters.status.map(TaskStatus::as_str),
         &search_params,
     )
-    .await?
-    .into_iter()
-    .map(|task| task.to_response())
-    .collect::<Result<Vec<_>, _>>()?;
+    .await?;
+    let tasks = tasks
+        .into_iter()
+        .map(|task| task.to_response())
+        .collect::<Result<Vec<_>, _>>()?;
 
-    paginated_json_response(tasks, StatusCode::OK, &params)
+    paginated_json_response(tasks, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(
@@ -189,10 +191,11 @@ pub async fn get_task_events(
     load_authorized_task(&pool, &requestor.user, task_id).await?;
     let (params, _) = parse_query_parameter_with_passthrough(req.query_string(), &[])?;
     let search_params = prepare_db_pagination::<TaskEventResponse>(&params)?;
-    let events = list_task_events(&pool, task_id, &search_params)
-        .await?
+    let (events, total_count) =
+        list_task_events_with_total_count(&pool, task_id, &search_params).await?;
+    let events = events
         .into_iter()
         .map(TaskEventResponse::from)
         .collect::<Vec<_>>();
-    paginated_json_response(events, StatusCode::OK, &params)
+    paginated_json_response(events, total_count, StatusCode::OK, &params)
 }

--- a/src/api/v1/handlers/templates.rs
+++ b/src/api/v1/handlers/templates.rs
@@ -98,14 +98,15 @@ pub async fn get_templates(
             .map(|namespace| namespace.id)
             .collect::<Vec<_>>();
 
-    let templates = crate::models::report_template::list_report_templates(
-        &pool,
-        &allowed_namespace_ids,
-        &search_params,
-    )
-    .await?;
+    let (templates, total_count) =
+        crate::models::report_template::list_report_templates_with_total_count(
+            &pool,
+            &allowed_namespace_ids,
+            &search_params,
+        )
+        .await?;
 
-    paginated_json_response(templates, StatusCode::OK, &params)
+    paginated_json_response(templates, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(

--- a/src/api/v1/handlers/users.rs
+++ b/src/api/v1/handlers/users.rs
@@ -5,7 +5,7 @@ use crate::extractors::{AdminAccess, AdminOrSelfAccess, UserAccess};
 use crate::models::search::parse_query_parameter;
 use crate::models::user::{NewUser, UpdateUser, UserID};
 use crate::models::{Group, User, UserToken, UserTokenMetadata};
-use crate::pagination::prepare_db_pagination;
+use crate::pagination::{count_query_options, prepare_db_pagination};
 use crate::utilities::response::{
     json_response, json_response_created, paginated_json_mapped_response, paginated_json_response,
 };
@@ -42,10 +42,13 @@ pub async fn get_users(
 
     debug!(message = "User list requested", requestor = user.username);
 
+    let total_count = user
+        .count_users(&pool, count_query_options(&params))
+        .await?;
     let search_params = prepare_db_pagination::<User>(&params)?;
     let result = user.search_users(&pool, search_params).await?;
 
-    paginated_json_response(result, StatusCode::OK, &params)
+    paginated_json_response(result, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(
@@ -115,10 +118,16 @@ pub async fn get_user_tokens(
     );
 
     let search_params = prepare_db_pagination::<UserToken>(&params)?;
-    let valid_tokens = user.tokens_paginated(&pool, &search_params).await?;
-    paginated_json_mapped_response(valid_tokens, StatusCode::OK, &params, |tokens| {
-        tokens.into_iter().map(UserTokenMetadata::from).collect()
-    })
+    let (valid_tokens, total_count) = user
+        .tokens_paginated_with_total_count(&pool, &search_params)
+        .await?;
+    paginated_json_mapped_response(
+        valid_tokens,
+        total_count,
+        StatusCode::OK,
+        &params,
+        |tokens| tokens.into_iter().map(UserTokenMetadata::from).collect(),
+    )
 }
 
 #[utoipa::path(
@@ -183,8 +192,10 @@ pub async fn get_user_groups(
     );
 
     let search_params = prepare_db_pagination::<Group>(&params)?;
-    let groups = user.groups_paginated(&pool, &search_params).await?;
-    paginated_json_response(groups, StatusCode::OK, &params)
+    let (groups, total_count) = user
+        .groups_paginated_with_total_count(&pool, &search_params)
+        .await?;
+    paginated_json_response(groups, total_count, StatusCode::OK, &params)
 }
 
 #[utoipa::path(

--- a/src/db/traits/active_tokens.rs
+++ b/src/db/traits/active_tokens.rs
@@ -35,12 +35,12 @@ where
         active_tokens_by_user_id(self.id(), pool).await
     }
 
-    async fn tokens_paginated(
+    async fn tokens_paginated_with_total_count(
         &self,
         pool: &DbPool,
         query_options: &QueryOptions,
-    ) -> Result<Vec<UserToken>, ApiError> {
-        active_tokens_by_user_id_paginated(self.id(), pool, query_options).await
+    ) -> Result<(Vec<UserToken>, i64), ApiError> {
+        active_tokens_by_user_id_paginated_with_total_count(self.id(), pool, query_options).await
     }
 }
 
@@ -57,36 +57,50 @@ async fn active_tokens_by_user_id(user_id: i32, pool: &DbPool) -> Result<Vec<Use
     })
 }
 
-async fn active_tokens_by_user_id_paginated(
+fn active_tokens_cutoff() -> chrono::NaiveDateTime {
+    let hours = token_lifetime_hours_i32() as i64;
+    chrono::Utc::now().naive_utc() - chrono::Duration::hours(hours)
+}
+
+async fn active_tokens_by_user_id_paginated_with_total_count(
     user_id: i32,
     pool: &DbPool,
     query_options: &QueryOptions,
-) -> Result<Vec<UserToken>, ApiError> {
+) -> Result<(Vec<UserToken>, i64), ApiError> {
     use crate::schema::tokens::dsl::{issued, token, tokens, user_id as token_user_id};
     use crate::{date_search, string_search};
 
-    let query_options = hash_token_name_filters(query_options)?;
-    let hours = token_lifetime_hours_i32() as i64;
-    let mut base_query = tokens
-        .into_boxed()
-        .filter(token_user_id.eq(user_id))
-        .filter(issued.gt(chrono::Utc::now().naive_utc() - chrono::Duration::hours(hours)));
+    let prepared_query_options = hash_token_name_filters(query_options)?;
+    let active_after = active_tokens_cutoff();
+    let build_query = || -> Result<_, ApiError> {
+        let mut base_query = tokens
+            .into_boxed()
+            .filter(token_user_id.eq(user_id))
+            .filter(issued.gt(active_after));
 
-    for param in &query_options.filters {
-        let operator = param.operator.clone();
-        match param.field {
-            FilterField::IssuedAt => date_search!(base_query, param, operator, issued),
-            FilterField::Name => string_search!(base_query, param, operator, token),
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' isn't searchable (or does not exist) for user tokens",
-                    param.field
-                )));
+        for param in &prepared_query_options.filters {
+            let operator = param.operator.clone();
+            match param.field {
+                FilterField::IssuedAt => date_search!(base_query, param, operator, issued),
+                FilterField::Name => string_search!(base_query, param, operator, token),
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't searchable (or does not exist) for user tokens",
+                        param.field
+                    )));
+                }
             }
         }
-    }
 
-    crate::apply_query_options!(base_query, &query_options, UserToken);
+        Ok(base_query)
+    };
 
-    with_connection(pool, |conn| base_query.load::<UserToken>(conn))
+    let base_query = build_query()?;
+    let total_count = with_connection(pool, |conn| base_query.count().get_result::<i64>(conn))?;
+
+    let mut base_query = build_query()?;
+    crate::apply_query_options!(base_query, &prepared_query_options, UserToken);
+    let items = with_connection(pool, |conn| base_query.load::<UserToken>(conn))?;
+
+    Ok((items, total_count))
 }

--- a/src/db/traits/group.rs
+++ b/src/db/traits/group.rs
@@ -85,6 +85,12 @@ pub trait GroupMembersBackend {
         query_options: &QueryOptions,
     ) -> Result<Vec<User>, ApiError>;
 
+    async fn count_group_members_paginated(
+        &self,
+        pool: &DbPool,
+        query_options: &QueryOptions,
+    ) -> Result<i64, ApiError>;
+
     async fn remove_group_member_from_backend(
         &self,
         user: &User,
@@ -144,6 +150,41 @@ impl GroupMembersBackend for Group {
         crate::apply_query_options!(base_query, query_options, User);
 
         with_connection(pool, |conn| base_query.load::<User>(conn))
+    }
+
+    async fn count_group_members_paginated(
+        &self,
+        pool: &DbPool,
+        query_options: &QueryOptions,
+    ) -> Result<i64, ApiError> {
+        use crate::schema::user_groups::dsl::{group_id, user_groups, user_id};
+        use crate::schema::users::dsl::{created_at, email, id, updated_at, username, users};
+
+        let mut base_query = user_groups
+            .filter(group_id.eq(self.id))
+            .inner_join(users.on(id.eq(user_id)))
+            .into_boxed();
+
+        for param in &query_options.filters {
+            let operator = param.operator.clone();
+            match param.field {
+                FilterField::Id => numeric_search!(base_query, param, operator, id),
+                FilterField::Name | FilterField::Username => {
+                    string_search!(base_query, param, operator, username)
+                }
+                FilterField::Email => string_search!(base_query, param, operator, email),
+                FilterField::CreatedAt => date_search!(base_query, param, operator, created_at),
+                FilterField::UpdatedAt => date_search!(base_query, param, operator, updated_at),
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't searchable (or does not exist) for users",
+                        param.field
+                    )));
+                }
+            }
+        }
+
+        with_connection(pool, |conn| base_query.count().get_result::<i64>(conn))
     }
 
     async fn remove_group_member_from_backend(

--- a/src/db/traits/mod.rs
+++ b/src/db/traits/mod.rs
@@ -43,11 +43,11 @@ pub trait ActiveTokens {
     /// Get all active tokens for a given structure.
     #[allow(dead_code)]
     async fn tokens(&self, pool: &DbPool) -> Result<Vec<UserToken>, ApiError>;
-    async fn tokens_paginated(
+    async fn tokens_paginated_with_total_count(
         &self,
         pool: &DbPool,
         query_options: &QueryOptions,
-    ) -> Result<Vec<UserToken>, ApiError>;
+    ) -> Result<(Vec<UserToken>, i64), ApiError>;
 }
 
 /// Trait for getting the namespace(s) of a structure from the backend database.

--- a/src/db/traits/namespace/permissions.rs
+++ b/src/db/traits/namespace/permissions.rs
@@ -99,12 +99,12 @@ pub async fn user_on_from_backend<T: NamespaceAccessors>(
     Ok(rows.into_iter().map(GroupPermission::from_tuple).collect())
 }
 
-pub async fn user_on_paginated_from_backend<T: NamespaceAccessors>(
+pub async fn user_on_paginated_with_total_count_from_backend<T: NamespaceAccessors>(
     pool: &DbPool,
     user_id: UserID,
     namespace_ref: T,
     query_options: &QueryOptions,
-) -> Result<Vec<GroupPermission>, ApiError> {
+) -> Result<(Vec<GroupPermission>, i64), ApiError> {
     use crate::models::traits::output::FromTuple;
     use crate::schema::groups::dsl::{groupname, groups, id as group_table_id};
     use crate::schema::permissions::dsl::{
@@ -114,47 +114,57 @@ pub async fn user_on_paginated_from_backend<T: NamespaceAccessors>(
     use crate::{date_search, numeric_search, string_search};
 
     let namespace_target_id = namespace_ref.namespace_id(pool).await?;
-    let group_ids_subquery = user_id.group_ids_subquery_from_backend();
+    let build_query = || -> Result<_, ApiError> {
+        let group_ids_subquery = user_id.group_ids_subquery_from_backend();
+        let mut query = groups
+            .inner_join(permissions.on(group_table_id.eq(group_id)))
+            .filter(namespace_id.eq(namespace_target_id))
+            .filter(group_id.eq_any(group_ids_subquery))
+            .into_boxed();
 
-    let mut query = groups
-        .inner_join(permissions.on(group_table_id.eq(group_id)))
-        .filter(namespace_id.eq(namespace_target_id))
-        .filter(group_id.eq_any(group_ids_subquery))
-        .into_boxed();
+        for perm in query_options.filters.permissions()?.iter().cloned() {
+            query = query.filter(diesel::dsl::sql::<diesel::sql_types::Bool>(
+                permission_filter_sql(perm, true),
+            ));
+        }
 
-    for perm in query_options.filters.permissions()?.iter().cloned() {
-        query = query.filter(diesel::dsl::sql::<diesel::sql_types::Bool>(
-            permission_filter_sql(perm, true),
-        ));
-    }
-
-    for param in &query_options.filters {
-        let operator = param.operator.clone();
-        match param.field {
-            FilterField::Id => numeric_search!(query, param, operator, permission_id),
-            FilterField::Name | FilterField::Groupname => {
-                string_search!(query, param, operator, groupname)
-            }
-            FilterField::CreatedAt => {
-                date_search!(query, param, operator, permission_created_at)
-            }
-            FilterField::UpdatedAt => {
-                date_search!(query, param, operator, permission_updated_at)
-            }
-            FilterField::Permissions => {}
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' isn't searchable (or does not exist) for permissions",
-                    param.field
-                )));
+        for param in &query_options.filters {
+            let operator = param.operator.clone();
+            match param.field {
+                FilterField::Id => numeric_search!(query, param, operator, permission_id),
+                FilterField::Name | FilterField::Groupname => {
+                    string_search!(query, param, operator, groupname)
+                }
+                FilterField::CreatedAt => {
+                    date_search!(query, param, operator, permission_created_at)
+                }
+                FilterField::UpdatedAt => {
+                    date_search!(query, param, operator, permission_updated_at)
+                }
+                FilterField::Permissions => {}
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't searchable (or does not exist) for permissions",
+                        param.field
+                    )));
+                }
             }
         }
-    }
 
+        Ok(query)
+    };
+
+    let query = build_query()?;
+    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
+
+    let mut query = build_query()?;
     crate::apply_query_options!(query, query_options, GroupPermission);
-
     let rows = with_connection(pool, |conn| query.load::<(Group, Permission)>(conn))?;
-    Ok(rows.into_iter().map(GroupPermission::from_tuple).collect())
+
+    Ok((
+        rows.into_iter().map(GroupPermission::from_tuple).collect(),
+        total_count,
+    ))
 }
 
 pub async fn user_can_on_any_from_backend<U: SelfAccessors<User> + GroupAccessors>(
@@ -239,47 +249,56 @@ pub async fn groups_can_on_from_backend(
     })
 }
 
-pub async fn groups_can_on_paginated_from_backend(
+pub async fn groups_can_on_paginated_with_total_count_from_backend(
     pool: &DbPool,
     nid: i32,
     permission_type: Permissions,
     query_options: &QueryOptions,
-) -> Result<Vec<Group>, ApiError> {
+) -> Result<(Vec<Group>, i64), ApiError> {
     use crate::schema::groups::dsl::{
         created_at, description, groupname, groups, id as group_table_id, updated_at,
     };
     use crate::schema::permissions::dsl::*;
     use crate::{date_search, numeric_search, string_search};
 
-    let base_query = permissions.into_boxed().filter(namespace_id.eq(nid));
-    let filtered_query = permission_type.create_boxed_filter(base_query, true);
+    let build_query = || -> Result<_, ApiError> {
+        let base_query = permissions.into_boxed().filter(namespace_id.eq(nid));
+        let filtered_query = permission_type.create_boxed_filter(base_query, true);
 
-    let mut query = groups
-        .filter(group_table_id.eq_any(filtered_query.select(group_id).distinct()))
-        .into_boxed();
+        let mut query = groups
+            .filter(group_table_id.eq_any(filtered_query.select(group_id).distinct()))
+            .into_boxed();
 
-    for param in &query_options.filters {
-        let operator = param.operator.clone();
-        match param.field {
-            FilterField::Id => numeric_search!(query, param, operator, group_table_id),
-            FilterField::Name | FilterField::Groupname => {
-                string_search!(query, param, operator, groupname)
-            }
-            FilterField::Description => string_search!(query, param, operator, description),
-            FilterField::CreatedAt => date_search!(query, param, operator, created_at),
-            FilterField::UpdatedAt => date_search!(query, param, operator, updated_at),
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' isn't searchable (or does not exist) for groups",
-                    param.field
-                )));
+        for param in &query_options.filters {
+            let operator = param.operator.clone();
+            match param.field {
+                FilterField::Id => numeric_search!(query, param, operator, group_table_id),
+                FilterField::Name | FilterField::Groupname => {
+                    string_search!(query, param, operator, groupname)
+                }
+                FilterField::Description => string_search!(query, param, operator, description),
+                FilterField::CreatedAt => date_search!(query, param, operator, created_at),
+                FilterField::UpdatedAt => date_search!(query, param, operator, updated_at),
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't searchable (or does not exist) for groups",
+                        param.field
+                    )));
+                }
             }
         }
-    }
 
+        Ok(query)
+    };
+
+    let query = build_query()?;
+    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
+
+    let mut query = build_query()?;
     crate::apply_query_options!(query, query_options, Group);
+    let items = with_connection(pool, |conn| query.load::<Group>(conn))?;
 
-    with_connection(pool, |conn| query.load::<Group>(conn))
+    Ok((items, total_count))
 }
 
 pub async fn groups_on_from_backend<T: NamespaceAccessors>(
@@ -375,6 +394,22 @@ pub async fn groups_on_paginated_from_backend<T: NamespaceAccessors>(
     permissions_filter: Vec<Permissions>,
     query_options: &QueryOptions,
 ) -> Result<Vec<GroupPermission>, ApiError> {
+    let (items, _) = groups_on_paginated_with_total_count_from_backend(
+        pool,
+        namespace_ref,
+        permissions_filter,
+        query_options,
+    )
+    .await?;
+    Ok(items)
+}
+
+pub async fn groups_on_paginated_with_total_count_from_backend<T: NamespaceAccessors>(
+    pool: &DbPool,
+    namespace_ref: T,
+    permissions_filter: Vec<Permissions>,
+    query_options: &QueryOptions,
+) -> Result<(Vec<GroupPermission>, i64), ApiError> {
     use crate::models::traits::output::FromTuple;
     use crate::schema::groups::dsl::{groupname, groups, id as group_table_id};
     use crate::schema::permissions::dsl::{
@@ -387,48 +422,75 @@ pub async fn groups_on_paginated_from_backend<T: NamespaceAccessors>(
     let mut permission_filters = query_options.filters.permissions()?;
     permission_filters.ensure_contains(&permissions_filter);
 
-    let mut query = groups
-        .inner_join(permissions.on(group_table_id.eq(group_id)))
-        .filter(namespace_id.eq(namespace_target_id))
-        .into_boxed();
+    let build_query = || -> Result<_, ApiError> {
+        let mut query = groups
+            .inner_join(permissions.on(group_table_id.eq(group_id)))
+            .filter(namespace_id.eq(namespace_target_id))
+            .into_boxed();
 
-    for perm in permission_filters.iter().cloned() {
-        query = query.filter(diesel::dsl::sql::<diesel::sql_types::Bool>(
-            permission_filter_sql(perm, true),
-        ));
-    }
+        for perm in permission_filters.iter().cloned() {
+            query = query.filter(diesel::dsl::sql::<diesel::sql_types::Bool>(
+                permission_filter_sql(perm, true),
+            ));
+        }
 
-    for param in &query_options.filters {
-        let operator = param.operator.clone();
-        match param.field {
-            FilterField::Id => numeric_search!(query, param, operator, permission_id),
-            FilterField::Name | FilterField::Groupname => {
-                string_search!(query, param, operator, groupname)
-            }
-            FilterField::CreatedAt => {
-                date_search!(query, param, operator, permission_created_at)
-            }
-            FilterField::UpdatedAt => {
-                date_search!(query, param, operator, permission_updated_at)
-            }
-            FilterField::Permissions => {}
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' isn't searchable (or does not exist) for permissions",
-                    param.field
-                )));
+        for param in &query_options.filters {
+            let operator = param.operator.clone();
+            match param.field {
+                FilterField::Id => numeric_search!(query, param, operator, permission_id),
+                FilterField::Name | FilterField::Groupname => {
+                    string_search!(query, param, operator, groupname)
+                }
+                FilterField::CreatedAt => {
+                    date_search!(query, param, operator, permission_created_at)
+                }
+                FilterField::UpdatedAt => {
+                    date_search!(query, param, operator, permission_updated_at)
+                }
+                FilterField::Permissions => {}
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't searchable (or does not exist) for permissions",
+                        param.field
+                    )));
+                }
             }
         }
-    }
 
+        Ok(query)
+    };
+
+    let query = build_query()?;
+    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
+
+    let mut query = build_query()?;
     crate::apply_query_options!(query, query_options, GroupPermission);
-
     let rows = with_connection(pool, |conn| {
         query
             .select((groups::all_columns(), permissions::all_columns()))
             .load::<(Group, Permission)>(conn)
     })?;
-    Ok(rows.into_iter().map(GroupPermission::from_tuple).collect())
+
+    Ok((
+        rows.into_iter().map(GroupPermission::from_tuple).collect(),
+        total_count,
+    ))
+}
+
+pub async fn count_groups_on_paginated_from_backend<T: NamespaceAccessors>(
+    pool: &DbPool,
+    namespace_ref: T,
+    permissions_filter: Vec<Permissions>,
+    query_options: &QueryOptions,
+) -> Result<i64, ApiError> {
+    let (_, total_count) = groups_on_paginated_with_total_count_from_backend(
+        pool,
+        namespace_ref,
+        permissions_filter,
+        query_options,
+    )
+    .await?;
+    Ok(total_count)
 }
 
 pub async fn group_on_from_backend(

--- a/src/db/traits/task.rs
+++ b/src/db/traits/task.rs
@@ -69,41 +69,57 @@ pub async fn find_task_by_idempotency(
     })
 }
 
-pub async fn list_tasks(
+fn build_task_query<'a>(
+    submitted_by_filter: Option<i32>,
+    kind_filter: Option<&'a str>,
+    status_filter: Option<&'a str>,
+) -> crate::schema::tasks::BoxedQuery<'a, diesel::pg::Pg> {
+    use crate::schema::tasks::dsl::{kind, status, submitted_by, tasks};
+
+    let mut query = tasks.into_boxed();
+
+    if let Some(submitter_id) = submitted_by_filter {
+        query = query.filter(submitted_by.eq(Some(submitter_id)));
+    }
+
+    if let Some(task_kind) = kind_filter {
+        query = query.filter(kind.eq(task_kind));
+    }
+
+    if let Some(task_status) = status_filter {
+        query = query.filter(status.eq(task_status));
+    }
+
+    query
+}
+
+pub async fn list_tasks_with_total_count(
     pool: &DbPool,
     submitted_by_filter: Option<i32>,
     kind_filter: Option<&str>,
     status_filter: Option<&str>,
     query_options: &QueryOptions,
-) -> Result<Vec<TaskRecord>, ApiError> {
-    use crate::schema::tasks::dsl::{kind, status, submitted_by, tasks};
+) -> Result<(Vec<TaskRecord>, i64), ApiError> {
+    let total_count = with_connection(pool, |conn| {
+        build_task_query(submitted_by_filter, kind_filter, status_filter)
+            .count()
+            .get_result::<i64>(conn)
+    })?;
 
-    with_connection(pool, |conn| -> Result<Vec<TaskRecord>, ApiError> {
-        let mut query = tasks.into_boxed();
-
-        if let Some(submitter_id) = submitted_by_filter {
-            query = query.filter(submitted_by.eq(Some(submitter_id)));
-        }
-
-        if let Some(task_kind) = kind_filter {
-            query = query.filter(kind.eq(task_kind));
-        }
-
-        if let Some(task_status) = status_filter {
-            query = query.filter(status.eq(task_status));
-        }
-
+    let items = with_connection(pool, |conn| -> Result<Vec<TaskRecord>, ApiError> {
+        let mut query = build_task_query(submitted_by_filter, kind_filter, status_filter);
         apply_query_options!(query, query_options, TaskResponse);
-
         Ok(query.load::<TaskRecord>(conn)?)
-    })
+    })?;
+
+    Ok((items, total_count))
 }
 
-pub async fn list_task_events(
+pub async fn list_task_events_with_total_count(
     pool: &DbPool,
     task_id_value: i32,
     query_options: &QueryOptions,
-) -> Result<Vec<TaskEventRecord>, ApiError> {
+) -> Result<(Vec<TaskEventRecord>, i64), ApiError> {
     use crate::schema::task_events::dsl::{id, task_events, task_id};
 
     let limit = query_options
@@ -116,7 +132,14 @@ pub async fn list_task_events(
         .unwrap_or(false);
     let cursor_id = decode_history_cursor_id(query_options)?;
 
-    with_connection(pool, |conn| {
+    let total_count = with_connection(pool, |conn| {
+        task_events
+            .filter(task_id.eq(task_id_value))
+            .count()
+            .get_result::<i64>(conn)
+    })?;
+
+    let items = with_connection(pool, |conn| {
         let mut query = task_events.filter(task_id.eq(task_id_value)).into_boxed();
         if let Some(cursor_id) = cursor_id {
             query = if descending {
@@ -137,14 +160,16 @@ pub async fn list_task_events(
                 .limit(limit as i64)
                 .load::<TaskEventRecord>(conn)
         }
-    })
+    })?;
+
+    Ok((items, total_count))
 }
 
-pub async fn list_import_results(
+pub async fn list_import_results_with_total_count(
     pool: &DbPool,
     task_id_value: i32,
     query_options: &QueryOptions,
-) -> Result<Vec<ImportTaskResultRecord>, ApiError> {
+) -> Result<(Vec<ImportTaskResultRecord>, i64), ApiError> {
     use crate::schema::import_task_results::dsl::{id, import_task_results, task_id};
 
     let limit = query_options
@@ -157,7 +182,14 @@ pub async fn list_import_results(
         .unwrap_or(false);
     let cursor_id = decode_history_cursor_id(query_options)?;
 
-    with_connection(pool, |conn| {
+    let total_count = with_connection(pool, |conn| {
+        import_task_results
+            .filter(task_id.eq(task_id_value))
+            .count()
+            .get_result::<i64>(conn)
+    })?;
+
+    let items = with_connection(pool, |conn| {
         let mut query = import_task_results
             .filter(task_id.eq(task_id_value))
             .into_boxed();
@@ -180,7 +212,9 @@ pub async fn list_import_results(
                 .limit(limit as i64)
                 .load::<ImportTaskResultRecord>(conn)
         }
-    })
+    })?;
+
+    Ok((items, total_count))
 }
 
 pub async fn count_import_results_summary(
@@ -447,7 +481,10 @@ mod tests {
     use std::sync::mpsc;
     use std::thread;
 
-    use super::{claim_next_queued_task, create_task_record, find_task_record, list_task_events};
+    use super::{
+        claim_next_queued_task, create_task_record, find_task_record,
+        list_task_events_with_total_count,
+    };
     use crate::db::traits::user::DeleteUserRecord;
     use crate::db::with_transaction;
     use crate::models::search::QueryOptions;
@@ -517,7 +554,7 @@ mod tests {
         assert_ne!(claimed.unwrap(), locked_id);
         assert!(created_ids.contains(&locked_id));
 
-        let claimed_events = block_on(list_task_events(
+        let (claimed_events, _) = block_on(list_task_events_with_total_count(
             &context.pool,
             claimed.unwrap(),
             &QueryOptions {

--- a/src/db/traits/user/membership.rs
+++ b/src/db/traits/user/membership.rs
@@ -22,56 +22,64 @@ where
 }
 
 pub trait LoadUserGroupsPaginated: SelfAccessors<User> {
-    async fn load_user_groups_paginated(
+    async fn load_user_groups_paginated_with_total_count(
         &self,
         pool: &DbPool,
         query_options: &QueryOptions,
-    ) -> Result<Vec<Group>, ApiError>;
+    ) -> Result<(Vec<Group>, i64), ApiError>;
 }
 
 impl<T: ?Sized> LoadUserGroupsPaginated for T
 where
     T: SelfAccessors<User>,
 {
-    async fn load_user_groups_paginated(
+    async fn load_user_groups_paginated_with_total_count(
         &self,
         pool: &DbPool,
         query_options: &QueryOptions,
-    ) -> Result<Vec<Group>, ApiError> {
+    ) -> Result<(Vec<Group>, i64), ApiError> {
         use crate::schema::groups::dsl::*;
         use crate::schema::user_groups::dsl::{group_id, user_groups, user_id};
         use crate::{date_search, numeric_search, string_search};
 
-        let mut base_query = user_groups
-            .inner_join(groups.on(id.eq(group_id)))
-            .filter(user_id.eq(self.id()))
-            .select(groups::all_columns())
-            .into_boxed();
+        let build_query = || -> Result<_, ApiError> {
+            let mut base_query = user_groups
+                .inner_join(groups.on(id.eq(group_id)))
+                .filter(user_id.eq(self.id()))
+                .into_boxed();
 
-        for param in &query_options.filters {
-            let operator = param.operator.clone();
-            match param.field {
-                FilterField::Id => numeric_search!(base_query, param, operator, id),
-                FilterField::Name | FilterField::Groupname => {
-                    string_search!(base_query, param, operator, groupname)
-                }
-                FilterField::Description => {
-                    string_search!(base_query, param, operator, description)
-                }
-                FilterField::CreatedAt => date_search!(base_query, param, operator, created_at),
-                FilterField::UpdatedAt => date_search!(base_query, param, operator, updated_at),
-                _ => {
-                    return Err(ApiError::BadRequest(format!(
-                        "Field '{}' isn't searchable (or does not exist) for groups",
-                        param.field
-                    )));
+            for param in &query_options.filters {
+                let operator = param.operator.clone();
+                match param.field {
+                    FilterField::Id => numeric_search!(base_query, param, operator, id),
+                    FilterField::Name | FilterField::Groupname => {
+                        string_search!(base_query, param, operator, groupname)
+                    }
+                    FilterField::Description => {
+                        string_search!(base_query, param, operator, description)
+                    }
+                    FilterField::CreatedAt => date_search!(base_query, param, operator, created_at),
+                    FilterField::UpdatedAt => date_search!(base_query, param, operator, updated_at),
+                    _ => {
+                        return Err(ApiError::BadRequest(format!(
+                            "Field '{}' isn't searchable (or does not exist) for groups",
+                            param.field
+                        )));
+                    }
                 }
             }
-        }
 
+            Ok(base_query)
+        };
+
+        let base_query = build_query()?;
+        let total_count = with_connection(pool, |conn| base_query.count().get_result::<i64>(conn))?;
+
+        let mut base_query = build_query()?.select(groups::all_columns());
         crate::apply_query_options!(base_query, query_options, Group);
+        let items = with_connection(pool, |conn| base_query.load::<Group>(conn))?;
 
-        with_connection(pool, |conn| base_query.load::<Group>(conn))
+        Ok((items, total_count))
     }
 }
 

--- a/src/db/traits/user/search.rs
+++ b/src/db/traits/user/search.rs
@@ -1,5 +1,52 @@
 use super::*;
 use crate::models::search::SQLValue;
+use crate::traits::{CursorPaginated, CursorSqlMapping};
+use crate::utilities::extensions::CustomStringExtensions;
+
+#[derive(diesel::QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    count: i64,
+}
+
+#[derive(Debug, Clone)]
+struct RawSqlQuerySpec {
+    sql: String,
+    bind_variables: Vec<SQLValue>,
+}
+
+impl RawSqlQuerySpec {
+    fn into_count_query(self, alias: &str) -> Self {
+        Self {
+            sql: format!("SELECT COUNT(*) AS count FROM ({}) AS {alias}", self.sql),
+            bind_variables: self.bind_variables,
+        }
+    }
+
+    fn into_indexed_sql(self) -> Self {
+        Self {
+            sql: self.sql.replace_question_mark_with_indexed_n(),
+            bind_variables: self.bind_variables,
+        }
+    }
+}
+
+macro_rules! bind_raw_sql_query {
+    ($spec:expr) => {{
+        let spec = $spec.into_indexed_sql();
+        let mut query = diesel::sql_query(spec.sql).into_boxed();
+        for bind_var in spec.bind_variables {
+            query = match bind_var {
+                SQLValue::Integer(i) => query.bind::<diesel::sql_types::Integer, _>(i),
+                SQLValue::String(s) => query.bind::<diesel::sql_types::Text, _>(s),
+                SQLValue::Boolean(b) => query.bind::<diesel::sql_types::Bool, _>(b),
+                SQLValue::Float(f) => query.bind::<diesel::sql_types::Float8, _>(f),
+                SQLValue::Date(d) => query.bind::<diesel::sql_types::Timestamp, _>(d),
+            };
+        }
+        query
+    }};
+}
 
 pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
     async fn search_namespaces_from_backend(
@@ -9,6 +56,16 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
     ) -> Result<Vec<Namespace>, ApiError> {
         let is_admin = self.is_admin(pool).await?;
         self.search_namespaces_from_backend_with_admin_status(pool, query_options, is_admin)
+            .await
+    }
+
+    async fn count_namespaces_from_backend(
+        &self,
+        pool: &DbPool,
+        query_options: QueryOptions,
+    ) -> Result<i64, ApiError> {
+        let is_admin = self.is_admin(pool).await?;
+        self.count_namespaces_from_backend_with_admin_status(pool, query_options, is_admin)
             .await
     }
 
@@ -90,6 +147,71 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
         })
     }
 
+    async fn count_namespaces_from_backend_with_admin_status(
+        &self,
+        pool: &DbPool,
+        query_options: QueryOptions,
+        is_admin: bool,
+    ) -> Result<i64, ApiError> {
+        use crate::schema::namespaces::dsl::{
+            created_at as namespace_created_at, description as namespace_description,
+            id as namespace_id, name as namespace_name, namespaces,
+            updated_at as namespace_updated_at,
+        };
+        use crate::schema::permissions::dsl::{
+            group_id, namespace_id as permissions_nid, permissions,
+        };
+
+        let query_params = query_options.filters.clone();
+        let mut permissions_list = query_params.permissions()?;
+        permissions_list.ensure_contains(&[Permissions::ReadCollection]);
+
+        let mut base_query = if is_admin {
+            namespaces.into_boxed()
+        } else {
+            let group_id_subquery = self.group_ids_subquery_from_backend();
+
+            namespaces
+                .filter(
+                    namespace_id.eq_any(
+                        permissions
+                            .filter(group_id.eq_any(group_id_subquery))
+                            .select(permissions_nid),
+                    ),
+                )
+                .into_boxed()
+        };
+
+        for param in query_params {
+            use crate::{date_search, numeric_search, string_search};
+            let operator = param.operator.clone();
+            match param.field {
+                FilterField::Id => numeric_search!(base_query, param, operator, namespace_id),
+                FilterField::CreatedAt => {
+                    date_search!(base_query, param, operator, namespace_created_at)
+                }
+                FilterField::UpdatedAt => {
+                    date_search!(base_query, param, operator, namespace_updated_at)
+                }
+                FilterField::Name => {
+                    string_search!(base_query, param, operator, namespace_name)
+                }
+                FilterField::Description => {
+                    string_search!(base_query, param, operator, namespace_description)
+                }
+                FilterField::Permissions => {}
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't searchable (or does not exist) for namespaces",
+                        param.field
+                    )));
+                }
+            }
+        }
+
+        with_connection(pool, |conn| base_query.count().get_result::<i64>(conn))
+    }
+
     async fn search_classes_from_backend(
         &self,
         pool: &DbPool,
@@ -97,6 +219,16 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
     ) -> Result<Vec<HubuumClassExpanded>, ApiError> {
         let is_admin = self.is_admin(pool).await?;
         self.search_classes_from_backend_with_admin_status(pool, query_options, is_admin)
+            .await
+    }
+
+    async fn count_classes_from_backend(
+        &self,
+        pool: &DbPool,
+        query_options: QueryOptions,
+    ) -> Result<i64, ApiError> {
+        let is_admin = self.is_admin(pool).await?;
+        self.count_classes_from_backend_with_admin_status(pool, query_options, is_admin)
             .await
     }
 
@@ -221,6 +353,82 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
         Ok(result.expand_namespace_from_map(&namespace_map))
     }
 
+    async fn count_classes_from_backend_with_admin_status(
+        &self,
+        pool: &DbPool,
+        query_options: QueryOptions,
+        is_admin: bool,
+    ) -> Result<i64, ApiError> {
+        use crate::schema::hubuumclass::dsl::{
+            created_at as class_created_at, description as class_description, hubuumclass,
+            id as class_id, name as class_name, namespace_id as class_namespace_id,
+            updated_at as class_updated_at, validate_schema as class_validate_schema,
+        };
+
+        let query_params = query_options.filters.clone();
+
+        let mut permissions_list = query_params.permissions()?;
+        permissions_list.ensure_contains(&[Permissions::ReadClass, Permissions::ReadCollection]);
+
+        let namespaces = self
+            .load_namespaces_with_permissions_with_admin_status(pool, &permissions_list, is_admin)
+            .await?;
+        let namespace_ids: Vec<i32> = namespaces.iter().map(|n| n.id).collect();
+
+        let mut base_query = hubuumclass
+            .filter(class_namespace_id.eq_any(namespace_ids))
+            .into_boxed();
+
+        let json_schema_queries = query_params.json_schemas()?;
+        if !json_schema_queries.is_empty() {
+            let json_schema_integers = self.json_schema_subquery(pool, json_schema_queries)?;
+            if json_schema_integers.is_empty() {
+                return Ok(0);
+            }
+            base_query = base_query.filter(class_id.eq_any(json_schema_integers));
+        }
+
+        for param in query_params {
+            use crate::{boolean_search, date_search, numeric_search, string_search};
+            let operator = param.operator.clone();
+            match param.field {
+                FilterField::Id => numeric_search!(base_query, param, operator, class_id),
+                FilterField::Namespaces => {
+                    numeric_search!(base_query, param, operator, class_namespace_id)
+                }
+                FilterField::CreatedAt => {
+                    date_search!(base_query, param, operator, class_created_at)
+                }
+                FilterField::UpdatedAt => {
+                    date_search!(base_query, param, operator, class_updated_at)
+                }
+                FilterField::Name => string_search!(base_query, param, operator, class_name),
+                FilterField::Description => {
+                    string_search!(base_query, param, operator, class_description)
+                }
+                FilterField::ValidateSchema => {
+                    boolean_search!(base_query, param, operator, class_validate_schema)
+                }
+                FilterField::JsonSchema => {}
+                FilterField::Permissions => {}
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't searchable (or does not exist) for classes",
+                        param.field
+                    )));
+                }
+            }
+        }
+
+        with_connection(pool, |conn| {
+            base_query
+                .select(class_id)
+                .distinct()
+                .count()
+                .get_result::<i64>(conn)
+        })
+    }
+
     async fn search_objects_from_backend(
         &self,
         pool: &DbPool,
@@ -228,6 +436,16 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
     ) -> Result<Vec<HubuumObject>, ApiError> {
         let is_admin = self.is_admin(pool).await?;
         self.search_objects_from_backend_with_admin_status(pool, query_options, is_admin)
+            .await
+    }
+
+    async fn count_objects_from_backend(
+        &self,
+        pool: &DbPool,
+        query_options: QueryOptions,
+    ) -> Result<i64, ApiError> {
+        let is_admin = self.is_admin(pool).await?;
+        self.count_objects_from_backend_with_admin_status(pool, query_options, is_admin)
             .await
     }
 
@@ -351,6 +569,87 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
         })
     }
 
+    async fn count_objects_from_backend_with_admin_status(
+        &self,
+        pool: &DbPool,
+        query_options: QueryOptions,
+        is_admin: bool,
+    ) -> Result<i64, ApiError> {
+        use crate::schema::hubuumobject::dsl::{
+            created_at as object_created_at, description as object_description, hubuum_class_id,
+            hubuumobject, id as object_id, name as object_name,
+            namespace_id as object_namespace_id, updated_at as object_updated_at,
+        };
+
+        let query_params = query_options.filters.clone();
+
+        let mut permission_list = query_params.permissions()?;
+        permission_list.ensure_contains(&[Permissions::ReadObject, Permissions::ReadCollection]);
+
+        let namespace_ids: Vec<i32> = self
+            .load_namespaces_with_permissions_with_admin_status(pool, &permission_list, is_admin)
+            .await?
+            .into_iter()
+            .map(|n| n.id)
+            .collect();
+
+        let mut base_query = hubuumobject
+            .filter(object_namespace_id.eq_any(namespace_ids))
+            .into_boxed();
+
+        let json_data_queries = query_params.json_datas(FilterField::JsonData)?;
+        if !json_data_queries.is_empty() {
+            let json_data_integers = self.json_data_subquery(pool, json_data_queries)?;
+            if json_data_integers.is_empty() {
+                return Ok(0);
+            }
+            base_query = base_query.filter(object_id.eq_any(json_data_integers));
+        }
+
+        for param in query_params {
+            use crate::{date_search, numeric_search, string_search};
+            let operator = param.operator.clone();
+            match param.field {
+                FilterField::Id => numeric_search!(base_query, param, operator, object_id),
+                FilterField::Namespaces => {
+                    numeric_search!(base_query, param, operator, object_namespace_id)
+                }
+                FilterField::CreatedAt => {
+                    date_search!(base_query, param, operator, object_created_at)
+                }
+                FilterField::UpdatedAt => {
+                    date_search!(base_query, param, operator, object_updated_at)
+                }
+                FilterField::Name => string_search!(base_query, param, operator, object_name),
+                FilterField::Description => {
+                    string_search!(base_query, param, operator, object_description)
+                }
+                FilterField::Classes => {
+                    numeric_search!(base_query, param, operator, hubuum_class_id)
+                }
+                FilterField::ClassId => {
+                    numeric_search!(base_query, param, operator, hubuum_class_id)
+                }
+                FilterField::JsonData => {}
+                FilterField::Permissions => {}
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't searchable (or does not exist) for objects",
+                        param.field
+                    )));
+                }
+            }
+        }
+
+        with_connection(pool, |conn| {
+            base_query
+                .select(object_id)
+                .distinct()
+                .count()
+                .get_result::<i64>(conn)
+        })
+    }
+
     async fn search_class_relations_from_backend(
         &self,
         pool: &DbPool,
@@ -361,12 +660,34 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
             .await
     }
 
+    async fn class_relations_page_from_backend(
+        &self,
+        pool: &DbPool,
+        query_options: QueryOptions,
+    ) -> Result<(Vec<HubuumClassRelation>, i64), ApiError> {
+        let is_admin = self.is_admin(pool).await?;
+        self.class_relations_page_from_backend_with_admin_status(pool, query_options, is_admin)
+            .await
+    }
+
     async fn search_class_relations_from_backend_with_admin_status(
         &self,
         pool: &DbPool,
         query_options: QueryOptions,
         is_admin: bool,
     ) -> Result<Vec<HubuumClassRelation>, ApiError> {
+        let (items, _) = self
+            .class_relations_page_from_backend_with_admin_status(pool, query_options, is_admin)
+            .await?;
+        Ok(items)
+    }
+
+    async fn class_relations_page_from_backend_with_admin_status(
+        &self,
+        pool: &DbPool,
+        query_options: QueryOptions,
+        is_admin: bool,
+    ) -> Result<(Vec<HubuumClassRelation>, i64), ApiError> {
         use crate::schema::hubuumclass::dsl::{
             hubuumclass, id as class_id, namespace_id as class_namespace_id,
         };
@@ -402,8 +723,6 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
             namespace_ids = ?namespace_ids
         );
 
-        let mut base_query = hubuumclass_relation.into_boxed();
-
         for param in &[FilterField::ClassFromName, FilterField::ClassToName] {
             if let Some(class_param) = query_params.iter().find(|p| &p.field == param) {
                 let qparam = ParsedQueryParam {
@@ -429,7 +748,7 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
                         user_id = self.id(),
                         result = "No class IDs found, returning empty result"
                     );
-                    return Ok(vec![]);
+                    return Ok((vec![], 0));
                 }
 
                 debug!(
@@ -458,73 +777,92 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
             }
         }
 
-        base_query = base_query
-            .filter(
-                from_hubuum_class_id.eq_any(
-                    hubuumclass
-                        .select(class_id)
-                        .filter(class_namespace_id.eq_any(&namespace_ids)),
-                ),
-            )
-            .filter(
-                to_hubuum_class_id.eq_any(
-                    hubuumclass
-                        .select(class_id)
-                        .filter(class_namespace_id.eq_any(&namespace_ids)),
-                ),
-            );
+        let build_query = || -> Result<_, ApiError> {
+            let mut base_query = hubuumclass_relation
+                .filter(
+                    from_hubuum_class_id.eq_any(
+                        hubuumclass
+                            .select(class_id)
+                            .filter(class_namespace_id.eq_any(&namespace_ids)),
+                    ),
+                )
+                .filter(
+                    to_hubuum_class_id.eq_any(
+                        hubuumclass
+                            .select(class_id)
+                            .filter(class_namespace_id.eq_any(&namespace_ids)),
+                    ),
+                )
+                .into_boxed();
 
-        for param in query_params {
-            use crate::{date_search, numeric_search};
-            let operator = param.operator.clone();
-            match param.field {
-                FilterField::Id => numeric_search!(base_query, param, operator, class_relation_id),
-                FilterField::ClassFrom => {
-                    numeric_search!(base_query, param, operator, from_hubuum_class_id)
-                }
-                FilterField::ClassTo => {
-                    numeric_search!(base_query, param, operator, to_hubuum_class_id)
-                }
-                FilterField::CreatedAt => {
-                    date_search!(base_query, param, operator, class_relation_created_at)
-                }
-                FilterField::UpdatedAt => {
-                    date_search!(base_query, param, operator, class_relation_updated_at)
-                }
-                FilterField::ClassFromName => {}
-                FilterField::ClassToName => {}
-                _ => {
-                    return Err(ApiError::BadRequest(format!(
-                        "Field '{}' isn't searchable (or does not exist) for class relations",
-                        param.field
-                    )));
+            for param in &query_params {
+                use crate::{date_search, numeric_search};
+                let operator = param.operator.clone();
+                match param.field {
+                    FilterField::Id => {
+                        numeric_search!(base_query, param, operator, class_relation_id)
+                    }
+                    FilterField::ClassFrom => {
+                        numeric_search!(base_query, param, operator, from_hubuum_class_id)
+                    }
+                    FilterField::ClassTo => {
+                        numeric_search!(base_query, param, operator, to_hubuum_class_id)
+                    }
+                    FilterField::CreatedAt => {
+                        date_search!(base_query, param, operator, class_relation_created_at)
+                    }
+                    FilterField::UpdatedAt => {
+                        date_search!(base_query, param, operator, class_relation_updated_at)
+                    }
+                    FilterField::ClassFromName => {}
+                    FilterField::ClassToName => {}
+                    _ => {
+                        return Err(ApiError::BadRequest(format!(
+                            "Field '{}' isn't searchable (or does not exist) for class relations",
+                            param.field
+                        )));
+                    }
                 }
             }
-        }
 
+            Ok(base_query)
+        };
+
+        let base_query = build_query()?;
+        let total_count = with_connection(pool, |conn| {
+            base_query
+                .select(class_relation_id)
+                .distinct()
+                .count()
+                .get_result::<i64>(conn)
+        })?;
+
+        let mut base_query = build_query()?;
         crate::apply_query_options!(base_query, query_options, HubuumClassRelation);
 
         trace_query!(base_query, "Searching class relations");
 
-        with_connection(pool, |conn| {
+        let items = with_connection(pool, |conn| {
             base_query
                 .select(hubuumclass_relation::all_columns())
                 .distinct()
                 .load::<HubuumClassRelation>(conn)
-        })
+        })?;
+
+        Ok((items, total_count))
     }
 
-    async fn search_class_relations_touching_from_backend<K>(
+    async fn class_relations_touching_page_from_backend<K>(
         &self,
         pool: &DbPool,
         class: K,
         query_options: QueryOptions,
-    ) -> Result<Vec<HubuumClassRelation>, ApiError>
+    ) -> Result<(Vec<HubuumClassRelation>, i64), ApiError>
     where
         K: SelfAccessors<HubuumClass>,
     {
         let is_admin = self.is_admin(pool).await?;
-        self.search_class_relations_touching_from_backend_with_admin_status(
+        self.class_relations_touching_page_from_backend_with_admin_status(
             pool,
             class,
             query_options,
@@ -533,13 +871,13 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
         .await
     }
 
-    async fn search_class_relations_touching_from_backend_with_admin_status<K>(
+    async fn class_relations_touching_page_from_backend_with_admin_status<K>(
         &self,
         pool: &DbPool,
         class: K,
         query_options: QueryOptions,
         is_admin: bool,
-    ) -> Result<Vec<HubuumClassRelation>, ApiError>
+    ) -> Result<(Vec<HubuumClassRelation>, i64), ApiError>
     where
         K: SelfAccessors<HubuumClass>,
     {
@@ -564,56 +902,68 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
             .map(|n| n.id)
             .collect();
 
-        let mut base_query = hubuumclass_relation
-            .filter(
-                from_hubuum_class_id
-                    .eq(class.id())
-                    .or(to_hubuum_class_id.eq(class.id())),
-            )
-            .into_boxed();
+        let build_query = || -> Result<_, ApiError> {
+            let mut base_query = hubuumclass_relation
+                .filter(
+                    from_hubuum_class_id
+                        .eq(class.id())
+                        .or(to_hubuum_class_id.eq(class.id())),
+                )
+                .filter(
+                    from_hubuum_class_id.eq_any(
+                        hubuumclass
+                            .select(class_id)
+                            .filter(class_namespace_id.eq_any(&namespace_ids)),
+                    ),
+                )
+                .filter(
+                    to_hubuum_class_id.eq_any(
+                        hubuumclass
+                            .select(class_id)
+                            .filter(class_namespace_id.eq_any(&namespace_ids)),
+                    ),
+                )
+                .into_boxed();
 
-        base_query = base_query
-            .filter(
-                from_hubuum_class_id.eq_any(
-                    hubuumclass
-                        .select(class_id)
-                        .filter(class_namespace_id.eq_any(&namespace_ids)),
-                ),
-            )
-            .filter(
-                to_hubuum_class_id.eq_any(
-                    hubuumclass
-                        .select(class_id)
-                        .filter(class_namespace_id.eq_any(&namespace_ids)),
-                ),
-            );
-
-        for param in query_params {
-            use crate::{date_search, numeric_search};
-            let operator = param.operator.clone();
-            match param.field {
-                FilterField::Id => numeric_search!(base_query, param, operator, relation_id),
-                FilterField::ClassFrom => {
-                    numeric_search!(base_query, param, operator, from_hubuum_class_id)
-                }
-                FilterField::ClassTo => {
-                    numeric_search!(base_query, param, operator, to_hubuum_class_id)
-                }
-                FilterField::CreatedAt => {
-                    date_search!(base_query, param, operator, relation_created_at)
-                }
-                FilterField::UpdatedAt => {
-                    date_search!(base_query, param, operator, relation_updated_at)
-                }
-                _ => {
-                    return Err(ApiError::BadRequest(format!(
-                        "Field '{}' isn't searchable (or does not exist) for class relations",
-                        param.field
-                    )));
+            for param in &query_params {
+                use crate::{date_search, numeric_search};
+                let operator = param.operator.clone();
+                match param.field {
+                    FilterField::Id => numeric_search!(base_query, param, operator, relation_id),
+                    FilterField::ClassFrom => {
+                        numeric_search!(base_query, param, operator, from_hubuum_class_id)
+                    }
+                    FilterField::ClassTo => {
+                        numeric_search!(base_query, param, operator, to_hubuum_class_id)
+                    }
+                    FilterField::CreatedAt => {
+                        date_search!(base_query, param, operator, relation_created_at)
+                    }
+                    FilterField::UpdatedAt => {
+                        date_search!(base_query, param, operator, relation_updated_at)
+                    }
+                    _ => {
+                        return Err(ApiError::BadRequest(format!(
+                            "Field '{}' isn't searchable (or does not exist) for class relations",
+                            param.field
+                        )));
+                    }
                 }
             }
-        }
 
+            Ok(base_query)
+        };
+
+        let base_query = build_query()?;
+        let total_count = with_connection(pool, |conn| {
+            base_query
+                .select(relation_id)
+                .distinct()
+                .count()
+                .get_result::<i64>(conn)
+        })?;
+
+        let mut base_query = build_query()?;
         crate::apply_query_options!(base_query, query_options, HubuumClassRelation);
 
         trace_query!(
@@ -621,12 +971,14 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
             "Searching direct class relations touching class"
         );
 
-        with_connection(pool, |conn| {
+        let items = with_connection(pool, |conn| {
             base_query
                 .select(hubuumclass_relation::all_columns())
                 .distinct()
                 .load::<HubuumClassRelation>(conn)
-        })
+        })?;
+
+        Ok((items, total_count))
     }
 
     async fn search_class_relations_between_ids_from_backend(
@@ -709,6 +1061,25 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
         .await
     }
 
+    async fn classes_related_to_page_from_backend<K>(
+        &self,
+        pool: &DbPool,
+        class: K,
+        query_options: QueryOptions,
+    ) -> Result<(Vec<ClassClosureRow>, i64), ApiError>
+    where
+        K: SelfAccessors<HubuumClass>,
+    {
+        let is_admin = self.is_admin(pool).await?;
+        self.classes_related_to_page_from_backend_with_admin_status(
+            pool,
+            class,
+            query_options,
+            is_admin,
+        )
+        .await
+    }
+
     async fn search_classes_related_to_from_backend_with_admin_status<K>(
         &self,
         pool: &DbPool,
@@ -719,89 +1090,47 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
     where
         K: SelfAccessors<HubuumClass>,
     {
-        use crate::pagination::{cursor_filter_sql, normalized_sorts, order_sql_clause};
-        use crate::utilities::extensions::CustomStringExtensions;
-        use diesel::sql_query;
-
-        let query_params = query_options.filters.clone();
-
-        let mut permissions_list = query_params.permissions()?;
-        permissions_list.ensure_contains(&[Permissions::ReadClass, Permissions::ReadClassRelation]);
-
-        let namespace_ids: Vec<i32> = self
-            .load_namespaces_with_permissions_with_admin_status(pool, &permissions_list, is_admin)
-            .await?
-            .into_iter()
-            .map(|n| n.id)
-            .collect();
-
-        if namespace_ids.is_empty() {
-            return Ok(vec![]);
-        }
-
-        let sorts = normalized_sorts::<ClassClosureRow>(&query_options.sort)?;
-        let mut bind_variables = Vec::<SQLValue>::new();
-        bind_variables.push(SQLValue::Integer(class.id()));
-        let related_depth_upper_bound = related_depth_upper_bound(&query_params)?;
-        let namespace_array_sql = sql_integer_array(&namespace_ids, &mut bind_variables);
-        let mut raw_sql = if let Some(max_depth) = related_depth_upper_bound {
-            bind_variables.push(SQLValue::Integer(max_depth));
-            format!(
-                "SELECT * FROM get_bidirectionally_related_classes(?, {namespace_array_sql}, ?) AS related_classes"
+        let (items, _) = self
+            .classes_related_to_page_from_backend_with_admin_status(
+                pool,
+                class,
+                query_options,
+                is_admin,
             )
-        } else {
-            format!(
-                "SELECT * FROM get_bidirectionally_related_classes(?, {namespace_array_sql}, NULL) AS related_classes"
-            )
+            .await?;
+        Ok(items)
+    }
+
+    async fn classes_related_to_page_from_backend_with_admin_status<K>(
+        &self,
+        pool: &DbPool,
+        class: K,
+        query_options: QueryOptions,
+        is_admin: bool,
+    ) -> Result<(Vec<ClassClosureRow>, i64), ApiError>
+    where
+        K: SelfAccessors<HubuumClass>,
+    {
+        let Some(base_spec) =
+            build_related_classes_query_spec(self, pool, class, query_options.clone(), is_admin)
+                .await?
+        else {
+            return Ok((vec![], 0));
         };
+        let total_count_spec = base_spec.clone().into_count_query("related_classes_count");
+        let spec = apply_raw_sql_pagination::<ClassClosureRow>(base_spec, &query_options)?;
 
-        let mut where_clauses = Vec::new();
+        let total_count = with_connection(pool, |conn| {
+            bind_raw_sql_query!(total_count_spec)
+                .get_result::<CountRow>(conn)
+                .map(|row| row.count)
+        })?;
 
-        for param in &query_params {
-            let clause = build_related_classes_clause(param, &mut bind_variables)?;
-            if let Some(clause) = clause {
-                where_clauses.push(clause);
-            }
-        }
-
-        if let Some(cursor_sql) =
-            cursor_filter_sql::<ClassClosureRow>(&sorts, query_options.cursor.as_deref())?
-        {
-            where_clauses.push(cursor_sql);
-        }
-
-        if !where_clauses.is_empty() {
-            raw_sql.push_str("\nWHERE ");
-            raw_sql.push_str(&where_clauses.join("\n  AND "));
-        }
-
-        let order_by = sorts
-            .iter()
-            .map(order_sql_clause::<ClassClosureRow>)
-            .collect::<Result<Vec<_>, _>>()?
-            .join(", ");
-        raw_sql.push_str(&format!("\nORDER BY {order_by}"));
-
-        if let Some(limit) = query_options.limit {
-            raw_sql.push_str(&format!("\nLIMIT {limit}"));
-        }
-
-        raw_sql = raw_sql.replace_question_mark_with_indexed_n();
-
-        let mut query = sql_query(raw_sql).into_boxed();
-        for bind_var in bind_variables {
-            query = match bind_var {
-                SQLValue::Integer(i) => query.bind::<diesel::sql_types::Integer, _>(i),
-                SQLValue::String(s) => query.bind::<diesel::sql_types::Text, _>(s),
-                SQLValue::Boolean(b) => query.bind::<diesel::sql_types::Bool, _>(b),
-                SQLValue::Float(f) => query.bind::<diesel::sql_types::Float8, _>(f),
-                SQLValue::Date(d) => query.bind::<diesel::sql_types::Timestamp, _>(d),
-            };
-        }
-
+        let query = bind_raw_sql_query!(spec);
         trace_query!(query, "Searching related classes");
+        let items = with_connection(pool, |conn| query.get_results::<ClassClosureRow>(conn))?;
 
-        with_connection(pool, |conn| query.get_results::<ClassClosureRow>(conn))
+        Ok((items, total_count))
     }
 
     async fn search_object_relations_from_backend(
@@ -814,12 +1143,34 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
             .await
     }
 
+    async fn object_relations_page_from_backend(
+        &self,
+        pool: &DbPool,
+        query_options: QueryOptions,
+    ) -> Result<(Vec<HubuumObjectRelation>, i64), ApiError> {
+        let is_admin = self.is_admin(pool).await?;
+        self.object_relations_page_from_backend_with_admin_status(pool, query_options, is_admin)
+            .await
+    }
+
     async fn search_object_relations_from_backend_with_admin_status(
         &self,
         pool: &DbPool,
         query_options: QueryOptions,
         is_admin: bool,
     ) -> Result<Vec<HubuumObjectRelation>, ApiError> {
+        let (items, _) = self
+            .object_relations_page_from_backend_with_admin_status(pool, query_options, is_admin)
+            .await?;
+        Ok(items)
+    }
+
+    async fn object_relations_page_from_backend_with_admin_status(
+        &self,
+        pool: &DbPool,
+        query_options: QueryOptions,
+        is_admin: bool,
+    ) -> Result<(Vec<HubuumObjectRelation>, i64), ApiError> {
         use crate::schema::hubuumobject::dsl::{
             hubuumobject, id as object_id, namespace_id as object_namespace_id,
         };
@@ -855,76 +1206,91 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
             namespace_ids = ?namespace_ids
         );
 
-        let mut base_query = hubuumobject_relation.into_boxed();
+        let build_query = || -> Result<_, ApiError> {
+            let mut base_query = hubuumobject_relation
+                .filter(
+                    from_hubuum_object_id.eq_any(
+                        hubuumobject
+                            .select(object_id)
+                            .filter(object_namespace_id.eq_any(&namespace_ids)),
+                    ),
+                )
+                .filter(
+                    to_hubuum_object_id.eq_any(
+                        hubuumobject
+                            .select(object_id)
+                            .filter(object_namespace_id.eq_any(&namespace_ids)),
+                    ),
+                )
+                .into_boxed();
 
-        base_query = base_query
-            .filter(
-                from_hubuum_object_id.eq_any(
-                    hubuumobject
-                        .select(object_id)
-                        .filter(object_namespace_id.eq_any(&namespace_ids)),
-                ),
-            )
-            .filter(
-                to_hubuum_object_id.eq_any(
-                    hubuumobject
-                        .select(object_id)
-                        .filter(object_namespace_id.eq_any(&namespace_ids)),
-                ),
-            );
-
-        for param in query_params {
-            use crate::{date_search, numeric_search};
-            let operator = param.operator.clone();
-            match param.field {
-                FilterField::Id => numeric_search!(base_query, param, operator, relation_id),
-                FilterField::ClassRelation => {
-                    numeric_search!(base_query, param, operator, class_relation_id)
-                }
-                FilterField::ObjectFrom => {
-                    numeric_search!(base_query, param, operator, from_hubuum_object_id)
-                }
-                FilterField::ObjectTo => {
-                    numeric_search!(base_query, param, operator, to_hubuum_object_id)
-                }
-                FilterField::CreatedAt => {
-                    date_search!(base_query, param, operator, relation_created_at)
-                }
-                FilterField::UpdatedAt => {
-                    date_search!(base_query, param, operator, relation_updated_at)
-                }
-                _ => {
-                    return Err(ApiError::BadRequest(format!(
-                        "Field '{}' isn't searchable (or does not exist) for object relations",
-                        param.field
-                    )));
+            for param in &query_params {
+                use crate::{date_search, numeric_search};
+                let operator = param.operator.clone();
+                match param.field {
+                    FilterField::Id => numeric_search!(base_query, param, operator, relation_id),
+                    FilterField::ClassRelation => {
+                        numeric_search!(base_query, param, operator, class_relation_id)
+                    }
+                    FilterField::ObjectFrom => {
+                        numeric_search!(base_query, param, operator, from_hubuum_object_id)
+                    }
+                    FilterField::ObjectTo => {
+                        numeric_search!(base_query, param, operator, to_hubuum_object_id)
+                    }
+                    FilterField::CreatedAt => {
+                        date_search!(base_query, param, operator, relation_created_at)
+                    }
+                    FilterField::UpdatedAt => {
+                        date_search!(base_query, param, operator, relation_updated_at)
+                    }
+                    _ => {
+                        return Err(ApiError::BadRequest(format!(
+                            "Field '{}' isn't searchable (or does not exist) for object relations",
+                            param.field
+                        )));
+                    }
                 }
             }
-        }
 
+            Ok(base_query)
+        };
+
+        let base_query = build_query()?;
+        let total_count = with_connection(pool, |conn| {
+            base_query
+                .select(relation_id)
+                .distinct()
+                .count()
+                .get_result::<i64>(conn)
+        })?;
+
+        let mut base_query = build_query()?;
         crate::apply_query_options!(base_query, query_options, HubuumObjectRelation);
 
         trace_query!(base_query, "Searching object relations");
 
-        with_connection(pool, |conn| {
+        let items = with_connection(pool, |conn| {
             base_query
                 .select(hubuumobject_relation::all_columns())
                 .distinct()
                 .load::<HubuumObjectRelation>(conn)
-        })
+        })?;
+
+        Ok((items, total_count))
     }
 
-    async fn search_object_relations_touching_from_backend<O>(
+    async fn object_relations_touching_page_from_backend<O>(
         &self,
         pool: &DbPool,
         object: O,
         query_options: QueryOptions,
-    ) -> Result<Vec<HubuumObjectRelation>, ApiError>
+    ) -> Result<(Vec<HubuumObjectRelation>, i64), ApiError>
     where
         O: SelfAccessors<HubuumObject>,
     {
         let is_admin = self.is_admin(pool).await?;
-        self.search_object_relations_touching_from_backend_with_admin_status(
+        self.object_relations_touching_page_from_backend_with_admin_status(
             pool,
             object,
             query_options,
@@ -933,13 +1299,13 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
         .await
     }
 
-    async fn search_object_relations_touching_from_backend_with_admin_status<O>(
+    async fn object_relations_touching_page_from_backend_with_admin_status<O>(
         &self,
         pool: &DbPool,
         object: O,
         query_options: QueryOptions,
         is_admin: bool,
-    ) -> Result<Vec<HubuumObjectRelation>, ApiError>
+    ) -> Result<(Vec<HubuumObjectRelation>, i64), ApiError>
     where
         O: SelfAccessors<HubuumObject>,
     {
@@ -981,59 +1347,71 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
             namespace_ids = ?namespace_ids
         );
 
-        let mut base_query = hubuumobject_relation
-            .filter(
-                from_hubuum_object_id
-                    .eq(object.id())
-                    .or(to_hubuum_object_id.eq(object.id())),
-            )
-            .into_boxed();
+        let build_query = || -> Result<_, ApiError> {
+            let mut base_query = hubuumobject_relation
+                .filter(
+                    from_hubuum_object_id
+                        .eq(object.id())
+                        .or(to_hubuum_object_id.eq(object.id())),
+                )
+                .filter(
+                    from_hubuum_object_id.eq_any(
+                        hubuumobject
+                            .select(object_id_column)
+                            .filter(object_namespace_id.eq_any(&namespace_ids)),
+                    ),
+                )
+                .filter(
+                    to_hubuum_object_id.eq_any(
+                        hubuumobject
+                            .select(object_id_column)
+                            .filter(object_namespace_id.eq_any(&namespace_ids)),
+                    ),
+                )
+                .into_boxed();
 
-        base_query = base_query
-            .filter(
-                from_hubuum_object_id.eq_any(
-                    hubuumobject
-                        .select(object_id_column)
-                        .filter(object_namespace_id.eq_any(&namespace_ids)),
-                ),
-            )
-            .filter(
-                to_hubuum_object_id.eq_any(
-                    hubuumobject
-                        .select(object_id_column)
-                        .filter(object_namespace_id.eq_any(&namespace_ids)),
-                ),
-            );
-
-        for param in query_params {
-            use crate::{date_search, numeric_search};
-            let operator = param.operator.clone();
-            match param.field {
-                FilterField::Id => numeric_search!(base_query, param, operator, relation_id),
-                FilterField::ClassRelation => {
-                    numeric_search!(base_query, param, operator, class_relation_id)
-                }
-                FilterField::ObjectFrom => {
-                    numeric_search!(base_query, param, operator, from_hubuum_object_id)
-                }
-                FilterField::ObjectTo => {
-                    numeric_search!(base_query, param, operator, to_hubuum_object_id)
-                }
-                FilterField::CreatedAt => {
-                    date_search!(base_query, param, operator, relation_created_at)
-                }
-                FilterField::UpdatedAt => {
-                    date_search!(base_query, param, operator, relation_updated_at)
-                }
-                _ => {
-                    return Err(ApiError::BadRequest(format!(
-                        "Field '{}' isn't searchable (or does not exist) for object relations",
-                        param.field
-                    )));
+            for param in &query_params {
+                use crate::{date_search, numeric_search};
+                let operator = param.operator.clone();
+                match param.field {
+                    FilterField::Id => numeric_search!(base_query, param, operator, relation_id),
+                    FilterField::ClassRelation => {
+                        numeric_search!(base_query, param, operator, class_relation_id)
+                    }
+                    FilterField::ObjectFrom => {
+                        numeric_search!(base_query, param, operator, from_hubuum_object_id)
+                    }
+                    FilterField::ObjectTo => {
+                        numeric_search!(base_query, param, operator, to_hubuum_object_id)
+                    }
+                    FilterField::CreatedAt => {
+                        date_search!(base_query, param, operator, relation_created_at)
+                    }
+                    FilterField::UpdatedAt => {
+                        date_search!(base_query, param, operator, relation_updated_at)
+                    }
+                    _ => {
+                        return Err(ApiError::BadRequest(format!(
+                            "Field '{}' isn't searchable (or does not exist) for object relations",
+                            param.field
+                        )));
+                    }
                 }
             }
-        }
 
+            Ok(base_query)
+        };
+
+        let base_query = build_query()?;
+        let total_count = with_connection(pool, |conn| {
+            base_query
+                .select(relation_id)
+                .distinct()
+                .count()
+                .get_result::<i64>(conn)
+        })?;
+
+        let mut base_query = build_query()?;
         crate::apply_query_options!(base_query, query_options, HubuumObjectRelation);
 
         trace_query!(
@@ -1041,12 +1419,14 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
             "Searching direct object relations touching object"
         );
 
-        with_connection(pool, |conn| {
+        let items = with_connection(pool, |conn| {
             base_query
                 .select(hubuumobject_relation::all_columns())
                 .distinct()
                 .load::<HubuumObjectRelation>(conn)
-        })
+        })?;
+
+        Ok((items, total_count))
     }
 
     async fn search_object_relations_between_ids_from_backend(
@@ -1136,6 +1516,25 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
         .await
     }
 
+    async fn objects_related_to_page_from_backend<O>(
+        &self,
+        pool: &DbPool,
+        object: O,
+        query_options: QueryOptions,
+    ) -> Result<(Vec<RelatedObjectClosureRow>, i64), ApiError>
+    where
+        O: SelfAccessors<HubuumObject> + ClassAccessors,
+    {
+        let is_admin = self.is_admin(pool).await?;
+        self.objects_related_to_page_from_backend_with_admin_status(
+            pool,
+            object,
+            query_options,
+            is_admin,
+        )
+        .await
+    }
+
     async fn search_objects_related_to_from_backend_with_admin_status<O>(
         &self,
         pool: &DbPool,
@@ -1146,122 +1545,237 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
     where
         O: SelfAccessors<HubuumObject> + ClassAccessors,
     {
-        use crate::models::search::SQLValue;
-        use crate::pagination::{cursor_filter_sql, normalized_sorts, order_sql_clause};
-        use crate::utilities::extensions::CustomStringExtensions;
-        use diesel::sql_query;
+        let (items, _) = self
+            .objects_related_to_page_from_backend_with_admin_status(
+                pool,
+                object,
+                query_options,
+                is_admin,
+            )
+            .await?;
+        Ok(items)
+    }
 
-        let query_params = query_options.filters.clone();
+    async fn objects_related_to_page_from_backend_with_admin_status<O>(
+        &self,
+        pool: &DbPool,
+        object: O,
+        query_options: QueryOptions,
+        is_admin: bool,
+    ) -> Result<(Vec<RelatedObjectClosureRow>, i64), ApiError>
+    where
+        O: SelfAccessors<HubuumObject> + ClassAccessors,
+    {
+        let Some(base_spec) =
+            build_related_objects_query_spec(self, pool, object, query_options.clone(), is_admin)
+                .await?
+        else {
+            return Ok((vec![], 0));
+        };
+        let total_count_spec = base_spec.clone().into_count_query("related_objects_count");
+        let spec = apply_raw_sql_pagination::<RelatedObjectClosureRow>(base_spec, &query_options)?;
 
+        let total_count = with_connection(pool, |conn| {
+            bind_raw_sql_query!(total_count_spec)
+                .get_result::<CountRow>(conn)
+                .map(|row| row.count)
+        })?;
+
+        let query = bind_raw_sql_query!(spec.clone());
         debug!(
-            message = "Searching objects related to object",
-            stage = "Starting",
-            user_id = self.id(),
-            object_id = object.id(),
-            query_params = ?query_params
+            message = "Searching source-relative related objects",
+            raw_sql = %spec.sql,
+            bind_variables = ?spec.bind_variables
         );
+        trace_query!(query, "Searching source-relative related objects");
+        let items = with_connection(pool, |conn| {
+            query.get_results::<RelatedObjectClosureRow>(conn)
+        })?;
 
-        let mut permissions_list = query_params.permissions()?;
-        permissions_list
-            .ensure_contains(&[Permissions::ReadObject, Permissions::ReadObjectRelation]);
+        Ok((items, total_count))
+    }
+}
 
-        let namespace_ids: Vec<i32> = self
-            .load_namespaces_with_permissions_with_admin_status(pool, &permissions_list, is_admin)
-            .await?
-            .into_iter()
-            .map(|n| n.id)
-            .collect();
+fn apply_raw_sql_pagination<T>(
+    mut spec: RawSqlQuerySpec,
+    query_options: &QueryOptions,
+) -> Result<RawSqlQuerySpec, ApiError>
+where
+    T: CursorPaginated + CursorSqlMapping,
+{
+    use crate::pagination::{cursor_filter_sql, normalized_sorts, order_sql_clause};
 
-        if namespace_ids.is_empty() {
-            debug!(
-                message = "Searching object relations related to object",
-                stage = "Namespace IDs",
-                user_id = self.id(),
-                result = "No namespace IDs found, returning empty result"
-            );
-            return Ok(vec![]);
+    let sorts = normalized_sorts::<T>(&query_options.sort)?;
+    let mut where_clauses = Vec::new();
+    if let Some(cursor_sql) = cursor_filter_sql::<T>(&sorts, query_options.cursor.as_deref())? {
+        where_clauses.push(cursor_sql);
+    }
+
+    if !where_clauses.is_empty() {
+        if spec.sql.contains("\nWHERE ") {
+            spec.sql.push_str("\n  AND ");
+        } else {
+            spec.sql.push_str("\nWHERE ");
         }
+        spec.sql.push_str(&where_clauses.join("\n  AND "));
+    }
 
+    let order_by = sorts
+        .iter()
+        .map(order_sql_clause::<T>)
+        .collect::<Result<Vec<_>, _>>()?
+        .join(", ");
+    spec.sql.push_str(&format!("\nORDER BY {order_by}"));
+
+    if let Some(limit) = query_options.limit {
+        spec.sql.push_str(&format!("\nLIMIT {limit}"));
+    }
+
+    Ok(spec)
+}
+
+async fn build_related_classes_query_spec<U, K>(
+    user: &U,
+    pool: &DbPool,
+    class: K,
+    query_options: QueryOptions,
+    is_admin: bool,
+) -> Result<Option<RawSqlQuerySpec>, ApiError>
+where
+    U: SelfAccessors<User> + UserNamespaceAccessors + ?Sized,
+    K: SelfAccessors<HubuumClass>,
+{
+    let query_params = query_options.filters.clone();
+
+    let mut permissions_list = query_params.permissions()?;
+    permissions_list.ensure_contains(&[Permissions::ReadClass, Permissions::ReadClassRelation]);
+
+    let namespace_ids: Vec<i32> = user
+        .load_namespaces_with_permissions_with_admin_status(pool, &permissions_list, is_admin)
+        .await?
+        .into_iter()
+        .map(|n| n.id)
+        .collect();
+
+    if namespace_ids.is_empty() {
+        return Ok(None);
+    }
+
+    let mut bind_variables = Vec::<SQLValue>::new();
+    bind_variables.push(SQLValue::Integer(class.id()));
+    let related_depth_upper_bound = related_depth_upper_bound(&query_params)?;
+    let namespace_array_sql = sql_integer_array(&namespace_ids, &mut bind_variables);
+    let mut raw_sql = if let Some(max_depth) = related_depth_upper_bound {
+        bind_variables.push(SQLValue::Integer(max_depth));
+        format!(
+            "SELECT * FROM get_bidirectionally_related_classes(?, {namespace_array_sql}, ?) AS related_classes"
+        )
+    } else {
+        format!(
+            "SELECT * FROM get_bidirectionally_related_classes(?, {namespace_array_sql}, NULL) AS related_classes"
+        )
+    };
+
+    let mut where_clauses = Vec::new();
+    for param in &query_params {
+        let clause = build_related_classes_clause(param, &mut bind_variables)?;
+        if let Some(clause) = clause {
+            where_clauses.push(clause);
+        }
+    }
+
+    if !where_clauses.is_empty() {
+        raw_sql.push_str("\nWHERE ");
+        raw_sql.push_str(&where_clauses.join("\n  AND "));
+    }
+
+    Ok(Some(RawSqlQuerySpec {
+        sql: raw_sql,
+        bind_variables,
+    }))
+}
+
+async fn build_related_objects_query_spec<U, O>(
+    user: &U,
+    pool: &DbPool,
+    object: O,
+    query_options: QueryOptions,
+    is_admin: bool,
+) -> Result<Option<RawSqlQuerySpec>, ApiError>
+where
+    U: SelfAccessors<User> + UserNamespaceAccessors + ?Sized,
+    O: SelfAccessors<HubuumObject> + ClassAccessors,
+{
+    let query_params = query_options.filters.clone();
+
+    debug!(
+        message = "Searching objects related to object",
+        stage = "Starting",
+        user_id = user.id(),
+        object_id = object.id(),
+        query_params = ?query_params
+    );
+
+    let mut permissions_list = query_params.permissions()?;
+    permissions_list.ensure_contains(&[Permissions::ReadObject, Permissions::ReadObjectRelation]);
+
+    let namespace_ids: Vec<i32> = user
+        .load_namespaces_with_permissions_with_admin_status(pool, &permissions_list, is_admin)
+        .await?
+        .into_iter()
+        .map(|n| n.id)
+        .collect();
+
+    if namespace_ids.is_empty() {
         debug!(
             message = "Searching object relations related to object",
             stage = "Namespace IDs",
-            user_id = self.id(),
-            result = "Found namespace IDs",
-            namespace_ids = ?namespace_ids
+            user_id = user.id(),
+            result = "No namespace IDs found, returning empty result"
         );
-
-        let sorts = normalized_sorts::<RelatedObjectClosureRow>(&query_options.sort)?;
-        let mut bind_variables = Vec::<SQLValue>::new();
-        bind_variables.push(SQLValue::Integer(object.id()));
-        let related_depth_upper_bound = related_depth_upper_bound(&query_params)?;
-        let namespace_array_sql = sql_integer_array(&namespace_ids, &mut bind_variables);
-        let mut raw_sql = if let Some(max_depth) = related_depth_upper_bound {
-            bind_variables.push(SQLValue::Integer(max_depth));
-            format!(
-                "SELECT * FROM get_bidirectionally_related_objects(?, {namespace_array_sql}, ?) AS related_objects"
-            )
-        } else {
-            format!(
-                "SELECT * FROM get_bidirectionally_related_objects(?, {namespace_array_sql}, NULL) AS related_objects"
-            )
-        };
-
-        let mut where_clauses = Vec::new();
-
-        for param in &query_params {
-            let clause = build_related_objects_clause(self, pool, param, &mut bind_variables)?;
-            if let Some(clause) = clause {
-                where_clauses.push(clause);
-            }
-        }
-
-        if let Some(cursor_sql) =
-            cursor_filter_sql::<RelatedObjectClosureRow>(&sorts, query_options.cursor.as_deref())?
-        {
-            where_clauses.push(cursor_sql);
-        }
-
-        if !where_clauses.is_empty() {
-            raw_sql.push_str("\nWHERE ");
-            raw_sql.push_str(&where_clauses.join("\n  AND "));
-        }
-
-        let order_by = sorts
-            .iter()
-            .map(order_sql_clause::<RelatedObjectClosureRow>)
-            .collect::<Result<Vec<_>, _>>()?
-            .join(", ");
-        raw_sql.push_str(&format!("\nORDER BY {order_by}"));
-
-        if let Some(limit) = query_options.limit {
-            raw_sql.push_str(&format!("\nLIMIT {limit}"));
-        }
-
-        raw_sql = raw_sql.replace_question_mark_with_indexed_n();
-
-        debug!(
-            message = "Searching source-relative related objects",
-            raw_sql = %raw_sql,
-            bind_variables = ?bind_variables
-        );
-
-        let mut query = sql_query(raw_sql).into_boxed();
-        for bind_var in bind_variables {
-            query = match bind_var {
-                SQLValue::Integer(i) => query.bind::<diesel::sql_types::Integer, _>(i),
-                SQLValue::String(s) => query.bind::<diesel::sql_types::Text, _>(s),
-                SQLValue::Boolean(b) => query.bind::<diesel::sql_types::Bool, _>(b),
-                SQLValue::Float(f) => query.bind::<diesel::sql_types::Float8, _>(f),
-                SQLValue::Date(d) => query.bind::<diesel::sql_types::Timestamp, _>(d),
-            };
-        }
-
-        trace_query!(query, "Searching source-relative related objects");
-
-        with_connection(pool, |conn| {
-            query.get_results::<RelatedObjectClosureRow>(conn)
-        })
+        return Ok(None);
     }
+
+    debug!(
+        message = "Searching object relations related to object",
+        stage = "Namespace IDs",
+        user_id = user.id(),
+        result = "Found namespace IDs",
+        namespace_ids = ?namespace_ids
+    );
+
+    let mut bind_variables = Vec::<SQLValue>::new();
+    bind_variables.push(SQLValue::Integer(object.id()));
+    let related_depth_upper_bound = related_depth_upper_bound(&query_params)?;
+    let namespace_array_sql = sql_integer_array(&namespace_ids, &mut bind_variables);
+    let mut raw_sql = if let Some(max_depth) = related_depth_upper_bound {
+        bind_variables.push(SQLValue::Integer(max_depth));
+        format!(
+            "SELECT * FROM get_bidirectionally_related_objects(?, {namespace_array_sql}, ?) AS related_objects"
+        )
+    } else {
+        format!(
+            "SELECT * FROM get_bidirectionally_related_objects(?, {namespace_array_sql}, NULL) AS related_objects"
+        )
+    };
+
+    let mut where_clauses = Vec::new();
+    for param in &query_params {
+        let clause = build_related_objects_clause(user, pool, param, &mut bind_variables)?;
+        if let Some(clause) = clause {
+            where_clauses.push(clause);
+        }
+    }
+
+    if !where_clauses.is_empty() {
+        raw_sql.push_str("\nWHERE ");
+        raw_sql.push_str(&where_clauses.join("\n  AND "));
+    }
+
+    Ok(Some(RawSqlQuerySpec {
+        sql: raw_sql,
+        bind_variables,
+    }))
 }
 
 fn sql_integer_array(values: &[i32], bind_variables: &mut Vec<SQLValue>) -> String {
@@ -1987,6 +2501,43 @@ impl User {
         Ok(result)
     }
 
+    pub async fn count_users(
+        &self,
+        pool: &DbPool,
+        query_options: QueryOptions,
+    ) -> Result<i64, ApiError> {
+        use crate::schema::users::dsl::{created_at, email, id, updated_at, username, users};
+
+        let query_params = query_options.filters.clone();
+        let mut base_query = users.into_boxed();
+
+        for param in query_params {
+            let operator = param.operator.clone();
+            match param.field {
+                FilterField::Id => numeric_search!(base_query, param, operator, id),
+                FilterField::Name => string_search!(base_query, param, operator, username),
+                FilterField::Username => string_search!(base_query, param, operator, username),
+                FilterField::Email => string_search!(base_query, param, operator, email),
+                FilterField::CreatedAt => date_search!(base_query, param, operator, created_at),
+                FilterField::UpdatedAt => date_search!(base_query, param, operator, updated_at),
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't searchable (or does not exist) for users",
+                        param.field
+                    )));
+                }
+            }
+        }
+
+        with_connection(pool, |conn| {
+            base_query
+                .select(id)
+                .distinct()
+                .count()
+                .get_result::<i64>(conn)
+        })
+    }
+
     pub async fn search_groups(
         &self,
         pool: &DbPool,
@@ -2039,5 +2590,46 @@ impl User {
         })?;
 
         Ok(result)
+    }
+
+    pub async fn count_groups(
+        &self,
+        pool: &DbPool,
+        query_options: QueryOptions,
+    ) -> Result<i64, ApiError> {
+        use crate::schema::groups::dsl::{
+            created_at, description, groupname, groups, id, updated_at,
+        };
+
+        let query_params = query_options.filters.clone();
+        let mut base_query = groups.into_boxed();
+
+        for param in query_params {
+            let operator = param.operator.clone();
+            match param.field {
+                FilterField::Id => numeric_search!(base_query, param, operator, id),
+                FilterField::Name => string_search!(base_query, param, operator, groupname),
+                FilterField::Groupname => string_search!(base_query, param, operator, groupname),
+                FilterField::Description => {
+                    string_search!(base_query, param, operator, description)
+                }
+                FilterField::CreatedAt => date_search!(base_query, param, operator, created_at),
+                FilterField::UpdatedAt => date_search!(base_query, param, operator, updated_at),
+                _ => {
+                    return Err(ApiError::BadRequest(format!(
+                        "Field '{}' isn't searchable (or does not exist) for groups",
+                        param.field
+                    )));
+                }
+            }
+        }
+
+        with_connection(pool, |conn| {
+            base_query
+                .select(id)
+                .distinct()
+                .count()
+                .get_result::<i64>(conn)
+        })
     }
 }

--- a/src/models/group.rs
+++ b/src/models/group.rs
@@ -96,6 +96,18 @@ impl Group {
             .await
     }
 
+    pub async fn count_members_paginated<C>(
+        &self,
+        backend: &C,
+        query_options: &QueryOptions,
+    ) -> Result<i64, ApiError>
+    where
+        C: BackendContext + ?Sized,
+    {
+        self.count_group_members_paginated(backend.db_pool(), query_options)
+            .await
+    }
+
     /// Add a member to a group. If the user is already a member, do nothing.
     ///
     /// ## Arguments

--- a/src/models/namespace.rs
+++ b/src/models/namespace.rs
@@ -110,17 +110,17 @@ where
     namespace_backend::user_on_from_backend(backend.db_pool(), user_id, namespace_ref).await
 }
 
-pub async fn user_on_paginated<C, T>(
+pub async fn user_on_paginated_with_total_count<C, T>(
     backend: &C,
     user_id: UserID,
     namespace_ref: T,
     query_options: &QueryOptions,
-) -> Result<Vec<GroupPermission>, ApiError>
+) -> Result<(Vec<GroupPermission>, i64), ApiError>
 where
     C: BackendContext + ?Sized,
     T: NamespaceAccessors,
 {
-    namespace_backend::user_on_paginated_from_backend(
+    namespace_backend::user_on_paginated_with_total_count_from_backend(
         backend.db_pool(),
         user_id,
         namespace_ref,
@@ -206,16 +206,16 @@ where
     namespace_backend::groups_can_on_from_backend(backend.db_pool(), nid, permission_type).await
 }
 
-pub async fn groups_can_on_paginated<C>(
+pub async fn groups_can_on_paginated_with_total_count<C>(
     backend: &C,
     nid: i32,
     permission_type: Permissions,
     query_options: &QueryOptions,
-) -> Result<Vec<Group>, ApiError>
+) -> Result<(Vec<Group>, i64), ApiError>
 where
     C: BackendContext + ?Sized,
 {
-    namespace_backend::groups_can_on_paginated_from_backend(
+    namespace_backend::groups_can_on_paginated_with_total_count_from_backend(
         backend.db_pool(),
         nid,
         permission_type,
@@ -264,6 +264,44 @@ where
     T: NamespaceAccessors,
 {
     namespace_backend::groups_on_paginated_from_backend(
+        backend.db_pool(),
+        namespace_ref,
+        permissions_filter,
+        query_options,
+    )
+    .await
+}
+
+pub async fn groups_on_paginated_with_total_count<C, T>(
+    backend: &C,
+    namespace_ref: T,
+    permissions_filter: Vec<Permissions>,
+    query_options: &QueryOptions,
+) -> Result<(Vec<GroupPermission>, i64), ApiError>
+where
+    C: BackendContext + ?Sized,
+    T: NamespaceAccessors,
+{
+    namespace_backend::groups_on_paginated_with_total_count_from_backend(
+        backend.db_pool(),
+        namespace_ref,
+        permissions_filter,
+        query_options,
+    )
+    .await
+}
+
+pub async fn count_groups_on_paginated<C, T>(
+    backend: &C,
+    namespace_ref: T,
+    permissions_filter: Vec<Permissions>,
+    query_options: &QueryOptions,
+) -> Result<i64, ApiError>
+where
+    C: BackendContext + ?Sized,
+    T: NamespaceAccessors,
+{
+    namespace_backend::count_groups_on_paginated_from_backend(
         backend.db_pool(),
         namespace_ref,
         permissions_filter,

--- a/src/models/report_template.rs
+++ b/src/models/report_template.rs
@@ -216,17 +216,18 @@ pub async fn delete_report_template(pool: &DbPool, template_id: i32) -> Result<(
     Ok(())
 }
 
-pub async fn list_report_templates(
-    pool: &DbPool,
-    allowed_namespace_ids: &[i32],
-    query_options: &QueryOptions,
-) -> Result<Vec<ReportTemplate>, ApiError> {
+fn build_report_template_query<'a>(
+    allowed_namespace_ids: &'a [i32],
+    query_options: &'a QueryOptions,
+) -> Result<crate::schema::report_templates::BoxedQuery<'a, diesel::pg::Pg>, ApiError> {
     use crate::schema::report_templates::dsl::{
         created_at, description, id, name, namespace_id, report_templates, updated_at,
     };
 
     if allowed_namespace_ids.is_empty() {
-        return Ok(Vec::new());
+        return Ok(report_templates
+            .into_boxed()
+            .filter(namespace_id.eq_any(allowed_namespace_ids)));
     }
 
     let mut query = report_templates
@@ -253,11 +254,31 @@ pub async fn list_report_templates(
         }
     }
 
-    crate::apply_query_options!(query, query_options, ReportTemplate);
+    Ok(query)
+}
 
+pub async fn list_report_templates_with_total_count(
+    pool: &DbPool,
+    allowed_namespace_ids: &[i32],
+    query_options: &QueryOptions,
+) -> Result<(Vec<ReportTemplate>, i64), ApiError> {
+    if allowed_namespace_ids.is_empty() {
+        return Ok((Vec::new(), 0));
+    }
+
+    let query = build_report_template_query(allowed_namespace_ids, query_options)?;
+    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
+
+    let mut query = build_report_template_query(allowed_namespace_ids, query_options)?;
+    crate::apply_query_options!(query, query_options, ReportTemplate);
     let rows = with_connection(pool, |conn| query.load::<ReportTemplateRow>(conn))?;
 
-    rows.into_iter().map(TryInto::try_into).collect()
+    let items = rows
+        .into_iter()
+        .map(TryInto::try_into)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok((items, total_count))
 }
 
 impl IdAccessor for ReportTemplate {

--- a/src/models/traits/user.rs
+++ b/src/models/traits/user.rs
@@ -36,6 +36,18 @@ pub trait Search: SelfAccessors<User> + UserNamespaceAccessors {
             .await
     }
 
+    async fn count_namespaces<C>(
+        &self,
+        backend: &C,
+        query_options: QueryOptions,
+    ) -> Result<i64, ApiError>
+    where
+        C: BackendContext + ?Sized,
+    {
+        self.count_namespaces_from_backend(backend.db_pool(), query_options)
+            .await
+    }
+
     async fn search_classes<C>(
         &self,
         backend: &C,
@@ -45,6 +57,18 @@ pub trait Search: SelfAccessors<User> + UserNamespaceAccessors {
         C: BackendContext + ?Sized,
     {
         self.search_classes_from_backend(backend.db_pool(), query_options)
+            .await
+    }
+
+    async fn count_classes<C>(
+        &self,
+        backend: &C,
+        query_options: QueryOptions,
+    ) -> Result<i64, ApiError>
+    where
+        C: BackendContext + ?Sized,
+    {
+        self.count_classes_from_backend(backend.db_pool(), query_options)
             .await
     }
 
@@ -60,6 +84,18 @@ pub trait Search: SelfAccessors<User> + UserNamespaceAccessors {
             .await
     }
 
+    async fn count_objects<C>(
+        &self,
+        backend: &C,
+        query_options: QueryOptions,
+    ) -> Result<i64, ApiError>
+    where
+        C: BackendContext + ?Sized,
+    {
+        self.count_objects_from_backend(backend.db_pool(), query_options)
+            .await
+    }
+
     async fn search_class_relations<C>(
         &self,
         backend: &C,
@@ -69,6 +105,18 @@ pub trait Search: SelfAccessors<User> + UserNamespaceAccessors {
         C: BackendContext + ?Sized,
     {
         self.search_class_relations_from_backend(backend.db_pool(), query_options)
+            .await
+    }
+
+    async fn class_relations_page<C>(
+        &self,
+        backend: &C,
+        query_options: QueryOptions,
+    ) -> Result<(Vec<HubuumClassRelation>, i64), ApiError>
+    where
+        C: BackendContext + ?Sized,
+    {
+        self.class_relations_page_from_backend(backend.db_pool(), query_options)
             .await
     }
 
@@ -86,17 +134,31 @@ pub trait Search: SelfAccessors<User> + UserNamespaceAccessors {
             .await
     }
 
-    async fn search_class_relations_touching<C, K>(
+    async fn classes_related_to_page<C, K>(
         &self,
         backend: &C,
         class: K,
         query_options: QueryOptions,
-    ) -> Result<Vec<HubuumClassRelation>, ApiError>
+    ) -> Result<(Vec<ClassClosureRow>, i64), ApiError>
     where
         C: BackendContext + ?Sized,
         K: SelfAccessors<HubuumClass>,
     {
-        self.search_class_relations_touching_from_backend(backend.db_pool(), class, query_options)
+        self.classes_related_to_page_from_backend(backend.db_pool(), class, query_options)
+            .await
+    }
+
+    async fn class_relations_touching_page<C, K>(
+        &self,
+        backend: &C,
+        class: K,
+        query_options: QueryOptions,
+    ) -> Result<(Vec<HubuumClassRelation>, i64), ApiError>
+    where
+        C: BackendContext + ?Sized,
+        K: SelfAccessors<HubuumClass>,
+    {
+        self.class_relations_touching_page_from_backend(backend.db_pool(), class, query_options)
             .await
     }
 
@@ -124,6 +186,18 @@ pub trait Search: SelfAccessors<User> + UserNamespaceAccessors {
             .await
     }
 
+    async fn object_relations_page<C>(
+        &self,
+        backend: &C,
+        query_options: QueryOptions,
+    ) -> Result<(Vec<HubuumObjectRelation>, i64), ApiError>
+    where
+        C: BackendContext + ?Sized,
+    {
+        self.object_relations_page_from_backend(backend.db_pool(), query_options)
+            .await
+    }
+
     async fn search_objects_related_to<C, O>(
         &self,
         backend: &C,
@@ -138,17 +212,31 @@ pub trait Search: SelfAccessors<User> + UserNamespaceAccessors {
             .await
     }
 
-    async fn search_object_relations_touching<C, O>(
+    async fn objects_related_to_page<C, O>(
         &self,
         backend: &C,
         object: O,
         query_options: QueryOptions,
-    ) -> Result<Vec<HubuumObjectRelation>, ApiError>
+    ) -> Result<(Vec<RelatedObjectClosureRow>, i64), ApiError>
+    where
+        C: BackendContext + ?Sized,
+        O: SelfAccessors<HubuumObject> + ClassAccessors,
+    {
+        self.objects_related_to_page_from_backend(backend.db_pool(), object, query_options)
+            .await
+    }
+
+    async fn object_relations_touching_page<C, O>(
+        &self,
+        backend: &C,
+        object: O,
+        query_options: QueryOptions,
+    ) -> Result<(Vec<HubuumObjectRelation>, i64), ApiError>
     where
         C: BackendContext + ?Sized,
         O: SelfAccessors<HubuumObject>,
     {
-        self.search_object_relations_touching_from_backend(backend.db_pool(), object, query_options)
+        self.object_relations_touching_page_from_backend(backend.db_pool(), object, query_options)
             .await
     }
 
@@ -213,15 +301,15 @@ pub trait GroupAccessors: SelfAccessors<User> {
     }
 
     #[allow(async_fn_in_trait)]
-    async fn groups_paginated<C>(
+    async fn groups_paginated_with_total_count<C>(
         &self,
         backend: &C,
         query_options: &QueryOptions,
-    ) -> Result<Vec<Group>, ApiError>
+    ) -> Result<(Vec<Group>, i64), ApiError>
     where
         C: BackendContext + ?Sized,
     {
-        self.load_user_groups_paginated(backend.db_pool(), query_options)
+        self.load_user_groups_paginated_with_total_count(backend.db_pool(), query_options)
             .await
     }
 

--- a/src/pagination/mod.rs
+++ b/src/pagination/mod.rs
@@ -11,6 +11,7 @@ pub use crate::traits::pagination::{
 };
 
 pub const NEXT_CURSOR_HEADER: &str = "X-Next-Cursor";
+pub const TOTAL_COUNT_HEADER: &str = "X-Total-Count";
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CursorPageRequest {
@@ -81,6 +82,14 @@ where
     Ok(prepared)
 }
 
+pub fn count_query_options(query_options: &QueryOptions) -> QueryOptions {
+    let mut prepared = query_options.clone();
+    prepared.sort.clear();
+    prepared.limit = None;
+    prepared.cursor = None;
+    prepared
+}
+
 pub fn finalize_page<T>(
     mut items: Vec<T>,
     query_options: &QueryOptions,
@@ -106,12 +115,16 @@ where
     Ok(Page { items, next_cursor })
 }
 
-pub fn next_cursor_header(next_cursor: &Option<String>) -> Option<HashMap<String, String>> {
-    next_cursor.as_ref().map(|cursor| {
-        let mut headers = HashMap::new();
+pub fn pagination_headers(
+    next_cursor: &Option<String>,
+    total_count: i64,
+) -> HashMap<String, String> {
+    let mut headers = HashMap::new();
+    headers.insert(TOTAL_COUNT_HEADER.to_string(), total_count.to_string());
+    if let Some(cursor) = next_cursor.as_ref() {
         headers.insert(NEXT_CURSOR_HEADER.to_string(), cursor.clone());
-        headers
-    })
+    }
+    headers
 }
 
 pub fn page_request<T>(query_options: &QueryOptions) -> Result<CursorPageRequest, ApiError>

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -20,7 +20,7 @@ use super::types::{
 use super::worker::{background_worker_action, mark_claimed_task_failed, process_one_task};
 use crate::db::traits::task::{
     count_import_results_summary, create_task_record, find_task_record, insert_import_results,
-    list_task_events,
+    list_task_events_with_total_count,
 };
 use crate::db::traits::task_import::{create_class_db, create_object_db};
 use crate::db::with_connection;
@@ -335,7 +335,7 @@ fn test_process_one_task_marks_claimed_task_failed_when_execution_setup_errors()
             assert!(stored.finished_at.is_some());
             assert!(stored.request_redacted_at.is_some());
 
-            let events = block_on(list_task_events(
+            let (events, _) = block_on(list_task_events_with_total_count(
                 &context.pool,
                 task.id,
                 &crate::models::search::QueryOptions {

--- a/src/tests/api/v1/classes.rs
+++ b/src/tests/api/v1/classes.rs
@@ -6,7 +6,7 @@ pub mod tests {
 
     use rstest::rstest;
 
-    use crate::pagination::NEXT_CURSOR_HEADER;
+    use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER};
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
     use crate::tests::asserts::{assert_response_status, header_value};
     use crate::tests::constants::{SchemaType, get_schema};
@@ -541,11 +541,14 @@ pub mod tests {
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
         let next_cursor = header_value(&resp, NEXT_CURSOR_HEADER);
+        let total_count =
+            header_value(&resp, TOTAL_COUNT_HEADER).and_then(|value| value.parse::<i64>().ok());
         let classes: Vec<HubuumClassExpanded> = test::read_body_json(resp).await;
 
         assert_eq!(classes.len(), 2);
         assert_eq!(classes[0].id, created_classes[0].id);
         assert_eq!(classes[1].id, created_classes[1].id);
+        assert_eq!(total_count, Some(6));
         assert!(next_cursor.is_some());
 
         let resp = get_request(
@@ -559,11 +562,14 @@ pub mod tests {
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
         let second_cursor = header_value(&resp, NEXT_CURSOR_HEADER);
+        let second_total_count =
+            header_value(&resp, TOTAL_COUNT_HEADER).and_then(|value| value.parse::<i64>().ok());
         let classes: Vec<HubuumClassExpanded> = test::read_body_json(resp).await;
 
         assert_eq!(classes.len(), 2);
         assert_eq!(classes[0].id, created_classes[2].id);
         assert_eq!(classes[1].id, created_classes[3].id);
+        assert_eq!(second_total_count, Some(6));
         assert!(second_cursor.is_some());
 
         let resp = get_request(
@@ -577,11 +583,14 @@ pub mod tests {
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
         let final_cursor = header_value(&resp, NEXT_CURSOR_HEADER);
+        let final_total_count =
+            header_value(&resp, TOTAL_COUNT_HEADER).and_then(|value| value.parse::<i64>().ok());
         let classes: Vec<HubuumClassExpanded> = test::read_body_json(resp).await;
 
         assert_eq!(classes.len(), 2);
         assert_eq!(classes[0].id, created_classes[4].id);
         assert_eq!(classes[1].id, created_classes[5].id);
+        assert_eq!(final_total_count, Some(6));
         assert!(final_cursor.is_none());
 
         cleanup(&created_classes).await;

--- a/src/tests/api/v1/imports.rs
+++ b/src/tests/api/v1/imports.rs
@@ -16,7 +16,7 @@ mod tests {
         ImportPermissionPolicy, ImportRequest, ImportTaskResultResponse, NamespaceKey,
         NewTaskRecord, Permissions, TaskEventResponse, TaskKind, TaskResponse, TaskStatus,
     };
-    use crate::pagination::NEXT_CURSOR_HEADER;
+    use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER};
     use crate::schema::hubuumclass::dsl::{hubuumclass, name as class_name_col, namespace_id};
     use crate::schema::namespaces::dsl::{
         description as namespace_description, id as namespace_id_field, namespaces,
@@ -602,8 +602,11 @@ mod tests {
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
         let next_cursor = header_value(&resp, NEXT_CURSOR_HEADER);
+        let first_event_total =
+            header_value(&resp, TOTAL_COUNT_HEADER).and_then(|value| value.parse::<i64>().ok());
         let first_events: Vec<TaskEventResponse> = test::read_body_json(resp).await;
         assert_eq!(first_events.len(), 2);
+        assert!(first_event_total.unwrap_or_default() >= first_events.len() as i64);
         assert!(next_cursor.is_some());
 
         let resp = get_request(
@@ -617,7 +620,10 @@ mod tests {
         )
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
+        let second_event_total =
+            header_value(&resp, TOTAL_COUNT_HEADER).and_then(|value| value.parse::<i64>().ok());
         let second_events: Vec<TaskEventResponse> = test::read_body_json(resp).await;
+        assert_eq!(second_event_total, first_event_total);
         assert!(!second_events.is_empty());
         assert!(second_events[0].id > first_events.last().unwrap().id);
 
@@ -629,8 +635,11 @@ mod tests {
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
         let next_cursor = header_value(&resp, NEXT_CURSOR_HEADER);
+        let first_result_total =
+            header_value(&resp, TOTAL_COUNT_HEADER).and_then(|value| value.parse::<i64>().ok());
         let first_results: Vec<ImportTaskResultResponse> = test::read_body_json(resp).await;
         assert_eq!(first_results.len(), 2);
+        assert!(first_result_total.unwrap_or_default() >= first_results.len() as i64);
         assert!(next_cursor.is_some());
 
         let resp = get_request(
@@ -644,7 +653,10 @@ mod tests {
         )
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
+        let second_result_total =
+            header_value(&resp, TOTAL_COUNT_HEADER).and_then(|value| value.parse::<i64>().ok());
         let second_results: Vec<ImportTaskResultResponse> = test::read_body_json(resp).await;
+        assert_eq!(second_result_total, first_result_total);
         assert!(!second_results.is_empty());
         assert!(second_results[0].id > first_results.last().unwrap().id);
     }

--- a/src/tests/api/v1/namespaces.rs
+++ b/src/tests/api/v1/namespaces.rs
@@ -1,16 +1,17 @@
 #[cfg(test)]
 mod tests {
     use crate::models::{
-        GroupPermission, Namespace, NewGroup, NewNamespaceWithAssignee, Permission, Permissions,
-        UpdateNamespace,
+        Group, GroupPermission, Namespace, NewGroup, NewNamespaceWithAssignee, Permission,
+        Permissions, UpdateNamespace,
     };
 
     use crate::pagination::NEXT_CURSOR_HEADER;
     use crate::tests::api_operations::{
         delete_request, get_request, patch_request, post_request, put_request,
     };
-    use crate::tests::asserts::assert_response_status;
-    use crate::tests::asserts::header_value;
+    use crate::tests::asserts::{
+        assert_paginated_collection_total_count, assert_response_status, header_value,
+    };
     use crate::tests::{
         NamespaceFixture, TestContext, create_test_group, create_test_user, ensure_admin_group,
         test_context,
@@ -587,6 +588,114 @@ mod tests {
 
         group_one.delete(&context.pool).await.unwrap();
         group_two.delete(&context.pool).await.unwrap();
+        ns.cleanup().await.unwrap();
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_namespace_permission_listings_total_count_match_paginated_results(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let ns = context
+            .namespace_fixture("namespace_permissions_total_count")
+            .await;
+        let group_one = NewGroup {
+            groupname: format!("ns-total-count-group-a-{}", ns.namespace.id),
+            description: Some("group a".to_string()),
+        }
+        .save(&context.pool)
+        .await
+        .unwrap();
+        let group_two = NewGroup {
+            groupname: format!("ns-total-count-group-b-{}", ns.namespace.id),
+            description: Some("group b".to_string()),
+        }
+        .save(&context.pool)
+        .await
+        .unwrap();
+        let group_three = NewGroup {
+            groupname: format!("ns-total-count-group-c-{}", ns.namespace.id),
+            description: Some("group c".to_string()),
+        }
+        .save(&context.pool)
+        .await
+        .unwrap();
+        let user = create_test_user(&context.pool).await;
+
+        group_one.add_member(&context.pool, &user).await.unwrap();
+        group_two.add_member(&context.pool, &user).await.unwrap();
+
+        for group in [&group_one, &group_two, &group_three] {
+            ns.namespace
+                .grant_one(&context.pool, group.id, Permissions::ReadCollection)
+                .await
+                .unwrap();
+        }
+
+        let (permissions, permissions_total): (Vec<GroupPermission>, i64) =
+            assert_paginated_collection_total_count(
+            &context.pool,
+            &context.admin_token,
+            10,
+            |cursor| match cursor {
+                Some(cursor) => format!(
+                    "{NAMESPACE_ENDPOINT}/{}/permissions?permissions=ReadCollection&groupname__contains=ns-total-count-group&sort=id&limit=2&cursor={cursor}",
+                    ns.namespace.id
+                ),
+                None => format!(
+                    "{NAMESPACE_ENDPOINT}/{}/permissions?permissions=ReadCollection&groupname__contains=ns-total-count-group&sort=id&limit=2",
+                    ns.namespace.id
+                ),
+            },
+        )
+        .await;
+        assert_eq!(permissions_total, 3);
+        assert_eq!(permissions.len(), 3);
+
+        let (user_permissions, user_permissions_total): (Vec<GroupPermission>, i64) =
+            assert_paginated_collection_total_count(
+            &context.pool,
+            &context.admin_token,
+            10,
+            |cursor| match cursor {
+                Some(cursor) => format!(
+                    "{NAMESPACE_ENDPOINT}/{}/permissions/user/{}?sort=id&limit=1&cursor={cursor}",
+                    ns.namespace.id, user.id
+                ),
+                None => format!(
+                    "{NAMESPACE_ENDPOINT}/{}/permissions/user/{}?sort=id&limit=1",
+                    ns.namespace.id, user.id
+                ),
+            },
+        )
+        .await;
+        assert_eq!(user_permissions_total, 2);
+        assert_eq!(user_permissions.len(), 2);
+
+        let (groups, groups_total): (Vec<Group>, i64) = assert_paginated_collection_total_count(
+            &context.pool,
+            &context.admin_token,
+            10,
+            |cursor| match cursor {
+                Some(cursor) => format!(
+                    "{NAMESPACE_ENDPOINT}/{}/has_permissions/ReadCollection?groupname__contains=ns-total-count-group&sort=id&limit=2&cursor={cursor}",
+                    ns.namespace.id
+                ),
+                None => format!(
+                    "{NAMESPACE_ENDPOINT}/{}/has_permissions/ReadCollection?groupname__contains=ns-total-count-group&sort=id&limit=2",
+                    ns.namespace.id
+                ),
+            },
+        )
+        .await;
+        assert_eq!(groups_total, 3);
+        assert_eq!(groups.len(), 3);
+
+        group_one.delete(&context.pool).await.unwrap();
+        group_two.delete(&context.pool).await.unwrap();
+        group_three.delete(&context.pool).await.unwrap();
+        user.delete(&context.pool).await.unwrap();
         ns.cleanup().await.unwrap();
     }
 

--- a/src/tests/api/v1/relations.rs
+++ b/src/tests/api/v1/relations.rs
@@ -15,7 +15,9 @@ mod tests {
     use crate::{assert_contains_all, assert_contains_same_ids};
 
     use crate::tests::api_operations::{delete_request, get_request, post_request};
-    use crate::tests::asserts::{assert_response_status, header_value};
+    use crate::tests::asserts::{
+        assert_paginated_collection_total_count, assert_response_status, header_value,
+    };
     use crate::tests::{
         ClassFixture, TestContext, create_class_fixture, create_test_group, ensure_normal_user,
         test_context,
@@ -321,6 +323,72 @@ mod tests {
         let resp = assert_response_status(resp, StatusCode::OK).await;
         let relations: Vec<HubuumClassRelation> = test::read_body_json(resp).await;
         assert!(!relations.is_empty());
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_related_classes_total_count_stays_constant_across_pages(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let (classes, _relations) =
+            create_classes_and_relations(&context, "related_classes_total_count").await;
+        let (related_classes, total_count): (Vec<HubuumClassWithPath>, i64) =
+            assert_paginated_collection_total_count(
+                &context.pool,
+                &context.admin_token,
+                10,
+                |cursor| match cursor {
+                    Some(cursor) => format!(
+                        "{}?sort=class_id&limit=2&cursor={cursor}",
+                        related_classes_endpoint(classes[0].id)
+                    ),
+                    None => format!(
+                        "{}?sort=class_id&limit=2",
+                        related_classes_endpoint(classes[0].id)
+                    ),
+                },
+            )
+            .await;
+
+        assert_eq!(total_count, 5);
+        assert_eq!(related_classes.len(), 5);
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_class_relations_total_count_matches_paginated_results(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let (classes, _relations) =
+            create_classes_and_relations(&context, "class_relations_total_count").await;
+        let class_ids = classes
+            .iter()
+            .map(|class| class.id.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let (relations, total_count): (Vec<HubuumClassRelation>, i64) =
+            assert_paginated_collection_total_count(
+            &context.pool,
+            &context.admin_token,
+            10,
+            |cursor| match cursor {
+                Some(cursor) => format!(
+                    "{CLASS_RELATIONS_ENDPOINT}?from_classes={class_ids}&sort=id&limit=2&cursor={cursor}"
+                ),
+                None => format!("{CLASS_RELATIONS_ENDPOINT}?from_classes={class_ids}&sort=id&limit=2"),
+            },
+        )
+        .await;
+
+        assert_eq!(total_count, 5);
+        assert_eq!(relations.len(), 5);
 
         cleanup(&classes).await;
     }
@@ -935,6 +1003,48 @@ mod tests {
         cleanup(&classes).await;
     }
 
+    #[rstest]
+    #[actix_web::test]
+    async fn test_object_relations_total_count_matches_paginated_results(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let (classes, class_relations) =
+            create_classes_and_relations(&context, "object_relations_total_count").await;
+        let objects = create_objects_in_classes(&context.pool, &classes).await;
+
+        create_object_relation(&context.pool, &objects[0], &objects[1], &class_relations[0]).await;
+        create_object_relation(&context.pool, &objects[1], &objects[2], &class_relations[1]).await;
+        create_object_relation(&context.pool, &objects[2], &objects[3], &class_relations[2]).await;
+
+        let class_relation_ids = class_relations[0..3]
+            .iter()
+            .map(|relation| relation.id.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let (relations, total_count): (Vec<HubuumObjectRelation>, i64) =
+            assert_paginated_collection_total_count(
+            &context.pool,
+            &context.admin_token,
+            10,
+            |cursor| match cursor {
+                Some(cursor) => format!(
+                    "{OBJECT_RELATIONS_ENDPOINT}?class_relation={class_relation_ids}&sort=id&limit=2&cursor={cursor}"
+                ),
+                None => format!(
+                    "{OBJECT_RELATIONS_ENDPOINT}?class_relation={class_relation_ids}&sort=id&limit=2"
+                ),
+            },
+        )
+        .await;
+
+        assert_eq!(total_count, 3);
+        assert_eq!(relations.len(), 3);
+
+        cleanup(&classes).await;
+    }
+
     // class_idx object_idx, expected_code, filter, expected_object_ids
     // TODO: Add tests against _classes / _namespaces / _object
     // Note that <int> in the filter will be replaced with the object id with that index.
@@ -1142,6 +1252,117 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(fetched_ids, vec![relation_12.id, relation_15.id]);
         assert!(!fetched_ids.contains(&relation_23.id));
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_related_class_relations_total_count_matches_paginated_results(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let (classes, _relations) =
+            create_classes_and_relations(&context, "related_class_relations_total_count").await;
+
+        let (relations, total_count): (Vec<HubuumClassRelation>, i64) =
+            assert_paginated_collection_total_count(
+                &context.pool,
+                &context.admin_token,
+                10,
+                |cursor| match cursor {
+                    Some(cursor) => format!(
+                        "{}?sort=id&limit=1&cursor={cursor}",
+                        related_class_relations_endpoint(classes[2].id)
+                    ),
+                    None => format!(
+                        "{}?sort=id&limit=1",
+                        related_class_relations_endpoint(classes[2].id)
+                    ),
+                },
+            )
+            .await;
+
+        assert_eq!(total_count, 2);
+        assert_eq!(relations.len(), 2);
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_related_object_relations_total_count_matches_paginated_results(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let (classes, relations) =
+            create_classes_and_relations(&context, "related_object_relations_total_count").await;
+        let objects = create_objects_in_classes(&context.pool, &classes).await;
+
+        create_object_relation(&context.pool, &objects[0], &objects[1], &relations[0]).await;
+        create_object_relation(&context.pool, &objects[1], &objects[2], &relations[1]).await;
+        let class_relation_15 = create_relation(&context.pool, &classes[0], &classes[4]).await;
+        create_object_relation(&context.pool, &objects[0], &objects[4], &class_relation_15).await;
+
+        let (object_relations, total_count): (Vec<HubuumObjectRelation>, i64) =
+            assert_paginated_collection_total_count(
+                &context.pool,
+                &context.admin_token,
+                10,
+                |cursor| match cursor {
+                    Some(cursor) => format!(
+                        "{}?sort=id&limit=1&cursor={cursor}",
+                        related_relations_endpoint(classes[0].id, objects[0].id)
+                    ),
+                    None => format!(
+                        "{}?sort=id&limit=1",
+                        related_relations_endpoint(classes[0].id, objects[0].id)
+                    ),
+                },
+            )
+            .await;
+
+        assert_eq!(total_count, 2);
+        assert_eq!(object_relations.len(), 2);
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_related_objects_total_count_matches_paginated_results(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let (classes, relations) =
+            create_classes_and_relations(&context, "related_objects_total_count").await;
+        let objects = create_objects_in_classes(&context.pool, &classes).await;
+
+        create_object_relation(&context.pool, &objects[0], &objects[1], &relations[0]).await;
+        create_object_relation(&context.pool, &objects[1], &objects[2], &relations[1]).await;
+        let class_relation_15 = create_relation(&context.pool, &classes[0], &classes[4]).await;
+        create_object_relation(&context.pool, &objects[0], &objects[4], &class_relation_15).await;
+
+        let (related_objects, total_count): (Vec<HubuumObjectWithPath>, i64) =
+            assert_paginated_collection_total_count(
+                &context.pool,
+                &context.admin_token,
+                10,
+                |cursor| match cursor {
+                    Some(cursor) => format!(
+                        "{}?sort=id&limit=2&cursor={cursor}",
+                        related_objects_endpoint(classes[0].id, objects[0].id)
+                    ),
+                    None => format!(
+                        "{}?sort=id&limit=2",
+                        related_objects_endpoint(classes[0].id, objects[0].id)
+                    ),
+                },
+            )
+            .await;
+
+        assert_eq!(total_count, 3);
+        assert_eq!(related_objects.len(), 3);
 
         cleanup(&classes).await;
     }

--- a/src/tests/api/v1/tasks.rs
+++ b/src/tests/api/v1/tasks.rs
@@ -8,7 +8,9 @@ mod tests {
     use crate::models::{NewTaskRecord, TaskKind, TaskResponse, TaskStatus};
     use crate::pagination::NEXT_CURSOR_HEADER;
     use crate::tests::api_operations::get_request;
-    use crate::tests::asserts::{assert_response_status, header_value};
+    use crate::tests::asserts::{
+        assert_paginated_collection_total_count, assert_response_status, header_value,
+    };
     use crate::tests::{TestContext, create_test_user, test_context};
 
     const TASKS_ENDPOINT: &str = "/api/v1/tasks";
@@ -279,5 +281,64 @@ mod tests {
         let ids = tasks.iter().map(|task| task.id).collect::<Vec<_>>();
 
         assert_eq!(ids, vec![import_id, report_id_two, report_id_one]);
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_list_tasks_total_count_matches_paginated_results(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let other_user = create_test_user(&context.pool).await;
+
+        let expected_ids = vec![
+            create_synthetic_task(
+                &context,
+                other_user.id,
+                TaskKind::Import,
+                TaskStatus::Succeeded,
+                "tasks_total_count_one",
+            )
+            .await,
+            create_synthetic_task(
+                &context,
+                other_user.id,
+                TaskKind::Import,
+                TaskStatus::Succeeded,
+                "tasks_total_count_two",
+            )
+            .await,
+            create_synthetic_task(
+                &context,
+                other_user.id,
+                TaskKind::Import,
+                TaskStatus::Succeeded,
+                "tasks_total_count_three",
+            )
+            .await,
+        ];
+
+        let (tasks, total_count): (Vec<TaskResponse>, i64) = assert_paginated_collection_total_count(
+            &context.pool,
+            &context.admin_token,
+            10,
+            |cursor| match cursor {
+                Some(cursor) => format!(
+                    "{TASKS_ENDPOINT}?submitted_by={}&kind=import&status=succeeded&sort=id&limit=2&cursor={cursor}",
+                    other_user.id
+                ),
+                None => format!(
+                    "{TASKS_ENDPOINT}?submitted_by={}&kind=import&status=succeeded&sort=id&limit=2",
+                    other_user.id
+                ),
+            },
+        )
+        .await;
+
+        assert_eq!(total_count, expected_ids.len() as i64);
+        assert_eq!(
+            tasks.iter().map(|task| task.id).collect::<Vec<_>>(),
+            expected_ids
+        );
     }
 }

--- a/src/tests/api/v1/templates.rs
+++ b/src/tests/api/v1/templates.rs
@@ -7,7 +7,7 @@ mod tests {
         ReportContentType, ReportTemplate, UpdateReportTemplate,
     };
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
-    use crate::tests::asserts::assert_response_status;
+    use crate::tests::asserts::{assert_paginated_collection_total_count, assert_response_status};
     use crate::tests::{
         create_test_group, create_test_user, ensure_admin_group, setup_pool_and_tokens,
     };
@@ -113,6 +113,72 @@ mod tests {
         )
         .await;
         assert_response_status(resp, StatusCode::NOT_FOUND).await;
+
+        namespace.delete(&pool).await.unwrap();
+    }
+
+    #[actix_web::test]
+    async fn test_template_list_total_count_matches_paginated_results() {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let namespace = create_namespace(&pool, "pagination").await;
+
+        let expected_ids = vec![
+            post_request(
+                &pool,
+                &admin_token,
+                TEMPLATES_ENDPOINT,
+                &new_template_payload(namespace.id, "tmpl-page-a"),
+            )
+            .await,
+            post_request(
+                &pool,
+                &admin_token,
+                TEMPLATES_ENDPOINT,
+                &new_template_payload(namespace.id, "tmpl-page-b"),
+            )
+            .await,
+            post_request(
+                &pool,
+                &admin_token,
+                TEMPLATES_ENDPOINT,
+                &new_template_payload(namespace.id, "tmpl-page-c"),
+            )
+            .await,
+        ];
+
+        let mut created_ids = Vec::new();
+        for resp in expected_ids {
+            let resp = assert_response_status(resp, StatusCode::CREATED).await;
+            let created: ReportTemplate = test::read_body_json(resp).await;
+            created_ids.push(created.id);
+        }
+
+        let (templates, total_count): (Vec<ReportTemplate>, i64) =
+            assert_paginated_collection_total_count(
+                &pool,
+                &admin_token,
+                10,
+                |cursor| match cursor {
+                    Some(cursor) => format!(
+                        "{TEMPLATES_ENDPOINT}?namespace_id={}&sort=id&limit=2&cursor={cursor}",
+                        namespace.id
+                    ),
+                    None => format!(
+                        "{TEMPLATES_ENDPOINT}?namespace_id={}&sort=id&limit=2",
+                        namespace.id
+                    ),
+                },
+            )
+            .await;
+
+        assert_eq!(total_count, created_ids.len() as i64);
+        assert_eq!(
+            templates
+                .iter()
+                .map(|template| template.id)
+                .collect::<Vec<_>>(),
+            created_ids
+        );
 
         namespace.delete(&pool).await.unwrap();
     }

--- a/src/tests/api/v1/users.rs
+++ b/src/tests/api/v1/users.rs
@@ -1,15 +1,17 @@
 #[cfg(test)]
 mod tests {
     use crate::db::traits::ActiveTokens;
-    use crate::models::Token;
     use crate::models::group::NewGroup;
     use crate::models::user::{NewUser, UpdateUser, User};
+    use crate::models::{Group, Token, UserTokenMetadata};
     use crate::pagination::NEXT_CURSOR_HEADER;
     use actix_web::{http::StatusCode, test};
     use rstest::rstest;
 
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
-    use crate::tests::asserts::{assert_response_status, header_value};
+    use crate::tests::asserts::{
+        assert_paginated_collection_total_count, assert_response_status, header_value,
+    };
     use crate::tests::{TestContext, create_test_admin, create_test_user, test_context};
 
     const USERS_ENDPOINT: &str = "/api/v1/iam/users";
@@ -357,6 +359,41 @@ mod tests {
 
     #[rstest]
     #[actix_web::test]
+    async fn test_user_tokens_total_count_matches_paginated_results(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let test_user = create_test_user(&context.pool).await;
+        let auth_token = test_user
+            .create_token(&context.pool)
+            .await
+            .unwrap()
+            .get_token();
+
+        test_user.create_token(&context.pool).await.unwrap();
+        test_user.create_token(&context.pool).await.unwrap();
+
+        let (tokens, total_count): (Vec<UserTokenMetadata>, i64) =
+            assert_paginated_collection_total_count(&context.pool, &auth_token, 10, |cursor| {
+                match cursor {
+                    Some(cursor) => format!(
+                        "{}/{}/tokens?sort=issued_at.asc,name.asc&limit=1&cursor={cursor}",
+                        USERS_ENDPOINT, test_user.id
+                    ),
+                    None => format!(
+                        "{}/{}/tokens?sort=issued_at.asc,name.asc&limit=1",
+                        USERS_ENDPOINT, test_user.id
+                    ),
+                }
+            })
+            .await;
+
+        assert_eq!(total_count, tokens.len() as i64);
+        assert!(tokens.iter().all(|token| token.user_id == test_user.id));
+    }
+
+    #[rstest]
+    #[actix_web::test]
     async fn test_user_groups_filtering(#[future(awt)] test_context: TestContext) {
         let context = test_context;
         let user = create_test_user(&context.pool).await;
@@ -398,6 +435,73 @@ mod tests {
 
         matching_group.delete(&context.pool).await.unwrap();
         other_group.delete(&context.pool).await.unwrap();
+        user.delete(&context.pool).await.unwrap();
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_user_groups_total_count_matches_paginated_results(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let user = create_test_user(&context.pool).await;
+        let expected_groups = vec![
+            NewGroup {
+                groupname: format!("pagination-user-groups-a-{}", user.id),
+                description: Some("first group".to_string()),
+            }
+            .save(&context.pool)
+            .await
+            .unwrap(),
+            NewGroup {
+                groupname: format!("pagination-user-groups-b-{}", user.id),
+                description: Some("second group".to_string()),
+            }
+            .save(&context.pool)
+            .await
+            .unwrap(),
+            NewGroup {
+                groupname: format!("pagination-user-groups-c-{}", user.id),
+                description: Some("third group".to_string()),
+            }
+            .save(&context.pool)
+            .await
+            .unwrap(),
+        ];
+
+        for group in &expected_groups {
+            group.add_member(&context.pool, &user).await.unwrap();
+        }
+
+        let (groups, total_count): (Vec<Group>, i64) = assert_paginated_collection_total_count(
+            &context.pool,
+            &context.admin_token,
+            10,
+            |cursor| match cursor {
+                Some(cursor) => format!(
+                    "{}/{}/groups?groupname__contains=pagination-user-groups&sort=id&limit=2&cursor={cursor}",
+                    USERS_ENDPOINT, user.id
+                ),
+                None => format!(
+                    "{}/{}/groups?groupname__contains=pagination-user-groups&sort=id&limit=2",
+                    USERS_ENDPOINT, user.id
+                ),
+            },
+        )
+        .await;
+
+        assert_eq!(total_count, expected_groups.len() as i64);
+        assert_eq!(
+            groups.iter().map(|group| group.id).collect::<Vec<_>>(),
+            expected_groups
+                .iter()
+                .map(|group| group.id)
+                .collect::<Vec<_>>()
+        );
+
+        for group in expected_groups {
+            group.delete(&context.pool).await.unwrap();
+        }
         user.delete(&context.pool).await.unwrap();
     }
 

--- a/src/tests/asserts.rs
+++ b/src/tests/asserts.rs
@@ -1,4 +1,9 @@
 use actix_web::{http, test};
+use serde::de::DeserializeOwned;
+
+use crate::db::DbPool;
+use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER};
+use crate::tests::api_operations::get_request;
 
 /// ## Asserts that a given item is found within the specified vector.
 ///
@@ -287,4 +292,53 @@ pub fn header_value(resp: &actix_web::dev::ServiceResponse, name: &str) -> Optio
         .get(name)
         .and_then(|value| value.to_str().ok())
         .map(|value| value.to_string())
+}
+
+pub async fn assert_paginated_collection_total_count<T, F>(
+    pool: &DbPool,
+    token: &str,
+    max_pages: usize,
+    mut endpoint_for_cursor: F,
+) -> (Vec<T>, i64)
+where
+    T: DeserializeOwned,
+    F: FnMut(Option<&str>) -> String,
+{
+    let mut cursor = None;
+    let mut expected_total_count = None;
+    let mut collected = Vec::new();
+
+    for _ in 0..max_pages {
+        let endpoint = endpoint_for_cursor(cursor.as_deref());
+        let resp = get_request(pool, token, &endpoint).await;
+        let resp = assert_response_status(resp, http::StatusCode::OK).await;
+
+        let total_count = header_value(&resp, TOTAL_COUNT_HEADER)
+            .and_then(|value| value.parse::<i64>().ok())
+            .expect("paginated responses must include a valid X-Total-Count header");
+        if let Some(expected) = expected_total_count {
+            assert_eq!(
+                total_count, expected,
+                "X-Total-Count must stay constant across paginated responses"
+            );
+        } else {
+            expected_total_count = Some(total_count);
+        }
+
+        cursor = header_value(&resp, NEXT_CURSOR_HEADER);
+        let page_items: Vec<T> = test::read_body_json(resp).await;
+        collected.extend(page_items);
+
+        if cursor.is_none() {
+            let expected = expected_total_count.unwrap_or_default();
+            assert_eq!(
+                collected.len() as i64,
+                expected,
+                "X-Total-Count must match the total number of collected items across pages"
+            );
+            return (collected, expected);
+        }
+    }
+
+    panic!("pagination did not terminate within {max_pages} pages");
 }

--- a/src/utilities/response.rs
+++ b/src/utilities/response.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 
 use crate::errors::ApiError;
 use crate::models::search::QueryOptions;
-use crate::pagination::{CursorPaginated, finalize_page, next_cursor_header};
+use crate::pagination::{CursorPaginated, finalize_page, pagination_headers};
 
 static NO_CONTENT_STATUS_CODES: Lazy<HashSet<StatusCode>> = Lazy::new(|| {
     let mut m = HashSet::new();
@@ -60,6 +60,7 @@ pub fn json_response_created<T: Serialize>(object: T, location: &str) -> HttpRes
 
 pub fn paginated_json_response<T>(
     data: Vec<T>,
+    total_count: i64,
     status: StatusCode,
     query_options: &QueryOptions,
 ) -> Result<HttpResponse, ApiError>
@@ -70,12 +71,13 @@ where
     Ok(json_response_with_header(
         page.items,
         status,
-        next_cursor_header(&page.next_cursor),
+        Some(pagination_headers(&page.next_cursor, total_count)),
     ))
 }
 
 pub fn paginated_json_mapped_response<T, U, F>(
     data: Vec<T>,
+    total_count: i64,
     status: StatusCode,
     query_options: &QueryOptions,
     map: F,
@@ -89,6 +91,6 @@ where
     Ok(json_response_with_header(
         map(page.items),
         status,
-        next_cursor_header(&page.next_cursor),
+        Some(pagination_headers(&page.next_cursor, total_count)),
     ))
 }


### PR DESCRIPTION
## Summary
- derive paginated rows and X-Total-Count from shared Diesel/raw-SQL query specs
- add reusable pagination parity assertions and extend coverage across tasks, templates, users, namespaces, and relations
- remove legacy split list/count pagination paths and dead wrappers

## Verification
- cargo check
- cargo check --tests
- tests::api::v1::templates::tests::
- test_list_tasks_total_count_matches_paginated_results
- test_user_tokens_total_count_matches_paginated_results
- test_user_groups_total_count_matches_paginated_results
- test_namespace_permission_listings_total_count_match_paginated_results
- tests::api::v1::relations::tests::