### PR TITLE
Harden report subsystem robustness (#50)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,6 +1355,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1448,6 +1453,7 @@ dependencies = [
  "iai-callgrind",
  "ipnet",
  "jsonschema",
+ "lru",
  "minijinja",
  "openssl",
  "percent-encoding",
@@ -1905,6 +1911,15 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "matchers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ uuid = { version = "1", features = ["v4"] }
 percent-encoding = "2"
 rustls = { version = "0.23", features = ["aws-lc-rs", "ring"], optional = true }
 openssl = { version = "0.10.80", optional = true }
+lru = "0.18.0"
 
 [dev-dependencies]
 criterion = "0.8.2"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5831,6 +5831,16 @@
                 }
               }
             }
+          },
+          "410": {
+            "description": "Report output expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -8963,7 +8973,8 @@
         "type": "object",
         "required": [
           "output_url",
-          "output_available"
+          "output_available",
+          "output_expired"
         ],
         "properties": {
           "output_available": {
@@ -8974,6 +8985,10 @@
               "string",
               "null"
             ]
+          },
+          "output_expired": {
+            "type": "boolean",
+            "description": "True when output was produced but has since passed its retention window. Distinguishes an\nexpired report from one that was never generated (both have `output_available = false`)."
           },
           "output_expires_at": {
             "type": [

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -26,9 +26,9 @@ use crate::models::{
     NewReportTaskOutputRecord, NewTaskEventRecord, Permissions, RELATED_INCLUDE_DEFAULT_LIMIT,
     RELATED_INCLUDE_DEFAULT_MAX_DEPTH, ReportContentType, ReportIncludeRelatedDirection,
     ReportIncludeRelatedQuery, ReportIncludeRelatedSort, ReportJsonResponse, ReportMeta,
-    ReportMissingDataPolicy, ReportRequest, ReportScope, ReportScopeKind, ReportTaskOutputRecord,
-    ReportTemplate, ReportTemplateID, ReportWarning, TaskID, TaskKind, TaskRecord, TaskResponse,
-    User,
+    ReportMissingDataPolicy, ReportOutputLookup, ReportRequest, ReportScope, ReportScopeKind,
+    ReportTaskOutputRecord, ReportTemplate, ReportTemplateID, ReportWarning, TaskID, TaskKind,
+    TaskRecord, TaskResponse, User,
 };
 use crate::pagination::page_limits_or_defaults;
 use crate::tasks::{
@@ -307,7 +307,8 @@ pub async fn get_report(
             )
         ),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
-        (status = 404, description = "Report output not found", body = ApiErrorResponse)
+        (status = 404, description = "Report output not found", body = ApiErrorResponse),
+        (status = 410, description = "Report output expired", body = ApiErrorResponse)
     )
 )]
 #[get("/{task_id}/output")]
