### PR TITLE
Fix admin CLI config parsing

### DIFF
--- a/src/bin/admin.rs
+++ b/src/bin/admin.rs
@@ -7,7 +7,11 @@ use tracing_subscriber::{
     filter::EnvFilter, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
 };
 
-use hubuum::db::{DbPool, init_pool, with_connection};
+use hubuum::config::{
+    DEFAULT_DB_STATEMENT_TIMEOUT_MS, DEFAULT_REPORT_TEMPLATE_FUEL,
+    DEFAULT_REPORT_TEMPLATE_RECURSION_LIMIT,
+};
+use hubuum::db::{DbPool, init_pool_with_statement_timeout, with_connection};
 use hubuum::errors::{ApiError, EXIT_CODE_CONFIG_ERROR, fatal_error};
 use hubuum::logger;
 use hubuum::models::report_template::{list_all_report_templates, report_templates_in_namespace};
@@ -15,7 +19,7 @@ use hubuum::models::{ReportTaskOutputRecord, User};
 use hubuum::schema::report_task_outputs::dsl::report_task_outputs;
 use hubuum::utilities::auth::generate_random_password;
 use hubuum::utilities::is_valid_log_level;
-use hubuum::utilities::reporting::validate_template;
+use hubuum::utilities::reporting::validate_template_with_limits;
 
 #[derive(Parser)]
 #[command(
@@ -41,6 +45,30 @@ struct AdminCli {
     #[arg(long, env = "HUBUUM_DATABASE_URL")]
     database_url: Option<String>,
 
+    /// Pool-global Postgres statement_timeout in milliseconds (0 disables it)
+    #[arg(
+        long,
+        env = "HUBUUM_DB_STATEMENT_TIMEOUT_MS",
+        default_value_t = DEFAULT_DB_STATEMENT_TIMEOUT_MS
+    )]
+    db_statement_timeout_ms: u64,
+
+    /// MiniJinja recursion limit for report template validation
+    #[arg(
+        long,
+        env = "HUBUUM_REPORT_TEMPLATE_RECURSION_LIMIT",
+        default_value_t = DEFAULT_REPORT_TEMPLATE_RECURSION_LIMIT
+    )]
+    report_template_recursion_limit: usize,
+
+    /// MiniJinja fuel budget for report template validation
+    #[arg(
+        long,
+        env = "HUBUUM_REPORT_TEMPLATE_FUEL",
+        default_value_t = DEFAULT_REPORT_TEMPLATE_FUEL
+    )]
+    report_template_fuel: u64,
+
     /// Log level
     /// Possible values: trace, debug, info, warn, error
     #[arg(long, env = "HUBUUM_LOG_LEVEL", default_value = "info")]
@@ -62,12 +90,18 @@ async fn main() -> Result<(), ApiError> {
     });
 
     // Initialize database connection
