### PR TITLE
Extend report templates and related object includes

### DIFF
--- a/docs/report_api.md
+++ b/docs/report_api.md
@@ -26,6 +26,9 @@ Authentication:
     "related_objects": {
       "room": {
         "class_id": 91,
+        "class_relation_id": 77,
+        "direction": "outgoing",
+        "sort": "name",
         "max_depth": 1,
         "limit": 1
       }
@@ -121,6 +124,9 @@ Report objects related to a root object:
     "related_objects": {
       "room": {
         "class_id": 91,
+        "class_relation_id": 77,
+        "direction": "outgoing",
+        "sort": "name",
         "max_depth": 1,
         "limit": 1
       }
@@ -132,14 +138,16 @@ Report objects related to a root object:
 }
 ```
 
-Each key under `include.related_objects` is an alias. The alias must match `[A-Za-z_][A-Za-z0-9_]*` and is exposed as an array at `this.related.<alias>`.
+Each key under `include.related_objects` is an alias. The alias must match `[A-Za-z_][A-Za-z0-9_]*`, and a request can include at most 8 aliases. Aliases are exposed as arrays at `this.related.<alias>`. The top-level `related` report item field is reserved for report includes.
 
 ```text
 {{#each items}}{{this.name}} is in {{this.related.room[0].name}}
 {{/each}}
 ```
 
-`class_id` is required and selects the related object class to include. `max_depth` defaults to `1` and must be between `1` and `10`. `limit` defaults to `1` and must be between `1` and `50`; it is applied per root object and per alias. Missing related objects render as an empty array, so `this.related.room` is always present when the alias was requested.
+`class_id` is required and selects the related object class to include. `class_relation_id` is optional and restricts traversal to a specific class relation. `direction` is optional and can be `any` (default), `outgoing`, or `incoming`. `sort` is optional and can be `path` (default), `name`, or `created_at`; it decides which related objects are kept first when `limit` is smaller than the number of matches.
+
+`max_depth` defaults to `1` and must be between `1` and `10`. `limit` defaults to `1` and must be between `1` and `50`; it is applied per root object and per alias. Missing related objects render as an empty array, so `this.related.room` is always present when the alias was requested.
 
 ## Output selection
 

--- a/docs/report_api.md
+++ b/docs/report_api.md
@@ -48,12 +48,54 @@ Authentication:
 Examples:
 
 - `name__contains=server&sort=name`
-- `class_from=12&sort=created_at.desc`
-- `depth__lte=2&class_to=91`
+- `from_classes=12&sort=created_at.desc`
+- `depth__lte=2&to_classes=91`
 
 Reports do not support cursor pagination. If `cursor` is present in `query`, the request fails with `400 Bad Request`.
 
 If the rendered response exceeds `limits.max_output_bytes`, the request fails with `413 Payload Too Large`. The server does not stream partial JSON, HTML, CSV, or text bodies.
+
+### Relation report examples
+
+Report class relations from one class:
+
+```json
+{
+  "scope": {
+    "kind": "class_relations"
+  },
+  "query": "from_classes=42&sort=created_at.desc",
+  "limits": {
+    "max_items": 50
+  }
+}
+```
+
+Report object relations for relations pointing at one object:
+
+```json
+{
+  "scope": {
+    "kind": "object_relations"
+  },
+  "query": "to_objects=101&sort=created_at.desc"
+}
+```
+
+Report objects related to a root object:
+
+```json
+{
+  "scope": {
+    "kind": "related_objects",
+    "class_id": 42,
+    "object_id": 101
+  },
+  "query": "depth__lte=2&to_classes=91&sort=path"
+}
+```
+
+`related_objects` first verifies that `object_id` belongs to `class_id`, then returns matching related objects. The returned items include the related object fields plus the relation `path`, so templates can render both the object data and how it was reached. The `depth` field is available for filtering and sorting through `query`, but is not included in the rendered item payload.
 
 ## Output selection
 
@@ -108,6 +150,8 @@ Templates use a minimal template language:
 
 - `{{path.to.value}}` to interpolate a value
 - `{{this.name}}` inside loops
+- `{{this.data.tags[0]}}` or `{{this.data.tags.0}}` to read array elements
+- `{{this.data["field.with.dots"]}}` to read data keys that are not valid dot segments
 - `{{#each items}}...{{/each}}` to iterate arrays
 - nested loops are supported
 

--- a/docs/report_api.md
+++ b/docs/report_api.md
@@ -22,6 +22,15 @@ Authentication:
   "output": {
     "template_id": 12
   },
+  "include": {
+    "related_objects": {
+      "room": {
+        "class_id": 91,
+        "max_depth": 1,
+        "limit": 1
+      }
+    }
+  },
   "missing_data_policy": "strict",
   "limits": {
     "max_items": 100,
@@ -96,6 +105,41 @@ Report objects related to a root object:
 ```
 
 `related_objects` first verifies that `object_id` belongs to `class_id`, then returns matching related objects. The returned items include the related object fields plus the relation `path`, so templates can render both the object data and how it was reached. The `depth` field is available for filtering and sorting through `query`, but is not included in the rendered item payload.
+
+### Including related objects
+
+`objects_in_class` reports can include related objects for every returned object. This is intended for reports such as "host is in room" where the base report lists hosts and the template needs a small bounded set of related room objects.
+
+```json
+{
+  "scope": {
+    "kind": "objects_in_class",
+    "class_id": 42
+  },
+  "query": "name__equals=nommo",
+  "include": {
+    "related_objects": {
+      "room": {
+        "class_id": 91,
+        "max_depth": 1,
+        "limit": 1
+      }
+    }
+  },
+  "output": {
+    "template_id": 12
+  }
+}
+```
+
+Each key under `include.related_objects` is an alias. The alias must match `[A-Za-z_][A-Za-z0-9_]*` and is exposed as an array at `this.related.<alias>`.
+
+```text
+{{#each items}}{{this.name}} is in {{this.related.room[0].name}}
+{{/each}}
+```
+
+`class_id` is required and selects the related object class to include. `max_depth` defaults to `1` and must be between `1` and `10`. `limit` defaults to `1` and must be between `1` and `50`; it is applied per root object and per alias. Missing related objects render as an empty array, so `this.related.room` is always present when the alias was requested.
 
 ## Output selection
 

--- a/docs/template_guide.md
+++ b/docs/template_guide.md
@@ -117,6 +117,8 @@ The stored template language is intentionally small:
 
 - `{{path.to.value}}` interpolates a value
 - `{{this.name}}` reads from the current item inside a loop
+- `{{this.data.tags[0]}}` or `{{this.data.tags.0}}` reads an array element by index
+- `{{this.data["field.with.dots"]}}` reads object keys that cannot be written as dot segments
 - `{{#each items}}...{{/each}}` iterates arrays
 - nested `each` blocks are supported
 
@@ -125,12 +127,17 @@ Path resolution rules:
 - `this` starts from the current loop item
 - `root` starts from the full template context
 - bare paths try `this` first, then `root`
+- bracket keys can use single or double quotes, for example `{{this.data['service-owner']}}`
 
 Examples:
 
 ```text
 {{meta.count}}
 {{request.scope.kind}}
+{{#each items}}{{this.data.tags[0]}}
+{{/each}}
+{{#each items}}{{this.data["owner.name"]}}
+{{/each}}
 {{#each items}}{{this.name}}
 {{/each}}
 {{#each items}}{{#each this.data.tags}}- {{this}}
@@ -226,6 +233,51 @@ srv-db-01
   - prod
   - db
 ```
+
+You can also read a single array element directly:
+
+```text
+{{#each items}}{{this.name}} primary_tag={{this.data.tags[0]}}
+{{/each}}
+```
+
+For data keys that contain dots, spaces, or punctuation, use bracket notation:
+
+```text
+{{#each items}}{{this.data["owner.name"]}} {{this.data['service tier']}}
+{{/each}}
+```
+
+## Relation report example
+
+Relation scopes use the same template context. For `related_objects`, each item is a related object with its normal object fields plus a `path` array describing the relation traversal.
+
+Example report request:
+
+```json
+{
+  "scope": {
+    "kind": "related_objects",
+    "class_id": 42,
+    "object_id": 101
+  },
+  "query": "depth__lte=2&to_classes=91&sort=path",
+  "output": {
+    "template_id": 12
+  },
+  "missing_data_policy": "strict"
+}
+```
+
+Template:
+
+```text
+Related objects for {{request.scope.object_id}}
+{{#each items}}- {{this.name}} path={{this.path}} host={{this.data.hostname}}
+{{/each}}
+```
+
+For direct relation reports, `class_relations` items contain fields such as `from_hubuum_class_id` and `to_hubuum_class_id`, while `object_relations` items contain fields such as `from_hubuum_object_id`, `to_hubuum_object_id`, and `class_relation_id`.
 
 ## Missing data policy
 

--- a/docs/template_guide.md
+++ b/docs/template_guide.md
@@ -279,6 +279,44 @@ Related objects for {{request.scope.object_id}}
 
 For direct relation reports, `class_relations` items contain fields such as `from_hubuum_class_id` and `to_hubuum_class_id`, while `object_relations` items contain fields such as `from_hubuum_object_id`, `to_hubuum_object_id`, and `class_relation_id`.
 
+## Included related objects
+
+`objects_in_class` reports can add bounded related-object arrays to each item with `include.related_objects`. Use this when the report is centered on one class but the template needs nearby objects, such as a host's room.
+
+Example report request:
+
+```json
+{
+  "scope": {
+    "kind": "objects_in_class",
+    "class_id": 42
+  },
+  "query": "name__equals=nommo",
+  "include": {
+    "related_objects": {
+      "room": {
+        "class_id": 91,
+        "max_depth": 1,
+        "limit": 1
+      }
+    }
+  },
+  "output": {
+    "template_id": 12
+  },
+  "missing_data_policy": "strict"
+}
+```
+
+Template:
+
+```text
+{{#each items}}{{this.name}} is in {{this.related.room[0].name}}
+{{/each}}
+```
+
+The alias (`room` above) becomes `this.related.room`. Included values are arrays even when `limit` is `1`, and each related object includes its normal object fields plus `path`.
+
 ## Missing data policy
 
 Missing values are controlled by `missing_data_policy` on the report request.

--- a/docs/template_guide.md
+++ b/docs/template_guide.md
@@ -296,6 +296,9 @@ Example report request:
     "related_objects": {
       "room": {
         "class_id": 91,
+        "class_relation_id": 77,
+        "direction": "outgoing",
+        "sort": "name",
         "max_depth": 1,
         "limit": 1
       }
@@ -315,7 +318,9 @@ Template:
 {{/each}}
 ```
 
-The alias (`room` above) becomes `this.related.room`. Included values are arrays even when `limit` is `1`, and each related object includes its normal object fields plus `path`.
+The alias (`room` above) becomes `this.related.room`. Included values are arrays even when `limit` is `1`, and each related object includes its normal object fields plus `path`. A report can include up to 8 related-object aliases.
+
+Use `class_relation_id` and `direction` when the relation meaning matters. Use `sort` (`path`, `name`, or `created_at`) to decide which related object appears first when the alias has a small `limit`. The top-level `related` item field is reserved for these report includes.
 
 ## Missing data policy
 

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -22,7 +22,8 @@ use crate::extractors::UserAccess;
 use crate::models::search::{FilterField, ParsedQueryParam, QueryOptions, parse_query_parameter};
 use crate::models::{
     HubuumClassID, HubuumObjectID, NamespaceID, Permissions, ReportContentType,
-    ReportIncludeRelatedObject, ReportJsonResponse, ReportMeta, ReportMissingDataPolicy,
+    ReportIncludeRelatedDirection, ReportIncludeRelatedObject, ReportIncludeRelatedQuery,
+    ReportIncludeRelatedSort, ReportJsonResponse, ReportMeta, ReportMissingDataPolicy,
     ReportRequest, ReportScope, ReportScopeKind, ReportTemplate, ReportTemplateID, ReportWarning,
 };
 use crate::pagination::page_limits_or_defaults;
@@ -39,6 +40,7 @@ const RELATED_INCLUDE_DEFAULT_MAX_DEPTH: i32 = 1;
 const RELATED_INCLUDE_MAX_DEPTH_LIMIT: i32 = 10;
 const RELATED_INCLUDE_DEFAULT_LIMIT: i32 = 1;
 const RELATED_INCLUDE_MAX_LIMIT: i32 = 50;
+const RELATED_INCLUDE_MAX_ALIASES: usize = 8;
 
 struct ReportRuntime {
     report: ReportRequest,
@@ -244,6 +246,12 @@ fn validate_report_include(report: &ReportRequest) -> Result<(), ApiError> {
         ));
     }
 
+    if related_objects.len() > RELATED_INCLUDE_MAX_ALIASES {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects supports at most {RELATED_INCLUDE_MAX_ALIASES} aliases"
+        )));
+    }
+
     for (alias, include) in related_objects {
         validate_related_include_alias(alias)?;
         validate_related_include_options(alias, include)?;
@@ -278,6 +286,14 @@ fn validate_related_include_options(
     if include.class_id <= 0 {
         return Err(ApiError::BadRequest(format!(
             "include.related_objects.{alias}.class_id must be greater than 0"
+        )));
+    }
+
+    if let Some(class_relation_id) = include.class_relation_id
+        && class_relation_id <= 0
+    {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects.{alias}.class_relation_id must be greater than 0"
         )));
     }
 
@@ -670,8 +686,20 @@ async fn apply_report_includes(
             .max_depth
             .unwrap_or(RELATED_INCLUDE_DEFAULT_MAX_DEPTH);
         let limit = include.limit.unwrap_or(RELATED_INCLUDE_DEFAULT_LIMIT);
+        let direction = include
+            .direction
+            .unwrap_or(ReportIncludeRelatedDirection::Any);
+        let sort = include.sort.unwrap_or(ReportIncludeRelatedSort::Path);
+        let include_query = ReportIncludeRelatedQuery {
+            class_id: include.class_id,
+            class_relation_id: include.class_relation_id,
+            direction,
+            sort,
+            max_depth,
+            limit,
+        };
         let related = user
-            .related_objects_for_roots(pool, &root_object_ids, include.class_id, max_depth, limit)
+            .related_objects_for_roots(pool, &root_object_ids, include_query)
             .await?;
 
         for row in related {

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -21,9 +21,9 @@ use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::search::{FilterField, ParsedQueryParam, QueryOptions, parse_query_parameter};
 use crate::models::{
-    HubuumClassID, HubuumObjectID, NamespaceID, Permissions, ReportContentType, ReportJsonResponse,
-    ReportMeta, ReportMissingDataPolicy, ReportRequest, ReportScope, ReportScopeKind,
-    ReportTemplate, ReportTemplateID, ReportWarning,
+    HubuumClassID, HubuumObjectID, NamespaceID, Permissions, ReportContentType,
+    ReportIncludeRelatedObject, ReportJsonResponse, ReportMeta, ReportMissingDataPolicy,
+    ReportRequest, ReportScope, ReportScopeKind, ReportTemplate, ReportTemplateID, ReportWarning,
 };
 use crate::pagination::page_limits_or_defaults;
 use crate::traits::{NamespaceAccessors, Search, SelfAccessors};
@@ -35,6 +35,10 @@ use super::check_if_object_in_class;
 const DEFAULT_MAX_OUTPUT_BYTES: usize = 262_144;
 const REPORT_WARNINGS_HEADER: &str = "X-Hubuum-Report-Warnings";
 const REPORT_TRUNCATED_HEADER: &str = "X-Hubuum-Report-Truncated";
+const RELATED_INCLUDE_DEFAULT_MAX_DEPTH: i32 = 1;
+const RELATED_INCLUDE_MAX_DEPTH_LIMIT: i32 = 10;
+const RELATED_INCLUDE_DEFAULT_LIMIT: i32 = 1;
+const RELATED_INCLUDE_MAX_LIMIT: i32 = 50;
 
 struct ReportRuntime {
     report: ReportRequest,
@@ -158,6 +162,7 @@ async fn prepare_report_runtime(
     report: ReportRequest,
 ) -> Result<ReportRuntime, ApiError> {
     report.scope.validate()?;
+    validate_report_include(&report)?;
 
     let template = resolve_template(pool, user, &report).await?;
     let content_type = resolve_content_type(req, template.as_ref())?;
@@ -207,6 +212,8 @@ async fn build_report_execution(
     let query_options = prepare_query_options(&runtime.report)?;
     let (items, mut warnings, truncated) =
         execute_scope(pool, user, &runtime.report.scope, query_options).await?;
+    let mut items = items;
+    apply_report_includes(pool, user, &runtime.report, &mut items).await?;
 
     add_truncation_warning(&mut warnings, truncated);
 
@@ -220,6 +227,77 @@ async fn build_report_execution(
         items,
         warnings,
     })
+}
+
+fn validate_report_include(report: &ReportRequest) -> Result<(), ApiError> {
+    let Some(include) = &report.include else {
+        return Ok(());
+    };
+
+    let Some(related_objects) = &include.related_objects else {
+        return Ok(());
+    };
+
+    if !related_objects.is_empty() && report.scope.kind != ReportScopeKind::ObjectsInClass {
+        return Err(ApiError::BadRequest(
+            "include.related_objects is only supported for scope 'objects_in_class'".to_string(),
+        ));
+    }
+
+    for (alias, include) in related_objects {
+        validate_related_include_alias(alias)?;
+        validate_related_include_options(alias, include)?;
+    }
+
+    Ok(())
+}
+
+fn validate_related_include_alias(alias: &str) -> Result<(), ApiError> {
+    let mut chars = alias.chars();
+    let Some(first) = chars.next() else {
+        return Err(ApiError::BadRequest(
+            "include.related_objects aliases must not be empty".to_string(),
+        ));
+    };
+
+    if !(first == '_' || first.is_ascii_alphabetic())
+        || !chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+    {
+        return Err(ApiError::BadRequest(format!(
+            "Invalid include.related_objects alias '{alias}'; expected [A-Za-z_][A-Za-z0-9_]*"
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_related_include_options(
+    alias: &str,
+    include: &ReportIncludeRelatedObject,
+) -> Result<(), ApiError> {
+    if include.class_id <= 0 {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects.{alias}.class_id must be greater than 0"
+        )));
+    }
+
+    let max_depth = include
+        .max_depth
+        .unwrap_or(RELATED_INCLUDE_DEFAULT_MAX_DEPTH);
+    if !(1..=RELATED_INCLUDE_MAX_DEPTH_LIMIT).contains(&max_depth) {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects.{alias}.max_depth must be between 1 and {RELATED_INCLUDE_MAX_DEPTH_LIMIT}"
+        )));
+    }
+
+    let limit = include.limit.unwrap_or(RELATED_INCLUDE_DEFAULT_LIMIT);
+    if !(1..=RELATED_INCLUDE_MAX_LIMIT).contains(&limit) {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects.{alias}.limit must be between 1 and {RELATED_INCLUDE_MAX_LIMIT}"
+        )));
+    }
+
+    Ok(())
 }
 
 fn add_truncation_warning(warnings: &mut Vec<ReportWarning>, truncated: bool) {
@@ -556,6 +634,125 @@ async fn execute_scope(
 
     let (items, truncated) = truncate_items(data, item_limit);
     Ok((items, Vec::new(), truncated))
+}
+
+async fn apply_report_includes(
+    pool: &DbPool,
+    user: &crate::models::User,
+    report: &ReportRequest,
+    items: &mut [serde_json::Value],
+) -> Result<(), ApiError> {
+    let Some(related_objects) = report
+        .include
+        .as_ref()
+        .and_then(|include| include.related_objects.as_ref())
+    else {
+        return Ok(());
+    };
+
+    if related_objects.is_empty() || items.is_empty() {
+        return Ok(());
+    }
+
+    let root_object_ids = report_item_ids(items)?;
+    for alias in related_objects.keys() {
+        initialize_related_alias(items, alias)?;
+    }
+
+    let item_indexes = root_object_ids
+        .iter()
+        .enumerate()
+        .map(|(index, object_id)| (*object_id, index))
+        .collect::<HashMap<i32, usize>>();
+
+    for (alias, include) in related_objects {
+        let max_depth = include
+            .max_depth
+            .unwrap_or(RELATED_INCLUDE_DEFAULT_MAX_DEPTH);
+        let limit = include.limit.unwrap_or(RELATED_INCLUDE_DEFAULT_LIMIT);
+        let related = user
+            .related_objects_for_roots(pool, &root_object_ids, include.class_id, max_depth, limit)
+            .await?;
+
+        for row in related {
+            let Some(item_index) = item_indexes.get(&row.root_object_id) else {
+                continue;
+            };
+            let related_object = row.to_descendant_object_with_path();
+            let related_value = serde_json::to_value(related_object).map_err(ApiError::from)?;
+            push_related_alias_value(&mut items[*item_index], alias, related_value)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn report_item_ids(items: &[serde_json::Value]) -> Result<Vec<i32>, ApiError> {
+    items
+        .iter()
+        .map(|item| {
+            let id = item
+                .get("id")
+                .and_then(serde_json::Value::as_i64)
+                .ok_or_else(|| {
+                    ApiError::InternalServerError(
+                        "Report object item did not include integer id".to_string(),
+                    )
+                })?;
+            i32::try_from(id).map_err(|_| {
+                ApiError::InternalServerError(format!(
+                    "Report object item id '{id}' is outside i32 range"
+                ))
+            })
+        })
+        .collect()
+}
+
+fn initialize_related_alias(items: &mut [serde_json::Value], alias: &str) -> Result<(), ApiError> {
+    for item in items {
+        let related = related_object_mut(item)?;
+        related.insert(alias.to_string(), serde_json::Value::Array(Vec::new()));
+    }
+    Ok(())
+}
+
+fn push_related_alias_value(
+    item: &mut serde_json::Value,
+    alias: &str,
+    value: serde_json::Value,
+) -> Result<(), ApiError> {
+    let related = related_object_mut(item)?;
+    let Some(alias_value) = related.get_mut(alias) else {
+        return Err(ApiError::InternalServerError(format!(
+            "Related include alias '{alias}' was not initialized"
+        )));
+    };
+    let Some(alias_values) = alias_value.as_array_mut() else {
+        return Err(ApiError::InternalServerError(format!(
+            "Related include alias '{alias}' is not an array"
+        )));
+    };
+    alias_values.push(value);
+    Ok(())
+}
+
+fn related_object_mut(
+    item: &mut serde_json::Value,
+) -> Result<&mut serde_json::Map<String, serde_json::Value>, ApiError> {
+    let Some(item_object) = item.as_object_mut() else {
+        return Err(ApiError::InternalServerError(
+            "Report object item was not a JSON object".to_string(),
+        ));
+    };
+
+    let related = item_object
+        .entry("related")
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    related.as_object_mut().ok_or_else(|| {
+        ApiError::InternalServerError(
+            "Report object item related field was not an object".to_string(),
+        )
+    })
 }
 
 fn push_exact_filter(

--- a/src/db/traits/user/mod.rs
+++ b/src/db/traits/user/mod.rs
@@ -10,8 +10,8 @@ use crate::models::traits::ExpandNamespaceFromMap;
 use crate::models::traits::user::UserNamespaceAccessors;
 use crate::models::{
     ClassGraphRow, Group, HubuumClass, HubuumClassExpanded, HubuumClassRelation, HubuumObject,
-    HubuumObjectRelation, Namespace, NewUser, Permissions, RelatedObjectGraphRow, Token,
-    UpdateUser, User, UserID, UserToken,
+    HubuumObjectRelation, Namespace, NewUser, Permissions, PermissionsList, RelatedObjectGraphRow,
+    RelatedObjectIncludeRow, Token, UpdateUser, User, UserID, UserToken,
 };
 use crate::traits::{ClassAccessors, GroupAccessors, NamespaceAccessors, SelfAccessors};
 use crate::utilities::auth::hash_password;

--- a/src/db/traits/user/mod.rs
+++ b/src/db/traits/user/mod.rs
@@ -11,7 +11,8 @@ use crate::models::traits::user::UserNamespaceAccessors;
 use crate::models::{
     ClassGraphRow, Group, HubuumClass, HubuumClassExpanded, HubuumClassRelation, HubuumObject,
     HubuumObjectRelation, Namespace, NewUser, Permissions, PermissionsList, RelatedObjectGraphRow,
-    RelatedObjectIncludeRow, Token, UpdateUser, User, UserID, UserToken,
+    RelatedObjectIncludeRow, ReportIncludeRelatedDirection, ReportIncludeRelatedQuery,
+    ReportIncludeRelatedSort, Token, UpdateUser, User, UserID, UserToken,
 };
 use crate::traits::{ClassAccessors, GroupAccessors, NamespaceAccessors, SelfAccessors};
 use crate::utilities::auth::hash_password;

--- a/src/db/traits/user/search.rs
+++ b/src/db/traits/user/search.rs
@@ -1622,17 +1622,13 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
         &self,
         pool: &DbPool,
         root_object_ids: &[i32],
-        target_class_id: i32,
-        max_depth: i32,
-        per_root_limit: i32,
+        include: ReportIncludeRelatedQuery,
     ) -> Result<Vec<RelatedObjectIncludeRow>, ApiError> {
         let is_admin = self.is_admin(pool).await?;
         self.related_objects_for_roots_from_backend_with_admin_status(
             pool,
             root_object_ids,
-            target_class_id,
-            max_depth,
-            per_root_limit,
+            include,
             is_admin,
         )
         .await
@@ -1642,9 +1638,7 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
         &self,
         pool: &DbPool,
         root_object_ids: &[i32],
-        target_class_id: i32,
-        max_depth: i32,
-        per_root_limit: i32,
+        include: ReportIncludeRelatedQuery,
         is_admin: bool,
     ) -> Result<Vec<RelatedObjectIncludeRow>, ApiError> {
         if root_object_ids.is_empty() {
@@ -1667,10 +1661,18 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
         let mut bind_variables = Vec::<SQLValue>::new();
         let root_array_sql = sql_integer_array(root_object_ids, &mut bind_variables);
         let namespace_array_sql = sql_integer_array(&namespace_ids, &mut bind_variables);
-        bind_variables.push(SQLValue::Integer(max_depth));
-        bind_variables.push(SQLValue::Integer(max_depth));
-        bind_variables.push(SQLValue::Integer(target_class_id));
-        bind_variables.push(SQLValue::Integer(per_root_limit));
+
+        let object_edges_sql = related_include_object_edges_sql(
+            include.direction,
+            include.class_relation_id,
+            &mut bind_variables,
+        );
+        let related_order_sql = related_include_order_sql(include.sort);
+
+        bind_variables.push(SQLValue::Integer(include.max_depth));
+        bind_variables.push(SQLValue::Integer(include.max_depth));
+        bind_variables.push(SQLValue::Integer(include.class_id));
+        bind_variables.push(SQLValue::Integer(include.limit));
 
         let spec = RawSqlQuerySpec {
             sql: format!(
@@ -1683,13 +1685,7 @@ valid_namespaces AS (
     SELECT unnest({namespace_array_sql}) AS namespace_id
 ),
 object_edges AS (
-    SELECT from_hubuum_object_id AS source_object_id, to_hubuum_object_id AS target_object_id
-    FROM hubuumobject_relation
-
-    UNION ALL
-
-    SELECT to_hubuum_object_id AS source_object_id, from_hubuum_object_id AS target_object_id
-    FROM hubuumobject_relation
+{object_edges_sql}
 ),
 graph_walk AS (
     SELECT
@@ -1738,7 +1734,7 @@ ranked_walk AS (
         deduped_walk.*,
         row_number() OVER (
             PARTITION BY deduped_walk.root_object_id
-            ORDER BY deduped_walk.path ASC, deduped_walk.descendant_object_id ASC
+            ORDER BY {related_order_sql}
         ) AS related_rank
     FROM deduped_walk
     JOIN hubuumobject target_object
@@ -1783,9 +1779,12 @@ ORDER BY ranked_walk.root_object_id ASC, ranked_walk.related_rank ASC
         debug!(
             message = "Searching batched related objects",
             root_object_count = root_object_ids.len(),
-            target_class_id,
-            max_depth,
-            per_root_limit,
+            target_class_id = include.class_id,
+            class_relation_id = include.class_relation_id,
+            direction = ?include.direction,
+            sort = ?include.sort,
+            max_depth = include.max_depth,
+            per_root_limit = include.limit,
             raw_sql = %spec.sql,
             bind_variables = ?spec.bind_variables
         );
@@ -1794,6 +1793,82 @@ ORDER BY ranked_walk.root_object_id ASC, ranked_walk.related_rank ASC
         with_connection(pool, |conn| {
             query.get_results::<RelatedObjectIncludeRow>(conn)
         })
+    }
+}
+
+fn related_include_object_edges_sql(
+    direction: ReportIncludeRelatedDirection,
+    class_relation_id: Option<i32>,
+    bind_variables: &mut Vec<SQLValue>,
+) -> String {
+    let mut selects = Vec::new();
+
+    match direction {
+        ReportIncludeRelatedDirection::Any | ReportIncludeRelatedDirection::Outgoing => {
+            selects.push(related_include_object_edge_select_sql(
+                "from_hubuum_object_id",
+                "to_hubuum_object_id",
+                class_relation_id,
+                bind_variables,
+            ));
+        }
+        ReportIncludeRelatedDirection::Incoming => {}
+    }
+
+    match direction {
+        ReportIncludeRelatedDirection::Any | ReportIncludeRelatedDirection::Incoming => {
+            selects.push(related_include_object_edge_select_sql(
+                "to_hubuum_object_id",
+                "from_hubuum_object_id",
+                class_relation_id,
+                bind_variables,
+            ));
+        }
+        ReportIncludeRelatedDirection::Outgoing => {}
+    }
+
+    selects.join("\n\n    UNION ALL\n\n")
+}
+
+fn related_include_object_edge_select_sql(
+    source_column: &str,
+    target_column: &str,
+    class_relation_id: Option<i32>,
+    bind_variables: &mut Vec<SQLValue>,
+) -> String {
+    let class_relation_filter_sql = if let Some(class_relation_id) = class_relation_id {
+        bind_variables.push(SQLValue::Integer(class_relation_id));
+        "  AND hubuumobject_relation.class_relation_id = ?\n"
+    } else {
+        ""
+    };
+
+    format!(
+        r#"    SELECT
+        hubuumobject_relation.{source_column} AS source_object_id,
+        hubuumobject_relation.{target_column} AS target_object_id
+    FROM hubuumobject_relation
+    JOIN hubuumobject source_edge_object
+      ON source_edge_object.id = hubuumobject_relation.{source_column}
+    JOIN hubuumobject target_edge_object
+      ON target_edge_object.id = hubuumobject_relation.{target_column}
+    WHERE source_edge_object.namespace_id IN (SELECT namespace_id FROM valid_namespaces)
+      AND target_edge_object.namespace_id IN (SELECT namespace_id FROM valid_namespaces)
+{class_relation_filter_sql}"#
+    )
+}
+
+fn related_include_order_sql(sort: ReportIncludeRelatedSort) -> &'static str {
+    match sort {
+        ReportIncludeRelatedSort::Path => {
+            "deduped_walk.path ASC, deduped_walk.descendant_object_id ASC"
+        }
+        ReportIncludeRelatedSort::Name => {
+            "target_object.name ASC, target_object.id ASC, deduped_walk.path ASC"
+        }
+        ReportIncludeRelatedSort::CreatedAt => {
+            "target_object.created_at ASC, target_object.id ASC, deduped_walk.path ASC"
+        }
     }
 }
 

--- a/src/db/traits/user/search.rs
+++ b/src/db/traits/user/search.rs
@@ -1574,7 +1574,9 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
         );
         trace_query!(query, "Searching source-relative related objects");
 
-        with_connection(pool, |conn| query.get_results::<RelatedObjectGraphRow>(conn))
+        with_connection(pool, |conn| {
+            query.get_results::<RelatedObjectGraphRow>(conn)
+        })
     }
 
     async fn objects_related_to_page_from_backend_with_admin_status<O>(
@@ -1614,6 +1616,184 @@ pub trait UserSearchBackend: SelfAccessors<User> + UserNamespaceAccessors {
         })?;
 
         Ok((items, total_count))
+    }
+
+    async fn related_objects_for_roots_from_backend(
+        &self,
+        pool: &DbPool,
+        root_object_ids: &[i32],
+        target_class_id: i32,
+        max_depth: i32,
+        per_root_limit: i32,
+    ) -> Result<Vec<RelatedObjectIncludeRow>, ApiError> {
+        let is_admin = self.is_admin(pool).await?;
+        self.related_objects_for_roots_from_backend_with_admin_status(
+            pool,
+            root_object_ids,
+            target_class_id,
+            max_depth,
+            per_root_limit,
+            is_admin,
+        )
+        .await
+    }
+
+    async fn related_objects_for_roots_from_backend_with_admin_status(
+        &self,
+        pool: &DbPool,
+        root_object_ids: &[i32],
+        target_class_id: i32,
+        max_depth: i32,
+        per_root_limit: i32,
+        is_admin: bool,
+    ) -> Result<Vec<RelatedObjectIncludeRow>, ApiError> {
+        if root_object_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let permissions =
+            PermissionsList::new([Permissions::ReadObject, Permissions::ReadObjectRelation]);
+        let namespace_ids: Vec<i32> = self
+            .load_namespaces_with_permissions_with_admin_status(pool, &permissions, is_admin)
+            .await?
+            .into_iter()
+            .map(|namespace| namespace.id)
+            .collect();
+
+        if namespace_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut bind_variables = Vec::<SQLValue>::new();
+        let root_array_sql = sql_integer_array(root_object_ids, &mut bind_variables);
+        let namespace_array_sql = sql_integer_array(&namespace_ids, &mut bind_variables);
+        bind_variables.push(SQLValue::Integer(max_depth));
+        bind_variables.push(SQLValue::Integer(max_depth));
+        bind_variables.push(SQLValue::Integer(target_class_id));
+        bind_variables.push(SQLValue::Integer(per_root_limit));
+
+        let spec = RawSqlQuerySpec {
+            sql: format!(
+                r#"
+WITH RECURSIVE
+root_objects AS (
+    SELECT unnest({root_array_sql}) AS root_object_id
+),
+valid_namespaces AS (
+    SELECT unnest({namespace_array_sql}) AS namespace_id
+),
+object_edges AS (
+    SELECT from_hubuum_object_id AS source_object_id, to_hubuum_object_id AS target_object_id
+    FROM hubuumobject_relation
+
+    UNION ALL
+
+    SELECT to_hubuum_object_id AS source_object_id, from_hubuum_object_id AS target_object_id
+    FROM hubuumobject_relation
+),
+graph_walk AS (
+    SELECT
+        root_objects.root_object_id,
+        root_objects.root_object_id AS ancestor_object_id,
+        object_edges.target_object_id AS descendant_object_id,
+        1 AS depth,
+        ARRAY[root_objects.root_object_id, object_edges.target_object_id] AS path
+    FROM root_objects
+    JOIN object_edges
+      ON object_edges.source_object_id = root_objects.root_object_id
+    JOIN hubuumobject target_object
+      ON target_object.id = object_edges.target_object_id
+    WHERE ? >= 1
+      AND target_object.namespace_id IN (SELECT namespace_id FROM valid_namespaces)
+
+    UNION ALL
+
+    SELECT
+        graph_walk.root_object_id,
+        graph_walk.ancestor_object_id,
+        object_edges.target_object_id AS descendant_object_id,
+        graph_walk.depth + 1,
+        graph_walk.path || object_edges.target_object_id
+    FROM graph_walk
+    JOIN object_edges
+      ON object_edges.source_object_id = graph_walk.descendant_object_id
+    JOIN hubuumobject target_object
+      ON target_object.id = object_edges.target_object_id
+    WHERE NOT (object_edges.target_object_id = ANY(graph_walk.path))
+      AND graph_walk.depth < ?
+      AND target_object.namespace_id IN (SELECT namespace_id FROM valid_namespaces)
+),
+deduped_walk AS (
+    SELECT DISTINCT ON (root_object_id, descendant_object_id)
+        root_object_id,
+        ancestor_object_id,
+        descendant_object_id,
+        depth,
+        path
+    FROM graph_walk
+    ORDER BY root_object_id ASC, descendant_object_id ASC, depth ASC, path ASC
+),
+ranked_walk AS (
+    SELECT
+        deduped_walk.*,
+        row_number() OVER (
+            PARTITION BY deduped_walk.root_object_id
+            ORDER BY deduped_walk.path ASC, deduped_walk.descendant_object_id ASC
+        ) AS related_rank
+    FROM deduped_walk
+    JOIN hubuumobject target_object
+      ON target_object.id = deduped_walk.descendant_object_id
+    WHERE target_object.hubuum_class_id = ?
+)
+SELECT
+    ranked_walk.root_object_id,
+    source_object.id AS ancestor_object_id,
+    target_object.id AS descendant_object_id,
+    ranked_walk.depth,
+    ranked_walk.path,
+    source_object.name AS ancestor_name,
+    target_object.name AS descendant_name,
+    source_object.namespace_id AS ancestor_namespace_id,
+    target_object.namespace_id AS descendant_namespace_id,
+    source_object.hubuum_class_id AS ancestor_class_id,
+    target_object.hubuum_class_id AS descendant_class_id,
+    source_object.description AS ancestor_description,
+    target_object.description AS descendant_description,
+    source_object.data AS ancestor_data,
+    target_object.data AS descendant_data,
+    source_object.created_at AS ancestor_created_at,
+    target_object.created_at AS descendant_created_at,
+    source_object.updated_at AS ancestor_updated_at,
+    target_object.updated_at AS descendant_updated_at
+FROM ranked_walk
+JOIN hubuumobject source_object
+  ON source_object.id = ranked_walk.ancestor_object_id
+JOIN hubuumobject target_object
+  ON target_object.id = ranked_walk.descendant_object_id
+WHERE ranked_walk.related_rank <= ?
+  AND source_object.namespace_id IN (SELECT namespace_id FROM valid_namespaces)
+  AND target_object.namespace_id IN (SELECT namespace_id FROM valid_namespaces)
+ORDER BY ranked_walk.root_object_id ASC, ranked_walk.related_rank ASC
+"#
+            ),
+            bind_variables,
+        };
+
+        let query = bind_raw_sql_query!(spec.clone());
+        debug!(
+            message = "Searching batched related objects",
+            root_object_count = root_object_ids.len(),
+            target_class_id,
+            max_depth,
+            per_root_limit,
+            raw_sql = %spec.sql,
+            bind_variables = ?spec.bind_variables
+        );
+        trace_query!(query, "Searching batched related objects");
+
+        with_connection(pool, |conn| {
+            query.get_results::<RelatedObjectIncludeRow>(conn)
+        })
     }
 }
 

--- a/src/models/relation.rs
+++ b/src/models/relation.rs
@@ -190,6 +190,48 @@ pub struct RelatedObjectGraphRow {
     pub descendant_updated_at: chrono::NaiveDateTime,
 }
 
+#[derive(Debug, QueryableByName, Serialize, Deserialize, Clone)]
+pub struct RelatedObjectIncludeRow {
+    #[diesel(sql_type = Integer)]
+    pub root_object_id: i32,
+    #[diesel(sql_type = Integer)]
+    pub ancestor_object_id: i32,
+    #[diesel(sql_type = Integer)]
+    pub descendant_object_id: i32,
+    #[diesel(sql_type = Integer)]
+    pub depth: i32,
+    #[diesel(sql_type = Array<Integer>)]
+    pub path: Vec<i32>,
+    #[diesel(sql_type = Text)]
+    pub ancestor_name: String,
+    #[diesel(sql_type = Text)]
+    pub descendant_name: String,
+    #[diesel(sql_type = Integer)]
+    pub ancestor_namespace_id: i32,
+    #[diesel(sql_type = Integer)]
+    pub descendant_namespace_id: i32,
+    #[diesel(sql_type = Integer)]
+    pub ancestor_class_id: i32,
+    #[diesel(sql_type = Integer)]
+    pub descendant_class_id: i32,
+    #[diesel(sql_type = Text)]
+    pub ancestor_description: String,
+    #[diesel(sql_type = Text)]
+    pub descendant_description: String,
+    #[diesel(sql_type = Jsonb)]
+    pub ancestor_data: serde_json::Value,
+    #[diesel(sql_type = Jsonb)]
+    pub descendant_data: serde_json::Value,
+    #[diesel(sql_type = Timestamp)]
+    pub ancestor_created_at: chrono::NaiveDateTime,
+    #[diesel(sql_type = Timestamp)]
+    pub descendant_created_at: chrono::NaiveDateTime,
+    #[diesel(sql_type = Timestamp)]
+    pub ancestor_updated_at: chrono::NaiveDateTime,
+    #[diesel(sql_type = Timestamp)]
+    pub descendant_updated_at: chrono::NaiveDateTime,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct RelatedObjectGraph {
     pub objects: Vec<HubuumObjectWithPath>,

--- a/src/models/report.rs
+++ b/src/models/report.rs
@@ -142,11 +142,40 @@ pub struct ReportLimits {
     pub max_output_bytes: Option<usize>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReportIncludeRelatedDirection {
+    Any,
+    Outgoing,
+    Incoming,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReportIncludeRelatedSort {
+    Path,
+    Name,
+    CreatedAt,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct ReportIncludeRelatedObject {
     pub class_id: i32,
+    pub class_relation_id: Option<i32>,
+    pub direction: Option<ReportIncludeRelatedDirection>,
+    pub sort: Option<ReportIncludeRelatedSort>,
     pub max_depth: Option<i32>,
     pub limit: Option<i32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReportIncludeRelatedQuery {
+    pub class_id: i32,
+    pub class_relation_id: Option<i32>,
+    pub direction: ReportIncludeRelatedDirection,
+    pub sort: ReportIncludeRelatedSort,
+    pub max_depth: i32,
+    pub limit: i32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]

--- a/src/models/report.rs
+++ b/src/models/report.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -141,6 +143,18 @@ pub struct ReportLimits {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct ReportIncludeRelatedObject {
+    pub class_id: i32,
+    pub max_depth: Option<i32>,
+    pub limit: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct ReportInclude {
+    pub related_objects: Option<HashMap<String, ReportIncludeRelatedObject>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[schema(example = openapi_examples::report_request_example)]
 pub struct ReportRequest {
     pub scope: ReportScope,
@@ -148,6 +162,7 @@ pub struct ReportRequest {
     pub output: Option<ReportOutputRequest>,
     pub missing_data_policy: Option<ReportMissingDataPolicy>,
     pub limits: Option<ReportLimits>,
+    pub include: Option<ReportInclude>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
@@ -222,6 +237,7 @@ mod openapi_examples {
             output: Some(report_output_example()),
             missing_data_policy: Some(ReportMissingDataPolicy::Strict),
             limits: Some(report_limits_example()),
+            include: None,
         }
     }
 

--- a/src/models/traits/object_relation.rs
+++ b/src/models/traits/object_relation.rs
@@ -7,7 +7,7 @@ use crate::errors::ApiError;
 
 use crate::models::{
     HubuumObjectRelation, HubuumObjectRelationID, HubuumObjectWithPath, NewHubuumObjectRelation,
-    ObjectGraphRow, RelatedObjectGraphRow,
+    ObjectGraphRow, RelatedObjectGraphRow, RelatedObjectIncludeRow,
 };
 use crate::traits::accessors::{IdAccessor, InstanceAdapter};
 use crate::traits::crud::{DeleteAdapter, SaveAdapter};
@@ -72,6 +72,22 @@ impl ObjectGraphRow {
 }
 
 impl RelatedObjectGraphRow {
+    pub fn to_descendant_object_with_path(&self) -> HubuumObjectWithPath {
+        HubuumObjectWithPath {
+            id: self.descendant_object_id,
+            name: self.descendant_name.clone(),
+            namespace_id: self.descendant_namespace_id,
+            hubuum_class_id: self.descendant_class_id,
+            data: self.descendant_data.clone(),
+            description: self.descendant_description.clone(),
+            created_at: self.descendant_created_at,
+            updated_at: self.descendant_updated_at,
+            path: self.path.clone(),
+        }
+    }
+}
+
+impl RelatedObjectIncludeRow {
     pub fn to_descendant_object_with_path(&self) -> HubuumObjectWithPath {
         HubuumObjectWithPath {
             id: self.descendant_object_id,

--- a/src/models/traits/user.rs
+++ b/src/models/traits/user.rs
@@ -4,7 +4,7 @@ use crate::models::search::{FilterField, ParsedQueryParam, QueryOptions, SortPar
 use crate::models::{
     ClassGraphRow, Group, HubuumClass, HubuumClassExpanded, HubuumClassRelation, HubuumObject,
     HubuumObjectRelation, Namespace, Permissions, RelatedObjectGraphRow, RelatedObjectIncludeRow,
-    UnifiedSearchSpec, User, UserID,
+    ReportIncludeRelatedQuery, UnifiedSearchSpec, User, UserID,
 };
 
 use crate::db::DbPool;
@@ -230,21 +230,13 @@ pub trait Search: SelfAccessors<User> + UserNamespaceAccessors {
         &self,
         backend: &C,
         root_object_ids: &[i32],
-        target_class_id: i32,
-        max_depth: i32,
-        per_root_limit: i32,
+        include: ReportIncludeRelatedQuery,
     ) -> Result<Vec<RelatedObjectIncludeRow>, ApiError>
     where
         C: BackendContext + ?Sized,
     {
-        self.related_objects_for_roots_from_backend(
-            backend.db_pool(),
-            root_object_ids,
-            target_class_id,
-            max_depth,
-            per_root_limit,
-        )
-        .await
+        self.related_objects_for_roots_from_backend(backend.db_pool(), root_object_ids, include)
+            .await
     }
 
     async fn object_relations_touching_page<C, O>(

--- a/src/models/traits/user.rs
+++ b/src/models/traits/user.rs
@@ -3,8 +3,8 @@ use std::iter::IntoIterator;
 use crate::models::search::{FilterField, ParsedQueryParam, QueryOptions, SortParam};
 use crate::models::{
     ClassGraphRow, Group, HubuumClass, HubuumClassExpanded, HubuumClassRelation, HubuumObject,
-    HubuumObjectRelation, Namespace, Permissions, RelatedObjectGraphRow, UnifiedSearchSpec, User,
-    UserID,
+    HubuumObjectRelation, Namespace, Permissions, RelatedObjectGraphRow, RelatedObjectIncludeRow,
+    UnifiedSearchSpec, User, UserID,
 };
 
 use crate::db::DbPool;
@@ -224,6 +224,27 @@ pub trait Search: SelfAccessors<User> + UserNamespaceAccessors {
     {
         self.objects_related_to_page_from_backend(backend.db_pool(), object, query_options)
             .await
+    }
+
+    async fn related_objects_for_roots<C>(
+        &self,
+        backend: &C,
+        root_object_ids: &[i32],
+        target_class_id: i32,
+        max_depth: i32,
+        per_root_limit: i32,
+    ) -> Result<Vec<RelatedObjectIncludeRow>, ApiError>
+    where
+        C: BackendContext + ?Sized,
+    {
+        self.related_objects_for_roots_from_backend(
+            backend.db_pool(),
+            root_object_ids,
+            target_class_id,
+            max_depth,
+            per_root_limit,
+        )
+        .await
     }
 
     async fn object_relations_touching_page<C, O>(

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -6,8 +6,9 @@ mod tests {
     };
 
     use crate::models::{
-        HubuumClass, NewHubuumObject, NewReportTemplate, ReportContentType, ReportJsonResponse,
-        ReportRequest, ReportScope, ReportScopeKind,
+        HubuumClass, HubuumClassRelation, HubuumObject, HubuumObjectRelation,
+        NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, NewReportTemplate,
+        ReportContentType, ReportJsonResponse, ReportRequest, ReportScope, ReportScopeKind,
     };
     use crate::tests::api::v1::classes::tests::{cleanup, create_test_classes};
     use crate::tests::api_operations::post_request_with_headers;
@@ -44,6 +45,82 @@ mod tests {
             created.push(object.save(pool).await.unwrap());
         }
         created
+    }
+
+    async fn create_report_relation_fixture(
+        pool: &crate::db::DbPool,
+        classes: &[HubuumClass],
+    ) -> (
+        Vec<HubuumObject>,
+        Vec<HubuumClassRelation>,
+        Vec<HubuumObjectRelation>,
+    ) {
+        let objects = vec![
+            NewHubuumObject {
+                name: "report-root-01".to_string(),
+                description: "Report root object".to_string(),
+                namespace_id: classes[0].namespace_id,
+                hubuum_class_id: classes[0].id,
+                data: serde_json::json!({"hostname": "report-root-01", "role": "root"}),
+            },
+            NewHubuumObject {
+                name: "report-mid-01".to_string(),
+                description: "Report middle object".to_string(),
+                namespace_id: classes[1].namespace_id,
+                hubuum_class_id: classes[1].id,
+                data: serde_json::json!({"hostname": "report-mid-01", "role": "middle"}),
+            },
+            NewHubuumObject {
+                name: "report-leaf-01".to_string(),
+                description: "Report leaf object".to_string(),
+                namespace_id: classes[2].namespace_id,
+                hubuum_class_id: classes[2].id,
+                data: serde_json::json!({"hostname": "report-leaf-01", "role": "leaf"}),
+            },
+        ];
+
+        let mut created_objects = Vec::new();
+        for object in objects {
+            created_objects.push(object.save(pool).await.unwrap());
+        }
+
+        let class_relations = vec![
+            NewHubuumClassRelation {
+                from_hubuum_class_id: classes[0].id,
+                to_hubuum_class_id: classes[1].id,
+            }
+            .save(pool)
+            .await
+            .unwrap(),
+            NewHubuumClassRelation {
+                from_hubuum_class_id: classes[1].id,
+                to_hubuum_class_id: classes[2].id,
+            }
+            .save(pool)
+            .await
+            .unwrap(),
+        ];
+
+        let object_relations = vec![
+            NewHubuumObjectRelation {
+                from_hubuum_object_id: created_objects[0].id,
+                to_hubuum_object_id: created_objects[1].id,
+                class_relation_id: class_relations[0].id,
+            }
+            .save(pool)
+            .await
+            .unwrap(),
+            NewHubuumObjectRelation {
+                from_hubuum_object_id: created_objects[1].id,
+                to_hubuum_object_id: created_objects[2].id,
+                class_relation_id: class_relations[1].id,
+            }
+            .save(pool)
+            .await
+            .unwrap(),
+        ];
+
+        (created_objects, class_relations, object_relations)
     }
 
     async fn create_template(
@@ -118,6 +195,154 @@ mod tests {
         assert_eq!(report.items.len(), 2);
         assert_eq!(report.items[0]["name"], "report-app-01");
         assert_eq!(report.items[1]["name"], "report-db-01");
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn docs_report_class_relations_example_runs(#[future(awt)] test_context: TestContext) {
+        let context = test_context;
+        let pool = &context.pool;
+        let admin_token = &context.admin_token;
+        let classes = create_test_classes(
+            &context,
+            &context.scoped_name("report_class_relations_docs"),
+        )
+        .await;
+        let (_objects, class_relations, _object_relations) =
+            create_report_relation_fixture(pool, &classes).await;
+
+        let body = serde_json::json!({
+            "scope": {
+                "kind": "class_relations"
+            },
+            "query": format!("from_classes={}&sort=created_at.desc", classes[0].id),
+            "limits": {
+                "max_items": 50
+            }
+        });
+
+        let resp = post_request_with_headers(
+            pool,
+            admin_token,
+            REPORTS_ENDPOINT,
+            &body,
+            vec![(header::ACCEPT, "application/json".to_string())],
+        )
+        .await;
+
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let report: ReportJsonResponse = test::read_body_json(resp).await;
+
+        assert_eq!(report.meta.scope.kind, ReportScopeKind::ClassRelations);
+        assert_eq!(report.items.len(), 1);
+        assert_eq!(report.items[0]["id"], class_relations[0].id);
+        assert_eq!(
+            report.items[0]["from_hubuum_class_id"],
+            class_relations[0].from_hubuum_class_id
+        );
+        assert_eq!(
+            report.items[0]["to_hubuum_class_id"],
+            class_relations[0].to_hubuum_class_id
+        );
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn docs_report_object_relations_example_runs(#[future(awt)] test_context: TestContext) {
+        let context = test_context;
+        let pool = &context.pool;
+        let admin_token = &context.admin_token;
+        let classes = create_test_classes(
+            &context,
+            &context.scoped_name("report_object_relations_docs"),
+        )
+        .await;
+        let (objects, _class_relations, object_relations) =
+            create_report_relation_fixture(pool, &classes).await;
+
+        let body = serde_json::json!({
+            "scope": {
+                "kind": "object_relations"
+            },
+            "query": format!("to_objects={}&sort=created_at.desc", objects[1].id)
+        });
+
+        let resp = post_request_with_headers(
+            pool,
+            admin_token,
+            REPORTS_ENDPOINT,
+            &body,
+            vec![(header::ACCEPT, "application/json".to_string())],
+        )
+        .await;
+
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let report: ReportJsonResponse = test::read_body_json(resp).await;
+
+        assert_eq!(report.meta.scope.kind, ReportScopeKind::ObjectRelations);
+        assert_eq!(report.items.len(), 1);
+        assert_eq!(report.items[0]["id"], object_relations[0].id);
+        assert_eq!(
+            report.items[0]["from_hubuum_object_id"],
+            object_relations[0].from_hubuum_object_id
+        );
+        assert_eq!(
+            report.items[0]["to_hubuum_object_id"],
+            object_relations[0].to_hubuum_object_id
+        );
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn docs_report_related_objects_example_runs(#[future(awt)] test_context: TestContext) {
+        let context = test_context;
+        let pool = &context.pool;
+        let admin_token = &context.admin_token;
+        let classes = create_test_classes(
+            &context,
+            &context.scoped_name("report_related_objects_docs"),
+        )
+        .await;
+        let (objects, _class_relations, _object_relations) =
+            create_report_relation_fixture(pool, &classes).await;
+
+        let body = serde_json::json!({
+            "scope": {
+                "kind": "related_objects",
+                "class_id": classes[0].id,
+                "object_id": objects[0].id
+            },
+            "query": format!("depth__lte=2&to_classes={}&sort=path", classes[2].id)
+        });
+
+        let resp = post_request_with_headers(
+            pool,
+            admin_token,
+            REPORTS_ENDPOINT,
+            &body,
+            vec![(header::ACCEPT, "application/json".to_string())],
+        )
+        .await;
+
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let report: ReportJsonResponse = test::read_body_json(resp).await;
+
+        assert_eq!(report.meta.scope.kind, ReportScopeKind::RelatedObjects);
+        assert_eq!(report.items.len(), 1);
+        assert_eq!(report.items[0]["id"], objects[2].id);
+        assert_eq!(report.items[0]["name"], "report-leaf-01");
+        assert_eq!(report.items[0]["data"]["hostname"], "report-leaf-01");
+        assert!(
+            report.items[0]["path"].as_array().is_some(),
+            "expected related object report item to include path array, got {}",
+            report.items[0]
+        );
 
         cleanup(&classes).await;
     }

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -166,6 +166,7 @@ mod tests {
             output: None,
             missing_data_policy: None,
             limits: None,
+            include: None,
         };
 
         let resp = post_request_with_headers(
@@ -345,6 +346,366 @@ mod tests {
         );
 
         cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_report_objects_in_class_includes_related_objects(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let pool = &context.pool;
+        let admin_token = &context.admin_token;
+        let classes = create_test_classes(
+            &context,
+            &context.scoped_name("report_include_related_json"),
+        )
+        .await;
+        let (objects, class_relations, _object_relations) =
+            create_report_relation_fixture(pool, &classes).await;
+
+        let second_room = NewHubuumObject {
+            name: "report-mid-02".to_string(),
+            description: "Second related object".to_string(),
+            namespace_id: classes[1].namespace_id,
+            hubuum_class_id: classes[1].id,
+            data: serde_json::json!({"hostname": "report-mid-02", "role": "middle"}),
+        }
+        .save(pool)
+        .await
+        .unwrap();
+        NewHubuumObjectRelation {
+            from_hubuum_object_id: objects[0].id,
+            to_hubuum_object_id: second_room.id,
+            class_relation_id: class_relations[0].id,
+        }
+        .save(pool)
+        .await
+        .unwrap();
+
+        let body = serde_json::json!({
+            "scope": {
+                "kind": "objects_in_class",
+                "class_id": classes[0].id
+            },
+            "query": "name__equals=report-root-01",
+            "include": {
+                "related_objects": {
+                    "room": {
+                        "class_id": classes[1].id,
+                        "limit": 1
+                    }
+                }
+            }
+        });
+
+        let resp = post_request_with_headers(
+            pool,
+            admin_token,
+            REPORTS_ENDPOINT,
+            &body,
+            vec![(header::ACCEPT, "application/json".to_string())],
+        )
+        .await;
+
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let report: ReportJsonResponse = test::read_body_json(resp).await;
+
+        assert_eq!(report.items.len(), 1);
+        assert_eq!(report.items[0]["name"], "report-root-01");
+        let room = report.items[0]["related"]["room"].as_array().unwrap();
+        assert_eq!(room.len(), 1);
+        assert_eq!(room[0]["name"], "report-mid-01");
+        assert_eq!(room[0]["data"]["hostname"], "report-mid-01");
+        assert!(room[0]["path"].as_array().is_some());
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_report_template_renders_included_related_objects(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let pool = &context.pool;
+        let admin_token = &context.admin_token;
+        let classes = create_test_classes(
+            &context,
+            &context.scoped_name("report_include_related_template"),
+        )
+        .await;
+        let _fixture = create_report_relation_fixture(pool, &classes).await;
+        let template_id = create_template(
+            pool,
+            classes[0].namespace_id,
+            "included-related-template",
+            ReportContentType::TextPlain,
+            "{{#each items}}{{this.name}} is in {{this.related.room[0].name}}\\n{{/each}}",
+        )
+        .await;
+
+        let body = serde_json::json!({
+            "scope": {
+                "kind": "objects_in_class",
+                "class_id": classes[0].id
+            },
+            "query": "name__equals=report-root-01",
+            "output": {
+                "template_id": template_id
+            },
+            "include": {
+                "related_objects": {
+                    "room": {
+                        "class_id": classes[1].id
+                    }
+                }
+            }
+        });
+
+        let resp =
+            post_request_with_headers(pool, admin_token, REPORTS_ENDPOINT, &body, vec![]).await;
+
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let rendered = String::from_utf8(test::read_body(resp).await.to_vec()).unwrap();
+        assert_eq!(rendered, "report-root-01 is in report-mid-01\\n");
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_report_included_related_objects_empty_when_missing(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let pool = &context.pool;
+        let admin_token = &context.admin_token;
+        let classes = create_test_classes(
+            &context,
+            &context.scoped_name("report_include_related_empty"),
+        )
+        .await;
+        let _fixture = create_report_relation_fixture(pool, &classes).await;
+        let unlinked = NewHubuumObject {
+            name: "report-root-02".to_string(),
+            description: "Unlinked root object".to_string(),
+            namespace_id: classes[0].namespace_id,
+            hubuum_class_id: classes[0].id,
+            data: serde_json::json!({"hostname": "report-root-02", "role": "root"}),
+        }
+        .save(pool)
+        .await
+        .unwrap();
+
+        let body = serde_json::json!({
+            "scope": {
+                "kind": "objects_in_class",
+                "class_id": classes[0].id
+            },
+            "query": format!("id={}", unlinked.id),
+            "include": {
+                "related_objects": {
+                    "room": {
+                        "class_id": classes[1].id
+                    }
+                }
+            }
+        });
+
+        let resp = post_request_with_headers(
+            pool,
+            admin_token,
+            REPORTS_ENDPOINT,
+            &body,
+            vec![(header::ACCEPT, "application/json".to_string())],
+        )
+        .await;
+
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let report: ReportJsonResponse = test::read_body_json(resp).await;
+
+        assert_eq!(report.items.len(), 1);
+        assert_eq!(
+            report.items[0]["related"]["room"].as_array().unwrap().len(),
+            0
+        );
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_report_included_related_objects_respects_max_depth(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let pool = &context.pool;
+        let admin_token = &context.admin_token;
+        let classes = create_test_classes(
+            &context,
+            &context.scoped_name("report_include_related_depth"),
+        )
+        .await;
+        let _fixture = create_report_relation_fixture(pool, &classes).await;
+
+        let direct_body = serde_json::json!({
+            "scope": {
+                "kind": "objects_in_class",
+                "class_id": classes[0].id
+            },
+            "query": "name__equals=report-root-01",
+            "include": {
+                "related_objects": {
+                    "leaf": {
+                        "class_id": classes[2].id,
+                        "max_depth": 1
+                    }
+                }
+            }
+        });
+        let transitive_body = serde_json::json!({
+            "scope": {
+                "kind": "objects_in_class",
+                "class_id": classes[0].id
+            },
+            "query": "name__equals=report-root-01",
+            "include": {
+                "related_objects": {
+                    "leaf": {
+                        "class_id": classes[2].id,
+                        "max_depth": 2
+                    }
+                }
+            }
+        });
+
+        let direct_resp = post_request_with_headers(
+            pool,
+            admin_token,
+            REPORTS_ENDPOINT,
+            &direct_body,
+            vec![(header::ACCEPT, "application/json".to_string())],
+        )
+        .await;
+        let direct_resp = assert_response_status(direct_resp, StatusCode::OK).await;
+        let direct_report: ReportJsonResponse = test::read_body_json(direct_resp).await;
+        assert_eq!(
+            direct_report.items[0]["related"]["leaf"]
+                .as_array()
+                .unwrap()
+                .len(),
+            0
+        );
+
+        let transitive_resp = post_request_with_headers(
+            pool,
+            admin_token,
+            REPORTS_ENDPOINT,
+            &transitive_body,
+            vec![(header::ACCEPT, "application/json".to_string())],
+        )
+        .await;
+        let transitive_resp = assert_response_status(transitive_resp, StatusCode::OK).await;
+        let transitive_report: ReportJsonResponse = test::read_body_json(transitive_resp).await;
+        assert_eq!(
+            transitive_report.items[0]["related"]["leaf"][0]["name"],
+            "report-leaf-01"
+        );
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_report_rejects_related_include_on_other_scopes(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let pool = &context.pool;
+        let admin_token = &context.admin_token;
+
+        let body = serde_json::json!({
+            "scope": {
+                "kind": "classes"
+            },
+            "include": {
+                "related_objects": {
+                    "room": {
+                        "class_id": 1
+                    }
+                }
+            }
+        });
+
+        let resp =
+            post_request_with_headers(pool, admin_token, REPORTS_ENDPOINT, &body, vec![]).await;
+
+        assert_response_status(resp, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_report_rejects_invalid_related_include_options(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let pool = &context.pool;
+        let admin_token = &context.admin_token;
+
+        let invalid_includes = vec![
+            serde_json::json!({
+                "bad-alias": {
+                    "class_id": 1
+                }
+            }),
+            serde_json::json!({
+                "room": {
+                    "class_id": 0
+                }
+            }),
+            serde_json::json!({
+                "room": {
+                    "class_id": 1,
+                    "max_depth": 0
+                }
+            }),
+            serde_json::json!({
+                "room": {
+                    "class_id": 1,
+                    "max_depth": 11
+                }
+            }),
+            serde_json::json!({
+                "room": {
+                    "class_id": 1,
+                    "limit": 0
+                }
+            }),
+            serde_json::json!({
+                "room": {
+                    "class_id": 1,
+                    "limit": 51
+                }
+            }),
+        ];
+
+        for related_objects in invalid_includes {
+            let body = serde_json::json!({
+                "scope": {
+                    "kind": "objects_in_class",
+                    "class_id": 1
+                },
+                "include": {
+                    "related_objects": related_objects
+                }
+            });
+
+            let resp =
+                post_request_with_headers(pool, admin_token, REPORTS_ENDPOINT, &body, vec![]).await;
+
+            assert_response_status(resp, StatusCode::BAD_REQUEST).await;
+        }
     }
 
     #[rstest]
@@ -803,6 +1164,7 @@ mod tests {
             output: None,
             missing_data_policy: None,
             limits: None,
+            include: None,
         };
 
         let resp = post_request_with_headers(
@@ -842,6 +1204,7 @@ mod tests {
             output: None,
             missing_data_policy: None,
             limits: None,
+            include: None,
         };
 
         // Accept header explicitly excluding application/json with q=0
@@ -882,6 +1245,7 @@ mod tests {
             output: None,
             missing_data_policy: None,
             limits: None,
+            include: None,
         };
 
         // Accept: application/*;q=0.9, text/*;q=0.5 should pick application/json
@@ -929,6 +1293,7 @@ mod tests {
             output: None,
             missing_data_policy: None,
             limits: None,
+            include: None,
         };
 
         // Should pick application/json with higher q-value

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -6,15 +6,16 @@ mod tests {
     };
 
     use crate::models::{
-        HubuumClass, HubuumClassRelation, HubuumObject, HubuumObjectRelation,
+        HubuumClass, HubuumClassRelation, HubuumObject, HubuumObjectRelation, NamespaceID,
         NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, NewReportTemplate,
-        ReportContentType, ReportJsonResponse, ReportRequest, ReportScope, ReportScopeKind,
+        Permissions, ReportContentType, ReportJsonResponse, ReportRequest, ReportScope,
+        ReportScopeKind,
     };
     use crate::tests::api::v1::classes::tests::{cleanup, create_test_classes};
     use crate::tests::api_operations::post_request_with_headers;
     use crate::tests::asserts::assert_response_status;
-    use crate::tests::{TestContext, test_context};
-    use crate::traits::CanSave;
+    use crate::tests::{TestContext, create_test_group, test_context};
+    use crate::traits::{CanSave, PermissionController, SelfAccessors};
     use rstest::rstest;
 
     const REPORTS_ENDPOINT: &str = "/api/v1/reports";
@@ -618,6 +619,265 @@ mod tests {
 
     #[rstest]
     #[actix_web::test]
+    async fn test_run_report_included_related_objects_filters_relation_and_direction(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let pool = &context.pool;
+        let admin_token = &context.admin_token;
+        let classes = create_test_classes(
+            &context,
+            &context.scoped_name("report_include_related_filters"),
+        )
+        .await;
+        let (_objects, class_relations, _object_relations) =
+            create_report_relation_fixture(pool, &classes).await;
+
+        let incoming_body = serde_json::json!({
+            "scope": {
+                "kind": "objects_in_class",
+                "class_id": classes[0].id
+            },
+            "query": "name__equals=report-root-01",
+            "include": {
+                "related_objects": {
+                    "room": {
+                        "class_id": classes[1].id,
+                        "class_relation_id": class_relations[0].id,
+                        "direction": "incoming"
+                    }
+                }
+            }
+        });
+        let wrong_relation_body = serde_json::json!({
+            "scope": {
+                "kind": "objects_in_class",
+                "class_id": classes[0].id
+            },
+            "query": "name__equals=report-root-01",
+            "include": {
+                "related_objects": {
+                    "room": {
+                        "class_id": classes[1].id,
+                        "class_relation_id": class_relations[1].id
+                    }
+                }
+            }
+        });
+        let outgoing_body = serde_json::json!({
+            "scope": {
+                "kind": "objects_in_class",
+                "class_id": classes[0].id
+            },
+            "query": "name__equals=report-root-01",
+            "include": {
+                "related_objects": {
+                    "room": {
+                        "class_id": classes[1].id,
+                        "class_relation_id": class_relations[0].id,
+                        "direction": "outgoing"
+                    }
+                }
+            }
+        });
+
+        for body in [incoming_body, wrong_relation_body] {
+            let resp = post_request_with_headers(
+                pool,
+                admin_token,
+                REPORTS_ENDPOINT,
+                &body,
+                vec![(header::ACCEPT, "application/json".to_string())],
+            )
+            .await;
+            let resp = assert_response_status(resp, StatusCode::OK).await;
+            let report: ReportJsonResponse = test::read_body_json(resp).await;
+            assert_eq!(
+                report.items[0]["related"]["room"].as_array().unwrap().len(),
+                0
+            );
+        }
+
+        let resp = post_request_with_headers(
+            pool,
+            admin_token,
+            REPORTS_ENDPOINT,
+            &outgoing_body,
+            vec![(header::ACCEPT, "application/json".to_string())],
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let report: ReportJsonResponse = test::read_body_json(resp).await;
+        assert_eq!(
+            report.items[0]["related"]["room"][0]["name"],
+            "report-mid-01"
+        );
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_report_included_related_objects_sorts_per_alias(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let pool = &context.pool;
+        let admin_token = &context.admin_token;
+        let classes = create_test_classes(
+            &context,
+            &context.scoped_name("report_include_related_sort"),
+        )
+        .await;
+        let (objects, class_relations, _object_relations) =
+            create_report_relation_fixture(pool, &classes).await;
+
+        let first_by_name = NewHubuumObject {
+            name: "aaa-report-mid".to_string(),
+            description: "First by name".to_string(),
+            namespace_id: classes[1].namespace_id,
+            hubuum_class_id: classes[1].id,
+            data: serde_json::json!({"hostname": "aaa-report-mid", "role": "middle"}),
+        }
+        .save(pool)
+        .await
+        .unwrap();
+        NewHubuumObjectRelation {
+            from_hubuum_object_id: objects[0].id,
+            to_hubuum_object_id: first_by_name.id,
+            class_relation_id: class_relations[0].id,
+        }
+        .save(pool)
+        .await
+        .unwrap();
+
+        let body = serde_json::json!({
+            "scope": {
+                "kind": "objects_in_class",
+                "class_id": classes[0].id
+            },
+            "query": "name__equals=report-root-01",
+            "include": {
+                "related_objects": {
+                    "room": {
+                        "class_id": classes[1].id,
+                        "sort": "name",
+                        "limit": 1
+                    }
+                }
+            }
+        });
+
+        let resp = post_request_with_headers(
+            pool,
+            admin_token,
+            REPORTS_ENDPOINT,
+            &body,
+            vec![(header::ACCEPT, "application/json".to_string())],
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let report: ReportJsonResponse = test::read_body_json(resp).await;
+
+        assert_eq!(
+            report.items[0]["related"]["room"][0]["name"],
+            "aaa-report-mid"
+        );
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_report_include_requires_relation_permission_for_related_objects(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let pool = &context.pool;
+        let group = create_test_group(pool).await;
+        group.add_member(pool, &context.normal_user).await.unwrap();
+
+        let classes = create_test_classes(
+            &context,
+            &context.scoped_name("report_include_related_permissions"),
+        )
+        .await;
+        let _fixture = create_report_relation_fixture(pool, &classes).await;
+
+        let namespace = NamespaceID(classes[0].namespace_id)
+            .instance(pool)
+            .await
+            .unwrap();
+        namespace
+            .grant_one(pool, group.id, Permissions::ReadObject)
+            .await
+            .unwrap();
+        namespace
+            .grant_one(pool, group.id, Permissions::ReadCollection)
+            .await
+            .unwrap();
+        namespace
+            .grant_one(pool, group.id, Permissions::ReadClass)
+            .await
+            .unwrap();
+
+        let body = serde_json::json!({
+            "scope": {
+                "kind": "objects_in_class",
+                "class_id": classes[0].id
+            },
+            "query": "name__equals=report-root-01",
+            "include": {
+                "related_objects": {
+                    "room": {
+                        "class_id": classes[1].id
+                    }
+                }
+            }
+        });
+
+        let resp = post_request_with_headers(
+            pool,
+            &context.normal_token,
+            REPORTS_ENDPOINT,
+            &body,
+            vec![(header::ACCEPT, "application/json".to_string())],
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let report: ReportJsonResponse = test::read_body_json(resp).await;
+        assert_eq!(report.items.len(), 1);
+        assert_eq!(
+            report.items[0]["related"]["room"].as_array().unwrap().len(),
+            0
+        );
+
+        namespace
+            .grant_one(pool, group.id, Permissions::ReadObjectRelation)
+            .await
+            .unwrap();
+
+        let resp = post_request_with_headers(
+            pool,
+            &context.normal_token,
+            REPORTS_ENDPOINT,
+            &body,
+            vec![(header::ACCEPT, "application/json".to_string())],
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let report: ReportJsonResponse = test::read_body_json(resp).await;
+        assert_eq!(
+            report.items[0]["related"]["room"][0]["name"],
+            "report-mid-01"
+        );
+
+        group.delete(pool).await.unwrap();
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
     async fn test_run_report_rejects_related_include_on_other_scopes(
         #[future(awt)] test_context: TestContext,
     ) {
@@ -667,6 +927,12 @@ mod tests {
             serde_json::json!({
                 "room": {
                     "class_id": 1,
+                    "class_relation_id": 0
+                }
+            }),
+            serde_json::json!({
+                "room": {
+                    "class_id": 1,
                     "max_depth": 0
                 }
             }),
@@ -706,6 +972,41 @@ mod tests {
 
             assert_response_status(resp, StatusCode::BAD_REQUEST).await;
         }
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_report_rejects_too_many_related_include_aliases(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let pool = &context.pool;
+        let admin_token = &context.admin_token;
+
+        let body = serde_json::json!({
+            "scope": {
+                "kind": "objects_in_class",
+                "class_id": 1
+            },
+            "include": {
+                "related_objects": {
+                    "a": {"class_id": 1},
+                    "b": {"class_id": 1},
+                    "c": {"class_id": 1},
+                    "d": {"class_id": 1},
+                    "e": {"class_id": 1},
+                    "f": {"class_id": 1},
+                    "g": {"class_id": 1},
+                    "h": {"class_id": 1},
+                    "i": {"class_id": 1}
+                }
+            }
+        });
+
+        let resp =
+            post_request_with_headers(pool, admin_token, REPORTS_ENDPOINT, &body, vec![]).await;
+
+        assert_response_status(resp, StatusCode::BAD_REQUEST).await;
     }
 
     #[rstest]

--- a/src/utilities/reporting.rs
+++ b/src/utilities/reporting.rs
@@ -3,6 +3,12 @@ use std::collections::HashMap;
 use crate::errors::ApiError;
 use crate::models::{ReportContentType, ReportMissingDataPolicy, ReportWarning};
 
+#[derive(Clone, Debug, PartialEq)]
+enum PathSegment {
+    Key(String),
+    Index(usize),
+}
+
 pub fn render_template(
     template: &str,
     context: &serde_json::Value,
@@ -45,7 +51,7 @@ fn render_section(
         if let Some(expr) = tag.strip_prefix("#each ") {
             let block_start = end + 2;
             let (inner, next_index) = extract_each_block(template, block_start)?;
-            let Some(value) = lookup_value(root, current, expr.trim()) else {
+            let Some(value) = lookup_value(root, current, expr.trim())? else {
                 handle_missing_loop(expr.trim(), missing_data_policy, warnings)?;
                 index = next_index;
                 continue;
@@ -94,7 +100,7 @@ fn render_section(
             ));
         }
 
-        let rendered = match lookup_value(root, current, tag) {
+        let rendered = match lookup_value(root, current, tag)? {
             Some(value) => stringify_value(value, content_type),
             None => handle_missing_value(tag, missing_data_policy, warnings)?,
         };
@@ -139,17 +145,17 @@ fn lookup_value<'a>(
     root: &'a serde_json::Value,
     current: &'a serde_json::Value,
     expr: &str,
-) -> Option<&'a serde_json::Value> {
+) -> Result<Option<&'a serde_json::Value>, ApiError> {
     let expr = expr.trim();
     if expr.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     if expr == "this" {
-        return Some(current);
+        return Ok(Some(current));
     }
 
-    let candidates = candidate_paths(expr);
+    let candidates = candidate_paths(expr)?;
     for (base, path) in candidates {
         let value = match base.as_str() {
             "root" => walk_path(root, &path),
@@ -158,43 +164,162 @@ fn lookup_value<'a>(
         };
 
         if value.is_some() {
-            return value;
+            return Ok(value);
         }
     }
 
-    None
+    Ok(None)
 }
 
-fn candidate_paths(expr: &str) -> Vec<(String, Vec<&str>)> {
-    let parts = expr
-        .split('.')
-        .filter(|piece| !piece.is_empty())
-        .collect::<Vec<_>>();
+fn candidate_paths(expr: &str) -> Result<Vec<(String, Vec<PathSegment>)>, ApiError> {
+    let mut parts = parse_path(expr)?;
 
     if parts.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
-    if parts[0] == "root" || parts[0] == "this" {
-        return vec![(parts[0].to_string(), parts[1..].to_vec())];
+    if matches!(parts.first(), Some(PathSegment::Key(base)) if base == "root" || base == "this") {
+        let PathSegment::Key(base) = parts.remove(0) else {
+            unreachable!("first path segment was matched as a key");
+        };
+        return Ok(vec![(base, parts)]);
     }
 
-    vec![
+    Ok(vec![
         ("this".to_string(), parts.clone()),
         ("root".to_string(), parts),
-    ]
+    ])
 }
 
-fn walk_path<'a>(value: &'a serde_json::Value, path: &[&str]) -> Option<&'a serde_json::Value> {
+fn parse_path(expr: &str) -> Result<Vec<PathSegment>, ApiError> {
+    let chars = expr.chars().collect::<Vec<_>>();
+    let mut parts = Vec::new();
+    let mut index = 0usize;
+
+    while index < chars.len() {
+        match chars[index] {
+            '.' => {
+                index += 1;
+            }
+            '[' => {
+                let (segment, next_index) = parse_bracket_segment(&chars, index, expr)?;
+                parts.push(segment);
+                index = next_index;
+                let is_invalid_next = chars
+                    .get(index)
+                    .is_some_and(|next| *next != '.' && *next != '[');
+                if is_invalid_next {
+                    return Err(invalid_template_path(expr));
+                }
+            }
+            _ => {
+                let start = index;
+                while index < chars.len() && chars[index] != '.' && chars[index] != '[' {
+                    index += 1;
+                }
+                let key = chars[start..index].iter().collect::<String>();
+                if !key.is_empty() {
+                    parts.push(PathSegment::Key(key));
+                }
+            }
+        }
+    }
+
+    Ok(parts)
+}
+
+fn parse_bracket_segment(
+    chars: &[char],
+    start: usize,
+    expr: &str,
+) -> Result<(PathSegment, usize), ApiError> {
+    let mut index = start + 1;
+    while index < chars.len() && chars[index].is_whitespace() {
+        index += 1;
+    }
+
+    if index >= chars.len() {
+        return Err(invalid_template_path(expr));
+    }
+
+    if chars[index] == '"' || chars[index] == '\'' {
+        let quote = chars[index];
+        index += 1;
+        let mut key = String::new();
+        while index < chars.len() {
+            match chars[index] {
+                '\\' => {
+                    index += 1;
+                    if index >= chars.len() {
+                        return Err(invalid_template_path(expr));
+                    }
+                    key.push(chars[index]);
+                    index += 1;
+                }
+                ch if ch == quote => {
+                    index += 1;
+                    while index < chars.len() && chars[index].is_whitespace() {
+                        index += 1;
+                    }
+                    if chars.get(index) != Some(&']') {
+                        return Err(invalid_template_path(expr));
+                    }
+                    return Ok((PathSegment::Key(key), index + 1));
+                }
+                ch => {
+                    key.push(ch);
+                    index += 1;
+                }
+            }
+        }
+
+        return Err(invalid_template_path(expr));
+    }
+
+    let value_start = index;
+    while index < chars.len() && chars[index] != ']' {
+        index += 1;
+    }
+    if index >= chars.len() {
+        return Err(invalid_template_path(expr));
+    }
+
+    let value = chars[value_start..index]
+        .iter()
+        .collect::<String>()
+        .trim()
+        .to_string();
+    if value.is_empty() {
+        return Err(invalid_template_path(expr));
+    }
+
+    let segment = value
+        .parse::<usize>()
+        .map(PathSegment::Index)
+        .unwrap_or(PathSegment::Key(value));
+    Ok((segment, index + 1))
+}
+
+fn invalid_template_path(expr: &str) -> ApiError {
+    ApiError::BadRequest(format!("Invalid template path syntax: '{expr}'"))
+}
+
+fn walk_path<'a>(
+    value: &'a serde_json::Value,
+    path: &[PathSegment],
+) -> Option<&'a serde_json::Value> {
     let mut current = value;
 
-    for piece in path {
-        match current {
-            serde_json::Value::Object(map) => {
-                current = map.get(*piece)?;
+    for segment in path {
+        match (current, segment) {
+            (serde_json::Value::Object(map), PathSegment::Key(key)) => {
+                current = map.get(key)?;
             }
-            serde_json::Value::Array(items) => {
-                let index = piece.parse::<usize>().ok()?;
+            (serde_json::Value::Array(items), PathSegment::Index(index)) => {
+                current = items.get(*index)?;
+            }
+            (serde_json::Value::Array(items), PathSegment::Key(key)) => {
+                let index = key.parse::<usize>().ok()?;
                 current = items.get(index)?;
             }
             _ => return None,
@@ -316,6 +441,71 @@ mod tests {
 
         assert_eq!(rendered, "srv-01=alice\nsrv-02=bob\n");
         assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn renders_array_indexes_in_dotted_paths() {
+        let context = serde_json::json!({
+            "items": [
+                {"name": "srv-01", "data": {"tags": ["prod", "app"]}},
+            ]
+        });
+
+        let (rendered, warnings) = render_template(
+            "{{#each items}}{{this.name}}={{this.data.tags.0}}/{{this.data.tags[1]}}\n{{/each}}",
+            &context,
+            ReportContentType::TextPlain,
+            ReportMissingDataPolicy::Strict,
+        )
+        .unwrap();
+
+        assert_eq!(rendered, "srv-01=prod/app\n");
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn renders_quoted_hash_keys_in_bracket_paths() {
+        let context = serde_json::json!({
+            "items": [
+                {
+                    "name": "srv-01",
+                    "data": {
+                        "owner.name": "alice",
+                        "service-list": [{"display name": "frontend"}]
+                    }
+                },
+            ]
+        });
+
+        let (rendered, warnings) = render_template(
+            "{{#each items}}{{this.data[\"owner.name\"]}}/{{this.data['service-list'][0]['display name']}}\n{{/each}}",
+            &context,
+            ReportContentType::TextPlain,
+            ReportMissingDataPolicy::Strict,
+        )
+        .unwrap();
+
+        assert_eq!(rendered, "alice/frontend\n");
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn rejects_bare_path_segment_after_bracket_segment() {
+        let context = serde_json::json!({
+            "items": [{"data": [{"name": "srv-01"}]}]
+        });
+
+        let error = render_template(
+            "{{#each items}}{{this.data[0]name}}{{/each}}",
+            &context,
+            ReportContentType::TextPlain,
+            ReportMissingDataPolicy::Strict,
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(error, ApiError::BadRequest(message) if message == "Invalid template path syntax: 'this.data[0]name'")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add bracket-aware report template path parsing for array indexes and quoted object keys
- add objects_in_class report includes via include.related_objects, exposed as this.related.<alias>[] in templates and JSON output
- bound related includes with alias/depth/limit validation, plus optional class_relation_id, direction, and sort controls
- tighten related include traversal by filtering visible endpoints and optional relation constraints in the batched recursive query
- document data paths, included related objects, and the reserved top-level related field

## Tests
- source .env && cargo test tests::api::v1::reports -- --nocapture
- cargo clippy --all-targets --all-features -- -D warnings
- source .env && ./run_tests.sh