### PR TITLE
Fix core API security and consistency issues

### DIFF
--- a/benches/object_validation_geo_callgrind.rs
+++ b/benches/object_validation_geo_callgrind.rs
@@ -1,5 +1,4 @@
 use hubuum::models::NewHubuumObject;
-use hubuum::tests::constants::{SchemaType, get_schema};
 use hubuum::traits::ValidateAgainstSchema;
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
@@ -7,6 +6,28 @@ use std::sync::LazyLock;
 use tokio::runtime::Runtime;
 
 static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| Runtime::new().expect("tokio runtime"));
+static GEO_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
+    serde_json::json!({
+        "$id": "https://example.com/geographical-location.schema.json",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "Geographical Location",
+        "description": "A geographical location",
+        "type": "object",
+        "required": ["latitude", "longitude"],
+        "properties": {
+            "latitude": {
+                "type": "number",
+                "minimum": -90,
+                "maximum": 90
+            },
+            "longitude": {
+                "type": "number",
+                "minimum": -180,
+                "maximum": 180
+            }
+        }
+    })
+});
 
 #[library_benchmark]
 fn bench_validate_geo_schema() -> usize {
@@ -22,7 +43,7 @@ fn bench_validate_geo_schema() -> usize {
     };
 
     RUNTIME
-        .block_on(object.validate_against_schema(black_box(get_schema(SchemaType::Geo))))
+        .block_on(object.validate_against_schema(black_box(&*GEO_SCHEMA)))
         .expect("validation should succeed");
 
     black_box(object.data.as_object().map_or(0, |data| data.len()))

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2996,7 +2996,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/User"
+                    "$ref": "#/components/schemas/UserResponse"
                   }
                 }
               }
@@ -3211,7 +3211,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/User"
+                    "$ref": "#/components/schemas/UserResponse"
                   }
                 }
               }
@@ -3229,6 +3229,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -3267,7 +3277,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/User"
+                  "$ref": "#/components/schemas/UserResponse"
                 }
               }
             }
@@ -3336,13 +3346,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/User"
+                  "$ref": "#/components/schemas/UserResponse"
                 }
               }
             }
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -3453,7 +3473,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/User"
+                  "$ref": "#/components/schemas/UserResponse"
                 }
               }
             }
