### PR TITLE
[codex] add single-host deployment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,13 @@ curl -H "Authorization: Bearer <token>" http://localhost:8080/api/v1/iam/users
 - The default image can also run without TLS if no certificate and key are configured.
 - Slim container tags ending in `-rustls-only` include only the `rustls` backend.
 
+### Deployment
+
+- Single-host Docker/Podman Compose deployment scripts are documented in [docs/deployment.md](docs/deployment.md).
+- The scripts support all-in-one frontend/backend installs, backend-only installs, managed Postgres, and an existing external Postgres URL.
+- All-in-one installs expose both frontend and backend API hostnames; browser frontend flows can still use the frontend BFF routes.
+- Published container images are used by default; local repository cloning/building is opt-in for source builds.
+- Curl-style install, update, stop, and uninstall flows are supported; systemd service installation is opt-in.
+
 [^1]: Hubuum is probably a loanword from Akkadian.
 [^2]: [JSON schema](https://json-schema.org) is a powerful tool for validating the structure of JSON data. It allows you to define the expected format of your data, including required fields, data types, and constraints on values.

--- a/README.md
+++ b/README.md
@@ -128,5 +128,13 @@ inspecting and releasing throttled scopes), see [docs/login_rate_limiting.md](do
 - The canonical environment-variable reference lives in [docs/quick_start.md](docs/quick_start.md).
 - Task-worker and async report-template tuning settings are documented there alongside the core server, DB, auth, and TLS settings.
 
+### Deployment
+
+- Single-host Docker/Podman Compose deployment scripts are documented in [docs/deployment.md](docs/deployment.md).
+- The scripts support all-in-one frontend/backend installs, backend-only installs, managed Postgres, and an existing external Postgres URL.
+- All-in-one installs expose both frontend and backend API hostnames; browser frontend flows can still use the frontend BFF routes.
+- Published container images are used by default; local repository cloning/building is opt-in for source builds.
+- Curl-style install, update, stop, and uninstall flows are supported; systemd service installation is opt-in.
+
 [^1]: Hubuum is probably a loanword from Akkadian.
 [^2]: [JSON schema](https://json-schema.org) is a powerful tool for validating the structure of JSON data. It allows you to define the expected format of your data, including required fields, data types, and constraints on values.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,263 @@
+# Single-Host Container Deployment
+
+Hubuum can be installed on one host with Docker Compose or rootful Podman Compose. The installer uses published container images by default and can deploy either:
+
+- `all`: backend API, frontend, Caddy, Postgres, and Valkey.
+- `backend`: backend API, Caddy, and Postgres.
+
+Both modes can also use an existing Postgres server instead of creating a Postgres container.
+
+## Requirements
+
+- Linux host with inbound TCP `80` and `443` open.
+- DNS for the selected hostnames pointing at the host.
+- `openssl` and either Docker with the Docker Compose plugin or rootful Podman with `podman compose`.
+- `git` is only required when using `--build-from-source`.
+- Run the script as `root` or through `sudo`.
+- Rootless Podman is not supported by this installer because Caddy binds privileged host ports `80` and `443`.
+
+## Container Engine
+
+By default, the installer auto-detects a compose engine:
+
+- Docker Compose is preferred when both Docker and Podman are available.
+- Podman Compose is used when Docker Compose is unavailable.
+- Use `--engine docker` or `--engine podman` to force one engine.
+
+Podman support is intended for rootful installs only.
+
+## All-In-One
+
+```bash
+sudo ./scripts/install-single-host.sh \
+  --web hubuum.example.com \
+  --api hubuum-api.example.com \
+  --email admin@example.com
+```
+
+This creates `/opt/hubuum` by default, generates `/opt/hubuum/.env`, writes `compose.yml` and `Caddyfile`, pulls published images, and starts the stack.
+
+By default, the installer starts the stack directly with Compose. Pass `--systemd` to also write `/etc/systemd/system/hubuum.service`, enable it, and start the stack through that unit.
+
+Default app images:
+
+- Backend: `ghcr.io/hubuum/hubuum-server:main`
+- Frontend: `ghcr.io/hubuum/hubuum-frontend:main`
+
+## Frontend BFF And Public API
+
+All-in-one installs expose both public hostnames:
+
+- `--web` serves the frontend.
+- `--api` serves the backend API directly for integrations and API users.
+
+The frontend is still configured as a BFF-style service. Browser clients can call frontend-owned routes such as `/api/v0/auth/login`, `/api/v1/...`, and `/api/hubuum/...`; the frontend reaches the backend over the private compose network with:
+
+```env
+BACKEND_BASE_URL=http://hubuum-api:8080
+```
+
+That keeps backend bearer tokens server-side for frontend browser flows, while still leaving the backend API publicly available on the API hostname.
+
+## Curl Install
+
+The installer is self-contained enough to run directly from the repository:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hubuum/hubuum/main/scripts/install-single-host.sh \
+  | sudo bash -s -- \
+      --web hubuum.example.com \
+      --api hubuum-api.example.com \
+      --email admin@example.com
+```
+
+Use a branch, tag, commit SHA, or PR ref by changing the raw GitHub URL. Pass the same ref with `--script-ref` so the installed management helpers come from the same source:
+
+```bash
+REF=main
+curl -fsSL "https://raw.githubusercontent.com/hubuum/hubuum/${REF}/scripts/install-single-host.sh" \
+  | sudo bash -s -- \
+      --script-ref "${REF}" \
+      --web hubuum.example.com \
+      --api hubuum-api.example.com \
+      --email admin@example.com
+```
+
+Examples:
+
+- Branch: `REF=my-feature-branch`
+- Tag: `REF=v0.1.0`
+- Commit: `REF=1a2b3c4d5e6f...`
+- Pull request head: `REF=refs/pull/123/head`
+
+For pull requests from forks, GitHub may not expose package/image changes yet; use `--build-from-source` when you need to test code from that PR rather than the published `:main` images.
+
+The script installs management helpers into the install directory:
+
+- `install-single-host.sh`
+- `update-single-host.sh`
+- `stop-single-host.sh`
+- `uninstall-single-host.sh`
+
+## Backend Only
+
+```bash
+sudo ./scripts/install-backend.sh \
+  --api hubuum-api.example.com \
+  --email admin@example.com
+```
+
+Equivalent explicit form:
+
+```bash
+sudo ./scripts/install-single-host.sh \
+  --mode backend \
+  --api hubuum-api.example.com \
+  --email admin@example.com
+```
+
+## Existing Postgres
+
+Pass `--database-url` to skip the managed Postgres container:
+
+```bash
+sudo ./scripts/install-single-host.sh \
+  --web hubuum.example.com \
+  --api hubuum-api.example.com \
+  --email admin@example.com \
+  --database-url 'postgres://hubuum:secret@postgres.example.com:5432/hubuum?sslmode=require'
+```
+
+The database must already exist and be reachable from containers on the host. Avoid `localhost` in the URL unless Postgres is inside the same container; from a container, `localhost` means the API container itself.
+
+## Source Builds
+
+The installer does not clone repositories by default. Use `--build-from-source` only when you need to build local images from Git refs that are not available as published container images:
+
+```bash
+sudo ./scripts/install-single-host.sh \
+  --web hubuum.example.com \
+  --api hubuum-api.example.com \
+  --email admin@example.com \
+  --build-from-source \
+  --backend-ref main \
+  --frontend-ref main
+```
+
+In source-build mode, the installer clones the repositories under `/opt/hubuum/src` and builds `local/hubuum-api:single-host` and `local/hubuum-web:single-host`.
+
+## Service Management
+
+Systemd service management is opt-in. Install with `--systemd` to manage the stack with systemd:
+
+```bash
+sudo systemctl status hubuum
+sudo systemctl restart hubuum
+sudo systemctl stop hubuum
+sudo systemctl start hubuum
+```
+
+The containers use `restart: unless-stopped`; a systemd unit adds an explicit host-boot contract. It runs `compose up -d` on start and `compose down` on stop from the install directory.
+
+Use `--service-name NAME` to install the unit under a different name. Without `--systemd`, manage the stack directly with Compose.
+
+## Updates
+
+The installer copies `update-single-host.sh` into the install directory:
+
+```bash
+cd /opt/hubuum
+sudo ./update-single-host.sh
+```
+
+For image-based installs, the update command pulls the latest configured images and restarts the stack. For source-build installs, it fetches the source checkouts, rebuilds the local app images, and restarts the stack.
+
+If the systemd unit exists, updates restart through systemd. Otherwise, updates fall back to `compose up -d`.
+
+## Stop And Uninstall
+
+Stop the stack:
+
+```bash
+cd /opt/hubuum
+sudo ./stop-single-host.sh
+```
+
+Equivalent direct form:
+
+```bash
+sudo ./install-single-host.sh --stop --dir /opt/hubuum
+```
+
+Uninstall stops the stack and removes the systemd unit if one exists. By default, it preserves `/opt/hubuum` and compose volumes:
+
+```bash
+cd /opt/hubuum
+sudo ./uninstall-single-host.sh
+```
+
+Use `--purge` to also remove compose volumes and the install directory:
+
+```bash
+cd /opt/hubuum
+sudo ./uninstall-single-host.sh --purge
+```
+
+## Parameters
+
+Required:
+
+- `--api`: public backend API hostname served by Caddy.
+- `--email`: Let's Encrypt registration email.
+- `--web`: public frontend hostname. Required only in `all` mode.
+
+Common optional parameters:
+
+- `--stop`: stop the installed stack and exit.
+- `--uninstall`: stop the stack, remove the systemd unit if present, and exit.
+- `--purge`: with `--uninstall`, also remove compose volumes and the install directory.
+- `--dir`: install directory. Default: `/opt/hubuum`.
+- `--mode`: `all` or `backend`. Default: `all`.
+- `--database-url`: existing Postgres URL. If omitted, the installer creates a managed Postgres container.
+- `--engine`: `auto`, `docker`, or `podman`. Default: `auto`.
+- `--backend-image`: backend image. Default: `ghcr.io/hubuum/hubuum-server:main`.
+- `--frontend-image`: frontend image. Default: `ghcr.io/hubuum/hubuum-frontend:main`.
+- `--postgres-image`: managed Postgres image. Default: `docker.io/library/postgres:18-alpine`.
+- `--valkey-image`: frontend session/cache Valkey image. Default: `docker.io/valkey/valkey:9-alpine`.
+- `--caddy-image`: reverse proxy image. Default: `docker.io/library/caddy:2-alpine`.
+- `--network-subnet`: container bridge subnet and backend client allowlist. Default: `172.30.42.0/24`.
+- `--systemd`: install and enable a systemd service.
+- `--service-name`: systemd service name. Default: `hubuum`.
+- `--no-systemd`: skip systemd unit installation. This is the default.
+- `--script-base-url`: base URL for downloading management scripts during curl-based installs.
+- `--script-ref`: Git ref used to derive raw GitHub management script URLs.
+- `--build-from-source`: clone repositories and build app images locally.
+- `--backend-ref`: source build backend Git ref. Default: `main`.
+- `--frontend-ref`: source build frontend Git ref. Default: `main`.
+- `--recreate`: regenerate generated secrets.
+- `--no-pull`: skip pulling images before starting.
+
+## Generated Environment
+
+Backend:
+
+- `HUBUUM_DATABASE_URL` and `DATABASE_URL`: Postgres connection URL.
+- `HUBUUM_BIND_IP=0.0.0.0`
+- `HUBUUM_BIND_PORT=8080`
+- `HUBUUM_LOG_LEVEL=info`
+- `HUBUUM_TOKEN_HASH_KEY`: generated stable token hash key.
+- `HUBUUM_CLIENT_ALLOWLIST`: defaults to the container bridge subnet.
+- `HUBUUM_TRUST_IP_HEADERS=false`
+- `HUBUUM_TOKEN_LIFETIME_HOURS=24`
+- `HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS=5`
+- `HUBUUM_LOGIN_RATE_LIMIT_WINDOW_SECONDS=300`
+
+Frontend, all-in-one mode only:
+
+- `BACKEND_BASE_URL=http://hubuum-api:8080`
+- `VALKEY_URL=redis://valkey:6379/0`
+- `SESSION_TTL_SECONDS=28800`
+- `SESSION_PREFIX=hubuum:sess:`
+- `NEXT_PUBLIC_APP_NAME="Hubuum Console"`
+
+The backend creates the initial admin user and group on first startup. The generated admin password is not logged; reset it with `hubuum-admin` in the API container after installation.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -59,6 +59,26 @@ BACKEND_BASE_URL=http://hubuum-api:8080
 
 That keeps backend bearer tokens server-side for frontend browser flows, while still leaving the backend API publicly available on the API hostname.
 
+## Shared Host Routing
+
+You can use the same DNS name and public `80`/`443` ports for both frontend and API by setting `--web` and `--api` to the same hostname. In that case, choose an explicit routing mode:
+
+```bash
+sudo ./scripts/install-single-host.sh \
+  --web hubuum.example.com \
+  --api hubuum.example.com \
+  --shared-host-routing prefixed \
+  --email admin@example.com
+```
+
+Modes:
+
+- `prefixed`: exposes the backend under `/hubuum-api/` and sends everything else to the frontend. This avoids collisions with frontend-owned `/api/...` BFF routes and is the recommended shared-host mode.
+- `direct`: sends backend-owned paths such as `/api/v0...`, `/api/v1...`, `/api-doc...`, and `/swagger-ui...` directly to the backend, with everything else going to the frontend. This makes the backend available at its normal paths, but those paths bypass the frontend BFF.
+- `bff`: sends all traffic to the frontend. The backend is publicly available only through frontend-owned BFF/proxy routes. Use this only if the frontend intentionally proxies every backend API route you need to expose.
+
+For the frontend to make shared-host deployments easier, it should keep its internal/BFF routes under a distinct prefix that will never collide with direct backend routes, for example `/_hubuum-bff/...` or `/api/frontend/...`. That would let Caddy route backend paths like `/api/v1/...` directly to the backend while reserving a separate namespace for frontend-only session and proxy behavior.
+
 ## Curl Install
 
 The installer is self-contained enough to run directly from the repository:
@@ -227,6 +247,7 @@ Common optional parameters:
 - `--valkey-image`: frontend session/cache Valkey image. Default: `docker.io/valkey/valkey:9-alpine`.
 - `--caddy-image`: reverse proxy image. Default: `docker.io/library/caddy:2-alpine`.
 - `--network-subnet`: container bridge subnet and backend client allowlist. Default: `172.30.42.0/24`.
+- `--shared-host-routing`: required when `--web` and `--api` are the same in `all` mode. Accepted values: `bff`, `direct`, `prefixed`.
 - `--systemd`: install and enable a systemd service.
 - `--service-name`: systemd service name. Default: `hubuum`.
 - `--no-systemd`: skip systemd unit installation. This is the default.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,17 +67,17 @@ You can use the same DNS name and public `80`/`443` ports for both frontend and 
 sudo ./scripts/install-single-host.sh \
   --web hubuum.example.com \
   --api hubuum.example.com \
-  --shared-host-routing prefixed \
+  --shared-host-routing direct \
   --email admin@example.com
 ```
 
 Modes:
 
-- `prefixed`: exposes the backend under `/hubuum-api/` and sends everything else to the frontend. This avoids collisions with frontend-owned `/api/...` BFF routes and is the recommended shared-host mode.
-- `direct`: sends backend-owned paths such as `/api/v0...`, `/api/v1...`, `/api-doc...`, and `/swagger-ui...` directly to the backend, with everything else going to the frontend. This makes the backend available at its normal paths, but those paths bypass the frontend BFF.
-- `bff`: sends all traffic to the frontend. The backend is publicly available only through frontend-owned BFF/proxy routes. Use this only if the frontend intentionally proxies every backend API route you need to expose.
+- `direct`: sends backend-owned paths such as `/api/v0...`, `/api/v1...`, `/api-doc...`, and `/swagger-ui...` directly to the backend, with everything else going to the frontend. This is the recommended shared-host mode now that frontend-owned BFF routes live under `/_hubuum-bff/...`.
+- `prefixed`: exposes the backend under `/hubuum-api/` and sends everything else to the frontend. This is useful if you want to avoid exposing backend routes at their native paths.
+- `bff`: sends all traffic to the frontend. The backend is not directly exposed by Caddy in this mode; use it only when frontend proxy coverage is the intended public API surface.
 
-For the frontend to make shared-host deployments easier, it should keep its internal/BFF routes under a distinct prefix that will never collide with direct backend routes, for example `/_hubuum-bff/...` or `/api/frontend/...`. That would let Caddy route backend paths like `/api/v1/...` directly to the backend while reserving a separate namespace for frontend-only session and proxy behavior.
+The frontend makes shared-host deployments easier by keeping internal/BFF routes under `/_hubuum-bff/...`, which does not collide with direct backend routes like `/api/v1/...`.
 
 ## Curl Install
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -208,6 +208,7 @@ sudo ./uninstall-single-host.sh --purge
 Required:
 
 - `--api`: public backend API hostname served by Caddy.
+- `--api-port`: internal backend API listen port. Default: `8080`.
 - `--email`: Let's Encrypt registration email.
 - `--web`: public frontend hostname. Required only in `all` mode.
 
@@ -243,7 +244,7 @@ Backend:
 
 - `HUBUUM_DATABASE_URL` and `DATABASE_URL`: Postgres connection URL.
 - `HUBUUM_BIND_IP=0.0.0.0`
-- `HUBUUM_BIND_PORT=8080`
+- `HUBUUM_BIND_PORT`: internal backend API listen port. Default: `8080`.
 - `HUBUUM_LOG_LEVEL=info`
 - `HUBUUM_TOKEN_HASH_KEY`: generated stable token hash key.
 - `HUBUUM_CLIENT_ALLOWLIST`: defaults to the container bridge subnet.
@@ -254,7 +255,7 @@ Backend:
 
 Frontend, all-in-one mode only:
 
-- `BACKEND_BASE_URL=http://hubuum-api:8080`
+- `BACKEND_BASE_URL`: internal backend URL, derived from `--api-port`.
 - `VALKEY_URL=redis://valkey:6379/0`
 - `SESSION_TTL_SECONDS=28800`
 - `SESSION_PREFIX=hubuum:sess:`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -192,7 +192,22 @@ sudo ./update-single-host.sh
 
 For image-based installs, the update command pulls the latest configured images and restarts the stack. For source-build installs, it fetches the source checkouts, rebuilds the local app images, and restarts the stack.
 
-If the systemd unit exists, updates restart through systemd. Otherwise, updates fall back to `compose up -d`.
+If the systemd unit exists, updates restart through systemd, whose stop/start steps recreate the containers. Otherwise the update tears the stack down and brings it back up (`compose down` then `compose up -d`) so the freshly pulled images are actually picked up; a plain `compose up -d` does not reliably recreate running containers, particularly under Podman.
+
+### Re-running The Installer To Update
+
+The installer is idempotent and doubles as an in-place updater. Re-running it against an existing install directory reuses the configuration recorded in `.env` (mode, hostnames, email, images, refs, ports, network subnet, container engine, and systemd service name) and preserves generated secrets and the managed database, so you only need to pass the arguments you want to change:
+
+```bash
+# Pull the latest configured images and apply any changed configuration in place.
+curl -fsSL https://raw.githubusercontent.com/hubuum/hubuum/main/scripts/install-single-host.sh \
+  | sudo bash -s -- --dir /opt/hubuum
+
+# Change a single setting (for example, pin a new backend image) and reuse the rest.
+sudo ./install-single-host.sh --backend-image ghcr.io/hubuum/hubuum-server:v1.2.3
+```
+
+Any value passed explicitly on the command line overrides the stored one; everything else is taken from the existing `.env`. Compose applies only the services whose definition or image changed. For a clean recreate of every container (useful under Podman), use `update-single-host.sh` instead.
 
 ## Stop And Uninstall
 
@@ -256,7 +271,7 @@ Common optional parameters:
 - `--build-from-source`: clone repositories and build app images locally.
 - `--backend-ref`: source build backend Git ref. Default: `main`.
 - `--frontend-ref`: source build frontend Git ref. Default: `main`.
-- `--recreate`: regenerate generated secrets.
+- `--recreate`: regenerate generated secrets. The managed Postgres password is preserved, because the existing database volume was initialized with it and rotating it would break authentication. To reset the database, uninstall with `--purge` first, then reinstall.
 - `--no-pull`: skip pulling images before starting.
 
 ## Generated Environment

--- a/scripts/install-backend.sh
+++ b/scripts/install-backend.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+exec "$SCRIPT_DIR/install-single-host.sh" --mode backend "$@"

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -7,6 +7,7 @@ MODE="all"
 WEB_FQDN=""
 API_FQDN=""
 API_PORT="8080"
+SHARED_HOST_ROUTING=""
 LETSENCRYPT_EMAIL=""
 BACKEND_REF="main"
 FRONTEND_REF="main"
@@ -49,6 +50,8 @@ Options:
   --web FQDN              Public frontend hostname. Required in all mode
   --api FQDN              Public backend API hostname. Required
   --api-port PORT         Internal backend API listen port. Default: 8080
+  --shared-host-routing MODE
+                          Required when --web and --api are the same in all mode: bff, direct, or prefixed
   --email EMAIL           Let's Encrypt registration email. Required
   --backend-image IMAGE   Backend image. Default: ghcr.io/hubuum/hubuum-server:main
   --frontend-image IMAGE  Frontend image. Default: ghcr.io/hubuum/hubuum-frontend:main
@@ -117,6 +120,7 @@ while [[ $# -gt 0 ]]; do
     --web) WEB_FQDN="$2"; shift 2 ;;
     --api) API_FQDN="$2"; shift 2 ;;
     --api-port) API_PORT="$2"; shift 2 ;;
+    --shared-host-routing) SHARED_HOST_ROUTING="$2"; shift 2 ;;
     --email) LETSENCRYPT_EMAIL="$2"; shift 2 ;;
     --backend-image) BACKEND_IMAGE="$2"; shift 2 ;;
     --frontend-image) FRONTEND_IMAGE="$2"; shift 2 ;;
