### PR TITLE
Add JSON structure operators and related functionality

### DIFF
--- a/docs/querying.md
+++ b/docs/querying.md
@@ -35,6 +35,8 @@ Example:
 - `iendswith`
 - `like`
 - `regex`
+- `in`
+- `is_null`
 
 ### Numeric and date fields
 
@@ -44,15 +46,19 @@ Example:
 - `lt`
 - `lte`
 - `between`
+- `in`
+- `is_null`
 
 ### Array fields
 
 - `equals`
 - `contains`
+- `is_null`
 
 ### Boolean fields
 
 - `equals`
+- `is_null`
 
 ### IP/network JSON fields
 
@@ -243,6 +249,40 @@ Examples:
 /api/v1/classes/12/?json_data__contains_ip=network,address=10.0.0.10
 /api/v1/classes/12/?json_data__overlaps_network=network,address=10.0.0.64/26
 /api/v1/classes/12/?json_data__inet_equals=network,address=10.0.0.10
+```
+
+### JSON array and structure operators
+
+- `in`
+- `all`
+- `array_length`
+- `has_key`
+- `is_null`
+
+JSON fields support operators for arrays, key existence, and null checking.
+`in` is aliased as `any`; both names parse to the same operator.
+
+- `in` (alias: `any`): Matches when the stored JSON scalar value is one of the given values, or when a stored JSON array contains any of the given values. Values are comma-separated.
+  Example: `json_data__in=status=active,standby` matches if `status` is `"active"` or `"standby"`.
+  Example: `json_data__in=tags=web,api` matches if `tags` is `["web", "frontend"]` because `"web"` is present.
+- `all`: Matches when the stored JSON array contains all of the given values. Values are comma-separated.
+  Example: `json_data__all=tags=web,api` matches only if `tags` contains both `"web"` and `"api"`.
+- `array_length`: Matches when the stored JSON array has exactly the given number of elements.
+  Example: `json_data__array_length=tags=3` matches if `tags` has exactly 3 elements.
+- `has_key`: Matches when the stored JSON object contains the given key, regardless of the key's value (including JSON `null`).
+  Example: `json_data__has_key=config=hostname` matches if `config` is an object with a `hostname` key.
+- `is_null`: Matches when the stored JSON path is null or does not exist. Unlike other operators, `is_null` does not use a `key=value` format; the entire right-hand side is the JSON path.
+  Example: `json_data__is_null=optional_field` matches if `optional_field` is missing or JSON `null`.
+
+Examples:
+
+```text
+/api/v1/classes/12/?json_data__in=status=active,standby,maintenance
+/api/v1/classes/12/?json_data__all=tags=web,api
+/api/v1/classes/12/?json_data__array_length=tags=2
+/api/v1/classes/12/?json_data__has_key=config=hostname
+/api/v1/classes/12/?json_data__is_null=decommissioned_at
+/api/v1/classes/12/?json_data__not_is_null=hostname
 ```
 
 If the JSON path does not exist, or the stored value cannot be interpreted as the requested JSON type, the filter does not match, but it does not fail the request.

--- a/migrations/2023-12-27-011440_initial/up.sql
+++ b/migrations/2023-12-27-011440_initial/up.sql
@@ -341,6 +341,63 @@
     END;
     $$;
 
+    CREATE OR REPLACE FUNCTION jsonb_contains_any(val jsonb, items text[])
+    RETURNS boolean
+    LANGUAGE plpgsql
+    IMMUTABLE
+    STRICT
+    PARALLEL SAFE
+    AS $$
+    BEGIN
+        IF jsonb_typeof(val) = 'array' THEN
+            RETURN EXISTS (
+                SELECT 1 FROM jsonb_array_elements_text(val) AS elem
+                WHERE elem = ANY(items)
+            );
+        END IF;
+        RETURN false;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RETURN false;
+    END;
+    $$;
+
+    CREATE OR REPLACE FUNCTION jsonb_contains_all(val jsonb, items text[])
+    RETURNS boolean
+    LANGUAGE plpgsql
+    IMMUTABLE
+    STRICT
+    PARALLEL SAFE
+    AS $$
+    BEGIN
+        IF jsonb_typeof(val) = 'array' THEN
+            RETURN (
+                SELECT count(DISTINCT elem) FROM jsonb_array_elements_text(val) AS elem
+                WHERE elem = ANY(items)
+            ) = array_length(items, 1);
+        END IF;
+        RETURN false;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RETURN false;
+    END;
+    $$;
+
+    CREATE OR REPLACE FUNCTION jsonb_has_key(val jsonb, k text)
+    RETURNS boolean
+    LANGUAGE plpgsql
+    IMMUTABLE
+    STRICT
+    PARALLEL SAFE
+    AS $$
+    BEGIN
+        RETURN val ? k;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RETURN false;
+    END;
+    $$;
+
     -- In relation tables, ensure that the from entry is always less than the to entry, this ensures
     -- that we don't need to check for both directions when querying the database
     CREATE OR REPLACE FUNCTION enforce_class_relation_order()

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -165,6 +165,12 @@ macro_rules! numeric_search {
         use diesel::dsl::not;
         use $crate::errors::ApiError;
         use $crate::models::search::{DataType, Operator};
+
+        let (op_pre, _) = $operator.op_and_neg();
+        if op_pre == Operator::IsNull {
+            $crate::is_null_search!($base_query, $parsed_query_param, $operator, $diesel_field);
+        } else {
+
         let values = $parsed_query_param.value_as_integer()?;
 
         if !$operator.is_applicable_to(DataType::NumericOrDate) {
@@ -210,18 +216,18 @@ macro_rules! numeric_search {
         // and combine them along the lines of
         // "WHERE field = any([1,3]) or (field BETWEEN 5 AND 7 OR field BETWEEN 11 AND 17)"
         // while merging with the rest of the filters via AND.
-        if op == Operator::Equals && values.len() > 50 {
+        if (op == Operator::Equals || op == Operator::In) && values.len() > 50 {
             return Err(ApiError::OperatorMismatch(format!(
-                "Operator 'equals' is limited to 50 values, got {} (use between?)",
-                values.len()
+                "Operator '{}' is limited to 50 values, got {} (use between?)",
+                op, values.len()
             )));
         }
 
         match (op, negated) {
-            (Operator::Equals, false) => {
+            (Operator::Equals, false) | (Operator::In, false) => {
                 $base_query = $base_query.filter($diesel_field.eq_any(values.clone()))
             }
-            (Operator::Equals, true) => {
+            (Operator::Equals, true) | (Operator::In, true) => {
                 $base_query = $base_query.filter(not($diesel_field.eq_any(values.clone())))
             }
             (Operator::Gt, false) => {
@@ -257,6 +263,8 @@ macro_rules! numeric_search {
                 )));
             }
         };
+
+        } // end else (not IsNull)
     }};
 }
 
@@ -268,6 +276,11 @@ macro_rules! date_search {
         use diesel::prelude::*;
         use $crate::errors::ApiError;
         use $crate::models::search::{DataType, Operator};
+
+        let (op_pre, _) = $operator.op_and_neg();
+        if op_pre == Operator::IsNull {
+            $crate::is_null_search!($base_query, $parsed_query_param, $operator, $diesel_field);
+        } else {
 
         let values = $parsed_query_param.value_as_date()?;
 
@@ -309,10 +322,10 @@ macro_rules! date_search {
         }
 
         match (op, negated) {
-            (Operator::Equals, false) => {
+            (Operator::Equals, false) | (Operator::In, false) => {
                 $base_query = $base_query.filter($diesel_field.eq_any(values.clone()))
             }
-            (Operator::Equals, true) => {
+            (Operator::Equals, true) | (Operator::In, true) => {
                 $base_query = $base_query.filter(not($diesel_field.eq_any(values.clone())))
             }
             (Operator::Gt, false) => {
@@ -348,6 +361,8 @@ macro_rules! date_search {
                 )));
             }
         };
+
+        } // end else (not IsNull)
     }};
 }
 
@@ -359,6 +374,11 @@ macro_rules! array_search {
         use diesel::prelude::*;
         use $crate::errors::ApiError;
         use $crate::models::search::{DataType, Operator};
+
+        let (op_pre, _) = $operator.op_and_neg();
+        if op_pre == Operator::IsNull {
+            $crate::is_null_search!($base_query, $param, $operator, $diesel_field);
+        } else {
 
         let values = $param.value_as_integer()?;
 
@@ -397,6 +417,8 @@ macro_rules! array_search {
                 )));
             }
         }
+
+        } // end else (not IsNull)
     }};
 }
 
@@ -408,6 +430,11 @@ macro_rules! string_search {
         use diesel::prelude::*;
         use $crate::errors::ApiError;
         use $crate::models::search::{DataType, Operator};
+
+        let (op_pre, _) = $operator.op_and_neg();
+        if op_pre == Operator::IsNull {
+            $crate::is_null_search!($base_query, $param, $operator, $diesel_field);
+        } else {
 
         let value = $param.value.clone();
 
@@ -432,6 +459,14 @@ macro_rules! string_search {
             (Operator::Equals, false) => $base_query = $base_query.filter($diesel_field.eq(value)),
             (Operator::Equals, true) => {
                 $base_query = $base_query.filter(not($diesel_field.eq(value)))
+            }
+            (Operator::In, false) => {
+                let values: Vec<String> = value.split(',').map(|s| s.to_string()).collect();
+                $base_query = $base_query.filter($diesel_field.eq_any(values))
+            }
+            (Operator::In, true) => {
+                let values: Vec<String> = value.split(',').map(|s| s.to_string()).collect();
+                $base_query = $base_query.filter(not($diesel_field.eq_any(values)))
             }
             (Operator::IEquals, false) => {
                 $base_query = $base_query.filter($diesel_field.ilike(value))
@@ -493,6 +528,8 @@ macro_rules! string_search {
                 )));
             }
         }
+
+        } // end else (not IsNull)
     }};
 }
 
@@ -503,6 +540,11 @@ macro_rules! boolean_search {
         use diesel::dsl::not;
         use $crate::errors::ApiError;
         use $crate::models::search::{DataType, Operator};
+
+        let (op_pre, _) = $operator.op_and_neg();
+        if op_pre == Operator::IsNull {
+            $crate::is_null_search!($base_query, $param, $operator, $diesel_field);
+        } else {
 
         let value = $param.value_as_boolean()?;
 
@@ -526,6 +568,23 @@ macro_rules! boolean_search {
                     $operator, $param.field
                 )));
             }
+        }
+
+        } // end else (not IsNull)
+    }};
+}
+
+#[macro_export]
+/// A null check search macro for is_null operator on any field type
+macro_rules! is_null_search {
+    ($base_query:expr, $param:expr, $operator:expr, $diesel_field:expr) => {{
+        let is_null_value = $param.value_as_boolean()?;
+        let (_, is_null_negated) = $operator.op_and_neg();
+        let should_be_null = is_null_value != is_null_negated;
+        if should_be_null {
+            $base_query = $base_query.filter($diesel_field.is_null())
+        } else {
+            $base_query = $base_query.filter($diesel_field.is_not_null())
         }
     }};
 }

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -407,11 +407,18 @@ impl ParsedQueryParam {
 
         let field = self.field.clone();
 
+        let (op, neg) = self.operator.op_and_neg();
+
+        // is_null has no value part — the entire RHS is the JSON path
+        if op == Operator::IsNull {
+            return self.as_json_is_null_sql(&field, neg);
+        }
+
         // split the value on key=value
         let parts: Vec<&str> = self.value.splitn(2, '=').collect();
 
         let (key, value) = match parts.as_slice() {
-            [key, value] => (key, value),
+            [key, value] => (*key, *value),
             _ => {
                 return Err(ApiError::BadRequest(
                     "Expected exactly two parts of key=value".to_string(),
@@ -436,7 +443,8 @@ impl ParsedQueryParam {
         }
         */
 
-        let key = format!("'{{{key}}}'");
+        let raw_key = key;
+        let key = format!("'{{{raw_key}}}'");
         let field_expr = format!("{} #>> {}", field.table_field(), key);
 
         // The bind variables for the SQL query. We can't bind the key as using
@@ -446,11 +454,26 @@ impl ParsedQueryParam {
         // TODO: Optionally validate that the keys exist:
         // https://github.com/terjekv/hubuum_rust/issues/4
 
-        let (op, neg) = self.operator.op_and_neg();
         let neg_str = if neg { "NOT " } else { "" };
 
         if op.is_ip_operator() {
             return self.as_json_ip_sql(&field_expr, value, op, neg);
+        }
+
+        if op == Operator::HasKey {
+            return self.as_json_has_key_sql(&field, raw_key, value, neg);
+        }
+
+        if op == Operator::All {
+            return self.as_json_all_sql(&field, raw_key, value, neg);
+        }
+
+        if op == Operator::ArrayLength {
+            return self.as_json_array_length_sql(&field, raw_key, value, neg);
+        }
+
+        if op == Operator::In {
+            return self.as_json_in_sql(&field, &field_expr, raw_key, value, neg);
         }
 
         let sql_type = get_jsonb_field_type_from_value_and_operator(value, op.clone());
@@ -547,6 +570,158 @@ impl ParsedQueryParam {
         Ok(SQLComponent {
             sql: format!("{lhs_expr} IS NOT NULL AND {predicate}"),
             bind_variables: vec![SQLValue::String(value)],
+        })
+    }
+
+    fn as_json_is_null_sql(
+        &self,
+        field: &FilterField,
+        negated: bool,
+    ) -> Result<SQLComponent, ApiError> {
+        let path = &self.value;
+        if !path.is_valid_jsonb_search_key() {
+            return Err(ApiError::BadRequest(format!(
+                "Invalid JSON search key: '{path}'"
+            )));
+        }
+        let key = format!("'{{{path}}}'");
+        let field_expr = format!("{} #>> {}", field.table_field(), key);
+        let sql = if negated {
+            format!("{field_expr} IS NOT NULL")
+        } else {
+            format!("{field_expr} IS NULL")
+        };
+        Ok(SQLComponent {
+            sql,
+            bind_variables: vec![],
+        })
+    }
+
+    fn as_json_has_key_sql(
+        &self,
+        field: &FilterField,
+        path: &str,
+        key_name: &str,
+        negated: bool,
+    ) -> Result<SQLComponent, ApiError> {
+        let key = format!("'{{{path}}}'");
+        let jsonb_expr = format!("{} #> {}", field.table_field(), key);
+        let predicate = format!("jsonb_has_key({jsonb_expr}, ?)");
+        let sql = if negated {
+            format!("NOT ({predicate})")
+        } else {
+            predicate
+        };
+        Ok(SQLComponent {
+            sql,
+            bind_variables: vec![SQLValue::String(key_name.to_string())],
+        })
+    }
+
+    fn as_json_in_sql(
+        &self,
+        field: &FilterField,
+        field_expr: &str,
+        path: &str,
+        value: &str,
+        negated: bool,
+    ) -> Result<SQLComponent, ApiError> {
+        let values: Vec<&str> = value.split(',').collect();
+        if values.is_empty() {
+            return Err(ApiError::BadRequest(
+                "'in' requires at least one value".to_string(),
+            ));
+        }
+
+        // Scalar check: text extraction IN
+        let scalar_placeholders = values.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let scalar_check = format!("{field_expr} IN ({scalar_placeholders})");
+
+        // Array check: jsonb containment
+        let array_placeholders = values.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let key = format!("'{{{path}}}'");
+        let jsonb_expr = format!("{} #> {}", field.table_field(), key);
+        let array_check =
+            format!("jsonb_contains_any({jsonb_expr}, ARRAY[{array_placeholders}])");
+
+        let combined = format!("({scalar_check} OR {array_check})");
+        let sql = if negated {
+            format!("NOT {combined}")
+        } else {
+            combined
+        };
+
+        // Bind values twice: once for IN, once for ARRAY
+        let mut bind_variables: Vec<SQLValue> = values
+            .iter()
+            .map(|v| SQLValue::String(v.to_string()))
+            .collect();
+        let array_binds: Vec<SQLValue> = values
+            .iter()
+            .map(|v| SQLValue::String(v.to_string()))
+            .collect();
+        bind_variables.extend(array_binds);
+
+        Ok(SQLComponent {
+            sql,
+            bind_variables,
+        })
+    }
+
+    fn as_json_all_sql(
+        &self,
+        field: &FilterField,
+        path: &str,
+        value: &str,
+        negated: bool,
+    ) -> Result<SQLComponent, ApiError> {
+        let values: Vec<&str> = value.split(',').collect();
+        if values.is_empty() {
+            return Err(ApiError::BadRequest(
+                "'all' requires at least one value".to_string(),
+            ));
+        }
+        let placeholders = values.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let key = format!("'{{{path}}}'");
+        let jsonb_expr = format!("{} #> {}", field.table_field(), key);
+        let predicate = format!("jsonb_contains_all({jsonb_expr}, ARRAY[{placeholders}])");
+        let sql = if negated {
+            format!("NOT ({predicate})")
+        } else {
+            predicate
+        };
+        let bind_variables = values
+            .iter()
+            .map(|v| SQLValue::String(v.to_string()))
+            .collect();
+        Ok(SQLComponent {
+            sql,
+            bind_variables,
+        })
+    }
+
+    fn as_json_array_length_sql(
+        &self,
+        field: &FilterField,
+        path: &str,
+        value: &str,
+        negated: bool,
+    ) -> Result<SQLComponent, ApiError> {
+        let length: i32 = value.parse().map_err(|_| {
+            ApiError::BadRequest(format!(
+                "array_length requires an integer, got '{value}'"
+            ))
+        })?;
+        let key = format!("'{{{path}}}'");
+        let jsonb_expr = format!("{} #> {}", field.table_field(), key);
+        let len_expr = format!("jsonb_array_length({jsonb_expr})");
+        let cmp = if negated { "!=" } else { "=" };
+        let sql = format!(
+            "jsonb_typeof({jsonb_expr}) = 'array' AND {len_expr} {cmp} ?"
+        );
+        Ok(SQLComponent {
+            sql,
+            bind_variables: vec![SQLValue::Integer(length)],
         })
     }
 
@@ -891,6 +1066,11 @@ pub enum Operator {
     ContainsIp,
     OverlapsNetwork,
     InetEquals,
+    In,
+    All,
+    ArrayLength,
+    HasKey,
+    IsNull,
 }
 
 impl std::fmt::Display for Operator {
@@ -916,6 +1096,11 @@ impl std::fmt::Display for Operator {
             Operator::ContainsIp => "contains_ip",
             Operator::OverlapsNetwork => "overlaps_network",
             Operator::InetEquals => "inet_equals",
+            Operator::In => "in",
+            Operator::All => "all",
+            Operator::ArrayLength => "array_length",
+            Operator::HasKey => "has_key",
+            Operator::IsNull => "is_null",
         };
         write!(f, "{op}")
     }
@@ -930,6 +1115,17 @@ impl Operator {
                 | Operator::ContainsIp
                 | Operator::OverlapsNetwork
                 | Operator::InetEquals
+        )
+    }
+
+    fn is_json_structure_operator(&self) -> bool {
+        matches!(
+            self,
+            Operator::In
+                | Operator::All
+                | Operator::ArrayLength
+                | Operator::HasKey
+                | Operator::IsNull
         )
     }
 }
@@ -960,6 +1156,11 @@ pub enum SearchOperator {
     ContainsIp { is_negated: bool },
     OverlapsNetwork { is_negated: bool },
     InetEquals { is_negated: bool },
+    In { is_negated: bool },
+    All { is_negated: bool },
+    ArrayLength { is_negated: bool },
+    HasKey { is_negated: bool },
+    IsNull { is_negated: bool },
 }
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum DataType {
@@ -993,6 +1194,12 @@ impl SearchOperator {
             | SO::ContainsIp { .. }
             | SO::OverlapsNetwork { .. }
             | SO::InetEquals { .. } => false,
+            SO::In { .. } => {
+                matches!(data_type, DataType::String)
+                    || matches!(data_type, DataType::NumericOrDate)
+            }
+            SO::IsNull { .. } => true,
+            SO::All { .. } | SO::ArrayLength { .. } | SO::HasKey { .. } => false,
             SO::Contains { .. } => {
                 matches!(data_type, DataType::String) || matches!(data_type, DataType::Array)
             }
@@ -1028,6 +1235,11 @@ impl SearchOperator {
                 (Operator::OverlapsNetwork, *is_negated)
             }
             SearchOperator::InetEquals { is_negated, .. } => (Operator::InetEquals, *is_negated),
+            SearchOperator::In { is_negated, .. } => (Operator::In, *is_negated),
+            SearchOperator::All { is_negated, .. } => (Operator::All, *is_negated),
+            SearchOperator::ArrayLength { is_negated, .. } => (Operator::ArrayLength, *is_negated),
+            SearchOperator::HasKey { is_negated, .. } => (Operator::HasKey, *is_negated),
+            SearchOperator::IsNull { is_negated, .. } => (Operator::IsNull, *is_negated),
         }
     }
 
@@ -1103,6 +1315,21 @@ impl SearchOperator {
                 is_negated: negated,
             }),
             "inet_equals" => Ok(SO::InetEquals {
+                is_negated: negated,
+            }),
+            "in" | "any" => Ok(SO::In {
+                is_negated: negated,
+            }),
+            "all" => Ok(SO::All {
+                is_negated: negated,
+            }),
+            "array_length" => Ok(SO::ArrayLength {
+                is_negated: negated,
+            }),
+            "has_key" => Ok(SO::HasKey {
+                is_negated: negated,
+            }),
+            "is_null" => Ok(SO::IsNull {
                 is_negated: negated,
             }),
 
@@ -1300,6 +1527,11 @@ pub fn get_jsonb_field_type_from_value_and_operator(
         | Operator::ContainsIp
         | Operator::OverlapsNetwork
         | Operator::InetEquals => None,
+        Operator::In => Some(SQLMappedType::String),
+        Operator::All
+        | Operator::ArrayLength
+        | Operator::HasKey
+        | Operator::IsNull => None,
     }
 }
 

--- a/src/tests/api/v1/objects.rs
+++ b/src/tests/api/v1/objects.rs
@@ -1144,4 +1144,196 @@ mod tests {
         assert_eq!(objects[1].id, created_objects[3].id);
         created_objects.cleanup().await.unwrap();
     }
+
+    async fn create_json_structure_filter_fixture(
+        context: &TestContext,
+        prefix: &str,
+    ) -> (crate::tests::NamespaceFixture, crate::models::HubuumClass) {
+        let namespace = context.namespace_fixture(prefix).await;
+        let class = NewHubuumClass {
+            namespace_id: namespace.namespace.id,
+            name: format!("json struct filter class {prefix}"),
+            description: format!("json struct filter class {prefix}"),
+            json_schema: None,
+            validate_schema: Some(false),
+        }
+        .save(&context.pool)
+        .await
+        .unwrap();
+
+        let test_objects = [
+            (
+                "struct_obj_0",
+                serde_json::json!({
+                    "status": "active",
+                    "tags": ["web", "api"],
+                    "ports": [80, 443],
+                    "config": { "hostname": "srv-01", "port": 8080 },
+                    "optional_field": "present"
+                }),
+            ),
+            (
+                "struct_obj_1",
+                serde_json::json!({
+                    "status": "standby",
+                    "tags": ["web", "frontend"],
+                    "ports": [8080],
+                    "config": { "hostname": "srv-02" },
+                    "optional_field": null
+                }),
+            ),
+            (
+                "struct_obj_2",
+                serde_json::json!({
+                    "status": "maintenance",
+                    "tags": ["api", "backend", "internal"],
+                    "ports": [443, 8443, 9090],
+                    "config": { "port": 9090 }
+                }),
+            ),
+            (
+                "struct_obj_3",
+                serde_json::json!({
+                    "status": "active",
+                    "tags": ["web", "api", "frontend"],
+                    "ports": [80, 8080, 443],
+                    "config": {}
+                }),
+            ),
+        ];
+
+        for (name, data) in test_objects {
+            NewHubuumObject {
+                namespace_id: namespace.namespace.id,
+                hubuum_class_id: class.id,
+                data,
+                name: name.to_string(),
+                description: name.to_string(),
+            }
+            .save(&context.pool)
+            .await
+            .unwrap();
+        }
+
+        (namespace, class)
+    }
+
+    async fn assert_json_structure_filter_query(
+        context: &TestContext,
+        prefix: &str,
+        query_string: &str,
+        expected_names: Vec<&str>,
+    ) {
+        let (namespace, class) = create_json_structure_filter_fixture(context, prefix).await;
+
+        let resp = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!(
+                "{OBJECT_ENDPOINT}/{}/?namespaces={}&{}&sort=id",
+                class.id, namespace.namespace.id, query_string
+            ),
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let objects: Vec<HubuumObject> = test::read_body_json(resp).await;
+
+        let object_names: Vec<&str> = objects.iter().map(|object| object.name.as_str()).collect();
+        assert_eq!(object_names, expected_names);
+
+        namespace.cleanup().await.unwrap();
+    }
+
+    #[rstest]
+    // in (scalar): status is one of "active", "standby"
+    #[case::in_scalar(
+        "json_data__in=status=active,standby",
+        vec!["struct_obj_0", "struct_obj_1", "struct_obj_3"]
+    )]
+    // in (array): tags array contains "frontend"
+    #[case::in_array(
+        "json_data__in=tags=frontend",
+        vec!["struct_obj_1", "struct_obj_3"]
+    )]
+    // not_in (scalar)
+    #[case::not_in_scalar(
+        "json_data__not_in=status=active,standby",
+        vec!["struct_obj_2"]
+    )]
+    // not_in (array): tags array does NOT contain "frontend"
+    #[case::not_in_array(
+        "json_data__not_in=tags=frontend",
+        vec!["struct_obj_0", "struct_obj_2"]
+    )]
+    // all: tags array contains both "web" AND "api"
+    #[case::all_tags(
+        "json_data__all=tags=web,api",
+        vec!["struct_obj_0", "struct_obj_3"]
+    )]
+    // not_all: tags does NOT contain both
+    #[case::not_all_tags(
+        "json_data__not_all=tags=web,api",
+        vec!["struct_obj_1", "struct_obj_2"]
+    )]
+    // array_length: tags has exactly 2 elements
+    #[case::array_length_2(
+        "json_data__array_length=tags=2",
+        vec!["struct_obj_0", "struct_obj_1"]
+    )]
+    // array_length: tags has exactly 3 elements
+    #[case::array_length_3(
+        "json_data__array_length=tags=3",
+        vec!["struct_obj_2", "struct_obj_3"]
+    )]
+    // in on numeric array: ports array contains 443
+    #[case::in_numeric_array(
+        "json_data__in=ports=443",
+        vec!["struct_obj_0", "struct_obj_2", "struct_obj_3"]
+    )]
+    // all on numeric array: ports array contains both 80 and 443
+    #[case::all_numeric_array(
+        "json_data__all=ports=80,443",
+        vec!["struct_obj_0", "struct_obj_3"]
+    )]
+    // not_array_length: tags does NOT have exactly 2 elements
+    #[case::not_array_length(
+        "json_data__not_array_length=tags=2",
+        vec!["struct_obj_2", "struct_obj_3"]
+    )]
+    // has_key: config object has "hostname" key
+    #[case::has_key(
+        "json_data__has_key=config=hostname",
+        vec!["struct_obj_0", "struct_obj_1"]
+    )]
+    // not_has_key: config does NOT have "hostname"
+    #[case::not_has_key(
+        "json_data__not_has_key=config=hostname",
+        vec!["struct_obj_2", "struct_obj_3"]
+    )]
+    // is_null: optional_field is null or missing
+    #[case::is_null(
+        "json_data__is_null=optional_field",
+        vec!["struct_obj_1", "struct_obj_2", "struct_obj_3"]
+    )]
+    // not_is_null: optional_field is present and not null
+    #[case::not_is_null(
+        "json_data__not_is_null=optional_field",
+        vec!["struct_obj_0"]
+    )]
+    #[actix_web::test]
+    async fn test_api_objects_filter_json_data_structure_operators(
+        #[case] query: &str,
+        #[case] expected_names: Vec<&str>,
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let prefix = format!(
+            "json_struct_{}",
+            query
+                .chars()
+                .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+                .collect::<String>()
+        );
+        assert_json_structure_filter_query(&context, &prefix, query, expected_names).await;
+    }
 }

--- a/src/tests/api/v1/querying.rs
+++ b/src/tests/api/v1/querying.rs
@@ -32,10 +32,13 @@ mod tests {
         "iendswith",
         "like",
         "regex",
+        "in",
+        "is_null",
     ];
-    const NUMERIC_DATE_OPERATORS: &[&str] = &["equals", "gt", "gte", "lt", "lte", "between"];
-    const ARRAY_OPERATORS: &[&str] = &["equals", "contains"];
-    const BOOLEAN_OPERATORS: &[&str] = &["equals"];
+    const NUMERIC_DATE_OPERATORS: &[&str] =
+        &["equals", "gt", "gte", "lt", "lte", "between", "in", "is_null"];
+    const ARRAY_OPERATORS: &[&str] = &["equals", "contains", "is_null"];
+    const BOOLEAN_OPERATORS: &[&str] = &["equals", "is_null"];
     const IP_NETWORK_JSON_OPERATORS: &[&str] = &[
         "within_network",
         "contains_network",
@@ -43,6 +46,8 @@ mod tests {
         "overlaps_network",
         "inet_equals",
     ];
+    const JSON_STRUCTURE_OPERATORS: &[&str] =
+        &["in", "all", "array_length", "has_key", "is_null"];
 
     fn objects_in_class_endpoint(class_id: i32) -> String {
         format!("/api/v1/classes/{class_id}/")
@@ -234,6 +239,7 @@ mod tests {
     #[case::array("Array fields", ARRAY_OPERATORS)]
     #[case::boolean("Boolean fields", BOOLEAN_OPERATORS)]
     #[case::ip_network_json("IP/network JSON fields", IP_NETWORK_JSON_OPERATORS)]
+    #[case::json_structure("JSON array and structure operators", JSON_STRUCTURE_OPERATORS)]
     fn test_querying_docs_operator_lists(
         #[case] section: &str,
         #[case] expected_operators: &[&str],
@@ -260,6 +266,46 @@ mod tests {
             assert!(
                 parsed.is_applicable_to(data_type),
                 "operator '{operator}' from section '{section}' should apply to {data_type:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_any_is_alias_for_in() {
+        let from_in = SearchOperator::new_from_string("in").unwrap();
+        let from_any = SearchOperator::new_from_string("any").unwrap();
+        assert_eq!(from_in, from_any);
+        assert_eq!(from_in.to_string(), "in");
+
+        let neg_in = SearchOperator::new_from_string("not_in").unwrap();
+        let neg_any = SearchOperator::new_from_string("not_any").unwrap();
+        assert_eq!(neg_in, neg_any);
+        assert_eq!(neg_in.to_string(), "not_in");
+    }
+
+    #[test]
+    fn test_documented_json_structure_operators_parse() {
+        let documented = documented_operators("JSON array and structure operators");
+        let expected = JSON_STRUCTURE_OPERATORS
+            .iter()
+            .map(|operator| operator.to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(documented, expected);
+
+        for operator in documented {
+            let parsed = SearchOperator::new_from_string(&operator).unwrap();
+            let rendered = parsed.to_string();
+            assert_eq!(
+                rendered, operator,
+                "operator '{operator}' should round-trip"
+            );
+
+            let negated = SearchOperator::new_from_string(&format!("not_{operator}")).unwrap();
+            assert_eq!(
+                negated.to_string(),
+                format!("not_{operator}"),
+                "operator '{operator}' should support not_ round-trip"
             );
         }
     }
@@ -302,6 +348,11 @@ mod tests {
     #[case::iendswith("name__iendswith=one", vec!["Alpha-One", "Beta-ONE"])]
     #[case::like("name__like=Alpha-%", vec!["Alpha-One"])]
     #[case::regex("name__regex=^(Alpha|Beta)-.*$", vec!["Alpha-One", "Beta-ONE"])]
+    #[case::in_op("name__in=Alpha-One,alpha-two", vec!["Alpha-One", "alpha-two"])]
+    #[case::not_in_op("name__not_in=Alpha-One,alpha-two", vec!["Beta-ONE", "Gamma-Three"])]
+    #[case::is_null_false("name__is_null=false", vec!["Alpha-One", "alpha-two", "Beta-ONE", "Gamma-Three"])]
+    #[case::is_null_true("name__is_null=true", vec![])]
+    #[case::not_is_null_true("name__not_is_null=true", vec!["Alpha-One", "alpha-two", "Beta-ONE", "Gamma-Three"])]
     #[actix_web::test]
     async fn test_documented_string_operators_on_objects(
         #[case] query: &str,
@@ -349,6 +400,8 @@ mod tests {
     #[case::lt("id__lt=<2>", vec![0, 1])]
     #[case::lte("id__lte=<1>", vec![0, 1])]
     #[case::between("id__between=<0>,<1>", vec![0, 1])]
+    #[case::in_op("id__in=<0>,<2>", vec![0, 2])]
+    #[case::not_in_op("id__not_in=<0>,<2>", vec![1])]
     #[actix_web::test]
     async fn test_documented_numeric_operators_on_objects(
         #[case] query_template: &str,
@@ -403,6 +456,8 @@ mod tests {
     #[case::lt("created_at__lt=2024-01-03", vec!["dated-0", "dated-1"])]
     #[case::lte("created_at__lte=2024-01-02", vec!["dated-0", "dated-1"])]
     #[case::between("created_at__between=2024-01-02,2024-01-03", vec!["dated-1", "dated-2"])]
+    #[case::in_op("created_at__in=2024-01-01,2024-01-03", vec!["dated-0", "dated-2"])]
+    #[case::not_in_op("created_at__not_in=2024-01-01,2024-01-03", vec!["dated-1"])]
     #[actix_web::test]
     async fn test_documented_date_operators_on_objects(
         #[case] query: &str,


### PR DESCRIPTION
- Introduced new operators: `in` (alias `any`), `all`, `array_length`, `has_key`, and `is_null` for JSON data querying.
- Updated SQL functions to support new operators for JSONB data types.
- Updated search macros to handle new operators and their negations.
- Added comprehensive tests for new JSON structure operators and their expected behaviors.