@@ -8325,7 +8345,7 @@
       },
       "NewUser": {
         "type": "object",
-        "description": "Struct to create a new user.\n\nThe password is expected to be hashed\nbefore being passed to the database.",
+        "description": "Struct to create a new user.\n\nThe password is expected to be plaintext.",
         "required": [
           "username",
           "password"
@@ -9911,7 +9931,7 @@
       },
       "UpdateUser": {
         "type": "object",
-        "description": "Struct to update a user.\n\nThe password, if present, is expected to be hashed\nbefore being passed to the database.",
+        "description": "Struct to update a user.\n\nThe password, if present, is expected to be plaintext.",
         "properties": {
           "email": {
             "type": [
@@ -9938,12 +9958,11 @@
           "username": "alice"
         }
       },
-      "User": {
+      "UserResponse": {
         "type": "object",
         "required": [
           "id",
           "username",
-          "password",
           "created_at",
           "updated_at"
         ],
@@ -9961,9 +9980,6 @@
           "id": {
             "type": "integer",
             "format": "int32"
-          },
-          "password": {
-            "type": "string"
           },
           "updated_at": {
             "type": "string",

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -19,7 +19,7 @@ use crate::models::{
     TaskProgress, TaskResponse, TaskStatus, UnifiedSearchBatchResponse, UnifiedSearchDoneEvent,
     UnifiedSearchErrorEvent, UnifiedSearchKind, UnifiedSearchResponse, UnifiedSearchStartedEvent,
     UpdateGroup, UpdateHubuumClass, UpdateHubuumObject, UpdateNamespace, UpdateReportTemplate,
-    UpdateUser, User, UserToken, UserTokenMetadata,
+    UpdateUser, UserResponse, UserToken, UserTokenMetadata,
 };
 use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER, page_limits_or_defaults};
 use actix_web::{HttpResponse, Responder};
@@ -144,7 +144,7 @@ use utoipa::{Modify, OpenApi, ToSchema};
             meta::ReleaseRateLimitResponse,
             meta::ClearRateLimitResponse,
             ObjectsByClass,
-            User,
+            UserResponse,
             NewUser,
             UpdateUser,
             LoginUser,

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -9,7 +9,9 @@ use crate::db::traits::{ClassRelation, ObjectRelationMemberships, UserPermission
 use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::traits::{ExpandNamespace, ToHubuumObjects};
-use crate::pagination::{count_query_options, prepare_db_pagination};
+use crate::pagination::{
+    count_query_options, page_limits, prepare_db_pagination, validate_page_limit,
+};
 use crate::utilities::response::{
     json_response, json_response_created, paginated_json_mapped_response, paginated_json_response,
 };
@@ -96,6 +98,80 @@ fn parse_related_objects_query(
             ignore_self_class: ignore_self_class.unwrap_or(true),
         },
     ))
+}
+
+fn ensure_new_object_matches_path_class(
+    object: &NewHubuumObject,
+    class: &HubuumClass,
+) -> Result<(), ApiError> {
+    if object.hubuum_class_id != class.id {
+        return Err(ApiError::BadRequest(format!(
+            "Object hubuum_class_id {} does not match path class_id {}",
+            object.hubuum_class_id, class.id
+        )));
+    }
+
+    if object.namespace_id != class.namespace_id {
+        return Err(ApiError::BadRequest(format!(
+            "Object namespace_id {} does not match class namespace_id {}",
+            object.namespace_id, class.namespace_id
+        )));
+    }
+
+    Ok(())
+}
+
+fn ensure_object_update_stays_in_path_class(
+    update: &UpdateHubuumObject,
+    object: &HubuumObject,
+) -> Result<(), ApiError> {
+    if let Some(class_id) = update.hubuum_class_id
+        && class_id != object.hubuum_class_id
+    {
+        return Err(ApiError::BadRequest(
+            "Object class cannot be changed through a class-scoped object endpoint".to_string(),
+        ));
+    }
+
+    if let Some(namespace_id) = update.namespace_id
+        && namespace_id != object.namespace_id
+    {
+        return Err(ApiError::BadRequest(
+            "Object namespace cannot be changed through a class-scoped object endpoint".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn prepare_graph_query_options(
+    mut params: QueryOptions,
+) -> Result<(QueryOptions, usize), ApiError> {
+    if params.cursor.is_some() {
+        return Err(ApiError::BadRequest(
+            "Graph endpoint does not support cursor".to_string(),
+        ));
+    }
+
+    let (default_limit, _) = page_limits()?;
+    let limit = validate_page_limit(params.limit.unwrap_or(default_limit))?;
+    params.limit = Some(limit + 1);
+
+    Ok((params, limit))
+}
+
+fn ensure_graph_result_within_limit<T>(
+    items: &[T],
+    limit: usize,
+    resource_name: &str,
+) -> Result<(), ApiError> {
+    if items.len() > limit {
+        return Err(ApiError::BadRequest(format!(
+            "Graph contains more than {limit} related {resource_name}; narrow the query or increase limit"
+        )));
+    }
+
+    Ok(())
 }
 
 // GET /api/v1/classes, list all classes the user may see.
@@ -253,6 +329,17 @@ async fn update_class(
 
     let class = class_id.instance(&pool).await?;
     can!(&pool, user, [Permissions::UpdateClass], class);
+
+    if let Some(target_namespace_id) = class_data.namespace_id
+        && target_namespace_id != class.namespace_id
+    {
+        can!(
+            &pool,
+            user,
+            [Permissions::CreateClass],
+            NamespaceID(target_namespace_id)
+        );
+    }
 
     let class = class_data
         .update(&pool, class.id)
@@ -618,17 +705,14 @@ async fn get_related_class_graph(
 ) -> Result<impl Responder, ApiError> {
     let user = requestor.user;
     let class_id = class_id.into_inner();
-    let params = parse_query_parameter(req.query_string())?;
-    if params.limit.is_some() || params.cursor.is_some() {
-        return Err(ApiError::BadRequest(
-            "Graph endpoint does not support limit or cursor".to_string(),
-        ));
-    }
+    let (params, graph_limit) =
+        prepare_graph_query_options(parse_query_parameter(req.query_string())?)?;
     let class = class_id.instance(&pool).await?;
     can!(&pool, user, [Permissions::ReadClass], class);
 
     let root_class = class_with_root_path(&class);
     let connected_classes = user.search_classes_related_to(&pool, class, params).await?;
+    ensure_graph_result_within_limit(&connected_classes, graph_limit, "classes")?;
     let mut classes = Vec::with_capacity(connected_classes.len() + 1);
     classes.push(root_class);
     classes.extend(connected_classes.to_descendant_classes_with_path());
@@ -733,13 +817,15 @@ async fn create_object_in_class(
         object_data = object_data.name,
     );
 
-    can!(&pool, user, [Permissions::CreateObject], class_id);
+    let class = class_id.instance(&pool).await?;
+    can!(&pool, user, [Permissions::CreateObject], class);
+    ensure_new_object_matches_path_class(&object_data, &class)?;
 
     let object = object_data.save(&pool).await?;
 
     Ok(json_response_created(
         &object,
-        &format!("/api/v1/classes/{}/{}", class_id.id(), object.id()),
+        &format!("/api/v1/classes/{}/{}", class.id, object.id()),
     ))
 }
 
@@ -774,10 +860,7 @@ async fn get_object_in_class(
         object_id = object_id.id()
     );
 
-    // Can you read objects in a class you can't read? Hm.
-    // let class = class_id.instance(&pool).await?;
-    // check_permissions!(class.namespace_id, pool, user, Permissions::ReadClass);
-
+    check_if_object_in_class(&pool, &class_id, &object_id).await?;
     let object = object_id.instance(&pool).await?;
     can!(&pool, user, [Permissions::ReadObject], object);
 
@@ -819,8 +902,10 @@ async fn patch_object_in_class(
         object_id = object_id.id()
     );
 
+    check_if_object_in_class(&pool, &class_id, &object_id).await?;
     let object = object_id.instance(&pool).await?;
     can!(&pool, user, [Permissions::UpdateObject], object);
+    ensure_object_update_stays_in_path_class(&object_data, &object)?;
 
     let object = object_data.update(&pool, object.id).await?;
     Ok(json_response(object, StatusCode::OK))
@@ -857,6 +942,7 @@ async fn delete_object_in_class(
         object_id = object_id.id()
     );
 
+    check_if_object_in_class(&pool, &class_id, &object_id).await?;
     let object = object_id.instance(&pool).await?;
     can!(&pool, user, [Permissions::DeleteObject], object);
 
@@ -1018,13 +1104,8 @@ async fn get_related_object_graph(
 ) -> Result<impl Responder, ApiError> {
     let user = requestor.user;
     let (class_id, object_id) = paths.into_inner();
-    let params = parse_query_parameter(req.query_string())?;
-
-    if params.limit.is_some() || params.cursor.is_some() {
-        return Err(ApiError::BadRequest(
-            "Graph endpoint does not support limit or cursor".to_string(),
-        ));
-    }
+    let (params, graph_limit) =
+        prepare_graph_query_options(parse_query_parameter(req.query_string())?)?;
 
     check_if_object_in_class(&pool, &class_id, &object_id).await?;
     let object = object_id.instance(&pool).await?;
@@ -1042,6 +1123,7 @@ async fn get_related_object_graph(
     let connected_objects = user
         .search_objects_related_to(&pool, object, params)
         .await?;
+    ensure_graph_result_within_limit(&connected_objects, graph_limit, "objects")?;
     let mut objects = Vec::with_capacity(connected_objects.len() + 1);
     objects.push(root_object);
     objects.extend(connected_objects.to_descendant_objects_with_path());

--- a/src/api/v1/handlers/groups.rs
+++ b/src/api/v1/handlers/groups.rs
@@ -4,9 +4,11 @@ use crate::errors::ApiError;
 use crate::extractors::{AdminAccess, UserAccess};
 use crate::models::group::{GroupID, NewGroup, UpdateGroup};
 use crate::models::search::parse_query_parameter;
-use crate::models::{Group, User, UserID};
+use crate::models::{Group, User, UserID, UserResponse};
 use crate::pagination::{count_query_options, prepare_db_pagination};
-use crate::utilities::response::{json_response, json_response_created, paginated_json_response};
+use crate::utilities::response::{
+    json_response, json_response_created, paginated_json_mapped_response, paginated_json_response,
+};
 use actix_web::{HttpRequest, Responder, delete, get, http::StatusCode, patch, post, routes, web};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -200,7 +202,7 @@ pub async fn delete_group(
         ("group_id" = i32, Path, description = "Group ID")
     ),
     responses(
-        (status = 200, description = "Members of group", body = [User]),
+        (status = 200, description = "Members of group", body = [UserResponse]),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
         (status = 404, description = "Group not found", body = ApiErrorResponse)
     )
@@ -227,7 +229,9 @@ pub async fn get_group_members(
     let search_params = prepare_db_pagination::<User>(&params)?;
     let members = group.members_paginated(&pool, &search_params).await?;
 
-    paginated_json_response(members, total_count, StatusCode::OK, &params)
+    paginated_json_mapped_response(members, total_count, StatusCode::OK, &params, |users| {
+        users.into_iter().map(UserResponse::from).collect()
+    })
 }
 
 #[utoipa::path(

--- a/src/api/v1/handlers/users.rs
+++ b/src/api/v1/handlers/users.rs
@@ -1,9 +1,9 @@
 use crate::api::openapi::ApiErrorResponse;
 use crate::db::DbPool;
 use crate::errors::ApiError;
-use crate::extractors::{AdminAccess, AdminOrSelfAccess, UserAccess};
+use crate::extractors::{AdminAccess, AdminOrSelfAccess};
 use crate::models::search::parse_query_parameter;
-use crate::models::user::{NewUser, UpdateUser, UserID};
+use crate::models::user::{NewUser, UpdateUser, UserID, UserResponse};
 use crate::models::{Group, User, UserToken, UserTokenMetadata};
 use crate::pagination::{count_query_options, prepare_db_pagination};
 use crate::utilities::response::{
@@ -19,9 +19,10 @@ use tracing::debug;
     tag = "users",
     security(("bearer_auth" = [])),
     responses(
-        (status = 200, description = "Users matching optional query filters", body = [User]),
+        (status = 200, description = "Users matching optional query filters", body = [UserResponse]),
         (status = 400, description = "Bad request", body = ApiErrorResponse),
-        (status = 401, description = "Unauthorized", body = ApiErrorResponse)
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Forbidden", body = ApiErrorResponse)
     )
 )]
 #[routes]
@@ -29,7 +30,7 @@ use tracing::debug;
 #[get("/")]
 pub async fn get_users(
     pool: web::Data<DbPool>,
-    requestor: UserAccess,
+    requestor: AdminAccess,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let user = requestor.user;
@@ -48,7 +49,9 @@ pub async fn get_users(
     let search_params = prepare_db_pagination::<User>(&params)?;
     let result = user.search_users(&pool, search_params).await?;
 
-    paginated_json_response(result, total_count, StatusCode::OK, &params)
+    paginated_json_mapped_response(result, total_count, StatusCode::OK, &params, |users| {
+        users.into_iter().map(UserResponse::from).collect()
+    })
 }
 
 #[utoipa::path(
@@ -58,7 +61,7 @@ pub async fn get_users(
     security(("bearer_auth" = [])),
     request_body = NewUser,
     responses(
-        (status = 201, description = "User created", body = User),
+        (status = 201, description = "User created", body = UserResponse),
         (status = 400, description = "Bad request", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
         (status = 409, description = "Conflict", body = ApiErrorResponse)
@@ -81,7 +84,7 @@ pub async fn create_user(
     let user = new_user.into_inner().save(&pool).await?;
 
     Ok(json_response_created(
-        &user,
+        UserResponse::from(&user),
         format!("/api/v1/iam/users/{}", user.id).as_str(),
     ))
 }
@@ -139,8 +142,9 @@ pub async fn get_user_tokens(
         ("user_id" = i32, Path, description = "User ID")
     ),
     responses(
-        (status = 200, description = "User", body = User),
+        (status = 200, description = "User", body = UserResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Forbidden", body = ApiErrorResponse),
         (status = 404, description = "User not found", body = ApiErrorResponse)
     )
 )]
@@ -148,7 +152,7 @@ pub async fn get_user_tokens(
 pub async fn get_user(
     pool: web::Data<DbPool>,
     user_id: web::Path<UserID>,
-    requestor: UserAccess,
+    requestor: AdminOrSelfAccess,
 ) -> Result<impl Responder, ApiError> {
     let user = user_id.into_inner().user(&pool).await?;
     debug!(
@@ -157,7 +161,7 @@ pub async fn get_user(
         requestor = requestor.user.id
     );
 
-    Ok(json_response(user, StatusCode::OK))
+    Ok(json_response(UserResponse::from(user), StatusCode::OK))
 }
 
 #[utoipa::path(
@@ -208,7 +212,7 @@ pub async fn get_user_groups(
     ),
     request_body = UpdateUser,
     responses(
-        (status = 200, description = "Updated user", body = User),
+        (status = 200, description = "Updated user", body = UserResponse),
         (status = 400, description = "Bad request", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
         (status = 404, description = "User not found", body = ApiErrorResponse)
@@ -228,12 +232,8 @@ pub async fn update_user(
         requestor = requestor.user.id
     );
 
-    let user = updated_user
-        .into_inner()
-        .hash_password()?
-        .save(user.id, &pool)
-        .await?;
-    Ok(json_response(user, StatusCode::OK))
+    let user = updated_user.into_inner().save(user.id, &pool).await?;
+    Ok(json_response(UserResponse::from(user), StatusCode::OK))
 }
 
 #[utoipa::path(

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -6,50 +6,17 @@ use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::Pool;
 use diesel::r2d2::PooledConnection;
 
-use std::time::Duration;
-use tracing::{debug, error, warn};
+use tracing::debug;
 
 use crate::errors::{ApiError, EXIT_CODE_CONFIG_ERROR, EXIT_CODE_DATABASE_ERROR, fatal_error};
 use crate::utilities::db::DatabaseUrlComponents;
 
 pub type DbPool = Pool<ConnectionManager<PgConnection>>;
 
-const MAX_RETRIES: u32 = 3;
-const RETRY_DELAY: Duration = Duration::from_millis(100);
-
 fn acquire_connection(
     pool: &DbPool,
 ) -> Result<PooledConnection<ConnectionManager<PgConnection>>, ApiError> {
-    let mut last_error = None;
-
-    for attempt in 1..=MAX_RETRIES {
-        match pool.get() {
-            Ok(conn) => return Ok(conn),
-            Err(e) => {
-                warn!(
-                    "Failed to get database connection (attempt {}): {}",
-                    attempt, e
-                );
-                last_error = Some(e);
-                if attempt < MAX_RETRIES {
-                    std::thread::sleep(RETRY_DELAY);
-                }
-            }
-        }
-    }
-
-    error!(
-        "Failed to get database connection after {} attempts",
-        MAX_RETRIES
-    );
-    // last_error should always be Some since we iterate at least once,
-    // but we handle it defensively with a fallback message
-    match last_error {
-        Some(e) => Err(ApiError::from(e)),
-        None => Err(ApiError::DbConnectionError(
-            "Failed to establish database connection after retries".to_string(),
-        )),
-    }
+    pool.get().map_err(ApiError::from)
 }
 
 /// Run database work on a single pooled connection without starting an explicit transaction.

--- a/src/db/traits/object.rs
+++ b/src/db/traits/object.rs
@@ -179,6 +179,13 @@ impl ValidateObjectRecord for NewHubuumObject {
     async fn validate_object_record(&self, pool: &DbPool) -> Result<(), ApiError> {
         let class = HubuumClassID(self.hubuum_class_id).class(pool).await?;
 
+        if self.namespace_id != class.namespace_id {
+            return Err(ApiError::BadRequest(format!(
+                "Object namespace_id {} does not match class namespace_id {}",
+                self.namespace_id, class.namespace_id
+            )));
+        }
+
         if class.validate_schema
             && let Some(ref schema) = class.json_schema
         {
@@ -194,6 +201,13 @@ impl ValidateObjectRecord for (&UpdateHubuumObject, i32) {
         let original = HubuumObjectID(*object_id).instance(pool).await?;
         let merged = original.merge_update(update_obj);
         let class = HubuumClassID(merged.hubuum_class_id).class(pool).await?;
+
+        if merged.namespace_id != class.namespace_id {
+            return Err(ApiError::BadRequest(format!(
+                "Object namespace_id {} does not match class namespace_id {}",
+                merged.namespace_id, class.namespace_id
+            )));
+        }
 
         if class.validate_schema
             && let Some(ref schema) = class.json_schema

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod models;
 pub mod pagination;
 pub mod schema;
 pub mod tasks;
+#[cfg(test)]
 pub mod tests;
 pub mod traits;
 pub mod utilities;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod models;
 mod pagination;
 mod schema;
 mod tasks;
+#[cfg(test)]
 mod tests;
 mod tls;
 mod traits;

--- a/src/middlewares/client_allowlist.rs
+++ b/src/middlewares/client_allowlist.rs
@@ -108,23 +108,19 @@ where
     }
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
-        let allowlist = self.allowlist.clone();
         let client_ip = extract_client_ip(&req, &self.proxy_trust);
-        let fut = self.service.call(req);
 
-        Box::pin(async move {
-            match client_ip {
-                Some(ip) if allowlist.allows(ip) => fut.await,
-                Some(ip) => {
-                    warn!(message = "Rejected request from disallowed IP", client_ip = %ip);
-                    Err(ErrorForbidden("Client not allowed"))
-                }
-                None => {
-                    warn!(message = "Rejected request with missing client IP");
-                    Err(ErrorForbidden("Client not allowed"))
-                }
+        match client_ip {
+            Some(ip) if self.allowlist.allows(ip) => Box::pin(self.service.call(req)),
+            Some(ip) => {
+                warn!(message = "Rejected request from disallowed IP", client_ip = %ip);
+                Box::pin(async { Err(ErrorForbidden("Client not allowed")) })
             }
-        })
+            None => {
+                warn!(message = "Rejected request with missing client IP");
+                Box::pin(async { Err(ErrorForbidden("Client not allowed")) })
+            }
+        }
     }
 }
 

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -119,20 +119,25 @@ fn decode_query_parameter_pairs(qs: &str) -> Result<Vec<(String, String)>, ApiEr
             )));
         }
 
-        let key = parts[0].to_string();
-        let value = match percent_encoding::percent_decode(parts[1].as_bytes()).decode_utf8() {
-            Ok(value) => value.to_string(),
-            Err(e) => {
-                return Err(ApiError::BadRequest(format!(
-                    "Invalid query parameter: '{chunk}', invalid value: {e}",
-                )));
-            }
-        };
+        let key = decode_query_component(parts[0], chunk, "key")?;
+        let value = decode_query_component(parts[1], chunk, "value")?;
 
         pairs.push((key, value));
     }
 
     Ok(pairs)
+}
+
+fn decode_query_component(raw: &str, chunk: &str, component: &str) -> Result<String, ApiError> {
+    let form_encoded = raw.replace('+', " ");
+    percent_encoding::percent_decode(form_encoded.as_bytes())
+        .decode_utf8()
+        .map(|value| value.to_string())
+        .map_err(|e| {
+            ApiError::BadRequest(format!(
+                "Invalid query parameter: '{chunk}', invalid {component}: {e}",
+            ))
+        })
 }
 
 fn parse_single_filter(key: &str, value: &str) -> Result<ParsedQueryParam, ApiError> {
@@ -2679,6 +2684,19 @@ mod test {
             SearchOperator::Equals { is_negated: false }
         );
         assert_eq!(query_options.filters[0].value, "alpha");
+    }
+
+    #[test]
+    fn test_parse_query_parameter_decodes_keys_values_and_plus() {
+        let query_options = parse_query_parameter("name%5F%5Fcontains=alpha+beta").unwrap();
+
+        assert_eq!(query_options.filters.len(), 1);
+        assert_eq!(query_options.filters[0].field, FilterField::Name);
+        assert_eq!(
+            query_options.filters[0].operator,
+            SearchOperator::Contains { is_negated: false }
+        );
+        assert_eq!(query_options.filters[0].value, "alpha beta");
     }
 
     // Covers docs/querying.md "Negation" (`not_` works with `between`).

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -129,15 +129,26 @@ fn decode_query_parameter_pairs(qs: &str) -> Result<Vec<(String, String)>, ApiEr
 }
 
 fn decode_query_component(raw: &str, chunk: &str, component: &str) -> Result<String, ApiError> {
-    let form_encoded = raw.replace('+', " ");
-    percent_encoding::percent_decode(form_encoded.as_bytes())
-        .decode_utf8()
-        .map(|value| value.to_string())
-        .map_err(|e| {
-            ApiError::BadRequest(format!(
-                "Invalid query parameter: '{chunk}', invalid {component}: {e}",
-            ))
-        })
+    // `percent_decode().decode_utf8()` returns a borrowing Cow when there are no
+    // `%` escapes, so the common case allocates at most once via `into_owned()`.
+    // Only the `+` -> space pre-pass needs its own allocation, so skip it when
+    // there is no `+` to avoid the unconditional `replace` allocation.
+    let decoded = if raw.contains('+') {
+        let form_encoded = raw.replace('+', " ");
+        percent_encoding::percent_decode(form_encoded.as_bytes())
+            .decode_utf8()
+            .map(|value| value.into_owned())
+    } else {
+        percent_encoding::percent_decode(raw.as_bytes())
+            .decode_utf8()
+            .map(|value| value.into_owned())
+    };
+
+    decoded.map_err(|e| {
+        ApiError::BadRequest(format!(
+            "Invalid query parameter: '{chunk}', invalid {component}: {e}",
+        ))
+    })
 }
 
 fn parse_single_filter(key: &str, value: &str) -> Result<ParsedQueryParam, ApiError> {

--- a/src/models/traits/object.rs
+++ b/src/models/traits/object.rs
@@ -117,6 +117,7 @@ impl UpdateAdapter for UpdateHubuumObject {
         pool: &DbPool,
         object_id: i32,
     ) -> Result<Self::Output, ApiError> {
+        (self, object_id).validate_object_record(pool).await?;
         self.update_object_record(pool, object_id).await
     }
 }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -18,10 +18,44 @@ use tracing::{error, warn};
 pub struct User {
     pub id: i32,
     pub username: String,
+    #[serde(skip_serializing)]
     pub password: String,
     pub email: Option<String>,
     pub created_at: chrono::NaiveDateTime,
     pub updated_at: chrono::NaiveDateTime,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, ToSchema)]
+pub struct UserResponse {
+    pub id: i32,
+    pub username: String,
+    pub email: Option<String>,
+    pub created_at: chrono::NaiveDateTime,
+    pub updated_at: chrono::NaiveDateTime,
+}
+
+impl From<User> for UserResponse {
+    fn from(user: User) -> Self {
+        Self {
+            id: user.id,
+            username: user.username,
+            email: user.email,
+            created_at: user.created_at,
+            updated_at: user.updated_at,
+        }
+    }
+}
+
+impl From<&User> for UserResponse {
+    fn from(user: &User) -> Self {
+        Self {
+            id: user.id,
+            username: user.username.clone(),
+            email: user.email.clone(),
+            created_at: user.created_at,
+            updated_at: user.updated_at,
+        }
+    }
 }
 
 impl User {
@@ -74,8 +108,7 @@ impl User {
 
 /// Struct to update a user.
 ///
-/// The password, if present, is expected to be hashed
-/// before being passed to the database.
+/// The password, if present, is expected to be plaintext.
 #[derive(AsChangeset, Deserialize, Serialize, Clone, ToSchema)]
 #[schema(example = update_user_example)]
 #[diesel(table_name = users)]
@@ -112,8 +145,7 @@ impl UpdateUser {
 
 /// Struct to create a new user.
 ///
-/// The password is expected to be hashed
-/// before being passed to the database.
+/// The password is expected to be plaintext.
 #[derive(Serialize, Deserialize, Insertable, Debug, ToSchema)]
 #[schema(example = new_user_example)]
 #[diesel(table_name = users)]
@@ -142,13 +174,11 @@ impl NewUser {
     }
 
     pub fn hash_password(mut self) -> Result<Self, ApiError> {
-        if !self.password.starts_with("$argon2") {
-            match crate::utilities::auth::hash_password(&self.password) {
-                Ok(hashed_password) => {
-                    self.password = hashed_password;
-                }
-                Err(e) => return Err(ApiError::HashError(format!("Failed to hash password: {e}"))),
+        match crate::utilities::auth::hash_password(&self.password) {
+            Ok(hashed_password) => {
+                self.password = hashed_password;
             }
+            Err(e) => return Err(ApiError::HashError(format!("Failed to hash password: {e}"))),
         }
         Ok(self)
     }

--- a/src/tests/acl.rs
+++ b/src/tests/acl.rs
@@ -35,6 +35,7 @@ async fn test_endpoint_access() {
 
     let normal_user = crate::tests::create_test_user(&pool).await;
     let admin_user = crate::tests::create_test_admin(&pool).await;
+    let normal_user_endpoint = &format!("/api/v1/iam/users/{}", normal_user.id);
     let admin_user_endpoint = &format!("/api/v1/iam/users/{}", admin_user.id);
 
     let endpoints = vec![
@@ -56,8 +57,9 @@ async fn test_endpoint_access() {
         ),
         ("/api/v0/meta/db", Method::GET, AccessLevel::Admin, None),
         ("/api/v0/meta/counts", Method::GET, AccessLevel::Admin, None),
-        ("/api/v1/iam/users", Method::GET, AccessLevel::User, None),
-        (admin_user_endpoint, Method::GET, AccessLevel::User, None),
+        ("/api/v1/iam/users", Method::GET, AccessLevel::Admin, None),
+        (normal_user_endpoint, Method::GET, AccessLevel::User, None),
+        (admin_user_endpoint, Method::GET, AccessLevel::Admin, None),
         ("/api/v1/namespaces", Method::GET, AccessLevel::User, None),
     ];
 

--- a/src/tests/api/v1/classes.rs
+++ b/src/tests/api/v1/classes.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 pub mod tests {
-    use crate::models::{HubuumClassExpanded, NamespaceID, NewHubuumClass};
-    use crate::traits::CanSave;
+    use crate::models::{
+        HubuumClassExpanded, NamespaceID, NewHubuumClass, Permissions, PermissionsList,
+    };
+    use crate::traits::{CanSave, PermissionController};
     use actix_web::{http::StatusCode, test};
 
     use rstest::rstest;
@@ -10,7 +12,9 @@ pub mod tests {
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
     use crate::tests::asserts::{assert_response_status, header_value};
     use crate::tests::constants::{SchemaType, get_schema};
-    use crate::tests::{ClassFixture, TestContext, create_class_fixture, test_context};
+    use crate::tests::{
+        ClassFixture, TestContext, create_class_fixture, create_test_group, test_context,
+    };
     use crate::{assert_contains_all, assert_contains_same_ids};
 
     const CLASSES_ENDPOINT: &str = "/api/v1/classes";
@@ -430,6 +434,80 @@ pub mod tests {
             created_class.json_schema
         );
         assert!(!updated_class_from_patch.validate_schema);
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_api_classes_patch_requires_target_namespace_permission(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        use crate::models::UpdateHubuumClass;
+
+        let context = test_context;
+        let source = context
+            .scope
+            .namespace_fixture("api_patch_class_move_source")
+            .await;
+        let target = context
+            .scope
+            .namespace_fixture("api_patch_class_move_target")
+            .await;
+        let group = create_test_group(&context.pool).await;
+        group
+            .add_member(&context.pool, &context.normal_user)
+            .await
+            .unwrap();
+        source
+            .namespace
+            .grant(
+                &context.pool,
+                group.id,
+                PermissionsList::new([Permissions::UpdateClass]),
+            )
+            .await
+            .unwrap();
+
+        let created_class = NewHubuumClass {
+            name: "api_patch_class_move".to_string(),
+            description: "api_patch_class_move".to_string(),
+            namespace_id: source.namespace.id,
+            json_schema: None,
+            validate_schema: Some(false),
+        }
+        .save(&context.pool)
+        .await
+        .unwrap();
+
+        let update_class = UpdateHubuumClass {
+            name: None,
+            namespace_id: Some(target.namespace.id),
+            json_schema: None,
+            validate_schema: None,
+            description: None,
+        };
+        let url = format!("{}/{}", CLASSES_ENDPOINT, created_class.id);
+
+        let resp = patch_request(&context.pool, &context.normal_token, &url, &update_class).await;
+        let _ = assert_response_status(resp, StatusCode::FORBIDDEN).await;
+
+        target
+            .namespace
+            .grant(
+                &context.pool,
+                group.id,
+                PermissionsList::new([Permissions::CreateClass]),
+            )
+            .await
+            .unwrap();
+
+        let resp = patch_request(&context.pool, &context.normal_token, &url, &update_class).await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let updated_class: HubuumClassExpanded = test::read_body_json(resp).await;
+        assert_eq!(updated_class.namespace.id, target.namespace.id);
+
+        source.cleanup().await.unwrap();
+        target.cleanup().await.unwrap();
+        group.delete(&context.pool).await.unwrap();
     }
 
     #[rstest]

--- a/src/tests/api/v1/groups.rs
+++ b/src/tests/api/v1/groups.rs
@@ -4,7 +4,7 @@ mod tests {
     use rstest::rstest;
 
     use crate::models::group::{Group, NewGroup, UpdateGroup};
-    use crate::models::user::{NewUser, User};
+    use crate::models::user::{NewUser, User, UserResponse};
     use crate::pagination::NEXT_CURSOR_HEADER;
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
     use crate::tests::asserts::{assert_response_status, header_value};
@@ -223,7 +223,7 @@ mod tests {
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
 
-        let members: Vec<User> = test::read_body_json(resp).await;
+        let members: Vec<UserResponse> = test::read_body_json(resp).await;
         assert_eq!(members.len(), 1);
         assert_eq!(members[0].id, user.id);
 
@@ -243,7 +243,7 @@ mod tests {
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
 
-        let members: Vec<User> = test::read_body_json(resp).await;
+        let members: Vec<UserResponse> = test::read_body_json(resp).await;
         assert_eq!(members.len(), 0);
 
         user.delete(&context.pool).await.unwrap();
@@ -292,7 +292,7 @@ mod tests {
         )
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
-        let first_group_members: Vec<User> = test::read_body_json(resp).await;
+        let first_group_members: Vec<UserResponse> = test::read_body_json(resp).await;
         assert_eq!(first_group_members.len(), 0);
 
         let resp = get_request(
@@ -302,7 +302,7 @@ mod tests {
         )
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
-        let second_group_members: Vec<User> = test::read_body_json(resp).await;
+        let second_group_members: Vec<UserResponse> = test::read_body_json(resp).await;
         assert_eq!(second_group_members.len(), 1);
         assert_eq!(second_group_members[0].id, user.id);
 
@@ -466,7 +466,7 @@ mod tests {
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
         let next_cursor = header_value(&resp, NEXT_CURSOR_HEADER);
-        let members: Vec<User> = test::read_body_json(resp).await;
+        let members: Vec<UserResponse> = test::read_body_json(resp).await;
 
         assert_eq!(members.len(), 1);
         assert!(next_cursor.is_some());
@@ -483,7 +483,7 @@ mod tests {
         )
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
-        let members: Vec<User> = test::read_body_json(resp).await;
+        let members: Vec<UserResponse> = test::read_body_json(resp).await;
         assert_eq!(members.len(), 1);
     }
 
@@ -525,7 +525,7 @@ mod tests {
         )
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
-        let members: Vec<User> = test::read_body_json(resp).await;
+        let members: Vec<UserResponse> = test::read_body_json(resp).await;
 
         assert_eq!(members.len(), 1);
         assert_eq!(members[0].id, matching_user.id);

--- a/src/tests/api/v1/objects.rs
+++ b/src/tests/api/v1/objects.rs
@@ -419,6 +419,190 @@ mod tests {
     }
 
     #[rstest]
+    #[actix_web::test]
+    async fn create_object_in_class_rejects_body_class_mismatch(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "create_object_body_class_mismatch").await;
+        let path_class = &classes[0];
+        let body_class = &classes[1];
+
+        let object = NewHubuumObject {
+            namespace_id: body_class.namespace_id,
+            hubuum_class_id: body_class.id,
+            data: serde_json::json!({"test": "data"}),
+            name: "test create object mismatch".to_string(),
+            description: "test create object mismatch".to_string(),
+        };
+
+        let resp = post_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("{}/{}/", OBJECT_ENDPOINT, path_class.id),
+            &object,
+        )
+        .await;
+        let _ = assert_response_status(resp, StatusCode::BAD_REQUEST).await;
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn object_in_class_routes_require_matching_path_class(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "object_path_class_mismatch").await;
+        let owning_class = &classes[0];
+        let other_class = &classes[1];
+
+        let object = NewHubuumObject {
+            namespace_id: owning_class.namespace_id,
+            hubuum_class_id: owning_class.id,
+            data: serde_json::json!({"test": "data"}),
+            name: "test object path class mismatch".to_string(),
+            description: "test object path class mismatch".to_string(),
+        }
+        .save(&context.pool)
+        .await
+        .unwrap();
+
+        let wrong_path = object_in_class_endpoint(other_class.id, object.id);
+        let resp = get_request(&context.pool, &context.admin_token, &wrong_path).await;
+        let _ = assert_response_status(resp, StatusCode::NOT_FOUND).await;
+
+        let updated_object = UpdateHubuumObject {
+            namespace_id: None,
+            hubuum_class_id: None,
+            data: None,
+            name: Some("should not update".to_string()),
+            description: None,
+        };
+        let resp = patch_request(
+            &context.pool,
+            &context.admin_token,
+            &wrong_path,
+            &updated_object,
+        )
+        .await;
+        let _ = assert_response_status(resp, StatusCode::NOT_FOUND).await;
+
+        let resp = delete_request(&context.pool, &context.admin_token, &wrong_path).await;
+        let _ = assert_response_status(resp, StatusCode::NOT_FOUND).await;
+
+        let resp = get_request(
+            &context.pool,
+            &context.admin_token,
+            &object_in_class_endpoint(owning_class.id, object.id),
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let object_after_requests: HubuumObject = test::read_body_json(resp).await;
+        assert_eq!(object_after_requests.name, object.name);
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn patch_object_in_class_rejects_class_or_namespace_move(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "patch_object_move_rejected").await;
+        let owning_class = &classes[0];
+        let other_class = &classes[1];
+
+        let object = NewHubuumObject {
+            namespace_id: owning_class.namespace_id,
+            hubuum_class_id: owning_class.id,
+            data: serde_json::json!({"test": "data"}),
+            name: "test object move rejected".to_string(),
+            description: "test object move rejected".to_string(),
+        }
+        .save(&context.pool)
+        .await
+        .unwrap();
+
+        let updated_object = UpdateHubuumObject {
+            namespace_id: None,
+            hubuum_class_id: Some(other_class.id),
+            data: None,
+            name: None,
+            description: None,
+        };
+        let resp = patch_request(
+            &context.pool,
+            &context.admin_token,
+            &object_in_class_endpoint(owning_class.id, object.id),
+            &updated_object,
+        )
+        .await;
+        let _ = assert_response_status(resp, StatusCode::BAD_REQUEST).await;
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn patch_object_in_class_validates_schema(#[future(awt)] test_context: TestContext) {
+        let context = test_context;
+        let namespace = context
+            .namespace_fixture("patch_object_schema_validation")
+            .await;
+        let class = NewHubuumClass {
+            namespace_id: namespace.namespace.id,
+            name: "patch object schema validation".to_string(),
+            description: "patch object schema validation".to_string(),
+            json_schema: Some(get_schema(SchemaType::Geo).clone()),
+            validate_schema: Some(true),
+        }
+        .save(&context.pool)
+        .await
+        .unwrap();
+        let object = NewHubuumObject {
+            namespace_id: namespace.namespace.id,
+            hubuum_class_id: class.id,
+            data: serde_json::json!({"latitude": 59.9, "longitude": 10.7}),
+            name: "valid geo object".to_string(),
+            description: "valid geo object".to_string(),
+        }
+        .save(&context.pool)
+        .await
+        .unwrap();
+
+        let updated_object = UpdateHubuumObject {
+            namespace_id: None,
+            hubuum_class_id: None,
+            data: Some(serde_json::json!({"latitude": "north", "longitude": 10.7})),
+            name: None,
+            description: None,
+        };
+        let resp = patch_request(
+            &context.pool,
+            &context.admin_token,
+            &object_in_class_endpoint(class.id, object.id),
+            &updated_object,
+        )
+        .await;
+        let _ = assert_response_status(resp, StatusCode::NOT_ACCEPTABLE).await;
+
+        let resp = get_request(
+            &context.pool,
+            &context.admin_token,
+            &object_in_class_endpoint(class.id, object.id),
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let object_after_patch: HubuumObject = test::read_body_json(resp).await;
+        assert_eq!(object_after_patch.data, object.data);
+
+        namespace.cleanup().await.unwrap();
+    }
+
+    #[rstest]
     #[actix_rt::test]
     async fn get_objects_in_class(#[future(awt)] test_context: TestContext) {
         let context = test_context;

--- a/src/tests/api/v1/relations.rs
+++ b/src/tests/api/v1/relations.rs
@@ -480,6 +480,35 @@ mod tests {
 
     #[rstest]
     #[actix_web::test]
+    async fn test_related_class_graph_enforces_limit(#[future(awt)] test_context: TestContext) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "related_class_graph_limit").await;
+        let _ = create_relation(&context.pool, &classes[0], &classes[1]).await;
+        let _ = create_relation(&context.pool, &classes[1], &classes[2]).await;
+
+        let resp = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("{}?limit=1", related_class_graph_endpoint(classes[0].id)),
+        )
+        .await;
+        let _ = assert_response_status(resp, StatusCode::BAD_REQUEST).await;
+
+        let resp = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("{}?limit=2", related_class_graph_endpoint(classes[0].id)),
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let graph: RelatedClassGraph = test::read_body_json(resp).await;
+        assert_eq!(graph.classes.len(), 3);
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
     async fn test_related_classes_cursor_pagination_with_path_sort(
         #[future(awt)] test_context: TestContext,
     ) {

--- a/src/tests/api/v1/users.rs
+++ b/src/tests/api/v1/users.rs
@@ -2,7 +2,7 @@
 mod tests {
     use crate::db::traits::ActiveTokens;
     use crate::models::group::NewGroup;
-    use crate::models::user::{NewUser, UpdateUser, User};
+    use crate::models::user::{LoginUser, NewUser, UpdateUser, User, UserID, UserResponse};
     use crate::models::{Group, Token, UserTokenMetadata};
     use crate::pagination::NEXT_CURSOR_HEADER;
     use actix_web::{http::StatusCode, test};
@@ -15,6 +15,14 @@ mod tests {
     use crate::tests::{TestContext, create_test_admin, create_test_user, test_context};
 
     const USERS_ENDPOINT: &str = "/api/v1/iam/users";
+
+    fn assert_user_response_matches(user: &User, response: &UserResponse) {
+        assert_eq!(response.id, user.id);
+        assert_eq!(response.username, user.username);
+        assert_eq!(response.email, user.email);
+        assert_eq!(response.created_at, user.created_at);
+        assert_eq!(response.updated_at, user.updated_at);
+    }
 
     async fn check_show_user(
         context: &TestContext,
@@ -36,9 +44,12 @@ mod tests {
         .await;
         let resp = assert_response_status(resp, expected_status).await;
 
-        if resp.status() == expected_status {
-            let returned_user: User = test::read_body_json(resp).await;
-            assert_eq!(target, &returned_user);
+        if expected_status == StatusCode::OK {
+            let body = test::read_body(resp).await;
+            let returned_value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert!(returned_value.get("password").is_none());
+            let returned_user: UserResponse = serde_json::from_value(returned_value).unwrap();
+            assert_user_response_matches(target, &returned_user);
         }
     }
 
@@ -72,7 +83,13 @@ mod tests {
 
         // The format here is (target, requester, expected_status).
         check_show_user(&context, &test_user, &test_user, StatusCode::OK).await;
-        check_show_user(&context, &test_admin_user, &test_user, StatusCode::OK).await;
+        check_show_user(
+            &context,
+            &test_admin_user,
+            &test_user,
+            StatusCode::FORBIDDEN,
+        )
+        .await;
         check_show_user(&context, &test_user, &test_admin_user, StatusCode::OK).await;
 
         // Tokens are admin_or_self. Note that the format is (target, requester, expected_status).
@@ -119,11 +136,14 @@ mod tests {
 
         let headers = resp.headers().clone();
         let created_user_url = headers.get("Location").unwrap().to_str().unwrap();
-        let created_user_from_create: User = test::read_body_json(resp).await;
+        let body = test::read_body(resp).await;
+        let created_value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(created_value.get("password").is_none());
+        let created_user_from_create: UserResponse = serde_json::from_value(created_value).unwrap();
 
         let resp = get_request(&context.pool, &context.admin_token, created_user_url).await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
-        let created_user_from_get: User = test::read_body_json(resp).await;
+        let created_user_from_get: UserResponse = test::read_body_json(resp).await;
 
         assert_eq!(created_user_from_create, created_user_from_get);
 
@@ -177,11 +197,31 @@ mod tests {
         )
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
-        let patched_user: User = test::read_body_json(resp).await;
+        let body = test::read_body(resp).await;
+        let patched_value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(patched_value.get("password").is_none());
+        let patched_user: UserResponse = serde_json::from_value(patched_value).unwrap();
 
         assert_eq!(patched_user.username, test_user.username);
-        assert_ne!(patched_user.password, test_user.password);
         assert_eq!(patched_user.email, test_user.email);
+
+        let stored_user = UserID(test_user.id).user(&context.pool).await.unwrap();
+        assert_ne!(stored_user.password, test_user.password);
+        LoginUser {
+            username: test_user.username,
+            password: "newpassword".to_string(),
+        }
+        .login(&context.pool)
+        .await
+        .unwrap();
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_list_users_requires_admin(#[future(awt)] test_context: TestContext) {
+        let context = test_context;
+        let resp = get_request(&context.pool, &context.normal_token, USERS_ENDPOINT).await;
+        let _ = assert_response_status(resp, StatusCode::FORBIDDEN).await;
     }
 
     #[rstest]
@@ -214,7 +254,7 @@ mod tests {
         let url = format!("{USERS_ENDPOINT}?username__contains={prefix}&sort={sort_order}");
         let resp = get_request(&context.pool, &context.admin_token, &url).await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
-        let users: Vec<User> = test::read_body_json(resp).await;
+        let users: Vec<UserResponse> = test::read_body_json(resp).await;
 
         assert_eq!(users.len(), created_users.len());
         assert_eq!(users[0].id, created_users[expected_order[0]].id);
@@ -251,7 +291,7 @@ mod tests {
         let url = format!("{USERS_ENDPOINT}?username__contains={prefix}&sort=id&limit={limit}");
         let resp = get_request(&context.pool, &context.admin_token, &url).await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
-        let users: Vec<User> = test::read_body_json(resp).await;
+        let users: Vec<UserResponse> = test::read_body_json(resp).await;
 
         assert_eq!(users.len(), limit);
 
@@ -288,7 +328,7 @@ mod tests {
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
         let next_cursor = header_value(&resp, NEXT_CURSOR_HEADER);
-        let users: Vec<User> = test::read_body_json(resp).await;
+        let users: Vec<UserResponse> = test::read_body_json(resp).await;
 
         assert_eq!(users.len(), 2);
         assert!(next_cursor.is_some());
@@ -304,7 +344,7 @@ mod tests {
         )
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
-        let users: Vec<User> = test::read_body_json(resp).await;
+        let users: Vec<UserResponse> = test::read_body_json(resp).await;
         assert!(!users.is_empty());
 
         for user in created_users {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -536,9 +536,14 @@ pub async fn ensure_normal_user(pool: &DbPool) -> User {
 
 pub async fn ensure_admin_group(pool: &DbPool) -> Group {
     use crate::schema::groups::dsl::*;
+    let admin_groupname = get_config()
+        .map(|config| config.admin_groupname.clone())
+        .unwrap_or_else(|_| "admin".to_string());
 
     let result = with_connection(pool, |conn| {
-        groups.filter(groupname.eq("admin")).first::<Group>(conn)
+        groups
+            .filter(groupname.eq(&admin_groupname))
+            .first::<Group>(conn)
     });
 
     if let Ok(group) = result {
@@ -546,7 +551,7 @@ pub async fn ensure_admin_group(pool: &DbPool) -> Group {
     }
 
     let result = NewGroup {
-        groupname: "admin".to_string(),
+        groupname: admin_groupname.clone(),
         description: Some("Admin group".to_string()),
     }
     .save(pool)
@@ -556,7 +561,9 @@ pub async fn ensure_admin_group(pool: &DbPool) -> Group {
         match e {
             ApiError::Conflict(_) => {
                 return with_connection(pool, |conn| {
-                    groups.filter(groupname.eq("admin")).first::<Group>(conn)
+                    groups
+                        .filter(groupname.eq(&admin_groupname))
+                        .first::<Group>(conn)
                 })
                 .expect("Failed to fetch user after conflict");
             }

--- a/src/utilities/extensions.rs
+++ b/src/utilities/extensions.rs
@@ -6,8 +6,8 @@ use tracing::error;
 pub trait CustomStringExtensions {
     /// ## Check if the value is a valid json key for hubuum
     ///
-    /// We support only lowercase alphanumeric characters and underscores, as
-    /// well as the comma character for nested keys. No spaces are allowed.
+    /// We support only ASCII alphanumeric characters, underscores, `$`, and
+    /// comma separators for nested keys. No spaces are allowed.
     ///
     /// ### Returns
     ///
@@ -78,7 +78,7 @@ impl<T: AsRef<str>> CustomStringExtensions for T {
     fn is_valid_jsonb_search_key(&self) -> bool {
         self.as_ref()
             .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == ',' || c == '$')
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == ',' || c == '$')
     }
 
     fn as_integer(&self) -> Result<Vec<i32>, ApiError> {

--- a/src/utilities/init.rs
+++ b/src/utilities/init.rs
@@ -43,9 +43,16 @@ pub async fn init(pool: DbPool) -> InitResult {
     }
 
     debug!(message = "No users or groups found. Creating default admin user and group.");
+    let admin_groupname = crate::config::get_config()
+        .map(|config| config.admin_groupname.clone())
+        .map_err(|e| {
+            let err_msg = format!("Failed to load config during initialization: {}", e);
+            error!(message = &err_msg);
+            err_msg
+        })?;
 
     let adm_group = match (NewGroup {
-        groupname: "admin".to_string(),
+        groupname: admin_groupname,
         description: Some("Default admin group.".to_string()),
     }
     .save(&pool))


### PR DESCRIPTION
## Summary
- remove password exposure from user-facing API responses and tighten user read/list permissions
- enforce class/object namespace and scoped-route invariants, including target namespace permissions
- bound related graph endpoints and improve query parsing, JSON key consistency, admin bootstrap config, benchmark/test target hygiene, and middleware ordering

## Database Pooling Note
- Removing the manual sleep loop does not make database acquisition instant or remove retry/wait behavior.
- All database helpers still acquire connections through r2d2 Pool::get(), which waits up to the pool connection_timeout for an idle or newly established connection.
- r2d2 also retries failed connection creation in the background with exponential backoff while callers wait.
- This code currently only configures max_size, so the acquisition timeout remains r2d2's default of 30 seconds.
- If the pool remains exhausted or the database stays unavailable past that timeout, the error maps to ApiError::DbConnectionError.

## Verification
- cargo check --all-targets
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo run --quiet --bin hubuum-openapi > docs/openapi.json
- source .env && ./run_tests.sh