### PR TITLE
Streamline executable report templates

### DIFF
--- a/benches/database_url_parsing_criterion.rs
+++ b/benches/database_url_parsing_criterion.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use hubuum::utilities::db::DatabaseUrlComponents;
 use std::hint::black_box;
 

--- a/benches/jsonb_type_inference_callgrind.rs
+++ b/benches/jsonb_type_inference_callgrind.rs
@@ -1,4 +1,4 @@
-use hubuum::models::search::{get_jsonb_field_type_from_value_and_operator, Operator};
+use hubuum::models::search::{Operator, get_jsonb_field_type_from_value_and_operator};
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 

--- a/benches/object_validation_geo_callgrind.rs
+++ b/benches/object_validation_geo_callgrind.rs
@@ -1,5 +1,5 @@
 use hubuum::models::NewHubuumObject;
-use hubuum::tests::constants::{get_schema, SchemaType};
+use hubuum::tests::constants::{SchemaType, get_schema};
 use hubuum::traits::ValidateAgainstSchema;
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;

--- a/benches/password_hashing_criterion.rs
+++ b/benches/password_hashing_criterion.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use hubuum::utilities::auth::{hash_password, verify_password};
 use std::hint::black_box;
 use std::time::Duration;

--- a/benches/unified_search_cursor_callgrind.rs
+++ b/benches/unified_search_cursor_callgrind.rs
@@ -1,4 +1,4 @@
-use hubuum::models::{decode_cursor, encode_cursor, UnifiedSearchCursorToken};
+use hubuum::models::{UnifiedSearchCursorToken, decode_cursor, encode_cursor};
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9900,15 +9900,11 @@
         },
         "example": {
           "class_id": null,
-          "default_limits": null,
-          "default_missing_data_policy": null,
           "default_query": "sort=name.desc",
           "description": "Updated template description",
-          "include": null,
           "kind": null,
           "name": "owner-report-v2",
           "namespace_id": 9,
-          "relation_context": null,
           "scope_kind": null,
           "template": "{% for item in items %}{{ item.name }}\n{% endfor %}"
         }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -419,6 +419,205 @@
         ]
       }
     },
+    "/api/v0/meta/login-rate-limit": {
+      "get": {
+        "tags": [
+          "meta"
+        ],
+        "summary": "Get Api V0 Meta Login Rate Limit",
+        "description": "Auto-generated documentation for GET /api/v0/meta/login-rate-limit.",
+        "operationId": "getApiV0MetaLoginRateLimit",
+        "parameters": [
+          {
+            "name": "include",
+            "in": "query",
+            "description": "`locked` (default) or `all`",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "description": "Filter by scope kind: `user_ip`, `ip`, or `subnet`",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Case-insensitive substring match on the scope identifier",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Login rate-limit configuration and tracked scopes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginRateLimitStateResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "meta"
+        ],
+        "summary": "Delete Api V0 Meta Login Rate Limit",
+        "description": "Auto-generated documentation for DELETE /api/v0/meta/login-rate-limit.",
+        "operationId": "deleteApiV0MetaLoginRateLimit",
+        "responses": {
+          "200": {
+            "description": "All entries cleared",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClearRateLimitResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/v0/meta/login-rate-limit/{id}": {
+      "delete": {
+        "tags": [
+          "meta"
+        ],
+        "summary": "Delete Api V0 Meta Login Rate Limit By Id",
+        "description": "Auto-generated documentation for DELETE /api/v0/meta/login-rate-limit/{id}.",
+        "operationId": "deleteApiV0MetaLoginRateLimitById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Opaque entry id from the list endpoint",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Entry released",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseRateLimitResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid entry id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Entry not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/v0/meta/tasks": {
       "get": {
         "tags": [
@@ -6514,6 +6713,115 @@
           }
         ]
       }
+    },
+    "/api/v1/templates/{template_id}/reports": {
+      "post": {
+        "tags": [
+          "templates"
+        ],
+        "summary": "Post Api V1 Templates By Template Id Reports",
+        "description": "Auto-generated documentation for POST /api/v1/templates/{template_id}/reports.",
+        "operationId": "postApiV1TemplatesByTemplateIdReports",
+        "parameters": [
+          {
+            "name": "template_id",
+            "in": "path",
+            "description": "Executable report template ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReportTemplateRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Report task accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many active report tasks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -6561,6 +6869,18 @@
               "string",
               "null"
             ]
+          }
+        }
+      },
+      "ClearRateLimitResponse": {
+        "type": "object",
+        "required": [
+          "cleared"
+        ],
+        "properties": {
+          "cleared": {
+            "type": "integer",
+            "minimum": 0
           }
         }
       },
@@ -7436,6 +7756,150 @@
           }
         }
       },
+      "LoginRateLimitConfigResponse": {
+        "type": "object",
+        "description": "Effective login rate-limit configuration, echoed back in the admin state endpoint.",
+        "required": [
+          "enabled",
+          "max_attempts",
+          "max_attempts_per_ip",
+          "max_attempts_per_subnet",
+          "window_seconds",
+          "backoff_base_seconds",
+          "backoff_max_seconds",
+          "subnet_prefix_v4",
+          "subnet_prefix_v6"
+        ],
+        "properties": {
+          "backoff_base_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "backoff_max_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "max_attempts": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "max_attempts_per_ip": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "max_attempts_per_subnet": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "subnet_prefix_v4": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "subnet_prefix_v6": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "window_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
+      "LoginRateLimitEntryResponse": {
+        "type": "object",
+        "description": "One tracked rate-limit scope (a user+IP pair, an IP, or a subnet).",
+        "required": [
+          "id",
+          "scope",
+          "identifier",
+          "attempts",
+          "locked",
+          "lockout_level"
+        ],
+        "properties": {
+          "attempts": {
+            "type": "integer",
+            "description": "Failed attempts currently within the sliding window.",
+            "minimum": 0
+          },
+          "id": {
+            "type": "string",
+            "description": "Opaque, URL-safe id; pass to `DELETE /meta/login-rate-limit/{id}` to release it."
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Human-readable identifier for the scope."
+          },
+          "locked": {
+            "type": "boolean",
+            "description": "Whether the scope is locked out right now."
+          },
+          "locked_for_seconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Remaining lockout time in seconds, if currently locked.",
+            "minimum": 0
+          },
+          "lockout_level": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Current exponential-backoff level.",
+            "minimum": 0
+          },
+          "scope": {
+            "type": "string",
+            "description": "Scope kind: `user_ip`, `ip`, or `subnet`."
+          }
+        }
+      },
+      "LoginRateLimitStateResponse": {
+        "type": "object",
+        "required": [
+          "config",
+          "tracked_entries",
+          "locked_entries",
+          "returned_entries",
+          "entries"
+        ],
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/LoginRateLimitConfigResponse"
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LoginRateLimitEntryResponse"
+            },
+            "description": "The tracked scopes matching the `include`, `scope`, and `q` query parameters."
+          },
+          "locked_entries": {
+            "type": "integer",
+            "description": "Number of scopes currently locked out (before filtering).",
+            "minimum": 0
+          },
+          "returned_entries": {
+            "type": "integer",
+            "description": "Number of scopes returned in `entries` after applying the query filters.",
+            "minimum": 0
+          },
+          "tracked_entries": {
+            "type": "integer",
+            "description": "Total number of tracked scopes (before filtering).",
+            "minimum": 0
+          }
+        }
+      },
       "LoginResponse": {
         "type": "object",
         "required": [
@@ -7753,14 +8217,61 @@
           "name",
           "description",
           "content_type",
-          "template"
+          "template",
+          "kind"
         ],
         "properties": {
+          "class_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
           "content_type": {
             "$ref": "#/components/schemas/ReportContentType"
           },
+          "default_limits": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportLimits"
+              }
+            ]
+          },
+          "default_missing_data_policy": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportMissingDataPolicy"
+              }
+            ]
+          },
+          "default_query": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "description": {
             "type": "string"
+          },
+          "include": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportInclude"
+              }
+            ]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/ReportTemplateKind"
           },
           "name": {
             "type": "string"
@@ -7769,15 +8280,46 @@
             "type": "integer",
             "format": "int32"
           },
+          "relation_context": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportRelationContext"
+              }
+            ]
+          },
+          "scope_kind": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportScopeKind"
+              }
+            ]
+          },
           "template": {
             "type": "string"
           }
         },
         "example": {
+          "class_id": 42,
           "content_type": "text/plain",
+          "default_limits": {
+            "max_items": 100,
+            "max_output_bytes": 262144
+          },
+          "default_missing_data_policy": "strict",
+          "default_query": "sort=name",
           "description": "Template for owner listing",
+          "include": null,
+          "kind": "report",
           "name": "owner-report",
           "namespace_id": 7,
+          "relation_context": null,
+          "scope_kind": "objects_in_class",
           "template": "{% for item in items %}{{ item.name }}={{ item.data.owner }}\n{% endfor %}"
         }
       },
@@ -8051,6 +8593,17 @@
           }
         }
       },
+      "ReleaseRateLimitResponse": {
+        "type": "object",
+        "required": [
+          "released"
+        ],
+        "properties": {
+          "released": {
+            "type": "boolean"
+          }
+        }
+      },
       "ReportContentType": {
         "type": "string",
         "enum": [
@@ -8257,22 +8810,6 @@
           "omit"
         ]
       },
-      "ReportOutputRequest": {
-        "type": "object",
-        "properties": {
-          "template_id": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int32"
-          }
-        },
-        "additionalProperties": false,
-        "example": {
-          "template_id": 12
-        }
-      },
       "ReportRelationContext": {
         "type": "object",
         "properties": {
@@ -8325,16 +8862,6 @@
               }
             ]
           },
-          "output": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/ReportOutputRequest"
-              }
-            ]
-          },
           "query": {
             "type": [
               "string",
@@ -8362,9 +8889,6 @@
             "max_output_bytes": 262144
           },
           "missing_data_policy": "strict",
-          "output": {
-            "template_id": 12
-          },
           "query": "name__icontains=server&sort=name",
           "relation_context": null,
           "scope": {
@@ -8471,16 +8995,50 @@
           "description",
           "content_type",
           "template",
+          "kind",
           "created_at",
           "updated_at"
         ],
         "properties": {
+          "class_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
           "content_type": {
             "$ref": "#/components/schemas/ReportContentType"
           },
           "created_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "default_limits": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportLimits"
+              }
+            ]
+          },
+          "default_missing_data_policy": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportMissingDataPolicy"
+              }
+            ]
+          },
+          "default_query": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "description": {
             "type": "string"
@@ -8489,12 +9047,45 @@
             "type": "integer",
             "format": "int32"
           },
+          "include": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportInclude"
+              }
+            ]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/ReportTemplateKind"
+          },
           "name": {
             "type": "string"
           },
           "namespace_id": {
             "type": "integer",
             "format": "int32"
+          },
+          "relation_context": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportRelationContext"
+              }
+            ]
+          },
+          "scope_kind": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportScopeKind"
+              }
+            ]
           },
           "template": {
             "type": "string"
@@ -8505,12 +9096,23 @@
           }
         },
         "example": {
+          "class_id": 42,
           "content_type": "text/plain",
           "created_at": "2026-03-06T12:00:00",
+          "default_limits": {
+            "max_items": 100,
+            "max_output_bytes": 262144
+          },
+          "default_missing_data_policy": "strict",
+          "default_query": "sort=name",
           "description": "Template for owner listing",
           "id": 1,
+          "include": null,
+          "kind": "report",
           "name": "owner-report",
           "namespace_id": 7,
+          "relation_context": null,
+          "scope_kind": "objects_in_class",
           "template": "{% for item in items %}{{ item.name }}={{ item.data.owner }}\n{% endfor %}",
           "updated_at": "2026-03-06T12:00:00"
         }
@@ -8518,6 +9120,61 @@
       "ReportTemplateID": {
         "type": "integer",
         "format": "int32"
+      },
+      "ReportTemplateKind": {
+        "type": "string",
+        "enum": [
+          "report",
+          "fragment"
+        ]
+      },
+      "ReportTemplateRunRequest": {
+        "type": "object",
+        "properties": {
+          "limits": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportLimits"
+              }
+            ]
+          },
+          "missing_data_policy": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportMissingDataPolicy"
+              }
+            ]
+          },
+          "object_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
+          "query": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "example": {
+          "limits": {
+            "max_items": 100,
+            "max_output_bytes": 262144
+          },
+          "missing_data_policy": "strict",
+          "object_id": null,
+          "query": "name__icontains=server&sort=name"
+        }
       },
       "ReportWarning": {
         "type": "object",
@@ -9142,10 +9799,63 @@
       "UpdateReportTemplate": {
         "type": "object",
         "properties": {
+          "class_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
+          "default_limits": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportLimits"
+              }
+            ]
+          },
+          "default_missing_data_policy": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportMissingDataPolicy"
+              }
+            ]
+          },
+          "default_query": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "description": {
             "type": [
               "string",
               "null"
+            ]
+          },
+          "include": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportInclude"
+              }
+            ]
+          },
+          "kind": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportTemplateKind"
+              }
             ]
           },
           "name": {
@@ -9161,6 +9871,26 @@
             ],
             "format": "int32"
           },
+          "relation_context": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportRelationContext"
+              }
+            ]
+          },
+          "scope_kind": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReportScopeKind"
+              }
+            ]
+          },
           "template": {
             "type": [
               "string",
@@ -9169,9 +9899,17 @@
           }
         },
         "example": {
+          "class_id": null,
+          "default_limits": null,
+          "default_missing_data_policy": null,
+          "default_query": "sort=name.desc",
           "description": "Updated template description",
+          "include": null,
+          "kind": null,
           "name": "owner-report-v2",
           "namespace_id": 9,
+          "relation_context": null,
+          "scope_kind": null,
           "template": "{% for item in items %}{{ item.name }}\n{% endfor %}"
         }
       },

--- a/docs/report_api.md
+++ b/docs/report_api.md
@@ -212,6 +212,14 @@ For `related_objects` templates, pass the runtime root object:
 The template stores the scope, class, include settings, relation context, content type, and default
 query/limits/policy. Runtime `query` replaces the template's default query when supplied.
 
+Executable templates support every report scope kind:
+
+- `objects_in_class` and `related_objects` are bound to a single class and require the template's `class_id`.
+- `namespaces`, `classes`, `class_relations`, and `object_relations` are class-agnostic and must not set `class_id`.
+
+`object_id` is only accepted at run time for `related_objects` templates; supplying it for any other scope
+is rejected with `400 Bad Request`.
+
 ## Output selection
 
 The server determines the output format at submission time based on the endpoint:

--- a/docs/report_api.md
+++ b/docs/report_api.md
@@ -5,6 +5,7 @@ The report API executes an authorized Hubuum query server-side through the gener
 Endpoints:
 
 - `POST /api/v1/reports`
+- `POST /api/v1/templates/{template_id}/reports`
 - `GET /api/v1/reports/{task_id}`
 - `GET /api/v1/reports/{task_id}/output`
 
@@ -21,9 +22,6 @@ Authentication:
     "class_id": 42
   },
   "query": "name__contains=server&sort=name",
-  "output": {
-    "template_id": 12
-  },
   "include": {
     "related_objects": {
       "room": {
@@ -44,7 +42,7 @@ Authentication:
 }
 ```
 
-`POST /api/v1/reports` is asynchronous and mirrors `POST /api/v1/imports`:
+`POST /api/v1/reports` is asynchronous, returns JSON output, and mirrors `POST /api/v1/imports`:
 
 - it returns `202 Accepted`
 - the response body is a generic `TaskResponse`
@@ -173,9 +171,6 @@ Report objects related to a root object:
       }
     }
   },
-  "output": {
-    "template_id": 12
-  }
 }
 ```
 
@@ -190,12 +185,39 @@ Each key under `include.related_objects` is an alias. The alias must match `[A-Z
 
 `max_depth` defaults to `1` and must be between `1` and `10`. `limit` defaults to `1` and must be between `1` and `50`; it is applied per root object and per alias. Missing related objects render as an empty array, so `item.related.room` is always present in templates when the alias was requested.
 
+## Template execution
+
+Text, HTML, and CSV reports are executed from executable report templates:
+
+```json
+{
+  "query": "name__contains=server&sort=name",
+  "missing_data_policy": "strict",
+  "limits": {
+    "max_items": 100,
+    "max_output_bytes": 262144
+  }
+}
+```
+
+For `related_objects` templates, pass the runtime root object:
+
+```json
+{
+  "object_id": 101,
+  "query": "depth__lte=2&to_classes=91&sort=path"
+}
+```
+
+The template stores the scope, class, include settings, relation context, content type, and default
+query/limits/policy. Runtime `query` replaces the template's default query when supplied.
+
 ## Output selection
 
-The server determines the output format at submission time based on:
+The server determines the output format at submission time based on the endpoint:
 
-1. If `output.template_id` is provided, the stored template's `content_type` is used
-2. Otherwise, it defaults to `application/json`
+1. `POST /api/v1/reports` returns `application/json`
+2. `POST /api/v1/templates/{template_id}/reports` returns the template's stored `content_type`
 
 Supported output types:
 
@@ -232,7 +254,8 @@ Supported output types:
 
 ## Template output
 
-`text/plain`, `text/html`, and `text/csv` outputs require referencing a stored template via `output.template_id`.
+`text/plain`, `text/html`, and `text/csv` outputs require running an executable stored template with
+`POST /api/v1/templates/{template_id}/reports`.
 
 For concrete template examples and example context data, see [template_guide.md](template_guide.md).
 

--- a/docs/template_guide.md
+++ b/docs/template_guide.md
@@ -734,6 +734,9 @@ host,room,person
 
 - Stored templates support only `text/plain`, `text/html`, and `text/csv`
 - `application/json` does not use stored templates; submit JSON reports with `POST /api/v1/reports`
+- Executable report templates support every scope kind (`namespaces`, `classes`, `objects_in_class`,
+  `class_relations`, `object_relations`, `related_objects`); `class_id` is set only for
+  `objects_in_class` and `related_objects`, and `include`/`relation_context` apply only to those scopes
 - Template loading for `include`/`import`/`extends` is limited to the same namespace
 - HTML templates are autoescaped; plain text and CSV templates should use `tojson` or `csv_cell`
   when embedding JSON- or CSV-sensitive values

--- a/docs/template_guide.md
+++ b/docs/template_guide.md
@@ -2,8 +2,8 @@
 
 Stored report templates format stored report output from the async report API.
 
-Use templates when you want `text/plain`, `text/html`, or `text/csv` output from a stored definition in `POST /api/v1/templates`.
-Submit the report request with `POST /api/v1/reports`, then fetch the rendered result from
+Use executable templates when you want `text/plain`, `text/html`, or `text/csv` output from a stored definition in `POST /api/v1/templates`.
+Run the template with `POST /api/v1/templates/{template_id}/reports`, then fetch the rendered result from
 `GET /api/v1/reports/{task_id}/output`.
 
 See also:
@@ -59,27 +59,36 @@ Assume you have a class called `server` with objects like these:
 ]
 ```
 
-If you run a report over that class:
+If you create an executable template for that class:
 
 ```json
 {
-  "scope": {
-    "kind": "objects_in_class",
-    "class_id": 42
-  },
-  "query": "name__contains=srv-&sort=name",
-  "output": {
-    "template_id": 12
-  },
-  "missing_data_policy": "strict",
-  "limits": {
+  "namespace_id": 7,
+  "name": "report.servers",
+  "description": "Server owner report",
+  "content_type": "text/plain",
+  "template": "{% for item in items %}{{ item.name }}={{ item.data.owner }}\n{% endfor %}",
+  "kind": "report",
+  "scope_kind": "objects_in_class",
+  "class_id": 42,
+  "default_query": "name__contains=srv-&sort=name",
+  "default_missing_data_policy": "strict",
+  "default_limits": {
     "max_items": 100,
     "max_output_bytes": 262144
   }
 }
 ```
 
-then `items` contains those objects, so templates can reference fields like:
+and run it:
+
+```json
+{
+  "query": "name__contains=srv-&sort=name"
+}
+```
+
+then `items` contains the matching objects, so templates can reference fields like:
 
 - `{{ item.name }}`
 - `{{ item.description }}`
@@ -363,20 +372,28 @@ For data keys that contain dots, spaces, or punctuation, use bracket notation:
 
 Direct relation scopes use the normal `items` context. Templated `related_objects` reports are rooted at the requested source object: `items` contains that single hydrated source object, and `source` points to the same value.
 
-Example report request:
+Example executable template:
 
 ```json
 {
-  "scope": {
-    "kind": "related_objects",
-    "class_id": 42,
-    "object_id": 101
-  },
-  "query": "depth__lte=2&to_classes=91&sort=path",
-  "output": {
-    "template_id": 12
-  },
-  "missing_data_policy": "strict"
+  "namespace_id": 7,
+  "name": "report.host-related",
+  "description": "Related host report",
+  "content_type": "text/plain",
+  "template": "Related objects for {{ source.name }}",
+  "kind": "report",
+  "scope_kind": "related_objects",
+  "class_id": 42,
+  "default_query": "depth__lte=2&to_classes=91&sort=path",
+  "default_missing_data_policy": "strict"
+}
+```
+
+Run it with:
+
+```json
+{
+  "object_id": 101
 }
 ```
 
@@ -394,15 +411,19 @@ For direct relation reports, `class_relations` items contain fields such as `fro
 
 `objects_in_class` reports can add bounded related-object arrays to each item with `include.related_objects`. Use this when the report is centered on one class but the template needs nearby objects, such as a host's room.
 
-Example report request:
+Example executable template:
 
 ```json
 {
-  "scope": {
-    "kind": "objects_in_class",
-    "class_id": 42
-  },
-  "query": "name__equals=nommo",
+  "namespace_id": 7,
+  "name": "report.host-room",
+  "description": "Host room report",
+  "content_type": "text/plain",
+  "template": "{% for item in items %}{{ item.name }}{% endfor %}",
+  "kind": "report",
+  "scope_kind": "objects_in_class",
+  "class_id": 42,
+  "default_query": "name__equals=nommo",
   "include": {
     "related_objects": {
       "room": {
@@ -415,10 +436,7 @@ Example report request:
       }
     }
   },
-  "output": {
-    "template_id": 12
-  },
-  "missing_data_policy": "strict"
+  "default_missing_data_policy": "strict"
 }
 ```
 
@@ -715,7 +733,7 @@ host,room,person
 ## Limits and constraints
 
 - Stored templates support only `text/plain`, `text/html`, and `text/csv`
-- `application/json` does not use stored templates
+- `application/json` does not use stored templates; submit JSON reports with `POST /api/v1/reports`
 - Template loading for `include`/`import`/`extends` is limited to the same namespace
 - HTML templates are autoescaped; plain text and CSV templates should use `tojson` or `csv_cell`
   when embedding JSON- or CSV-sensitive values
@@ -759,25 +777,18 @@ Current behavior:
 
 ## Typical workflow
 
-1. Create a stored template with `POST /api/v1/templates`
-2. Reference that template with `output.template_id` in `POST /api/v1/reports`
+1. Create an executable stored template with `POST /api/v1/templates`
+2. Run that template with `POST /api/v1/templates/{template_id}/reports`
 3. Read the returned `TaskResponse`, wait for completion, then fetch the rendered result from `GET /api/v1/reports/{task_id}/output`
 
-Example report request using a stored template:
+Example template run request:
 
 ```json
 {
-  "scope": {
-    "kind": "objects_in_class",
-    "class_id": 42
-  },
   "query": "name__contains=srv-&sort=name",
-  "output": {
-    "template_id": 12
-  },
   "missing_data_policy": "omit",
-  "relation_context": {
-    "depth": 2
+  "limits": {
+    "max_items": 100
   }
 }
 ```

--- a/migrations/2023-12-27-011440_initial/up.sql
+++ b/migrations/2023-12-27-011440_initial/up.sql
@@ -151,10 +151,26 @@
         description VARCHAR NOT NULL,
         content_type VARCHAR NOT NULL,
         template TEXT NOT NULL,
+        kind VARCHAR NOT NULL,
+        scope_kind VARCHAR,
+        class_id INT REFERENCES hubuumclass (id) ON DELETE CASCADE,
+        default_query TEXT,
+        include JSONB,
+        relation_context JSONB,
+        default_missing_data_policy VARCHAR,
+        default_limits JSONB,
         created_at TIMESTAMP NOT NULL DEFAULT now(),
         updated_at TIMESTAMP NOT NULL DEFAULT now(),
         UNIQUE (namespace_id, name),
-        CHECK (content_type IN ('text/plain', 'text/html', 'text/csv'))
+        CHECK (content_type IN ('text/plain', 'text/html', 'text/csv')),
+        CHECK (kind IN ('report', 'fragment')),
+        CHECK (scope_kind IS NULL OR scope_kind IN ('objects_in_class', 'related_objects')),
+        CHECK (default_missing_data_policy IS NULL OR default_missing_data_policy IN ('strict', 'null', 'omit')),
+        CHECK (
+            (kind = 'fragment' AND scope_kind IS NULL AND class_id IS NULL)
+            OR
+            (kind = 'report' AND scope_kind IS NOT NULL AND class_id IS NOT NULL)
+        )
     );
 
     DROP TABLE IF EXISTS tasks CASCADE;

--- a/migrations/2023-12-27-011440_initial/up.sql
+++ b/migrations/2023-12-27-011440_initial/up.sql
@@ -164,12 +164,17 @@
         UNIQUE (namespace_id, name),
         CHECK (content_type IN ('text/plain', 'text/html', 'text/csv')),
         CHECK (kind IN ('report', 'fragment')),
-        CHECK (scope_kind IS NULL OR scope_kind IN ('objects_in_class', 'related_objects')),
+        CHECK (scope_kind IS NULL OR scope_kind IN (
+            'namespaces', 'classes', 'objects_in_class',
+            'class_relations', 'object_relations', 'related_objects'
+        )),
         CHECK (default_missing_data_policy IS NULL OR default_missing_data_policy IN ('strict', 'null', 'omit')),
         CHECK (
             (kind = 'fragment' AND scope_kind IS NULL AND class_id IS NULL)
             OR
-            (kind = 'report' AND scope_kind IS NOT NULL AND class_id IS NOT NULL)
+            (kind = 'report' AND scope_kind IN ('objects_in_class', 'related_objects') AND class_id IS NOT NULL)
+            OR
+            (kind = 'report' AND scope_kind IN ('namespaces', 'classes', 'class_relations', 'object_relations') AND class_id IS NULL)
         )
     );
 

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -13,13 +13,13 @@ use crate::models::{
     NewHubuumClassRelationFromClass, NewHubuumObject, NewHubuumObjectRelation,
     NewNamespaceWithAssignee, NewReportTemplate, NewUser, ObjectKey, ObjectsByClass, Permission,
     Permissions, RelatedClassGraph, RelatedObjectGraph, ReportContentType, ReportJsonResponse,
-    ReportLimits, ReportMeta, ReportMissingDataPolicy, ReportOutputRequest, ReportRequest,
-    ReportScope, ReportScopeKind, ReportTaskDetails, ReportTemplate, ReportTemplateID,
-    ReportWarning, TaskDetails, TaskEventResponse, TaskKind, TaskLinks, TaskProgress, TaskResponse,
-    TaskStatus, UnifiedSearchBatchResponse, UnifiedSearchDoneEvent, UnifiedSearchErrorEvent,
-    UnifiedSearchKind, UnifiedSearchResponse, UnifiedSearchStartedEvent, UpdateGroup,
-    UpdateHubuumClass, UpdateHubuumObject, UpdateNamespace, UpdateReportTemplate, UpdateUser, User,
-    UserToken, UserTokenMetadata,
+    ReportLimits, ReportMeta, ReportMissingDataPolicy, ReportRequest, ReportScope, ReportScopeKind,
+    ReportTaskDetails, ReportTemplate, ReportTemplateID, ReportTemplateKind,
+    ReportTemplateRunRequest, ReportWarning, TaskDetails, TaskEventResponse, TaskKind, TaskLinks,
+    TaskProgress, TaskResponse, TaskStatus, UnifiedSearchBatchResponse, UnifiedSearchDoneEvent,
+    UnifiedSearchErrorEvent, UnifiedSearchKind, UnifiedSearchResponse, UnifiedSearchStartedEvent,
+    UpdateGroup, UpdateHubuumClass, UpdateHubuumObject, UpdateNamespace, UpdateReportTemplate,
+    UpdateUser, User, UserToken, UserTokenMetadata,
 };
 use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER, page_limits_or_defaults};
 use actix_web::{HttpResponse, Responder};
@@ -104,6 +104,7 @@ use utoipa::{Modify, OpenApi, ToSchema};
         templates::get_templates,
         templates::create_template,
         templates::get_template,
+        templates::run_template_report,
         templates::patch_template,
         templates::delete_template,
         classes::get_classes,
@@ -204,7 +205,6 @@ use utoipa::{Modify, OpenApi, ToSchema};
             ReportScopeKind,
             ReportScope,
             ReportContentType,
-            ReportOutputRequest,
             ReportMissingDataPolicy,
             ReportLimits,
             ReportRequest,
@@ -218,7 +218,9 @@ use utoipa::{Modify, OpenApi, ToSchema};
             UnifiedSearchDoneEvent,
             UnifiedSearchErrorEvent,
             ReportTemplateID,
+            ReportTemplateKind,
             ReportTemplate,
+            ReportTemplateRunRequest,
             NewReportTemplate,
             UpdateReportTemplate
         )
@@ -699,6 +701,7 @@ mod tests {
             "/api/v1/tasks/{task_id}/events",
             "/api/v1/templates",
             "/api/v1/templates/{template_id}",
+            "/api/v1/templates/{template_id}/reports",
             "/api/v1/relations/classes",
             "/api/v1/relations/classes/{relation_id}",
             "/api/v1/relations/objects",
@@ -745,6 +748,10 @@ mod tests {
                 .is_some()
         );
         assert!(json.pointer("/paths/~1api~1v1~1templates/get").is_some());
+        assert!(
+            json.pointer("/paths/~1api~1v1~1templates~1{template_id}~1reports/post")
+                .is_some()
+        );
         assert!(
             json.pointer("/paths/~1api~1v1~1relations~1objects/post")
                 .is_some()

--- a/src/api/v1/handlers/imports.rs
+++ b/src/api/v1/handlers/imports.rs
@@ -4,9 +4,7 @@ use actix_web::{HttpRequest, Responder, get, http::StatusCode, post, web};
 
 use crate::api::openapi::ApiErrorResponse;
 use crate::db::DbPool;
-use crate::db::traits::task::{
-    TaskBackend, TaskCreateRequest, create_generic_task, find_task_by_idempotency,
-};
+use crate::db::traits::task::{TaskBackend, TaskCreateRequest};
 use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::search::parse_query_parameter;
@@ -37,7 +35,7 @@ async fn find_or_create_import_task(
     };
 
     if let Some(key) = idempotency_key.as_deref()
-        && let Some(existing) = find_task_by_idempotency(pool, submitted_by, key).await?
+        && let Some(existing) = TaskRecord::find_by_idempotency(pool, submitted_by, key).await?
     {
         if matches_request(&existing) {
             return Ok(existing);
@@ -50,23 +48,22 @@ async fn find_or_create_import_task(
 
     let create_idempotency_key = idempotency_key.clone();
 
-    match create_generic_task(
-        pool,
-        TaskCreateRequest {
-            kind: TaskKind::Import,
-            submitted_by,
-            idempotency_key: create_idempotency_key,
-            request_hash: Some(request_hash),
-            request_payload: payload,
-            total_items,
-        },
-    )
+    match (TaskCreateRequest {
+        kind: TaskKind::Import,
+        submitted_by,
+        idempotency_key: create_idempotency_key,
+        request_hash: Some(request_hash),
+        request_payload: payload,
+        total_items,
+    })
+    .create_generic(pool)
     .await
     {
         Ok(task) => Ok(task),
         Err(ApiError::Conflict(_)) => {
             if let Some(key) = idempotency_key.as_deref()
-                && let Some(existing) = find_task_by_idempotency(pool, submitted_by, key).await?
+                && let Some(existing) =
+                    TaskRecord::find_by_idempotency(pool, submitted_by, key).await?
                 && matches_request(&existing)
             {
                 return Ok(existing);

--- a/src/api/v1/handlers/imports.rs
+++ b/src/api/v1/handlers/imports.rs
@@ -12,7 +12,7 @@ use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
-    CURRENT_IMPORT_VERSION, ImportRequest, ImportTaskResultResponse, TaskKind, TaskRecord,
+    CURRENT_IMPORT_VERSION, ImportRequest, ImportTaskResultResponse, TaskID, TaskKind, TaskRecord,
     TaskResponse, User,
 };
 use crate::pagination::prepare_db_pagination;
@@ -176,10 +176,11 @@ pub async fn create_import(
 pub async fn get_import(
     pool: web::Data<DbPool>,
     requestor: UserAccess,
-    task_id: web::Path<i32>,
+    task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(pool.get_ref().clone());
-    let task = load_authorized_import_task(&pool, &requestor.user, task_id.into_inner()).await?;
+    let task =
+        load_authorized_import_task(&pool, &requestor.user, task_id.into_inner().id()).await?;
     Ok(json_response(task.to_response()?, StatusCode::OK))
 }
 
@@ -203,10 +204,10 @@ pub async fn get_import_results(
     pool: web::Data<DbPool>,
     requestor: UserAccess,
     req: HttpRequest,
-    task_id: web::Path<i32>,
+    task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(pool.get_ref().clone());
-    let task_id = task_id.into_inner();
+    let task_id = task_id.into_inner().id();
     load_authorized_import_task(&pool, &requestor.user, task_id).await?;
     let params = parse_query_parameter(req.query_string())?;
     let search_params = prepare_db_pagination::<ImportTaskResultResponse>(&params)?;

--- a/src/api/v1/handlers/imports.rs
+++ b/src/api/v1/handlers/imports.rs
@@ -5,44 +5,22 @@ use actix_web::{HttpRequest, Responder, get, http::StatusCode, post, web};
 use crate::api::openapi::ApiErrorResponse;
 use crate::db::DbPool;
 use crate::db::traits::task::{
-    TaskCreateRequest, create_generic_task, find_task_by_idempotency, find_task_record,
-    list_import_results_with_total_count,
+    TaskBackend, TaskCreateRequest, create_generic_task, find_task_by_idempotency,
 };
 use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
     CURRENT_IMPORT_VERSION, ImportRequest, ImportTaskResultResponse, TaskID, TaskKind, TaskRecord,
-    TaskResponse, User,
+    TaskResponse,
 };
 use crate::pagination::prepare_db_pagination;
 use crate::tasks::{
     ensure_task_worker_running, idempotency_key_from_headers, kick_task_worker, request_hash,
 };
-use crate::traits::GroupMemberships;
 use crate::utilities::response::{
     json_response, json_response_with_header, paginated_json_response,
 };
-
-async fn load_authorized_import_task(
-    pool: &DbPool,
-    requestor: &User,
-    task_id: i32,
-) -> Result<TaskRecord, ApiError> {
-    let task = find_task_record(pool, task_id).await?;
-    if task.kind != TaskKind::Import.as_str() {
-        return Err(ApiError::NotFound(format!(
-            "Import task {} not found",
-            task_id
-        )));
-    }
-    if task.submitted_by == Some(requestor.id) || requestor.is_admin(pool).await? {
-        Ok(task)
-    } else {
-        // Return 404 instead of 403 to hide existence of task from unauthorized users
-        Err(ApiError::NotFound("Import task not found".to_string()))
-    }
-}
 
 async fn find_or_create_import_task(
     pool: &DbPool,
@@ -179,8 +157,10 @@ pub async fn get_import(
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(pool.get_ref().clone());
-    let task =
-        load_authorized_import_task(&pool, &requestor.user, task_id.into_inner().id()).await?;
+    let task = task_id
+        .into_inner()
+        .load_authorized_import(&pool, &requestor.user)
+        .await?;
     Ok(json_response(task.to_response()?, StatusCode::OK))
 }
 
@@ -207,12 +187,15 @@ pub async fn get_import_results(
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(pool.get_ref().clone());
-    let task_id = task_id.into_inner().id();
-    load_authorized_import_task(&pool, &requestor.user, task_id).await?;
+    let task_id = task_id.into_inner();
+    task_id
+        .load_authorized_import(&pool, &requestor.user)
+        .await?;
     let params = parse_query_parameter(req.query_string())?;
     let search_params = prepare_db_pagination::<ImportTaskResultResponse>(&params)?;
-    let (results, total_count) =
-        list_import_results_with_total_count(&pool, task_id, &search_params).await?;
+    let (results, total_count) = task_id
+        .list_import_results_with_total_count(&pool, &search_params)
+        .await?;
     let results = results
         .into_iter()
         .map(ImportTaskResultResponse::from)

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -15,9 +15,8 @@ use crate::config::{
 };
 use crate::db::traits::UserPermissions;
 use crate::db::traits::task::{
-    TaskCreateRequest, TaskStateUpdate, append_task_event, create_report_task_with_active_limit,
-    finalize_report_task_with_output, find_report_task_output, find_report_task_output_summary,
-    find_task_by_idempotency, find_task_record, update_task_state,
+    TaskBackend, TaskCreateRequest, TaskStateUpdate, append_task_event,
+    create_report_task_with_active_limit, find_task_by_idempotency,
 };
 use crate::db::{DbPool, with_connection};
 use crate::errors::ApiError;
@@ -38,7 +37,7 @@ use crate::pagination::page_limits_or_defaults;
 use crate::tasks::{
     ensure_task_worker_running, idempotency_key_from_headers, kick_task_worker, request_hash,
 };
-use crate::traits::{GroupMemberships, NamespaceAccessors, Search, SelfAccessors};
+use crate::traits::{NamespaceAccessors, Search, SelfAccessors};
 use crate::utilities::reporting::{SizeLimitedWriter, render_template};
 use crate::utilities::response::{json_response, json_response_with_header};
 
@@ -280,9 +279,11 @@ pub async fn get_report(
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(pool.get_ref().clone());
-    let task =
-        load_authorized_report_task(&pool, &requestor.user, task_id.into_inner().id()).await?;
-    let output = find_report_task_output_summary(&pool, task.id).await?;
+    let task = task_id
+        .into_inner()
+        .load_authorized_report(&pool, &requestor.user)
+        .await?;
+    let output = task.find_report_output_summary(&pool).await?;
     Ok(json_response(
         task.to_response_with_report_output(output.as_ref())?,
         StatusCode::OK,
@@ -319,9 +320,12 @@ pub async fn get_report_output(
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(pool.get_ref().clone());
-    let task_id = task_id.into_inner().id();
-    load_authorized_report_task(&pool, &requestor.user, task_id).await?;
-    let output = find_report_task_output(&pool, task_id)
+    let task_id = task_id.into_inner();
+    task_id
+        .load_authorized_report(&pool, &requestor.user)
+        .await?;
+    let output = task_id
+        .find_report_output(&pool)
         .await?
         .ok_or_else(|| ApiError::NotFound("Report output not found".to_string()))?;
     render_report_task_output(output)
@@ -465,26 +469,6 @@ async fn find_or_create_report_task(
     }
 }
 
-async fn load_authorized_report_task(
-    pool: &DbPool,
-    requestor: &User,
-    task_id: i32,
-) -> Result<TaskRecord, ApiError> {
-    let is_admin = requestor.is_admin(pool).await?;
-    let task = find_task_record(pool, task_id).await?;
-    if task.kind != TaskKind::Report.as_str() {
-        return Err(ApiError::NotFound(format!(
-            "Report task {} not found",
-            task_id
-        )));
-    }
-    if task.submitted_by == Some(requestor.id) || is_admin {
-        Ok(task)
-    } else {
-        Err(ApiError::NotFound("Report task not found".to_string()))
-    }
-}
-
 pub(crate) async fn execute_report_task(
     pool: &DbPool,
     task: &TaskRecord,
@@ -511,9 +495,8 @@ pub(crate) async fn execute_report_task(
         },
     )
     .await?;
-    update_task_state(
+    task.update_state(
         pool,
-        task.id,
         TaskStateUpdate {
             status: crate::models::TaskStatus::Running,
             summary: None,
@@ -635,9 +618,8 @@ pub(crate) async fn execute_report_task(
     )
     .await?;
 
-    finalize_report_task_with_output(
+    task.finalize_report_with_output(
         pool,
-        task.id,
         TaskStateUpdate {
             status: crate::models::TaskStatus::Succeeded,
             summary: Some("Report completed successfully".to_string()),

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -29,8 +29,8 @@ use crate::models::search::{
 use crate::models::{
     HubuumClassID, HubuumClassRelation, HubuumObject, HubuumObjectID, HubuumObjectRelation,
     HubuumObjectWithPath, NamespaceID, NewReportTaskOutputRecord, NewTaskEventRecord, Permissions,
-    ReportContentType, ReportIncludeRelatedDirection, ReportIncludeRelatedObject,
-    ReportIncludeRelatedQuery, ReportIncludeRelatedSort, ReportJsonResponse, ReportMeta,
+    ReportContentType, ReportIncludeRelatedDirection, ReportIncludeRelatedQuery,
+    ReportIncludeRelatedSort, ReportJsonResponse, ReportMeta,
     ReportMissingDataPolicy, ReportRequest, ReportScope, ReportScopeKind, ReportTaskOutputRecord,
     ReportTemplate, ReportTemplateID, ReportWarning, TaskKind, TaskRecord, TaskResponse, User,
 };
@@ -39,7 +39,10 @@ use crate::tasks::{
     ensure_task_worker_running, idempotency_key_from_headers, kick_task_worker, request_hash,
 };
 use crate::traits::{GroupMemberships, NamespaceAccessors, Search, SelfAccessors};
-use crate::utilities::reporting::render_template;
+use crate::utilities::reporting::{
+    RELATED_INCLUDE_DEFAULT_LIMIT, RELATED_INCLUDE_DEFAULT_MAX_DEPTH, render_template,
+    validate_related_objects_include,
+};
 use crate::utilities::response::{json_response, json_response_with_header};
 
 use super::check_if_object_in_class;
@@ -62,11 +65,6 @@ struct ReportArtifact {
 
 const REPORT_WARNINGS_HEADER: &str = "X-Hubuum-Report-Warnings";
 const REPORT_TRUNCATED_HEADER: &str = "X-Hubuum-Report-Truncated";
-const RELATED_INCLUDE_DEFAULT_MAX_DEPTH: i32 = 1;
-const RELATED_INCLUDE_MAX_DEPTH_LIMIT: i32 = 10;
-const RELATED_INCLUDE_DEFAULT_LIMIT: i32 = 1;
-const RELATED_INCLUDE_MAX_LIMIT: i32 = 50;
-const RELATED_INCLUDE_MAX_ALIASES: usize = 8;
 
 struct ReportRuntime {
     report: ReportRequest,
@@ -238,25 +236,19 @@ pub(crate) async fn submit_report_task(
     user: &User,
     req: HttpRequest,
     report: ReportRequest,
-    template_id: Option<i32>,
+    template: Option<ReportTemplate>,
 ) -> Result<TaskRecord, ApiError> {
     ensure_task_worker_running(pool.clone());
 
     let task_payload = StoredReportTaskPayload {
         report,
-        template_id,
+        template_id: template.as_ref().map(|template| template.id),
     };
     let payload = serde_json::to_value(&task_payload)?;
     let hash = request_hash(&payload)?;
     let idempotency_key = idempotency_key_from_headers(req.headers())?;
 
-    let runtime = prepare_report_runtime(
-        pool,
-        user,
-        task_payload.report.clone(),
-        task_payload.template_id,
-    )
-    .await?;
+    let runtime = prepare_report_runtime(pool, task_payload.report.clone(), template).await?;
     validate_report_submission(&runtime)?;
     let task_payload = runtime_to_task_payload(&runtime)?;
 
@@ -339,14 +331,12 @@ pub async fn get_report_output(
 
 async fn prepare_report_runtime(
     pool: &DbPool,
-    user: &User,
     report: ReportRequest,
-    template_id: Option<i32>,
+    template: Option<ReportTemplate>,
 ) -> Result<ReportRuntime, ApiError> {
     report.scope.validate()?;
     validate_report_include(&report)?;
 
-    let template = resolve_template(pool, user, template_id).await?;
     let namespace_templates = match &template {
         Some(template) => {
             crate::models::report_template::report_templates_in_namespace(
@@ -507,7 +497,8 @@ pub(crate) async fn execute_report_task(
         .clone()
         .ok_or_else(|| ApiError::BadRequest("Report task payload is missing".to_string()))?;
     let payload: StoredReportTaskPayload = serde_json::from_value(payload)?;
-    let runtime = prepare_report_runtime(pool, user, payload.report, payload.template_id).await?;
+    let template = resolve_template(pool, user, payload.template_id).await?;
+    let runtime = prepare_report_runtime(pool, payload.report, template).await?;
     validate_report_submission(&runtime)?;
     let total_start = Instant::now();
     let mut timings = ReportExecutionTimings::default();
@@ -725,74 +716,7 @@ fn validate_report_include(report: &ReportRequest) -> Result<(), ApiError> {
         ));
     }
 
-    if related_objects.len() > RELATED_INCLUDE_MAX_ALIASES {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects supports at most {RELATED_INCLUDE_MAX_ALIASES} aliases"
-        )));
-    }
-
-    for (alias, include) in related_objects {
-        validate_related_include_alias(alias)?;
-        validate_related_include_options(alias, include)?;
-    }
-
-    Ok(())
-}
-
-fn validate_related_include_alias(alias: &str) -> Result<(), ApiError> {
-    let mut chars = alias.chars();
-    let Some(first) = chars.next() else {
-        return Err(ApiError::BadRequest(
-            "include.related_objects aliases must not be empty".to_string(),
-        ));
-    };
-
-    if !(first == '_' || first.is_ascii_alphabetic())
-        || !chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-    {
-        return Err(ApiError::BadRequest(format!(
-            "Invalid include.related_objects alias '{alias}'; expected [A-Za-z_][A-Za-z0-9_]*"
-        )));
-    }
-
-    Ok(())
-}
-
-fn validate_related_include_options(
-    alias: &str,
-    include: &ReportIncludeRelatedObject,
-) -> Result<(), ApiError> {
-    if include.class_id <= 0 {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects.{alias}.class_id must be greater than 0"
-        )));
-    }
-
-    if let Some(class_relation_id) = include.class_relation_id
-        && class_relation_id <= 0
-    {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects.{alias}.class_relation_id must be greater than 0"
-        )));
-    }
-
-    let max_depth = include
-        .max_depth
-        .unwrap_or(RELATED_INCLUDE_DEFAULT_MAX_DEPTH);
-    if !(1..=RELATED_INCLUDE_MAX_DEPTH_LIMIT).contains(&max_depth) {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects.{alias}.max_depth must be between 1 and {RELATED_INCLUDE_MAX_DEPTH_LIMIT}"
-        )));
-    }
-
-    let limit = include.limit.unwrap_or(RELATED_INCLUDE_DEFAULT_LIMIT);
-    if !(1..=RELATED_INCLUDE_MAX_LIMIT).contains(&limit) {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects.{alias}.limit must be between 1 and {RELATED_INCLUDE_MAX_LIMIT}"
-        )));
-    }
-
-    Ok(())
+    validate_related_objects_include(include)
 }
 
 fn add_truncation_warning(warnings: &mut Vec<ReportWarning>, truncated: bool) {

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, HashMap, VecDeque};
-use std::io::{self, Write};
 use std::time::Instant;
 
 use actix_web::{HttpRequest, HttpResponse, Responder, get, http::StatusCode, post, web};
@@ -29,20 +28,18 @@ use crate::models::search::{
 use crate::models::{
     HubuumClassID, HubuumClassRelation, HubuumObject, HubuumObjectID, HubuumObjectRelation,
     HubuumObjectWithPath, NamespaceID, NewReportTaskOutputRecord, NewTaskEventRecord, Permissions,
-    ReportContentType, ReportIncludeRelatedDirection, ReportIncludeRelatedQuery,
-    ReportIncludeRelatedSort, ReportJsonResponse, ReportMeta, ReportMissingDataPolicy,
-    ReportRequest, ReportScope, ReportScopeKind, ReportTaskOutputRecord, ReportTemplate,
-    ReportTemplateID, ReportWarning, TaskKind, TaskRecord, TaskResponse, User,
+    RELATED_INCLUDE_DEFAULT_LIMIT, RELATED_INCLUDE_DEFAULT_MAX_DEPTH, ReportContentType,
+    ReportIncludeRelatedDirection, ReportIncludeRelatedQuery, ReportIncludeRelatedSort,
+    ReportJsonResponse, ReportMeta, ReportMissingDataPolicy, ReportRequest, ReportScope,
+    ReportScopeKind, ReportTaskOutputRecord, ReportTemplate, ReportTemplateID, ReportWarning,
+    TaskKind, TaskRecord, TaskResponse, User,
 };
 use crate::pagination::page_limits_or_defaults;
 use crate::tasks::{
     ensure_task_worker_running, idempotency_key_from_headers, kick_task_worker, request_hash,
 };
 use crate::traits::{GroupMemberships, NamespaceAccessors, Search, SelfAccessors};
-use crate::utilities::reporting::{
-    RELATED_INCLUDE_DEFAULT_LIMIT, RELATED_INCLUDE_DEFAULT_MAX_DEPTH, render_template,
-    validate_related_objects_include,
-};
+use crate::utilities::reporting::{SizeLimitedWriter, render_template};
 use crate::utilities::response::{json_response, json_response_with_header};
 
 use super::check_if_object_in_class;
@@ -716,7 +713,7 @@ fn validate_report_include(report: &ReportRequest) -> Result<(), ApiError> {
         ));
     }
 
-    validate_related_objects_include(include)
+    include.validate_related_objects()
 }
 
 fn add_truncation_warning(warnings: &mut Vec<ReportWarning>, truncated: bool) {
@@ -2249,7 +2246,7 @@ fn enforce_json_output_limit(
         .and_then(|limits| limits.max_output_bytes)
         .unwrap_or_else(configured_report_max_output_bytes);
 
-    let mut writer = LimitedJsonWriter::new(max_output_bytes);
+    let mut writer = SizeLimitedWriter::new(max_output_bytes);
     if let Err(error) = serde_json::to_writer(&mut writer, response) {
         if writer.exceeded() {
             return Err(ApiError::PayloadTooLarge(format!(
@@ -2263,45 +2260,6 @@ fn enforce_json_output_limit(
     }
 
     Ok(())
-}
-
-// This exists only for output-size enforcement: serde_json::to_vec would allocate
-// the whole response before we can reject an oversized report, while to_writer can
-// stop as soon as the configured byte budget is crossed.
-struct LimitedJsonWriter {
-    max_bytes: usize,
-    written: usize,
-    exceeded: bool,
-}
-
-impl LimitedJsonWriter {
-    fn new(max_bytes: usize) -> Self {
-        Self {
-            max_bytes,
-            written: 0,
-            exceeded: false,
-        }
-    }
-
-    fn exceeded(&self) -> bool {
-        self.exceeded
-    }
-}
-
-impl Write for LimitedJsonWriter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        if self.written.saturating_add(buf.len()) > self.max_bytes {
-            self.exceeded = true;
-            return Err(io::Error::other("json output limit exceeded"));
-        }
-
-        self.written += buf.len();
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
 }
 
 #[cfg(test)]

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -370,7 +370,7 @@ async fn resolve_template(
         return Ok(None);
     };
 
-    let template = ReportTemplateID(template_id).instance(pool).await?;
+    let template = ReportTemplateID::new(template_id)?.instance(pool).await?;
     can!(
         pool,
         user.clone(),

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -32,7 +32,7 @@ use crate::models::{
     ReportIncludeRelatedDirection, ReportIncludeRelatedQuery, ReportIncludeRelatedSort,
     ReportJsonResponse, ReportMeta, ReportMissingDataPolicy, ReportRequest, ReportScope,
     ReportScopeKind, ReportTaskOutputRecord, ReportTemplate, ReportTemplateID, ReportWarning,
-    TaskKind, TaskRecord, TaskResponse, User,
+    TaskID, TaskKind, TaskRecord, TaskResponse, User,
 };
 use crate::pagination::page_limits_or_defaults;
 use crate::tasks::{
@@ -277,10 +277,11 @@ pub(crate) async fn submit_report_task(
 pub async fn get_report(
     pool: web::Data<DbPool>,
     requestor: UserAccess,
-    task_id: web::Path<i32>,
+    task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(pool.get_ref().clone());
-    let task = load_authorized_report_task(&pool, &requestor.user, task_id.into_inner()).await?;
+    let task =
+        load_authorized_report_task(&pool, &requestor.user, task_id.into_inner().id()).await?;
     let output = find_report_task_output_summary(&pool, task.id).await?;
     Ok(json_response(
         task.to_response_with_report_output(output.as_ref())?,
@@ -315,10 +316,10 @@ pub async fn get_report(
 pub async fn get_report_output(
     pool: web::Data<DbPool>,
     requestor: UserAccess,
-    task_id: web::Path<i32>,
+    task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(pool.get_ref().clone());
-    let task_id = task_id.into_inner();
+    let task_id = task_id.into_inner().id();
     load_authorized_report_task(&pool, &requestor.user, task_id).await?;
     let output = find_report_task_output(&pool, task_id)
         .await?

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::time::Instant;
 
 use actix_web::{HttpRequest, HttpResponse, Responder, get, http::StatusCode, post, web};
-use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -13,25 +12,23 @@ use crate::config::{
     DEFAULT_REPORT_OUTPUT_RETENTION_HOURS, DEFAULT_REPORT_STAGE_TIMEOUT_MS,
     DEFAULT_REPORT_TEMPLATE_MAX_OBJECTS, get_config,
 };
+use crate::db::DbPool;
 use crate::db::traits::UserPermissions;
-use crate::db::traits::task::{
-    TaskBackend, TaskCreateRequest, TaskStateUpdate, append_task_event,
-    create_report_task_with_active_limit, find_task_by_idempotency,
-};
-use crate::db::{DbPool, with_connection};
+use crate::db::traits::task::{TaskBackend, TaskCreateRequest, TaskStateUpdate};
 use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::search::{
     FilterField, ParsedQueryParam, QueryOptions, SearchOperator, parse_query_parameter,
 };
 use crate::models::{
-    HubuumClassID, HubuumClassRelation, HubuumObject, HubuumObjectID, HubuumObjectRelation,
-    HubuumObjectWithPath, NamespaceID, NewReportTaskOutputRecord, NewTaskEventRecord, Permissions,
-    RELATED_INCLUDE_DEFAULT_LIMIT, RELATED_INCLUDE_DEFAULT_MAX_DEPTH, ReportContentType,
-    ReportIncludeRelatedDirection, ReportIncludeRelatedQuery, ReportIncludeRelatedSort,
-    ReportJsonResponse, ReportMeta, ReportMissingDataPolicy, ReportRequest, ReportScope,
-    ReportScopeKind, ReportTaskOutputRecord, ReportTemplate, ReportTemplateID, ReportWarning,
-    TaskID, TaskKind, TaskRecord, TaskResponse, User,
+    ClassIdSet, HubuumClassID, HubuumClassRelation, HubuumObject, HubuumObjectID,
+    HubuumObjectRelation, HubuumObjectWithPath, NamespaceID, NamespaceReportTemplates,
+    NewReportTaskOutputRecord, NewTaskEventRecord, Permissions, RELATED_INCLUDE_DEFAULT_LIMIT,
+    RELATED_INCLUDE_DEFAULT_MAX_DEPTH, ReportContentType, ReportIncludeRelatedDirection,
+    ReportIncludeRelatedQuery, ReportIncludeRelatedSort, ReportJsonResponse, ReportMeta,
+    ReportMissingDataPolicy, ReportRequest, ReportScope, ReportScopeKind, ReportTaskOutputRecord,
+    ReportTemplate, ReportTemplateID, ReportWarning, TaskID, TaskKind, TaskRecord, TaskResponse,
+    User,
 };
 use crate::pagination::page_limits_or_defaults;
 use crate::tasks::{
@@ -341,12 +338,9 @@ async fn prepare_report_runtime(
 
     let namespace_templates = match &template {
         Some(template) => {
-            crate::models::report_template::report_templates_in_namespace(
-                pool,
-                template.namespace_id,
-                None,
-            )
-            .await?
+            NamespaceID(template.namespace_id)
+                .report_templates(pool, None)
+                .await?
         }
         None => Vec::new(),
     };
@@ -427,7 +421,7 @@ async fn find_or_create_report_task(
     };
 
     if let Some(key) = idempotency_key.as_deref()
-        && let Some(existing) = find_task_by_idempotency(pool, submitted_by, key).await?
+        && let Some(existing) = TaskRecord::find_by_idempotency(pool, submitted_by, key).await?
     {
         if matches_request(&existing) {
             return Ok(existing);
@@ -438,24 +432,22 @@ async fn find_or_create_report_task(
         )));
     }
 
-    match create_report_task_with_active_limit(
-        pool,
-        TaskCreateRequest {
-            kind: TaskKind::Report,
-            submitted_by,
-            idempotency_key: idempotency_key.clone(),
-            request_hash: Some(request_hash_value),
-            request_payload: payload,
-            total_items: 1,
-        },
-        max_active_report_tasks_per_user(),
-    )
+    match (TaskCreateRequest {
+        kind: TaskKind::Report,
+        submitted_by,
+        idempotency_key: idempotency_key.clone(),
+        request_hash: Some(request_hash_value),
+        request_payload: payload,
+        total_items: 1,
+    })
+    .create_with_active_report_limit(pool, max_active_report_tasks_per_user())
     .await
     {
         Ok(task) => Ok(task),
         Err(ApiError::Conflict(_)) => {
             if let Some(key) = idempotency_key.as_deref()
-                && let Some(existing) = find_task_by_idempotency(pool, submitted_by, key).await?
+                && let Some(existing) =
+                    TaskRecord::find_by_idempotency(pool, submitted_by, key).await?
                 && matches_request(&existing)
             {
                 return Ok(existing);
@@ -485,15 +477,13 @@ pub(crate) async fn execute_report_task(
     let total_start = Instant::now();
     let mut timings = ReportExecutionTimings::default();
 
-    append_task_event(
-        pool,
-        NewTaskEventRecord {
-            task_id: task.id,
-            event_type: "running".to_string(),
-            message: "Report execution started".to_string(),
-            data: None,
-        },
-    )
+    NewTaskEventRecord {
+        task_id: task.id,
+        event_type: "running".to_string(),
+        message: "Report execution started".to_string(),
+        data: None,
+    }
+    .append(pool)
     .await?;
     task.update_state(
         pool,
@@ -509,18 +499,16 @@ pub(crate) async fn execute_report_task(
     )
     .await?;
 
-    append_task_event(
-        pool,
-        NewTaskEventRecord {
-            task_id: task.id,
-            event_type: "running".to_string(),
-            message: "Query execution started".to_string(),
-            data: Some(serde_json::json!({
-                "scope": runtime.report.scope.kind.as_str(),
-                "content_type": runtime.content_type.as_mime(),
-            })),
-        },
-    )
+    NewTaskEventRecord {
+        task_id: task.id,
+        event_type: "running".to_string(),
+        message: "Query execution started".to_string(),
+        data: Some(serde_json::json!({
+            "scope": runtime.report.scope.kind.as_str(),
+            "content_type": runtime.content_type.as_mime(),
+        })),
+    }
+    .append(pool)
     .await?;
 
     let mut query_options = prepare_query_options(&runtime.report)?;
@@ -537,19 +525,17 @@ pub(crate) async fn execute_report_task(
         .as_ref()
         .is_some_and(|plan| plan.enabled_for_scope)
     {
-        append_task_event(
-            pool,
-            NewTaskEventRecord {
-                task_id: task.id,
-                event_type: "running".to_string(),
-                message: "Hydrating relation-aware template context".to_string(),
-                data: relation_hydration.as_ref().map(|plan| {
-                    serde_json::json!({
-                        "depth_limit": plan.depth_limit,
-                    })
-                }),
-            },
-        )
+        NewTaskEventRecord {
+            task_id: task.id,
+            event_type: "running".to_string(),
+            message: "Hydrating relation-aware template context".to_string(),
+            data: relation_hydration.as_ref().map(|plan| {
+                serde_json::json!({
+                    "depth_limit": plan.depth_limit,
+                })
+            }),
+        }
+        .append(pool)
         .await?;
     }
 
@@ -584,15 +570,13 @@ pub(crate) async fn execute_report_task(
         source,
     };
 
-    append_task_event(
-        pool,
-        NewTaskEventRecord {
-            task_id: task.id,
-            event_type: "running".to_string(),
-            message: "Rendering report output".to_string(),
-            data: None,
-        },
-    )
+    NewTaskEventRecord {
+        task_id: task.id,
+        event_type: "running".to_string(),
+        message: "Rendering report output".to_string(),
+        data: None,
+    }
+    .append(pool)
     .await?;
 
     let render_start = Instant::now();
@@ -607,15 +591,13 @@ pub(crate) async fn execute_report_task(
         ..artifact
     };
 
-    append_task_event(
-        pool,
-        NewTaskEventRecord {
-            task_id: task.id,
-            event_type: "running".to_string(),
-            message: "Persisting report output".to_string(),
-            data: None,
-        },
-    )
+    NewTaskEventRecord {
+        task_id: task.id,
+        event_type: "running".to_string(),
+        message: "Persisting report output".to_string(),
+        data: None,
+    }
+    .append(pool)
     .await?;
 
     task.finalize_report_with_output(
@@ -1211,23 +1193,19 @@ async fn load_hydration_class_metadata(
     pool: &DbPool,
     objects_by_id: &BTreeMap<i32, HubuumObjectWithPath>,
 ) -> Result<HydrationClassMetadata, ApiError> {
-    let mut object_class_ids = objects_by_id
-        .values()
-        .map(|object| object.hubuum_class_id)
-        .collect::<Vec<_>>();
-    object_class_ids.sort_unstable();
-    object_class_ids.dedup();
+    let object_class_ids =
+        ClassIdSet::new(objects_by_id.values().map(|object| object.hubuum_class_id))?;
 
-    let mut class_relations =
-        load_class_relations_touching_classes(pool, &object_class_ids).await?;
+    let mut class_relations = object_class_ids.load_relations_touching(pool).await?;
     class_relations.sort_by_key(|relation| relation.id);
 
     let mut class_relations_by_object_class = BTreeMap::<i32, Vec<HubuumClassRelation>>::new();
-    let mut name_ids = object_class_ids.clone();
+    let mut name_ids = object_class_ids.as_slice().to_vec();
     for relation in &class_relations {
         name_ids.push(relation.from_hubuum_class_id);
         name_ids.push(relation.to_hubuum_class_id);
         if object_class_ids
+            .as_slice()
             .binary_search(&relation.from_hubuum_class_id)
             .is_ok()
         {
@@ -1238,6 +1216,7 @@ async fn load_hydration_class_metadata(
         }
         if relation.to_hubuum_class_id != relation.from_hubuum_class_id
             && object_class_ids
+                .as_slice()
                 .binary_search(&relation.to_hubuum_class_id)
                 .is_ok()
         {
@@ -1393,69 +1372,28 @@ async fn ensure_class_name_ids(
     class_ids: &[i32],
     class_names: &mut BTreeMap<i32, String>,
 ) -> Result<(), ApiError> {
-    let mut missing_ids = class_ids
-        .iter()
-        .copied()
-        .filter(|class_id| !class_names.contains_key(class_id))
-        .collect::<Vec<_>>();
-    missing_ids.sort_unstable();
-    missing_ids.dedup();
+    let missing = ClassIdSet::new(
+        class_ids
+            .iter()
+            .copied()
+            .filter(|class_id| !class_names.contains_key(class_id)),
+    )?;
 
-    if missing_ids.is_empty() {
+    if missing.is_empty() {
         return Ok(());
     }
 
-    for (class_id, class_name) in load_class_names(pool, &missing_ids).await? {
+    for (class_id, class_name) in missing.load_names(pool).await? {
         class_names.insert(class_id, class_name);
     }
 
-    for class_id in missing_ids {
-        if !class_names.contains_key(&class_id) {
+    for class_id in missing.as_slice() {
+        if !class_names.contains_key(class_id) {
             return Err(ApiError::NotFound(format!("Class {class_id} not found")));
         }
     }
 
     Ok(())
-}
-
-async fn load_class_names(
-    pool: &DbPool,
-    class_ids: &[i32],
-) -> Result<Vec<(i32, String)>, ApiError> {
-    use crate::schema::hubuumclass::dsl::{hubuumclass, id, name};
-
-    if class_ids.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let class_ids = class_ids.to_vec();
-    with_connection(pool, |conn| {
-        hubuumclass
-            .filter(id.eq_any(class_ids))
-            .select((id, name))
-            .load::<(i32, String)>(conn)
-    })
-}
-
-async fn load_class_relations_touching_classes(
-    pool: &DbPool,
-    class_ids: &[i32],
-) -> Result<Vec<HubuumClassRelation>, ApiError> {
-    use crate::schema::hubuumclass_relation::dsl::{
-        from_hubuum_class_id, hubuumclass_relation, to_hubuum_class_id,
-    };
-
-    if class_ids.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let class_ids = class_ids.to_vec();
-    with_connection(pool, |conn| {
-        hubuumclass_relation
-            .filter(from_hubuum_class_id.eq_any(&class_ids))
-            .or_filter(to_hubuum_class_id.eq_any(&class_ids))
-            .load::<HubuumClassRelation>(conn)
-    })
 }
 
 fn add_bidirectional_alias_edge(

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -30,9 +30,9 @@ use crate::models::{
     HubuumClassID, HubuumClassRelation, HubuumObject, HubuumObjectID, HubuumObjectRelation,
     HubuumObjectWithPath, NamespaceID, NewReportTaskOutputRecord, NewTaskEventRecord, Permissions,
     ReportContentType, ReportIncludeRelatedDirection, ReportIncludeRelatedQuery,
-    ReportIncludeRelatedSort, ReportJsonResponse, ReportMeta,
-    ReportMissingDataPolicy, ReportRequest, ReportScope, ReportScopeKind, ReportTaskOutputRecord,
-    ReportTemplate, ReportTemplateID, ReportWarning, TaskKind, TaskRecord, TaskResponse, User,
+    ReportIncludeRelatedSort, ReportJsonResponse, ReportMeta, ReportMissingDataPolicy,
+    ReportRequest, ReportScope, ReportScopeKind, ReportTaskOutputRecord, ReportTemplate,
+    ReportTemplateID, ReportWarning, TaskKind, TaskRecord, TaskResponse, User,
 };
 use crate::pagination::page_limits_or_defaults;
 use crate::tasks::{

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -47,6 +47,7 @@ use super::check_if_object_in_class;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct StoredReportTaskPayload {
     report: ReportRequest,
+    template_id: Option<i32>,
 }
 
 struct ReportArtifact {
@@ -217,25 +218,8 @@ pub async fn run_report(
     req: HttpRequest,
     report: web::Json<ReportRequest>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.get_ref().clone());
-
     let report = report.into_inner();
-    let payload = serde_json::to_value(&report)?;
-    let hash = request_hash(&payload)?;
-    let idempotency_key = idempotency_key_from_headers(req.headers())?;
-
-    let runtime = prepare_report_runtime(&pool, &requestor.user, report).await?;
-    validate_report_submission(&runtime)?;
-    let task_payload = runtime_to_task_payload(&runtime)?;
-
-    let task = find_or_create_report_task(
-        &pool,
-        requestor.user.id,
-        idempotency_key,
-        serde_json::to_value(task_payload)?,
-        hash,
-    )
-    .await?;
+    let task = submit_report_task(&pool, &requestor.user, req, report, None).await?;
 
     let response = task.to_response()?;
     let mut headers = HashMap::new();
@@ -247,6 +231,43 @@ pub async fn run_report(
         StatusCode::ACCEPTED,
         Some(headers),
     ))
+}
+
+pub(crate) async fn submit_report_task(
+    pool: &DbPool,
+    user: &User,
+    req: HttpRequest,
+    report: ReportRequest,
+    template_id: Option<i32>,
+) -> Result<TaskRecord, ApiError> {
+    ensure_task_worker_running(pool.clone());
+
+    let task_payload = StoredReportTaskPayload {
+        report,
+        template_id,
+    };
+    let payload = serde_json::to_value(&task_payload)?;
+    let hash = request_hash(&payload)?;
+    let idempotency_key = idempotency_key_from_headers(req.headers())?;
+
+    let runtime = prepare_report_runtime(
+        pool,
+        user,
+        task_payload.report.clone(),
+        task_payload.template_id,
+    )
+    .await?;
+    validate_report_submission(&runtime)?;
+    let task_payload = runtime_to_task_payload(&runtime)?;
+
+    find_or_create_report_task(
+        pool,
+        user.id,
+        idempotency_key,
+        serde_json::to_value(task_payload)?,
+        hash,
+    )
+    .await
 }
 
 #[utoipa::path(
@@ -320,11 +341,12 @@ async fn prepare_report_runtime(
     pool: &DbPool,
     user: &User,
     report: ReportRequest,
+    template_id: Option<i32>,
 ) -> Result<ReportRuntime, ApiError> {
     report.scope.validate()?;
     validate_report_include(&report)?;
 
-    let template = resolve_template(pool, user, &report).await?;
+    let template = resolve_template(pool, user, template_id).await?;
     let namespace_templates = match &template {
         Some(template) => {
             crate::models::report_template::report_templates_in_namespace(
@@ -355,9 +377,9 @@ async fn prepare_report_runtime(
 async fn resolve_template(
     pool: &DbPool,
     user: &crate::models::User,
-    report: &ReportRequest,
+    template_id: Option<i32>,
 ) -> Result<Option<ReportTemplate>, ApiError> {
-    let Some(template_id) = report.output.as_ref().and_then(|output| output.template_id) else {
+    let Some(template_id) = template_id else {
         return Ok(None);
     };
 
@@ -395,6 +417,7 @@ fn runtime_to_task_payload(runtime: &ReportRuntime) -> Result<StoredReportTaskPa
     validate_report_submission(runtime)?;
     Ok(StoredReportTaskPayload {
         report: runtime.report.clone(),
+        template_id: runtime.template.as_ref().map(|template| template.id),
     })
 }
 
@@ -484,7 +507,7 @@ pub(crate) async fn execute_report_task(
         .clone()
         .ok_or_else(|| ApiError::BadRequest("Report task payload is missing".to_string()))?;
     let payload: StoredReportTaskPayload = serde_json::from_value(payload)?;
-    let runtime = prepare_report_runtime(pool, user, payload.report).await?;
+    let runtime = prepare_report_runtime(pool, user, payload.report, payload.template_id).await?;
     validate_report_submission(&runtime)?;
     let total_start = Instant::now();
     let mut timings = ReportExecutionTimings::default();
@@ -802,7 +825,6 @@ fn build_json_report_artifact(
     execution: ReportExecution,
     timings: ReportExecutionTimings,
 ) -> Result<ReportArtifact, ApiError> {
-    ensure_json_output_has_no_template_id(&runtime.report)?;
     let response = ReportJsonResponse {
         items: execution.items,
         meta: execution.meta.clone(),
@@ -857,29 +879,13 @@ fn build_text_report_artifact(
     })
 }
 
-fn ensure_json_output_has_no_template_id(report: &ReportRequest) -> Result<(), ApiError> {
-    if report
-        .output
-        .as_ref()
-        .and_then(|output| output.template_id)
-        .is_some()
-    {
-        return Err(ApiError::BadRequest(
-            "Template references are only supported for text/plain, text/html, and text/csv output"
-                .to_string(),
-        ));
-    }
-
-    Ok(())
-}
-
 fn required_template(
     runtime: &ReportRuntime,
     content_type: ReportContentType,
 ) -> Result<&ReportTemplate, ApiError> {
     runtime.template.as_ref().ok_or_else(|| {
         ApiError::BadRequest(format!(
-            "Output type '{}' requires output.template_id",
+            "Output type '{}' requires running an executable report template",
             content_type.as_mime()
         ))
     })
@@ -2381,7 +2387,7 @@ mod tests {
     use crate::models::{
         ReportContentType, ReportInclude, ReportIncludeRelatedObject, ReportLimits, ReportMeta,
         ReportMissingDataPolicy, ReportRelationContext, ReportRequest, ReportScope,
-        ReportScopeKind, ReportTaskOutputRecord, ReportTemplate,
+        ReportScopeKind, ReportTaskOutputRecord, ReportTemplate, ReportTemplateKind,
     };
 
     use super::{
@@ -2470,7 +2476,6 @@ mod tests {
                 object_id: None,
             },
             query: None,
-            output: None,
             missing_data_policy: None,
             limits: Some(limits),
             include: None,
@@ -2488,7 +2493,6 @@ mod tests {
                 object_id: None,
             },
             query: None,
-            output: None,
             missing_data_policy: None,
             limits: None,
             include: Some(ReportInclude {
@@ -2510,6 +2514,14 @@ mod tests {
                 description: String::new(),
                 content_type: ReportContentType::TextPlain,
                 template: "{{ items|length }}".to_string(),
+                kind: ReportTemplateKind::Report,
+                scope_kind: Some(ReportScopeKind::ObjectsInClass),
+                class_id: Some(1),
+                default_query: None,
+                include: None,
+                relation_context: None,
+                default_missing_data_policy: None,
+                default_limits: None,
                 created_at: test_timestamp(),
                 updated_at: test_timestamp(),
             }),

--- a/src/api/v1/handlers/tasks.rs
+++ b/src/api/v1/handlers/tasks.rs
@@ -3,15 +3,12 @@ use actix_web::{HttpRequest, Responder, get, http::StatusCode, routes, web};
 use crate::api::openapi::ApiErrorResponse;
 use crate::db::DbPool;
 use crate::db::traits::task::{
-    find_report_task_output_summary, find_task_record, list_report_task_output_summaries,
-    list_task_events_with_total_count, list_tasks_with_total_count,
+    TaskBackend, list_report_task_output_summaries, list_tasks_with_total_count,
 };
 use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::search::parse_query_parameter_with_passthrough;
-use crate::models::{
-    TaskEventResponse, TaskID, TaskKind, TaskRecord, TaskResponse, TaskStatus, User,
-};
+use crate::models::{TaskEventResponse, TaskID, TaskKind, TaskResponse, TaskStatus};
 use crate::pagination::prepare_db_pagination;
 use crate::tasks::ensure_task_worker_running;
 use crate::traits::GroupMemberships;
@@ -73,21 +70,6 @@ fn parse_task_list_query(
             submitted_by,
         },
     ))
-}
-
-async fn load_authorized_task(
-    pool: &DbPool,
-    requestor: &User,
-    task_id: i32,
-) -> Result<TaskRecord, ApiError> {
-    let is_admin = requestor.is_admin(pool).await?;
-    let task = find_task_record(pool, task_id).await?;
-    if task.submitted_by == Some(requestor.id) || is_admin {
-        Ok(task)
-    } else {
-        // Return 404 instead of 403 to hide existence of task from unauthorized users
-        Err(ApiError::NotFound("Task not found".to_string()))
-    }
 }
 
 #[utoipa::path(
@@ -175,9 +157,12 @@ pub async fn get_task(
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(pool.get_ref().clone());
-    let task = load_authorized_task(&pool, &requestor.user, task_id.into_inner().id()).await?;
+    let task = task_id
+        .into_inner()
+        .load_authorized(&pool, &requestor.user)
+        .await?;
     let report_output = if task.kind == TaskKind::Report.as_str() {
-        find_report_task_output_summary(&pool, task.id).await?
+        task.find_report_output_summary(&pool).await?
     } else {
         None
     };
@@ -210,12 +195,13 @@ pub async fn get_task_events(
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(pool.get_ref().clone());
-    let task_id = task_id.into_inner().id();
-    load_authorized_task(&pool, &requestor.user, task_id).await?;
+    let task_id = task_id.into_inner();
+    task_id.load_authorized(&pool, &requestor.user).await?;
     let (params, _) = parse_query_parameter_with_passthrough(req.query_string(), &[])?;
     let search_params = prepare_db_pagination::<TaskEventResponse>(&params)?;
-    let (events, total_count) =
-        list_task_events_with_total_count(&pool, task_id, &search_params).await?;
+    let (events, total_count) = task_id
+        .list_events_with_total_count(&pool, &search_params)
+        .await?;
     let events = events
         .into_iter()
         .map(TaskEventResponse::from)

--- a/src/api/v1/handlers/tasks.rs
+++ b/src/api/v1/handlers/tasks.rs
@@ -9,7 +9,9 @@ use crate::db::traits::task::{
 use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::search::parse_query_parameter_with_passthrough;
-use crate::models::{TaskEventResponse, TaskKind, TaskRecord, TaskResponse, TaskStatus, User};
+use crate::models::{
+    TaskEventResponse, TaskID, TaskKind, TaskRecord, TaskResponse, TaskStatus, User,
+};
 use crate::pagination::prepare_db_pagination;
 use crate::tasks::ensure_task_worker_running;
 use crate::traits::GroupMemberships;
@@ -170,10 +172,10 @@ pub async fn get_tasks(
 pub async fn get_task(
     pool: web::Data<DbPool>,
     requestor: UserAccess,
-    task_id: web::Path<i32>,
+    task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(pool.get_ref().clone());
-    let task = load_authorized_task(&pool, &requestor.user, task_id.into_inner()).await?;
+    let task = load_authorized_task(&pool, &requestor.user, task_id.into_inner().id()).await?;
     let report_output = if task.kind == TaskKind::Report.as_str() {
         find_report_task_output_summary(&pool, task.id).await?
     } else {
@@ -205,10 +207,10 @@ pub async fn get_task_events(
     pool: web::Data<DbPool>,
     requestor: UserAccess,
     req: HttpRequest,
-    task_id: web::Path<i32>,
+    task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(pool.get_ref().clone());
-    let task_id = task_id.into_inner();
+    let task_id = task_id.into_inner().id();
     load_authorized_task(&pool, &requestor.user, task_id).await?;
     let (params, _) = parse_query_parameter_with_passthrough(req.query_string(), &[])?;
     let search_params = prepare_db_pagination::<TaskEventResponse>(&params)?;

--- a/src/api/v1/handlers/templates.rs
+++ b/src/api/v1/handlers/templates.rs
@@ -1,4 +1,4 @@
-use actix_web::{HttpRequest, Responder, delete, get, http::StatusCode, patch, routes, web};
+use actix_web::{HttpRequest, Responder, delete, get, http::StatusCode, patch, post, routes, web};
 use tracing::{debug, info};
 
 use crate::api::openapi::ApiErrorResponse;
@@ -9,12 +9,15 @@ use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
-    NamespaceID, NewReportTemplate, Permissions, ReportTemplate, ReportTemplateID,
+    NamespaceID, NewReportTemplate, Permissions, ReportScope, ReportScopeKind, ReportTemplate,
+    ReportTemplateID, ReportTemplateKind, ReportTemplateRunRequest, TaskResponse,
     UpdateReportTemplate,
 };
 use crate::pagination::prepare_db_pagination;
 use crate::traits::NamespaceAccessors;
-use crate::utilities::response::{json_response, json_response_created, paginated_json_response};
+use crate::utilities::response::{
+    json_response, json_response_created, json_response_with_header, paginated_json_response,
+};
 
 #[utoipa::path(
     post,
@@ -149,6 +152,124 @@ pub async fn get_template(
     );
 
     Ok(json_response(template, StatusCode::OK))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/templates/{template_id}/reports",
+    tag = "templates",
+    security(("bearer_auth" = [])),
+    params(
+        ("template_id" = i32, Path, description = "Executable report template ID")
+    ),
+    request_body = ReportTemplateRunRequest,
+    responses(
+        (status = 202, description = "Report task accepted", body = TaskResponse),
+        (status = 400, description = "Bad request", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Forbidden", body = ApiErrorResponse),
+        (status = 404, description = "Template not found", body = ApiErrorResponse),
+        (status = 409, description = "Conflict", body = ApiErrorResponse),
+        (status = 429, description = "Too many active report tasks", body = ApiErrorResponse)
+    )
+)]
+#[post("/{template_id}/reports")]
+pub async fn run_template_report(
+    pool: web::Data<DbPool>,
+    requestor: UserAccess,
+    req: HttpRequest,
+    template_id: web::Path<ReportTemplateID>,
+    run: web::Json<ReportTemplateRunRequest>,
+) -> Result<impl Responder, ApiError> {
+    let user = requestor.user;
+    let template_id = template_id.into_inner().0;
+    let run = run.into_inner();
+
+    debug!(
+        message = "Report template execution requested",
+        user_id = user.id,
+        template_id = template_id
+    );
+
+    let template = crate::models::report_template::report_template(&pool, template_id).await?;
+
+    can!(
+        &pool,
+        user.clone(),
+        [Permissions::ReadTemplate],
+        NamespaceID(template.namespace_id)
+    );
+
+    let report = report_request_from_template(&template, run)?;
+    let task = crate::api::v1::handlers::reports::submit_report_task(
+        &pool,
+        &user,
+        req,
+        report,
+        Some(template.id),
+    )
+    .await?;
+    let response = task.to_response()?;
+    let mut headers = std::collections::HashMap::new();
+    headers.insert("Location".to_string(), format!("/api/v1/tasks/{}", task.id));
+
+    Ok(json_response_with_header(
+        response,
+        StatusCode::ACCEPTED,
+        Some(headers),
+    ))
+}
+
+fn report_request_from_template(
+    template: &ReportTemplate,
+    run: ReportTemplateRunRequest,
+) -> Result<crate::models::ReportRequest, ApiError> {
+    if template.kind != ReportTemplateKind::Report {
+        return Err(ApiError::BadRequest(
+            "Only report templates can be executed".to_string(),
+        ));
+    }
+
+    let scope_kind = template.scope_kind.ok_or_else(|| {
+        ApiError::BadRequest("Executable report template is missing scope_kind".to_string())
+    })?;
+    let class_id = template.class_id.ok_or_else(|| {
+        ApiError::BadRequest("Executable report template is missing class_id".to_string())
+    })?;
+
+    let object_id = match scope_kind {
+        ReportScopeKind::ObjectsInClass => {
+            if run.object_id.is_some() {
+                return Err(ApiError::BadRequest(
+                    "object_id is not accepted for objects_in_class report templates".to_string(),
+                ));
+            }
+            None
+        }
+        ReportScopeKind::RelatedObjects => Some(run.object_id.ok_or_else(|| {
+            ApiError::BadRequest("related_objects report templates require object_id".to_string())
+        })?),
+        _ => {
+            return Err(ApiError::BadRequest(
+                "Executable report template has an unsupported scope_kind".to_string(),
+            ));
+        }
+    };
+
+    Ok(crate::models::ReportRequest {
+        scope: ReportScope {
+            kind: scope_kind,
+            class_id: Some(class_id),
+            object_id,
+        },
+        query: run.query.or_else(|| template.default_query.clone()),
+        missing_data_policy: run
+            .missing_data_policy
+            .or(template.default_missing_data_policy),
+        limits: run.limits.or_else(|| template.default_limits.clone()),
+        include: template.include.clone(),
+        relation_context: template.relation_context.clone(),
+    })
 }
 
 #[utoipa::path(

--- a/src/api/v1/handlers/templates.rs
+++ b/src/api/v1/handlers/templates.rs
@@ -101,12 +101,8 @@ pub async fn get_templates(
             .collect::<Vec<_>>();
 
     let (templates, total_count) =
-        crate::models::report_template::list_report_templates_with_total_count(
-            &pool,
-            &allowed_namespace_ids,
-            &search_params,
-        )
-        .await?;
+        ReportTemplate::list_with_total_count(&pool, &allowed_namespace_ids, &search_params)
+            .await?;
 
     paginated_json_response(templates, total_count, StatusCode::OK, &params)
 }

--- a/src/api/v1/handlers/templates.rs
+++ b/src/api/v1/handlers/templates.rs
@@ -13,7 +13,7 @@ use crate::models::{
     ReportTemplateRunRequest, TaskResponse, UpdateReportTemplate,
 };
 use crate::pagination::prepare_db_pagination;
-use crate::traits::NamespaceAccessors;
+use crate::traits::{CanDelete, CanSave, CanUpdate, NamespaceAccessors, SelfAccessors};
 use crate::utilities::response::{
     json_response, json_response_created, json_response_with_header, paginated_json_response,
 };
@@ -57,7 +57,7 @@ pub async fn create_template(
         NamespaceID(template.namespace_id)
     );
 
-    let created = crate::models::report_template::create_report_template(&pool, template).await?;
+    let created = template.save(&pool).await?;
 
     Ok(json_response_created(
         &created,
@@ -133,15 +133,15 @@ pub async fn get_template(
     template_id: web::Path<ReportTemplateID>,
 ) -> Result<impl Responder, ApiError> {
     let user = requestor.user;
-    let template_id = template_id.into_inner().0;
+    let template_id = template_id.into_inner();
 
     debug!(
         message = "Report template get requested",
         user_id = user.id,
-        template_id = template_id
+        template_id = template_id.id()
     );
 
-    let template = crate::models::report_template::report_template(&pool, template_id).await?;
+    let template = template_id.instance(&pool).await?;
 
     can!(
         &pool,
@@ -181,16 +181,16 @@ pub async fn run_template_report(
     run: web::Json<ReportTemplateRunRequest>,
 ) -> Result<impl Responder, ApiError> {
     let user = requestor.user;
-    let template_id = template_id.into_inner().0;
+    let template_id = template_id.into_inner();
     let run = run.into_inner();
 
     debug!(
         message = "Report template execution requested",
         user_id = user.id,
-        template_id = template_id
+        template_id = template_id.id()
     );
 
-    let template = crate::models::report_template::report_template(&pool, template_id).await?;
+    let template = template_id.instance(&pool).await?;
 
     can!(
         &pool,
@@ -245,16 +245,16 @@ pub async fn patch_template(
     update: web::Json<UpdateReportTemplate>,
 ) -> Result<impl Responder, ApiError> {
     let user = requestor.user;
-    let template_id = template_id.into_inner().0;
+    let template_id = template_id.into_inner();
     let update = update.into_inner();
 
     debug!(
         message = "Report template patch requested",
         user_id = user.id,
-        template_id = template_id
+        template_id = template_id.id()
     );
 
-    let existing = crate::models::report_template::report_template(&pool, template_id).await?;
+    let existing = template_id.instance(&pool).await?;
 
     can!(
         &pool,
@@ -274,8 +274,7 @@ pub async fn patch_template(
         );
     }
 
-    let updated =
-        crate::models::report_template::update_report_template(&pool, template_id, update).await?;
+    let updated = update.update(&pool, existing.id).await?;
 
     Ok(json_response(updated, StatusCode::OK))
 }
@@ -302,15 +301,15 @@ pub async fn delete_template(
     template_id: web::Path<ReportTemplateID>,
 ) -> Result<impl Responder, ApiError> {
     let user = requestor.user;
-    let template_id = template_id.into_inner().0;
+    let template_id = template_id.into_inner();
 
     debug!(
         message = "Report template delete requested",
         user_id = user.id,
-        template_id = template_id
+        template_id = template_id.id()
     );
 
-    let template = crate::models::report_template::report_template(&pool, template_id).await?;
+    let template = template_id.instance(&pool).await?;
 
     can!(
         &pool,
@@ -319,7 +318,7 @@ pub async fn delete_template(
         NamespaceID(template.namespace_id)
     );
 
-    crate::models::report_template::delete_report_template(&pool, template_id).await?;
+    template_id.delete(&pool).await?;
 
     Ok(json_response((), StatusCode::NO_CONTENT))
 }

--- a/src/api/v1/handlers/templates.rs
+++ b/src/api/v1/handlers/templates.rs
@@ -201,14 +201,9 @@ pub async fn run_template_report(
     );
 
     let report = report_request_from_template(&template, run)?;
-    let task = crate::api::v1::handlers::reports::submit_report_task(
-        &pool,
-        &user,
-        req,
-        report,
-        Some(template.id),
-    )
-    .await?;
+    let task =
+        crate::api::v1::handlers::reports::submit_report_task(&pool, &user, req, report, Some(template))
+            .await?;
     let response = task.to_response()?;
     let mut headers = std::collections::HashMap::new();
     headers.insert("Location".to_string(), format!("/api/v1/tasks/{}", task.id));
@@ -233,33 +228,48 @@ fn report_request_from_template(
     let scope_kind = template.scope_kind.ok_or_else(|| {
         ApiError::BadRequest("Executable report template is missing scope_kind".to_string())
     })?;
-    let class_id = template.class_id.ok_or_else(|| {
-        ApiError::BadRequest("Executable report template is missing class_id".to_string())
-    })?;
 
-    let object_id = match scope_kind {
-        ReportScopeKind::ObjectsInClass => {
-            if run.object_id.is_some() {
-                return Err(ApiError::BadRequest(
-                    "object_id is not accepted for objects_in_class report templates".to_string(),
-                ));
-            }
-            None
+    let template_class_id = || {
+        template.class_id.ok_or_else(|| {
+            ApiError::BadRequest("Executable report template is missing class_id".to_string())
+        })
+    };
+    let reject_object_id = || {
+        if run.object_id.is_some() {
+            return Err(ApiError::BadRequest(format!(
+                "object_id is not accepted for {} report templates",
+                scope_kind.as_str()
+            )));
         }
-        ReportScopeKind::RelatedObjects => Some(run.object_id.ok_or_else(|| {
-            ApiError::BadRequest("related_objects report templates require object_id".to_string())
-        })?),
-        _ => {
-            return Err(ApiError::BadRequest(
-                "Executable report template has an unsupported scope_kind".to_string(),
-            ));
+        Ok(())
+    };
+
+    let (class_id, object_id) = match scope_kind {
+        ReportScopeKind::ObjectsInClass => {
+            reject_object_id()?;
+            (Some(template_class_id()?), None)
+        }
+        ReportScopeKind::RelatedObjects => {
+            let object_id = run.object_id.ok_or_else(|| {
+                ApiError::BadRequest(
+                    "related_objects report templates require object_id".to_string(),
+                )
+            })?;
+            (Some(template_class_id()?), Some(object_id))
+        }
+        ReportScopeKind::Namespaces
+        | ReportScopeKind::Classes
+        | ReportScopeKind::ClassRelations
+        | ReportScopeKind::ObjectRelations => {
+            reject_object_id()?;
+            (None, None)
         }
     };
 
     Ok(crate::models::ReportRequest {
         scope: ReportScope {
             kind: scope_kind,
-            class_id: Some(class_id),
+            class_id,
             object_id,
         },
         query: run.query.or_else(|| template.default_query.clone()),

--- a/src/api/v1/handlers/templates.rs
+++ b/src/api/v1/handlers/templates.rs
@@ -201,9 +201,14 @@ pub async fn run_template_report(
     );
 
     let report = report_request_from_template(&template, run)?;
-    let task =
-        crate::api::v1::handlers::reports::submit_report_task(&pool, &user, req, report, Some(template))
-            .await?;
+    let task = crate::api::v1::handlers::reports::submit_report_task(
+        &pool,
+        &user,
+        req,
+        report,
+        Some(template),
+    )
+    .await?;
     let response = task.to_response()?;
     let mut headers = std::collections::HashMap::new();
     headers.insert("Location".to_string(), format!("/api/v1/tasks/{}", task.id));

--- a/src/api/v1/handlers/templates.rs
+++ b/src/api/v1/handlers/templates.rs
@@ -9,9 +9,8 @@ use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
-    NamespaceID, NewReportTemplate, Permissions, ReportScope, ReportScopeKind, ReportTemplate,
-    ReportTemplateID, ReportTemplateKind, ReportTemplateRunRequest, TaskResponse,
-    UpdateReportTemplate,
+    NamespaceID, NewReportTemplate, Permissions, ReportTemplate, ReportTemplateID,
+    ReportTemplateRunRequest, TaskResponse, UpdateReportTemplate,
 };
 use crate::pagination::prepare_db_pagination;
 use crate::traits::NamespaceAccessors;
@@ -200,7 +199,7 @@ pub async fn run_template_report(
         NamespaceID(template.namespace_id)
     );
 
-    let report = report_request_from_template(&template, run)?;
+    let report = template.build_report_request(run)?;
     let task = crate::api::v1::handlers::reports::submit_report_task(
         &pool,
         &user,
@@ -218,73 +217,6 @@ pub async fn run_template_report(
         StatusCode::ACCEPTED,
         Some(headers),
     ))
-}
-
-fn report_request_from_template(
-    template: &ReportTemplate,
-    run: ReportTemplateRunRequest,
-) -> Result<crate::models::ReportRequest, ApiError> {
-    if template.kind != ReportTemplateKind::Report {
-        return Err(ApiError::BadRequest(
-            "Only report templates can be executed".to_string(),
-        ));
-    }
-
-    let scope_kind = template.scope_kind.ok_or_else(|| {
-        ApiError::BadRequest("Executable report template is missing scope_kind".to_string())
-    })?;
-
-    let template_class_id = || {
-        template.class_id.ok_or_else(|| {
-            ApiError::BadRequest("Executable report template is missing class_id".to_string())
-        })
-    };
-    let reject_object_id = || {
-        if run.object_id.is_some() {
-            return Err(ApiError::BadRequest(format!(
-                "object_id is not accepted for {} report templates",
-                scope_kind.as_str()
-            )));
-        }
-        Ok(())
-    };
-
-    let (class_id, object_id) = match scope_kind {
-        ReportScopeKind::ObjectsInClass => {
-            reject_object_id()?;
-            (Some(template_class_id()?), None)
-        }
-        ReportScopeKind::RelatedObjects => {
-            let object_id = run.object_id.ok_or_else(|| {
-                ApiError::BadRequest(
-                    "related_objects report templates require object_id".to_string(),
-                )
-            })?;
-            (Some(template_class_id()?), Some(object_id))
-        }
-        ReportScopeKind::Namespaces
-        | ReportScopeKind::Classes
-        | ReportScopeKind::ClassRelations
-        | ReportScopeKind::ObjectRelations => {
-            reject_object_id()?;
-            (None, None)
-        }
-    };
-
-    Ok(crate::models::ReportRequest {
-        scope: ReportScope {
-            kind: scope_kind,
-            class_id,
-            object_id,
-        },
-        query: run.query.or_else(|| template.default_query.clone()),
-        missing_data_policy: run
-            .missing_data_policy
-            .or(template.default_missing_data_policy),
-        limits: run.limits.or_else(|| template.default_limits.clone()),
-        include: template.include.clone(),
-        relation_context: template.relation_context.clone(),
-    })
 }
 
 #[utoipa::path(

--- a/src/api/v1/routes/templates.rs
+++ b/src/api/v1/routes/templates.rs
@@ -6,6 +6,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
     cfg.service(templates::get_templates)
         .service(templates::create_template)
         .service(templates::get_template)
+        .service(templates::run_template_report)
         .service(templates::patch_template)
         .service(templates::delete_template);
 }

--- a/src/bin/admin.rs
+++ b/src/bin/admin.rs
@@ -14,8 +14,7 @@ use hubuum::config::{
 use hubuum::db::{DbPool, init_pool_with_statement_timeout, with_connection};
 use hubuum::errors::{ApiError, EXIT_CODE_CONFIG_ERROR, fatal_error};
 use hubuum::logger;
-use hubuum::models::report_template::{list_all_report_templates, report_templates_in_namespace};
-use hubuum::models::{ReportTaskOutputRecord, User};
+use hubuum::models::{ReportTaskOutputRecord, ReportTemplate, User};
 use hubuum::schema::report_task_outputs::dsl::report_task_outputs;
 use hubuum::utilities::auth::generate_random_password;
 use hubuum::utilities::is_valid_log_level;
@@ -124,12 +123,11 @@ async fn audit_templates(
     report_template_recursion_limit: usize,
     report_template_fuel: u64,
 ) -> Result<(), ApiError> {
-    let templates = list_all_report_templates(&pool).await?;
+    let templates = ReportTemplate::list_all(&pool).await?;
     let mut failures = Vec::new();
 
     for template in templates {
-        let namespace_templates =
-            report_templates_in_namespace(&pool, template.namespace_id, Some(template.id)).await?;
+        let namespace_templates = template.namespace_siblings(&pool).await?;
         if let Err(error) = validate_template_with_limits(
             &template.name,
             &template.template,

--- a/src/db/traits/class.rs
+++ b/src/db/traits/class.rs
@@ -4,7 +4,7 @@ use crate::db::traits::GetClass;
 use crate::db::{DbPool, with_connection};
 use crate::errors::ApiError;
 use crate::models::{
-    HubuumClass, HubuumClassID, HubuumClassRelation, HubuumClassRelationID, Namespace,
+    ClassIdSet, HubuumClass, HubuumClassID, HubuumClassRelation, HubuumClassRelationID, Namespace,
     NewHubuumClass, NewHubuumClassRelation, UpdateHubuumClass,
 };
 
@@ -202,4 +202,46 @@ pub async fn total_class_count_from_backend(pool: &DbPool) -> Result<i64, ApiErr
     use crate::schema::hubuumclass::dsl::*;
 
     with_connection(pool, |conn| hubuumclass.count().get_result::<i64>(conn))
+}
+
+impl ClassIdSet {
+    /// Load the `(id, name)` pairs for the classes in this set. Ids without a matching row are
+    /// simply absent from the result; callers that require completeness must check themselves.
+    pub(crate) async fn load_names(&self, pool: &DbPool) -> Result<Vec<(i32, String)>, ApiError> {
+        use crate::schema::hubuumclass::dsl::{hubuumclass, id, name};
+
+        if self.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let ids = self.as_slice().to_vec();
+        with_connection(pool, |conn| {
+            hubuumclass
+                .filter(id.eq_any(ids))
+                .select((id, name))
+                .load::<(i32, String)>(conn)
+        })
+    }
+
+    /// Load every class relation that touches a class in this set as either endpoint.
+    pub(crate) async fn load_relations_touching(
+        &self,
+        pool: &DbPool,
+    ) -> Result<Vec<HubuumClassRelation>, ApiError> {
+        use crate::schema::hubuumclass_relation::dsl::{
+            from_hubuum_class_id, hubuumclass_relation, to_hubuum_class_id,
+        };
+
+        if self.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let ids = self.as_slice().to_vec();
+        with_connection(pool, |conn| {
+            hubuumclass_relation
+                .filter(from_hubuum_class_id.eq_any(&ids))
+                .or_filter(to_hubuum_class_id.eq_any(&ids))
+                .load::<HubuumClassRelation>(conn)
+        })
+    }
 }

--- a/src/db/traits/mod.rs
+++ b/src/db/traits/mod.rs
@@ -6,6 +6,7 @@ pub mod namespace;
 pub mod object;
 pub mod permissions;
 pub mod relations;
+pub mod report_template;
 pub mod task;
 pub mod task_import;
 pub mod user;

--- a/src/db/traits/report_template.rs
+++ b/src/db/traits/report_template.rs
@@ -2,71 +2,126 @@
 //!
 //! All Diesel/Postgres query construction for `report_templates` lives here so the model layer
 //! (`crate::models::report_template`) stays thin and free of backend details, mirroring the other
-//! entities under `src/db/traits/`. These functions operate on the row types defined alongside the
-//! domain type; the model owns the domain<->row conversions and all validation.
+//! entities under `src/db/traits/`. Instance-scoped CRUD is exposed as self-methods via the record
+//! traits below (matching `LoadClassRecord` and friends); collection, search, cross-table, and
+//! aggregate queries — which have no single owning instance — stay free functions, as elsewhere in
+//! this module. The model owns the domain<->row conversions and all validation.
 
 use diesel::prelude::*;
 
 use crate::db::{DbPool, with_connection};
 use crate::errors::ApiError;
 use crate::models::report_template::{
-    NewReportTemplateRow, ReportTemplate, ReportTemplateRow, UpdateReportTemplateRow,
+    NewReportTemplateRow, ReportTemplate, ReportTemplateID, ReportTemplateRow,
+    UpdateReportTemplateRow,
 };
 use crate::models::search::{FilterField, QueryOptions};
 use crate::{date_search, numeric_search, string_search};
 
-/// Insert a new report-template row and return the persisted row.
-pub(crate) async fn insert_row(
-    pool: &DbPool,
-    new_row: &NewReportTemplateRow,
-) -> Result<ReportTemplateRow, ApiError> {
-    use crate::schema::report_templates::dsl::report_templates;
-
-    with_connection(pool, |conn| {
-        diesel::insert_into(report_templates)
-            .values(new_row)
-            .get_result::<ReportTemplateRow>(conn)
-    })
+/// Load the report-template row identified by this id.
+pub(crate) trait LoadReportTemplateRecord {
+    async fn load_report_template_record(
+        &self,
+        pool: &DbPool,
+    ) -> Result<ReportTemplateRow, ApiError>;
 }
 
-/// Load a single report-template row by id.
-pub(crate) async fn load_row(
-    pool: &DbPool,
-    template_id: i32,
-) -> Result<ReportTemplateRow, ApiError> {
-    use crate::schema::report_templates::dsl::{id, report_templates};
+impl LoadReportTemplateRecord for ReportTemplateID {
+    async fn load_report_template_record(
+        &self,
+        pool: &DbPool,
+    ) -> Result<ReportTemplateRow, ApiError> {
+        use crate::schema::report_templates::dsl::{id, report_templates};
 
-    with_connection(pool, |conn| {
-        report_templates
-            .filter(id.eq(template_id))
-            .first::<ReportTemplateRow>(conn)
-    })
+        with_connection(pool, |conn| {
+            report_templates
+                .filter(id.eq(self.id()))
+                .first::<ReportTemplateRow>(conn)
+        })
+    }
 }
 
-/// Apply a changeset to the report-template row with the given id and return the updated row.
-pub(crate) async fn update_row(
-    pool: &DbPool,
-    template_id: i32,
-    changeset: &UpdateReportTemplateRow,
-) -> Result<ReportTemplateRow, ApiError> {
-    use crate::schema::report_templates::dsl::{id, report_templates};
-
-    with_connection(pool, |conn| {
-        diesel::update(report_templates.filter(id.eq(template_id)))
-            .set(changeset)
-            .get_result::<ReportTemplateRow>(conn)
-    })
+/// Insert this new report-template row and return the persisted row.
+pub(crate) trait SaveReportTemplateRecord {
+    async fn save_report_template_record(
+        &self,
+        pool: &DbPool,
+    ) -> Result<ReportTemplateRow, ApiError>;
 }
 
-/// Delete the report-template row with the given id.
-pub(crate) async fn delete_row(pool: &DbPool, template_id: i32) -> Result<(), ApiError> {
-    use crate::schema::report_templates::dsl::{id, report_templates};
+impl SaveReportTemplateRecord for NewReportTemplateRow {
+    async fn save_report_template_record(
+        &self,
+        pool: &DbPool,
+    ) -> Result<ReportTemplateRow, ApiError> {
+        use crate::schema::report_templates::dsl::report_templates;
 
-    with_connection(pool, |conn| {
-        diesel::delete(report_templates.filter(id.eq(template_id))).execute(conn)
-    })?;
+        with_connection(pool, |conn| {
+            diesel::insert_into(report_templates)
+                .values(self)
+                .get_result::<ReportTemplateRow>(conn)
+        })
+    }
+}
 
-    Ok(())
+/// Apply this changeset to the report-template row with the given id and return the updated row.
+pub(crate) trait UpdateReportTemplateRecord {
+    async fn update_report_template_record(
+        &self,
+        pool: &DbPool,
+        template_id: i32,
+    ) -> Result<ReportTemplateRow, ApiError>;
+}
+
+impl UpdateReportTemplateRecord for UpdateReportTemplateRow {
+    async fn update_report_template_record(
+        &self,
+        pool: &DbPool,
+        template_id: i32,
+    ) -> Result<ReportTemplateRow, ApiError> {
+        use crate::schema::report_templates::dsl::{id, report_templates};
+
+        with_connection(pool, |conn| {
+            diesel::update(report_templates.filter(id.eq(template_id)))
+                .set(self)
+                .get_result::<ReportTemplateRow>(conn)
+        })
+    }
+}
+
+/// Delete the report-template row identified by this id.
+pub(crate) trait DeleteReportTemplateRecord {
+    async fn delete_report_template_record(&self, pool: &DbPool) -> Result<(), ApiError>;
+}
+
+impl DeleteReportTemplateRecord for ReportTemplateID {
+    async fn delete_report_template_record(&self, pool: &DbPool) -> Result<(), ApiError> {
+        use crate::schema::report_templates::dsl::{id, report_templates};
+
+        with_connection(pool, |conn| {
+            diesel::delete(report_templates.filter(id.eq(self.id()))).execute(conn)
+        })?;
+
+        Ok(())
+    }
+}
+
+/// Look up the namespace id of the report template identified by this id.
+pub(crate) trait ReportTemplateNamespaceLookup {
+    async fn lookup_report_template_namespace_id(&self, pool: &DbPool) -> Result<i32, ApiError>;
+}
+
+impl ReportTemplateNamespaceLookup for ReportTemplateID {
+    async fn lookup_report_template_namespace_id(&self, pool: &DbPool) -> Result<i32, ApiError> {
+        use crate::schema::report_templates::dsl::{id, namespace_id, report_templates};
+
+        with_connection(pool, |conn| {
+            report_templates
+                .filter(id.eq(self.id()))
+                .select(namespace_id)
+                .first::<i32>(conn)
+        })
+    }
 }
 
 /// Load all report-template rows in a namespace, optionally excluding one template id.
@@ -134,18 +189,6 @@ pub(crate) async fn class_namespace_id(
             .select(namespace_id)
             .first::<i32>(conn)
             .optional()
-    })
-}
-
-/// The namespace id of the report template with the given id.
-pub(crate) async fn namespace_id_for(pool: &DbPool, template_id: i32) -> Result<i32, ApiError> {
-    use crate::schema::report_templates::dsl::{id, namespace_id, report_templates};
-
-    with_connection(pool, |conn| {
-        report_templates
-            .filter(id.eq(template_id))
-            .select(namespace_id)
-            .first::<i32>(conn)
     })
 }
 

--- a/src/db/traits/report_template.rs
+++ b/src/db/traits/report_template.rs
@@ -1,0 +1,213 @@
+//! Backend persistence for report templates.
+//!
+//! All Diesel/Postgres query construction for `report_templates` lives here so the model layer
+//! (`crate::models::report_template`) stays thin and free of backend details, mirroring the other
+//! entities under `src/db/traits/`. These functions operate on the row types defined alongside the
+//! domain type; the model owns the domain<->row conversions and all validation.
+
+use diesel::prelude::*;
+
+use crate::db::{DbPool, with_connection};
+use crate::errors::ApiError;
+use crate::models::report_template::{
+    NewReportTemplateRow, ReportTemplate, ReportTemplateRow, UpdateReportTemplateRow,
+};
+use crate::models::search::{FilterField, QueryOptions};
+use crate::{date_search, numeric_search, string_search};
+
+/// Insert a new report-template row and return the persisted row.
+pub(crate) async fn insert_row(
+    pool: &DbPool,
+    new_row: &NewReportTemplateRow,
+) -> Result<ReportTemplateRow, ApiError> {
+    use crate::schema::report_templates::dsl::report_templates;
+
+    with_connection(pool, |conn| {
+        diesel::insert_into(report_templates)
+            .values(new_row)
+            .get_result::<ReportTemplateRow>(conn)
+    })
+}
+
+/// Load a single report-template row by id.
+pub(crate) async fn load_row(
+    pool: &DbPool,
+    template_id: i32,
+) -> Result<ReportTemplateRow, ApiError> {
+    use crate::schema::report_templates::dsl::{id, report_templates};
+
+    with_connection(pool, |conn| {
+        report_templates
+            .filter(id.eq(template_id))
+            .first::<ReportTemplateRow>(conn)
+    })
+}
+
+/// Apply a changeset to the report-template row with the given id and return the updated row.
+pub(crate) async fn update_row(
+    pool: &DbPool,
+    template_id: i32,
+    changeset: &UpdateReportTemplateRow,
+) -> Result<ReportTemplateRow, ApiError> {
+    use crate::schema::report_templates::dsl::{id, report_templates};
+
+    with_connection(pool, |conn| {
+        diesel::update(report_templates.filter(id.eq(template_id)))
+            .set(changeset)
+            .get_result::<ReportTemplateRow>(conn)
+    })
+}
+
+/// Delete the report-template row with the given id.
+pub(crate) async fn delete_row(pool: &DbPool, template_id: i32) -> Result<(), ApiError> {
+    use crate::schema::report_templates::dsl::{id, report_templates};
+
+    with_connection(pool, |conn| {
+        diesel::delete(report_templates.filter(id.eq(template_id))).execute(conn)
+    })?;
+
+    Ok(())
+}
+
+/// Load all report-template rows in a namespace, optionally excluding one template id.
+pub(crate) async fn load_rows_in_namespace(
+    pool: &DbPool,
+    target_namespace_id: i32,
+    exclude_template_id: Option<i32>,
+) -> Result<Vec<ReportTemplateRow>, ApiError> {
+    use crate::schema::report_templates::dsl::{id, namespace_id, report_templates};
+
+    with_connection(pool, |conn| {
+        let mut query = report_templates
+            .into_boxed()
+            .filter(namespace_id.eq(target_namespace_id));
+        if let Some(exclude_template_id) = exclude_template_id {
+            query = query.filter(id.ne(exclude_template_id));
+        }
+        query.load::<ReportTemplateRow>(conn)
+    })
+}
+
+/// Load every report-template row.
+pub(crate) async fn load_all_rows(pool: &DbPool) -> Result<Vec<ReportTemplateRow>, ApiError> {
+    use crate::schema::report_templates::dsl::report_templates;
+
+    with_connection(pool, |conn| {
+        report_templates.load::<ReportTemplateRow>(conn)
+    })
+}
+
+/// Whether a template with `target_name` already exists in the namespace, optionally ignoring one
+/// template id (used so an update does not conflict with itself).
+pub(crate) async fn name_conflict_exists(
+    pool: &DbPool,
+    target_namespace_id: i32,
+    target_name: &str,
+    exclude_template_id: Option<i32>,
+) -> Result<bool, ApiError> {
+    use crate::schema::report_templates::dsl::{id, name, namespace_id, report_templates};
+
+    let existing = with_connection(pool, |conn| {
+        let mut query = report_templates
+            .into_boxed()
+            .filter(namespace_id.eq(target_namespace_id))
+            .filter(name.eq(target_name));
+        if let Some(exclude_template_id) = exclude_template_id {
+            query = query.filter(id.ne(exclude_template_id));
+        }
+        query.first::<ReportTemplateRow>(conn).optional()
+    })?;
+
+    Ok(existing.is_some())
+}
+
+/// The namespace a class belongs to, or `None` if the class does not exist.
+pub(crate) async fn class_namespace_id(
+    pool: &DbPool,
+    target_class_id: i32,
+) -> Result<Option<i32>, ApiError> {
+    use crate::schema::hubuumclass::dsl::{hubuumclass, id, namespace_id};
+
+    with_connection(pool, |conn| {
+        hubuumclass
+            .filter(id.eq(target_class_id))
+            .select(namespace_id)
+            .first::<i32>(conn)
+            .optional()
+    })
+}
+
+/// The namespace id of the report template with the given id.
+pub(crate) async fn namespace_id_for(pool: &DbPool, template_id: i32) -> Result<i32, ApiError> {
+    use crate::schema::report_templates::dsl::{id, namespace_id, report_templates};
+
+    with_connection(pool, |conn| {
+        report_templates
+            .filter(id.eq(template_id))
+            .select(namespace_id)
+            .first::<i32>(conn)
+    })
+}
+
+/// Build the filtered (but unsorted, unpaginated) query for listing report templates within the
+/// namespaces the caller may see.
+fn build_list_query<'a>(
+    allowed_namespace_ids: &'a [i32],
+    query_options: &'a QueryOptions,
+) -> Result<crate::schema::report_templates::BoxedQuery<'a, diesel::pg::Pg>, ApiError> {
+    use crate::schema::report_templates::dsl::{
+        class_id, created_at, description, id, kind, name, namespace_id, report_templates,
+        updated_at,
+    };
+
+    if allowed_namespace_ids.is_empty() {
+        return Ok(report_templates
+            .into_boxed()
+            .filter(namespace_id.eq_any(allowed_namespace_ids)));
+    }
+
+    let mut query = report_templates
+        .into_boxed()
+        .filter(namespace_id.eq_any(allowed_namespace_ids));
+
+    for param in &query_options.filters {
+        let operator = param.operator.clone();
+        match param.field {
+            FilterField::Id => numeric_search!(query, param, operator, id),
+            FilterField::Name => string_search!(query, param, operator, name),
+            FilterField::Description => string_search!(query, param, operator, description),
+            FilterField::Namespaces | FilterField::NamespaceId => {
+                numeric_search!(query, param, operator, namespace_id)
+            }
+            FilterField::Kind => string_search!(query, param, operator, kind),
+            FilterField::ClassId => numeric_search!(query, param, operator, class_id),
+            FilterField::CreatedAt => date_search!(query, param, operator, created_at),
+            FilterField::UpdatedAt => date_search!(query, param, operator, updated_at),
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' isn't searchable (or does not exist) for report templates",
+                    param.field
+                )));
+            }
+        }
+    }
+
+    Ok(query)
+}
+
+/// List report-template rows (sorted/paginated per `query_options`) together with the total count
+/// matching the filters, scoped to the namespaces the caller may see.
+pub(crate) async fn list_rows_with_total_count(
+    pool: &DbPool,
+    allowed_namespace_ids: &[i32],
+    query_options: &QueryOptions,
+) -> Result<(Vec<ReportTemplateRow>, i64), ApiError> {
+    let query = build_list_query(allowed_namespace_ids, query_options)?;
+    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
+
+    let mut query = build_list_query(allowed_namespace_ids, query_options)?;
+    crate::apply_query_options!(query, query_options, ReportTemplate);
+    let rows = with_connection(pool, |conn| query.load::<ReportTemplateRow>(conn))?;
+
+    Ok((rows, total_count))
+}

--- a/src/db/traits/task.rs
+++ b/src/db/traits/task.rs
@@ -386,33 +386,36 @@ pub trait TaskBackend: TaskIdentifier {
 impl<T: TaskIdentifier + ?Sized> TaskBackend for T {}
 
 #[cfg(test)]
-pub async fn create_task_record(
-    pool: &DbPool,
-    new_task: NewTaskRecord,
-) -> Result<TaskRecord, ApiError> {
-    use crate::schema::tasks::dsl::tasks;
+impl NewTaskRecord {
+    /// Insert this new task row and return the persisted record.
+    pub async fn create(self, pool: &DbPool) -> Result<TaskRecord, ApiError> {
+        use crate::schema::tasks::dsl::tasks;
 
-    with_connection(pool, |conn| {
-        diesel::insert_into(tasks)
-            .values(&new_task)
-            .get_result::<TaskRecord>(conn)
-    })
+        with_connection(pool, |conn| {
+            diesel::insert_into(tasks)
+                .values(&self)
+                .get_result::<TaskRecord>(conn)
+        })
+    }
 }
 
-pub async fn find_task_by_idempotency(
-    pool: &DbPool,
-    submitter_id: i32,
-    key: &str,
-) -> Result<Option<TaskRecord>, ApiError> {
-    use crate::schema::tasks::dsl::{idempotency_key, submitted_by, tasks};
+impl TaskRecord {
+    /// Find the task submitted by `submitter_id` carrying the given idempotency key, if any.
+    pub async fn find_by_idempotency(
+        pool: &DbPool,
+        submitter_id: i32,
+        key: &str,
+    ) -> Result<Option<TaskRecord>, ApiError> {
+        use crate::schema::tasks::dsl::{idempotency_key, submitted_by, tasks};
 
-    with_connection(pool, |conn| {
-        tasks
-            .filter(submitted_by.eq(Some(submitter_id)))
-            .filter(idempotency_key.eq(key))
-            .first::<TaskRecord>(conn)
-            .optional()
-    })
+        with_connection(pool, |conn| {
+            tasks
+                .filter(submitted_by.eq(Some(submitter_id)))
+                .filter(idempotency_key.eq(key))
+                .first::<TaskRecord>(conn)
+                .optional()
+        })
+    }
 }
 
 fn build_task_query<'a>(
@@ -545,17 +548,17 @@ fn decode_history_cursor_id(query_options: &QueryOptions) -> Result<Option<i32>,
     }
 }
 
-pub async fn append_task_event(
-    pool: &DbPool,
-    event: NewTaskEventRecord,
-) -> Result<TaskEventRecord, ApiError> {
-    use crate::schema::task_events::dsl::task_events;
+impl NewTaskEventRecord {
+    /// Append this event to its task's history and return the persisted event.
+    pub async fn append(self, pool: &DbPool) -> Result<TaskEventRecord, ApiError> {
+        use crate::schema::task_events::dsl::task_events;
 
-    with_connection(pool, |conn| {
-        diesel::insert_into(task_events)
-            .values(&event)
-            .get_result::<TaskEventRecord>(conn)
-    })
+        with_connection(pool, |conn| {
+            diesel::insert_into(task_events)
+                .values(&self)
+                .get_result::<TaskEventRecord>(conn)
+        })
+    }
 }
 
 pub async fn insert_import_results(
@@ -628,47 +631,51 @@ pub async fn claim_next_queued_task(pool: &DbPool) -> Result<Option<TaskRecord>,
     Ok(record)
 }
 
-pub async fn create_generic_task(
-    pool: &DbPool,
-    request: TaskCreateRequest,
-) -> Result<TaskRecord, ApiError> {
-    let task = with_transaction(pool, |conn| -> Result<TaskRecord, ApiError> {
-        insert_queued_task_with_event(conn, request)
-    })?;
+impl TaskCreateRequest {
+    /// Queue this task (with its initial "queued" event) in a single transaction.
+    pub async fn create_generic(self, pool: &DbPool) -> Result<TaskRecord, ApiError> {
+        let task = with_transaction(pool, |conn| -> Result<TaskRecord, ApiError> {
+            insert_queued_task_with_event(conn, self)
+        })?;
 
-    log_task_queued(&task);
+        log_task_queued(&task);
 
-    Ok(task)
-}
-
-pub async fn create_report_task_with_active_limit(
-    pool: &DbPool,
-    request: TaskCreateRequest,
-    max_active_report_tasks: usize,
-) -> Result<TaskRecord, ApiError> {
-    if request.kind != TaskKind::Report {
-        return Err(ApiError::BadRequest(
-            "create_report_task_with_active_limit only accepts report tasks".to_string(),
-        ));
+        Ok(task)
     }
 
-    let max_active_report_tasks = i64::try_from(max_active_report_tasks).unwrap_or(i64::MAX);
-    let submitter_id = request.submitted_by;
-    let task = with_transaction(pool, |conn| -> Result<TaskRecord, ApiError> {
-        acquire_report_task_capacity_lock(conn, submitter_id)?;
-        let active_count = count_active_report_tasks_for_user_in_transaction(conn, submitter_id)?;
-        if active_count >= max_active_report_tasks {
-            return Err(ApiError::TooManyRequests(format!(
-                "Too many active report tasks for user ({active_count} >= {max_active_report_tasks}); wait for queued or running reports to finish"
-            )));
+    /// Queue this report task, rejecting it with `429` if the submitter already has
+    /// `max_active_report_tasks` queued/validating/running reports. Capacity is checked under a
+    /// per-user advisory lock so concurrent submissions cannot race past the limit.
+    pub async fn create_with_active_report_limit(
+        self,
+        pool: &DbPool,
+        max_active_report_tasks: usize,
+    ) -> Result<TaskRecord, ApiError> {
+        if self.kind != TaskKind::Report {
+            return Err(ApiError::BadRequest(
+                "create_with_active_report_limit only accepts report tasks".to_string(),
+            ));
         }
 
-        insert_queued_task_with_event(conn, request)
-    })?;
+        let max_active_report_tasks = i64::try_from(max_active_report_tasks).unwrap_or(i64::MAX);
+        let submitter_id = self.submitted_by;
+        let task = with_transaction(pool, |conn| -> Result<TaskRecord, ApiError> {
+            acquire_report_task_capacity_lock(conn, submitter_id)?;
+            let active_count =
+                count_active_report_tasks_for_user_in_transaction(conn, submitter_id)?;
+            if active_count >= max_active_report_tasks {
+                return Err(ApiError::TooManyRequests(format!(
+                    "Too many active report tasks for user ({active_count} >= {max_active_report_tasks}); wait for queued or running reports to finish"
+                )));
+            }
 
-    log_task_queued(&task);
+            insert_queued_task_with_event(conn, self)
+        })?;
 
-    Ok(task)
+        log_task_queued(&task);
+
+        Ok(task)
+    }
 }
 
 fn insert_queued_task_with_event(
@@ -771,10 +778,7 @@ mod tests {
     use std::sync::mpsc;
     use std::thread;
 
-    use super::{
-        TaskBackend, TaskCreateRequest, claim_next_queued_task,
-        create_report_task_with_active_limit, create_task_record,
-    };
+    use super::{TaskBackend, TaskCreateRequest, claim_next_queued_task};
     use crate::db::traits::user::DeleteUserRecord;
     use crate::db::with_transaction;
     use crate::errors::ApiError;
@@ -789,8 +793,7 @@ mod tests {
         let claim_prefix = context.scoped_name("claim");
 
         for index in 0..3 {
-            let task = block_on(create_task_record(
-                &context.pool,
+            let task = block_on(
                 NewTaskRecord {
                     kind: TaskKind::Import.as_str().to_string(),
                     status: TaskStatus::Queued.as_str().to_string(),
@@ -806,8 +809,9 @@ mod tests {
                     request_redacted_at: None,
                     started_at: None,
                     finished_at: None,
-                },
-            ))
+                }
+                .create(&context.pool),
+            )
             .unwrap();
             created_ids.push(task.id);
         }
@@ -872,8 +876,7 @@ mod tests {
     fn test_task_history_survives_user_deletion() {
         let context = block_on(TestContext::new());
         let task_owner = block_on(create_test_user(&context.pool));
-        let task = block_on(create_task_record(
-            &context.pool,
+        let task = block_on(
             NewTaskRecord {
                 kind: TaskKind::Import.as_str().to_string(),
                 status: TaskStatus::Succeeded.as_str().to_string(),
@@ -889,8 +892,9 @@ mod tests {
                 request_redacted_at: None,
                 started_at: None,
                 finished_at: None,
-            },
-        ))
+            }
+            .create(&context.pool),
+        )
         .unwrap();
 
         block_on(task_owner.delete_user_record(&context.pool)).unwrap();
@@ -902,8 +906,7 @@ mod tests {
     #[test]
     fn test_report_task_active_limit_blocks_new_work_for_same_user() {
         let context = block_on(TestContext::new());
-        let first = block_on(create_report_task_with_active_limit(
-            &context.pool,
+        let first = block_on(
             TaskCreateRequest {
                 kind: TaskKind::Report,
                 submitted_by: context.admin_user.id,
@@ -911,15 +914,14 @@ mod tests {
                 request_hash: Some(context.scoped_name("report-cap-first-hash")),
                 request_payload: serde_json::json!({"report": "first"}),
                 total_items: 1,
-            },
-            1,
-        ))
+            }
+            .create_with_active_report_limit(&context.pool, 1),
+        )
         .unwrap();
 
         assert_eq!(first.status, TaskStatus::Queued.as_str());
 
-        let error = block_on(create_report_task_with_active_limit(
-            &context.pool,
+        let error = block_on(
             TaskCreateRequest {
                 kind: TaskKind::Report,
                 submitted_by: context.admin_user.id,
@@ -927,9 +929,9 @@ mod tests {
                 request_hash: Some(context.scoped_name("report-cap-second-hash")),
                 request_payload: serde_json::json!({"report": "second"}),
                 total_items: 1,
-            },
-            1,
-        ))
+            }
+            .create_with_active_report_limit(&context.pool, 1),
+        )
         .unwrap_err();
 
         match error {

--- a/src/db/traits/task.rs
+++ b/src/db/traits/task.rs
@@ -12,7 +12,7 @@ use crate::models::search::QueryOptions;
 use crate::models::{
     ImportTaskResultRecord, NewImportTaskResultRecord, NewReportTaskOutputRecord,
     NewTaskEventRecord, NewTaskRecord, ReportTaskOutputRecord, ReportTaskOutputSummaryRecord,
-    TaskEventRecord, TaskKind, TaskRecord, TaskResponse, TaskResultCounts, TaskStatus,
+    TaskEventRecord, TaskID, TaskKind, TaskRecord, TaskResponse, TaskResultCounts, TaskStatus,
 };
 use crate::pagination::{CursorValue, decode_cursor_values, page_limits_or_defaults};
 
@@ -41,6 +41,350 @@ struct AdvisoryLockRow {
     locked: bool,
 }
 
+/// Anything that can name a task for a backend query: a [`TaskID`] from a request path or an
+/// already-loaded [`TaskRecord`] (and references to either). The required `task_id` resolves the
+/// raw id at the persistence boundary so it never leaks into the domain.
+pub trait TaskIdentifier {
+    fn task_id(&self) -> i32;
+}
+
+impl TaskIdentifier for TaskID {
+    fn task_id(&self) -> i32 {
+        self.id()
+    }
+}
+
+impl TaskIdentifier for TaskRecord {
+    fn task_id(&self) -> i32 {
+        self.id
+    }
+}
+
+impl<T: TaskIdentifier + ?Sized> TaskIdentifier for &T {
+    fn task_id(&self) -> i32 {
+        (**self).task_id()
+    }
+}
+
+/// Single-task backend persistence, as self-methods on any [`TaskIdentifier`]. Callers write
+/// `task.find_record(pool)` / `task.update_state(pool, ..)` rather than passing a bare id to a free
+/// function; all Diesel query construction stays here in the backend layer.
+pub trait TaskBackend: TaskIdentifier {
+    async fn find_record(&self, pool: &DbPool) -> Result<TaskRecord, ApiError> {
+        use crate::schema::tasks::dsl::{id, tasks};
+
+        let task_id_value = self.task_id();
+        with_connection(pool, |conn| {
+            tasks.filter(id.eq(task_id_value)).first::<TaskRecord>(conn)
+        })
+    }
+
+    async fn list_events_with_total_count(
+        &self,
+        pool: &DbPool,
+        query_options: &QueryOptions,
+    ) -> Result<(Vec<TaskEventRecord>, i64), ApiError> {
+        use crate::schema::task_events::dsl::{id, task_events, task_id};
+
+        let task_id_value = self.task_id();
+        let limit = query_options
+            .limit
+            .unwrap_or(page_limits_or_defaults().0.saturating_add(1));
+        let descending = query_options
+            .sort
+            .first()
+            .map(|sort| sort.descending)
+            .unwrap_or(false);
+        let cursor_id = decode_history_cursor_id(query_options)?;
+
+        let total_count = with_connection(pool, |conn| {
+            task_events
+                .filter(task_id.eq(task_id_value))
+                .count()
+                .get_result::<i64>(conn)
+        })?;
+
+        let items = with_connection(pool, |conn| {
+            let mut query = task_events.filter(task_id.eq(task_id_value)).into_boxed();
+            if let Some(cursor_id) = cursor_id {
+                query = if descending {
+                    query.filter(id.lt(cursor_id))
+                } else {
+                    query.filter(id.gt(cursor_id))
+                };
+            }
+
+            if descending {
+                query
+                    .order(id.desc())
+                    .limit(limit as i64)
+                    .load::<TaskEventRecord>(conn)
+            } else {
+                query
+                    .order(id.asc())
+                    .limit(limit as i64)
+                    .load::<TaskEventRecord>(conn)
+            }
+        })?;
+
+        Ok((items, total_count))
+    }
+
+    async fn list_import_results_with_total_count(
+        &self,
+        pool: &DbPool,
+        query_options: &QueryOptions,
+    ) -> Result<(Vec<ImportTaskResultRecord>, i64), ApiError> {
+        use crate::schema::import_task_results::dsl::{id, import_task_results, task_id};
+
+        let task_id_value = self.task_id();
+        let limit = query_options
+            .limit
+            .unwrap_or(page_limits_or_defaults().0.saturating_add(1));
+        let descending = query_options
+            .sort
+            .first()
+            .map(|sort| sort.descending)
+            .unwrap_or(false);
+        let cursor_id = decode_history_cursor_id(query_options)?;
+
+        let total_count = with_connection(pool, |conn| {
+            import_task_results
+                .filter(task_id.eq(task_id_value))
+                .count()
+                .get_result::<i64>(conn)
+        })?;
+
+        let items = with_connection(pool, |conn| {
+            let mut query = import_task_results
+                .filter(task_id.eq(task_id_value))
+                .into_boxed();
+            if let Some(cursor_id) = cursor_id {
+                query = if descending {
+                    query.filter(id.lt(cursor_id))
+                } else {
+                    query.filter(id.gt(cursor_id))
+                };
+            }
+
+            if descending {
+                query
+                    .order(id.desc())
+                    .limit(limit as i64)
+                    .load::<ImportTaskResultRecord>(conn)
+            } else {
+                query
+                    .order(id.asc())
+                    .limit(limit as i64)
+                    .load::<ImportTaskResultRecord>(conn)
+            }
+        })?;
+
+        Ok((items, total_count))
+    }
+
+    async fn find_report_output(
+        &self,
+        pool: &DbPool,
+    ) -> Result<Option<ReportTaskOutputRecord>, ApiError> {
+        use crate::schema::report_task_outputs::dsl::{
+            output_expires_at, report_task_outputs, task_id,
+        };
+
+        let task_id_value = self.task_id();
+        let now = Utc::now().naive_utc();
+        with_connection(pool, |conn| {
+            report_task_outputs
+                .filter(task_id.eq(task_id_value))
+                .filter(output_expires_at.gt(now))
+                .first::<ReportTaskOutputRecord>(conn)
+                .optional()
+        })
+    }
+
+    async fn find_report_output_summary(
+        &self,
+        pool: &DbPool,
+    ) -> Result<Option<ReportTaskOutputSummaryRecord>, ApiError> {
+        use crate::schema::report_task_outputs::dsl::{
+            output_expires_at, report_task_outputs, task_id,
+        };
+
+        let task_id_value = self.task_id();
+        let now = Utc::now().naive_utc();
+        with_connection(pool, |conn| {
+            report_task_outputs
+                .filter(task_id.eq(task_id_value))
+                .filter(output_expires_at.gt(now))
+                .select(ReportTaskOutputSummaryRecord::as_select())
+                .first(conn)
+                .optional()
+        })
+    }
+
+    async fn count_import_results(&self, pool: &DbPool) -> Result<TaskResultCounts, ApiError> {
+        use crate::schema::import_task_results::dsl::{import_task_results, outcome, task_id};
+
+        let task_id_value = self.task_id();
+        with_connection(pool, |conn| -> Result<TaskResultCounts, ApiError> {
+            let processed = import_task_results
+                .filter(task_id.eq(task_id_value))
+                .count()
+                .get_result::<i64>(conn)?;
+            let failed = import_task_results
+                .filter(task_id.eq(task_id_value))
+                .filter(outcome.eq("failed"))
+                .count()
+                .get_result::<i64>(conn)?;
+            TaskResultCounts::new(processed, processed - failed, failed)
+        })
+    }
+
+    async fn update_state(
+        &self,
+        pool: &DbPool,
+        update: TaskStateUpdate,
+    ) -> Result<TaskRecord, ApiError> {
+        use crate::schema::tasks::dsl::{
+            failed_items, finished_at, id, processed_items, started_at, status, success_items,
+            summary, tasks, updated_at,
+        };
+
+        let task_id_value = self.task_id();
+        let now = Utc::now().naive_utc();
+        let record = with_connection(pool, |conn| {
+            diesel::update(tasks.filter(id.eq(task_id_value)))
+                .set((
+                    status.eq(update.status.as_str()),
+                    summary.eq(update.summary),
+                    processed_items.eq(update.processed_items),
+                    success_items.eq(update.success_items),
+                    failed_items.eq(update.failed_items),
+                    started_at.eq(update.started_at),
+                    finished_at.eq(update.finished_at),
+                    updated_at.eq(now),
+                ))
+                .get_result::<TaskRecord>(conn)
+        })?;
+
+        info!(
+            message = "Task state updated",
+            task_id = record.id,
+            task_kind = record.kind.as_str(),
+            status = record.status.as_str(),
+            processed_items = record.processed_items,
+            success_items = record.success_items,
+            failed_items = record.failed_items
+        );
+
+        Ok(record)
+    }
+
+    async fn finalize_terminal(
+        &self,
+        pool: &DbPool,
+        update: TaskStateUpdate,
+        event: NewTaskEventRecord,
+    ) -> Result<TaskRecord, ApiError> {
+        use crate::schema::task_events::dsl::task_events;
+        use crate::schema::tasks::dsl::{
+            failed_items, finished_at, id, processed_items, request_payload, request_redacted_at,
+            started_at, status, success_items, summary, tasks, updated_at,
+        };
+
+        let task_id_value = self.task_id();
+        let record = with_transaction(pool, |conn| {
+            let event_record = diesel::insert_into(task_events)
+                .values(event)
+                .get_result::<TaskEventRecord>(conn)?;
+
+            diesel::update(tasks.filter(id.eq(task_id_value)))
+                .set((
+                    status.eq(update.status.as_str()),
+                    summary.eq(update.summary),
+                    processed_items.eq(update.processed_items),
+                    success_items.eq(update.success_items),
+                    failed_items.eq(update.failed_items),
+                    started_at.eq(update.started_at),
+                    finished_at.eq(Some(event_record.created_at)),
+                    request_payload.eq::<Option<serde_json::Value>>(None),
+                    request_redacted_at.eq(event_record.created_at),
+                    updated_at.eq(event_record.created_at),
+                ))
+                .get_result::<TaskRecord>(conn)
+        })?;
+
+        info!(
+            message = "Task reached terminal state",
+            task_id = record.id,
+            task_kind = record.kind.as_str(),
+            status = record.status.as_str(),
+            processed_items = record.processed_items,
+            success_items = record.success_items,
+            failed_items = record.failed_items,
+            summary = record.summary.as_deref()
+        );
+
+        Ok(record)
+    }
+
+    async fn finalize_report_with_output(
+        &self,
+        pool: &DbPool,
+        update: TaskStateUpdate,
+        event: NewTaskEventRecord,
+        output: NewReportTaskOutputRecord,
+    ) -> Result<TaskRecord, ApiError> {
+        use crate::schema::report_task_outputs::dsl::report_task_outputs;
+        use crate::schema::task_events::dsl::task_events;
+        use crate::schema::tasks::dsl::{
+            failed_items, finished_at, id, processed_items, request_payload, request_redacted_at,
+            started_at, status, success_items, summary, tasks, updated_at,
+        };
+
+        let task_id_value = self.task_id();
+        let record = with_transaction(pool, |conn| {
+            diesel::insert_into(report_task_outputs)
+                .values(output)
+                .execute(conn)?;
+
+            let event_record = diesel::insert_into(task_events)
+                .values(event)
+                .get_result::<TaskEventRecord>(conn)?;
+
+            diesel::update(tasks.filter(id.eq(task_id_value)))
+                .set((
+                    status.eq(update.status.as_str()),
+                    summary.eq(update.summary),
+                    processed_items.eq(update.processed_items),
+                    success_items.eq(update.success_items),
+                    failed_items.eq(update.failed_items),
+                    started_at.eq(update.started_at),
+                    finished_at.eq(Some(event_record.created_at)),
+                    request_payload.eq::<Option<serde_json::Value>>(None),
+                    request_redacted_at.eq(event_record.created_at),
+                    updated_at.eq(event_record.created_at),
+                ))
+                .get_result::<TaskRecord>(conn)
+        })?;
+
+        info!(
+            message = "Report task output stored and task finalized",
+            task_id = record.id,
+            task_kind = record.kind.as_str(),
+            status = record.status.as_str(),
+            processed_items = record.processed_items,
+            success_items = record.success_items,
+            failed_items = record.failed_items,
+            summary = record.summary.as_deref()
+        );
+
+        Ok(record)
+    }
+}
+
+impl<T: TaskIdentifier + ?Sized> TaskBackend for T {}
+
 #[cfg(test)]
 pub async fn create_task_record(
     pool: &DbPool,
@@ -52,14 +396,6 @@ pub async fn create_task_record(
         diesel::insert_into(tasks)
             .values(&new_task)
             .get_result::<TaskRecord>(conn)
-    })
-}
-
-pub async fn find_task_record(pool: &DbPool, task_id: i32) -> Result<TaskRecord, ApiError> {
-    use crate::schema::tasks::dsl::{id, tasks};
-
-    with_connection(pool, |conn| {
-        tasks.filter(id.eq(task_id)).first::<TaskRecord>(conn)
     })
 }
 
@@ -123,145 +459,6 @@ pub async fn list_tasks_with_total_count(
     })?;
 
     Ok((items, total_count))
-}
-
-pub async fn list_task_events_with_total_count(
-    pool: &DbPool,
-    task_id_value: i32,
-    query_options: &QueryOptions,
-) -> Result<(Vec<TaskEventRecord>, i64), ApiError> {
-    use crate::schema::task_events::dsl::{id, task_events, task_id};
-
-    let limit = query_options
-        .limit
-        .unwrap_or(page_limits_or_defaults().0.saturating_add(1));
-    let descending = query_options
-        .sort
-        .first()
-        .map(|sort| sort.descending)
-        .unwrap_or(false);
-    let cursor_id = decode_history_cursor_id(query_options)?;
-
-    let total_count = with_connection(pool, |conn| {
-        task_events
-            .filter(task_id.eq(task_id_value))
-            .count()
-            .get_result::<i64>(conn)
-    })?;
-
-    let items = with_connection(pool, |conn| {
-        let mut query = task_events.filter(task_id.eq(task_id_value)).into_boxed();
-        if let Some(cursor_id) = cursor_id {
-            query = if descending {
-                query.filter(id.lt(cursor_id))
-            } else {
-                query.filter(id.gt(cursor_id))
-            };
-        }
-
-        if descending {
-            query
-                .order(id.desc())
-                .limit(limit as i64)
-                .load::<TaskEventRecord>(conn)
-        } else {
-            query
-                .order(id.asc())
-                .limit(limit as i64)
-                .load::<TaskEventRecord>(conn)
-        }
-    })?;
-
-    Ok((items, total_count))
-}
-
-pub async fn list_import_results_with_total_count(
-    pool: &DbPool,
-    task_id_value: i32,
-    query_options: &QueryOptions,
-) -> Result<(Vec<ImportTaskResultRecord>, i64), ApiError> {
-    use crate::schema::import_task_results::dsl::{id, import_task_results, task_id};
-
-    let limit = query_options
-        .limit
-        .unwrap_or(page_limits_or_defaults().0.saturating_add(1));
-    let descending = query_options
-        .sort
-        .first()
-        .map(|sort| sort.descending)
-        .unwrap_or(false);
-    let cursor_id = decode_history_cursor_id(query_options)?;
-
-    let total_count = with_connection(pool, |conn| {
-        import_task_results
-            .filter(task_id.eq(task_id_value))
-            .count()
-            .get_result::<i64>(conn)
-    })?;
-
-    let items = with_connection(pool, |conn| {
-        let mut query = import_task_results
-            .filter(task_id.eq(task_id_value))
-            .into_boxed();
-        if let Some(cursor_id) = cursor_id {
-            query = if descending {
-                query.filter(id.lt(cursor_id))
-            } else {
-                query.filter(id.gt(cursor_id))
-            };
-        }
-
-        if descending {
-            query
-                .order(id.desc())
-                .limit(limit as i64)
-                .load::<ImportTaskResultRecord>(conn)
-        } else {
-            query
-                .order(id.asc())
-                .limit(limit as i64)
-                .load::<ImportTaskResultRecord>(conn)
-        }
-    })?;
-
-    Ok((items, total_count))
-}
-
-pub async fn find_report_task_output(
-    pool: &DbPool,
-    task_id_value: i32,
-) -> Result<Option<ReportTaskOutputRecord>, ApiError> {
-    use crate::schema::report_task_outputs::dsl::{
-        output_expires_at, report_task_outputs, task_id,
-    };
-
-    let now = Utc::now().naive_utc();
-    with_connection(pool, |conn| {
-        report_task_outputs
-            .filter(task_id.eq(task_id_value))
-            .filter(output_expires_at.gt(now))
-            .first::<ReportTaskOutputRecord>(conn)
-            .optional()
-    })
-}
-
-pub async fn find_report_task_output_summary(
-    pool: &DbPool,
-    task_id_value: i32,
-) -> Result<Option<ReportTaskOutputSummaryRecord>, ApiError> {
-    use crate::schema::report_task_outputs::dsl::{
-        output_expires_at, report_task_outputs, task_id,
-    };
-
-    let now = Utc::now().naive_utc();
-    with_connection(pool, |conn| {
-        report_task_outputs
-            .filter(task_id.eq(task_id_value))
-            .filter(output_expires_at.gt(now))
-            .select(ReportTaskOutputSummaryRecord::as_select())
-            .first(conn)
-            .optional()
-    })
 }
 
 pub async fn list_report_task_output_summaries(
@@ -332,26 +529,6 @@ pub async fn purge_expired_report_outputs(pool: &DbPool) -> Result<Vec<i32>, Api
     Ok(expired_task_ids)
 }
 
-pub async fn count_import_results_summary(
-    pool: &DbPool,
-    task_id_value: i32,
-) -> Result<TaskResultCounts, ApiError> {
-    use crate::schema::import_task_results::dsl::{import_task_results, outcome, task_id};
-
-    with_connection(pool, |conn| -> Result<TaskResultCounts, ApiError> {
-        let processed = import_task_results
-            .filter(task_id.eq(task_id_value))
-            .count()
-            .get_result::<i64>(conn)?;
-        let failed = import_task_results
-            .filter(task_id.eq(task_id_value))
-            .filter(outcome.eq("failed"))
-            .count()
-            .get_result::<i64>(conn)?;
-        TaskResultCounts::new(processed, processed - failed, failed)
-    })
-}
-
 fn decode_history_cursor_id(query_options: &QueryOptions) -> Result<Option<i32>, ApiError> {
     let Some(cursor) = &query_options.cursor else {
         return Ok(None);
@@ -396,145 +573,6 @@ pub async fn insert_import_results(
             .values(entries)
             .execute(conn)
     })
-}
-
-pub async fn update_task_state(
-    pool: &DbPool,
-    task_id_value: i32,
-    update: TaskStateUpdate,
-) -> Result<TaskRecord, ApiError> {
-    use crate::schema::tasks::dsl::{
-        failed_items, finished_at, id, processed_items, started_at, status, success_items, summary,
-        tasks, updated_at,
-    };
-
-    let now = Utc::now().naive_utc();
-    let record = with_connection(pool, |conn| {
-        diesel::update(tasks.filter(id.eq(task_id_value)))
-            .set((
-                status.eq(update.status.as_str()),
-                summary.eq(update.summary),
-                processed_items.eq(update.processed_items),
-                success_items.eq(update.success_items),
-                failed_items.eq(update.failed_items),
-                started_at.eq(update.started_at),
-                finished_at.eq(update.finished_at),
-                updated_at.eq(now),
-            ))
-            .get_result::<TaskRecord>(conn)
-    })?;
-
-    info!(
-        message = "Task state updated",
-        task_id = record.id,
-        task_kind = record.kind.as_str(),
-        status = record.status.as_str(),
-        processed_items = record.processed_items,
-        success_items = record.success_items,
-        failed_items = record.failed_items
-    );
-
-    Ok(record)
-}
-
-pub async fn finalize_task_terminal_state(
-    pool: &DbPool,
-    task_id_value: i32,
-    update: TaskStateUpdate,
-    event: NewTaskEventRecord,
-) -> Result<TaskRecord, ApiError> {
-    use crate::schema::task_events::dsl::task_events;
-    use crate::schema::tasks::dsl::{
-        failed_items, finished_at, id, processed_items, request_payload, request_redacted_at,
-        started_at, status, success_items, summary, tasks, updated_at,
-    };
-
-    let record = with_transaction(pool, |conn| {
-        let event_record = diesel::insert_into(task_events)
-            .values(event)
-            .get_result::<TaskEventRecord>(conn)?;
-
-        diesel::update(tasks.filter(id.eq(task_id_value)))
-            .set((
-                status.eq(update.status.as_str()),
-                summary.eq(update.summary),
-                processed_items.eq(update.processed_items),
-                success_items.eq(update.success_items),
-                failed_items.eq(update.failed_items),
-                started_at.eq(update.started_at),
-                finished_at.eq(Some(event_record.created_at)),
-                request_payload.eq::<Option<serde_json::Value>>(None),
-                request_redacted_at.eq(event_record.created_at),
-                updated_at.eq(event_record.created_at),
-            ))
-            .get_result::<TaskRecord>(conn)
-    })?;
-
-    info!(
-        message = "Task reached terminal state",
-        task_id = record.id,
-        task_kind = record.kind.as_str(),
-        status = record.status.as_str(),
-        processed_items = record.processed_items,
-        success_items = record.success_items,
-        failed_items = record.failed_items,
-        summary = record.summary.as_deref()
-    );
-
-    Ok(record)
-}
-
-pub async fn finalize_report_task_with_output(
-    pool: &DbPool,
-    task_id_value: i32,
-    update: TaskStateUpdate,
-    event: NewTaskEventRecord,
-    output: NewReportTaskOutputRecord,
-) -> Result<TaskRecord, ApiError> {
-    use crate::schema::report_task_outputs::dsl::report_task_outputs;
-    use crate::schema::task_events::dsl::task_events;
-    use crate::schema::tasks::dsl::{
-        failed_items, finished_at, id, processed_items, request_payload, request_redacted_at,
-        started_at, status, success_items, summary, tasks, updated_at,
-    };
-
-    let record = with_transaction(pool, |conn| {
-        diesel::insert_into(report_task_outputs)
-            .values(output)
-            .execute(conn)?;
-
-        let event_record = diesel::insert_into(task_events)
-            .values(event)
-            .get_result::<TaskEventRecord>(conn)?;
-
-        diesel::update(tasks.filter(id.eq(task_id_value)))
-            .set((
-                status.eq(update.status.as_str()),
-                summary.eq(update.summary),
-                processed_items.eq(update.processed_items),
-                success_items.eq(update.success_items),
-                failed_items.eq(update.failed_items),
-                started_at.eq(update.started_at),
-                finished_at.eq(Some(event_record.created_at)),
-                request_payload.eq::<Option<serde_json::Value>>(None),
-                request_redacted_at.eq(event_record.created_at),
-                updated_at.eq(event_record.created_at),
-            ))
-            .get_result::<TaskRecord>(conn)
-    })?;
-
-    info!(
-        message = "Report task output stored and task finalized",
-        task_id = record.id,
-        task_kind = record.kind.as_str(),
-        status = record.status.as_str(),
-        processed_items = record.processed_items,
-        success_items = record.success_items,
-        failed_items = record.failed_items,
-        summary = record.summary.as_deref()
-    );
-
-    Ok(record)
 }
 
 pub async fn claim_next_queued_task(pool: &DbPool) -> Result<Option<TaskRecord>, ApiError> {
@@ -734,14 +772,14 @@ mod tests {
     use std::thread;
 
     use super::{
-        TaskCreateRequest, claim_next_queued_task, create_report_task_with_active_limit,
-        create_task_record, find_task_record, list_task_events_with_total_count,
+        TaskBackend, TaskCreateRequest, claim_next_queued_task,
+        create_report_task_with_active_limit, create_task_record,
     };
     use crate::db::traits::user::DeleteUserRecord;
     use crate::db::with_transaction;
     use crate::errors::ApiError;
     use crate::models::search::QueryOptions;
-    use crate::models::{NewTaskRecord, TaskKind, TaskStatus};
+    use crate::models::{NewTaskRecord, TaskID, TaskKind, TaskStatus};
     use crate::tests::{TestContext, create_test_user};
 
     #[test]
@@ -807,16 +845,19 @@ mod tests {
         assert_ne!(claimed.unwrap(), locked_id);
         assert!(created_ids.contains(&locked_id));
 
-        let (claimed_events, _) = block_on(list_task_events_with_total_count(
-            &context.pool,
-            claimed.unwrap(),
-            &QueryOptions {
-                filters: Vec::new(),
-                sort: Vec::new(),
-                limit: None,
-                cursor: None,
-            },
-        ))
+        let (claimed_events, _) = block_on(
+            TaskID::new(claimed.unwrap())
+                .unwrap()
+                .list_events_with_total_count(
+                    &context.pool,
+                    &QueryOptions {
+                        filters: Vec::new(),
+                        sort: Vec::new(),
+                        limit: None,
+                        cursor: None,
+                    },
+                ),
+        )
         .unwrap();
         assert_eq!(
             claimed_events
@@ -854,7 +895,7 @@ mod tests {
 
         block_on(task_owner.delete_user_record(&context.pool)).unwrap();
 
-        let stored = block_on(find_task_record(&context.pool, task.id)).unwrap();
+        let stored = block_on(task.find_record(&context.pool)).unwrap();
         assert_eq!(stored.submitted_by, None);
     }
 

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -67,6 +67,39 @@ pub struct HubuumClassWithPath {
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
 pub struct HubuumClassID(pub i32);
 
+/// A normalized set of class ids: deduplicated, sorted ascending, and guaranteed positive.
+///
+/// Construct via [`ClassIdSet::new`]; the inner vec stays private so the "sorted, deduped,
+/// positive" invariant holds for every consumer — including callers that `binary_search` the
+/// set and rely on the ordering. Bulk class-keyed backend lookups hang off this type (see
+/// `crate::db::traits::class`).
+#[derive(Debug, Clone)]
+pub(crate) struct ClassIdSet(Vec<i32>);
+
+impl ClassIdSet {
+    /// Normalize an iterator of class ids into a set, rejecting non-positive ids.
+    pub(crate) fn new(ids: impl IntoIterator<Item = i32>) -> Result<Self, ApiError> {
+        let mut ids = ids.into_iter().collect::<Vec<_>>();
+        if ids.iter().any(|class_id| *class_id <= 0) {
+            return Err(ApiError::BadRequest(
+                "class ids must be greater than 0".to_string(),
+            ));
+        }
+        ids.sort_unstable();
+        ids.dedup();
+        Ok(Self(ids))
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// The normalized ids, sorted ascending and deduplicated.
+    pub(crate) fn as_slice(&self) -> &[i32] {
+        &self.0
+    }
+}
+
 pub async fn total_class_count<C>(backend: &C) -> Result<i64, ApiError>
 where
     C: BackendContext + ?Sized,

--- a/src/models/report.rs
+++ b/src/models/report.rs
@@ -177,6 +177,91 @@ pub struct ReportInclude {
     pub related_objects: Option<HashMap<String, ReportIncludeRelatedObject>>,
 }
 
+/// Bounds for `include.related_objects` hydration, shared by ad-hoc report requests
+/// (`POST /api/v1/reports`) and stored executable report templates so the two paths cannot drift.
+pub const RELATED_INCLUDE_DEFAULT_MAX_DEPTH: i32 = 1;
+pub const RELATED_INCLUDE_MAX_DEPTH_LIMIT: i32 = 10;
+pub const RELATED_INCLUDE_DEFAULT_LIMIT: i32 = 1;
+pub const RELATED_INCLUDE_MAX_LIMIT: i32 = 50;
+pub const RELATED_INCLUDE_MAX_ALIASES: usize = 8;
+
+impl ReportInclude {
+    /// Validate the `related_objects` block: alias count, alias syntax, and per-alias option
+    /// bounds. Callers enforce scope-specific rules (e.g. that `include` is only valid for
+    /// `objects_in_class`).
+    pub fn validate_related_objects(&self) -> Result<(), ApiError> {
+        let Some(related_objects) = &self.related_objects else {
+            return Ok(());
+        };
+
+        if related_objects.len() > RELATED_INCLUDE_MAX_ALIASES {
+            return Err(ApiError::BadRequest(format!(
+                "include.related_objects supports at most {RELATED_INCLUDE_MAX_ALIASES} aliases"
+            )));
+        }
+
+        for (alias, include) in related_objects {
+            validate_related_include_alias(alias)?;
+            include.validate(alias)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl ReportIncludeRelatedObject {
+    fn validate(&self, alias: &str) -> Result<(), ApiError> {
+        if self.class_id <= 0 {
+            return Err(ApiError::BadRequest(format!(
+                "include.related_objects.{alias}.class_id must be greater than 0"
+            )));
+        }
+
+        if let Some(class_relation_id) = self.class_relation_id
+            && class_relation_id <= 0
+        {
+            return Err(ApiError::BadRequest(format!(
+                "include.related_objects.{alias}.class_relation_id must be greater than 0"
+            )));
+        }
+
+        let max_depth = self.max_depth.unwrap_or(RELATED_INCLUDE_DEFAULT_MAX_DEPTH);
+        if !(1..=RELATED_INCLUDE_MAX_DEPTH_LIMIT).contains(&max_depth) {
+            return Err(ApiError::BadRequest(format!(
+                "include.related_objects.{alias}.max_depth must be between 1 and {RELATED_INCLUDE_MAX_DEPTH_LIMIT}"
+            )));
+        }
+
+        let limit = self.limit.unwrap_or(RELATED_INCLUDE_DEFAULT_LIMIT);
+        if !(1..=RELATED_INCLUDE_MAX_LIMIT).contains(&limit) {
+            return Err(ApiError::BadRequest(format!(
+                "include.related_objects.{alias}.limit must be between 1 and {RELATED_INCLUDE_MAX_LIMIT}"
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+fn validate_related_include_alias(alias: &str) -> Result<(), ApiError> {
+    let mut chars = alias.chars();
+    let Some(first) = chars.next() else {
+        return Err(ApiError::BadRequest(
+            "include.related_objects aliases must not be empty".to_string(),
+        ));
+    };
+
+    if !(first == '_' || first.is_ascii_alphabetic())
+        || !chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+    {
+        return Err(ApiError::BadRequest(format!(
+            "Invalid include.related_objects alias '{alias}'; expected [A-Za-z_][A-Za-z0-9_]*"
+        )));
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[schema(example = openapi_examples::report_relation_context_example)]
 #[serde(deny_unknown_fields)]

--- a/src/models/report.rs
+++ b/src/models/report.rs
@@ -241,6 +241,13 @@ impl ReportScopeKind {
             ReportScopeKind::RelatedObjects => "related_objects",
         }
     }
+
+    /// Whether this scope targets a single class and therefore needs a `class_id`.
+    /// The collection scopes (`namespaces`, `classes`, `class_relations`,
+    /// `object_relations`) are class-agnostic.
+    pub fn requires_class_id(self) -> bool {
+        matches!(self, Self::ObjectsInClass | Self::RelatedObjects)
+    }
 }
 
 impl FromStr for ReportScopeKind {

--- a/src/models/report.rs
+++ b/src/models/report.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -120,13 +121,6 @@ impl ReportContentType {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
-#[schema(example = openapi_examples::report_output_example)]
-#[serde(deny_unknown_fields)]
-pub struct ReportOutputRequest {
-    pub template_id: Option<i32>,
-}
-
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ReportMissingDataPolicy {
@@ -195,7 +189,6 @@ pub struct ReportRelationContext {
 pub struct ReportRequest {
     pub scope: ReportScope,
     pub query: Option<String>,
-    pub output: Option<ReportOutputRequest>,
     pub missing_data_policy: Option<ReportMissingDataPolicy>,
     pub limits: Option<ReportLimits>,
     pub include: Option<ReportInclude>,
@@ -227,6 +220,16 @@ pub struct ReportJsonResponse {
     pub warnings: Vec<ReportWarning>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[schema(example = openapi_examples::report_template_run_request_example)]
+#[serde(deny_unknown_fields)]
+pub struct ReportTemplateRunRequest {
+    pub query: Option<String>,
+    pub object_id: Option<i32>,
+    pub missing_data_policy: Option<ReportMissingDataPolicy>,
+    pub limits: Option<ReportLimits>,
+}
+
 impl ReportScopeKind {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -236,6 +239,49 @@ impl ReportScopeKind {
             ReportScopeKind::ClassRelations => "class_relations",
             ReportScopeKind::ObjectRelations => "object_relations",
             ReportScopeKind::RelatedObjects => "related_objects",
+        }
+    }
+}
+
+impl FromStr for ReportScopeKind {
+    type Err = ApiError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "namespaces" => Ok(Self::Namespaces),
+            "classes" => Ok(Self::Classes),
+            "objects_in_class" => Ok(Self::ObjectsInClass),
+            "class_relations" => Ok(Self::ClassRelations),
+            "object_relations" => Ok(Self::ObjectRelations),
+            "related_objects" => Ok(Self::RelatedObjects),
+            _ => Err(ApiError::BadRequest(format!(
+                "Unsupported report scope kind: '{value}'"
+            ))),
+        }
+    }
+}
+
+impl ReportMissingDataPolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Strict => "strict",
+            Self::Null => "null",
+            Self::Omit => "omit",
+        }
+    }
+}
+
+impl FromStr for ReportMissingDataPolicy {
+    type Err = ApiError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "strict" => Ok(Self::Strict),
+            "null" => Ok(Self::Null),
+            "omit" => Ok(Self::Omit),
+            _ => Err(ApiError::BadRequest(format!(
+                "Unsupported report missing data policy: '{value}'"
+            ))),
         }
     }
 }
@@ -254,12 +300,6 @@ mod openapi_examples {
         }
     }
 
-    pub(super) fn report_output_example() -> ReportOutputRequest {
-        ReportOutputRequest {
-            template_id: Some(12),
-        }
-    }
-
     pub(super) fn report_limits_example() -> ReportLimits {
         ReportLimits {
             max_items: Some(100),
@@ -271,7 +311,6 @@ mod openapi_examples {
         ReportRequest {
             scope: report_scope_example(),
             query: Some("name__icontains=server&sort=name".to_string()),
-            output: Some(report_output_example()),
             missing_data_policy: Some(ReportMissingDataPolicy::Strict),
             limits: Some(report_limits_example()),
             include: None,
@@ -308,6 +347,15 @@ mod openapi_examples {
             ],
             meta: report_meta_example(),
             warnings: vec![],
+        }
+    }
+
+    pub(super) fn report_template_run_request_example() -> ReportTemplateRunRequest {
+        ReportTemplateRunRequest {
+            query: Some("name__icontains=server&sort=name".to_string()),
+            object_id: None,
+            missing_data_policy: Some(ReportMissingDataPolicy::Strict),
+            limits: Some(report_limits_example()),
         }
     }
 }

--- a/src/models/report_template.rs
+++ b/src/models/report_template.rs
@@ -9,14 +9,15 @@ use crate::errors::ApiError;
 use crate::models::search::{FilterField, QueryOptions, SortParam, parse_query_parameter};
 use crate::models::{
     Namespace, NamespaceID, ReportContentType, ReportInclude, ReportLimits,
-    ReportMissingDataPolicy, ReportRelationContext, ReportScopeKind,
+    ReportMissingDataPolicy, ReportRelationContext, ReportRequest, ReportScope, ReportScopeKind,
+    ReportTemplateRunRequest,
 };
 use crate::pagination::{
     CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
 };
 use crate::schema::report_templates;
 use crate::traits::accessors::{IdAccessor, InstanceAdapter, NamespaceAdapter};
-use crate::utilities::reporting::{validate_related_objects_include, validate_template};
+use crate::utilities::reporting::validate_template;
 use crate::{date_search, numeric_search, string_search};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
@@ -285,6 +286,77 @@ impl UpdateReportTemplate {
     }
 }
 
+impl ReportTemplate {
+    /// Build the report request to execute this template for a given run. Validates that the
+    /// template is an executable report and that the run's `object_id` matches the template scope:
+    /// `related_objects` requires one, the other scopes reject one, and `class_id` comes from the
+    /// template for the class-bound scopes. Runtime values override the template defaults.
+    pub fn build_report_request(
+        &self,
+        run: ReportTemplateRunRequest,
+    ) -> Result<ReportRequest, ApiError> {
+        if self.kind != ReportTemplateKind::Report {
+            return Err(ApiError::BadRequest(
+                "Only report templates can be executed".to_string(),
+            ));
+        }
+
+        let scope_kind = self.scope_kind.ok_or_else(|| {
+            ApiError::BadRequest("Executable report template is missing scope_kind".to_string())
+        })?;
+
+        let template_class_id = || {
+            self.class_id.ok_or_else(|| {
+                ApiError::BadRequest("Executable report template is missing class_id".to_string())
+            })
+        };
+        let reject_object_id = || {
+            if run.object_id.is_some() {
+                return Err(ApiError::BadRequest(format!(
+                    "object_id is not accepted for {} report templates",
+                    scope_kind.as_str()
+                )));
+            }
+            Ok(())
+        };
+
+        let (class_id, object_id) = match scope_kind {
+            ReportScopeKind::ObjectsInClass => {
+                reject_object_id()?;
+                (Some(template_class_id()?), None)
+            }
+            ReportScopeKind::RelatedObjects => {
+                let object_id = run.object_id.ok_or_else(|| {
+                    ApiError::BadRequest(
+                        "related_objects report templates require object_id".to_string(),
+                    )
+                })?;
+                (Some(template_class_id()?), Some(object_id))
+            }
+            ReportScopeKind::Namespaces
+            | ReportScopeKind::Classes
+            | ReportScopeKind::ClassRelations
+            | ReportScopeKind::ObjectRelations => {
+                reject_object_id()?;
+                (None, None)
+            }
+        };
+
+        Ok(ReportRequest {
+            scope: ReportScope {
+                kind: scope_kind,
+                class_id,
+                object_id,
+            },
+            query: run.query.or_else(|| self.default_query.clone()),
+            missing_data_policy: run.missing_data_policy.or(self.default_missing_data_policy),
+            limits: run.limits.or_else(|| self.default_limits.clone()),
+            include: self.include.clone(),
+            relation_context: self.relation_context.clone(),
+        })
+    }
+}
+
 pub async fn report_template(pool: &DbPool, template_id: i32) -> Result<ReportTemplate, ApiError> {
     use crate::schema::report_templates::dsl::{id, report_templates};
 
@@ -374,61 +446,15 @@ pub async fn update_report_template(
         ));
     }
 
-    let (
-        target_scope_kind,
-        target_class_id,
-        target_default_query,
-        target_include,
-        target_relation_context,
-        target_default_missing_data_policy,
-        target_default_limits,
-    ) = if target_kind == ReportTemplateKind::Fragment {
-        (None, None, None, None, None, None, None)
-    } else {
-        let target_scope_kind = update.scope_kind.or(current.scope_kind);
-
-        // Reconcile scope-dependent fields against the *target* scope. Without this,
-        // `update.field.or(current.field)` would carry forward a class_id/include/
-        // relation_context that the new scope forbids, making it impossible to PATCH an
-        // objects_in_class template into a collection scope. Carried-forward values are
-        // dropped when the target scope cannot hold them; an explicitly supplied
-        // incompatible value still falls through to validate_report_profile, which rejects
-        // it (matching the create path). This mirrors how switching to a fragment clears
-        // report metadata.
-        let scope_allows_class = target_scope_kind
-            .map(ReportScopeKind::requires_class_id)
-            .unwrap_or(false);
-        let scope_allows_include = target_scope_kind == Some(ReportScopeKind::ObjectsInClass);
-        let scope_allows_relation_context = matches!(
-            target_scope_kind,
-            Some(ReportScopeKind::ObjectsInClass) | Some(ReportScopeKind::RelatedObjects)
-        );
-
-        let target_class_id = if scope_allows_class {
-            update.class_id.or(current.class_id)
-        } else {
-            update.class_id
-        };
-        let target_include =
-            resolve_gated_patch(update.include, current.include, scope_allows_include);
-        let target_relation_context = resolve_gated_patch(
-            update.relation_context,
-            current.relation_context,
-            scope_allows_relation_context,
-        );
-
-        (
-            target_scope_kind,
-            target_class_id,
-            update.default_query.unwrap_or(current.default_query),
-            target_include,
-            target_relation_context,
-            update
-                .default_missing_data_policy
-                .unwrap_or(current.default_missing_data_policy),
-            update.default_limits.unwrap_or(current.default_limits),
-        )
-    };
+    let ResolvedReportProfile {
+        scope_kind: target_scope_kind,
+        class_id: target_class_id,
+        default_query: target_default_query,
+        include: target_include,
+        relation_context: target_relation_context,
+        default_missing_data_policy: target_default_missing_data_policy,
+        default_limits: target_default_limits,
+    } = resolve_report_profile(target_kind, update, &current);
 
     ensure_template_name_is_available(pool, target_namespace_id, &target_name, Some(template_id))
         .await?;
@@ -484,6 +510,81 @@ pub async fn update_report_template(
     })?;
 
     row.try_into()
+}
+
+/// The report-execution metadata resolved for an update, after applying the patch over the current
+/// template and reconciling fields against the target scope.
+struct ResolvedReportProfile {
+    scope_kind: Option<ReportScopeKind>,
+    class_id: Option<i32>,
+    default_query: Option<String>,
+    include: Option<ReportInclude>,
+    relation_context: Option<ReportRelationContext>,
+    default_missing_data_policy: Option<ReportMissingDataPolicy>,
+    default_limits: Option<ReportLimits>,
+}
+
+/// Resolve the target report-execution metadata for an update. A fragment clears everything.
+/// Otherwise each field is the patch value falling back to the current value, except that fields the
+/// target scope cannot hold (class_id/include/relation_context for the collection scopes, include
+/// for the non-`objects_in_class` scopes) drop their carried-forward value. An explicitly supplied
+/// incompatible value is preserved so `validate_report_profile` rejects it, matching the create path.
+fn resolve_report_profile(
+    target_kind: ReportTemplateKind,
+    update: UpdateReportTemplate,
+    current: &ReportTemplate,
+) -> ResolvedReportProfile {
+    if target_kind == ReportTemplateKind::Fragment {
+        return ResolvedReportProfile {
+            scope_kind: None,
+            class_id: None,
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
+        };
+    }
+
+    let scope_kind = update.scope_kind.or(current.scope_kind);
+    let scope_allows_class = scope_kind
+        .map(ReportScopeKind::requires_class_id)
+        .unwrap_or(false);
+    let scope_allows_include = scope_kind == Some(ReportScopeKind::ObjectsInClass);
+    let scope_allows_relation_context = matches!(
+        scope_kind,
+        Some(ReportScopeKind::ObjectsInClass) | Some(ReportScopeKind::RelatedObjects)
+    );
+
+    let class_id = if scope_allows_class {
+        update.class_id.or(current.class_id)
+    } else {
+        update.class_id
+    };
+
+    ResolvedReportProfile {
+        scope_kind,
+        class_id,
+        default_query: update
+            .default_query
+            .unwrap_or_else(|| current.default_query.clone()),
+        include: resolve_gated_patch(
+            update.include,
+            current.include.clone(),
+            scope_allows_include,
+        ),
+        relation_context: resolve_gated_patch(
+            update.relation_context,
+            current.relation_context.clone(),
+            scope_allows_relation_context,
+        ),
+        default_missing_data_policy: update
+            .default_missing_data_policy
+            .unwrap_or(current.default_missing_data_policy),
+        default_limits: update
+            .default_limits
+            .unwrap_or_else(|| current.default_limits.clone()),
+    }
 }
 
 pub async fn delete_report_template(pool: &DbPool, template_id: i32) -> Result<(), ApiError> {
@@ -547,88 +648,100 @@ async fn validate_report_profile(
     target_namespace_id: i32,
     profile: ReportProfileRef<'_>,
 ) -> Result<(), ApiError> {
-    let ReportProfileRef {
-        kind,
-        scope_kind,
-        class_id,
-        default_query,
-        include,
-        relation_context,
-        default_missing_data_policy,
-        default_limits,
-    } = profile;
-
-    match kind {
-        ReportTemplateKind::Fragment => {
-            if scope_kind.is_some() || class_id.is_some() {
-                return Err(ApiError::BadRequest(
-                    "Fragment templates cannot define report execution metadata".to_string(),
-                ));
-            }
-        }
+    match profile.kind {
+        ReportTemplateKind::Fragment => validate_fragment_metadata(&profile)?,
         ReportTemplateKind::Report => {
-            let scope_kind = scope_kind
-                .ok_or_else(|| ApiError::BadRequest("Report templates require scope_kind".into()))
-                .and_then(ReportScopeKind::from_str)?;
-
-            // `objects_in_class` and `related_objects` are scoped to a single class and
-            // require `class_id`; the collection scopes (`namespaces`, `classes`,
-            // `class_relations`, `object_relations`) are class-agnostic and must not set it.
-            if scope_kind.requires_class_id() {
-                let class_id = class_id.ok_or_else(|| {
-                    ApiError::BadRequest(format!(
-                        "Report templates with scope '{}' require class_id",
-                        scope_kind.as_str()
-                    ))
-                })?;
-                if class_id <= 0 {
-                    return Err(ApiError::BadRequest(
-                        "Report template class_id must be greater than 0".to_string(),
-                    ));
-                }
-                ensure_template_class_in_namespace(pool, target_namespace_id, class_id).await?;
-            } else if class_id.is_some() {
-                return Err(ApiError::BadRequest(format!(
-                    "Report templates with scope '{}' must not set class_id",
-                    scope_kind.as_str()
-                )));
-            }
-
-            if let Some(query) = default_query {
-                parse_query_parameter(query)?;
-            }
-
-            if include.is_some() && scope_kind != ReportScopeKind::ObjectsInClass {
-                return Err(ApiError::BadRequest(
-                    "include is only supported for objects_in_class report templates".to_string(),
-                ));
-            }
-
-            if relation_context.is_some()
-                && !matches!(
-                    scope_kind,
-                    ReportScopeKind::ObjectsInClass | ReportScopeKind::RelatedObjects
-                )
-            {
-                return Err(ApiError::BadRequest(
-                    "relation_context is only supported for objects_in_class and related_objects report templates"
-                        .to_string(),
-                ));
-            }
+            validate_report_scope_metadata(pool, target_namespace_id, &profile).await?
         }
     }
 
-    if include.is_some() && relation_context.is_some() {
+    validate_common_profile_fields(&profile)
+}
+
+/// Fragments are reusable partials with no execution metadata.
+fn validate_fragment_metadata(profile: &ReportProfileRef<'_>) -> Result<(), ApiError> {
+    if profile.scope_kind.is_some() || profile.class_id.is_some() {
+        return Err(ApiError::BadRequest(
+            "Fragment templates cannot define report execution metadata".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate the scope/class binding of an executable report template.
+async fn validate_report_scope_metadata(
+    pool: &DbPool,
+    target_namespace_id: i32,
+    profile: &ReportProfileRef<'_>,
+) -> Result<(), ApiError> {
+    let scope_kind = profile
+        .scope_kind
+        .ok_or_else(|| ApiError::BadRequest("Report templates require scope_kind".into()))
+        .and_then(ReportScopeKind::from_str)?;
+
+    // `objects_in_class` and `related_objects` are scoped to a single class and require
+    // `class_id`; the collection scopes (`namespaces`, `classes`, `class_relations`,
+    // `object_relations`) are class-agnostic and must not set it.
+    if scope_kind.requires_class_id() {
+        let class_id = profile.class_id.ok_or_else(|| {
+            ApiError::BadRequest(format!(
+                "Report templates with scope '{}' require class_id",
+                scope_kind.as_str()
+            ))
+        })?;
+        if class_id <= 0 {
+            return Err(ApiError::BadRequest(
+                "Report template class_id must be greater than 0".to_string(),
+            ));
+        }
+        ensure_template_class_in_namespace(pool, target_namespace_id, class_id).await?;
+    } else if profile.class_id.is_some() {
+        return Err(ApiError::BadRequest(format!(
+            "Report templates with scope '{}' must not set class_id",
+            scope_kind.as_str()
+        )));
+    }
+
+    if let Some(query) = profile.default_query {
+        parse_query_parameter(query)?;
+    }
+
+    if profile.include.is_some() && scope_kind != ReportScopeKind::ObjectsInClass {
+        return Err(ApiError::BadRequest(
+            "include is only supported for objects_in_class report templates".to_string(),
+        ));
+    }
+
+    if profile.relation_context.is_some()
+        && !matches!(
+            scope_kind,
+            ReportScopeKind::ObjectsInClass | ReportScopeKind::RelatedObjects
+        )
+    {
+        return Err(ApiError::BadRequest(
+            "relation_context is only supported for objects_in_class and related_objects report templates"
+                .to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate the profile fields whose rules are the same for every kind/scope: the
+/// include/relation_context exclusivity and the shape of each optional blob.
+fn validate_common_profile_fields(profile: &ReportProfileRef<'_>) -> Result<(), ApiError> {
+    if profile.include.is_some() && profile.relation_context.is_some() {
         return Err(ApiError::BadRequest(
             "include cannot be combined with relation_context".to_string(),
         ));
     }
 
-    if let Some(include) = include {
+    if let Some(include) = profile.include {
         let include: ReportInclude = serde_json::from_value(include.clone())?;
-        validate_related_objects_include(&include)?;
+        include.validate_related_objects()?;
     }
-    if let Some(relation_context) = relation_context {
+    if let Some(relation_context) = profile.relation_context {
         let context: ReportRelationContext = serde_json::from_value(relation_context.clone())?;
         if let Some(depth) = context.depth
             && !(1..=2).contains(&depth)
@@ -638,10 +751,10 @@ async fn validate_report_profile(
             ));
         }
     }
-    if let Some(policy) = default_missing_data_policy {
+    if let Some(policy) = profile.default_missing_data_policy {
         ReportMissingDataPolicy::from_str(policy)?;
     }
-    if let Some(limits) = default_limits {
+    if let Some(limits) = profile.default_limits {
         let _limits: ReportLimits = serde_json::from_value(limits.clone())?;
     }
 

--- a/src/models/report_template.rs
+++ b/src/models/report_template.rs
@@ -8,22 +8,16 @@ use crate::db::{DbPool, with_connection};
 use crate::errors::ApiError;
 use crate::models::search::{FilterField, QueryOptions, SortParam, parse_query_parameter};
 use crate::models::{
-    Namespace, NamespaceID, ReportContentType, ReportInclude, ReportIncludeRelatedObject,
-    ReportLimits, ReportMissingDataPolicy, ReportRelationContext, ReportScopeKind,
+    Namespace, NamespaceID, ReportContentType, ReportInclude, ReportLimits,
+    ReportMissingDataPolicy, ReportRelationContext, ReportScopeKind,
 };
 use crate::pagination::{
     CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
 };
 use crate::schema::report_templates;
 use crate::traits::accessors::{IdAccessor, InstanceAdapter, NamespaceAdapter};
-use crate::utilities::reporting::validate_template;
+use crate::utilities::reporting::{validate_related_objects_include, validate_template};
 use crate::{date_search, numeric_search, string_search};
-
-const RELATED_INCLUDE_DEFAULT_MAX_DEPTH: i32 = 1;
-const RELATED_INCLUDE_MAX_DEPTH_LIMIT: i32 = 10;
-const RELATED_INCLUDE_DEFAULT_LIMIT: i32 = 1;
-const RELATED_INCLUDE_MAX_LIMIT: i32 = 50;
-const RELATED_INCLUDE_MAX_ALIASES: usize = 8;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "snake_case")]
@@ -473,23 +467,29 @@ async fn validate_report_profile(
             let scope_kind = scope_kind
                 .ok_or_else(|| ApiError::BadRequest("Report templates require scope_kind".into()))
                 .and_then(ReportScopeKind::from_str)?;
-            if !matches!(
-                scope_kind,
-                ReportScopeKind::ObjectsInClass | ReportScopeKind::RelatedObjects
-            ) {
-                return Err(ApiError::BadRequest(
-                    "Report templates only support objects_in_class and related_objects scopes"
-                        .to_string(),
-                ));
+
+            // `objects_in_class` and `related_objects` are scoped to a single class and
+            // require `class_id`; the collection scopes (`namespaces`, `classes`,
+            // `class_relations`, `object_relations`) are class-agnostic and must not set it.
+            if scope_kind.requires_class_id() {
+                let class_id = class_id.ok_or_else(|| {
+                    ApiError::BadRequest(format!(
+                        "Report templates with scope '{}' require class_id",
+                        scope_kind.as_str()
+                    ))
+                })?;
+                if class_id <= 0 {
+                    return Err(ApiError::BadRequest(
+                        "Report template class_id must be greater than 0".to_string(),
+                    ));
+                }
+                ensure_template_class_in_namespace(pool, target_namespace_id, class_id).await?;
+            } else if class_id.is_some() {
+                return Err(ApiError::BadRequest(format!(
+                    "Report templates with scope '{}' must not set class_id",
+                    scope_kind.as_str()
+                )));
             }
-            let class_id = class_id
-                .ok_or_else(|| ApiError::BadRequest("Report templates require class_id".into()))?;
-            if class_id <= 0 {
-                return Err(ApiError::BadRequest(
-                    "Report template class_id must be greater than 0".to_string(),
-                ));
-            }
-            ensure_template_class_in_namespace(pool, target_namespace_id, class_id).await?;
 
             if let Some(query) = default_query {
                 parse_query_parameter(query)?;
@@ -498,6 +498,18 @@ async fn validate_report_profile(
             if include.is_some() && scope_kind != ReportScopeKind::ObjectsInClass {
                 return Err(ApiError::BadRequest(
                     "include is only supported for objects_in_class report templates".to_string(),
+                ));
+            }
+
+            if relation_context.is_some()
+                && !matches!(
+                    scope_kind,
+                    ReportScopeKind::ObjectsInClass | ReportScopeKind::RelatedObjects
+                )
+            {
+                return Err(ApiError::BadRequest(
+                    "relation_context is only supported for objects_in_class and related_objects report templates"
+                        .to_string(),
                 ));
             }
         }
@@ -511,7 +523,7 @@ async fn validate_report_profile(
 
     if let Some(include) = include {
         let include: ReportInclude = serde_json::from_value(include.clone())?;
-        validate_template_include(&include)?;
+        validate_related_objects_include(&include)?;
     }
     if let Some(relation_context) = relation_context {
         let context: ReportRelationContext = serde_json::from_value(relation_context.clone())?;
@@ -528,81 +540,6 @@ async fn validate_report_profile(
     }
     if let Some(limits) = default_limits {
         let _limits: ReportLimits = serde_json::from_value(limits.clone())?;
-    }
-
-    Ok(())
-}
-
-fn validate_template_include(include: &ReportInclude) -> Result<(), ApiError> {
-    let Some(related_objects) = &include.related_objects else {
-        return Ok(());
-    };
-
-    if related_objects.len() > RELATED_INCLUDE_MAX_ALIASES {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects supports at most {RELATED_INCLUDE_MAX_ALIASES} aliases"
-        )));
-    }
-
-    for (alias, include) in related_objects {
-        validate_related_include_alias(alias)?;
-        validate_related_include_options(alias, include)?;
-    }
-
-    Ok(())
-}
-
-fn validate_related_include_alias(alias: &str) -> Result<(), ApiError> {
-    let mut chars = alias.chars();
-    let Some(first) = chars.next() else {
-        return Err(ApiError::BadRequest(
-            "include.related_objects aliases must not be empty".to_string(),
-        ));
-    };
-
-    if !(first == '_' || first.is_ascii_alphabetic())
-        || !chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-    {
-        return Err(ApiError::BadRequest(format!(
-            "Invalid include.related_objects alias '{alias}'; expected [A-Za-z_][A-Za-z0-9_]*"
-        )));
-    }
-
-    Ok(())
-}
-
-fn validate_related_include_options(
-    alias: &str,
-    include: &ReportIncludeRelatedObject,
-) -> Result<(), ApiError> {
-    if include.class_id <= 0 {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects.{alias}.class_id must be greater than 0"
-        )));
-    }
-
-    if let Some(class_relation_id) = include.class_relation_id
-        && class_relation_id <= 0
-    {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects.{alias}.class_relation_id must be greater than 0"
-        )));
-    }
-
-    let max_depth = include
-        .max_depth
-        .unwrap_or(RELATED_INCLUDE_DEFAULT_MAX_DEPTH);
-    if !(1..=RELATED_INCLUDE_MAX_DEPTH_LIMIT).contains(&max_depth) {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects.{alias}.max_depth must be between 1 and {RELATED_INCLUDE_MAX_DEPTH_LIMIT}"
-        )));
-    }
-
-    let limit = include.limit.unwrap_or(RELATED_INCLUDE_DEFAULT_LIMIT);
-    if !(1..=RELATED_INCLUDE_MAX_LIMIT).contains(&limit) {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects.{alias}.limit must be between 1 and {RELATED_INCLUDE_MAX_LIMIT}"
-        )));
     }
 
     Ok(())
@@ -697,7 +634,8 @@ fn build_report_template_query<'a>(
     query_options: &'a QueryOptions,
 ) -> Result<crate::schema::report_templates::BoxedQuery<'a, diesel::pg::Pg>, ApiError> {
     use crate::schema::report_templates::dsl::{
-        created_at, description, id, name, namespace_id, report_templates, updated_at,
+        class_id, created_at, description, id, kind, name, namespace_id, report_templates,
+        updated_at,
     };
 
     if allowed_namespace_ids.is_empty() {
@@ -719,6 +657,8 @@ fn build_report_template_query<'a>(
             FilterField::Namespaces | FilterField::NamespaceId => {
                 numeric_search!(query, param, operator, namespace_id)
             }
+            FilterField::Kind => string_search!(query, param, operator, kind),
+            FilterField::ClassId => numeric_search!(query, param, operator, class_id),
             FilterField::CreatedAt => date_search!(query, param, operator, created_at),
             FilterField::UpdatedAt => date_search!(query, param, operator, updated_at),
             _ => {

--- a/src/models/report_template.rs
+++ b/src/models/report_template.rs
@@ -122,11 +122,58 @@ pub struct UpdateReportTemplate {
     pub kind: Option<ReportTemplateKind>,
     pub scope_kind: Option<ReportScopeKind>,
     pub class_id: Option<i32>,
-    pub default_query: Option<String>,
-    pub include: Option<ReportInclude>,
-    pub relation_context: Option<ReportRelationContext>,
-    pub default_missing_data_policy: Option<ReportMissingDataPolicy>,
-    pub default_limits: Option<ReportLimits>,
+    // The nullable report-profile fields use double `Option` so a PATCH can distinguish an
+    // omitted field (outer `None` — keep the current value) from an explicit JSON `null`
+    // (`Some(None)` — clear the value). A plain `Option` collapses both to `None`.
+    // `deserialize_double_option` makes serde populate the outer `Some` only when the key is
+    // present, and `skip_serializing_if` keeps omitted fields out of serialized payloads so the
+    // distinction survives a serialize/deserialize round-trip (e.g. in tests and examples).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_double_option"
+    )]
+    #[schema(value_type = Option<String>)]
+    pub default_query: Option<Option<String>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_double_option"
+    )]
+    #[schema(value_type = Option<ReportInclude>)]
+    pub include: Option<Option<ReportInclude>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_double_option"
+    )]
+    #[schema(value_type = Option<ReportRelationContext>)]
+    pub relation_context: Option<Option<ReportRelationContext>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_double_option"
+    )]
+    #[schema(value_type = Option<ReportMissingDataPolicy>)]
+    pub default_missing_data_policy: Option<Option<ReportMissingDataPolicy>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_double_option"
+    )]
+    #[schema(value_type = Option<ReportLimits>)]
+    pub default_limits: Option<Option<ReportLimits>>,
+}
+
+/// Deserialize a tri-state PATCH field. serde only invokes a field's `deserialize_with` when the
+/// key is present, so this wraps the inner `Option<T>` (which captures `null` vs a value) in an
+/// outer `Some`, leaving an omitted key as the `default` outer `None`.
+fn deserialize_double_option<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Some(Option::<T>::deserialize(deserializer)?))
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -360,27 +407,24 @@ pub async fn update_report_template(
         } else {
             update.class_id
         };
-        let target_include = if scope_allows_include {
-            update.include.clone().or(current.include)
-        } else {
-            update.include.clone()
-        };
-        let target_relation_context = if scope_allows_relation_context {
-            update.relation_context.clone().or(current.relation_context)
-        } else {
-            update.relation_context.clone()
-        };
+        let target_include =
+            resolve_gated_patch(update.include, current.include, scope_allows_include);
+        let target_relation_context = resolve_gated_patch(
+            update.relation_context,
+            current.relation_context,
+            scope_allows_relation_context,
+        );
 
         (
             target_scope_kind,
             target_class_id,
-            update.default_query.clone().or(current.default_query),
+            update.default_query.unwrap_or(current.default_query),
             target_include,
             target_relation_context,
             update
                 .default_missing_data_policy
-                .or(current.default_missing_data_policy),
-            update.default_limits.clone().or(current.default_limits),
+                .unwrap_or(current.default_missing_data_policy),
+            update.default_limits.unwrap_or(current.default_limits),
         )
     };
 
@@ -613,6 +657,26 @@ fn update_report_fields_present(update: &UpdateReportTemplate) -> bool {
         || update.relation_context.is_some()
         || update.default_missing_data_policy.is_some()
         || update.default_limits.is_some()
+}
+
+/// Resolve a tri-state PATCH field whose validity depends on the target scope.
+/// When the scope `allowed`s the field, this behaves like a normal tri-state resolve
+/// (absent keeps current, `Some(None)` clears, `Some(Some)` sets). When the scope forbids
+/// it, a carried-forward current value is dropped, but an explicitly supplied value is kept
+/// so `validate_report_profile` can reject it (matching the create path).
+fn resolve_gated_patch<T>(
+    update: Option<Option<T>>,
+    current: Option<T>,
+    allowed: bool,
+) -> Option<T> {
+    if allowed {
+        update.unwrap_or(current)
+    } else {
+        match update {
+            Some(Some(value)) => Some(value),
+            _ => None,
+        }
+    }
 }
 
 fn to_optional_json<T>(value: Option<T>) -> Result<Option<serde_json::Value>, ApiError>
@@ -936,7 +1000,7 @@ fn update_report_template_example() -> UpdateReportTemplate {
         kind: None,
         scope_kind: None,
         class_id: None,
-        default_query: Some("sort=name.desc".to_string()),
+        default_query: Some(Some("sort=name.desc".to_string())),
         include: None,
         relation_context: None,
         default_missing_data_policy: None,

--- a/src/models/report_template.rs
+++ b/src/models/report_template.rs
@@ -4,7 +4,8 @@ use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::db::{DbPool, with_connection};
+use crate::db::DbPool;
+use crate::db::traits::report_template as backend;
 use crate::errors::ApiError;
 use crate::models::search::{FilterField, QueryOptions, SortParam, parse_query_parameter};
 use crate::models::{
@@ -19,7 +20,6 @@ use crate::schema::report_templates;
 use crate::traits::accessors::{IdAccessor, InstanceAdapter, NamespaceAdapter};
 use crate::traits::crud::{DeleteAdapter, SaveAdapter, UpdateAdapter};
 use crate::utilities::reporting::validate_template;
-use crate::{date_search, numeric_search, string_search};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "snake_case")]
@@ -53,7 +53,7 @@ impl FromStr for ReportTemplateKind {
 
 #[derive(Debug, Clone, Queryable, Selectable)]
 #[diesel(table_name = report_templates)]
-struct ReportTemplateRow {
+pub(crate) struct ReportTemplateRow {
     id: i32,
     namespace_id: i32,
     name: String,
@@ -204,7 +204,7 @@ where
 
 #[derive(Debug, Clone, Insertable)]
 #[diesel(table_name = report_templates)]
-struct NewReportTemplateRow {
+pub(crate) struct NewReportTemplateRow {
     namespace_id: i32,
     name: String,
     description: String,
@@ -222,7 +222,7 @@ struct NewReportTemplateRow {
 
 #[derive(Debug, Clone, AsChangeset)]
 #[diesel(table_name = report_templates)]
-struct UpdateReportTemplateRow {
+pub(crate) struct UpdateReportTemplateRow {
     namespace_id: Option<i32>,
     name: Option<String>,
     description: Option<String>,
@@ -386,8 +386,6 @@ impl SaveAdapter for NewReportTemplate {
     type Output = ReportTemplate;
 
     async fn save_adapter(&self, pool: &DbPool) -> Result<ReportTemplate, ApiError> {
-        use crate::schema::report_templates::dsl::report_templates;
-
         let new_row = self.clone().into_row()?;
         ensure_template_name_is_available(pool, new_row.namespace_id, &new_row.name, None).await?;
         validate_report_profile(
@@ -414,11 +412,7 @@ impl SaveAdapter for NewReportTemplate {
             &namespace_templates,
             ReportContentType::from_mime(&new_row.content_type)?,
         )?;
-        let row = with_connection(pool, |conn| {
-            diesel::insert_into(report_templates)
-                .values(&new_row)
-                .get_result::<ReportTemplateRow>(conn)
-        })?;
+        let row = backend::insert_row(pool, &new_row).await?;
 
         row.try_into()
     }
@@ -441,13 +435,7 @@ async fn update_report_template_record(
     template_id: i32,
     update: UpdateReportTemplate,
 ) -> Result<ReportTemplate, ApiError> {
-    use crate::schema::report_templates::dsl::{id, report_templates};
-
-    let current_row = with_connection(pool, |conn| {
-        report_templates
-            .filter(id.eq(template_id))
-            .first::<ReportTemplateRow>(conn)
-    })?;
+    let current_row = backend::load_row(pool, template_id).await?;
 
     if update.is_empty() {
         return current_row.try_into();
@@ -529,11 +517,7 @@ async fn update_report_template_record(
         ),
         default_limits: Some(default_limits_json),
     };
-    let row = with_connection(pool, |conn| {
-        diesel::update(report_templates.filter(id.eq(template_id)))
-            .set(&changeset)
-            .get_result::<ReportTemplateRow>(conn)
-    })?;
+    let row = backend::update_row(pool, template_id, &changeset).await?;
 
     row.try_into()
 }
@@ -615,13 +599,7 @@ fn resolve_report_profile(
 
 impl DeleteAdapter for ReportTemplateID {
     async fn delete_adapter(&self, pool: &DbPool) -> Result<(), ApiError> {
-        use crate::schema::report_templates::dsl::{id, report_templates};
-
-        with_connection(pool, |conn| {
-            diesel::delete(report_templates.filter(id.eq(self.0))).execute(conn)
-        })?;
-
-        Ok(())
+        backend::delete_row(pool, self.0).await
     }
 }
 
@@ -630,28 +608,15 @@ pub async fn report_templates_in_namespace(
     target_namespace_id: i32,
     exclude_template_id: Option<i32>,
 ) -> Result<Vec<ReportTemplate>, ApiError> {
-    use crate::schema::report_templates::dsl::{id, namespace_id, report_templates};
-
-    let rows = with_connection(pool, |conn| {
-        let mut query = report_templates
-            .into_boxed()
-            .filter(namespace_id.eq(target_namespace_id));
-        if let Some(exclude_template_id) = exclude_template_id {
-            query = query.filter(id.ne(exclude_template_id));
-        }
-        query.load::<ReportTemplateRow>(conn)
-    })?;
+    let rows =
+        backend::load_rows_in_namespace(pool, target_namespace_id, exclude_template_id).await?;
 
     rows.into_iter().map(TryInto::try_into).collect()
 }
 
 #[allow(dead_code)]
 pub async fn list_all_report_templates(pool: &DbPool) -> Result<Vec<ReportTemplate>, ApiError> {
-    use crate::schema::report_templates::dsl::report_templates;
-
-    let rows = with_connection(pool, |conn| {
-        report_templates.load::<ReportTemplateRow>(conn)
-    })?;
+    let rows = backend::load_all_rows(pool).await?;
 
     rows.into_iter().map(TryInto::try_into).collect()
 }
@@ -794,16 +759,9 @@ async fn ensure_template_class_in_namespace(
     target_namespace_id: i32,
     target_class_id: i32,
 ) -> Result<(), ApiError> {
-    use crate::schema::hubuumclass::dsl::{hubuumclass, id, namespace_id};
-
-    let class_namespace_id = with_connection(pool, |conn| {
-        hubuumclass
-            .filter(id.eq(target_class_id))
-            .select(namespace_id)
-            .first::<i32>(conn)
-            .optional()
-    })?
-    .ok_or_else(|| ApiError::NotFound(format!("Class {target_class_id} not found")))?;
+    let class_namespace_id = backend::class_namespace_id(pool, target_class_id)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Class {target_class_id} not found")))?;
 
     if class_namespace_id != target_namespace_id {
         return Err(ApiError::BadRequest(format!(
@@ -870,20 +828,11 @@ async fn ensure_template_name_is_available(
     target_name: &str,
     exclude_template_id: Option<i32>,
 ) -> Result<(), ApiError> {
-    use crate::schema::report_templates::dsl::{id, name, namespace_id, report_templates};
+    let conflict =
+        backend::name_conflict_exists(pool, target_namespace_id, target_name, exclude_template_id)
+            .await?;
 
-    let existing_name_conflict = with_connection(pool, |conn| {
-        let mut query = report_templates
-            .into_boxed()
-            .filter(namespace_id.eq(target_namespace_id))
-            .filter(name.eq(target_name));
-        if let Some(exclude_template_id) = exclude_template_id {
-            query = query.filter(id.ne(exclude_template_id));
-        }
-        query.first::<ReportTemplateRow>(conn).optional()
-    })?;
-
-    if existing_name_conflict.is_some() {
+    if conflict {
         return Err(ApiError::Conflict(format!(
             "Template name '{}' already exists in namespace {}",
             target_name, target_namespace_id
@@ -891,50 +840,6 @@ async fn ensure_template_name_is_available(
     }
 
     Ok(())
-}
-
-fn build_report_template_query<'a>(
-    allowed_namespace_ids: &'a [i32],
-    query_options: &'a QueryOptions,
-) -> Result<crate::schema::report_templates::BoxedQuery<'a, diesel::pg::Pg>, ApiError> {
-    use crate::schema::report_templates::dsl::{
-        class_id, created_at, description, id, kind, name, namespace_id, report_templates,
-        updated_at,
-    };
-
-    if allowed_namespace_ids.is_empty() {
-        return Ok(report_templates
-            .into_boxed()
-            .filter(namespace_id.eq_any(allowed_namespace_ids)));
-    }
-
-    let mut query = report_templates
-        .into_boxed()
-        .filter(namespace_id.eq_any(allowed_namespace_ids));
-
-    for param in &query_options.filters {
-        let operator = param.operator.clone();
-        match param.field {
-            FilterField::Id => numeric_search!(query, param, operator, id),
-            FilterField::Name => string_search!(query, param, operator, name),
-            FilterField::Description => string_search!(query, param, operator, description),
-            FilterField::Namespaces | FilterField::NamespaceId => {
-                numeric_search!(query, param, operator, namespace_id)
-            }
-            FilterField::Kind => string_search!(query, param, operator, kind),
-            FilterField::ClassId => numeric_search!(query, param, operator, class_id),
-            FilterField::CreatedAt => date_search!(query, param, operator, created_at),
-            FilterField::UpdatedAt => date_search!(query, param, operator, updated_at),
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' isn't searchable (or does not exist) for report templates",
-                    param.field
-                )));
-            }
-        }
-    }
-
-    Ok(query)
 }
 
 pub async fn list_report_templates_with_total_count(
@@ -946,12 +851,8 @@ pub async fn list_report_templates_with_total_count(
         return Ok((Vec::new(), 0));
     }
 
-    let query = build_report_template_query(allowed_namespace_ids, query_options)?;
-    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
-
-    let mut query = build_report_template_query(allowed_namespace_ids, query_options)?;
-    crate::apply_query_options!(query, query_options, ReportTemplate);
-    let rows = with_connection(pool, |conn| query.load::<ReportTemplateRow>(conn))?;
+    let (rows, total_count) =
+        backend::list_rows_with_total_count(pool, allowed_namespace_ids, query_options).await?;
 
     let items = rows
         .into_iter()
@@ -981,15 +882,7 @@ impl IdAccessor for ReportTemplateID {
 
 impl InstanceAdapter<ReportTemplate> for ReportTemplateID {
     async fn instance_adapter(&self, pool: &DbPool) -> Result<ReportTemplate, ApiError> {
-        use crate::schema::report_templates::dsl::{id, report_templates};
-
-        let row = with_connection(pool, |conn| {
-            report_templates
-                .filter(id.eq(self.0))
-                .first::<ReportTemplateRow>(conn)
-        })?;
-
-        row.try_into()
+        backend::load_row(pool, self.0).await?.try_into()
     }
 }
 
@@ -1011,14 +904,7 @@ impl NamespaceAdapter for ReportTemplateID {
     }
 
     async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<i32, ApiError> {
-        use crate::schema::report_templates::dsl::{id, namespace_id, report_templates};
-
-        with_connection(pool, |conn| {
-            report_templates
-                .filter(id.eq(self.0))
-                .select(namespace_id)
-                .first::<i32>(conn)
-        })
+        backend::namespace_id_for(pool, self.0).await
     }
 }
 

--- a/src/models/report_template.rs
+++ b/src/models/report_template.rs
@@ -1,11 +1,16 @@
+use std::str::FromStr;
+
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::db::{DbPool, with_connection};
 use crate::errors::ApiError;
-use crate::models::search::{FilterField, QueryOptions, SortParam};
-use crate::models::{Namespace, NamespaceID, ReportContentType};
+use crate::models::search::{FilterField, QueryOptions, SortParam, parse_query_parameter};
+use crate::models::{
+    Namespace, NamespaceID, ReportContentType, ReportInclude, ReportIncludeRelatedObject,
+    ReportLimits, ReportMissingDataPolicy, ReportRelationContext, ReportScopeKind,
+};
 use crate::pagination::{
     CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
 };
@@ -13,6 +18,42 @@ use crate::schema::report_templates;
 use crate::traits::accessors::{IdAccessor, InstanceAdapter, NamespaceAdapter};
 use crate::utilities::reporting::validate_template;
 use crate::{date_search, numeric_search, string_search};
+
+const RELATED_INCLUDE_DEFAULT_MAX_DEPTH: i32 = 1;
+const RELATED_INCLUDE_MAX_DEPTH_LIMIT: i32 = 10;
+const RELATED_INCLUDE_DEFAULT_LIMIT: i32 = 1;
+const RELATED_INCLUDE_MAX_LIMIT: i32 = 50;
+const RELATED_INCLUDE_MAX_ALIASES: usize = 8;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReportTemplateKind {
+    Report,
+    Fragment,
+}
+
+impl ReportTemplateKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Report => "report",
+            Self::Fragment => "fragment",
+        }
+    }
+}
+
+impl FromStr for ReportTemplateKind {
+    type Err = ApiError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "report" => Ok(Self::Report),
+            "fragment" => Ok(Self::Fragment),
+            _ => Err(ApiError::BadRequest(format!(
+                "Unsupported report template kind: '{value}'"
+            ))),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Queryable, Selectable)]
 #[diesel(table_name = report_templates)]
@@ -23,6 +64,14 @@ struct ReportTemplateRow {
     description: String,
     content_type: String,
     template: String,
+    kind: String,
+    scope_kind: Option<String>,
+    class_id: Option<i32>,
+    default_query: Option<String>,
+    include: Option<serde_json::Value>,
+    relation_context: Option<serde_json::Value>,
+    default_missing_data_policy: Option<String>,
+    default_limits: Option<serde_json::Value>,
     created_at: chrono::NaiveDateTime,
     updated_at: chrono::NaiveDateTime,
 }
@@ -36,6 +85,14 @@ pub struct ReportTemplate {
     pub description: String,
     pub content_type: ReportContentType,
     pub template: String,
+    pub kind: ReportTemplateKind,
+    pub scope_kind: Option<ReportScopeKind>,
+    pub class_id: Option<i32>,
+    pub default_query: Option<String>,
+    pub include: Option<ReportInclude>,
+    pub relation_context: Option<ReportRelationContext>,
+    pub default_missing_data_policy: Option<ReportMissingDataPolicy>,
+    pub default_limits: Option<ReportLimits>,
     pub created_at: chrono::NaiveDateTime,
     pub updated_at: chrono::NaiveDateTime,
 }
@@ -51,6 +108,14 @@ pub struct NewReportTemplate {
     pub description: String,
     pub content_type: ReportContentType,
     pub template: String,
+    pub kind: ReportTemplateKind,
+    pub scope_kind: Option<ReportScopeKind>,
+    pub class_id: Option<i32>,
+    pub default_query: Option<String>,
+    pub include: Option<ReportInclude>,
+    pub relation_context: Option<ReportRelationContext>,
+    pub default_missing_data_policy: Option<ReportMissingDataPolicy>,
+    pub default_limits: Option<ReportLimits>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
@@ -60,6 +125,14 @@ pub struct UpdateReportTemplate {
     pub name: Option<String>,
     pub description: Option<String>,
     pub template: Option<String>,
+    pub kind: Option<ReportTemplateKind>,
+    pub scope_kind: Option<ReportScopeKind>,
+    pub class_id: Option<i32>,
+    pub default_query: Option<String>,
+    pub include: Option<ReportInclude>,
+    pub relation_context: Option<ReportRelationContext>,
+    pub default_missing_data_policy: Option<ReportMissingDataPolicy>,
+    pub default_limits: Option<ReportLimits>,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -70,15 +143,31 @@ struct NewReportTemplateRow {
     description: String,
     content_type: String,
     template: String,
+    kind: String,
+    scope_kind: Option<String>,
+    class_id: Option<i32>,
+    default_query: Option<String>,
+    include: Option<serde_json::Value>,
+    relation_context: Option<serde_json::Value>,
+    default_missing_data_policy: Option<String>,
+    default_limits: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Clone, AsChangeset, Default)]
+#[derive(Debug, Clone, AsChangeset)]
 #[diesel(table_name = report_templates)]
 struct UpdateReportTemplateRow {
     namespace_id: Option<i32>,
     name: Option<String>,
     description: Option<String>,
     template: Option<String>,
+    kind: Option<String>,
+    scope_kind: Option<Option<String>>,
+    class_id: Option<Option<i32>>,
+    default_query: Option<Option<String>>,
+    include: Option<Option<serde_json::Value>>,
+    relation_context: Option<Option<serde_json::Value>>,
+    default_missing_data_policy: Option<Option<String>>,
+    default_limits: Option<Option<serde_json::Value>>,
 }
 
 impl TryFrom<ReportTemplateRow> for ReportTemplate {
@@ -92,6 +181,22 @@ impl TryFrom<ReportTemplateRow> for ReportTemplate {
             description: row.description,
             content_type: ReportContentType::from_mime(&row.content_type)?,
             template: row.template,
+            kind: ReportTemplateKind::from_str(&row.kind)?,
+            scope_kind: row
+                .scope_kind
+                .as_deref()
+                .map(ReportScopeKind::from_str)
+                .transpose()?,
+            class_id: row.class_id,
+            default_query: row.default_query,
+            include: from_optional_json(row.include)?,
+            relation_context: from_optional_json(row.relation_context)?,
+            default_missing_data_policy: row
+                .default_missing_data_policy
+                .as_deref()
+                .map(ReportMissingDataPolicy::from_str)
+                .transpose()?,
+            default_limits: from_optional_json(row.default_limits)?,
             created_at: row.created_at,
             updated_at: row.updated_at,
         })
@@ -99,7 +204,7 @@ impl TryFrom<ReportTemplateRow> for ReportTemplate {
 }
 
 impl NewReportTemplate {
-    fn validate(self) -> Result<NewReportTemplateRow, ApiError> {
+    fn into_row(self) -> Result<NewReportTemplateRow, ApiError> {
         let content_type = self.content_type.ensure_template_output()?.as_mime();
 
         Ok(NewReportTemplateRow {
@@ -108,25 +213,34 @@ impl NewReportTemplate {
             description: self.description,
             content_type: content_type.to_string(),
             template: self.template,
+            kind: self.kind.as_str().to_string(),
+            scope_kind: self.scope_kind.map(|scope| scope.as_str().to_string()),
+            class_id: self.class_id,
+            default_query: self.default_query,
+            include: to_optional_json(self.include)?,
+            relation_context: to_optional_json(self.relation_context)?,
+            default_missing_data_policy: self
+                .default_missing_data_policy
+                .map(|policy| policy.as_str().to_string()),
+            default_limits: to_optional_json(self.default_limits)?,
         })
     }
 }
 
 impl UpdateReportTemplate {
-    fn as_changeset(&self) -> UpdateReportTemplateRow {
-        UpdateReportTemplateRow {
-            namespace_id: self.namespace_id,
-            name: self.name.clone(),
-            description: self.description.clone(),
-            template: self.template.clone(),
-        }
-    }
-
     fn is_empty(&self) -> bool {
         self.namespace_id.is_none()
             && self.name.is_none()
             && self.description.is_none()
             && self.template.is_none()
+            && self.kind.is_none()
+            && self.scope_kind.is_none()
+            && self.class_id.is_none()
+            && self.default_query.is_none()
+            && self.include.is_none()
+            && self.relation_context.is_none()
+            && self.default_missing_data_policy.is_none()
+            && self.default_limits.is_none()
     }
 }
 
@@ -148,8 +262,21 @@ pub async fn create_report_template(
 ) -> Result<ReportTemplate, ApiError> {
     use crate::schema::report_templates::dsl::report_templates;
 
-    let new_row = template.validate()?;
+    let new_row = template.into_row()?;
     ensure_template_name_is_available(pool, new_row.namespace_id, &new_row.name, None).await?;
+    validate_report_profile(
+        pool,
+        new_row.namespace_id,
+        ReportTemplateKind::from_str(&new_row.kind)?,
+        new_row.scope_kind.as_deref(),
+        new_row.class_id,
+        new_row.default_query.as_deref(),
+        new_row.include.as_ref(),
+        new_row.relation_context.as_ref(),
+        new_row.default_missing_data_policy.as_deref(),
+        new_row.default_limits.as_ref(),
+    )
+    .await?;
     let namespace_templates =
         report_templates_in_namespace(pool, new_row.namespace_id, None).await?;
     validate_template(
@@ -185,18 +312,67 @@ pub async fn update_report_template(
         return current_row.try_into();
     }
 
-    let target_namespace_id = update.namespace_id.unwrap_or(current_row.namespace_id);
-    let target_name = update
-        .name
+    let current = ReportTemplate::try_from(current_row.clone())?;
+    let target_namespace_id = update.namespace_id.unwrap_or(current.namespace_id);
+    let target_name = update.name.clone().unwrap_or_else(|| current.name.clone());
+    let target_description = update
+        .description
         .clone()
-        .unwrap_or_else(|| current_row.name.clone());
+        .unwrap_or_else(|| current.description.clone());
     let target_template = update
         .template
         .clone()
-        .unwrap_or_else(|| current_row.template.clone());
+        .unwrap_or_else(|| current.template.clone());
+    let target_kind = update.kind.unwrap_or(current.kind);
+
+    if target_kind == ReportTemplateKind::Fragment && update_report_fields_present(&update) {
+        return Err(ApiError::BadRequest(
+            "Fragment templates cannot define report execution metadata".to_string(),
+        ));
+    }
+
+    let (
+        target_scope_kind,
+        target_class_id,
+        target_default_query,
+        target_include,
+        target_relation_context,
+        target_default_missing_data_policy,
+        target_default_limits,
+    ) = if target_kind == ReportTemplateKind::Fragment {
+        (None, None, None, None, None, None, None)
+    } else {
+        (
+            update.scope_kind.or(current.scope_kind),
+            update.class_id.or(current.class_id),
+            update.default_query.clone().or(current.default_query),
+            update.include.clone().or(current.include),
+            update.relation_context.clone().or(current.relation_context),
+            update
+                .default_missing_data_policy
+                .or(current.default_missing_data_policy),
+            update.default_limits.clone().or(current.default_limits),
+        )
+    };
 
     ensure_template_name_is_available(pool, target_namespace_id, &target_name, Some(template_id))
         .await?;
+    let include_json = to_optional_json(target_include)?;
+    let relation_context_json = to_optional_json(target_relation_context)?;
+    let default_limits_json = to_optional_json(target_default_limits)?;
+    validate_report_profile(
+        pool,
+        target_namespace_id,
+        target_kind,
+        target_scope_kind.map(ReportScopeKind::as_str),
+        target_class_id,
+        target_default_query.as_deref(),
+        include_json.as_ref(),
+        relation_context_json.as_ref(),
+        target_default_missing_data_policy.map(ReportMissingDataPolicy::as_str),
+        default_limits_json.as_ref(),
+    )
+    .await?;
     let namespace_templates =
         report_templates_in_namespace(pool, target_namespace_id, Some(template_id)).await?;
     validate_template(
@@ -204,10 +380,25 @@ pub async fn update_report_template(
         &target_template,
         target_namespace_id,
         &namespace_templates,
-        ReportContentType::from_mime(&current_row.content_type)?,
+        current.content_type,
     )?;
 
-    let changeset = update.as_changeset();
+    let changeset = UpdateReportTemplateRow {
+        namespace_id: Some(target_namespace_id),
+        name: Some(target_name),
+        description: Some(target_description),
+        template: Some(target_template),
+        kind: Some(target_kind.as_str().to_string()),
+        scope_kind: Some(target_scope_kind.map(|scope| scope.as_str().to_string())),
+        class_id: Some(target_class_id),
+        default_query: Some(target_default_query),
+        include: Some(include_json),
+        relation_context: Some(relation_context_json),
+        default_missing_data_policy: Some(
+            target_default_missing_data_policy.map(|policy| policy.as_str().to_string()),
+        ),
+        default_limits: Some(default_limits_json),
+    };
     let row = with_connection(pool, |conn| {
         diesel::update(report_templates.filter(id.eq(template_id)))
             .set(&changeset)
@@ -256,6 +447,220 @@ pub async fn list_all_report_templates(pool: &DbPool) -> Result<Vec<ReportTempla
     })?;
 
     rows.into_iter().map(TryInto::try_into).collect()
+}
+
+async fn validate_report_profile(
+    pool: &DbPool,
+    target_namespace_id: i32,
+    kind: ReportTemplateKind,
+    scope_kind: Option<&str>,
+    class_id: Option<i32>,
+    default_query: Option<&str>,
+    include: Option<&serde_json::Value>,
+    relation_context: Option<&serde_json::Value>,
+    default_missing_data_policy: Option<&str>,
+    default_limits: Option<&serde_json::Value>,
+) -> Result<(), ApiError> {
+    match kind {
+        ReportTemplateKind::Fragment => {
+            if scope_kind.is_some() || class_id.is_some() {
+                return Err(ApiError::BadRequest(
+                    "Fragment templates cannot define report execution metadata".to_string(),
+                ));
+            }
+        }
+        ReportTemplateKind::Report => {
+            let scope_kind = scope_kind
+                .ok_or_else(|| ApiError::BadRequest("Report templates require scope_kind".into()))
+                .and_then(ReportScopeKind::from_str)?;
+            if !matches!(
+                scope_kind,
+                ReportScopeKind::ObjectsInClass | ReportScopeKind::RelatedObjects
+            ) {
+                return Err(ApiError::BadRequest(
+                    "Report templates only support objects_in_class and related_objects scopes"
+                        .to_string(),
+                ));
+            }
+            let class_id = class_id
+                .ok_or_else(|| ApiError::BadRequest("Report templates require class_id".into()))?;
+            if class_id <= 0 {
+                return Err(ApiError::BadRequest(
+                    "Report template class_id must be greater than 0".to_string(),
+                ));
+            }
+            ensure_template_class_in_namespace(pool, target_namespace_id, class_id).await?;
+
+            if let Some(query) = default_query {
+                parse_query_parameter(query)?;
+            }
+
+            if include.is_some() && scope_kind != ReportScopeKind::ObjectsInClass {
+                return Err(ApiError::BadRequest(
+                    "include is only supported for objects_in_class report templates".to_string(),
+                ));
+            }
+        }
+    }
+
+    if include.is_some() && relation_context.is_some() {
+        return Err(ApiError::BadRequest(
+            "include cannot be combined with relation_context".to_string(),
+        ));
+    }
+
+    if let Some(include) = include {
+        let include: ReportInclude = serde_json::from_value(include.clone())?;
+        validate_template_include(&include)?;
+    }
+    if let Some(relation_context) = relation_context {
+        let context: ReportRelationContext = serde_json::from_value(relation_context.clone())?;
+        if let Some(depth) = context.depth
+            && !(1..=2).contains(&depth)
+        {
+            return Err(ApiError::BadRequest(
+                "Templated relation hydration only supports depth 1 or 2".to_string(),
+            ));
+        }
+    }
+    if let Some(policy) = default_missing_data_policy {
+        ReportMissingDataPolicy::from_str(policy)?;
+    }
+    if let Some(limits) = default_limits {
+        let _limits: ReportLimits = serde_json::from_value(limits.clone())?;
+    }
+
+    Ok(())
+}
+
+fn validate_template_include(include: &ReportInclude) -> Result<(), ApiError> {
+    let Some(related_objects) = &include.related_objects else {
+        return Ok(());
+    };
+
+    if related_objects.len() > RELATED_INCLUDE_MAX_ALIASES {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects supports at most {RELATED_INCLUDE_MAX_ALIASES} aliases"
+        )));
+    }
+
+    for (alias, include) in related_objects {
+        validate_related_include_alias(alias)?;
+        validate_related_include_options(alias, include)?;
+    }
+
+    Ok(())
+}
+
+fn validate_related_include_alias(alias: &str) -> Result<(), ApiError> {
+    let mut chars = alias.chars();
+    let Some(first) = chars.next() else {
+        return Err(ApiError::BadRequest(
+            "include.related_objects aliases must not be empty".to_string(),
+        ));
+    };
+
+    if !(first == '_' || first.is_ascii_alphabetic())
+        || !chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+    {
+        return Err(ApiError::BadRequest(format!(
+            "Invalid include.related_objects alias '{alias}'; expected [A-Za-z_][A-Za-z0-9_]*"
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_related_include_options(
+    alias: &str,
+    include: &ReportIncludeRelatedObject,
+) -> Result<(), ApiError> {
+    if include.class_id <= 0 {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects.{alias}.class_id must be greater than 0"
+        )));
+    }
+
+    if let Some(class_relation_id) = include.class_relation_id
+        && class_relation_id <= 0
+    {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects.{alias}.class_relation_id must be greater than 0"
+        )));
+    }
+
+    let max_depth = include
+        .max_depth
+        .unwrap_or(RELATED_INCLUDE_DEFAULT_MAX_DEPTH);
+    if !(1..=RELATED_INCLUDE_MAX_DEPTH_LIMIT).contains(&max_depth) {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects.{alias}.max_depth must be between 1 and {RELATED_INCLUDE_MAX_DEPTH_LIMIT}"
+        )));
+    }
+
+    let limit = include.limit.unwrap_or(RELATED_INCLUDE_DEFAULT_LIMIT);
+    if !(1..=RELATED_INCLUDE_MAX_LIMIT).contains(&limit) {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects.{alias}.limit must be between 1 and {RELATED_INCLUDE_MAX_LIMIT}"
+        )));
+    }
+
+    Ok(())
+}
+
+async fn ensure_template_class_in_namespace(
+    pool: &DbPool,
+    target_namespace_id: i32,
+    target_class_id: i32,
+) -> Result<(), ApiError> {
+    use crate::schema::hubuumclass::dsl::{hubuumclass, id, namespace_id};
+
+    let class_namespace_id = with_connection(pool, |conn| {
+        hubuumclass
+            .filter(id.eq(target_class_id))
+            .select(namespace_id)
+            .first::<i32>(conn)
+            .optional()
+    })?
+    .ok_or_else(|| ApiError::NotFound(format!("Class {target_class_id} not found")))?;
+
+    if class_namespace_id != target_namespace_id {
+        return Err(ApiError::BadRequest(format!(
+            "Report template class {target_class_id} belongs to namespace {class_namespace_id}, not template namespace {target_namespace_id}"
+        )));
+    }
+
+    Ok(())
+}
+
+fn update_report_fields_present(update: &UpdateReportTemplate) -> bool {
+    update.scope_kind.is_some()
+        || update.class_id.is_some()
+        || update.default_query.is_some()
+        || update.include.is_some()
+        || update.relation_context.is_some()
+        || update.default_missing_data_policy.is_some()
+        || update.default_limits.is_some()
+}
+
+fn to_optional_json<T>(value: Option<T>) -> Result<Option<serde_json::Value>, ApiError>
+where
+    T: Serialize,
+{
+    value
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(Into::into)
+}
+
+fn from_optional_json<T>(value: Option<serde_json::Value>) -> Result<Option<T>, ApiError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    value
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(Into::into)
 }
 
 async fn ensure_template_name_is_available(
@@ -507,6 +912,17 @@ fn report_template_example() -> ReportTemplate {
         content_type: ReportContentType::TextPlain,
         template: "{% for item in items %}{{ item.name }}={{ item.data.owner }}\n{% endfor %}"
             .to_string(),
+        kind: ReportTemplateKind::Report,
+        scope_kind: Some(ReportScopeKind::ObjectsInClass),
+        class_id: Some(42),
+        default_query: Some("sort=name".to_string()),
+        include: None,
+        relation_context: None,
+        default_missing_data_policy: Some(ReportMissingDataPolicy::Strict),
+        default_limits: Some(ReportLimits {
+            max_items: Some(100),
+            max_output_bytes: Some(262_144),
+        }),
         created_at: example_timestamp,
         updated_at: example_timestamp,
     }
@@ -521,6 +937,17 @@ fn new_report_template_example() -> NewReportTemplate {
         content_type: ReportContentType::TextPlain,
         template: "{% for item in items %}{{ item.name }}={{ item.data.owner }}\n{% endfor %}"
             .to_string(),
+        kind: ReportTemplateKind::Report,
+        scope_kind: Some(ReportScopeKind::ObjectsInClass),
+        class_id: Some(42),
+        default_query: Some("sort=name".to_string()),
+        include: None,
+        relation_context: None,
+        default_missing_data_policy: Some(ReportMissingDataPolicy::Strict),
+        default_limits: Some(ReportLimits {
+            max_items: Some(100),
+            max_output_bytes: Some(262_144),
+        }),
     }
 }
 
@@ -531,5 +958,13 @@ fn update_report_template_example() -> UpdateReportTemplate {
         name: Some("owner-report-v2".to_string()),
         description: Some("Updated template description".to_string()),
         template: Some("{% for item in items %}{{ item.name }}\n{% endfor %}".to_string()),
+        kind: None,
+        scope_kind: None,
+        class_id: None,
+        default_query: Some("sort=name.desc".to_string()),
+        include: None,
+        relation_context: None,
+        default_missing_data_policy: None,
+        default_limits: None,
     }
 }

--- a/src/models/report_template.rs
+++ b/src/models/report_template.rs
@@ -20,7 +20,8 @@ use crate::pagination::{
     CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
 };
 use crate::schema::report_templates;
-use crate::traits::accessors::{IdAccessor, InstanceAdapter, NamespaceAdapter};
+use crate::traits::BackendContext;
+use crate::traits::accessors::{IdAccessor, InstanceAdapter, NamespaceAccessors, NamespaceAdapter};
 use crate::traits::crud::{DeleteAdapter, SaveAdapter, UpdateAdapter};
 use crate::utilities::reporting::validate_template;
 
@@ -388,7 +389,75 @@ impl ReportTemplate {
             relation_context: self.relation_context.clone(),
         })
     }
+
+    /// The other report templates sharing this template's namespace (this template excluded).
+    #[allow(dead_code)]
+    pub async fn namespace_siblings(&self, pool: &DbPool) -> Result<Vec<ReportTemplate>, ApiError> {
+        self.report_templates(pool, Some(self.id)).await
+    }
+
+    /// Every report template across all namespaces.
+    #[allow(dead_code)]
+    pub async fn list_all(pool: &DbPool) -> Result<Vec<ReportTemplate>, ApiError> {
+        let rows = backend::load_all_rows(pool).await?;
+
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+
+    /// List report templates (sorted/paginated per `query_options`) together with the total count
+    /// matching the filters, scoped to the namespaces the caller may see.
+    pub async fn list_with_total_count(
+        pool: &DbPool,
+        allowed_namespace_ids: &[i32],
+        query_options: &QueryOptions,
+    ) -> Result<(Vec<ReportTemplate>, i64), ApiError> {
+        if allowed_namespace_ids.is_empty() {
+            return Ok((Vec::new(), 0));
+        }
+
+        let (rows, total_count) =
+            backend::list_rows_with_total_count(pool, allowed_namespace_ids, query_options).await?;
+
+        let items = rows
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok((items, total_count))
+    }
 }
+
+/// List the report templates in a value's namespace. Available on anything that resolves to a
+/// namespace via [`NamespaceAccessors`] — `NamespaceID`, `Namespace`, `ReportTemplate`, classes,
+/// objects, and so on. For id-only types whose namespace must be looked up (e.g.
+/// `ReportTemplateID`) this performs that lookup before listing.
+///
+/// Defined here, rather than in `models::namespace`, so the namespace layer stays unaware of report
+/// templates: the dependency points from this feature module to the core accessor trait.
+pub trait NamespaceReportTemplates: NamespaceAccessors {
+    /// The report templates in this value's namespace, optionally excluding one template id (so a
+    /// template's own row is not treated as a sibling when validating its body against the set).
+    async fn report_templates<C>(
+        &self,
+        backend: &C,
+        exclude_template_id: Option<i32>,
+    ) -> Result<Vec<ReportTemplate>, ApiError>
+    where
+        C: BackendContext + ?Sized,
+    {
+        let namespace_id = self.namespace_id(backend).await?;
+        let rows = crate::db::traits::report_template::load_rows_in_namespace(
+            backend.db_pool(),
+            namespace_id,
+            exclude_template_id,
+        )
+        .await?;
+
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+}
+
+impl<T: NamespaceAccessors> NamespaceReportTemplates for T {}
 
 impl SaveAdapter for NewReportTemplate {
     type Output = ReportTemplate;
@@ -411,8 +480,9 @@ impl SaveAdapter for NewReportTemplate {
             },
         )
         .await?;
-        let namespace_templates =
-            report_templates_in_namespace(pool, new_row.namespace_id, None).await?;
+        let namespace_templates = NamespaceID(new_row.namespace_id)
+            .report_templates(pool, None)
+            .await?;
         validate_template(
             &new_row.name,
             &new_row.template,
@@ -501,8 +571,9 @@ async fn apply_report_template_update(
         },
     )
     .await?;
-    let namespace_templates =
-        report_templates_in_namespace(pool, target_namespace_id, Some(template_id)).await?;
+    let namespace_templates = NamespaceID(target_namespace_id)
+        .report_templates(pool, Some(template_id))
+        .await?;
     validate_template(
         &target_name,
         &target_template,
@@ -613,24 +684,6 @@ impl DeleteAdapter for ReportTemplateID {
     async fn delete_adapter(&self, pool: &DbPool) -> Result<(), ApiError> {
         self.delete_report_template_record(pool).await
     }
-}
-
-pub async fn report_templates_in_namespace(
-    pool: &DbPool,
-    target_namespace_id: i32,
-    exclude_template_id: Option<i32>,
-) -> Result<Vec<ReportTemplate>, ApiError> {
-    let rows =
-        backend::load_rows_in_namespace(pool, target_namespace_id, exclude_template_id).await?;
-
-    rows.into_iter().map(TryInto::try_into).collect()
-}
-
-#[allow(dead_code)]
-pub async fn list_all_report_templates(pool: &DbPool) -> Result<Vec<ReportTemplate>, ApiError> {
-    let rows = backend::load_all_rows(pool).await?;
-
-    rows.into_iter().map(TryInto::try_into).collect()
 }
 
 /// Borrowed view of the report-execution metadata validated together. Bundled so
@@ -852,26 +905,6 @@ async fn ensure_template_name_is_available(
     }
 
     Ok(())
-}
-
-pub async fn list_report_templates_with_total_count(
-    pool: &DbPool,
-    allowed_namespace_ids: &[i32],
-    query_options: &QueryOptions,
-) -> Result<(Vec<ReportTemplate>, i64), ApiError> {
-    if allowed_namespace_ids.is_empty() {
-        return Ok((Vec::new(), 0));
-    }
-
-    let (rows, total_count) =
-        backend::list_rows_with_total_count(pool, allowed_namespace_ids, query_options).await?;
-
-    let items = rows
-        .into_iter()
-        .map(TryInto::try_into)
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok((items, total_count))
 }
 
 impl IdAccessor for ReportTemplate {

--- a/src/models/report_template.rs
+++ b/src/models/report_template.rs
@@ -17,6 +17,7 @@ use crate::pagination::{
 };
 use crate::schema::report_templates;
 use crate::traits::accessors::{IdAccessor, InstanceAdapter, NamespaceAdapter};
+use crate::traits::crud::{DeleteAdapter, SaveAdapter, UpdateAdapter};
 use crate::utilities::reporting::validate_template;
 use crate::{date_search, numeric_search, string_search};
 
@@ -92,8 +93,32 @@ pub struct ReportTemplate {
     pub updated_at: chrono::NaiveDateTime,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
-pub struct ReportTemplateID(pub i32);
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
+pub struct ReportTemplateID(i32);
+
+impl ReportTemplateID {
+    /// Validating constructor: report-template ids are positive integers. Constructing through
+    /// `new` (and the `Deserialize` impl, which routes through it) means an invalid id is rejected
+    /// at the edge with a clear `400` rather than surfacing later as a confusing lookup miss.
+    pub fn new(id: i32) -> Result<Self, ApiError> {
+        if id <= 0 {
+            return Err(ApiError::BadRequest(format!(
+                "Invalid report template id '{id}': must be a positive integer"
+            )));
+        }
+        Ok(Self(id))
+    }
+}
+
+impl<'de> Deserialize<'de> for ReportTemplateID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let id = i32::deserialize(deserializer)?;
+        ReportTemplateID::new(id).map_err(serde::de::Error::custom)
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[schema(example = new_report_template_example)]
@@ -357,60 +382,61 @@ impl ReportTemplate {
     }
 }
 
-pub async fn report_template(pool: &DbPool, template_id: i32) -> Result<ReportTemplate, ApiError> {
-    use crate::schema::report_templates::dsl::{id, report_templates};
+impl SaveAdapter for NewReportTemplate {
+    type Output = ReportTemplate;
 
-    let row = with_connection(pool, |conn| {
-        report_templates
-            .filter(id.eq(template_id))
-            .first::<ReportTemplateRow>(conn)
-    })?;
+    async fn save_adapter(&self, pool: &DbPool) -> Result<ReportTemplate, ApiError> {
+        use crate::schema::report_templates::dsl::report_templates;
 
-    row.try_into()
+        let new_row = self.clone().into_row()?;
+        ensure_template_name_is_available(pool, new_row.namespace_id, &new_row.name, None).await?;
+        validate_report_profile(
+            pool,
+            new_row.namespace_id,
+            ReportProfileRef {
+                kind: ReportTemplateKind::from_str(&new_row.kind)?,
+                scope_kind: new_row.scope_kind.as_deref(),
+                class_id: new_row.class_id,
+                default_query: new_row.default_query.as_deref(),
+                include: new_row.include.as_ref(),
+                relation_context: new_row.relation_context.as_ref(),
+                default_missing_data_policy: new_row.default_missing_data_policy.as_deref(),
+                default_limits: new_row.default_limits.as_ref(),
+            },
+        )
+        .await?;
+        let namespace_templates =
+            report_templates_in_namespace(pool, new_row.namespace_id, None).await?;
+        validate_template(
+            &new_row.name,
+            &new_row.template,
+            new_row.namespace_id,
+            &namespace_templates,
+            ReportContentType::from_mime(&new_row.content_type)?,
+        )?;
+        let row = with_connection(pool, |conn| {
+            diesel::insert_into(report_templates)
+                .values(&new_row)
+                .get_result::<ReportTemplateRow>(conn)
+        })?;
+
+        row.try_into()
+    }
 }
 
-pub async fn create_report_template(
-    pool: &DbPool,
-    template: NewReportTemplate,
-) -> Result<ReportTemplate, ApiError> {
-    use crate::schema::report_templates::dsl::report_templates;
+impl UpdateAdapter for UpdateReportTemplate {
+    type Output = ReportTemplate;
 
-    let new_row = template.into_row()?;
-    ensure_template_name_is_available(pool, new_row.namespace_id, &new_row.name, None).await?;
-    validate_report_profile(
-        pool,
-        new_row.namespace_id,
-        ReportProfileRef {
-            kind: ReportTemplateKind::from_str(&new_row.kind)?,
-            scope_kind: new_row.scope_kind.as_deref(),
-            class_id: new_row.class_id,
-            default_query: new_row.default_query.as_deref(),
-            include: new_row.include.as_ref(),
-            relation_context: new_row.relation_context.as_ref(),
-            default_missing_data_policy: new_row.default_missing_data_policy.as_deref(),
-            default_limits: new_row.default_limits.as_ref(),
-        },
-    )
-    .await?;
-    let namespace_templates =
-        report_templates_in_namespace(pool, new_row.namespace_id, None).await?;
-    validate_template(
-        &new_row.name,
-        &new_row.template,
-        new_row.namespace_id,
-        &namespace_templates,
-        ReportContentType::from_mime(&new_row.content_type)?,
-    )?;
-    let row = with_connection(pool, |conn| {
-        diesel::insert_into(report_templates)
-            .values(&new_row)
-            .get_result::<ReportTemplateRow>(conn)
-    })?;
-
-    row.try_into()
+    async fn update_adapter(
+        &self,
+        pool: &DbPool,
+        entry_id: i32,
+    ) -> Result<ReportTemplate, ApiError> {
+        update_report_template_record(pool, entry_id, self.clone()).await
+    }
 }
 
-pub async fn update_report_template(
+async fn update_report_template_record(
     pool: &DbPool,
     template_id: i32,
     update: UpdateReportTemplate,
@@ -587,14 +613,16 @@ fn resolve_report_profile(
     }
 }
 
-pub async fn delete_report_template(pool: &DbPool, template_id: i32) -> Result<(), ApiError> {
-    use crate::schema::report_templates::dsl::{id, report_templates};
+impl DeleteAdapter for ReportTemplateID {
+    async fn delete_adapter(&self, pool: &DbPool) -> Result<(), ApiError> {
+        use crate::schema::report_templates::dsl::{id, report_templates};
 
-    with_connection(pool, |conn| {
-        diesel::delete(report_templates.filter(id.eq(template_id))).execute(conn)
-    })?;
+        with_connection(pool, |conn| {
+            diesel::delete(report_templates.filter(id.eq(self.0))).execute(conn)
+        })?;
 
-    Ok(())
+        Ok(())
+    }
 }
 
 pub async fn report_templates_in_namespace(
@@ -953,7 +981,15 @@ impl IdAccessor for ReportTemplateID {
 
 impl InstanceAdapter<ReportTemplate> for ReportTemplateID {
     async fn instance_adapter(&self, pool: &DbPool) -> Result<ReportTemplate, ApiError> {
-        report_template(pool, self.0).await
+        use crate::schema::report_templates::dsl::{id, report_templates};
+
+        let row = with_connection(pool, |conn| {
+            report_templates
+                .filter(id.eq(self.0))
+                .first::<ReportTemplateRow>(conn)
+        })?;
+
+        row.try_into()
     }
 }
 

--- a/src/models/report_template.rs
+++ b/src/models/report_template.rs
@@ -336,12 +336,47 @@ pub async fn update_report_template(
     ) = if target_kind == ReportTemplateKind::Fragment {
         (None, None, None, None, None, None, None)
     } else {
+        let target_scope_kind = update.scope_kind.or(current.scope_kind);
+
+        // Reconcile scope-dependent fields against the *target* scope. Without this,
+        // `update.field.or(current.field)` would carry forward a class_id/include/
+        // relation_context that the new scope forbids, making it impossible to PATCH an
+        // objects_in_class template into a collection scope. Carried-forward values are
+        // dropped when the target scope cannot hold them; an explicitly supplied
+        // incompatible value still falls through to validate_report_profile, which rejects
+        // it (matching the create path). This mirrors how switching to a fragment clears
+        // report metadata.
+        let scope_allows_class = target_scope_kind
+            .map(ReportScopeKind::requires_class_id)
+            .unwrap_or(false);
+        let scope_allows_include = target_scope_kind == Some(ReportScopeKind::ObjectsInClass);
+        let scope_allows_relation_context = matches!(
+            target_scope_kind,
+            Some(ReportScopeKind::ObjectsInClass) | Some(ReportScopeKind::RelatedObjects)
+        );
+
+        let target_class_id = if scope_allows_class {
+            update.class_id.or(current.class_id)
+        } else {
+            update.class_id
+        };
+        let target_include = if scope_allows_include {
+            update.include.clone().or(current.include)
+        } else {
+            update.include.clone()
+        };
+        let target_relation_context = if scope_allows_relation_context {
+            update.relation_context.clone().or(current.relation_context)
+        } else {
+            update.relation_context.clone()
+        };
+
         (
-            update.scope_kind.or(current.scope_kind),
-            update.class_id.or(current.class_id),
+            target_scope_kind,
+            target_class_id,
             update.default_query.clone().or(current.default_query),
-            update.include.clone().or(current.include),
-            update.relation_context.clone().or(current.relation_context),
+            target_include,
+            target_relation_context,
             update
                 .default_missing_data_policy
                 .or(current.default_missing_data_policy),

--- a/src/models/report_template.rs
+++ b/src/models/report_template.rs
@@ -5,7 +5,10 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::db::DbPool;
-use crate::db::traits::report_template as backend;
+use crate::db::traits::report_template::{
+    self as backend, DeleteReportTemplateRecord, LoadReportTemplateRecord,
+    ReportTemplateNamespaceLookup, SaveReportTemplateRecord, UpdateReportTemplateRecord,
+};
 use crate::errors::ApiError;
 use crate::models::search::{FilterField, QueryOptions, SortParam, parse_query_parameter};
 use crate::models::{
@@ -107,6 +110,11 @@ impl ReportTemplateID {
             )));
         }
         Ok(Self(id))
+    }
+
+    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
+    pub fn id(self) -> i32 {
+        self.0
     }
 }
 
@@ -412,7 +420,7 @@ impl SaveAdapter for NewReportTemplate {
             &namespace_templates,
             ReportContentType::from_mime(&new_row.content_type)?,
         )?;
-        let row = backend::insert_row(pool, &new_row).await?;
+        let row = new_row.save_report_template_record(pool).await?;
 
         row.try_into()
     }
@@ -426,16 +434,18 @@ impl UpdateAdapter for UpdateReportTemplate {
         pool: &DbPool,
         entry_id: i32,
     ) -> Result<ReportTemplate, ApiError> {
-        update_report_template_record(pool, entry_id, self.clone()).await
+        apply_report_template_update(pool, entry_id, self.clone()).await
     }
 }
 
-async fn update_report_template_record(
+async fn apply_report_template_update(
     pool: &DbPool,
     template_id: i32,
     update: UpdateReportTemplate,
 ) -> Result<ReportTemplate, ApiError> {
-    let current_row = backend::load_row(pool, template_id).await?;
+    let current_row = ReportTemplateID::new(template_id)?
+        .load_report_template_record(pool)
+        .await?;
 
     if update.is_empty() {
         return current_row.try_into();
@@ -517,7 +527,9 @@ async fn update_report_template_record(
         ),
         default_limits: Some(default_limits_json),
     };
-    let row = backend::update_row(pool, template_id, &changeset).await?;
+    let row = changeset
+        .update_report_template_record(pool, template_id)
+        .await?;
 
     row.try_into()
 }
@@ -599,7 +611,7 @@ fn resolve_report_profile(
 
 impl DeleteAdapter for ReportTemplateID {
     async fn delete_adapter(&self, pool: &DbPool) -> Result<(), ApiError> {
-        backend::delete_row(pool, self.0).await
+        self.delete_report_template_record(pool).await
     }
 }
 
@@ -882,7 +894,7 @@ impl IdAccessor for ReportTemplateID {
 
 impl InstanceAdapter<ReportTemplate> for ReportTemplateID {
     async fn instance_adapter(&self, pool: &DbPool) -> Result<ReportTemplate, ApiError> {
-        backend::load_row(pool, self.0).await?.try_into()
+        self.load_report_template_record(pool).await?.try_into()
     }
 }
 
@@ -904,7 +916,7 @@ impl NamespaceAdapter for ReportTemplateID {
     }
 
     async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<i32, ApiError> {
-        backend::namespace_id_for(pool, self.0).await
+        self.lookup_report_template_namespace_id(pool).await
     }
 }
 

--- a/src/models/report_template.rs
+++ b/src/models/report_template.rs
@@ -308,14 +308,16 @@ pub async fn create_report_template(
     validate_report_profile(
         pool,
         new_row.namespace_id,
-        ReportTemplateKind::from_str(&new_row.kind)?,
-        new_row.scope_kind.as_deref(),
-        new_row.class_id,
-        new_row.default_query.as_deref(),
-        new_row.include.as_ref(),
-        new_row.relation_context.as_ref(),
-        new_row.default_missing_data_policy.as_deref(),
-        new_row.default_limits.as_ref(),
+        ReportProfileRef {
+            kind: ReportTemplateKind::from_str(&new_row.kind)?,
+            scope_kind: new_row.scope_kind.as_deref(),
+            class_id: new_row.class_id,
+            default_query: new_row.default_query.as_deref(),
+            include: new_row.include.as_ref(),
+            relation_context: new_row.relation_context.as_ref(),
+            default_missing_data_policy: new_row.default_missing_data_policy.as_deref(),
+            default_limits: new_row.default_limits.as_ref(),
+        },
     )
     .await?;
     let namespace_templates =
@@ -436,14 +438,17 @@ pub async fn update_report_template(
     validate_report_profile(
         pool,
         target_namespace_id,
-        target_kind,
-        target_scope_kind.map(ReportScopeKind::as_str),
-        target_class_id,
-        target_default_query.as_deref(),
-        include_json.as_ref(),
-        relation_context_json.as_ref(),
-        target_default_missing_data_policy.map(ReportMissingDataPolicy::as_str),
-        default_limits_json.as_ref(),
+        ReportProfileRef {
+            kind: target_kind,
+            scope_kind: target_scope_kind.map(ReportScopeKind::as_str),
+            class_id: target_class_id,
+            default_query: target_default_query.as_deref(),
+            include: include_json.as_ref(),
+            relation_context: relation_context_json.as_ref(),
+            default_missing_data_policy: target_default_missing_data_policy
+                .map(ReportMissingDataPolicy::as_str),
+            default_limits: default_limits_json.as_ref(),
+        },
     )
     .await?;
     let namespace_templates =
@@ -522,18 +527,37 @@ pub async fn list_all_report_templates(pool: &DbPool) -> Result<Vec<ReportTempla
     rows.into_iter().map(TryInto::try_into).collect()
 }
 
+/// Borrowed view of the report-execution metadata validated together. Bundled so
+/// `validate_report_profile` stays within a sensible argument count and both the create and
+/// update paths share one shape.
+#[derive(Debug, Clone, Copy)]
+struct ReportProfileRef<'a> {
+    kind: ReportTemplateKind,
+    scope_kind: Option<&'a str>,
+    class_id: Option<i32>,
+    default_query: Option<&'a str>,
+    include: Option<&'a serde_json::Value>,
+    relation_context: Option<&'a serde_json::Value>,
+    default_missing_data_policy: Option<&'a str>,
+    default_limits: Option<&'a serde_json::Value>,
+}
+
 async fn validate_report_profile(
     pool: &DbPool,
     target_namespace_id: i32,
-    kind: ReportTemplateKind,
-    scope_kind: Option<&str>,
-    class_id: Option<i32>,
-    default_query: Option<&str>,
-    include: Option<&serde_json::Value>,
-    relation_context: Option<&serde_json::Value>,
-    default_missing_data_policy: Option<&str>,
-    default_limits: Option<&serde_json::Value>,
+    profile: ReportProfileRef<'_>,
 ) -> Result<(), ApiError> {
+    let ReportProfileRef {
+        kind,
+        scope_kind,
+        class_id,
+        default_query,
+        include,
+        relation_context,
+        default_missing_data_policy,
+        default_limits,
+    } = profile;
+
     match kind {
         ReportTemplateKind::Fragment => {
             if scope_kind.is_some() || class_id.is_some() {

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -117,6 +117,38 @@ impl From<TaskResultCounts> for (i32, i32, i32) {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
+pub struct TaskID(i32);
+
+impl TaskID {
+    /// Validating constructor: task ids are positive integers. Constructing through `new` (and the
+    /// `Deserialize` impl, which routes through it) means an invalid id is rejected at the edge with
+    /// a clear `400` rather than surfacing later as a confusing lookup miss.
+    pub fn new(id: i32) -> Result<Self, ApiError> {
+        if id <= 0 {
+            return Err(ApiError::BadRequest(format!(
+                "Invalid task id '{id}': must be a positive integer"
+            )));
+        }
+        Ok(Self(id))
+    }
+
+    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
+    pub fn id(self) -> i32 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for TaskID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let id = i32::deserialize(deserializer)?;
+        TaskID::new(id).map_err(serde::de::Error::custom)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name = tasks)]
 pub struct TaskRecord {
@@ -601,5 +633,33 @@ impl CursorPaginated for ImportTaskResultResponse {
 
     fn tie_breaker_sort() -> Vec<SortParam> {
         Self::default_sort()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_id_new_accepts_positive() {
+        assert_eq!(TaskID::new(1).unwrap().id(), 1);
+        assert_eq!(TaskID::new(i32::MAX).unwrap().id(), i32::MAX);
+    }
+
+    #[test]
+    fn task_id_new_rejects_non_positive() {
+        for invalid in [0, -1, i32::MIN] {
+            let err = TaskID::new(invalid).unwrap_err();
+            assert!(matches!(err, ApiError::BadRequest(_)), "got {err:?}");
+        }
+    }
+
+    #[test]
+    fn task_id_deserialize_routes_through_new() {
+        // A valid id deserializes; a non-positive id is rejected by the validating constructor,
+        // so an invalid path segment never produces a TaskID.
+        assert_eq!(serde_json::from_str::<TaskID>("7").unwrap().id(), 7);
+        assert!(serde_json::from_str::<TaskID>("0").is_err());
+        assert!(serde_json::from_str::<TaskID>("-3").is_err());
     }
 }

--- a/src/models/traits/mod.rs
+++ b/src/models/traits/mod.rs
@@ -4,6 +4,7 @@ pub mod namespace;
 pub mod object;
 pub mod object_relation;
 pub mod output;
+pub mod task;
 pub mod user;
 
 #[allow(unused_imports)]

--- a/src/models/traits/task.rs
+++ b/src/models/traits/task.rs
@@ -1,0 +1,68 @@
+//! Authorization-aware task loads, as methods on the `TaskID` newtype.
+//!
+//! Tasks are user-owned rather than namespace-scoped, so they do not use the `PermissionController`
+//! path the other resources do. Authorization is "the submitter or an admin"; denial (and a kind
+//! mismatch) returns a `404` rather than a `403` so the existence of another user's task is not
+//! revealed. These methods replace the per-handler free functions that previously took a bare id.
+
+use crate::db::DbPool;
+use crate::db::traits::task::TaskBackend;
+use crate::errors::ApiError;
+use crate::models::{TaskID, TaskKind, TaskRecord, User};
+use crate::traits::GroupMemberships;
+
+impl TaskID {
+    /// Load this task for `user`, enforcing ownership-or-admin authorization.
+    pub async fn load_authorized(
+        &self,
+        pool: &DbPool,
+        user: &User,
+    ) -> Result<TaskRecord, ApiError> {
+        self.load_authorized_of_kind(pool, user, None, "Task").await
+    }
+
+    /// Load this task, additionally requiring it to be a report task.
+    pub async fn load_authorized_report(
+        &self,
+        pool: &DbPool,
+        user: &User,
+    ) -> Result<TaskRecord, ApiError> {
+        self.load_authorized_of_kind(pool, user, Some(TaskKind::Report), "Report task")
+            .await
+    }
+
+    /// Load this task, additionally requiring it to be an import task.
+    pub async fn load_authorized_import(
+        &self,
+        pool: &DbPool,
+        user: &User,
+    ) -> Result<TaskRecord, ApiError> {
+        self.load_authorized_of_kind(pool, user, Some(TaskKind::Import), "Import task")
+            .await
+    }
+
+    async fn load_authorized_of_kind(
+        &self,
+        pool: &DbPool,
+        user: &User,
+        kind: Option<TaskKind>,
+        label: &str,
+    ) -> Result<TaskRecord, ApiError> {
+        let task = self.find_record(pool).await?;
+
+        if let Some(kind) = kind
+            && task.kind != kind.as_str()
+        {
+            return Err(ApiError::NotFound(format!(
+                "{label} {} not found",
+                self.id()
+            )));
+        }
+
+        if task.submitted_by == Some(user.id) || user.is_admin(pool).await? {
+            Ok(task)
+        } else {
+            Err(ApiError::NotFound(format!("{label} not found")))
+        }
+    }
+}

--- a/src/models/unified_search.rs
+++ b/src/models/unified_search.rs
@@ -709,9 +709,8 @@ mod tests {
             parse_unified_search_query_with_limits("q=server&limit_per_kind=50", 25, 100).unwrap();
         assert_eq!(parsed.limit_per_kind, 50);
 
-        let error =
-            parse_unified_search_query_with_limits("q=server&limit_per_kind=101", 25, 100)
-                .unwrap_err();
+        let error = parse_unified_search_query_with_limits("q=server&limit_per_kind=101", 25, 100)
+            .unwrap_err();
         assert_eq!(error.to_string(), "limit must be at most 100");
     }
 

--- a/src/pagination/mod.rs
+++ b/src/pagination/mod.rs
@@ -55,7 +55,10 @@ pub fn validate_page_limit(limit: usize) -> Result<usize, ApiError> {
 /// explicitly instead of reading it from the global configuration. Useful where
 /// the caller already holds the limits, or wants to avoid touching global config
 /// (for example, benchmarks).
-pub fn validate_page_limit_with_max(limit: usize, max_page_limit: usize) -> Result<usize, ApiError> {
+pub fn validate_page_limit_with_max(
+    limit: usize,
+    max_page_limit: usize,
+) -> Result<usize, ApiError> {
     if limit == 0 {
         return Err(ApiError::BadRequest(
             "limit must be greater than 0".to_string(),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -157,6 +157,14 @@ diesel::table! {
         description -> Varchar,
         content_type -> Varchar,
         template -> Text,
+        kind -> Varchar,
+        scope_kind -> Nullable<Varchar>,
+        class_id -> Nullable<Int4>,
+        default_query -> Nullable<Text>,
+        include -> Nullable<Jsonb>,
+        relation_context -> Nullable<Jsonb>,
+        default_missing_data_policy -> Nullable<Varchar>,
+        default_limits -> Nullable<Jsonb>,
         created_at -> Timestamp,
         updated_at -> Timestamp,
     }
@@ -233,6 +241,7 @@ diesel::joinable!(import_task_results -> tasks (task_id));
 diesel::joinable!(permissions -> groups (group_id));
 diesel::joinable!(permissions -> namespaces (namespace_id));
 diesel::joinable!(report_task_outputs -> tasks (task_id));
+diesel::joinable!(report_templates -> hubuumclass (class_id));
 diesel::joinable!(report_templates -> namespaces (namespace_id));
 diesel::joinable!(task_events -> tasks (task_id));
 diesel::joinable!(tokens -> users (user_id));

--- a/src/tasks/execution.rs
+++ b/src/tasks/execution.rs
@@ -2,9 +2,7 @@ use std::time::Instant;
 
 use tracing::{Instrument, error, info, info_span, warn};
 
-use crate::db::traits::task::{
-    TaskStateUpdate, append_task_event, finalize_task_terminal_state, update_task_state,
-};
+use crate::db::traits::task::{TaskBackend, TaskStateUpdate, append_task_event};
 use crate::db::{DbPool, with_transaction};
 use crate::errors::ApiError;
 use crate::models::{
@@ -151,9 +149,8 @@ pub(super) async fn execute_import_task(
         )
         .await?;
 
-        update_task_state(
+        task.update_state(
             pool,
-            task.id,
             TaskStateUpdate {
                 status: TaskStatus::Running,
                 summary: None,
@@ -265,9 +262,8 @@ async fn finalize_task(
     task: &TaskRecord,
     terminal: TerminalTaskUpdate,
 ) -> Result<(), ApiError> {
-    finalize_task_terminal_state(
+    task.finalize_terminal(
         pool,
-        task.id,
         TaskStateUpdate {
             status: terminal.status,
             summary: Some(terminal.summary.clone()),

--- a/src/tasks/execution.rs
+++ b/src/tasks/execution.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use tracing::{Instrument, error, info, info_span, warn};
 
-use crate::db::traits::task::{TaskBackend, TaskStateUpdate, append_task_event};
+use crate::db::traits::task::{TaskBackend, TaskStateUpdate};
 use crate::db::{DbPool, with_transaction};
 use crate::errors::ApiError;
 use crate::models::{
@@ -129,24 +129,22 @@ pub(super) async fn execute_import_task(
             planning_time = ?planning_time
         );
 
-        append_task_event(
-            pool,
-            NewTaskEventRecord {
-                task_id: task.id,
-                event_type: "running".to_string(),
-                message: if request.dry_run() {
-                    "Import dry run planned successfully".to_string()
-                } else if failures.is_empty() {
-                    "Import execution started".to_string()
-                } else {
-                    format!(
-                        "Import execution started with {} planned failure(s)",
-                        failures.len()
-                    )
-                },
-                data: None,
+        NewTaskEventRecord {
+            task_id: task.id,
+            event_type: "running".to_string(),
+            message: if request.dry_run() {
+                "Import dry run planned successfully".to_string()
+            } else if failures.is_empty() {
+                "Import execution started".to_string()
+            } else {
+                format!(
+                    "Import execution started with {} planned failure(s)",
+                    failures.len()
+                )
             },
-        )
+            data: None,
+        }
+        .append(pool)
         .await?;
 
         task.update_state(

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -18,10 +18,7 @@ use super::types::{
     PlanningFailure, PlanningState, RuntimeState, WorkerLoopAction,
 };
 use super::worker::{background_worker_action, mark_claimed_task_failed, process_one_task};
-use crate::db::traits::task::{
-    count_import_results_summary, create_task_record, find_task_record, insert_import_results,
-    list_task_events_with_total_count,
-};
+use crate::db::traits::task::{TaskBackend, create_task_record, insert_import_results};
 use crate::db::traits::task_import::{create_class_db, create_object_db};
 use crate::db::with_connection;
 use crate::errors::ApiError;
@@ -330,14 +327,13 @@ fn test_process_one_task_marks_claimed_task_failed_when_execution_setup_errors()
     for _ in 0..20 {
         let _ = block_on(process_one_task(&context.pool)).unwrap();
 
-        let stored = block_on(find_task_record(&context.pool, task.id)).unwrap();
+        let stored = block_on(task.find_record(&context.pool)).unwrap();
         if stored.status == TaskStatus::Failed.as_str() {
             assert!(stored.finished_at.is_some());
             assert!(stored.request_redacted_at.is_some());
 
-            let (events, _) = block_on(list_task_events_with_total_count(
+            let (events, _) = block_on(task.list_events_with_total_count(
                 &context.pool,
-                task.id,
                 &crate::models::search::QueryOptions {
                     filters: Vec::new(),
                     sort: Vec::new(),
@@ -356,7 +352,7 @@ fn test_process_one_task_marks_claimed_task_failed_when_execution_setup_errors()
         }
     }
 
-    let stored = block_on(find_task_record(&context.pool, task.id)).unwrap();
+    let stored = block_on(task.find_record(&context.pool)).unwrap();
     panic!(
         "Task {} did not reach failed state after repeated processing attempts; current status: {}",
         task.id, stored.status
@@ -1303,7 +1299,7 @@ fn test_process_one_task_report_failure_marks_single_failed_item() {
 
     for _ in 0..20 {
         let _ = block_on(process_one_task(&context.pool)).unwrap();
-        let stored = block_on(find_task_record(&context.pool, task.id)).unwrap();
+        let stored = block_on(task.find_record(&context.pool)).unwrap();
         if stored.status == TaskStatus::Failed.as_str() {
             assert_eq!(stored.total_items, 0);
             assert_eq!(stored.processed_items, 1);
@@ -1312,7 +1308,7 @@ fn test_process_one_task_report_failure_marks_single_failed_item() {
         }
     }
 
-    let stored = block_on(find_task_record(&context.pool, task.id)).unwrap();
+    let stored = block_on(task.find_record(&context.pool)).unwrap();
     panic!(
         "Task {} did not reach failed state after repeated processing attempts; current status: {}",
         task.id, stored.status
@@ -1377,7 +1373,7 @@ fn test_mark_claimed_task_failed_uses_recorded_result_counts() {
     ))
     .unwrap();
 
-    let stored = block_on(find_task_record(&context.pool, task.id)).unwrap();
+    let stored = block_on(task.find_record(&context.pool)).unwrap();
     assert_eq!(stored.processed_items, 2);
     assert_eq!(stored.success_items, 1);
     assert_eq!(stored.failed_items, 1);
@@ -1444,7 +1440,7 @@ fn test_count_import_results_summary_counts_success_and_failure_rows() {
     ))
     .unwrap();
 
-    let counts = block_on(count_import_results_summary(&context.pool, task.id)).unwrap();
+    let counts = block_on(task.count_import_results(&context.pool)).unwrap();
 
     assert_eq!(counts.processed, 3);
     assert_eq!(counts.success, 2);

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -18,7 +18,7 @@ use super::types::{
     PlanningFailure, PlanningState, RuntimeState, WorkerLoopAction,
 };
 use super::worker::{background_worker_action, mark_claimed_task_failed, process_one_task};
-use crate::db::traits::task::{TaskBackend, create_task_record, insert_import_results};
+use crate::db::traits::task::{TaskBackend, insert_import_results};
 use crate::db::traits::task_import::{create_class_db, create_object_db};
 use crate::db::with_connection;
 use crate::errors::ApiError;
@@ -292,8 +292,7 @@ fn test_execute_import_strict_preserves_underlying_error_variant() {
 #[test]
 fn test_process_one_task_marks_claimed_task_failed_when_execution_setup_errors() {
     let context = block_on(TestContext::new());
-    let task = block_on(create_task_record(
-        &context.pool,
+    let task = block_on(
         NewTaskRecord {
             kind: TaskKind::Import.as_str().to_string(),
             status: TaskStatus::Queued.as_str().to_string(),
@@ -309,8 +308,9 @@ fn test_process_one_task_marks_claimed_task_failed_when_execution_setup_errors()
             request_redacted_at: None,
             started_at: None,
             finished_at: None,
-        },
-    ))
+        }
+        .create(&context.pool),
+    )
     .unwrap();
 
     let earliest = NaiveDate::from_ymd_opt(2000, 1, 1)
@@ -1265,8 +1265,7 @@ fn test_best_effort_execution_only_aborts_for_matching_policy_failures() {
 #[test]
 fn test_process_one_task_report_failure_marks_single_failed_item() {
     let context = block_on(TestContext::new());
-    let task = block_on(create_task_record(
-        &context.pool,
+    let task = block_on(
         NewTaskRecord {
             kind: TaskKind::Report.as_str().to_string(),
             status: TaskStatus::Queued.as_str().to_string(),
@@ -1282,8 +1281,9 @@ fn test_process_one_task_report_failure_marks_single_failed_item() {
             request_redacted_at: None,
             started_at: None,
             finished_at: None,
-        },
-    ))
+        }
+        .create(&context.pool),
+    )
     .unwrap();
 
     let earliest = NaiveDate::from_ymd_opt(2000, 1, 1)
@@ -1318,8 +1318,7 @@ fn test_process_one_task_report_failure_marks_single_failed_item() {
 #[test]
 fn test_mark_claimed_task_failed_uses_recorded_result_counts() {
     let context = block_on(TestContext::new());
-    let task = block_on(create_task_record(
-        &context.pool,
+    let task = block_on(
         NewTaskRecord {
             kind: TaskKind::Import.as_str().to_string(),
             status: TaskStatus::Queued.as_str().to_string(),
@@ -1335,8 +1334,9 @@ fn test_mark_claimed_task_failed_uses_recorded_result_counts() {
             request_redacted_at: None,
             started_at: None,
             finished_at: None,
-        },
-    ))
+        }
+        .create(&context.pool),
+    )
     .unwrap();
 
     block_on(insert_import_results(
@@ -1382,8 +1382,7 @@ fn test_mark_claimed_task_failed_uses_recorded_result_counts() {
 #[test]
 fn test_count_import_results_summary_counts_success_and_failure_rows() {
     let context = block_on(TestContext::new());
-    let task = block_on(create_task_record(
-        &context.pool,
+    let task = block_on(
         NewTaskRecord {
             kind: TaskKind::Import.as_str().to_string(),
             status: TaskStatus::Queued.as_str().to_string(),
@@ -1399,8 +1398,9 @@ fn test_count_import_results_summary_counts_success_and_failure_rows() {
             request_redacted_at: None,
             started_at: None,
             finished_at: None,
-        },
-    ))
+        }
+        .create(&context.pool),
+    )
     .unwrap();
 
     block_on(insert_import_results(

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -10,8 +10,7 @@ use crate::api::v1::handlers::reports::execute_report_task;
 use crate::config::{DEFAULT_TASK_POLL_INTERVAL_MS, get_config};
 use crate::db::DbPool;
 use crate::db::traits::task::{
-    TaskStateUpdate, claim_next_queued_task, count_import_results_summary,
-    finalize_task_terminal_state, purge_expired_report_outputs,
+    TaskBackend, TaskStateUpdate, claim_next_queued_task, purge_expired_report_outputs,
 };
 use crate::errors::ApiError;
 use crate::models::{
@@ -191,7 +190,7 @@ pub(super) async fn mark_claimed_task_failed(
 ) -> Result<(), ApiError> {
     let summary = sanitize_error_for_storage(err);
     let counts = match TaskKind::from_db(&task.kind)? {
-        TaskKind::Import => count_import_results_summary(pool, task.id).await?,
+        TaskKind::Import => task.count_import_results(pool).await?,
         TaskKind::Report => TaskResultCounts::new(1, 0, 1)?,
         _ => TaskResultCounts::default(),
     };
@@ -207,9 +206,8 @@ pub(super) async fn mark_claimed_task_failed(
         error = %err
     );
 
-    finalize_task_terminal_state(
+    task.finalize_terminal(
         pool,
-        task.id,
         TaskStateUpdate {
             status: TaskStatus::Failed,
             summary: Some(summary.clone()),

--- a/src/tests/api/v1/imports.rs
+++ b/src/tests/api/v1/imports.rs
@@ -8,7 +8,6 @@ mod tests {
     use rstest::rstest;
     use std::time::Duration;
 
-    use crate::db::traits::task::create_task_record;
     use crate::db::with_connection;
     use crate::models::{
         GroupKey, ImportAtomicity, ImportClassInput, ImportCollisionPolicy, ImportGraph,
@@ -234,25 +233,23 @@ mod tests {
         #[future(awt)] test_context: TestContext,
     ) {
         let context = test_context;
-        let task = create_task_record(
-            &context.pool,
-            NewTaskRecord {
-                kind: TaskKind::Report.as_str().to_string(),
-                status: TaskStatus::Succeeded.as_str().to_string(),
-                submitted_by: Some(context.admin_user.id),
-                idempotency_key: None,
-                request_hash: None,
-                request_payload: None,
-                summary: Some("Synthetic report task".to_string()),
-                total_items: 0,
-                processed_items: 0,
-                success_items: 0,
-                failed_items: 0,
-                request_redacted_at: Some(Utc::now().naive_utc()),
-                started_at: Some(Utc::now().naive_utc()),
-                finished_at: Some(Utc::now().naive_utc()),
-            },
-        )
+        let task = NewTaskRecord {
+            kind: TaskKind::Report.as_str().to_string(),
+            status: TaskStatus::Succeeded.as_str().to_string(),
+            submitted_by: Some(context.admin_user.id),
+            idempotency_key: None,
+            request_hash: None,
+            request_payload: None,
+            summary: Some("Synthetic report task".to_string()),
+            total_items: 0,
+            processed_items: 0,
+            success_items: 0,
+            failed_items: 0,
+            request_redacted_at: Some(Utc::now().naive_utc()),
+            started_at: Some(Utc::now().naive_utc()),
+            finished_at: Some(Utc::now().naive_utc()),
+        }
+        .create(&context.pool)
         .await
         .unwrap();
 
@@ -400,25 +397,23 @@ mod tests {
     ) {
         let context = test_context;
         let report_key = context.scoped_name("report-task-idempotency");
-        let report_task = create_task_record(
-            &context.pool,
-            NewTaskRecord {
-                kind: TaskKind::Report.as_str().to_string(),
-                status: TaskStatus::Queued.as_str().to_string(),
-                submitted_by: Some(context.admin_user.id),
-                idempotency_key: Some(report_key.clone()),
-                request_hash: Some(context.scoped_name("report-task-hash")),
-                request_payload: None,
-                summary: None,
-                total_items: 0,
-                processed_items: 0,
-                success_items: 0,
-                failed_items: 0,
-                request_redacted_at: None,
-                started_at: None,
-                finished_at: None,
-            },
-        )
+        let report_task = NewTaskRecord {
+            kind: TaskKind::Report.as_str().to_string(),
+            status: TaskStatus::Queued.as_str().to_string(),
+            submitted_by: Some(context.admin_user.id),
+            idempotency_key: Some(report_key.clone()),
+            request_hash: Some(context.scoped_name("report-task-hash")),
+            request_payload: None,
+            summary: None,
+            total_items: 0,
+            processed_items: 0,
+            success_items: 0,
+            failed_items: 0,
+            request_redacted_at: None,
+            started_at: None,
+            finished_at: None,
+        }
+        .create(&context.pool)
         .await
         .unwrap();
 

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -447,6 +447,404 @@ mod tests {
 
     #[rstest]
     #[actix_web::test]
+    async fn test_run_related_objects_template_requires_object_id(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "report_run_requires_object").await;
+        let class = classes[0].clone();
+        let template_id = create_template(
+            &context.pool,
+            class.namespace_id,
+            class.id,
+            ReportScopeKind::RelatedObjects,
+            "needs-object-id",
+            ReportContentType::TextPlain,
+            "{% for item in items %}{{ item.name }}{% endfor %}",
+        )
+        .await;
+
+        let resp = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/templates/{template_id}/reports"),
+            &serde_json::json!({}),
+            vec![],
+        )
+        .await;
+        assert_response_status(resp, StatusCode::BAD_REQUEST).await;
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_objects_in_class_template_rejects_object_id(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "report_run_rejects_object").await;
+        let class = classes[0].clone();
+        let template_id = create_template(
+            &context.pool,
+            class.namespace_id,
+            class.id,
+            ReportScopeKind::ObjectsInClass,
+            "rejects-object-id",
+            ReportContentType::TextPlain,
+            "{% for item in items %}{{ item.name }}{% endfor %}",
+        )
+        .await;
+
+        let resp = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/templates/{template_id}/reports"),
+            &serde_json::json!({ "object_id": 1 }),
+            vec![],
+        )
+        .await;
+        assert_response_status(resp, StatusCode::BAD_REQUEST).await;
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_template_uses_default_query_and_runtime_override(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "report_run_default_query").await;
+        let class = classes[0].clone();
+        let _ = create_report_objects(&context.pool, &class).await;
+
+        // Template carries a default query that selects only the "app" host.
+        let template = crate::models::report_template::create_report_template(
+            &context.pool,
+            NewReportTemplate {
+                namespace_id: class.namespace_id,
+                name: "report.default-query".to_string(),
+                description: "default query report".to_string(),
+                content_type: ReportContentType::TextPlain,
+                template: "{% for item in items %}{{ item.name }}\n{% endfor %}".to_string(),
+                kind: ReportTemplateKind::Report,
+                scope_kind: Some(ReportScopeKind::ObjectsInClass),
+                class_id: Some(class.id),
+                default_query: Some("name__contains=app-&sort=name".to_string()),
+                include: None,
+                relation_context: None,
+                default_missing_data_policy: None,
+                default_limits: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // An empty run body falls back to the template's default query.
+        let resp = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/templates/{}/reports", template.id),
+            &serde_json::json!({}),
+            vec![],
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::ACCEPTED).await;
+        let task: TaskResponse = test::read_body_json(resp).await;
+        let _ = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+        let output = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/reports/{}/output", task.id),
+        )
+        .await;
+        let output = assert_response_status(output, StatusCode::OK).await;
+        let body = String::from_utf8(test::read_body(output).await.to_vec()).unwrap();
+        assert_eq!(body, "report-app-01\n");
+
+        // A runtime query overrides the template default entirely.
+        let resp = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/templates/{}/reports", template.id),
+            &serde_json::json!({ "query": "name__contains=db-&sort=name" }),
+            vec![],
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::ACCEPTED).await;
+        let task: TaskResponse = test::read_body_json(resp).await;
+        let _ = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+        let output = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/reports/{}/output", task.id),
+        )
+        .await;
+        let output = assert_response_status(output, StatusCode::OK).await;
+        let body = String::from_utf8(test::read_body(output).await.to_vec()).unwrap();
+        assert_eq!(body, "report-db-01\n");
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_template_csv_output_end_to_end(#[future(awt)] test_context: TestContext) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "report_run_csv").await;
+        let class = classes[0].clone();
+        let _ = create_report_objects(&context.pool, &class).await;
+        let template_id = create_template(
+            &context.pool,
+            class.namespace_id,
+            class.id,
+            ReportScopeKind::ObjectsInClass,
+            "report.csv",
+            ReportContentType::TextCsv,
+            "host,owner\n{% for item in items %}{{ item.name|csv_cell }},{{ item.data.owner|csv_cell }}\n{% endfor %}",
+        )
+        .await;
+
+        let resp = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/templates/{template_id}/reports"),
+            &serde_json::json!({ "query": "sort=name" }),
+            vec![],
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::ACCEPTED).await;
+        let task: TaskResponse = test::read_body_json(resp).await;
+        let _ = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+
+        let output = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/reports/{}/output", task.id),
+        )
+        .await;
+        let output = assert_response_status(output, StatusCode::OK).await;
+        let content_type = header_value(&output, header::CONTENT_TYPE.as_str()).unwrap_or_default();
+        assert!(
+            content_type.starts_with("text/csv"),
+            "expected text/csv output, got {content_type}"
+        );
+        let body = String::from_utf8(test::read_body(output).await.to_vec()).unwrap();
+        assert_eq!(body, "host,owner\nreport-app-01,alice\nreport-db-01,bob\n");
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_namespaces_scope_template(#[future(awt)] test_context: TestContext) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "report_ns_scope").await;
+        let namespace_name = classes.namespace.namespace.name.clone();
+
+        let template = crate::models::report_template::create_report_template(
+            &context.pool,
+            NewReportTemplate {
+                namespace_id: classes[0].namespace_id,
+                name: "report.namespaces".to_string(),
+                description: "namespace listing".to_string(),
+                content_type: ReportContentType::TextPlain,
+                template: "{% for item in items %}{{ item.name }}\n{% endfor %}".to_string(),
+                kind: ReportTemplateKind::Report,
+                scope_kind: Some(ReportScopeKind::Namespaces),
+                class_id: None,
+                default_query: Some(format!("name__equals={namespace_name}")),
+                include: None,
+                relation_context: None,
+                default_missing_data_policy: None,
+                default_limits: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let resp = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/templates/{}/reports", template.id),
+            &serde_json::json!({}),
+            vec![],
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::ACCEPTED).await;
+        let task: TaskResponse = test::read_body_json(resp).await;
+        let _ = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+        let output = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/reports/{}/output", task.id),
+        )
+        .await;
+        let output = assert_response_status(output, StatusCode::OK).await;
+        let body = String::from_utf8(test::read_body(output).await.to_vec()).unwrap();
+        assert_eq!(body, format!("{namespace_name}\n"));
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_classes_scope_template(#[future(awt)] test_context: TestContext) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "report_cls_scope").await;
+
+        let template = crate::models::report_template::create_report_template(
+            &context.pool,
+            NewReportTemplate {
+                namespace_id: classes[0].namespace_id,
+                name: "report.classes".to_string(),
+                description: "class listing".to_string(),
+                content_type: ReportContentType::TextPlain,
+                template: "{% for item in items %}{{ item.name }}\n{% endfor %}".to_string(),
+                kind: ReportTemplateKind::Report,
+                scope_kind: Some(ReportScopeKind::Classes),
+                class_id: None,
+                default_query: Some("name__contains=report_cls_scope_api_class_&sort=name".to_string()),
+                include: None,
+                relation_context: None,
+                default_missing_data_policy: None,
+                default_limits: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let resp = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/templates/{}/reports", template.id),
+            &serde_json::json!({}),
+            vec![],
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::ACCEPTED).await;
+        let task: TaskResponse = test::read_body_json(resp).await;
+        let _ = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+        let output = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/reports/{}/output", task.id),
+        )
+        .await;
+        let output = assert_response_status(output, StatusCode::OK).await;
+        let body = String::from_utf8(test::read_body(output).await.to_vec()).unwrap();
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), classes.len());
+        assert!(body.contains(&classes[0].name));
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_class_relations_scope_template(#[future(awt)] test_context: TestContext) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "report_rel_scope").await;
+        let relation = create_class_relation(&context.pool, classes[0].id, classes[1].id).await;
+
+        let template = crate::models::report_template::create_report_template(
+            &context.pool,
+            NewReportTemplate {
+                namespace_id: classes[0].namespace_id,
+                name: "report.class-relations".to_string(),
+                description: "class relation listing".to_string(),
+                content_type: ReportContentType::TextPlain,
+                template:
+                    "{% for item in items %}[{{ item.from_hubuum_class_id }}->{{ item.to_hubuum_class_id }}]{% endfor %}"
+                        .to_string(),
+                kind: ReportTemplateKind::Report,
+                scope_kind: Some(ReportScopeKind::ClassRelations),
+                class_id: None,
+                default_query: None,
+                include: None,
+                relation_context: None,
+                default_missing_data_policy: None,
+                default_limits: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let resp = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/templates/{}/reports", template.id),
+            &serde_json::json!({ "limits": { "max_items": 1000 } }),
+            vec![],
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::ACCEPTED).await;
+        let task: TaskResponse = test::read_body_json(resp).await;
+        let _ = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+        let output = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/reports/{}/output", task.id),
+        )
+        .await;
+        let output = assert_response_status(output, StatusCode::OK).await;
+        let body = String::from_utf8(test::read_body(output).await.to_vec()).unwrap();
+        assert!(
+            body.contains(&format!(
+                "[{}->{}]",
+                relation.from_hubuum_class_id, relation.to_hubuum_class_id
+            )),
+            "expected relation marker in output, got: {body}"
+        );
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_run_collection_scope_template_rejects_object_id(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "report_collection_object_id").await;
+
+        let template = crate::models::report_template::create_report_template(
+            &context.pool,
+            NewReportTemplate {
+                namespace_id: classes[0].namespace_id,
+                name: "report.namespaces-no-object".to_string(),
+                description: "namespace listing".to_string(),
+                content_type: ReportContentType::TextPlain,
+                template: "{% for item in items %}{{ item.name }}{% endfor %}".to_string(),
+                kind: ReportTemplateKind::Report,
+                scope_kind: Some(ReportScopeKind::Namespaces),
+                class_id: None,
+                default_query: None,
+                include: None,
+                relation_context: None,
+                default_missing_data_policy: None,
+                default_limits: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let resp = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/templates/{}/reports", template.id),
+            &serde_json::json!({ "object_id": 1 }),
+            vec![],
+        )
+        .await;
+        assert_response_status(resp, StatusCode::BAD_REQUEST).await;
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
     async fn test_report_output_counts_template_missing_value_warnings(
         #[future(awt)] test_context: TestContext,
     ) {

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -13,8 +13,8 @@ mod tests {
         HubuumClass, HubuumClassRelation, HubuumObjectRelation, NewHubuumClass,
         NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, NewReportTemplate,
         NewTaskRecord, ReportContentType, ReportJsonResponse, ReportLimits, ReportRelationContext,
-        ReportRequest, ReportScope, ReportScopeKind, TaskEventResponse, TaskKind, TaskResponse,
-        TaskStatus, UpdateReportTemplate,
+        ReportRequest, ReportScope, ReportScopeKind, ReportTemplateKind, TaskEventResponse, TaskKind,
+        TaskResponse, TaskStatus, UpdateReportTemplate,
     };
     use crate::tests::api::v1::classes::tests::{cleanup, create_test_classes};
     use crate::tests::api_operations::{get_request, post_request_with_headers};
@@ -141,6 +141,8 @@ mod tests {
     async fn create_template(
         pool: &crate::db::DbPool,
         namespace_id: i32,
+        class_id: i32,
+        scope_kind: ReportScopeKind,
         name: &str,
         content_type: ReportContentType,
         template: &str,
@@ -153,12 +155,37 @@ mod tests {
                 description: "report template".to_string(),
                 content_type,
                 template: template.to_string(),
+                kind: ReportTemplateKind::Report,
+                scope_kind: Some(scope_kind),
+                class_id: Some(class_id),
+                default_query: None,
+                include: None,
+                relation_context: None,
+                default_missing_data_policy: None,
+                default_limits: None,
             },
         )
         .await
         .unwrap();
 
         template.id
+    }
+
+    fn empty_update_template_payload() -> UpdateReportTemplate {
+        UpdateReportTemplate {
+            namespace_id: None,
+            name: None,
+            description: None,
+            template: None,
+            kind: None,
+            scope_kind: None,
+            class_id: None,
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
+        }
     }
 
     #[rstest]
@@ -178,7 +205,6 @@ mod tests {
                 object_id: None,
             },
             query: Some("name__contains=report-&sort=name".to_string()),
-            output: None,
             missing_data_policy: None,
             limits: None,
             include: None,
@@ -345,6 +371,8 @@ mod tests {
         let template_id = create_template(
             &context.pool,
             class.namespace_id,
+            class.id,
+            ReportScopeKind::ObjectsInClass,
             "stable-template",
             ReportContentType::TextPlain,
             "{% for item in items %}{{ item.name }}={{ item.data.owner }}\n{% endfor %}",
@@ -352,20 +380,13 @@ mod tests {
         .await;
 
         let body = serde_json::json!({
-            "scope": {
-                "kind": "objects_in_class",
-                "class_id": class.id
-            },
-            "query": "name__contains=report-&sort=name",
-            "output": {
-                "template_id": template_id
-            }
+            "query": "name__contains=report-&sort=name"
         });
 
         let resp = post_request_with_headers(
             &context.pool,
             &context.admin_token,
-            REPORTS_ENDPOINT,
+            &format!("/api/v1/templates/{template_id}/reports"),
             &body,
             vec![],
         )
@@ -393,6 +414,7 @@ mod tests {
                 name: None,
                 description: None,
                 template: Some("changed output".to_string()),
+                ..empty_update_template_payload()
             },
         )
         .await
@@ -435,32 +457,23 @@ mod tests {
         let template_id = create_template(
             &context.pool,
             class.namespace_id,
+            class.id,
+            ReportScopeKind::ObjectsInClass,
             "warning-template",
             ReportContentType::TextPlain,
             "{% for item in items %}{{ item.name }}={{ item.data.primary_contact }}\n{% endfor %}",
         )
         .await;
 
-        let body = ReportRequest {
-            scope: ReportScope {
-                kind: ReportScopeKind::ObjectsInClass,
-                class_id: Some(class.id),
-                object_id: None,
-            },
-            query: Some("sort=name".to_string()),
-            output: Some(crate::models::ReportOutputRequest {
-                template_id: Some(template_id),
-            }),
-            missing_data_policy: Some(crate::models::ReportMissingDataPolicy::Omit),
-            limits: None,
-            include: None,
-            relation_context: None,
-        };
+        let body = serde_json::json!({
+            "query": "sort=name",
+            "missing_data_policy": "omit"
+        });
 
         let resp = post_request_with_headers(
             &context.pool,
             &context.admin_token,
-            REPORTS_ENDPOINT,
+            &format!("/api/v1/templates/{template_id}/reports"),
             &body,
             vec![],
         )
@@ -527,7 +540,6 @@ mod tests {
                 object_id: None,
             },
             query: Some("sort=name".to_string()),
-            output: None,
             missing_data_policy: None,
             limits: None,
             include: None,
@@ -606,7 +618,6 @@ mod tests {
                 object_id: None,
             },
             query: Some("sort=name".to_string()),
-            output: None,
             missing_data_policy: None,
             limits: None,
             include: None,
@@ -684,26 +695,20 @@ mod tests {
         let template_id = create_template(
             &context.pool,
             class.namespace_id,
+            class.id,
+            ReportScopeKind::ObjectsInClass,
             "restricted-template",
             ReportContentType::TextPlain,
             "{{ items|length }}",
         )
         .await;
 
-        let body = serde_json::json!({
-            "scope": {
-                "kind": "objects_in_class",
-                "class_id": class.id
-            },
-            "output": {
-                "template_id": template_id
-            }
-        });
+        let body = serde_json::json!({});
 
         let resp = post_request_with_headers(
             &context.pool,
             &context.normal_token,
-            REPORTS_ENDPOINT,
+            &format!("/api/v1/templates/{template_id}/reports"),
             &body,
             vec![],
         )
@@ -730,7 +735,6 @@ mod tests {
                 object_id: None,
             },
             query: Some("sort=name".to_string()),
-            output: None,
             missing_data_policy: None,
             limits: None,
             include: None,
@@ -859,32 +863,22 @@ mod tests {
         let template_id = create_template(
             &context.pool,
             namespace.namespace.id,
+            host_class.id,
+            ReportScopeKind::RelatedObjects,
             "reachable-template",
             ReportContentType::TextPlain,
             "{% for host in items %}Host: {{ host.name }} {% for person in host.reachable.persons %}{{ person.name }}{% endfor %}{% endfor %}",
         )
         .await;
 
-        let body = ReportRequest {
-            scope: ReportScope {
-                kind: ReportScopeKind::RelatedObjects,
-                class_id: Some(host_class.id),
-                object_id: Some(host.id),
-            },
-            query: None,
-            output: Some(crate::models::ReportOutputRequest {
-                template_id: Some(template_id),
-            }),
-            missing_data_policy: None,
-            limits: None,
-            include: None,
-            relation_context: None,
-        };
+        let body = serde_json::json!({
+            "object_id": host.id
+        });
 
         let resp = post_request_with_headers(
             &context.pool,
             &context.admin_token,
-            REPORTS_ENDPOINT,
+            &format!("/api/v1/templates/{template_id}/reports"),
             &body,
             vec![],
         )
@@ -1027,32 +1021,22 @@ mod tests {
         let template_id = create_template(
             &context.pool,
             namespace.namespace.id,
+            host_class.id,
+            ReportScopeKind::RelatedObjects,
             "paths-template",
             ReportContentType::TextPlain,
             "{% for host in items %}rooms={% for room in host.related.rooms %}{{ room.name }} {% endfor %}|reachable={% for person in host.reachable.persons %}{{ person.name }} {% endfor %}|paths={% for person in host.paths.persons %}[{{ person.name }} via {{ person.path_objects[1].name }}]{% endfor %}{% endfor %}",
         )
         .await;
 
-        let body = ReportRequest {
-            scope: ReportScope {
-                kind: ReportScopeKind::RelatedObjects,
-                class_id: Some(host_class.id),
-                object_id: Some(host.id),
-            },
-            query: None,
-            output: Some(crate::models::ReportOutputRequest {
-                template_id: Some(template_id),
-            }),
-            missing_data_policy: None,
-            limits: None,
-            include: None,
-            relation_context: None,
-        };
+        let body = serde_json::json!({
+            "object_id": host.id
+        });
 
         let resp = post_request_with_headers(
             &context.pool,
             &context.admin_token,
-            REPORTS_ENDPOINT,
+            &format!("/api/v1/templates/{template_id}/reports"),
             &body,
             vec![],
         )
@@ -1092,32 +1076,22 @@ mod tests {
         let template_id = create_template(
             &context.pool,
             class.namespace_id,
+            class.id,
+            ReportScopeKind::ObjectsInClass,
             "cleanup-template",
             ReportContentType::TextPlain,
             "{% for item in items %}{{ item.name }}\n{% endfor %}",
         )
         .await;
 
-        let body = ReportRequest {
-            scope: ReportScope {
-                kind: ReportScopeKind::ObjectsInClass,
-                class_id: Some(class.id),
-                object_id: None,
-            },
-            query: Some("sort=name".to_string()),
-            output: Some(crate::models::ReportOutputRequest {
-                template_id: Some(template_id),
-            }),
-            missing_data_policy: None,
-            limits: None,
-            include: None,
-            relation_context: None,
-        };
+        let body = serde_json::json!({
+            "query": "sort=name"
+        });
 
         let resp = post_request_with_headers(
             &context.pool,
             &context.admin_token,
-            REPORTS_ENDPOINT,
+            &format!("/api/v1/templates/{template_id}/reports"),
             &body,
             vec![],
         )

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -12,8 +12,8 @@ mod tests {
     use crate::models::{
         HubuumClass, HubuumClassRelation, HubuumObjectRelation, NewHubuumClass,
         NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, NewReportTemplate,
-        NewTaskRecord, ReportContentType, ReportJsonResponse, ReportLimits, ReportRelationContext,
-        ReportRequest, ReportScope, ReportScopeKind, ReportTemplateKind, TaskEventResponse, TaskKind,
+        NewTaskRecord, ReportContentType, ReportJsonResponse, ReportRelationContext, ReportRequest,
+        ReportScope, ReportScopeKind, ReportTemplateKind, TaskEventResponse, TaskKind,
         TaskResponse, TaskStatus, UpdateReportTemplate,
     };
     use crate::tests::api::v1::classes::tests::{cleanup, create_test_classes};
@@ -1570,36 +1570,19 @@ mod tests {
         let template_id = create_template(
             &context.pool,
             class.namespace_id,
+            class.id,
+            ReportScopeKind::ObjectsInClass,
             "oversized-template",
             ReportContentType::TextPlain,
             "{% for item in items %}{{ item.name }} has a description of {{ item.description }} and lives forever\n{% endfor %}",
         )
         .await;
 
-        let body = ReportRequest {
-            scope: ReportScope {
-                kind: ReportScopeKind::ObjectsInClass,
-                class_id: Some(class.id),
-                object_id: None,
-            },
-            query: None,
-            output: Some(crate::models::ReportOutputRequest {
-                template_id: Some(template_id),
-            }),
-            missing_data_policy: None,
-            limits: Some(ReportLimits {
-                max_items: None,
-                max_output_bytes: Some(8),
-            }),
-            include: None,
-            relation_context: None,
-        };
-
         let resp = post_request_with_headers(
             &context.pool,
             &context.admin_token,
-            REPORTS_ENDPOINT,
-            &body,
+            &format!("/api/v1/templates/{template_id}/reports"),
+            &serde_json::json!({ "limits": { "max_output_bytes": 8 } }),
             vec![],
         )
         .await;
@@ -1678,36 +1661,32 @@ mod tests {
         let _ = create_object_relation(&context.pool, host_b.id, room_b.id, host_room_relation.id)
             .await;
 
-        let template_id = create_template(
+        let template = crate::models::report_template::create_report_template(
             &context.pool,
-            namespace.namespace.id,
-            "multiroot-template",
-            ReportContentType::TextPlain,
-            "{% for host in items %}{{ host.name }}:{% for room in host.related.rooms %}{{ room.name }},{% endfor %};{% endfor %}",
-        )
-        .await;
-
-        let body = ReportRequest {
-            scope: ReportScope {
-                kind: ReportScopeKind::ObjectsInClass,
+            NewReportTemplate {
+                namespace_id: namespace.namespace.id,
+                name: "multiroot-template".to_string(),
+                description: "report template".to_string(),
+                content_type: ReportContentType::TextPlain,
+                template: "{% for host in items %}{{ host.name }}:{% for room in host.related.rooms %}{{ room.name }},{% endfor %};{% endfor %}".to_string(),
+                kind: ReportTemplateKind::Report,
+                scope_kind: Some(ReportScopeKind::ObjectsInClass),
                 class_id: Some(host_class.id),
-                object_id: None,
+                default_query: Some("sort=name".to_string()),
+                include: None,
+                relation_context: Some(ReportRelationContext { depth: Some(1) }),
+                default_missing_data_policy: None,
+                default_limits: None,
             },
-            query: Some("sort=name".to_string()),
-            output: Some(crate::models::ReportOutputRequest {
-                template_id: Some(template_id),
-            }),
-            missing_data_policy: None,
-            limits: None,
-            include: None,
-            relation_context: Some(ReportRelationContext { depth: Some(1) }),
-        };
+        )
+        .await
+        .unwrap();
 
         let resp = post_request_with_headers(
             &context.pool,
             &context.admin_token,
-            REPORTS_ENDPOINT,
-            &body,
+            &format!("/api/v1/templates/{}/reports", template.id),
+            &serde_json::json!({}),
             vec![],
         )
         .await;
@@ -1893,14 +1872,26 @@ mod tests {
         .save(&context.pool)
         .await
         .unwrap();
-        let template_id = create_template(
+        let template = crate::models::report_template::create_report_template(
             &context.pool,
-            namespace.namespace.id,
-            "bench-template",
-            ReportContentType::TextPlain,
-            "{% for host in items %}{{ host.name }}:{% for room in host.related.rooms %}{{ room.name }},{% endfor %};{% endfor %}",
+            NewReportTemplate {
+                namespace_id: namespace.namespace.id,
+                name: "bench-template".to_string(),
+                description: "report template".to_string(),
+                content_type: ReportContentType::TextPlain,
+                template: "{% for host in items %}{{ host.name }}:{% for room in host.related.rooms %}{{ room.name }},{% endfor %};{% endfor %}".to_string(),
+                kind: ReportTemplateKind::Report,
+                scope_kind: Some(ReportScopeKind::ObjectsInClass),
+                class_id: Some(host_class.id),
+                default_query: None,
+                include: None,
+                relation_context: Some(ReportRelationContext { depth: Some(1) }),
+                default_missing_data_policy: None,
+                default_limits: None,
+            },
         )
-        .await;
+        .await
+        .unwrap();
 
         let mut created_hosts = 0usize;
         let mut results: Vec<(usize, i64, i64)> = Vec::new();
@@ -1936,27 +1927,11 @@ mod tests {
             }
             created_hosts = target;
 
-            let body = ReportRequest {
-                scope: ReportScope {
-                    kind: ReportScopeKind::ObjectsInClass,
-                    class_id: Some(host_class.id),
-                    object_id: None,
-                },
-                query: None,
-                output: Some(crate::models::ReportOutputRequest {
-                    template_id: Some(template_id),
-                }),
-                missing_data_policy: None,
-                limits: None,
-                include: None,
-                relation_context: Some(ReportRelationContext { depth: Some(1) }),
-            };
-
             let resp = post_request_with_headers(
                 &context.pool,
                 &context.admin_token,
-                REPORTS_ENDPOINT,
-                &body,
+                &format!("/api/v1/templates/{}/reports", template.id),
+                &serde_json::json!({}),
                 vec![],
             )
             .await;

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -8,7 +8,7 @@ mod tests {
     use rstest::rstest;
     use std::time::Duration;
 
-    use crate::db::traits::task::{create_task_record, purge_expired_report_outputs};
+    use crate::db::traits::task::purge_expired_report_outputs;
     use crate::models::{
         HubuumClass, HubuumClassRelation, HubuumObjectRelation, NewHubuumClass,
         NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, NewReportTemplate,
@@ -969,25 +969,23 @@ mod tests {
     ) {
         let context = test_context;
         let report_key = context.scoped_name("foreign-task-idempotency");
-        let report_task = create_task_record(
-            &context.pool,
-            NewTaskRecord {
-                kind: TaskKind::Import.as_str().to_string(),
-                status: TaskStatus::Queued.as_str().to_string(),
-                submitted_by: Some(context.admin_user.id),
-                idempotency_key: Some(report_key.clone()),
-                request_hash: Some(context.scoped_name("foreign-task-hash")),
-                request_payload: None,
-                summary: None,
-                total_items: 1,
-                processed_items: 0,
-                success_items: 0,
-                failed_items: 0,
-                request_redacted_at: None,
-                started_at: None,
-                finished_at: None,
-            },
-        )
+        let report_task = NewTaskRecord {
+            kind: TaskKind::Import.as_str().to_string(),
+            status: TaskStatus::Queued.as_str().to_string(),
+            submitted_by: Some(context.admin_user.id),
+            idempotency_key: Some(report_key.clone()),
+            request_hash: Some(context.scoped_name("foreign-task-hash")),
+            request_payload: None,
+            summary: None,
+            total_items: 1,
+            processed_items: 0,
+            success_items: 0,
+            failed_items: 0,
+            request_redacted_at: None,
+            started_at: None,
+            finished_at: None,
+        }
+        .create(&context.pool)
         .await
         .unwrap();
 

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -20,7 +20,7 @@ mod tests {
     use crate::tests::api_operations::{get_request, post_request_with_headers};
     use crate::tests::asserts::{assert_response_status, header_value};
     use crate::tests::{TestContext, create_test_user, test_context};
-    use crate::traits::CanSave;
+    use crate::traits::{CanSave, CanUpdate};
     const REPORTS_ENDPOINT: &str = "/api/v1/reports";
 
     async fn wait_for_task(
@@ -147,24 +147,22 @@ mod tests {
         content_type: ReportContentType,
         template: &str,
     ) -> i32 {
-        let template = crate::models::report_template::create_report_template(
-            pool,
-            NewReportTemplate {
-                namespace_id,
-                name: name.to_string(),
-                description: "report template".to_string(),
-                content_type,
-                template: template.to_string(),
-                kind: ReportTemplateKind::Report,
-                scope_kind: Some(scope_kind),
-                class_id: Some(class_id),
-                default_query: None,
-                include: None,
-                relation_context: None,
-                default_missing_data_policy: None,
-                default_limits: None,
-            },
-        )
+        let template = NewReportTemplate {
+            namespace_id,
+            name: name.to_string(),
+            description: "report template".to_string(),
+            content_type,
+            template: template.to_string(),
+            kind: ReportTemplateKind::Report,
+            scope_kind: Some(scope_kind),
+            class_id: Some(class_id),
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
+        }
+        .save(pool)
         .await
         .unwrap();
 
@@ -406,17 +404,14 @@ mod tests {
         let first_body = String::from_utf8(test::read_body(first_output).await.to_vec()).unwrap();
         assert_eq!(first_body, "report-app-01=alice\nreport-db-01=bob\n");
 
-        crate::models::report_template::update_report_template(
-            &context.pool,
-            template_id,
-            UpdateReportTemplate {
-                namespace_id: None,
-                name: None,
-                description: None,
-                template: Some("changed output".to_string()),
-                ..empty_update_template_payload()
-            },
-        )
+        UpdateReportTemplate {
+            namespace_id: None,
+            name: None,
+            description: None,
+            template: Some("changed output".to_string()),
+            ..empty_update_template_payload()
+        }
+        .update(&context.pool, template_id)
         .await
         .unwrap();
 
@@ -520,24 +515,22 @@ mod tests {
         let _ = create_report_objects(&context.pool, &class).await;
 
         // Template carries a default query that selects only the "app" host.
-        let template = crate::models::report_template::create_report_template(
-            &context.pool,
-            NewReportTemplate {
-                namespace_id: class.namespace_id,
-                name: "report.default-query".to_string(),
-                description: "default query report".to_string(),
-                content_type: ReportContentType::TextPlain,
-                template: "{% for item in items %}{{ item.name }}\n{% endfor %}".to_string(),
-                kind: ReportTemplateKind::Report,
-                scope_kind: Some(ReportScopeKind::ObjectsInClass),
-                class_id: Some(class.id),
-                default_query: Some("name__contains=app-&sort=name".to_string()),
-                include: None,
-                relation_context: None,
-                default_missing_data_policy: None,
-                default_limits: None,
-            },
-        )
+        let template = NewReportTemplate {
+            namespace_id: class.namespace_id,
+            name: "report.default-query".to_string(),
+            description: "default query report".to_string(),
+            content_type: ReportContentType::TextPlain,
+            template: "{% for item in items %}{{ item.name }}\n{% endfor %}".to_string(),
+            kind: ReportTemplateKind::Report,
+            scope_kind: Some(ReportScopeKind::ObjectsInClass),
+            class_id: Some(class.id),
+            default_query: Some("name__contains=app-&sort=name".to_string()),
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
+        }
+        .save(&context.pool)
         .await
         .unwrap();
 
@@ -643,24 +636,22 @@ mod tests {
         let classes = create_test_classes(&context, "report_ns_scope").await;
         let namespace_name = classes.namespace.namespace.name.clone();
 
-        let template = crate::models::report_template::create_report_template(
-            &context.pool,
-            NewReportTemplate {
-                namespace_id: classes[0].namespace_id,
-                name: "report.namespaces".to_string(),
-                description: "namespace listing".to_string(),
-                content_type: ReportContentType::TextPlain,
-                template: "{% for item in items %}{{ item.name }}\n{% endfor %}".to_string(),
-                kind: ReportTemplateKind::Report,
-                scope_kind: Some(ReportScopeKind::Namespaces),
-                class_id: None,
-                default_query: Some(format!("name__equals={namespace_name}")),
-                include: None,
-                relation_context: None,
-                default_missing_data_policy: None,
-                default_limits: None,
-            },
-        )
+        let template = NewReportTemplate {
+            namespace_id: classes[0].namespace_id,
+            name: "report.namespaces".to_string(),
+            description: "namespace listing".to_string(),
+            content_type: ReportContentType::TextPlain,
+            template: "{% for item in items %}{{ item.name }}\n{% endfor %}".to_string(),
+            kind: ReportTemplateKind::Report,
+            scope_kind: Some(ReportScopeKind::Namespaces),
+            class_id: None,
+            default_query: Some(format!("name__equals={namespace_name}")),
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
+        }
+        .save(&context.pool)
         .await
         .unwrap();
 
@@ -694,26 +685,22 @@ mod tests {
         let context = test_context;
         let classes = create_test_classes(&context, "report_cls_scope").await;
 
-        let template = crate::models::report_template::create_report_template(
-            &context.pool,
-            NewReportTemplate {
-                namespace_id: classes[0].namespace_id,
-                name: "report.classes".to_string(),
-                description: "class listing".to_string(),
-                content_type: ReportContentType::TextPlain,
-                template: "{% for item in items %}{{ item.name }}\n{% endfor %}".to_string(),
-                kind: ReportTemplateKind::Report,
-                scope_kind: Some(ReportScopeKind::Classes),
-                class_id: None,
-                default_query: Some(
-                    "name__contains=report_cls_scope_api_class_&sort=name".to_string(),
-                ),
-                include: None,
-                relation_context: None,
-                default_missing_data_policy: None,
-                default_limits: None,
-            },
-        )
+        let template = NewReportTemplate {
+            namespace_id: classes[0].namespace_id,
+            name: "report.classes".to_string(),
+            description: "class listing".to_string(),
+            content_type: ReportContentType::TextPlain,
+            template: "{% for item in items %}{{ item.name }}\n{% endfor %}".to_string(),
+            kind: ReportTemplateKind::Report,
+            scope_kind: Some(ReportScopeKind::Classes),
+            class_id: None,
+            default_query: Some("name__contains=report_cls_scope_api_class_&sort=name".to_string()),
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
+        }
+        .save(&context.pool)
         .await
         .unwrap();
 
@@ -750,9 +737,7 @@ mod tests {
         let classes = create_test_classes(&context, "report_rel_scope").await;
         let relation = create_class_relation(&context.pool, classes[0].id, classes[1].id).await;
 
-        let template = crate::models::report_template::create_report_template(
-            &context.pool,
-            NewReportTemplate {
+        let template = NewReportTemplate {
                 namespace_id: classes[0].namespace_id,
                 name: "report.class-relations".to_string(),
                 description: "class relation listing".to_string(),
@@ -768,8 +753,8 @@ mod tests {
                 relation_context: None,
                 default_missing_data_policy: None,
                 default_limits: None,
-            },
-        )
+            }
+.save(&context.pool)
         .await
         .unwrap();
 
@@ -811,24 +796,22 @@ mod tests {
         let context = test_context;
         let classes = create_test_classes(&context, "report_collection_object_id").await;
 
-        let template = crate::models::report_template::create_report_template(
-            &context.pool,
-            NewReportTemplate {
-                namespace_id: classes[0].namespace_id,
-                name: "report.namespaces-no-object".to_string(),
-                description: "namespace listing".to_string(),
-                content_type: ReportContentType::TextPlain,
-                template: "{% for item in items %}{{ item.name }}{% endfor %}".to_string(),
-                kind: ReportTemplateKind::Report,
-                scope_kind: Some(ReportScopeKind::Namespaces),
-                class_id: None,
-                default_query: None,
-                include: None,
-                relation_context: None,
-                default_missing_data_policy: None,
-                default_limits: None,
-            },
-        )
+        let template = NewReportTemplate {
+            namespace_id: classes[0].namespace_id,
+            name: "report.namespaces-no-object".to_string(),
+            description: "namespace listing".to_string(),
+            content_type: ReportContentType::TextPlain,
+            template: "{% for item in items %}{{ item.name }}{% endfor %}".to_string(),
+            kind: ReportTemplateKind::Report,
+            scope_kind: Some(ReportScopeKind::Namespaces),
+            class_id: None,
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
+        }
+        .save(&context.pool)
         .await
         .unwrap();
 
@@ -1661,9 +1644,7 @@ mod tests {
         let _ = create_object_relation(&context.pool, host_b.id, room_b.id, host_room_relation.id)
             .await;
 
-        let template = crate::models::report_template::create_report_template(
-            &context.pool,
-            NewReportTemplate {
+        let template = NewReportTemplate {
                 namespace_id: namespace.namespace.id,
                 name: "multiroot-template".to_string(),
                 description: "report template".to_string(),
@@ -1677,8 +1658,8 @@ mod tests {
                 relation_context: Some(ReportRelationContext { depth: Some(1) }),
                 default_missing_data_policy: None,
                 default_limits: None,
-            },
-        )
+            }
+.save(&context.pool)
         .await
         .unwrap();
 
@@ -1872,9 +1853,7 @@ mod tests {
         .save(&context.pool)
         .await
         .unwrap();
-        let template = crate::models::report_template::create_report_template(
-            &context.pool,
-            NewReportTemplate {
+        let template = NewReportTemplate {
                 namespace_id: namespace.namespace.id,
                 name: "bench-template".to_string(),
                 description: "report template".to_string(),
@@ -1888,8 +1867,8 @@ mod tests {
                 relation_context: Some(ReportRelationContext { depth: Some(1) }),
                 default_missing_data_policy: None,
                 default_limits: None,
-            },
-        )
+            }
+.save(&context.pool)
         .await
         .unwrap();
 

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -705,7 +705,9 @@ mod tests {
                 kind: ReportTemplateKind::Report,
                 scope_kind: Some(ReportScopeKind::Classes),
                 class_id: None,
-                default_query: Some("name__contains=report_cls_scope_api_class_&sort=name".to_string()),
+                default_query: Some(
+                    "name__contains=report_cls_scope_api_class_&sort=name".to_string(),
+                ),
                 include: None,
                 relation_context: None,
                 default_missing_data_policy: None,

--- a/src/tests/api/v1/tasks.rs
+++ b/src/tests/api/v1/tasks.rs
@@ -4,7 +4,6 @@ mod tests {
     use chrono::Utc;
     use rstest::rstest;
 
-    use crate::db::traits::task::create_task_record;
     use crate::models::{NewTaskRecord, TaskKind, TaskResponse, TaskStatus};
     use crate::pagination::NEXT_CURSOR_HEADER;
     use crate::tests::api_operations::get_request;
@@ -22,25 +21,23 @@ mod tests {
         status: TaskStatus,
         label: &str,
     ) -> i32 {
-        let task = create_task_record(
-            &context.pool,
-            NewTaskRecord {
-                kind: kind.as_str().to_string(),
-                status: status.as_str().to_string(),
-                submitted_by: Some(submitted_by),
-                idempotency_key: None,
-                request_hash: None,
-                request_payload: None,
-                summary: Some(context.scoped_name(label)),
-                total_items: 0,
-                processed_items: 0,
-                success_items: 0,
-                failed_items: 0,
-                request_redacted_at: Some(Utc::now().naive_utc()),
-                started_at: Some(Utc::now().naive_utc()),
-                finished_at: Some(Utc::now().naive_utc()),
-            },
-        )
+        let task = NewTaskRecord {
+            kind: kind.as_str().to_string(),
+            status: status.as_str().to_string(),
+            submitted_by: Some(submitted_by),
+            idempotency_key: None,
+            request_hash: None,
+            request_payload: None,
+            summary: Some(context.scoped_name(label)),
+            total_items: 0,
+            processed_items: 0,
+            success_items: 0,
+            failed_items: 0,
+            request_redacted_at: Some(Utc::now().naive_utc()),
+            started_at: Some(Utc::now().naive_utc()),
+            finished_at: Some(Utc::now().naive_utc()),
+        }
+        .create(&context.pool)
         .await
         .unwrap();
 

--- a/src/tests/api/v1/templates.rs
+++ b/src/tests/api/v1/templates.rs
@@ -783,6 +783,108 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn test_report_template_rejects_class_id_for_collection_scope() {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let namespace = create_namespace(&pool, "collection_scope_class_id").await;
+        let class = NewHubuumClass {
+            name: "collection-scope-class".to_string(),
+            namespace_id: namespace.id,
+            json_schema: None,
+            validate_schema: Some(false),
+            description: "class".to_string(),
+        }
+        .save(&pool)
+        .await
+        .unwrap();
+
+        let payload = NewReportTemplate {
+            namespace_id: namespace.id,
+            name: "report.namespaces-with-class".to_string(),
+            description: "invalid collection report".to_string(),
+            content_type: ReportContentType::TextPlain,
+            template: "{% for item in items %}{{ item.name }}{% endfor %}".to_string(),
+            kind: ReportTemplateKind::Report,
+            scope_kind: Some(ReportScopeKind::Namespaces),
+            class_id: Some(class.id),
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
+        };
+
+        let resp = post_request(&pool, &admin_token, TEMPLATES_ENDPOINT, &payload).await;
+        assert_response_status(resp, StatusCode::BAD_REQUEST).await;
+
+        namespace.delete(&pool).await.unwrap();
+    }
+
+    #[actix_web::test]
+    async fn test_template_list_can_filter_by_kind() {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let namespace = create_namespace(&pool, "kind_filter").await;
+
+        let class = NewHubuumClass {
+            name: "kind-filter-class".to_string(),
+            namespace_id: namespace.id,
+            json_schema: None,
+            validate_schema: Some(false),
+            description: "class for kind filtering".to_string(),
+        }
+        .save(&pool)
+        .await
+        .unwrap();
+
+        let fragment = new_template_payload(namespace.id, "partial.kind-fragment");
+        let resp = post_request(&pool, &admin_token, TEMPLATES_ENDPOINT, &fragment).await;
+        assert_response_status(resp, StatusCode::CREATED).await;
+
+        let report = NewReportTemplate {
+            namespace_id: namespace.id,
+            name: "report.kind-report".to_string(),
+            description: "report template".to_string(),
+            content_type: ReportContentType::TextPlain,
+            template: "{% for item in items %}{{ item.name }}{% endfor %}".to_string(),
+            kind: ReportTemplateKind::Report,
+            scope_kind: Some(ReportScopeKind::ObjectsInClass),
+            class_id: Some(class.id),
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
+        };
+        let resp = post_request(&pool, &admin_token, TEMPLATES_ENDPOINT, &report).await;
+        assert_response_status(resp, StatusCode::CREATED).await;
+
+        let resp = get_request(
+            &pool,
+            &admin_token,
+            &format!("{TEMPLATES_ENDPOINT}?namespace_id={}&kind=report", namespace.id),
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let reports: Vec<ReportTemplate> = test::read_body_json(resp).await;
+        assert_eq!(reports.len(), 1);
+        assert!(reports.iter().all(|t| t.kind == ReportTemplateKind::Report));
+        assert_eq!(reports[0].name, "report.kind-report");
+
+        let resp = get_request(
+            &pool,
+            &admin_token,
+            &format!("{TEMPLATES_ENDPOINT}?namespace_id={}&kind=fragment", namespace.id),
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let fragments: Vec<ReportTemplate> = test::read_body_json(resp).await;
+        assert_eq!(fragments.len(), 1);
+        assert!(fragments.iter().all(|t| t.kind == ReportTemplateKind::Fragment));
+        assert_eq!(fragments[0].name, "partial.kind-fragment");
+
+        namespace.delete(&pool).await.unwrap();
+    }
+
+    #[actix_web::test]
     async fn test_template_update_content_requires_update_permission() {
         let (pool, admin_token, _normal_token) = setup_pool_and_tokens().await;
         let namespace = create_namespace(&pool, "update_content_forbidden").await;

--- a/src/tests/api/v1/templates.rs
+++ b/src/tests/api/v1/templates.rs
@@ -4,8 +4,8 @@ mod tests {
 
     use crate::models::{
         Namespace, NewHubuumClass, NewNamespaceWithAssignee, NewReportTemplate, Permissions,
-        PermissionsList, ReportContentType, ReportScopeKind, ReportTemplate, ReportTemplateKind,
-        UpdateReportTemplate,
+        PermissionsList, ReportContentType, ReportLimits, ReportMissingDataPolicy, ReportScopeKind,
+        ReportTemplate, ReportTemplateKind, UpdateReportTemplate,
     };
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
     use crate::tests::asserts::{assert_paginated_collection_total_count, assert_response_status};
@@ -834,6 +834,85 @@ mod tests {
         let patched: ReportTemplate = test::read_body_json(resp).await;
         assert_eq!(patched.scope_kind, Some(ReportScopeKind::Namespaces));
         assert_eq!(patched.class_id, None);
+
+        namespace.delete(&pool).await.unwrap();
+    }
+
+    #[actix_web::test]
+    async fn test_patch_report_template_clears_nullable_defaults() {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let namespace = create_namespace(&pool, "patch_clear_defaults").await;
+        let class = NewHubuumClass {
+            name: "patch-clear-class".to_string(),
+            namespace_id: namespace.id,
+            json_schema: None,
+            validate_schema: Some(false),
+            description: "class".to_string(),
+        }
+        .save(&pool)
+        .await
+        .unwrap();
+
+        let created = crate::models::report_template::create_report_template(
+            &pool,
+            NewReportTemplate {
+                namespace_id: namespace.id,
+                name: "report.clear-defaults".to_string(),
+                description: "clear defaults report".to_string(),
+                content_type: ReportContentType::TextPlain,
+                template: "{% for item in items %}{{ item.name }}{% endfor %}".to_string(),
+                kind: ReportTemplateKind::Report,
+                scope_kind: Some(ReportScopeKind::ObjectsInClass),
+                class_id: Some(class.id),
+                default_query: Some("sort=name".to_string()),
+                include: None,
+                relation_context: None,
+                default_missing_data_policy: Some(ReportMissingDataPolicy::Strict),
+                default_limits: Some(ReportLimits {
+                    max_items: Some(100),
+                    max_output_bytes: Some(262_144),
+                }),
+            },
+        )
+        .await
+        .unwrap();
+
+        // An unrelated PATCH that omits the default fields must leave them untouched.
+        let resp = patch_request(
+            &pool,
+            &admin_token,
+            &format!("{TEMPLATES_ENDPOINT}/{}", created.id),
+            &serde_json::json!({ "description": "still has defaults" }),
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let patched: ReportTemplate = test::read_body_json(resp).await;
+        assert_eq!(patched.default_query.as_deref(), Some("sort=name"));
+        assert_eq!(
+            patched.default_missing_data_policy,
+            Some(ReportMissingDataPolicy::Strict)
+        );
+        assert!(patched.default_limits.is_some());
+
+        // Explicit JSON null clears the nullable defaults while keeping the scope intact.
+        let resp = patch_request(
+            &pool,
+            &admin_token,
+            &format!("{TEMPLATES_ENDPOINT}/{}", created.id),
+            &serde_json::json!({
+                "default_query": null,
+                "default_missing_data_policy": null,
+                "default_limits": null
+            }),
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let patched: ReportTemplate = test::read_body_json(resp).await;
+        assert_eq!(patched.default_query, None);
+        assert_eq!(patched.default_missing_data_policy, None);
+        assert_eq!(patched.default_limits, None);
+        assert_eq!(patched.scope_kind, Some(ReportScopeKind::ObjectsInClass));
+        assert_eq!(patched.class_id, Some(class.id));
 
         namespace.delete(&pool).await.unwrap();
     }

--- a/src/tests/api/v1/templates.rs
+++ b/src/tests/api/v1/templates.rs
@@ -783,6 +783,62 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn test_patch_report_template_class_scope_to_collection_scope() {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let namespace = create_namespace(&pool, "patch_scope_change").await;
+        let class = NewHubuumClass {
+            name: "patch-scope-class".to_string(),
+            namespace_id: namespace.id,
+            json_schema: None,
+            validate_schema: Some(false),
+            description: "class".to_string(),
+        }
+        .save(&pool)
+        .await
+        .unwrap();
+
+        // Start as an objects_in_class report bound to a class.
+        let create_payload = NewReportTemplate {
+            namespace_id: namespace.id,
+            name: "report.scope-change".to_string(),
+            description: "scope change report".to_string(),
+            content_type: ReportContentType::TextPlain,
+            template: "{% for item in items %}{{ item.name }}{% endfor %}".to_string(),
+            kind: ReportTemplateKind::Report,
+            scope_kind: Some(ReportScopeKind::ObjectsInClass),
+            class_id: Some(class.id),
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
+        };
+        let resp = post_request(&pool, &admin_token, TEMPLATES_ENDPOINT, &create_payload).await;
+        let resp = assert_response_status(resp, StatusCode::CREATED).await;
+        let created: ReportTemplate = test::read_body_json(resp).await;
+
+        // PATCH to a collection scope without clearing class_id explicitly; the carried-forward
+        // class_id must be dropped rather than rejected.
+        let patch = UpdateReportTemplate {
+            scope_kind: Some(ReportScopeKind::Namespaces),
+            ..empty_update_template_payload()
+        };
+        let resp = patch_request(
+            &pool,
+            &admin_token,
+            &format!("{TEMPLATES_ENDPOINT}/{}", created.id),
+            &patch,
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let patched: ReportTemplate = test::read_body_json(resp).await;
+        assert_eq!(patched.scope_kind, Some(ReportScopeKind::Namespaces));
+        assert_eq!(patched.class_id, None);
+
+        namespace.delete(&pool).await.unwrap();
+    }
+
+    #[actix_web::test]
     async fn test_report_template_rejects_class_id_for_collection_scope() {
         let (pool, admin_token, _) = setup_pool_and_tokens().await;
         let namespace = create_namespace(&pool, "collection_scope_class_id").await;
@@ -860,7 +916,10 @@ mod tests {
         let resp = get_request(
             &pool,
             &admin_token,
-            &format!("{TEMPLATES_ENDPOINT}?namespace_id={}&kind=report", namespace.id),
+            &format!(
+                "{TEMPLATES_ENDPOINT}?namespace_id={}&kind=report",
+                namespace.id
+            ),
         )
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
@@ -872,13 +931,20 @@ mod tests {
         let resp = get_request(
             &pool,
             &admin_token,
-            &format!("{TEMPLATES_ENDPOINT}?namespace_id={}&kind=fragment", namespace.id),
+            &format!(
+                "{TEMPLATES_ENDPOINT}?namespace_id={}&kind=fragment",
+                namespace.id
+            ),
         )
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
         let fragments: Vec<ReportTemplate> = test::read_body_json(resp).await;
         assert_eq!(fragments.len(), 1);
-        assert!(fragments.iter().all(|t| t.kind == ReportTemplateKind::Fragment));
+        assert!(
+            fragments
+                .iter()
+                .all(|t| t.kind == ReportTemplateKind::Fragment)
+        );
         assert_eq!(fragments[0].name, "partial.kind-fragment");
 
         namespace.delete(&pool).await.unwrap();

--- a/src/tests/api/v1/templates.rs
+++ b/src/tests/api/v1/templates.rs
@@ -3,8 +3,9 @@ mod tests {
     use actix_web::{http::StatusCode, test};
 
     use crate::models::{
-        Namespace, NewNamespaceWithAssignee, NewReportTemplate, Permissions, PermissionsList,
-        ReportContentType, ReportTemplate, UpdateReportTemplate,
+        Namespace, NewHubuumClass, NewNamespaceWithAssignee, NewReportTemplate, Permissions,
+        PermissionsList, ReportContentType, ReportScopeKind, ReportTemplate, ReportTemplateKind,
+        UpdateReportTemplate,
     };
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
     use crate::tests::asserts::{assert_paginated_collection_total_count, assert_response_status};
@@ -35,6 +36,14 @@ mod tests {
             description: "template description".to_string(),
             content_type: ReportContentType::TextPlain,
             template: "{% for item in items %}{{ item.name }}\n{% endfor %}".to_string(),
+            kind: ReportTemplateKind::Fragment,
+            scope_kind: None,
+            class_id: None,
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
         }
     }
 
@@ -49,6 +58,31 @@ mod tests {
             description: "template description".to_string(),
             content_type,
             template: "{% for item in items %}{{ item.name }}\n{% endfor %}".to_string(),
+            kind: ReportTemplateKind::Fragment,
+            scope_kind: None,
+            class_id: None,
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
+        }
+    }
+
+    fn empty_update_template_payload() -> UpdateReportTemplate {
+        UpdateReportTemplate {
+            namespace_id: None,
+            name: None,
+            description: None,
+            template: None,
+            kind: None,
+            scope_kind: None,
+            class_id: None,
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
         }
     }
 
@@ -83,6 +117,7 @@ mod tests {
             template: Some(
                 "{% for item in items %}{{ item.name }}={{ item.id }}\n{% endfor %}".to_string(),
             ),
+            ..empty_update_template_payload()
         };
         let resp = patch_request(
             &pool,
@@ -208,6 +243,14 @@ mod tests {
             description: "legacy syntax".to_string(),
             content_type: ReportContentType::TextPlain,
             template: "{{#each items}}{{this.name}}\\n{{/each}}".to_string(),
+            kind: ReportTemplateKind::Fragment,
+            scope_kind: None,
+            class_id: None,
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
         };
 
         let resp = post_request(&pool, &admin_token, TEMPLATES_ENDPOINT, &payload).await;
@@ -227,6 +270,14 @@ mod tests {
             description: "layout".to_string(),
             content_type: ReportContentType::TextHtml,
             template: "<ul>{% block body %}{% endblock %}</ul>".to_string(),
+            kind: ReportTemplateKind::Fragment,
+            scope_kind: None,
+            class_id: None,
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
         };
         let resp = post_request(&pool, &admin_token, TEMPLATES_ENDPOINT, &layout).await;
         assert_response_status(resp, StatusCode::CREATED).await;
@@ -239,6 +290,14 @@ mod tests {
             template:
                 "{% extends \"layout.html\" %}{% block body %}<li>{{ items[0].name }}</li>{% endblock %}"
                     .to_string(),
+            kind: ReportTemplateKind::Fragment,
+            scope_kind: None,
+            class_id: None,
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
         };
         let resp = post_request(&pool, &admin_token, TEMPLATES_ENDPOINT, &child).await;
         assert_response_status(resp, StatusCode::CREATED).await;
@@ -257,6 +316,14 @@ mod tests {
             description: "helper coverage".to_string(),
             content_type: ReportContentType::TextPlain,
             template: "{{ csv|csv_cell }} {{ payload|tojson }} {{ coalesce(primary, fallback, \"owner\") }} {{ values|join_nonempty(\"; \") }} {{ when|format_datetime(\"date\") }}".to_string(),
+            kind: ReportTemplateKind::Fragment,
+            scope_kind: None,
+            class_id: None,
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
         };
 
         let resp = post_request(&pool, &admin_token, TEMPLATES_ENDPOINT, &payload).await;
@@ -277,6 +344,14 @@ mod tests {
             description: "layout".to_string(),
             content_type: ReportContentType::TextHtml,
             template: "<ul>{% block body %}{% endblock %}</ul>".to_string(),
+            kind: ReportTemplateKind::Fragment,
+            scope_kind: None,
+            class_id: None,
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
         };
         let resp = post_request(&pool, &admin_token, TEMPLATES_ENDPOINT, &layout).await;
         assert_response_status(resp, StatusCode::CREATED).await;
@@ -289,6 +364,14 @@ mod tests {
             template:
                 "{% extends \"layout.html\" %}{% block body %}<li>{{ items[0].name }}</li>{% endblock %}"
                     .to_string(),
+            kind: ReportTemplateKind::Fragment,
+            scope_kind: None,
+            class_id: None,
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
         };
         let resp = post_request(&pool, &admin_token, TEMPLATES_ENDPOINT, &child).await;
         assert_response_status(resp, StatusCode::BAD_REQUEST).await;
@@ -327,6 +410,7 @@ mod tests {
             name: None,
             description: None,
             template: None,
+            ..empty_update_template_payload()
         };
 
         let resp = patch_request(
@@ -383,6 +467,7 @@ mod tests {
             name: None,
             description: None,
             template: None,
+            ..empty_update_template_payload()
         };
 
         let resp = patch_request(
@@ -434,6 +519,7 @@ mod tests {
             name: Some(created_a.name),
             description: None,
             template: None,
+            ..empty_update_template_payload()
         };
 
         let resp = patch_request(
@@ -478,6 +564,7 @@ mod tests {
             name: None,
             description: None,
             template: None,
+            ..empty_update_template_payload()
         };
 
         let resp = patch_request(
@@ -635,6 +722,67 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn test_fragment_template_cannot_be_executed() {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let namespace = create_namespace(&pool, "fragment_execution").await;
+
+        let payload = new_template_payload(namespace.id, "partial.not-executable");
+        let resp = post_request(&pool, &admin_token, TEMPLATES_ENDPOINT, &payload).await;
+        let resp = assert_response_status(resp, StatusCode::CREATED).await;
+        let created: ReportTemplate = test::read_body_json(resp).await;
+
+        let resp = post_request(
+            &pool,
+            &admin_token,
+            &format!("{TEMPLATES_ENDPOINT}/{}/reports", created.id),
+            &serde_json::json!({}),
+        )
+        .await;
+        assert_response_status(resp, StatusCode::BAD_REQUEST).await;
+
+        namespace.delete(&pool).await.unwrap();
+    }
+
+    #[actix_web::test]
+    async fn test_report_template_rejects_class_in_another_namespace() {
+        let (pool, admin_token, _) = setup_pool_and_tokens().await;
+        let template_namespace = create_namespace(&pool, "report_class_template_ns").await;
+        let class_namespace = create_namespace(&pool, "report_class_target_ns").await;
+        let class = NewHubuumClass {
+            name: "foreign-template-class".to_string(),
+            namespace_id: class_namespace.id,
+            json_schema: None,
+            validate_schema: Some(false),
+            description: "foreign class".to_string(),
+        }
+        .save(&pool)
+        .await
+        .unwrap();
+
+        let payload = NewReportTemplate {
+            namespace_id: template_namespace.id,
+            name: "report.foreign-class".to_string(),
+            description: "bad report template".to_string(),
+            content_type: ReportContentType::TextPlain,
+            template: "{{ items|length }}".to_string(),
+            kind: ReportTemplateKind::Report,
+            scope_kind: Some(ReportScopeKind::ObjectsInClass),
+            class_id: Some(class.id),
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
+        };
+
+        let resp = post_request(&pool, &admin_token, TEMPLATES_ENDPOINT, &payload).await;
+        assert_response_status(resp, StatusCode::BAD_REQUEST).await;
+
+        template_namespace.delete(&pool).await.unwrap();
+        class_namespace.delete(&pool).await.unwrap();
+    }
+
+    #[actix_web::test]
     async fn test_template_update_content_requires_update_permission() {
         let (pool, admin_token, _normal_token) = setup_pool_and_tokens().await;
         let namespace = create_namespace(&pool, "update_content_forbidden").await;
@@ -664,6 +812,7 @@ mod tests {
             name: None,
             description: Some("updated description".to_string()),
             template: None,
+            ..empty_update_template_payload()
         };
 
         let resp = patch_request(

--- a/src/tests/api/v1/templates.rs
+++ b/src/tests/api/v1/templates.rs
@@ -853,27 +853,25 @@ mod tests {
         .await
         .unwrap();
 
-        let created = crate::models::report_template::create_report_template(
-            &pool,
-            NewReportTemplate {
-                namespace_id: namespace.id,
-                name: "report.clear-defaults".to_string(),
-                description: "clear defaults report".to_string(),
-                content_type: ReportContentType::TextPlain,
-                template: "{% for item in items %}{{ item.name }}{% endfor %}".to_string(),
-                kind: ReportTemplateKind::Report,
-                scope_kind: Some(ReportScopeKind::ObjectsInClass),
-                class_id: Some(class.id),
-                default_query: Some("sort=name".to_string()),
-                include: None,
-                relation_context: None,
-                default_missing_data_policy: Some(ReportMissingDataPolicy::Strict),
-                default_limits: Some(ReportLimits {
-                    max_items: Some(100),
-                    max_output_bytes: Some(262_144),
-                }),
-            },
-        )
+        let created = NewReportTemplate {
+            namespace_id: namespace.id,
+            name: "report.clear-defaults".to_string(),
+            description: "clear defaults report".to_string(),
+            content_type: ReportContentType::TextPlain,
+            template: "{% for item in items %}{{ item.name }}{% endfor %}".to_string(),
+            kind: ReportTemplateKind::Report,
+            scope_kind: Some(ReportScopeKind::ObjectsInClass),
+            class_id: Some(class.id),
+            default_query: Some("sort=name".to_string()),
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: Some(ReportMissingDataPolicy::Strict),
+            default_limits: Some(ReportLimits {
+                max_items: Some(100),
+                max_output_bytes: Some(262_144),
+            }),
+        }
+        .save(&pool)
         .await
         .unwrap();
 

--- a/src/utilities/reporting.rs
+++ b/src/utilities/reporting.rs
@@ -629,6 +629,7 @@ fn record_missing_value_warning(state: &State<'_, '_>, path: Option<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::{ReportScopeKind, ReportTemplateKind};
 
     #[test]
     fn limited_string_writer_accumulates_under_limit() {
@@ -662,6 +663,14 @@ mod tests {
             description: "template".to_string(),
             content_type,
             template: source.to_string(),
+            kind: ReportTemplateKind::Report,
+            scope_kind: Some(ReportScopeKind::ObjectsInClass),
+            class_id: Some(1),
+            default_query: None,
+            include: None,
+            relation_context: None,
+            default_missing_data_policy: None,
+            default_limits: None,
             created_at: now,
             updated_at: now,
         }

--- a/src/utilities/reporting.rs
+++ b/src/utilities/reporting.rs
@@ -13,99 +13,9 @@ use minijinja::{
 
 use crate::config::get_config;
 use crate::errors::ApiError;
-use crate::models::{
-    ReportContentType, ReportInclude, ReportIncludeRelatedObject, ReportMissingDataPolicy,
-    ReportTemplate, ReportWarning,
-};
+use crate::models::{ReportContentType, ReportMissingDataPolicy, ReportTemplate, ReportWarning};
 
 const TEMPLATE_ENV_CACHE_MAX_ENTRIES: usize = 128;
-
-/// Bounds for `include.related_objects` hydration. Shared by ad-hoc report requests
-/// (`POST /api/v1/reports`) and stored executable report templates so the two paths
-/// cannot drift apart.
-pub const RELATED_INCLUDE_DEFAULT_MAX_DEPTH: i32 = 1;
-pub const RELATED_INCLUDE_MAX_DEPTH_LIMIT: i32 = 10;
-pub const RELATED_INCLUDE_DEFAULT_LIMIT: i32 = 1;
-pub const RELATED_INCLUDE_MAX_LIMIT: i32 = 50;
-pub const RELATED_INCLUDE_MAX_ALIASES: usize = 8;
-
-/// Validate the `include.related_objects` block (alias count, alias syntax, and per-alias
-/// option bounds). The caller is responsible for any scope-specific rules (e.g. that
-/// `include` is only valid for `objects_in_class`).
-pub fn validate_related_objects_include(include: &ReportInclude) -> Result<(), ApiError> {
-    let Some(related_objects) = &include.related_objects else {
-        return Ok(());
-    };
-
-    if related_objects.len() > RELATED_INCLUDE_MAX_ALIASES {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects supports at most {RELATED_INCLUDE_MAX_ALIASES} aliases"
-        )));
-    }
-
-    for (alias, include) in related_objects {
-        validate_related_include_alias(alias)?;
-        validate_related_include_options(alias, include)?;
-    }
-
-    Ok(())
-}
-
-fn validate_related_include_alias(alias: &str) -> Result<(), ApiError> {
-    let mut chars = alias.chars();
-    let Some(first) = chars.next() else {
-        return Err(ApiError::BadRequest(
-            "include.related_objects aliases must not be empty".to_string(),
-        ));
-    };
-
-    if !(first == '_' || first.is_ascii_alphabetic())
-        || !chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-    {
-        return Err(ApiError::BadRequest(format!(
-            "Invalid include.related_objects alias '{alias}'; expected [A-Za-z_][A-Za-z0-9_]*"
-        )));
-    }
-
-    Ok(())
-}
-
-fn validate_related_include_options(
-    alias: &str,
-    include: &ReportIncludeRelatedObject,
-) -> Result<(), ApiError> {
-    if include.class_id <= 0 {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects.{alias}.class_id must be greater than 0"
-        )));
-    }
-
-    if let Some(class_relation_id) = include.class_relation_id
-        && class_relation_id <= 0
-    {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects.{alias}.class_relation_id must be greater than 0"
-        )));
-    }
-
-    let max_depth = include
-        .max_depth
-        .unwrap_or(RELATED_INCLUDE_DEFAULT_MAX_DEPTH);
-    if !(1..=RELATED_INCLUDE_MAX_DEPTH_LIMIT).contains(&max_depth) {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects.{alias}.max_depth must be between 1 and {RELATED_INCLUDE_MAX_DEPTH_LIMIT}"
-        )));
-    }
-
-    let limit = include.limit.unwrap_or(RELATED_INCLUDE_DEFAULT_LIMIT);
-    if !(1..=RELATED_INCLUDE_MAX_LIMIT).contains(&limit) {
-        return Err(ApiError::BadRequest(format!(
-            "include.related_objects.{alias}.limit must be between 1 and {RELATED_INCLUDE_MAX_LIMIT}"
-        )));
-    }
-
-    Ok(())
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct TemplateEnvCacheKey {
@@ -192,17 +102,20 @@ pub fn validate_template_with_limits(
     Ok(())
 }
 
-// Size-bounded sink for streaming a template render: minijinja's render_captured_to writes into
-// this as it evaluates, so an oversized text/html/csv report aborts at the byte budget instead of
-// being fully materialized before the 413. The JSON output path has an analogous LimitedJsonWriter.
-struct LimitedStringWriter {
+/// Size-bounded `Write` sink shared by both report output paths. minijinja's
+/// `render_captured_to` (text/html/csv) and `serde_json::to_writer` (JSON) both write into this as
+/// they produce bytes, so an oversized report aborts at the configured byte budget instead of being
+/// fully materialized before the 413. Memory stays bounded by `max_bytes` because writing stops at
+/// the cap. The JSON size check ignores the captured bytes; the template path keeps them via
+/// `into_string`.
+pub struct SizeLimitedWriter {
     max_bytes: usize,
     buffer: Vec<u8>,
     exceeded: bool,
 }
 
-impl LimitedStringWriter {
-    fn new(max_bytes: usize) -> Self {
+impl SizeLimitedWriter {
+    pub fn new(max_bytes: usize) -> Self {
         Self {
             max_bytes,
             buffer: Vec::new(),
@@ -210,22 +123,22 @@ impl LimitedStringWriter {
         }
     }
 
-    fn exceeded(&self) -> bool {
+    pub fn exceeded(&self) -> bool {
         self.exceeded
     }
 
-    fn into_string(self) -> Result<String, ApiError> {
+    pub fn into_string(self) -> Result<String, ApiError> {
         String::from_utf8(self.buffer).map_err(|error| {
             ApiError::InternalServerError(format!("Rendered report was not valid UTF-8: {error}"))
         })
     }
 }
 
-impl Write for LimitedStringWriter {
+impl Write for SizeLimitedWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if self.buffer.len().saturating_add(buf.len()) > self.max_bytes {
             self.exceeded = true;
-            return Err(io::Error::other("template output limit exceeded"));
+            return Err(io::Error::other("report output limit exceeded"));
         }
 
         self.buffer.extend_from_slice(buf);
@@ -294,7 +207,7 @@ pub fn render_template(
     };
 
     begin_template_warning_capture();
-    let mut writer = LimitedStringWriter::new(max_output_bytes);
+    let mut writer = SizeLimitedWriter::new(max_output_bytes);
     let lookup = env.env.get_template(&env.template_name);
     let render_result = match lookup {
         Ok(template) => template.render_captured_to(context, &mut writer),
@@ -721,7 +634,7 @@ mod tests {
 
     #[test]
     fn limited_string_writer_accumulates_under_limit() {
-        let mut writer = LimitedStringWriter::new(16);
+        let mut writer = SizeLimitedWriter::new(16);
         writer.write_all(b"hello ").unwrap();
         writer.write_all(b"world").unwrap();
         assert!(!writer.exceeded());
@@ -730,7 +643,7 @@ mod tests {
 
     #[test]
     fn limited_string_writer_aborts_over_limit() {
-        let mut writer = LimitedStringWriter::new(4);
+        let mut writer = SizeLimitedWriter::new(4);
         let err = writer.write_all(b"toolong").unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::Other);
         assert!(writer.exceeded());

--- a/src/utilities/reporting.rs
+++ b/src/utilities/reporting.rs
@@ -373,10 +373,6 @@ fn build_environment(
     missing_data_policy: ReportMissingDataPolicy,
     limits: TemplateLimits,
 ) -> Result<CachedTemplateEnvironment, ApiError> {
-    let TemplateLimits {
-        recursion_limit,
-        fuel,
-    } = limits;
     let mut env = Environment::new();
     let template_map = Arc::new(build_namespace_template_map(
         namespace_id,

--- a/src/utilities/reporting.rs
+++ b/src/utilities/reporting.rs
@@ -356,6 +356,8 @@ fn namespace_signature(
     }
 }
 
+/// Recursion and fuel bounds for a MiniJinja environment, bundled so `build_environment`
+/// stays within a sensible argument count.
 #[derive(Debug, Clone, Copy)]
 struct TemplateLimits {
     recursion_limit: usize,
@@ -385,8 +387,8 @@ fn build_environment(
 
     env.set_keep_trailing_newline(true);
     env.set_undefined_behavior(undefined_behavior(missing_data_policy));
-    env.set_recursion_limit(recursion_limit);
-    env.set_fuel(Some(fuel));
+    env.set_recursion_limit(limits.recursion_limit);
+    env.set_fuel(Some(limits.fuel));
     env.set_auto_escape_callback(move |_| match content_type {
         ReportContentType::TextHtml => AutoEscape::Html,
         _ => AutoEscape::None,

--- a/src/utilities/reporting.rs
+++ b/src/utilities/reporting.rs
@@ -13,9 +13,99 @@ use minijinja::{
 
 use crate::config::get_config;
 use crate::errors::ApiError;
-use crate::models::{ReportContentType, ReportMissingDataPolicy, ReportTemplate, ReportWarning};
+use crate::models::{
+    ReportContentType, ReportInclude, ReportIncludeRelatedObject, ReportMissingDataPolicy,
+    ReportTemplate, ReportWarning,
+};
 
 const TEMPLATE_ENV_CACHE_MAX_ENTRIES: usize = 128;
+
+/// Bounds for `include.related_objects` hydration. Shared by ad-hoc report requests
+/// (`POST /api/v1/reports`) and stored executable report templates so the two paths
+/// cannot drift apart.
+pub const RELATED_INCLUDE_DEFAULT_MAX_DEPTH: i32 = 1;
+pub const RELATED_INCLUDE_MAX_DEPTH_LIMIT: i32 = 10;
+pub const RELATED_INCLUDE_DEFAULT_LIMIT: i32 = 1;
+pub const RELATED_INCLUDE_MAX_LIMIT: i32 = 50;
+pub const RELATED_INCLUDE_MAX_ALIASES: usize = 8;
+
+/// Validate the `include.related_objects` block (alias count, alias syntax, and per-alias
+/// option bounds). The caller is responsible for any scope-specific rules (e.g. that
+/// `include` is only valid for `objects_in_class`).
+pub fn validate_related_objects_include(include: &ReportInclude) -> Result<(), ApiError> {
+    let Some(related_objects) = &include.related_objects else {
+        return Ok(());
+    };
+
+    if related_objects.len() > RELATED_INCLUDE_MAX_ALIASES {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects supports at most {RELATED_INCLUDE_MAX_ALIASES} aliases"
+        )));
+    }
+
+    for (alias, include) in related_objects {
+        validate_related_include_alias(alias)?;
+        validate_related_include_options(alias, include)?;
+    }
+
+    Ok(())
+}
+
+fn validate_related_include_alias(alias: &str) -> Result<(), ApiError> {
+    let mut chars = alias.chars();
+    let Some(first) = chars.next() else {
+        return Err(ApiError::BadRequest(
+            "include.related_objects aliases must not be empty".to_string(),
+        ));
+    };
+
+    if !(first == '_' || first.is_ascii_alphabetic())
+        || !chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+    {
+        return Err(ApiError::BadRequest(format!(
+            "Invalid include.related_objects alias '{alias}'; expected [A-Za-z_][A-Za-z0-9_]*"
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_related_include_options(
+    alias: &str,
+    include: &ReportIncludeRelatedObject,
+) -> Result<(), ApiError> {
+    if include.class_id <= 0 {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects.{alias}.class_id must be greater than 0"
+        )));
+    }
+
+    if let Some(class_relation_id) = include.class_relation_id
+        && class_relation_id <= 0
+    {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects.{alias}.class_relation_id must be greater than 0"
+        )));
+    }
+
+    let max_depth = include
+        .max_depth
+        .unwrap_or(RELATED_INCLUDE_DEFAULT_MAX_DEPTH);
+    if !(1..=RELATED_INCLUDE_MAX_DEPTH_LIMIT).contains(&max_depth) {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects.{alias}.max_depth must be between 1 and {RELATED_INCLUDE_MAX_DEPTH_LIMIT}"
+        )));
+    }
+
+    let limit = include.limit.unwrap_or(RELATED_INCLUDE_DEFAULT_LIMIT);
+    if !(1..=RELATED_INCLUDE_MAX_LIMIT).contains(&limit) {
+        return Err(ApiError::BadRequest(format!(
+            "include.related_objects.{alias}.limit must be between 1 and {RELATED_INCLUDE_MAX_LIMIT}"
+        )));
+    }
+
+    Ok(())
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct TemplateEnvCacheKey {


### PR DESCRIPTION
This pull request introduces a new, clearer workflow for generating text, HTML, and CSV reports using executable stored templates, and updates both the API and documentation accordingly. The main change is the addition of a dedicated endpoint, `POST /api/v1/templates/{template_id}/reports`, for running stored templates, as opposed to the previous approach of referencing templates via `output.template_id` in generic report requests. The documentation, OpenAPI schema, and backend logic are all updated to reflect this new, more intuitive design.

**API and Workflow Improvements:**

* Added a new endpoint, `POST /api/v1/templates/{template_id}/reports`, for executing stored report templates directly, returning output in the template's specified format. This replaces the previous pattern of referencing templates via `output.template_id` in `POST /api/v1/reports`. [[1]](diffhunk://#diff-2bf1e8a46ea9cd2266e134c82613e4b509729ef6aec829d7141b63afed3a8d08R8) [[2]](diffhunk://#diff-2bf1e8a46ea9cd2266e134c82613e4b509729ef6aec829d7141b63afed3a8d08R188-R220) [[3]](diffhunk://#diff-2bf1e8a46ea9cd2266e134c82613e4b509729ef6aec829d7141b63afed3a8d08L235-R258) [[4]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L5-R6) [[5]](diffhunk://#diff-a00c8e361c8c4fd7f4c2c56d0c54a6fd794e84a4c7d223bbbf23554abe5ff435R107) [[6]](diffhunk://#diff-a00c8e361c8c4fd7f4c2c56d0c54a6fd794e84a4c7d223bbbf23554abe5ff435R704) [[7]](diffhunk://#diff-a00c8e361c8c4fd7f4c2c56d0c54a6fd794e84a4c7d223bbbf23554abe5ff435R751-R754)
* Updated the backend logic to support the new endpoint, including changes to handler functions and the introduction of a `submit_report_task` helper to unify report submission logic for both endpoints. [[1]](diffhunk://#diff-4a6c8effbe52ebd902266d8062323746ceea1fac983afba05d51a1afecf5fc47R50) [[2]](diffhunk://#diff-4a6c8effbe52ebd902266d8062323746ceea1fac983afba05d51a1afecf5fc47L200-R202) [[3]](diffhunk://#diff-4a6c8effbe52ebd902266d8062323746ceea1fac983afba05d51a1afecf5fc47R216-R252) [[4]](diffhunk://#diff-4a6c8effbe52ebd902266d8062323746ceea1fac983afba05d51a1afecf5fc47R324-R329) [[5]](diffhunk://#diff-4a6c8effbe52ebd902266d8062323746ceea1fac983afba05d51a1afecf5fc47L338-R362) [[6]](diffhunk://#diff-4a6c8effbe52ebd902266d8062323746ceea1fac983afba05d51a1afecf5fc47R400)

**Documentation and Example Updates:**

* Revised the report API documentation to describe the new workflow, clearly distinguishing between JSON reports (`POST /api/v1/reports`) and template-based reports (`POST /api/v1/templates/{template_id}/reports`). Updated examples to match the new API, removing references to the old `output.template_id` mechanism. [[1]](diffhunk://#diff-2bf1e8a46ea9cd2266e134c82613e4b509729ef6aec829d7141b63afed3a8d08L24-L26) [[2]](diffhunk://#diff-2bf1e8a46ea9cd2266e134c82613e4b509729ef6aec829d7141b63afed3a8d08L47-R45) [[3]](diffhunk://#diff-2bf1e8a46ea9cd2266e134c82613e4b509729ef6aec829d7141b63afed3a8d08L176-L178) [[4]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L62-R91) [[5]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L366-L379) [[6]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L397-R426) [[7]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L418-R439) [[8]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L718-R736) [[9]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L762-R791)
* Updated the template guide to reflect the new executable template workflow, including concrete examples for creating and running templates, and clarified the distinction between template-based and JSON reports. [[1]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L5-R6) [[2]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L62-R91) [[3]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L366-L379) [[4]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L397-R426) [[5]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L418-R439) [[6]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L718-R736) [[7]](diffhunk://#diff-36d6e57df4d22375aad63b1fd056cf7173933dd1f2c2dc72b2b554f9b92d6893L762-R791)

**Schema and Model Enhancements:**

* Extended the database schema for report templates to include new fields (`kind`, `scope_kind`, `class_id`, `default_query`, `include`, `relation_context`, `default_missing_data_policy`, `default_limits`) and added constraints to enforce correct template usage and scoping.
* Updated OpenAPI schema and Rust type imports to include new request/response types and ensure accurate API documentation for the new endpoint and workflow. [[1]](diffhunk://#diff-a00c8e361c8c4fd7f4c2c56d0c54a6fd794e84a4c7d223bbbf23554abe5ff435L16-R22) [[2]](diffhunk://#diff-a00c8e361c8c4fd7f4c2c56d0c54a6fd794e84a4c7d223bbbf23554abe5ff435L207) [[3]](diffhunk://#diff-a00c8e361c8c4fd7f4c2c56d0c54a6fd794e84a4c7d223bbbf23554abe5ff435R221-R223)

These changes modernize and clarify the report generation workflow, making it easier for users to generate formatted reports and for developers to maintain the API.