### PR TITLE
Refactor login rate limiter into middleware module + regression test for per-user keying

### DIFF
--- a/src/api/handlers/auth.rs
+++ b/src/api/handlers/auth.rs
@@ -1,132 +1,17 @@
 use crate::api::openapi::{ApiErrorResponse, LoginResponse, MessageResponse};
-use crate::config::{AppConfig, login_rate_limit_max_attempts, login_rate_limit_window_seconds};
 use crate::db::DbPool;
 use crate::errors::ApiError;
 use crate::extractors::{AdminAccess, UserAccess};
-use crate::middlewares::client_allowlist::extract_client_ip_from_http_request;
+use crate::middlewares::rate_limit::{
+    clear_login_failures, client_ip_for_request, login_is_rate_limited, record_login_failure,
+};
 use crate::models::{LoginUser, Token, UserID};
 use crate::utilities::response::json_response;
 use actix_web::{HttpRequest, Responder, get, http::StatusCode, post, web};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::collections::{HashMap, VecDeque};
-use std::sync::LazyLock;
-use std::time::{Duration, Instant};
-use tokio::sync::Mutex;
 use tracing::{debug, warn};
 use utoipa::ToSchema;
-
-static LOGIN_ATTEMPTS: LazyLock<Mutex<HashMap<String, VecDeque<Instant>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-const MAX_LOGIN_ATTEMPT_KEYS: usize = 10_000;
-
-fn login_rate_limit_key(username: &str, client_ip: &str) -> String {
-    format!("{}|{}", username.trim().to_ascii_lowercase(), client_ip)
-}
-
-fn current_login_window() -> Duration {
-    Duration::from_secs(login_rate_limit_window_seconds())
-}
-
-fn prune_attempts(attempts: &mut VecDeque<Instant>, now: Instant) {
-    let window = current_login_window();
-    while let Some(first) = attempts.front() {
-        if now.duration_since(*first) > window {
-            attempts.pop_front();
-        } else {
-            break;
-        }
-    }
-}
-
-fn prune_login_attempts_map(
-    attempts_by_key: &mut HashMap<String, VecDeque<Instant>>,
-    now: Instant,
-) {
-    attempts_by_key.retain(|_, attempts| {
-        prune_attempts(attempts, now);
-        !attempts.is_empty()
-    });
-}
-
-fn evict_stalest_login_attempt_key(attempts_by_key: &mut HashMap<String, VecDeque<Instant>>) {
-    let stalest_key = attempts_by_key
-        .iter()
-        .filter_map(|(key, attempts)| {
-            attempts
-                .back()
-                .copied()
-                .map(|last_attempt| (key.clone(), last_attempt))
-        })
-        .min_by_key(|(_, last_attempt)| *last_attempt)
-        .map(|(key, _)| key);
-
-    if let Some(stalest_key) = stalest_key {
-        attempts_by_key.remove(&stalest_key);
-        warn!(
-            message = "Evicted stalest login limiter entry to enforce key cap",
-            max_tracked_keys = MAX_LOGIN_ATTEMPT_KEYS
-        );
-    }
-}
-
-fn client_ip_for_request(req: &HttpRequest) -> String {
-    let trust_ip_headers = req
-        .app_data::<web::Data<AppConfig>>()
-        .map(|config| config.trust_ip_headers)
-        .unwrap_or(false);
-
-    extract_client_ip_from_http_request(req, trust_ip_headers)
-        .map(|ip| ip.to_string())
-        .unwrap_or_else(|| "unknown".to_string())
-}
-
-async fn login_is_rate_limited(username: &str, client_ip: &str) -> bool {
-    let key = login_rate_limit_key(username, client_ip);
-    let now = Instant::now();
-    let mut guard = LOGIN_ATTEMPTS.lock().await;
-
-    // Only prune the current key's window on the hot path, not the entire map
-    if let Some(attempts) = guard.get_mut(&key) {
-        prune_attempts(attempts, now);
-        attempts.len() >= login_rate_limit_max_attempts()
-    } else {
-        false
-    }
-}
-
-async fn record_login_failure(username: &str, client_ip: &str) {
-    let key = login_rate_limit_key(username, client_ip);
-    let now = Instant::now();
-    let mut guard = LOGIN_ATTEMPTS.lock().await;
-
-    // Prune only the current key on the hot path
-    if let Some(attempts) = guard.get_mut(&key) {
-        prune_attempts(attempts, now);
-    }
-
-    // Only perform full-map eviction work when we're at capacity for a new key
-    if !guard.contains_key(&key) && guard.len() >= MAX_LOGIN_ATTEMPT_KEYS {
-        prune_login_attempts_map(&mut guard, now);
-        if guard.len() >= MAX_LOGIN_ATTEMPT_KEYS {
-            evict_stalest_login_attempt_key(&mut guard);
-        }
-    }
-
-    let attempts = guard.entry(key).or_default();
-    attempts.push_back(now);
-}
-
-async fn clear_login_failures(username: &str, client_ip: &str) {
-    let key = login_rate_limit_key(username, client_ip);
-    LOGIN_ATTEMPTS.lock().await.remove(&key);
-}
-
-#[cfg(test)]
-pub async fn reset_login_rate_limit_for_tests() {
-    LOGIN_ATTEMPTS.lock().await.clear();
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct LogoutTokenRequest {

--- a/src/middlewares/mod.rs
+++ b/src/middlewares/mod.rs
@@ -1,4 +1,5 @@
 pub mod client_allowlist;
+pub mod rate_limit;
 pub mod tracing;
 
 pub use client_allowlist::ClientAllowlistMiddleware;

--- a/src/middlewares/rate_limit.rs
+++ b/src/middlewares/rate_limit.rs
@@ -1,0 +1,119 @@
+use actix_web::{HttpRequest, web};
+
+use crate::config::{AppConfig, login_rate_limit_max_attempts, login_rate_limit_window_seconds};
+use crate::middlewares::client_allowlist::extract_client_ip_from_http_request;
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+use tracing::warn;
+
+static LOGIN_ATTEMPTS: LazyLock<Mutex<HashMap<String, VecDeque<Instant>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+const MAX_LOGIN_ATTEMPT_KEYS: usize = 10_000;
+
+fn login_rate_limit_key(username: &str, client_ip: &str) -> String {
+    format!("{}|{}", username.trim().to_ascii_lowercase(), client_ip)
+}
+
+fn current_login_window() -> Duration {
+    Duration::from_secs(login_rate_limit_window_seconds())
+}
+
+fn prune_attempts(attempts: &mut VecDeque<Instant>, now: Instant) {
+    let window = current_login_window();
+    while let Some(first) = attempts.front() {
+        if now.duration_since(*first) > window {
+            attempts.pop_front();
+        } else {
+            break;
+        }
+    }
+}
+
+fn prune_login_attempts_map(
+    attempts_by_key: &mut HashMap<String, VecDeque<Instant>>,
+    now: Instant,
+) {
+    attempts_by_key.retain(|_, attempts| {
+        prune_attempts(attempts, now);
+        !attempts.is_empty()
+    });
+}
+
+fn evict_stalest_login_attempt_key(attempts_by_key: &mut HashMap<String, VecDeque<Instant>>) {
+    let stalest_key = attempts_by_key
+        .iter()
+        .filter_map(|(key, attempts)| {
+            attempts
+                .back()
+                .copied()
+                .map(|last_attempt| (key.clone(), last_attempt))
+        })
+        .min_by_key(|(_, last_attempt)| *last_attempt)
+        .map(|(key, _)| key);
+
+    if let Some(stalest_key) = stalest_key {
+        attempts_by_key.remove(&stalest_key);
+        warn!(
+            message = "Evicted stalest login limiter entry to enforce key cap",
+            max_tracked_keys = MAX_LOGIN_ATTEMPT_KEYS
+        );
+    }
+}
+
+pub fn client_ip_for_request(req: &HttpRequest) -> String {
+    let trust_ip_headers = req
+        .app_data::<web::Data<AppConfig>>()
+        .map(|config| config.trust_ip_headers)
+        .unwrap_or(false);
+
+    extract_client_ip_from_http_request(req, trust_ip_headers)
+        .map(|ip| ip.to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+pub async fn login_is_rate_limited(username: &str, client_ip: &str) -> bool {
+    let key = login_rate_limit_key(username, client_ip);
+    let now = Instant::now();
+    let mut guard = LOGIN_ATTEMPTS.lock().await;
+
+    if let Some(attempts) = guard.get_mut(&key) {
+        prune_attempts(attempts, now);
+        attempts.len() >= login_rate_limit_max_attempts()
+    } else {
+        false
+    }
+}
+
+pub async fn record_login_failure(username: &str, client_ip: &str) {
+    let key = login_rate_limit_key(username, client_ip);
+    let now = Instant::now();
+    let mut guard = LOGIN_ATTEMPTS.lock().await;
+
+    if let Some(attempts) = guard.get_mut(&key) {
+        prune_attempts(attempts, now);
+    }
+
+    if !guard.contains_key(&key) && guard.len() >= MAX_LOGIN_ATTEMPT_KEYS {
+        prune_login_attempts_map(&mut guard, now);
+        if guard.len() >= MAX_LOGIN_ATTEMPT_KEYS {
+            evict_stalest_login_attempt_key(&mut guard);
+        }
+    }
+
+    let attempts = guard.entry(key).or_default();
+    attempts.push_back(now);
+}
+
+pub async fn clear_login_failures(username: &str, client_ip: &str) {
+    let key = login_rate_limit_key(username, client_ip);
+    LOGIN_ATTEMPTS.lock().await.remove(&key);
+}
+
+#[cfg(test)]
+pub async fn reset_login_rate_limit_for_tests() {
+    LOGIN_ATTEMPTS.lock().await.clear();
+}

--- a/src/middlewares/rate_limit.rs
+++ b/src/middlewares/rate_limit.rs
@@ -64,7 +64,7 @@ fn evict_stalest_login_attempt_key(attempts_by_key: &mut HashMap<String, VecDequ
     }
 }
 
-pub fn client_ip_for_request(req: &HttpRequest) -> String {
+pub(crate) fn client_ip_for_request(req: &HttpRequest) -> String {
     let trust_ip_headers = req
         .app_data::<web::Data<AppConfig>>()
         .map(|config| config.trust_ip_headers)
@@ -75,7 +75,7 @@ pub fn client_ip_for_request(req: &HttpRequest) -> String {
         .unwrap_or_else(|| "unknown".to_string())
 }
 
-pub async fn login_is_rate_limited(username: &str, client_ip: &str) -> bool {
+pub(crate) async fn login_is_rate_limited(username: &str, client_ip: &str) -> bool {
     let key = login_rate_limit_key(username, client_ip);
     let now = Instant::now();
     let mut guard = LOGIN_ATTEMPTS.lock().await;
@@ -88,7 +88,7 @@ pub async fn login_is_rate_limited(username: &str, client_ip: &str) -> bool {
     }
 }
 
-pub async fn record_login_failure(username: &str, client_ip: &str) {
+pub(crate) async fn record_login_failure(username: &str, client_ip: &str) {
     let key = login_rate_limit_key(username, client_ip);
     let now = Instant::now();
     let mut guard = LOGIN_ATTEMPTS.lock().await;
@@ -108,12 +108,68 @@ pub async fn record_login_failure(username: &str, client_ip: &str) {
     attempts.push_back(now);
 }
 
-pub async fn clear_login_failures(username: &str, client_ip: &str) {
+pub(crate) async fn clear_login_failures(username: &str, client_ip: &str) {
     let key = login_rate_limit_key(username, client_ip);
     LOGIN_ATTEMPTS.lock().await.remove(&key);
 }
 
 #[cfg(test)]
-pub async fn reset_login_rate_limit_for_tests() {
+pub(crate) async fn reset_login_rate_limit_for_tests() {
     LOGIN_ATTEMPTS.lock().await.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_attempts(times: &[Instant]) -> VecDeque<Instant> {
+        times.iter().copied().collect()
+    }
+
+    #[test]
+    fn evict_stalest_login_attempt_key_removes_entry_with_oldest_last_attempt() {
+        let now = Instant::now();
+        let mut map: HashMap<String, VecDeque<Instant>> = HashMap::new();
+        map.insert(
+            "fresh".to_string(),
+            make_attempts(&[now - Duration::from_secs(10), now]),
+        );
+        map.insert(
+            "stale".to_string(),
+            make_attempts(&[
+                now - Duration::from_secs(600),
+                now - Duration::from_secs(500),
+            ]),
+        );
+        map.insert(
+            "middle".to_string(),
+            make_attempts(&[now - Duration::from_secs(120)]),
+        );
+
+        evict_stalest_login_attempt_key(&mut map);
+
+        assert!(!map.contains_key("stale"));
+        assert!(map.contains_key("fresh"));
+        assert!(map.contains_key("middle"));
+    }
+
+    #[test]
+    fn evict_stalest_login_attempt_key_skips_entries_without_attempts() {
+        let now = Instant::now();
+        let mut map: HashMap<String, VecDeque<Instant>> = HashMap::new();
+        map.insert("empty".to_string(), VecDeque::new());
+        map.insert("only".to_string(), make_attempts(&[now]));
+
+        evict_stalest_login_attempt_key(&mut map);
+
+        assert!(map.contains_key("empty"));
+        assert!(!map.contains_key("only"));
+    }
+
+    #[test]
+    fn evict_stalest_login_attempt_key_is_noop_on_empty_map() {
+        let mut map: HashMap<String, VecDeque<Instant>> = HashMap::new();
+        evict_stalest_login_attempt_key(&mut map);
+        assert!(map.is_empty());
+    }
 }

--- a/src/tests/api/v1/auth.rs
+++ b/src/tests/api/v1/auth.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use crate::api::handlers::auth::reset_login_rate_limit_for_tests;
     use crate::config::get_config;
     use crate::db::traits::ActiveTokens;
     use crate::db::{init_pool, with_connection};
+    use crate::middlewares::rate_limit::reset_login_rate_limit_for_tests;
     use crate::models::user::LoginUser;
     use crate::tests::{create_test_admin, create_test_user};
     use crate::{api, assert_not_contains};
@@ -549,5 +549,18 @@ mod tests {
             .await;
 
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        let other_user_login = web::Form(LoginUser {
+            username: "other-throttle-user".to_string(),
+            password: "wrongpassword".to_string(),
+        });
+
+        let resp = test::TestRequest::post()
+            .uri(LOGIN_ENDPOINT)
+            .set_json(&other_user_login)
+            .send_request(&app)
+            .await;
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
## Summary
- move login rate-limit state into a dedicated middleware module
- keep throttling keyed by normalized username plus client IP, including trusted proxy IP extraction
- ensure a throttled username does not throttle other usernames from the same IP

## Verification
- cargo check
- cargo test openapi_operations_resolve_to_mounted_routes
- rustfmt --edition 2024 --check src/api/handlers/auth.rs src/middlewares/mod.rs src/middlewares/rate_limit.rs src/tests/api/v1/auth.rs
- git diff --check