@@ -146,6 +150,9 @@ done
 [[ "$MODE" == "all" || "$MODE" == "backend" ]] || die "--mode must be all or backend"
 [[ "$ENGINE" == "auto" || "$ENGINE" == "docker" || "$ENGINE" == "podman" ]] || die "--engine must be auto, docker, or podman"
 [[ "$API_PORT" =~ ^[0-9]+$ && "$API_PORT" -ge 1 && "$API_PORT" -le 65535 ]] || die "--api-port must be an integer between 1 and 65535"
+if [[ -n "$SHARED_HOST_ROUTING" && "$SHARED_HOST_ROUTING" != "bff" && "$SHARED_HOST_ROUTING" != "direct" && "$SHARED_HOST_ROUTING" != "prefixed" ]]; then
+  die "--shared-host-routing must be bff, direct, or prefixed"
+fi
 SERVICE_NAME="${SERVICE_NAME%.service}"
 if [[ "$PURGE" == "true" && "$ACTION" != "uninstall" ]]; then
   die "--purge can only be used with --uninstall"
@@ -164,6 +171,15 @@ fi
 if [[ "$ACTION" == "install" && "$MODE" == "all" && -z "$WEB_FQDN" ]]; then
   usage
   exit 2
+fi
+if [[ "$ACTION" == "install" && "$MODE" == "all" && "$WEB_FQDN" == "$API_FQDN" && -z "$SHARED_HOST_ROUTING" ]]; then
+  die "--shared-host-routing is required when --web and --api use the same hostname"
+fi
+if [[ "$ACTION" == "install" && "$MODE" == "all" && "$WEB_FQDN" != "$API_FQDN" && -n "$SHARED_HOST_ROUTING" ]]; then
+  die "--shared-host-routing only applies when --web and --api use the same hostname"
+fi
+if [[ "$ACTION" == "install" && "$MODE" == "backend" && -n "$SHARED_HOST_ROUTING" ]]; then
+  die "--shared-host-routing only applies in all mode"
 fi
 if [[ "$EUID" -ne 0 ]]; then
   die "run as root, or via sudo"