@@ -321,11 +322,15 @@ pub async fn get_report_output(
     task_id
         .load_authorized_report(&pool, &requestor.user)
         .await?;
-    let output = task_id
-        .find_report_output(&pool)
-        .await?
-        .ok_or_else(|| ApiError::NotFound("Report output not found".to_string()))?;
-    render_report_task_output(output)
+    match task_id.find_report_output(&pool).await? {
+        ReportOutputLookup::Available(output) => render_report_task_output(output),
+        ReportOutputLookup::Expired { expires_at } => Err(ApiError::Gone(format!(
+            "Report output expired at {expires_at} UTC"
+        ))),
+        ReportOutputLookup::Missing => {
+            Err(ApiError::NotFound("Report output not found".to_string()))
+        }
+    }
 }
 
 async fn prepare_report_runtime(

--- a/src/api/v1/handlers/tasks.rs
+++ b/src/api/v1/handlers/tasks.rs
@@ -129,13 +129,19 @@ pub async fn get_tasks(
         .into_iter()
         .map(|output| (output.task_id, output))
         .collect::<std::collections::HashMap<_, _>>();
+    let now = chrono::Utc::now().naive_utc();
     let tasks = tasks
         .into_iter()
         .map(|task| {
-            // The batch summary query already excludes expired rows, so a missing entry here is
-            // simply "no current output" rather than an expired one.
+            // Classify each summary the same way the single-task lookups do, so `output_expired`
+            // is reported consistently here as on GET /tasks/{id} and GET /reports/{id}.
             let report_output = match report_outputs.get(&task.id) {
-                Some(summary) => ReportOutputLookup::Available(summary),
+                Some(summary) if summary.output_expires_at > now => {
+                    ReportOutputLookup::Available(summary)
+                }
+                Some(summary) => ReportOutputLookup::Expired {
+                    expires_at: summary.output_expires_at,
+                },
                 None => ReportOutputLookup::Missing,
             };
             task.to_response_with_report_output(report_output)

--- a/src/api/v1/handlers/tasks.rs
+++ b/src/api/v1/handlers/tasks.rs
@@ -8,7 +8,9 @@ use crate::db::traits::task::{
 use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::search::parse_query_parameter_with_passthrough;
-use crate::models::{TaskEventResponse, TaskID, TaskKind, TaskResponse, TaskStatus};
+use crate::models::{
+    ReportOutputLookup, TaskEventResponse, TaskID, TaskKind, TaskResponse, TaskStatus,
+};
 use crate::pagination::prepare_db_pagination;
 use crate::tasks::ensure_task_worker_running;
 use crate::traits::GroupMemberships;
@@ -129,7 +131,15 @@ pub async fn get_tasks(
         .collect::<std::collections::HashMap<_, _>>();
     let tasks = tasks
         .into_iter()
-        .map(|task| task.to_response_with_report_output(report_outputs.get(&task.id)))
+        .map(|task| {
+            // The batch summary query already excludes expired rows, so a missing entry here is
+            // simply "no current output" rather than an expired one.
+            let report_output = match report_outputs.get(&task.id) {
+                Some(summary) => ReportOutputLookup::Available(summary),
+                None => ReportOutputLookup::Missing,
+            };
+            task.to_response_with_report_output(report_output)
+        })
         .collect::<Result<Vec<_>, _>>()?;
 
     paginated_json_response(tasks, total_count, StatusCode::OK, &params)
@@ -164,7 +174,7 @@ pub async fn get_task(
     let report_output = if task.kind == TaskKind::Report.as_str() {
         task.find_report_output_summary(&pool).await?
     } else {
-        None
+        ReportOutputLookup::Missing
     };
     Ok(json_response(
         task.to_response_with_report_output(report_output.as_ref())?,

--- a/src/db/traits/relations.rs
+++ b/src/db/traits/relations.rs
@@ -12,6 +12,7 @@ use crate::models::{
     HubuumObjectTransitiveLink, NewHubuumClassRelation, NewHubuumObjectRelation, User,
     user_can_on_any,
 };
+use crate::utilities::aliases::normalize_template_alias;
 use crate::{
     bind_transitive_filter_params, date_search, numeric_search, string_search, trace_query,
 };
@@ -733,49 +734,6 @@ impl SaveClassRelationRecord for NewHubuumClassRelation {
 
 fn normalize_template_alias_option(alias: &Option<String>) -> Result<Option<String>, ApiError> {
     alias.as_deref().map(normalize_template_alias).transpose()
-}
-
-fn normalize_template_alias(alias: &str) -> Result<String, ApiError> {
-    let trimmed = alias.trim();
-    if trimmed.is_empty() {
-        return Err(ApiError::BadRequest(
-            "template aliases cannot be empty".to_string(),
-        ));
-    }
-
-    let mut normalized = String::new();
-    let mut previous_was_separator = true;
-
-    for character in trimmed.chars() {
-        if character.is_ascii_alphanumeric() {
-            if character.is_ascii_uppercase()
-                && !previous_was_separator
-                && !normalized.ends_with('_')
-            {
-                normalized.push('_');
-            }
-            normalized.push(character.to_ascii_lowercase());
-            previous_was_separator = false;
-        } else if matches!(character, ' ' | '-' | '_') {
-            if !normalized.is_empty() && !normalized.ends_with('_') {
-                normalized.push('_');
-            }
-            previous_was_separator = true;
-        } else {
-            return Err(ApiError::BadRequest(format!(
-                "template aliases may only contain letters, numbers, spaces, hyphens, and underscores: '{alias}'"
-            )));
-        }
-    }
-
-    let normalized = normalized.trim_matches('_').to_string();
-    if normalized.is_empty() || normalized.starts_with(|ch: char| ch.is_ascii_digit()) {
-        return Err(ApiError::BadRequest(format!(
-            "template aliases must start with a letter and contain at least one alphanumeric character: '{alias}'"
-        )));
-    }
-
-    Ok(normalized)
 }
 
 pub trait LoadObjectRelationRecord {

--- a/src/db/traits/task.rs
+++ b/src/db/traits/task.rs
@@ -488,19 +488,18 @@ pub async fn list_report_task_output_summaries(
     pool: &DbPool,
     task_ids: &[i32],
 ) -> Result<Vec<ReportTaskOutputSummaryRecord>, ApiError> {
-    use crate::schema::report_task_outputs::dsl::{
-        output_expires_at, report_task_outputs, task_id,
-    };
+    use crate::schema::report_task_outputs::dsl::{report_task_outputs, task_id};
 
     if task_ids.is_empty() {
         return Ok(Vec::new());
     }
 
-    let now = Utc::now().naive_utc();
+    // Return expired-but-present rows too; the caller classifies each against `now` so the
+    // `output_expired` flag is consistent with the single-task lookups rather than silently
+    // collapsing expired rows into "no output" on the task-list endpoint.
     with_connection(pool, |conn| {
         report_task_outputs
             .filter(task_id.eq_any(task_ids))
-            .filter(output_expires_at.gt(now))
             .select(ReportTaskOutputSummaryRecord::as_select())
             .load(conn)
     })

--- a/src/db/traits/task.rs
+++ b/src/db/traits/task.rs
@@ -11,8 +11,9 @@ use crate::errors::ApiError;
 use crate::models::search::QueryOptions;
 use crate::models::{
     ImportTaskResultRecord, NewImportTaskResultRecord, NewReportTaskOutputRecord,
-    NewTaskEventRecord, NewTaskRecord, ReportTaskOutputRecord, ReportTaskOutputSummaryRecord,
-    TaskEventRecord, TaskID, TaskKind, TaskRecord, TaskResponse, TaskResultCounts, TaskStatus,
+    NewTaskEventRecord, NewTaskRecord, ReportOutputLookup, ReportTaskOutputRecord,
+    ReportTaskOutputSummaryRecord, TaskEventRecord, TaskID, TaskKind, TaskRecord, TaskResponse,
+    TaskResultCounts, TaskStatus,
 };
 use crate::pagination::{CursorValue, decode_cursor_values, page_limits_or_defaults};
 
@@ -186,39 +187,51 @@ pub trait TaskBackend: TaskIdentifier {
     async fn find_report_output(
         &self,
         pool: &DbPool,
-    ) -> Result<Option<ReportTaskOutputRecord>, ApiError> {
-        use crate::schema::report_task_outputs::dsl::{
-            output_expires_at, report_task_outputs, task_id,
-        };
+    ) -> Result<ReportOutputLookup<ReportTaskOutputRecord>, ApiError> {
+        use crate::schema::report_task_outputs::dsl::{report_task_outputs, task_id};
 
         let task_id_value = self.task_id();
         let now = Utc::now().naive_utc();
-        with_connection(pool, |conn| {
+        // Fetch without the expiry filter so an expired-but-present row is reported as `Expired`
+        // (410) rather than silently looking like a row that never existed (404).
+        let record = with_connection(pool, |conn| {
             report_task_outputs
                 .filter(task_id.eq(task_id_value))
-                .filter(output_expires_at.gt(now))
                 .first::<ReportTaskOutputRecord>(conn)
                 .optional()
+        })?;
+
+        Ok(match record {
+            Some(record) if record.output_expires_at > now => ReportOutputLookup::Available(record),
+            Some(record) => ReportOutputLookup::Expired {
+                expires_at: record.output_expires_at,
+            },
+            None => ReportOutputLookup::Missing,
         })
     }
 
     async fn find_report_output_summary(
         &self,
         pool: &DbPool,
-    ) -> Result<Option<ReportTaskOutputSummaryRecord>, ApiError> {
-        use crate::schema::report_task_outputs::dsl::{
-            output_expires_at, report_task_outputs, task_id,
-        };
+    ) -> Result<ReportOutputLookup<ReportTaskOutputSummaryRecord>, ApiError> {
+        use crate::schema::report_task_outputs::dsl::{report_task_outputs, task_id};
 
         let task_id_value = self.task_id();
         let now = Utc::now().naive_utc();
-        with_connection(pool, |conn| {
+        let record = with_connection(pool, |conn| {
             report_task_outputs
                 .filter(task_id.eq(task_id_value))
-                .filter(output_expires_at.gt(now))
                 .select(ReportTaskOutputSummaryRecord::as_select())
-                .first(conn)
+                .first::<ReportTaskOutputSummaryRecord>(conn)
                 .optional()
+        })?;
+
+        Ok(match record {
+            Some(record) if record.output_expires_at > now => ReportOutputLookup::Available(record),
+            Some(record) => ReportOutputLookup::Expired {
+                expires_at: record.output_expires_at,
+            },
+            None => ReportOutputLookup::Missing,
         })
     }
 
@@ -335,7 +348,9 @@ pub trait TaskBackend: TaskIdentifier {
         event: NewTaskEventRecord,
         output: NewReportTaskOutputRecord,
     ) -> Result<TaskRecord, ApiError> {
-        use crate::schema::report_task_outputs::dsl::report_task_outputs;
+        use crate::schema::report_task_outputs::dsl::{
+            report_task_outputs, task_id as report_output_task_id,
+        };
         use crate::schema::task_events::dsl::task_events;
         use crate::schema::tasks::dsl::{
             failed_items, finished_at, id, processed_items, request_payload, request_redacted_at,
@@ -344,8 +359,13 @@ pub trait TaskBackend: TaskIdentifier {
 
         let task_id_value = self.task_id();
         let record = with_transaction(pool, |conn| {
+            // Idempotent so a future requeue / manual re-claim that re-finalizes the same task
+            // cannot trip the `report_task_outputs.task_id` UNIQUE constraint and roll back the
+            // transaction, which would otherwise leave the task stuck mid-flight.
             diesel::insert_into(report_task_outputs)
                 .values(output)
+                .on_conflict(report_output_task_id)
+                .do_nothing()
                 .execute(conn)?;
 
             let event_record = diesel::insert_into(task_events)

--- a/src/db/traits/task_import.rs
+++ b/src/db/traits/task_import.rs
@@ -8,6 +8,7 @@ use crate::models::{
     NewHubuumObject, NewHubuumObjectRelation, NewPermission, Permission, Permissions,
     PermissionsList, UpdateHubuumClass, UpdateHubuumObject, UpdateNamespace, UpdatePermission,
 };
+use crate::utilities::aliases::normalize_template_alias;
 
 pub async fn lookup_namespace_by_name(
     pool: &DbPool,
@@ -382,48 +383,6 @@ pub fn create_class_relation_db(
 
 fn normalize_template_alias_option(alias: Option<&str>) -> Result<Option<String>, ApiError> {
     alias.map(normalize_template_alias).transpose()
-}
-
-fn normalize_template_alias(alias: &str) -> Result<String, ApiError> {
-    let trimmed = alias.trim();
-    if trimmed.is_empty() {
-        return Err(ApiError::BadRequest(
-            "template aliases cannot be empty".to_string(),
-        ));
-    }
-
-    let mut normalized = String::new();
-    let mut previous_was_separator = true;
-    for character in trimmed.chars() {
-        if character.is_ascii_alphanumeric() {
-            if character.is_ascii_uppercase()
-                && !previous_was_separator
-                && !normalized.ends_with('_')
-            {
-                normalized.push('_');
-            }
-            normalized.push(character.to_ascii_lowercase());
-            previous_was_separator = false;
-        } else if matches!(character, ' ' | '-' | '_') {
-            if !normalized.is_empty() && !normalized.ends_with('_') {
-                normalized.push('_');
-            }
-            previous_was_separator = true;
-        } else {
-            return Err(ApiError::BadRequest(format!(
-                "template aliases may only contain letters, numbers, spaces, hyphens, and underscores: '{alias}'"
-            )));
-        }
-    }
-
-    let normalized = normalized.trim_matches('_').to_string();
-    if normalized.is_empty() || normalized.starts_with(|ch: char| ch.is_ascii_digit()) {
-        return Err(ApiError::BadRequest(format!(
-            "template aliases must start with a letter and contain at least one alphanumeric character: '{alias}'"
-        )));
-    }
-
-    Ok(normalized)
 }
 
 pub fn create_object_relation_db(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -62,6 +62,7 @@ pub enum ApiError {
     Conflict(String),
     TooManyRequests(String),
     NotFound(String),
+    Gone(String),
     DbConnectionError(String),
     HashError(String),
     BadRequest(String),
@@ -96,6 +97,7 @@ impl fmt::Display for ApiError {
         match self {
             ApiError::HashError(message) => write!(f, "{message}"),
             ApiError::NotFound(message) => write!(f, "{message}"),
+            ApiError::Gone(message) => write!(f, "{message}"),
             ApiError::Conflict(message) => write!(f, "{message}"),
             ApiError::TooManyRequests(message) => write!(f, "{message}"),
             ApiError::Forbidden(message) => write!(f, "{message}"),
@@ -141,6 +143,9 @@ impl ResponseError for ApiError {
             ApiError::NotFound(message) => {
                 HttpResponse::NotFound().json(json!({ "error": "Not Found", "message": message }))
             }
+            ApiError::Gone(message) => {
+                HttpResponse::Gone().json(json!({ "error": "Gone", "message": message }))
+            }
             ApiError::BadRequest(message) => HttpResponse::BadRequest()
                 .json(json!({ "error": "Bad Request", "message": message })),
             ApiError::OperatorMismatch(message) => HttpResponse::BadRequest()
@@ -165,6 +170,7 @@ impl ResponseError for ApiError {
             ApiError::DbConnectionError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             ApiError::HashError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             ApiError::NotFound(_) => StatusCode::NOT_FOUND,
+            ApiError::Gone(_) => StatusCode::GONE,
             ApiError::BadRequest(_) => StatusCode::BAD_REQUEST,
             ApiError::OperatorMismatch(_) => StatusCode::BAD_REQUEST,
             ApiError::InvalidIntegerRange(_) => StatusCode::BAD_REQUEST,

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -267,6 +267,9 @@ pub struct ImportTaskDetails {
 pub struct ReportTaskDetails {
     pub output_url: String,
     pub output_available: bool,
+    /// True when output was produced but has since passed its retention window. Distinguishes an
+    /// expired report from one that was never generated (both have `output_available = false`).
+    pub output_expired: bool,
     pub output_expires_at: Option<NaiveDateTime>,
     pub template_name: Option<String>,
     pub output_content_type: Option<String>,
@@ -360,6 +363,31 @@ pub struct NewReportTaskOutputRecord {
     pub render_duration_ms: i32,
 }
 
+/// Outcome of looking up a report task's stored output.
+///
+/// Retention can lapse before the cleanup job purges the row, so a present-but-expired output is
+/// distinct from one that never existed. Callers map `Expired` to `410 Gone` and `Missing` to
+/// `404 Not Found` rather than collapsing both into a 404 that looks like data loss.
+#[derive(Debug, Clone)]
+pub enum ReportOutputLookup<T> {
+    Available(T),
+    Expired { expires_at: NaiveDateTime },
+    Missing,
+}
+
+impl<T> ReportOutputLookup<T> {
+    /// Borrow the contained value, mirroring `Option::as_ref`.
+    pub fn as_ref(&self) -> ReportOutputLookup<&T> {
+        match self {
+            ReportOutputLookup::Available(value) => ReportOutputLookup::Available(value),
+            ReportOutputLookup::Expired { expires_at } => ReportOutputLookup::Expired {
+                expires_at: *expires_at,
+            },
+            ReportOutputLookup::Missing => ReportOutputLookup::Missing,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Queryable, Selectable)]
 #[diesel(table_name = report_task_outputs)]
 #[allow(dead_code)]
@@ -380,12 +408,12 @@ pub struct ReportTaskOutputSummaryRecord {
 
 impl TaskRecord {
     pub fn to_response(&self) -> Result<TaskResponse, ApiError> {
-        self.to_response_with_report_output(None)
+        self.to_response_with_report_output(ReportOutputLookup::Missing)
     }
 
     pub fn to_response_with_report_output(
         &self,
-        report_output_summary: Option<&ReportTaskOutputSummaryRecord>,
+        report_output: ReportOutputLookup<&ReportTaskOutputSummaryRecord>,
     ) -> Result<TaskResponse, ApiError> {
         let kind = TaskKind::from_db(&self.kind)?;
         let status = TaskStatus::from_db(&self.status)?;
@@ -402,22 +430,26 @@ impl TaskRecord {
                 report: None,
             }),
             TaskKind::Report => report_output_url.clone().map(|output_url| {
-                let output_summary = report_output_summary.cloned();
+                let (output_summary, output_expired, expired_expires_at) = match report_output {
+                    ReportOutputLookup::Available(summary) => (Some(summary), false, None),
+                    ReportOutputLookup::Expired { expires_at } => (None, true, Some(expires_at)),
+                    ReportOutputLookup::Missing => (None, false, None),
+                };
                 TaskDetails {
                     import: None,
                     report: Some(ReportTaskDetails {
                         output_url,
                         output_available: output_summary.is_some(),
+                        output_expired,
                         output_expires_at: output_summary
-                            .as_ref()
-                            .map(|summary| summary.output_expires_at),
+                            .map(|summary| summary.output_expires_at)
+                            .or(expired_expires_at),
                         template_name: output_summary
-                            .as_ref()
                             .and_then(|summary| summary.template_name.clone()),
-                        output_content_type: report_output_summary
+                        output_content_type: output_summary
                             .map(|summary| summary.content_type.clone()),
-                        warning_count: report_output_summary.map(|summary| summary.warning_count),
-                        truncated: report_output_summary.map(|summary| summary.truncated),
+                        warning_count: output_summary.map(|summary| summary.warning_count),
+                        truncated: output_summary.map(|summary| summary.truncated),
                     }),
                 }
             }),

--- a/src/tasks/helpers.rs
+++ b/src/tasks/helpers.rs
@@ -66,6 +66,7 @@ pub(super) fn sanitize_error_for_storage(err: &ApiError) -> String {
         ApiError::Conflict(msg) => format!("Conflict: {}", msg),
         ApiError::Forbidden(msg) => format!("Permission denied: {}", msg),
         ApiError::NotFound(msg) => format!("Not found: {}", msg),
+        ApiError::Gone(msg) => format!("Gone: {}", msg),
         ApiError::BadRequest(msg) => format!("Invalid input: {}", msg),
         ApiError::ValidationError(msg) => format!("Validation failed: {}", msg),
         ApiError::DatabaseError(_) | ApiError::DbConnectionError(_) => {

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -8,13 +8,14 @@ mod tests {
     use rstest::rstest;
     use std::time::Duration;
 
-    use crate::db::traits::task::purge_expired_report_outputs;
+    use crate::db::traits::task::{TaskBackend, TaskStateUpdate, purge_expired_report_outputs};
     use crate::models::{
         HubuumClass, HubuumClassRelation, HubuumObjectRelation, NewHubuumClass,
-        NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, NewReportTemplate,
-        NewTaskRecord, ReportContentType, ReportJsonResponse, ReportRelationContext, ReportRequest,
-        ReportScope, ReportScopeKind, ReportTemplateKind, TaskEventResponse, TaskKind,
-        TaskResponse, TaskStatus, UpdateReportTemplate,
+        NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation,
+        NewReportTaskOutputRecord, NewReportTemplate, NewTaskEventRecord, NewTaskRecord,
+        ReportContentType, ReportJsonResponse, ReportRelationContext, ReportRequest, ReportScope,
+        ReportScopeKind, ReportTemplateKind, TaskEventResponse, TaskID, TaskKind, TaskResponse,
+        TaskStatus, UpdateReportTemplate,
     };
     use crate::tests::api::v1::classes::tests::{cleanup, create_test_classes};
     use crate::tests::api_operations::{get_request, post_request_with_headers};
@@ -1535,6 +1536,186 @@ mod tests {
                 .iter()
                 .any(|event| event.event_type == "cleanup" && event.message.contains("cleaned up"))
         );
+
+        cleanup(&classes).await;
+    }
+
+    /// An output whose retention has lapsed but which the purge job has not yet deleted must read as
+    /// explicitly expired (410 Gone + `output_expired`) rather than as a generic 404 that looks like
+    /// the report was never produced.
+    #[rstest]
+    #[actix_web::test]
+    async fn test_report_output_returns_gone_when_expired_before_purge(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        use diesel::prelude::*;
+
+        let context = test_context;
+        let classes = create_test_classes(&context, "report_expired").await;
+        let class = classes[0].clone();
+        let _ = create_report_objects(&context.pool, &class).await;
+        let template_id = create_template(
+            &context.pool,
+            class.namespace_id,
+            class.id,
+            ReportScopeKind::ObjectsInClass,
+            "expired-template",
+            ReportContentType::TextPlain,
+            "{% for item in items %}{{ item.name }}\n{% endfor %}",
+        )
+        .await;
+
+        let resp = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/templates/{template_id}/reports"),
+            &serde_json::json!({ "query": "sort=name" }),
+            vec![],
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::ACCEPTED).await;
+        let task: TaskResponse = test::read_body_json(resp).await;
+        let _ = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+
+        let backdated_expiry = chrono::Utc::now().naive_utc() - chrono::Duration::hours(1);
+        crate::db::with_connection(&context.pool, |conn| {
+            use crate::schema::report_task_outputs::dsl::{
+                output_expires_at, report_task_outputs, task_id,
+            };
+
+            diesel::update(report_task_outputs.filter(task_id.eq(task.id)))
+                .set(output_expires_at.eq(backdated_expiry))
+                .execute(conn)
+        })
+        .unwrap();
+
+        // Deliberately do NOT purge: the row still exists but is past its retention window.
+        let output = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/reports/{}/output", task.id),
+        )
+        .await;
+        assert_response_status(output, StatusCode::GONE).await;
+
+        let projection = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/reports/{}", task.id),
+        )
+        .await;
+        let projection = assert_response_status(projection, StatusCode::OK).await;
+        let projection: TaskResponse = test::read_body_json(projection).await;
+        let details = projection
+            .details
+            .as_ref()
+            .and_then(|details| details.report.as_ref())
+            .expect("report details");
+        assert!(!details.output_available);
+        assert!(details.output_expired);
+        assert_eq!(details.output_expires_at, Some(backdated_expiry));
+
+        cleanup(&classes).await;
+    }
+
+    /// Re-finalizing a report task must not trip the `report_task_outputs.task_id` UNIQUE
+    /// constraint: the second call is a no-op for the output row and leaves the task advanced.
+    #[rstest]
+    #[actix_web::test]
+    async fn test_finalize_report_with_output_is_idempotent(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        use diesel::prelude::*;
+
+        let context = test_context;
+        let classes = create_test_classes(&context, "report_refinalize").await;
+        let class = classes[0].clone();
+        let _ = create_report_objects(&context.pool, &class).await;
+        let template_id = create_template(
+            &context.pool,
+            class.namespace_id,
+            class.id,
+            ReportScopeKind::ObjectsInClass,
+            "refinalize-template",
+            ReportContentType::TextPlain,
+            "{% for item in items %}{{ item.name }}\n{% endfor %}",
+        )
+        .await;
+
+        let resp = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/templates/{template_id}/reports"),
+            &serde_json::json!({ "query": "sort=name" }),
+            vec![],
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::ACCEPTED).await;
+        let task: TaskResponse = test::read_body_json(resp).await;
+        let _ = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+
+        let task_handle = TaskID::new(task.id).expect("valid task id");
+        let duplicate_output = NewReportTaskOutputRecord {
+            task_id: task.id,
+            template_name: Some("refinalize-template".to_string()),
+            content_type: "text/plain".to_string(),
+            json_output: None,
+            text_output: Some("second finalize body".to_string()),
+            meta_json: serde_json::json!({}),
+            warnings_json: serde_json::json!([]),
+            warning_count: 0,
+            truncated: false,
+            output_expires_at: chrono::Utc::now().naive_utc() + chrono::Duration::hours(1),
+            total_duration_ms: 0,
+            query_duration_ms: 0,
+            hydration_duration_ms: 0,
+            render_duration_ms: 0,
+        };
+
+        let record = task_handle
+            .finalize_report_with_output(
+                &context.pool,
+                TaskStateUpdate {
+                    status: TaskStatus::Succeeded,
+                    summary: Some("re-finalized".to_string()),
+                    processed_items: 1,
+                    success_items: 1,
+                    failed_items: 0,
+                    started_at: None,
+                    finished_at: None,
+                },
+                NewTaskEventRecord {
+                    task_id: task.id,
+                    event_type: TaskStatus::Succeeded.as_str().to_string(),
+                    message: "re-finalize".to_string(),
+                    data: None,
+                },
+                duplicate_output,
+            )
+            .await
+            .expect("re-finalize should be idempotent, not error");
+        assert_eq!(record.status, TaskStatus::Succeeded.as_str());
+
+        // The output row is untouched: exactly one row, and the original body, not the duplicate.
+        let (count, text): (i64, Option<String>) =
+            crate::db::with_connection(&context.pool, |conn| {
+                use crate::schema::report_task_outputs::dsl::{
+                    report_task_outputs, task_id, text_output,
+                };
+
+                let count = report_task_outputs
+                    .filter(task_id.eq(task.id))
+                    .count()
+                    .get_result::<i64>(conn)?;
+                let text = report_task_outputs
+                    .filter(task_id.eq(task.id))
+                    .select(text_output)
+                    .first::<Option<String>>(conn)?;
+                Ok::<_, diesel::result::Error>((count, text))
+            })
+            .unwrap();
+        assert_eq!(count, 1);
+        assert_ne!(text.as_deref(), Some("second finalize body"));
 
         cleanup(&classes).await;
     }

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -1615,6 +1615,30 @@ mod tests {
         assert!(details.output_expired);
         assert_eq!(details.output_expires_at, Some(backdated_expiry));
 
+        // The batch task-list endpoint must classify expiry the same way as the single-task
+        // endpoints, not silently drop the expired row. Filtering by this test's (unique) admin
+        // keeps the result isolated under parallel execution.
+        let list_resp = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!(
+                "/api/v1/tasks?submitted_by={}&kind=report&limit=50",
+                context.admin_user.id
+            ),
+        )
+        .await;
+        let list_resp = assert_response_status(list_resp, StatusCode::OK).await;
+        let listed: Vec<TaskResponse> = test::read_body_json(list_resp).await;
+        let listed_details = listed
+            .iter()
+            .find(|entry| entry.id == task.id)
+            .and_then(|entry| entry.details.as_ref())
+            .and_then(|details| details.report.as_ref())
+            .expect("expired report task present in task list with report details");
+        assert!(!listed_details.output_available);
+        assert!(listed_details.output_expired);
+        assert_eq!(listed_details.output_expires_at, Some(backdated_expiry));
+
         cleanup(&classes).await;
     }
 

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -1577,7 +1577,14 @@ mod tests {
         let task: TaskResponse = test::read_body_json(resp).await;
         let _ = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
 
-        let backdated_expiry = chrono::Utc::now().naive_utc() - chrono::Duration::hours(1);
+        // Fixed, whole-second timestamp in the past: deterministically expired and round-trips
+        // through Postgres' microsecond-resolution `timestamp` column without precision loss.
+        // (A `now()`-derived value carries nanosecond precision on Linux that the column
+        // truncates, which would break the exact-equality assertions below.)
+        let backdated_expiry = chrono::NaiveDate::from_ymd_opt(2000, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
         crate::db::with_connection(&context.pool, |conn| {
             use crate::schema::report_task_outputs::dsl::{
                 output_expires_at, report_task_outputs, task_id,

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -24,6 +24,13 @@ mod tests {
     use crate::traits::{CanSave, CanUpdate};
     const REPORTS_ENDPOINT: &str = "/api/v1/reports";
 
+    /// Serializes only the two tests that contend over the process-wide set of expired report
+    /// outputs: one runs the global `purge_expired_report_outputs`, the other needs its expired
+    /// row to survive until it has queried it. They cannot safely interleave; every other test in
+    /// the suite remains free to run in parallel.
+    static EXPIRED_OUTPUT_PURGE_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+        std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+
     async fn wait_for_task(
         context: &TestContext,
         task_id: i32,
@@ -1482,6 +1489,10 @@ mod tests {
         let task: TaskResponse = test::read_body_json(resp).await;
         let _ = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
 
+        // Hold the purge lock from here: the global purge below must not race the expired-output
+        // test, which relies on its own expired row surviving.
+        let _purge_guard = EXPIRED_OUTPUT_PURGE_LOCK.lock().await;
+
         crate::db::with_connection(&context.pool, |conn| {
             use crate::schema::report_task_outputs::dsl::{
                 output_expires_at, report_task_outputs, task_id,
@@ -1496,8 +1507,14 @@ mod tests {
         })
         .unwrap();
 
+        // The purge is process-wide; assert it cleaned *our* task rather than asserting it cleaned
+        // nothing else, so other suites' expired rows can't make this brittle.
         let cleaned = purge_expired_report_outputs(&context.pool).await.unwrap();
-        assert_eq!(cleaned, vec![task.id]);
+        assert!(
+            cleaned.contains(&task.id),
+            "expected purge to include task {}, got {cleaned:?}",
+            task.id
+        );
 
         let projection = get_request(
             &context.pool,
@@ -1576,6 +1593,10 @@ mod tests {
         let resp = assert_response_status(resp, StatusCode::ACCEPTED).await;
         let task: TaskResponse = test::read_body_json(resp).await;
         let _ = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+
+        // Hold the purge lock so the cleanup test's global purge cannot delete our expired row
+        // out from under the assertions below.
+        let _purge_guard = EXPIRED_OUTPUT_PURGE_LOCK.lock().await;
 
         // Fixed, whole-second timestamp in the past: deterministically expired and round-trips
         // through Postgres' microsecond-resolution `timestamp` column without precision loss.

--- a/src/utilities/aliases.rs
+++ b/src/utilities/aliases.rs
@@ -1,0 +1,98 @@
+//! Shared normalization for report template aliases.
+//!
+//! Relation creation (`db::traits::relations`) and import processing
+//! (`db::traits::task_import`) both validate and canonicalize user-supplied template aliases the
+//! same way, so the rule lives here once.
+
+use crate::errors::ApiError;
+
+/// Normalize a template alias to `snake_case`, rejecting empty or otherwise invalid input.
+///
+/// Letters are lowercased, runs of spaces/hyphens/underscores collapse to a single underscore,
+/// and an underscore is inserted at `camelCase` boundaries. Any other character is an error, as is
+/// an alias that normalizes to empty or starts with a digit.
+pub(crate) fn normalize_template_alias(alias: &str) -> Result<String, ApiError> {
+    let trimmed = alias.trim();
+    if trimmed.is_empty() {
+        return Err(ApiError::BadRequest(
+            "template aliases cannot be empty".to_string(),
+        ));
+    }
+
+    let mut normalized = String::new();
+    let mut previous_was_separator = true;
+
+    for character in trimmed.chars() {
+        if character.is_ascii_alphanumeric() {
+            if character.is_ascii_uppercase()
+                && !previous_was_separator
+                && !normalized.ends_with('_')
+            {
+                normalized.push('_');
+            }
+            normalized.push(character.to_ascii_lowercase());
+            previous_was_separator = false;
+        } else if matches!(character, ' ' | '-' | '_') {
+            if !normalized.is_empty() && !normalized.ends_with('_') {
+                normalized.push('_');
+            }
+            previous_was_separator = true;
+        } else {
+            return Err(ApiError::BadRequest(format!(
+                "template aliases may only contain letters, numbers, spaces, hyphens, and underscores: '{alias}'"
+            )));
+        }
+    }
+
+    let normalized = normalized.trim_matches('_').to_string();
+    if normalized.is_empty() || normalized.starts_with(|ch: char| ch.is_ascii_digit()) {
+        return Err(ApiError::BadRequest(format!(
+            "template aliases must start with a letter and contain at least one alphanumeric character: '{alias}'"
+        )));
+    }
+
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lowercases_and_inserts_camel_case_boundaries() {
+        assert_eq!(normalize_template_alias("HostName").unwrap(), "host_name");
+        assert_eq!(normalize_template_alias("hostName").unwrap(), "host_name");
+    }
+
+    #[test]
+    fn collapses_separators_and_trims() {
+        assert_eq!(
+            normalize_template_alias("  host - name__alias ").unwrap(),
+            "host_name_alias"
+        );
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(matches!(
+            normalize_template_alias("   "),
+            Err(ApiError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_characters() {
+        assert!(matches!(
+            normalize_template_alias("host/name"),
+            Err(ApiError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_leading_digit() {
+        assert!(matches!(
+            normalize_template_alias("1host"),
+            Err(ApiError::BadRequest(_))
+        ));
+    }
+}

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -1,3 +1,4 @@
+pub mod aliases;
 pub mod auth;
 pub mod db;
 pub mod extensions;

--- a/src/utilities/reporting.rs
+++ b/src/utilities/reporting.rs
@@ -3,8 +3,10 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
+use std::num::NonZeroUsize;
 use std::sync::{Arc, OnceLock, RwLock};
 
+use lru::LruCache;
 use minijinja::value::Value;
 use minijinja::{
     AutoEscape, Environment, Error as MiniJinjaError, ErrorKind as MiniJinjaErrorKind, State,
@@ -39,7 +41,7 @@ struct CachedTemplateEnvironment {
 }
 
 static TEMPLATE_ENV_CACHE: OnceLock<
-    RwLock<HashMap<TemplateEnvCacheKey, Arc<CachedTemplateEnvironment>>>,
+    RwLock<LruCache<TemplateEnvCacheKey, Arc<CachedTemplateEnvironment>>>,
 > = OnceLock::new();
 
 #[derive(Debug, Default)]
@@ -168,8 +170,10 @@ pub fn render_template(
     };
 
     let cached = {
-        let cache = template_env_cache()
-            .read()
+        // `LruCache::get` updates recency, so the read path needs a write lock. Cheap at this
+        // cache size and keeps eviction honest about what was most recently used.
+        let mut cache = template_env_cache()
+            .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         cache.get(&cache_key).cloned()
     };
@@ -192,16 +196,20 @@ pub fn render_template(
             let mut cache = template_env_cache()
                 .write()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            cache.retain(|key, _| {
-                key.namespace_id != cache_key.namespace_id
-                    || key.namespace_signature == cache_key.namespace_signature
-            });
-            if cache.len() >= TEMPLATE_ENV_CACHE_MAX_ENTRIES
-                && let Some(eviction_key) = cache.keys().next().cloned()
-            {
-                cache.remove(&eviction_key);
+            // Drop now-stale environments for this namespace (templates changed) before inserting.
+            let stale_keys = cache
+                .iter()
+                .filter(|(key, _)| {
+                    key.namespace_id == cache_key.namespace_id
+                        && key.namespace_signature != cache_key.namespace_signature
+                })
+                .map(|(key, _)| key.clone())
+                .collect::<Vec<_>>();
+            for key in stale_keys {
+                cache.pop(&key);
             }
-            cache.insert(cache_key, built.clone());
+            // `put` evicts the least-recently-used entry when the cache is at capacity.
+            cache.put(cache_key, built.clone());
             built
         }
     };
@@ -232,8 +240,12 @@ pub fn render_template(
 }
 
 fn template_env_cache()
--> &'static RwLock<HashMap<TemplateEnvCacheKey, Arc<CachedTemplateEnvironment>>> {
-    TEMPLATE_ENV_CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+-> &'static RwLock<LruCache<TemplateEnvCacheKey, Arc<CachedTemplateEnvironment>>> {
+    TEMPLATE_ENV_CACHE.get_or_init(|| {
+        let capacity = NonZeroUsize::new(TEMPLATE_ENV_CACHE_MAX_ENTRIES)
+            .expect("TEMPLATE_ENV_CACHE_MAX_ENTRIES must be non-zero");
+        RwLock::new(LruCache::new(capacity))
+    })
 }
 
 fn namespace_signature(


### PR DESCRIPTION
Closes #50. Follow-up robustness/maintainability cleanup from the PR #42 review.

I verified each sub-item against the code before fixing; two differed from the issue text (noted below).

## Changes

### 1. Finalize idempotency
`finalize_report_with_output` (`src/db/traits/task.rs`) inserted into `report_task_outputs` (UNIQUE on `task_id`) with no `ON CONFLICT`. A double-finalize (future requeue / manual re-claim) would raise a unique violation, roll back the whole transaction, and leave the task stuck mid-flight. Now uses `on_conflict(task_id).do_nothing()`.

### 2. Explicit expired-output state
`find_report_output*` filtered `output_expires_at.gt(now)`, so an expired-but-present row (retention lapsed before the purge job runs) returned `None` → `404`, indistinguishable from data loss. They now fetch unfiltered and classify via a new `ReportOutputLookup` enum:
- `GET /reports/{id}/output` returns **410 Gone** (new `ApiError::Gone`) for expired output, **404** only when genuinely absent.
- The task projection (`ReportTaskDetails`) gains an `output_expired` flag.

### 3. True LRU template-env cache
`src/utilities/reporting.rs` evicted `cache.keys().next()` (arbitrary `HashMap` order), which could evict the entry about to be reused. Replaced with a true LRU (`lru` crate), preserving the stale-namespace-signature invalidation.

### 4. Consolidated duplicate helper
`normalize_template_alias` was byte-for-byte duplicated in `relations.rs` and `task_import.rs`; extracted to a shared `utilities::aliases` helper (`pub(crate)`) with unit tests.

## Notes on issue discrepancies
- The third "duplicate", `normalize_alias_segment` in `reports.rs`, is a **different** function (infallible, returns `String`, lenient). Merging it would change behavior, so it is left as-is.
- The "magic numbers `64`/`50_000`" sub-item is **already resolved** — `config.rs` and `reporting.rs` already reference `DEFAULT_REPORT_TEMPLATE_RECURSION_LIMIT`/`_FUEL`. No change needed.

## Testing
- New integration tests: expired output → 410 + `output_expired`; re-finalize is idempotent (one row, original body preserved).
- New unit tests for the shared alias helper.
- Full suite (`source .env && ./run_tests.sh`): 623 passed, 0 failed.
- `cargo clippy --all-targets -- -D warnings` clean; `rustfmt` applied; `docs/openapi.json` regenerated (410 response + `output_expired`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)