-    let pool = init_pool(&database_url, 1);
+    let pool =
+        init_pool_with_statement_timeout(&database_url, 1, admin_cli.db_statement_timeout_ms);
 
     if let Some(username) = admin_cli.reset_password {
         reset_password(pool, &username).await?;
     } else if admin_cli.audit_templates {
-        audit_templates(pool).await?;
+        audit_templates(
+            pool,
+            admin_cli.report_template_recursion_limit,
+            admin_cli.report_template_fuel,
+        )
+        .await?;
     } else if admin_cli.report_template_health {
         report_template_health(pool).await?;
     } else {
@@ -85,19 +119,25 @@ async fn reset_password(pool: DbPool, username: &str) -> Result<(), ApiError> {
     Ok(())
 }
 
-async fn audit_templates(pool: DbPool) -> Result<(), ApiError> {
+async fn audit_templates(
+    pool: DbPool,
+    report_template_recursion_limit: usize,
+    report_template_fuel: u64,
+) -> Result<(), ApiError> {
     let templates = list_all_report_templates(&pool).await?;
     let mut failures = Vec::new();
 
     for template in templates {
         let namespace_templates =
             report_templates_in_namespace(&pool, template.namespace_id, Some(template.id)).await?;
-        if let Err(error) = validate_template(
+        if let Err(error) = validate_template_with_limits(
             &template.name,
             &template.template,
             template.namespace_id,
             &namespace_templates,
             template.content_type,
+            report_template_recursion_limit,
+            report_template_fuel,
         ) {
             failures.push((template.namespace_id, template.name, error.to_string()));
         }

--- a/src/utilities/reporting.rs
+++ b/src/utilities/reporting.rs
@@ -58,6 +58,27 @@ pub fn validate_template(
     namespace_templates: &[ReportTemplate],
     content_type: ReportContentType,
 ) -> Result<(), ApiError> {
+    let (recursion_limit, fuel) = template_limits_from_config();
+    validate_template_with_limits(
+        template_name,
+        template_source,
+        namespace_id,
+        namespace_templates,
+        content_type,
+        recursion_limit,
+        fuel,
+    )
+}
+
+pub fn validate_template_with_limits(
+    template_name: &str,
+    template_source: &str,
+    namespace_id: i32,
+    namespace_templates: &[ReportTemplate],
+    content_type: ReportContentType,
+    recursion_limit: usize,
+    fuel: u64,
+) -> Result<(), ApiError> {
     let env = build_environment(
         template_name,
         template_source,
@@ -65,6 +86,8 @@ pub fn validate_template(
         namespace_templates,
         content_type,
         ReportMissingDataPolicy::Omit,
+        recursion_limit,
+        fuel,
     )?;
 
     env.env
@@ -83,6 +106,7 @@ pub fn render_template(
     content_type: ReportContentType,
     missing_data_policy: ReportMissingDataPolicy,
 ) -> Result<(String, Vec<ReportWarning>), ApiError> {
+    let (recursion_limit, fuel) = template_limits_from_config();
     let cache_key = TemplateEnvCacheKey {
         namespace_id: template.namespace_id,
         namespace_signature: namespace_signature(template.namespace_id, namespace_templates),
@@ -108,6 +132,8 @@ pub fn render_template(
                 namespace_templates,
                 content_type,
                 missing_data_policy,
+                recursion_limit,
+                fuel,
             )?);
             let mut cache = template_env_cache()
                 .write()
@@ -183,6 +209,8 @@ fn build_environment(
     namespace_templates: &[ReportTemplate],
     content_type: ReportContentType,
     missing_data_policy: ReportMissingDataPolicy,
+    recursion_limit: usize,
+    fuel: u64,
 ) -> Result<CachedTemplateEnvironment, ApiError> {
     let mut env = Environment::new();
     let template_map = Arc::new(build_namespace_template_map(
@@ -194,13 +222,7 @@ fn build_environment(
 
     env.set_keep_trailing_newline(true);
     env.set_undefined_behavior(undefined_behavior(missing_data_policy));
-    let recursion_limit = get_config()
-        .map(|config| config.report_template_recursion_limit)
-        .unwrap_or(64);
     env.set_recursion_limit(recursion_limit);
-    let fuel = get_config()
-        .map(|config| config.report_template_fuel)
-        .unwrap_or(50_000);
     env.set_fuel(Some(fuel));
     env.set_auto_escape_callback(move |_| match content_type {
         ReportContentType::TextHtml => AutoEscape::Html,
@@ -225,6 +247,20 @@ fn build_environment(
         env,
         template_name: template_name.to_string(),
     })
+}
+
+fn template_limits_from_config() -> (usize, u64) {
+    get_config()
+        .map(|config| {
+            (
+                config.report_template_recursion_limit,
+                config.report_template_fuel,
+            )
+        })
+        .unwrap_or((
+            crate::config::DEFAULT_REPORT_TEMPLATE_RECURSION_LIMIT,
+            crate::config::DEFAULT_REPORT_TEMPLATE_FUEL,
+        ))
 }
 
 fn build_namespace_template_map(

--- a/tests/admin_cli.rs
+++ b/tests/admin_cli.rs
@@ -1,0 +1,38 @@
+use std::process::Command;
+
+fn admin_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_hubuum-admin")
+}
+
+#[test]
+fn admin_help_exposes_reset_password() {
+    let output = Command::new(admin_binary())
+        .arg("--help")
+        .output()
+        .expect("hubuum-admin --help should run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--reset-password"));
+}
+
+#[test]
+fn reset_password_does_not_parse_server_config_arguments() {
+    let output = Command::new(admin_binary())
+        .args([
+            "--reset-password",
+            "admin",
+            "--database-url",
+            "mongodb://localhost/hubuum",
+        ])
+        .output()
+        .expect("hubuum-admin --reset-password should start");
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Unsupported database type"));
+    assert!(!stderr.contains("Invalid application configuration"));
+    assert!(!stderr.contains("unexpected argument '--reset-password'"));
+    assert!(!stderr.contains("panicked at"));
+}


### PR DESCRIPTION
## Summary
- Avoid parsing server AppConfig from hubuum-admin when creating the admin DB pool
- Pass DB statement timeout and template validation limits through admin CLI/env options explicitly
- Add DB-free integration coverage for --reset-password not hitting the server config parser panic

## Tests
- cargo check --bin hubuum-admin
- cargo test --test admin_cli