@@ -365,6 +381,7 @@ fi
   printf 'INSTALL_MODE=%s\n' "$MODE"
   printf 'WEB_FQDN=%s\n' "$WEB_FQDN"
   printf 'API_FQDN=%s\n' "$API_FQDN"
+  printf 'SHARED_HOST_ROUTING=%s\n' "$SHARED_HOST_ROUTING"
   printf 'LETSENCRYPT_EMAIL=%s\n' "$LETSENCRYPT_EMAIL"
   printf 'BUILD_FROM_SOURCE=%s\n' "$BUILD_FROM_SOURCE"
   printf 'CONTAINER_ENGINE=%s\n' "$ENGINE_BIN"
@@ -405,7 +422,7 @@ fi
 
 chmod 0600 "$ENV_FILE"
 
-if [[ "$MODE" == "all" ]]; then
+if [[ "$MODE" == "all" && -z "$SHARED_HOST_ROUTING" ]]; then
   cat > "$INSTALL_DIR/Caddyfile" <<'EOF'
 {
     email {$LETSENCRYPT_EMAIL}
@@ -419,6 +436,69 @@ if [[ "$MODE" == "all" ]]; then
 {$API_FQDN} {
     encode zstd gzip
     reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
+}
+EOF
+elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "bff" ]]; then
+  cat > "$INSTALL_DIR/Caddyfile" <<'EOF'
+{
+    email {$LETSENCRYPT_EMAIL}
+}
+
+{$WEB_FQDN} {
+    encode zstd gzip
+    reverse_proxy hubuum-web:3000
+}
+EOF
+elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "direct" ]]; then
+  cat > "$INSTALL_DIR/Caddyfile" <<'EOF'
+{
+    email {$LETSENCRYPT_EMAIL}
+}
+
+{$WEB_FQDN} {
+    encode zstd gzip
+
+    handle /api/v0* {
+        reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
+    }
+
+    handle /api/v1* {
+        reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
+    }
+
+    handle /api-doc* {
+        reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
+    }
+
+    handle /swagger-ui* {
+        reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
+    }
+
+    handle {
+        reverse_proxy hubuum-web:3000
+    }
+}
+EOF
+elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "prefixed" ]]; then
+  cat > "$INSTALL_DIR/Caddyfile" <<'EOF'
+{
+    email {$LETSENCRYPT_EMAIL}
+}
+
+{$WEB_FQDN} {
+    encode zstd gzip
+
+    handle /hubuum-api {
+        redir /hubuum-api/
+    }
+
+    handle_path /hubuum-api/* {
+        reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
+    }
+
+    handle {
+        reverse_proxy hubuum-web:3000
+    }
 }
 EOF
 else
@@ -687,8 +767,21 @@ Image source:
   $([[ "$BUILD_FROM_SOURCE" == "true" ]] && printf 'local source builds' || printf 'published container images')
 
 Backend API:
+EOF
+
+if [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "prefixed" ]]; then
+  cat <<EOF
+  https://${API_FQDN}/hubuum-api/
+EOF
+elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "bff" ]]; then
+  cat <<EOF
+  https://${API_FQDN} via frontend BFF routes
+EOF
+else
+  cat <<EOF
   https://${API_FQDN}
 EOF
+fi
 
 if [[ "$MODE" == "all" ]]; then
   cat <<EOF
@@ -730,7 +823,7 @@ Important:
   Make sure DNS for ${API_FQDN} points to this host.
 EOF
 
-if [[ "$MODE" == "all" ]]; then
+if [[ "$MODE" == "all" && "$WEB_FQDN" != "$API_FQDN" ]]; then
   cat <<EOF
   Make sure DNS for ${WEB_FQDN} points to this host.
 EOF

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -1,0 +1,738 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="/opt/hubuum"
+MODE="all"
+WEB_FQDN=""
+API_FQDN=""
+LETSENCRYPT_EMAIL=""
+BACKEND_REF="main"
+FRONTEND_REF="main"
+BACKEND_REPO="https://github.com/hubuum/hubuum.git"
+FRONTEND_REPO="https://github.com/hubuum/hubuum-frontend.git"
+BACKEND_IMAGE="ghcr.io/hubuum/hubuum-server:main"
+FRONTEND_IMAGE="ghcr.io/hubuum/hubuum-frontend:main"
+POSTGRES_IMAGE="docker.io/library/postgres:18-alpine"
+VALKEY_IMAGE="docker.io/valkey/valkey:9-alpine"
+CADDY_IMAGE="docker.io/library/caddy:2-alpine"
+EXTERNAL_DATABASE_URL=""
+NETWORK_SUBNET="172.30.42.0/24"
+RECREATE="false"
+PULL="true"
+ENGINE="auto"
+ENGINE_BIN=""
+ENGINE_PATH=""
+BUILD_FROM_SOURCE="false"
+INSTALL_SYSTEMD="false"
+SERVICE_NAME="hubuum"
+ACTION="install"
+PURGE="false"
+SERVICE_NAME_SET="false"
+SCRIPT_BASE_URL="https://raw.githubusercontent.com/hubuum/hubuum/main/scripts"
+SCRIPT_REF=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  install-single-host.sh --web hubuum.example.com --api hubuum-api.example.com --email admin@example.com
+  install-single-host.sh --mode backend --api hubuum-api.example.com --email admin@example.com
+  curl -fsSL https://raw.githubusercontent.com/hubuum/hubuum/main/scripts/install-single-host.sh | sudo bash -s -- --web hubuum.example.com --api hubuum-api.example.com --email admin@example.com
+
+Options:
+  --stop                  Stop the installed stack and exit
+  --uninstall             Stop the stack, remove systemd unit if present, and exit
+  --purge                 With --uninstall, also remove compose volumes and install directory
+  --mode MODE             Install mode: all or backend. Default: all
+  --dir PATH              Install directory. Default: /opt/hubuum
+  --web FQDN              Public frontend hostname. Required in all mode
+  --api FQDN              Public backend API hostname. Required
+  --email EMAIL           Let's Encrypt registration email. Required
+  --backend-image IMAGE   Backend image. Default: ghcr.io/hubuum/hubuum-server:main
+  --frontend-image IMAGE  Frontend image. Default: ghcr.io/hubuum/hubuum-frontend:main
+  --database-url URL      Existing Postgres URL. If set, no Postgres container is created
+  --engine ENGINE         Container engine: auto, docker, or podman. Default: auto
+  --postgres-image IMAGE  Postgres image. Default: docker.io/library/postgres:18-alpine
+  --valkey-image IMAGE    Valkey image. Default: docker.io/valkey/valkey:9-alpine
+  --caddy-image IMAGE     Caddy image. Default: docker.io/library/caddy:2-alpine
+  --network-subnet CIDR   Container bridge subnet. Default: 172.30.42.0/24
+  --systemd               Install and enable a systemd service
+  --service-name NAME     systemd service name. Default: hubuum
+  --no-systemd            Do not install or enable a systemd service. Default
+  --script-base-url URL   Base URL for management scripts when installing via curl
+  --script-ref REF        Git ref used to derive raw GitHub management script URLs
+  --build-from-source     Clone repositories and build app images locally
+  --backend-ref REF       Source build backend Git ref. Default: main
+  --frontend-ref REF      Source build frontend Git ref. Default: main
+  --backend-repo URL      Source build backend Git repository
+  --frontend-repo URL     Source build frontend Git repository
+  --no-pull               Do not pull dependency/base images before starting
+  --recreate              Regenerate .env secrets even if they exist
+  -h, --help              Show this help
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+quote_env() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '"%s"' "$value"
+}
+
+random_hex() {
+  openssl rand -hex "$1" | tr -d '\n'
+}
+
+read_env_value() {
+  local key="$1"
+  local line
+
+  [[ -f "$ENV_FILE" ]] || return 1
+  line="$(grep -E "^${key}=" "$ENV_FILE" | tail -n 1 || true)"
+  [[ -n "$line" ]] || return 1
+  line="${line#*=}"
+  line="${line%\"}"
+  line="${line#\"}"
+  printf '%s' "$line"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode) MODE="$2"; shift 2 ;;
+    --stop) ACTION="stop"; shift ;;
+    --uninstall) ACTION="uninstall"; shift ;;
+    --purge) PURGE="true"; shift ;;
+    --dir) INSTALL_DIR="$2"; shift 2 ;;
+    --web) WEB_FQDN="$2"; shift 2 ;;
+    --api) API_FQDN="$2"; shift 2 ;;
+    --email) LETSENCRYPT_EMAIL="$2"; shift 2 ;;
+    --backend-image) BACKEND_IMAGE="$2"; shift 2 ;;
+    --frontend-image) FRONTEND_IMAGE="$2"; shift 2 ;;
+    --backend-ref) BACKEND_REF="$2"; shift 2 ;;
+    --frontend-ref) FRONTEND_REF="$2"; shift 2 ;;
+    --backend-repo) BACKEND_REPO="$2"; shift 2 ;;
+    --frontend-repo) FRONTEND_REPO="$2"; shift 2 ;;
+    --database-url) EXTERNAL_DATABASE_URL="$2"; shift 2 ;;
+    --engine) ENGINE="$2"; shift 2 ;;
+    --postgres-image) POSTGRES_IMAGE="$2"; shift 2 ;;
+    --valkey-image) VALKEY_IMAGE="$2"; shift 2 ;;
+    --caddy-image) CADDY_IMAGE="$2"; shift 2 ;;
+    --network-subnet) NETWORK_SUBNET="$2"; shift 2 ;;
+    --systemd) INSTALL_SYSTEMD="true"; shift ;;
+    --service-name) SERVICE_NAME="$2"; SERVICE_NAME_SET="true"; shift 2 ;;
+    --no-systemd) INSTALL_SYSTEMD="false"; shift ;;
+    --script-base-url) SCRIPT_BASE_URL="${2%/}"; shift 2 ;;
+    --script-ref) SCRIPT_REF="$2"; shift 2 ;;
+    --build-from-source) BUILD_FROM_SOURCE="true"; shift ;;
+    --no-pull) PULL="false"; shift ;;
+    --recreate) RECREATE="true"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+[[ "$MODE" == "all" || "$MODE" == "backend" ]] || die "--mode must be all or backend"
+[[ "$ENGINE" == "auto" || "$ENGINE" == "docker" || "$ENGINE" == "podman" ]] || die "--engine must be auto, docker, or podman"
+SERVICE_NAME="${SERVICE_NAME%.service}"
+if [[ "$PURGE" == "true" && "$ACTION" != "uninstall" ]]; then
+  die "--purge can only be used with --uninstall"
+fi
+if [[ -n "$SCRIPT_REF" ]]; then
+  SCRIPT_BASE_URL="https://raw.githubusercontent.com/hubuum/hubuum/${SCRIPT_REF}/scripts"
+fi
+if [[ "$ACTION" == "install" && -z "$API_FQDN" ]]; then
+  usage
+  exit 2
+fi
+if [[ "$ACTION" == "install" && -z "$LETSENCRYPT_EMAIL" ]]; then
+  usage
+  exit 2
+fi
+if [[ "$ACTION" == "install" && "$MODE" == "all" && -z "$WEB_FQDN" ]]; then
+  usage
+  exit 2
+fi
+if [[ "$EUID" -ne 0 ]]; then
+  die "run as root, or via sudo"
+fi
+
+ENV_FILE="$INSTALL_DIR/.env"
+
+detect_engine() {
+  if [[ "$ENGINE" == "docker" || "$ENGINE" == "auto" ]]; then
+    if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+      ENGINE="docker"
+      ENGINE_BIN="docker"
+      return 0
+    fi
+
+    [[ "$ENGINE" == "auto" ]] || die "docker compose plugin is required"
+  fi
+
+  if [[ "$ENGINE" == "podman" || "$ENGINE" == "auto" ]]; then
+    if command -v podman >/dev/null 2>&1 && podman compose version >/dev/null 2>&1; then
+      ENGINE="podman"
+      ENGINE_BIN="podman"
+      return 0
+    fi
+
+    [[ "$ENGINE" == "auto" ]] || die "podman compose is required"
+  fi
+
+  die "no supported compose engine found; install docker compose or podman compose"
+}
+
+load_existing_runtime() {
+  [[ -f "$ENV_FILE" ]] || return 0
+
+  if [[ "$ENGINE" == "auto" ]]; then
+    ENGINE="$(read_env_value CONTAINER_ENGINE || printf 'auto')"
+  fi
+  if [[ "$SERVICE_NAME_SET" != "true" ]]; then
+    SERVICE_NAME="$(read_env_value SYSTEMD_SERVICE_NAME || printf '%s' "$SERVICE_NAME")"
+    SERVICE_NAME="${SERVICE_NAME%.service}"
+  fi
+}
+
+systemd_available() {
+  [[ -d /run/systemd/system ]] && command -v systemctl >/dev/null 2>&1
+}
+
+systemd_unit_exists() {
+  systemd_available && systemctl cat "${SERVICE_NAME}.service" >/dev/null 2>&1
+}
+
+compose_down() {
+  local purge_flag="${1:-false}"
+
+  [[ -f "$INSTALL_DIR/compose.yml" ]] || return 0
+  cd "$INSTALL_DIR"
+  if [[ "$purge_flag" == "true" ]]; then
+    "${COMPOSE_CMD[@]}" down -v --remove-orphans
+  else
+    "${COMPOSE_CMD[@]}" down --remove-orphans
+  fi
+}
+
+stop_stack() {
+  if systemd_unit_exists; then
+    systemctl stop "$SERVICE_NAME"
+  else
+    compose_down false
+  fi
+}
+
+uninstall_stack() {
+  if systemd_unit_exists; then
+    systemctl stop "$SERVICE_NAME" || true
+    systemctl disable "$SERVICE_NAME" || true
+    rm -f "/etc/systemd/system/${SERVICE_NAME}.service"
+    systemctl daemon-reload
+  fi
+
+  compose_down "$PURGE"
+
+  if [[ "$PURGE" == "true" ]]; then
+    rm -rf "$INSTALL_DIR"
+  fi
+}
+
+load_existing_runtime
+detect_engine
+ENGINE_PATH="$(command -v "$ENGINE_BIN")"
+COMPOSE_CMD=("$ENGINE_PATH" compose --env-file .env -f compose.yml)
+
+if [[ "$ACTION" == "stop" ]]; then
+  stop_stack
+  echo "Hubuum stack stopped."
+  exit 0
+fi
+
+if [[ "$ACTION" == "uninstall" ]]; then
+  uninstall_stack
+  if [[ "$PURGE" == "true" ]]; then
+    echo "Hubuum stack uninstalled and install directory removed."
+  else
+    echo "Hubuum stack uninstalled. Install files and volumes were preserved."
+  fi
+  exit 0
+fi
+
+need_cmd openssl
+if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
+  need_cmd git
+fi
+
+mkdir -p "$INSTALL_DIR"
+if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
+  mkdir -p "$INSTALL_DIR/src"
+fi
+
+install_management_script() {
+  local script_name="$1"
+  local local_path="$SCRIPT_DIR/$script_name"
+  local dest_path="$INSTALL_DIR/$script_name"
+
+  if [[ -f "$local_path" && "$local_path" != "$dest_path" ]]; then
+    install -m 0755 "$local_path" "$dest_path"
+    return 0
+  elif [[ -f "$dest_path" ]]; then
+    chmod 0755 "$dest_path"
+    return 0
+  fi
+
+  if command -v curl >/dev/null 2>&1; then
+    if curl -fsSL "${SCRIPT_BASE_URL}/${script_name}" -o "$dest_path"; then
+      chmod 0755 "$dest_path"
+      return 0
+    fi
+  fi
+
+  echo "WARNING: could not install $script_name; curl is unavailable and no local script was found" >&2
+}
+
+install_management_script install-single-host.sh
+install_management_script update-single-host.sh
+install_management_script stop-single-host.sh
+install_management_script uninstall-single-host.sh
+
+clone_or_update() {
+  local repo_url="$1"
+  local dest="$2"
+  local ref="$3"
+
+  if [[ -e "$dest" && ! -d "$dest/.git" ]]; then
+    die "$dest exists but is not a Git checkout"
+  fi
+
+  if [[ ! -d "$dest/.git" ]]; then
+    git clone "$repo_url" "$dest"
+  fi
+
+  git -C "$dest" remote set-url origin "$repo_url"
+  git -C "$dest" fetch --tags --prune origin
+
+  if git -C "$dest" show-ref --verify --quiet "refs/remotes/origin/$ref"; then
+    git -C "$dest" checkout -B "$ref" "origin/$ref"
+  else
+    git -C "$dest" checkout "$ref"
+  fi
+}
+
+if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
+  clone_or_update "$BACKEND_REPO" "$INSTALL_DIR/src/hubuum" "$BACKEND_REF"
+  if [[ "$MODE" == "all" ]]; then
+    clone_or_update "$FRONTEND_REPO" "$INSTALL_DIR/src/hubuum-frontend" "$FRONTEND_REF"
+  fi
+fi
+
+ENV_FILE="$INSTALL_DIR/.env"
+
+POSTGRES_PASSWORD=""
+HUBUUM_TOKEN_HASH_KEY=""
+if [[ "$RECREATE" != "true" ]]; then
+  if [[ -z "$EXTERNAL_DATABASE_URL" && "$(read_env_value DATABASE_MANAGED || true)" == "false" ]]; then
+    EXTERNAL_DATABASE_URL="$(read_env_value HUBUUM_DATABASE_URL || true)"
+  fi
+  POSTGRES_PASSWORD="$(read_env_value POSTGRES_PASSWORD || true)"
+  HUBUUM_TOKEN_HASH_KEY="$(read_env_value HUBUUM_TOKEN_HASH_KEY || true)"
+fi
+
+[[ -n "$POSTGRES_PASSWORD" ]] || POSTGRES_PASSWORD="$(random_hex 32)"
+[[ -n "$HUBUUM_TOKEN_HASH_KEY" ]] || HUBUUM_TOKEN_HASH_KEY="$(random_hex 32)"
+
+DATABASE_MANAGED="true"
+HUBUUM_DATABASE_URL="postgres://hubuum:${POSTGRES_PASSWORD}@postgres:5432/hubuum"
+if [[ -n "$EXTERNAL_DATABASE_URL" ]]; then
+  DATABASE_MANAGED="false"
+  HUBUUM_DATABASE_URL="$EXTERNAL_DATABASE_URL"
+fi
+
+{
+  printf 'INSTALL_MODE=%s\n' "$MODE"
+  printf 'WEB_FQDN=%s\n' "$WEB_FQDN"
+  printf 'API_FQDN=%s\n' "$API_FQDN"
+  printf 'LETSENCRYPT_EMAIL=%s\n' "$LETSENCRYPT_EMAIL"
+  printf 'BUILD_FROM_SOURCE=%s\n' "$BUILD_FROM_SOURCE"
+  printf 'CONTAINER_ENGINE=%s\n' "$ENGINE_BIN"
+  printf 'SYSTEMD_SERVICE_NAME=%s\n' "$SERVICE_NAME"
+  printf '\n'
+  printf 'BACKEND_IMAGE=%s\n' "$BACKEND_IMAGE"
+  printf 'FRONTEND_IMAGE=%s\n' "$FRONTEND_IMAGE"
+  printf 'BACKEND_REF=%s\n' "$BACKEND_REF"
+  printf 'FRONTEND_REF=%s\n' "$FRONTEND_REF"
+  printf 'BACKEND_REPO=%s\n' "$BACKEND_REPO"
+  printf 'FRONTEND_REPO=%s\n' "$FRONTEND_REPO"
+  printf 'POSTGRES_IMAGE=%s\n' "$POSTGRES_IMAGE"
+  printf 'VALKEY_IMAGE=%s\n' "$VALKEY_IMAGE"
+  printf 'CADDY_IMAGE=%s\n' "$CADDY_IMAGE"
+  printf 'DATABASE_MANAGED=%s\n' "$DATABASE_MANAGED"
+  printf 'POSTGRES_DB=hubuum\n'
+  printf 'POSTGRES_USER=hubuum\n'
+  printf 'POSTGRES_PASSWORD=%s\n' "$POSTGRES_PASSWORD"
+  printf '\n'
+  printf 'HUBUUM_DATABASE_URL=%s\n' "$(quote_env "$HUBUUM_DATABASE_URL")"
+  printf 'DATABASE_URL=%s\n' "$(quote_env "$HUBUUM_DATABASE_URL")"
+  printf 'HUBUUM_BIND_IP=0.0.0.0\n'
+  printf 'HUBUUM_BIND_PORT=8080\n'
+  printf 'HUBUUM_LOG_LEVEL=info\n'
+  printf 'HUBUUM_TOKEN_HASH_KEY=%s\n' "$HUBUUM_TOKEN_HASH_KEY"
+  printf 'HUBUUM_CLIENT_ALLOWLIST=%s\n' "$NETWORK_SUBNET"
+  printf 'HUBUUM_TRUST_IP_HEADERS=false\n'
+  printf 'HUBUUM_TOKEN_LIFETIME_HOURS=24\n'
+  printf 'HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS=5\n'
+  printf 'HUBUUM_LOGIN_RATE_LIMIT_WINDOW_SECONDS=300\n'
+  printf '\n'
+  printf 'BACKEND_BASE_URL=http://hubuum-api:8080\n'
+  printf 'VALKEY_URL=redis://valkey:6379/0\n'
+  printf 'SESSION_TTL_SECONDS=28800\n'
+  printf 'SESSION_PREFIX=hubuum:sess:\n'
+  printf 'NEXT_PUBLIC_APP_NAME=%s\n' "$(quote_env "Hubuum Console")"
+} > "$ENV_FILE"
+
+chmod 0600 "$ENV_FILE"
+
+if [[ "$MODE" == "all" ]]; then
+  cat > "$INSTALL_DIR/Caddyfile" <<'EOF'
+{
+    email {$LETSENCRYPT_EMAIL}
+}
+
+{$WEB_FQDN} {
+    encode zstd gzip
+    reverse_proxy hubuum-web:3000
+}
+
+{$API_FQDN} {
+    encode zstd gzip
+    reverse_proxy hubuum-api:8080
+}
+EOF
+else
+  cat > "$INSTALL_DIR/Caddyfile" <<'EOF'
+{
+    email {$LETSENCRYPT_EMAIL}
+}
+
+{$API_FQDN} {
+    encode zstd gzip
+    reverse_proxy hubuum-api:8080
+}
+EOF
+fi
+
+cat > "$INSTALL_DIR/compose.yml" <<'EOF'
+services:
+EOF
+
+if [[ "$DATABASE_MANAGED" == "true" ]]; then
+  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+  postgres:
+    image: ${POSTGRES_IMAGE}
+    container_name: hubuum-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      PGUSER: ${POSTGRES_USER}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - hubuum_net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+EOF
+fi
+
+cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+  hubuum-api:
+EOF
+
+if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
+  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    build:
+      context: ./src/hubuum
+    image: local/hubuum-api:single-host
+EOF
+else
+  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    image: ${BACKEND_IMAGE}
+EOF
+fi
+
+cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    container_name: hubuum-api
+    restart: unless-stopped
+    environment:
+      HUBUUM_BIND_IP: ${HUBUUM_BIND_IP}
+      HUBUUM_BIND_PORT: ${HUBUUM_BIND_PORT}
+      HUBUUM_DATABASE_URL: ${HUBUUM_DATABASE_URL}
+      DATABASE_URL: ${DATABASE_URL}
+      HUBUUM_LOG_LEVEL: ${HUBUUM_LOG_LEVEL}
+      HUBUUM_TOKEN_HASH_KEY: ${HUBUUM_TOKEN_HASH_KEY}
+      HUBUUM_CLIENT_ALLOWLIST: ${HUBUUM_CLIENT_ALLOWLIST}
+      HUBUUM_TRUST_IP_HEADERS: ${HUBUUM_TRUST_IP_HEADERS}
+      HUBUUM_TOKEN_LIFETIME_HOURS: ${HUBUUM_TOKEN_LIFETIME_HOURS}
+      HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS: ${HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS}
+      HUBUUM_LOGIN_RATE_LIMIT_WINDOW_SECONDS: ${HUBUUM_LOGIN_RATE_LIMIT_WINDOW_SECONDS}
+EOF
+
+if [[ "$DATABASE_MANAGED" == "true" ]]; then
+  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    depends_on:
+      - postgres
+EOF
+fi
+
+cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    expose:
+      - "8080"
+    networks:
+      - hubuum_net
+EOF
+
+if [[ "$MODE" == "all" ]]; then
+  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+
+  valkey:
+    image: ${VALKEY_IMAGE}
+    container_name: hubuum-valkey
+    restart: unless-stopped
+    command: ["valkey-server", "--appendonly", "yes"]
+    volumes:
+      - valkey_data:/data
+    networks:
+      - hubuum_net
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  hubuum-web:
+EOF
+
+  if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
+    cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    build:
+      context: ./src/hubuum-frontend
+    image: local/hubuum-web:single-host
+EOF
+  else
+    cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    image: ${FRONTEND_IMAGE}
+EOF
+  fi
+
+  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    container_name: hubuum-web
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      PORT: 3000
+      HOSTNAME: 0.0.0.0
+      BACKEND_BASE_URL: ${BACKEND_BASE_URL}
+      VALKEY_URL: ${VALKEY_URL}
+      SESSION_TTL_SECONDS: ${SESSION_TTL_SECONDS}
+      SESSION_PREFIX: ${SESSION_PREFIX}
+      NEXT_PUBLIC_APP_NAME: ${NEXT_PUBLIC_APP_NAME}
+    depends_on:
+      - hubuum-api
+      - valkey
+    expose:
+      - "3000"
+    networks:
+      - hubuum_net
+EOF
+fi
+
+cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+
+  caddy:
+    image: ${CADDY_IMAGE}
+    container_name: hubuum-caddy
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - hubuum-api
+EOF
+
+if [[ "$MODE" == "all" ]]; then
+  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+      - hubuum-web
+EOF
+fi
+
+cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    networks:
+      - hubuum_net
+
+volumes:
+EOF
+
+if [[ "$DATABASE_MANAGED" == "true" ]]; then
+  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+  postgres_data:
+EOF
+fi
+
+if [[ "$MODE" == "all" ]]; then
+  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+  valkey_data:
+EOF
+fi
+
+cat >> "$INSTALL_DIR/compose.yml" <<EOF
+  caddy_data:
+  caddy_config:
+
+networks:
+  hubuum_net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: ${NETWORK_SUBNET}
+EOF
+
+cd "$INSTALL_DIR"
+
+if [[ "$PULL" == "true" ]]; then
+  PULL_SERVICES=(caddy)
+  [[ "$BUILD_FROM_SOURCE" != "true" ]] && PULL_SERVICES+=(hubuum-api)
+  [[ "$BUILD_FROM_SOURCE" != "true" && "$MODE" == "all" ]] && PULL_SERVICES+=(hubuum-web)
+  [[ "$DATABASE_MANAGED" == "true" ]] && PULL_SERVICES+=(postgres)
+  [[ "$MODE" == "all" ]] && PULL_SERVICES+=(valkey)
+  "${COMPOSE_CMD[@]}" pull "${PULL_SERVICES[@]}"
+fi
+
+if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
+  "${COMPOSE_CMD[@]}" build --pull
+fi
+
+install_systemd_unit() {
+  local unit_path="/etc/systemd/system/${SERVICE_NAME}.service"
+
+  cat > "$unit_path" <<EOF
+[Unit]
+Description=Hubuum container stack
+Wants=network-online.target
+After=network-online.target docker.service podman.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=${INSTALL_DIR}
+ExecStart=${ENGINE_PATH} compose --env-file .env -f compose.yml up -d
+ExecStop=${ENGINE_PATH} compose --env-file .env -f compose.yml down
+TimeoutStartSec=0
+TimeoutStopSec=120
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  systemctl daemon-reload
+  systemctl enable "$SERVICE_NAME"
+  systemctl restart "$SERVICE_NAME"
+}
+
+SYSTEMD_STATUS="not installed"
+if [[ "$INSTALL_SYSTEMD" == "true" && -d /run/systemd/system && "$(command -v systemctl || true)" ]]; then
+  install_systemd_unit
+  SYSTEMD_STATUS="enabled as ${SERVICE_NAME}.service"
+else
+  "${COMPOSE_CMD[@]}" up -d
+  if [[ "$INSTALL_SYSTEMD" == "true" ]]; then
+    SYSTEMD_STATUS="skipped; systemd is not available"
+  fi
+fi
+
+cat <<EOF
+
+Hubuum ${MODE} stack started.
+
+Container engine:
+  ${ENGINE_BIN} compose
+
+Boot service:
+  ${SYSTEMD_STATUS}
+
+Image source:
+  $([[ "$BUILD_FROM_SOURCE" == "true" ]] && printf 'local source builds' || printf 'published container images')
+
+Backend API:
+  https://${API_FQDN}
+EOF
+
+if [[ "$MODE" == "all" ]]; then
+  cat <<EOF
+
+Frontend:
+  https://${WEB_FQDN}
+EOF
+fi
+
+cat <<EOF
+
+Useful commands:
+  cd ${INSTALL_DIR}
+  ./update-single-host.sh
+  ${ENGINE_BIN} compose --env-file .env -f compose.yml ps
+  ${ENGINE_BIN} compose --env-file .env -f compose.yml logs -f hubuum-api
+EOF
+
+if [[ "$MODE" == "all" ]]; then
+  cat <<EOF
+  ${ENGINE_BIN} compose --env-file .env -f compose.yml logs -f hubuum-web
+EOF
+fi
+
+PULL_SERVICES_DISPLAY="caddy"
+[[ "$BUILD_FROM_SOURCE" != "true" ]] && PULL_SERVICES_DISPLAY="${PULL_SERVICES_DISPLAY} hubuum-api"
+[[ "$BUILD_FROM_SOURCE" != "true" && "$MODE" == "all" ]] && PULL_SERVICES_DISPLAY="${PULL_SERVICES_DISPLAY} hubuum-web"
+[[ "$DATABASE_MANAGED" == "true" ]] && PULL_SERVICES_DISPLAY="${PULL_SERVICES_DISPLAY} postgres"
+[[ "$MODE" == "all" ]] && PULL_SERVICES_DISPLAY="${PULL_SERVICES_DISPLAY} valkey"
+
+UP_COMMAND="up -d"
+[[ "$BUILD_FROM_SOURCE" == "true" ]] && UP_COMMAND="up -d --build"
+
+cat <<EOF
+  ${ENGINE_BIN} compose --env-file .env -f compose.yml pull ${PULL_SERVICES_DISPLAY}
+  ${ENGINE_BIN} compose --env-file .env -f compose.yml ${UP_COMMAND}
+
+Important:
+  Make sure DNS for ${API_FQDN} points to this host.
+EOF
+
+if [[ "$MODE" == "all" ]]; then
+  cat <<EOF
+  Make sure DNS for ${WEB_FQDN} points to this host.
+EOF
+fi
+
+cat <<'EOF'
+  Make sure inbound TCP 80 and 443 are open.
+  The first admin password is not logged; use hubuum-admin in the API container to reset it.
+EOF

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -6,6 +6,7 @@ INSTALL_DIR="/opt/hubuum"
 MODE="all"
 WEB_FQDN=""
 API_FQDN=""
+API_PORT="8080"
 LETSENCRYPT_EMAIL=""
 BACKEND_REF="main"
 FRONTEND_REF="main"
@@ -47,6 +48,7 @@ Options:
   --dir PATH              Install directory. Default: /opt/hubuum
   --web FQDN              Public frontend hostname. Required in all mode
   --api FQDN              Public backend API hostname. Required
+  --api-port PORT         Internal backend API listen port. Default: 8080
   --email EMAIL           Let's Encrypt registration email. Required
   --backend-image IMAGE   Backend image. Default: ghcr.io/hubuum/hubuum-server:main
   --frontend-image IMAGE  Frontend image. Default: ghcr.io/hubuum/hubuum-frontend:main
@@ -114,6 +116,7 @@ while [[ $# -gt 0 ]]; do
     --dir) INSTALL_DIR="$2"; shift 2 ;;
     --web) WEB_FQDN="$2"; shift 2 ;;
     --api) API_FQDN="$2"; shift 2 ;;
+    --api-port) API_PORT="$2"; shift 2 ;;
     --email) LETSENCRYPT_EMAIL="$2"; shift 2 ;;
     --backend-image) BACKEND_IMAGE="$2"; shift 2 ;;
     --frontend-image) FRONTEND_IMAGE="$2"; shift 2 ;;
@@ -142,6 +145,7 @@ done
 
 [[ "$MODE" == "all" || "$MODE" == "backend" ]] || die "--mode must be all or backend"
 [[ "$ENGINE" == "auto" || "$ENGINE" == "docker" || "$ENGINE" == "podman" ]] || die "--engine must be auto, docker, or podman"
+[[ "$API_PORT" =~ ^[0-9]+$ && "$API_PORT" -ge 1 && "$API_PORT" -le 65535 ]] || die "--api-port must be an integer between 1 and 65535"
 SERVICE_NAME="${SERVICE_NAME%.service}"
 if [[ "$PURGE" == "true" && "$ACTION" != "uninstall" ]]; then
   die "--purge can only be used with --uninstall"
@@ -383,7 +387,7 @@ fi
   printf 'HUBUUM_DATABASE_URL=%s\n' "$(quote_env "$HUBUUM_DATABASE_URL")"
   printf 'DATABASE_URL=%s\n' "$(quote_env "$HUBUUM_DATABASE_URL")"
   printf 'HUBUUM_BIND_IP=0.0.0.0\n'
-  printf 'HUBUUM_BIND_PORT=8080\n'
+  printf 'HUBUUM_BIND_PORT=%s\n' "$API_PORT"
   printf 'HUBUUM_LOG_LEVEL=info\n'
   printf 'HUBUUM_TOKEN_HASH_KEY=%s\n' "$HUBUUM_TOKEN_HASH_KEY"
   printf 'HUBUUM_CLIENT_ALLOWLIST=%s\n' "$NETWORK_SUBNET"
@@ -392,7 +396,7 @@ fi
   printf 'HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS=5\n'
   printf 'HUBUUM_LOGIN_RATE_LIMIT_WINDOW_SECONDS=300\n'
   printf '\n'
-  printf 'BACKEND_BASE_URL=http://hubuum-api:8080\n'
+  printf 'BACKEND_BASE_URL=http://hubuum-api:%s\n' "$API_PORT"
   printf 'VALKEY_URL=redis://valkey:6379/0\n'
   printf 'SESSION_TTL_SECONDS=28800\n'
   printf 'SESSION_PREFIX=hubuum:sess:\n'
@@ -414,7 +418,7 @@ if [[ "$MODE" == "all" ]]; then
 
 {$API_FQDN} {
     encode zstd gzip
-    reverse_proxy hubuum-api:8080
+    reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
 }
 EOF
 else
@@ -425,7 +429,7 @@ else
 
 {$API_FQDN} {
     encode zstd gzip
-    reverse_proxy hubuum-api:8080
+    reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
 }
 EOF
 fi
@@ -500,7 +504,7 @@ fi
 
 cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
     expose:
-      - "8080"
+      - "${HUBUUM_BIND_PORT}"
     networks:
       - hubuum_net
 EOF

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -33,6 +33,10 @@ PURGE="false"
 SERVICE_NAME_SET="false"
 SCRIPT_BASE_URL="https://raw.githubusercontent.com/hubuum/hubuum/main/scripts"
 SCRIPT_REF=""
+# Space-delimited list of config variables the caller set explicitly on the
+# command line. Used to decide which values may be reused from an existing
+# installation's .env on a re-run.
+ARG_SET=""
 
 usage() {
   cat <<'EOF'
@@ -112,40 +116,79 @@ read_env_value() {
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --mode) MODE="$2"; shift 2 ;;
+    --mode) MODE="$2"; ARG_SET+=" MODE"; shift 2 ;;
     --stop) ACTION="stop"; shift ;;
     --uninstall) ACTION="uninstall"; shift ;;
     --purge) PURGE="true"; shift ;;
     --dir) INSTALL_DIR="$2"; shift 2 ;;
-    --web) WEB_FQDN="$2"; shift 2 ;;
-    --api) API_FQDN="$2"; shift 2 ;;
-    --api-port) API_PORT="$2"; shift 2 ;;
-    --shared-host-routing) SHARED_HOST_ROUTING="$2"; shift 2 ;;
-    --email) LETSENCRYPT_EMAIL="$2"; shift 2 ;;
-    --backend-image) BACKEND_IMAGE="$2"; shift 2 ;;
-    --frontend-image) FRONTEND_IMAGE="$2"; shift 2 ;;
-    --backend-ref) BACKEND_REF="$2"; shift 2 ;;
-    --frontend-ref) FRONTEND_REF="$2"; shift 2 ;;
-    --backend-repo) BACKEND_REPO="$2"; shift 2 ;;
-    --frontend-repo) FRONTEND_REPO="$2"; shift 2 ;;
+    --web) WEB_FQDN="$2"; ARG_SET+=" WEB_FQDN"; shift 2 ;;
+    --api) API_FQDN="$2"; ARG_SET+=" API_FQDN"; shift 2 ;;
+    --api-port) API_PORT="$2"; ARG_SET+=" API_PORT"; shift 2 ;;
+    --shared-host-routing) SHARED_HOST_ROUTING="$2"; ARG_SET+=" SHARED_HOST_ROUTING"; shift 2 ;;
+    --email) LETSENCRYPT_EMAIL="$2"; ARG_SET+=" LETSENCRYPT_EMAIL"; shift 2 ;;
+    --backend-image) BACKEND_IMAGE="$2"; ARG_SET+=" BACKEND_IMAGE"; shift 2 ;;
+    --frontend-image) FRONTEND_IMAGE="$2"; ARG_SET+=" FRONTEND_IMAGE"; shift 2 ;;
+    --backend-ref) BACKEND_REF="$2"; ARG_SET+=" BACKEND_REF"; shift 2 ;;
+    --frontend-ref) FRONTEND_REF="$2"; ARG_SET+=" FRONTEND_REF"; shift 2 ;;
+    --backend-repo) BACKEND_REPO="$2"; ARG_SET+=" BACKEND_REPO"; shift 2 ;;
+    --frontend-repo) FRONTEND_REPO="$2"; ARG_SET+=" FRONTEND_REPO"; shift 2 ;;
     --database-url) EXTERNAL_DATABASE_URL="$2"; shift 2 ;;
     --engine) ENGINE="$2"; shift 2 ;;
-    --postgres-image) POSTGRES_IMAGE="$2"; shift 2 ;;
-    --valkey-image) VALKEY_IMAGE="$2"; shift 2 ;;
-    --caddy-image) CADDY_IMAGE="$2"; shift 2 ;;
-    --network-subnet) NETWORK_SUBNET="$2"; shift 2 ;;
+    --postgres-image) POSTGRES_IMAGE="$2"; ARG_SET+=" POSTGRES_IMAGE"; shift 2 ;;
+    --valkey-image) VALKEY_IMAGE="$2"; ARG_SET+=" VALKEY_IMAGE"; shift 2 ;;
+    --caddy-image) CADDY_IMAGE="$2"; ARG_SET+=" CADDY_IMAGE"; shift 2 ;;
+    --network-subnet) NETWORK_SUBNET="$2"; ARG_SET+=" NETWORK_SUBNET"; shift 2 ;;
     --systemd) INSTALL_SYSTEMD="true"; shift ;;
     --service-name) SERVICE_NAME="$2"; SERVICE_NAME_SET="true"; shift 2 ;;
     --no-systemd) INSTALL_SYSTEMD="false"; shift ;;
     --script-base-url) SCRIPT_BASE_URL="${2%/}"; shift 2 ;;
     --script-ref) SCRIPT_REF="$2"; shift 2 ;;
-    --build-from-source) BUILD_FROM_SOURCE="true"; shift ;;
+    --build-from-source) BUILD_FROM_SOURCE="true"; ARG_SET+=" BUILD_FROM_SOURCE"; shift ;;
     --no-pull) PULL="false"; shift ;;
     --recreate) RECREATE="true"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
   esac
 done
+
+ENV_FILE="$INSTALL_DIR/.env"
+
+arg_was_set() {
+  [[ " $ARG_SET " == *" $1 "* ]]
+}
+
+# Reuse a value from an existing installation's .env when the caller did not
+# pass it explicitly, leaving the hardcoded default in place only for a fresh
+# install. This is what lets a bare re-run (including curl | bash) update an
+# existing deployment in place without re-specifying every argument.
+reuse_from_env() {
+  local var="$1" key="$2" val
+  arg_was_set "$var" && return 0
+  [[ -f "$ENV_FILE" ]] || return 0
+  val="$(read_env_value "$key" || true)"
+  [[ -n "$val" ]] || return 0
+  printf -v "$var" '%s' "$val"
+}
+
+if [[ "$ACTION" == "install" && -f "$ENV_FILE" ]]; then
+  reuse_from_env MODE INSTALL_MODE
+  reuse_from_env WEB_FQDN WEB_FQDN
+  reuse_from_env API_FQDN API_FQDN
+  reuse_from_env API_PORT HUBUUM_BIND_PORT
+  reuse_from_env SHARED_HOST_ROUTING SHARED_HOST_ROUTING
+  reuse_from_env LETSENCRYPT_EMAIL LETSENCRYPT_EMAIL
+  reuse_from_env BACKEND_IMAGE BACKEND_IMAGE
+  reuse_from_env FRONTEND_IMAGE FRONTEND_IMAGE
+  reuse_from_env POSTGRES_IMAGE POSTGRES_IMAGE
+  reuse_from_env VALKEY_IMAGE VALKEY_IMAGE
+  reuse_from_env CADDY_IMAGE CADDY_IMAGE
+  reuse_from_env BACKEND_REF BACKEND_REF
+  reuse_from_env FRONTEND_REF FRONTEND_REF
+  reuse_from_env BACKEND_REPO BACKEND_REPO
+  reuse_from_env FRONTEND_REPO FRONTEND_REPO
+  reuse_from_env BUILD_FROM_SOURCE BUILD_FROM_SOURCE
+  reuse_from_env NETWORK_SUBNET HUBUUM_CLIENT_ALLOWLIST
+fi
 
 [[ "$MODE" == "all" || "$MODE" == "backend" ]] || die "--mode must be all or backend"
 [[ "$ENGINE" == "auto" || "$ENGINE" == "docker" || "$ENGINE" == "podman" ]] || die "--engine must be auto, docker, or podman"
@@ -359,12 +402,22 @@ ENV_FILE="$INSTALL_DIR/.env"
 
 POSTGRES_PASSWORD=""
 HUBUUM_TOKEN_HASH_KEY=""
+EXISTING_POSTGRES_PASSWORD="$(read_env_value POSTGRES_PASSWORD || true)"
 if [[ "$RECREATE" != "true" ]]; then
   if [[ -z "$EXTERNAL_DATABASE_URL" && "$(read_env_value DATABASE_MANAGED || true)" == "false" ]]; then
     EXTERNAL_DATABASE_URL="$(read_env_value HUBUUM_DATABASE_URL || true)"
   fi
-  POSTGRES_PASSWORD="$(read_env_value POSTGRES_PASSWORD || true)"
+  POSTGRES_PASSWORD="$EXISTING_POSTGRES_PASSWORD"
   HUBUUM_TOKEN_HASH_KEY="$(read_env_value HUBUUM_TOKEN_HASH_KEY || true)"
+fi
+
+# A managed Postgres data volume is initialized with the password only on first
+# boot; rotating it afterwards leaves the stored credential out of sync and
+# breaks authentication. Preserve the existing password on --recreate and tell
+# the operator how to perform a real reset.
+if [[ "$RECREATE" == "true" && -z "$EXTERNAL_DATABASE_URL" && -n "$EXISTING_POSTGRES_PASSWORD" ]]; then
+  echo "WARNING: --recreate does not rotate the managed Postgres password, because the existing database volume was initialized with it. Rotating it would break authentication. To reset the database, uninstall with --purge first, then reinstall." >&2
+  POSTGRES_PASSWORD="$EXISTING_POSTGRES_PASSWORD"
 fi
 
 [[ -n "$POSTGRES_PASSWORD" ]] || POSTGRES_PASSWORD="$(random_hex 32)"
@@ -578,7 +631,8 @@ EOF
 if [[ "$DATABASE_MANAGED" == "true" ]]; then
   cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 EOF
 fi
 
@@ -635,8 +689,10 @@ EOF
       SESSION_PREFIX: ${SESSION_PREFIX}
       NEXT_PUBLIC_APP_NAME: ${NEXT_PUBLIC_APP_NAME}
     depends_on:
-      - hubuum-api
-      - valkey
+      hubuum-api:
+        condition: service_started
+      valkey:
+        condition: service_healthy
     expose:
       - "3000"
     networks:
@@ -650,8 +706,11 @@ cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
     image: ${CADDY_IMAGE}
     container_name: hubuum-caddy
     restart: unless-stopped
-    env_file:
-      - .env
+    environment:
+      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
+      WEB_FQDN: ${WEB_FQDN}
+      API_FQDN: ${API_FQDN}
+      HUBUUM_BIND_PORT: ${HUBUUM_BIND_PORT}
     ports:
       - "80:80"
       - "443:443"

--- a/scripts/stop-single-host.sh
+++ b/scripts/stop-single-host.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+exec "$SCRIPT_DIR/install-single-host.sh" --stop "$@"

--- a/scripts/uninstall-single-host.sh
+++ b/scripts/uninstall-single-host.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+exec "$SCRIPT_DIR/install-single-host.sh" --uninstall "$@"

--- a/scripts/update-single-host.sh
+++ b/scripts/update-single-host.sh
@@ -123,9 +123,15 @@ else
 fi
 
 if [[ "$USE_SYSTEMD" == "true" && -d /run/systemd/system && "$(command -v systemctl || true)" ]] && systemctl cat "${SERVICE_NAME}.service" >/dev/null 2>&1; then
+  # The systemd unit's ExecStop/ExecStart run compose down then up, so a
+  # restart recreates containers against the freshly pulled images.
   systemctl restart "$SERVICE_NAME"
   echo "Hubuum updated and restarted via ${SERVICE_NAME}.service"
 else
+  # `compose up -d` on its own does not reliably recreate containers after a
+  # pull (notably under podman compose, which leaves running containers on the
+  # previous image). Tear the stack down first so the new images are picked up.
+  "${COMPOSE_CMD[@]}" down --remove-orphans
   "${COMPOSE_CMD[@]}" up -d
   echo "Hubuum updated and restarted via ${ENGINE_BIN} compose"
 fi

--- a/scripts/update-single-host.sh
+++ b/scripts/update-single-host.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+INSTALL_DIR="/opt/hubuum"
+ENGINE="auto"
+SERVICE_NAME=""
+USE_SYSTEMD="true"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  update-single-host.sh [--dir /opt/hubuum] [--engine auto|docker|podman]
+
+Options:
+  --dir PATH              Install directory. Default: /opt/hubuum
+  --engine ENGINE         Container engine: auto, docker, or podman. Default: auto
+  --service-name NAME     systemd service name. Defaults to value in .env or hubuum
+  --no-systemd            Restart with compose directly even if a systemd service exists
+  -h, --help              Show this help
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+read_env_value() {
+  local key="$1"
+  local line
+
+  [[ -f "$ENV_FILE" ]] || return 1
+  line="$(grep -E "^${key}=" "$ENV_FILE" | tail -n 1 || true)"
+  [[ -n "$line" ]] || return 1
+  line="${line#*=}"
+  line="${line%\"}"
+  line="${line#\"}"
+  printf '%s' "$line"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir) INSTALL_DIR="$2"; shift 2 ;;
+    --engine) ENGINE="$2"; shift 2 ;;
+    --service-name) SERVICE_NAME="$2"; shift 2 ;;
+    --no-systemd) USE_SYSTEMD="false"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+[[ "$ENGINE" == "auto" || "$ENGINE" == "docker" || "$ENGINE" == "podman" ]] || die "--engine must be auto, docker, or podman"
+
+if [[ "$EUID" -ne 0 ]]; then
+  die "run as root, or via sudo"
+fi
+
+ENV_FILE="$INSTALL_DIR/.env"
+[[ -f "$ENV_FILE" ]] || die "missing $ENV_FILE; run install-single-host.sh first"
+[[ -f "$INSTALL_DIR/compose.yml" ]] || die "missing $INSTALL_DIR/compose.yml; run install-single-host.sh first"
+
+BUILD_FROM_SOURCE="$(read_env_value BUILD_FROM_SOURCE || printf 'false')"
+INSTALL_MODE="$(read_env_value INSTALL_MODE || printf 'all')"
+DATABASE_MANAGED="$(read_env_value DATABASE_MANAGED || printf 'true')"
+if [[ -z "$SERVICE_NAME" ]]; then
+  SERVICE_NAME="$(read_env_value SYSTEMD_SERVICE_NAME || printf 'hubuum')"
+fi
+SERVICE_NAME="${SERVICE_NAME%.service}"
+if [[ "$ENGINE" == "auto" ]]; then
+  ENGINE="$(read_env_value CONTAINER_ENGINE || printf 'auto')"
+fi
+
+detect_engine() {
+  if [[ "$ENGINE" == "docker" || "$ENGINE" == "auto" ]]; then
+    if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+      ENGINE_BIN="docker"
+      return 0
+    fi
+
+    [[ "$ENGINE" == "auto" ]] || die "docker compose plugin is required"
+  fi
+
+  if [[ "$ENGINE" == "podman" || "$ENGINE" == "auto" ]]; then
+    if command -v podman >/dev/null 2>&1 && podman compose version >/dev/null 2>&1; then
+      ENGINE_BIN="podman"
+      return 0
+    fi
+
+    [[ "$ENGINE" == "auto" ]] || die "podman compose is required"
+  fi
+
+  die "no supported compose engine found; install docker compose or podman compose"
+}
+
+update_source_checkout() {
+  local dest="$1"
+
+  [[ -d "$dest/.git" ]] || return 0
+  git -C "$dest" fetch --tags --prune origin
+  git -C "$dest" pull --ff-only || true
+}
+
+detect_engine
+ENGINE_PATH="$(command -v "$ENGINE_BIN")"
+COMPOSE_CMD=("$ENGINE_PATH" compose --env-file .env -f compose.yml)
+
+cd "$INSTALL_DIR"
+
+if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
+  command -v git >/dev/null 2>&1 || die "git is required for source-build updates"
+  update_source_checkout "$INSTALL_DIR/src/hubuum"
+  if [[ "$INSTALL_MODE" == "all" ]]; then
+    update_source_checkout "$INSTALL_DIR/src/hubuum-frontend"
+  fi
+
+  PULL_SERVICES=(caddy)
+  [[ "$DATABASE_MANAGED" == "true" ]] && PULL_SERVICES+=(postgres)
+  [[ "$INSTALL_MODE" == "all" ]] && PULL_SERVICES+=(valkey)
+  "${COMPOSE_CMD[@]}" pull "${PULL_SERVICES[@]}"
+  "${COMPOSE_CMD[@]}" build --pull
+else
+  "${COMPOSE_CMD[@]}" pull
+fi
+
+if [[ "$USE_SYSTEMD" == "true" && -d /run/systemd/system && "$(command -v systemctl || true)" ]] && systemctl cat "${SERVICE_NAME}.service" >/dev/null 2>&1; then
+  systemctl restart "$SERVICE_NAME"
+  echo "Hubuum updated and restarted via ${SERVICE_NAME}.service"
+else
+  "${COMPOSE_CMD[@]}" up -d
+  echo "Hubuum updated and restarted via ${ENGINE_BIN} compose"
+fi

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -998,12 +998,8 @@ impl QueryParamsExt for Vec<ParsedQueryParam> {
     fn permissions(&self) -> Result<PermissionsList<Permissions>, ApiError> {
         let mut unique_permissions = HashSet::new();
         for param in self.iter().filter(|p| p.is_permission()) {
-            match param.value_as_permission() {
-                Ok(permission) => {
-                    unique_permissions.insert(permission);
-                }
-                Err(e) => return Err(e),
-            }
+            let permission = param.value_as_permission()?;
+            unique_permissions.insert(permission);
         }
         Ok(PermissionsList::new(unique_permissions))
     }
@@ -1467,10 +1463,9 @@ fn get_jsonb_field_type_from_json_schema(
             Value::Object(map) => {
                 if let Some(sub_schema) = map.get("properties").and_then(|p| p.get(key)) {
                     current_schema = sub_schema;
-                } else if let Some(items_schema) = map.get("items") {
-                    current_schema = items_schema;
                 } else {
-                    return None;
+                    let items_schema = map.get("items")?;
+                    current_schema = items_schema;
                 }
             }
             _ => return None,

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -964,12 +964,8 @@ impl QueryParamsExt for Vec<ParsedQueryParam> {
     fn permissions(&self) -> Result<PermissionsList<Permissions>, ApiError> {
         let mut unique_permissions = HashSet::new();
         for param in self.iter().filter(|p| p.is_permission()) {
-            match param.value_as_permission() {
-                Ok(permission) => {
-                    unique_permissions.insert(permission);
-                }
-                Err(e) => return Err(e),
-            }
+            let permission = param.value_as_permission()?;
+            unique_permissions.insert(permission);
         }
         Ok(PermissionsList::new(unique_permissions))
     }
@@ -1431,10 +1427,9 @@ fn get_jsonb_field_type_from_json_schema(
             Value::Object(map) => {
                 if let Some(sub_schema) = map.get("properties").and_then(|p| p.get(key)) {
                     current_schema = sub_schema;
-                } else if let Some(items_schema) = map.get("items") {
-                    current_schema = items_schema;
                 } else {
-                    return None;
+                    let items_schema = map.get("items")?;
+                    current_schema = items_schema;
                 }
             }
             _ => return None,


### PR DESCRIPTION
## Summary
- add single-host Docker/Podman Compose installer using published Hubuum images by default
- add backend-only, update, stop, and uninstall helper scripts
- document curl-based installs, branch/commit/PR ref testing, external Postgres, optional systemd, and lifecycle commands

## Validation
- bash -n scripts/install-single-host.sh
- bash -n scripts/update-single-host.sh
- bash -n scripts/install-backend.sh
- bash -n scripts/stop-single-host.sh
- bash -n scripts/uninstall-single-host.sh
- git diff --cached --check before commit

## Notes
- pre-commit clippy failed on existing warnings in src/models/search.rs unrelated to this deployment-only change
- original unsigned commit was amended after GPG signing was fixed