### PR TITLE
Add report-scoped DB statement_timeout (#49)

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -53,6 +53,7 @@ Hubuum can be configured using environment variables or command-line arguments. 
 | `HUBUUM_REPORT_TEMPLATE_MAX_OBJECTS` | `2000` | Maximum hydrated relation-aware template objects per report |
 | `HUBUUM_REPORT_MAX_OUTPUT_BYTES` | `262144` | Server maximum for rendered report output size; request-level `limits.max_output_bytes` cannot exceed this |
 | `HUBUUM_REPORT_STAGE_TIMEOUT_MS` | `10000` | Post-completion rejection budget per report stage (ms). Rejects a report *after* a stage finishes if it exceeded this; it does not interrupt in-flight work. Use `HUBUUM_DB_STATEMENT_TIMEOUT_MS` to actually cancel slow queries |
+| `HUBUUM_REPORT_DB_STATEMENT_TIMEOUT_MS` | `0` | Report-scoped Postgres `statement_timeout` in ms (`0` disables). Cancels slow queries in-flight **only while executing reports** (applied as a transaction-local `SET LOCAL`), without affecting imports or other DB work. Typically set `<= HUBUUM_REPORT_STAGE_TIMEOUT_MS` |
 
 **Report/template note**: These settings control async report task behavior, including stored output retention, template execution limits, and relation hydration guardrails. See [Report API](report_api.md) and [Template Guide](template_guide.md) for the user-facing behavior these limits affect.
 

--- a/docs/report_api.md
+++ b/docs/report_api.md
@@ -392,6 +392,13 @@ enable `related.*` and `reachable.*`.
   Postgres `statement_timeout`: it applies to every database query the service
   makes, not only report stages, so choose a value that accommodates legitimate
   long-running operations (e.g. large imports).
+- to cancel slow in-flight queries **only while executing reports**, set
+  `HUBUUM_REPORT_DB_STATEMENT_TIMEOUT_MS` (0 = disabled). This is a
+  **report-scoped** Postgres `statement_timeout`, applied as a transaction-local
+  `SET LOCAL` on report queries (scope query, includes, relation hydration), so
+  it bounds report queries aggressively without capping imports, admin
+  operations, or other DB work sharing the pool. When set it should typically be
+  `<= HUBUUM_REPORT_STAGE_TIMEOUT_MS`.
 - successful stored outputs get an `output_expires_at` timestamp at completion time
 - background task workers clean up expired stored outputs and append a `cleanup` task event
 
@@ -406,6 +413,7 @@ Relevant env vars are documented centrally in [Quick Start](quick_start.md):
 - `HUBUUM_REPORT_MAX_OUTPUT_BYTES`
 - `HUBUUM_REPORT_STAGE_TIMEOUT_MS`
 - `HUBUUM_DB_STATEMENT_TIMEOUT_MS`
+- `HUBUUM_REPORT_DB_STATEMENT_TIMEOUT_MS`
 
 ## Cost controls
 

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -8,17 +8,18 @@ use serde_json::json;
 use crate::api::openapi::ApiErrorResponse;
 use crate::can;
 use crate::config::{
-    DEFAULT_REPORT_MAX_ACTIVE_TASKS_PER_USER, DEFAULT_REPORT_MAX_OUTPUT_BYTES,
-    DEFAULT_REPORT_OUTPUT_RETENTION_HOURS, DEFAULT_REPORT_STAGE_TIMEOUT_MS,
-    DEFAULT_REPORT_TEMPLATE_MAX_OBJECTS, get_config,
+    DEFAULT_REPORT_DB_STATEMENT_TIMEOUT_MS, DEFAULT_REPORT_MAX_ACTIVE_TASKS_PER_USER,
+    DEFAULT_REPORT_MAX_OUTPUT_BYTES, DEFAULT_REPORT_OUTPUT_RETENTION_HOURS,
+    DEFAULT_REPORT_STAGE_TIMEOUT_MS, DEFAULT_REPORT_TEMPLATE_MAX_OBJECTS, get_config,
 };
-use crate::db::DbPool;
 use crate::db::traits::UserPermissions;
 use crate::db::traits::task::{TaskBackend, TaskCreateRequest, TaskStateUpdate};
+use crate::db::{DbPool, with_statement_timeout_scope};
 use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::search::{
-    FilterField, ParsedQueryParam, QueryOptions, SearchOperator, parse_query_parameter,
+    FilterField, ParsedQueryParam, QueryOptions, SearchOperator, StatementTimeoutMs,
+    parse_query_parameter,
 };
 use crate::models::{
     ClassIdSet, HubuumClassID, HubuumClassRelation, HubuumObject, HubuumObjectID,
@@ -516,13 +517,25 @@ pub(crate) async fn execute_report_task(
     .append(pool)
     .await?;
 
+    // Report-scoped, in-flight query budget. While these query stages run, every
+    // DB query they issue is bounded by this `statement_timeout` (applied as a
+    // transaction-local `SET LOCAL`), independently of the pool-global timeout
+    // and without affecting bookkeeping writes outside these scopes.
+    let statement_timeout = report_statement_timeout();
     let mut query_options = prepare_query_options(&runtime.report)?;
     let relation_hydration = resolve_relation_hydration_plan(&runtime, &mut query_options)?;
     let query_start = Instant::now();
-    let (items, mut warnings, truncated) =
-        execute_scope(pool, user, &runtime.report.scope, query_options).await?;
+    let (items, mut warnings, truncated) = with_statement_timeout_scope(
+        statement_timeout,
+        execute_scope(pool, user, &runtime.report.scope, query_options),
+    )
+    .await?;
     let mut items = items;
-    apply_report_includes(pool, user, &runtime.report, &mut items).await?;
+    with_statement_timeout_scope(
+        statement_timeout,
+        apply_report_includes(pool, user, &runtime.report, &mut items),
+    )
+    .await?;
     timings.query_duration_ms = duration_to_millis_i32(query_start.elapsed());
     enforce_report_stage_timeout(query_start, "query execution")?;
 
@@ -546,8 +559,11 @@ pub(crate) async fn execute_report_task(
 
     add_truncation_warning(&mut warnings, truncated);
     let hydration_start = Instant::now();
-    let (template_items, source) =
-        build_template_items(pool, user, &runtime, &items, relation_hydration).await?;
+    let (template_items, source) = with_statement_timeout_scope(
+        statement_timeout,
+        build_template_items(pool, user, &runtime, &items, relation_hydration),
+    )
+    .await?;
     timings.hydration_duration_ms = duration_to_millis_i32(hydration_start.elapsed());
     enforce_report_stage_timeout(hydration_start, "relation hydration")?;
     let template_report = runtime.template.is_some();
@@ -820,14 +836,27 @@ fn duration_to_millis_i32(duration: std::time::Duration) -> i32 {
     i32::try_from(duration.as_millis()).unwrap_or(i32::MAX)
 }
 
+/// The report-scoped Postgres `statement_timeout` to apply to report queries,
+/// or `None` when disabled (`report_db_statement_timeout_ms == 0`).
+///
+/// This is the in-flight, server-side query cancel that complements the
+/// post-completion wall-clock budget enforced by [`enforce_report_stage_timeout`].
+fn report_statement_timeout() -> Option<StatementTimeoutMs> {
+    let milliseconds = get_config()
+        .map(|config| config.report_db_statement_timeout_ms)
+        .unwrap_or(DEFAULT_REPORT_DB_STATEMENT_TIMEOUT_MS);
+    StatementTimeoutMs::new(milliseconds)
+}
+
 /// Post-completion rejection guard for a report stage.
 ///
 /// This is **not** an in-flight interrupt: it is called after a stage has already
 /// finished and rejects the report if the stage took longer than the configured
 /// budget. It bounds how long a stage is *accepted* to have taken, not how long
 /// it is *allowed to run*. In-flight protection comes from the MiniJinja fuel
-/// budget, `report_template_max_objects`, the output byte caps, and the
-/// pool-global `db_statement_timeout_ms` (which cancels slow queries server-side).
+/// budget, `report_template_max_objects`, the output byte caps, the pool-global
+/// `db_statement_timeout_ms`, and the report-scoped `report_db_statement_timeout_ms`
+/// (both of which cancel slow queries server-side).
 fn enforce_report_stage_timeout(stage_start: Instant, stage_name: &str) -> Result<(), ApiError> {
     let stage_timeout_ms = get_config()
         .map(|config| config.report_stage_timeout_ms)

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ pub const DEFAULT_REPORT_TEMPLATE_MAX_OBJECTS: usize = 2_000;
 pub const DEFAULT_REPORT_MAX_OUTPUT_BYTES: usize = 262_144;
 pub const DEFAULT_REPORT_STAGE_TIMEOUT_MS: u64 = 10_000;
 pub const DEFAULT_DB_STATEMENT_TIMEOUT_MS: u64 = 0;
+pub const DEFAULT_REPORT_DB_STATEMENT_TIMEOUT_MS: u64 = 0;
 pub const DEFAULT_TOKEN_LIFETIME_HOURS: i64 = 24;
 pub const DEFAULT_LOGIN_RATE_LIMIT_ENABLED: bool = true;
 pub const DEFAULT_LOGIN_RATE_LIMIT_MAX_ATTEMPTS: usize = 5;
@@ -228,6 +229,23 @@ pub struct AppConfig {
         default_value_t = DEFAULT_DB_STATEMENT_TIMEOUT_MS
     )]
     pub db_statement_timeout_ms: u64,
+
+    /// Report-scoped Postgres `statement_timeout` in milliseconds (0 = disabled).
+    ///
+    /// Unlike `db_statement_timeout_ms`, this bounds *only* the queries issued
+    /// while executing a report (scope query, includes, relation hydration). It
+    /// is applied as a transaction-local `SET LOCAL statement_timeout` on those
+    /// queries, so it does not affect imports, admin commands, or any other DB
+    /// work sharing the pool. This lets operators cap report queries aggressively
+    /// without capping legitimately long-running work. When set it should
+    /// typically be `<= report_stage_timeout_ms` (the post-completion wall-clock
+    /// budget). Disabled by default to preserve existing behavior.
+    #[clap(
+        long,
+        env = "HUBUUM_REPORT_DB_STATEMENT_TIMEOUT_MS",
+        default_value_t = DEFAULT_REPORT_DB_STATEMENT_TIMEOUT_MS
+    )]
+    pub report_db_statement_timeout_ms: u64,
 
     /// Number of DB connections in the pool
     #[clap(long, env = "HUBUUM_DB_POOL_SIZE", default_value_t = 10)]
@@ -778,6 +796,10 @@ fn get_config_from_env() -> Result<AppConfig, ApiError> {
             .ok()
             .and_then(|value| value.parse().ok())
             .unwrap_or(DEFAULT_DB_STATEMENT_TIMEOUT_MS),
+        report_db_statement_timeout_ms: env::var("HUBUUM_REPORT_DB_STATEMENT_TIMEOUT_MS")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_REPORT_DB_STATEMENT_TIMEOUT_MS),
         db_pool_size: env_or_default("HUBUUM_DB_POOL_SIZE", "2")
             .parse()
             .unwrap_or(5),

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -9,6 +9,7 @@ use diesel::r2d2::PooledConnection;
 use tracing::debug;
 
 use crate::errors::{ApiError, EXIT_CODE_CONFIG_ERROR, EXIT_CODE_DATABASE_ERROR, fatal_error};
+use crate::models::search::StatementTimeoutMs;
 use crate::utilities::db::DatabaseUrlComponents;
 
 pub type DbPool = Pool<ConnectionManager<PgConnection>>;
@@ -17,6 +18,61 @@ fn acquire_connection(
     pool: &DbPool,
 ) -> Result<PooledConnection<ConnectionManager<PgConnection>>, ApiError> {
     pool.get().map_err(ApiError::from)
+}
+
+tokio::task_local! {
+    /// The per-query Postgres `statement_timeout` in effect for the current
+    /// async task, if any. Set for the duration of a scope via
+    /// [`with_statement_timeout_scope`] and consulted by [`with_connection`] /
+    /// [`with_transaction`] so that all DB work inside the scope is bounded
+    /// without threading a timeout through every caller. Outside any scope the
+    /// lookup yields `None`, so behavior is unchanged.
+    static AMBIENT_STATEMENT_TIMEOUT: Option<StatementTimeoutMs>;
+}
+
+/// Run `future` with an ambient per-query `statement_timeout` in effect.
+///
+/// While the future is being polled, every [`with_connection`] /
+/// [`with_transaction`] call made on the same task applies the given
+/// `statement_timeout` as a transaction-local `SET LOCAL statement_timeout`.
+/// This is how the report execution path bounds its queries independently of
+/// the pool-global `db_statement_timeout_ms`, without threading the timeout
+/// through the search layer. A `statement_timeout` of `None` is a no-op scope.
+pub async fn with_statement_timeout_scope<F, R>(
+    statement_timeout: Option<StatementTimeoutMs>,
+    future: F,
+) -> R
+where
+    F: std::future::Future<Output = R>,
+{
+    AMBIENT_STATEMENT_TIMEOUT
+        .scope(statement_timeout, future)
+        .await
+}
+
+/// The ambient per-query `statement_timeout` for the current task, or `None`
+/// when not running inside a [`with_statement_timeout_scope`] (including from
+/// synchronous, non-task contexts).
+fn ambient_statement_timeout() -> Option<StatementTimeoutMs> {
+    AMBIENT_STATEMENT_TIMEOUT
+        .try_with(|timeout| *timeout)
+        .unwrap_or(None)
+}
+
+/// Apply a transaction-local `SET LOCAL statement_timeout` to the current
+/// transaction. The value is bound rather than formatted into the SQL,
+/// mirroring [`StatementTimeoutCustomizer`]. `set_config(name, value,
+/// is_local=true)` scopes the value to the current transaction, so it reverts
+/// automatically at COMMIT/ROLLBACK and never leaks back to the shared pool.
+fn set_local_statement_timeout(
+    conn: &mut PgConnection,
+    statement_timeout: StatementTimeoutMs,
+) -> Result<(), diesel::result::Error> {
+    use diesel::RunQueryDsl;
+    diesel::sql_query("SELECT set_config('statement_timeout', $1, true)")
+        .bind::<diesel::sql_types::Text, _>(statement_timeout.as_millis().to_string())
+        .execute(conn)?;
+    Ok(())
 }
 
 /// Run database work on a single pooled connection without starting an explicit transaction.
@@ -30,6 +86,10 @@ fn acquire_connection(
 /// In practice this means the closure can return either Diesel errors directly or higher-level
 /// domain errors that already map into `ApiError`.
 ///
+/// If a [`with_statement_timeout_scope`] is in effect on the current task, the
+/// work is automatically bounded by that per-query `statement_timeout` (see
+/// [`with_connection_timeout`]). Otherwise no timeout is applied.
+///
 /// Note: block closures that use `?` and end with `Ok(...)` may require an explicit closure
 /// return type, for example:
 /// `with_connection(pool, |conn| -> Result<_, diesel::result::Error> { ... })`
@@ -38,8 +98,48 @@ where
     F: FnOnce(&mut PgConnection) -> Result<R, E>,
     ApiError: From<E>,
 {
+    with_connection_timeout(pool, ambient_statement_timeout(), f)
+}
+
+/// Run database work on a single pooled connection, optionally bounding it with
+/// an explicit per-query Postgres `statement_timeout`.
+///
+/// When `statement_timeout` is `None`, this behaves exactly like a plain pooled
+/// connection (no transaction, no override).
+///
+/// When it is `Some`, the closure runs inside a transaction that first issues a
+/// transaction-local `SET LOCAL statement_timeout`. Postgres cancels any
+/// statement exceeding the budget server-side, and the override reverts
+/// automatically at COMMIT/ROLLBACK, so it never leaks back to the shared pool.
+/// This is the mechanism that makes report queries bounded independently of the
+/// pool-global `db_statement_timeout_ms`.
+///
+/// Most callers should use [`with_connection`] and set the timeout ambiently via
+/// [`with_statement_timeout_scope`]; this explicit variant exists for callers
+/// (and tests) that want to pass the timeout directly.
+///
+/// Note: this intentionally wraps a (possibly read-only) closure in a
+/// transaction. That is contrary to the usual "single reads use
+/// [`with_connection`]" guidance, but the transaction here exists solely to
+/// scope `SET LOCAL`, not for multi-statement atomicity, and is encapsulated in
+/// this one helper rather than imposed on callers.
+pub fn with_connection_timeout<F, R, E>(
+    pool: &DbPool,
+    statement_timeout: Option<StatementTimeoutMs>,
+    f: F,
+) -> Result<R, ApiError>
+where
+    F: FnOnce(&mut PgConnection) -> Result<R, E>,
+    ApiError: From<E>,
+{
     let mut conn = acquire_connection(pool)?;
-    f(&mut conn).map_err(ApiError::from)
+    match statement_timeout {
+        None => f(&mut conn).map_err(ApiError::from),
+        Some(statement_timeout) => conn.transaction::<R, ApiError, _>(|conn| {
+            set_local_statement_timeout(conn, statement_timeout)?;
+            f(conn).map_err(ApiError::from)
+        }),
+    }
 }
 
 /// Run database work inside a SQL transaction on a single pooled connection.
@@ -53,6 +153,10 @@ where
 /// - read/modify/write sequences that must be atomic
 /// - permission mutations that must not leave partial state behind
 ///
+/// If a [`with_statement_timeout_scope`] is in effect on the current task, a
+/// transaction-local `SET LOCAL statement_timeout` is applied at the start of
+/// the transaction so this work is bounded too.
+///
 /// As with [`with_connection`], the closure may return any error type `E` that converts into
 /// [`ApiError`]. Block closures that end with `Ok(...)` may need an explicit closure return type,
 /// for example:
@@ -62,8 +166,14 @@ where
     F: FnOnce(&mut PgConnection) -> Result<R, E>,
     ApiError: From<E>,
 {
+    let statement_timeout = ambient_statement_timeout();
     let mut conn = acquire_connection(pool)?;
-    conn.transaction::<R, ApiError, _>(|conn| f(conn).map_err(ApiError::from))
+    conn.transaction::<R, ApiError, _>(|conn| {
+        if let Some(statement_timeout) = statement_timeout {
+            set_local_statement_timeout(conn, statement_timeout)?;
+        }
+        f(conn).map_err(ApiError::from)
+    })
 }
 
 pub fn init_pool(database_url: &str, max_size: u32) -> DbPool {
@@ -213,6 +323,65 @@ mod tests {
         diesel::sql_query("SELECT pg_sleep(0.1)")
             .execute(&mut conn)
             .expect("pg_sleep should complete when statement_timeout is disabled");
+    }
+
+    #[test]
+    fn statement_timeout_ms_new_treats_zero_as_disabled() {
+        assert_eq!(StatementTimeoutMs::new(0), None);
+        assert_eq!(
+            StatementTimeoutMs::new(50).map(StatementTimeoutMs::as_millis),
+            Some(50)
+        );
+    }
+
+    #[test]
+    fn with_connection_timeout_bounds_and_reverts() {
+        let config = get_config().expect("Failed to load config for test");
+        // Pool-global timeout disabled, so any cancellation must come from the
+        // per-query `SET LOCAL` applied by `with_connection_timeout` itself.
+        let pool = init_pool_with_statement_timeout(&config.database_url, 1, 0);
+
+        // A tiny explicit timeout cancels a query that sleeps past the budget.
+        let slow = with_connection_timeout(&pool, StatementTimeoutMs::new(50), |conn| {
+            diesel::sql_query("SELECT pg_sleep(1)").execute(conn)
+        });
+        assert!(
+            slow.is_err(),
+            "pg_sleep(1) should be cancelled by a 50ms per-query statement_timeout"
+        );
+
+        // The `SET LOCAL` reverts with the transaction, so a later checkout that
+        // passes `None` is unbounded again (proving no leak back to the pool).
+        with_connection_timeout(&pool, None, |conn| {
+            diesel::sql_query("SELECT pg_sleep(0.1)").execute(conn)
+        })
+        .expect("pg_sleep should complete when no per-query timeout is applied");
+    }
+
+    #[tokio::test]
+    async fn ambient_statement_timeout_scope_bounds_with_connection() {
+        let config = get_config().expect("Failed to load config for test");
+        // Pool-global timeout disabled; the only possible cancel is the ambient
+        // scope applied via `with_statement_timeout_scope`.
+        let pool = init_pool_with_statement_timeout(&config.database_url, 1, 0);
+
+        // Inside the scope, a plain `with_connection` call is bounded.
+        let bounded = with_statement_timeout_scope(StatementTimeoutMs::new(50), async {
+            with_connection(&pool, |conn| {
+                diesel::sql_query("SELECT pg_sleep(1)").execute(conn)
+            })
+        })
+        .await;
+        assert!(
+            bounded.is_err(),
+            "with_connection inside a 50ms scope should cancel pg_sleep(1)"
+        );
+
+        // Outside any scope, the ambient timeout is gone and slow work runs.
+        with_connection(&pool, |conn| {
+            diesel::sql_query("SELECT pg_sleep(0.1)").execute(conn)
+        })
+        .expect("with_connection outside a scope must not be bounded");
     }
 
     #[test]

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -177,6 +177,29 @@ fn parse_single_filter(key: &str, value: &str) -> Result<ParsedQueryParam, ApiEr
     Ok(parsed_query_param)
 }
 
+/// ## A per-query Postgres `statement_timeout`, in milliseconds.
+///
+/// A validated, *positive* timeout: the only way to construct one is
+/// [`StatementTimeoutMs::new`], which returns `None` for `0` (the "disabled"
+/// value), so a `StatementTimeoutMs` value always represents a meaningful budget.
+/// Callers thread `Option<StatementTimeoutMs>`, where `None` means "no
+/// per-query override" (the connection's pool-global timeout applies, if any).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StatementTimeoutMs(u64);
+
+impl StatementTimeoutMs {
+    /// Build a timeout from a raw millisecond value. `0` is treated as
+    /// "disabled" and yields `None`; any positive value yields `Some`.
+    pub fn new(milliseconds: u64) -> Option<Self> {
+        (milliseconds > 0).then_some(Self(milliseconds))
+    }
+
+    /// The timeout in milliseconds (always greater than zero).
+    pub fn as_millis(self) -> u64 {
+        self.0
+    }
+}
+
 /// ## A struct that represents a set of query options
 ///
 /// This struct holds a list of filters, a list of sort parameters, and a limit on the number of results.


### PR DESCRIPTION
Closes #49.

## Problem

The pool-global `HUBUUM_DB_STATEMENT_TIMEOUT_MS` (from PR #42) is applied to every connection via an r2d2 customizer, so it bounds **all** DB work — reports, imports, admin commands, health/auth queries. Operators cannot bound report queries aggressively without also capping legitimately long-running work that shares the pool. The wall-clock `report_stage_timeout_ms` only *rejects a stage after it finishes*; it never cancels an in-flight query.

## Solution

A **report-scoped** `statement_timeout` that cancels slow report queries server-side, without affecting any other DB work.

Rather than thread a timeout through the ~30 search leaf calls and 6 hydration methods, the timeout flows via an **ambient task-local**:

- `with_connection` keeps its signature and now delegates to `with_connection_timeout(pool, <ambient>, f)`. Outside a report the ambient is `None`, so behavior is identical to today.
- `with_statement_timeout_scope(timeout, future)` sets the ambient value for the duration of the report's query stages (`execute_scope`, `apply_report_includes`, `build_template_items`).
- When set, each leaf query runs in a transaction that issues a bound `SET LOCAL statement_timeout`, which auto-reverts at COMMIT/ROLLBACK — nothing leaks back to the shared pool.
- Bookkeeping writes (task state, events, finalize) run **outside** the scope and stay unbounded.

This keeps the search layer, `QueryOptions`, and all callers untouched.

## Config

New knob `HUBUUM_REPORT_DB_STATEMENT_TIMEOUT_MS` (default `0` = disabled → behavior unchanged). When set it should typically be `<= HUBUUM_REPORT_STAGE_TIMEOUT_MS`. It complements, rather than replaces, the existing wall-clock budget.

## Notes / trade-off

The timeout flows implicitly (task-local) instead of through signatures — that is the deliberate cost of avoiding wide caller churn. It is safe here because each report runs as a single async chain on a single-threaded worker runtime and nothing in the report path `tokio::spawn`s. A full report-path integration test was skipped intentionally: it would need a deterministically-slow report query, and since `get_config()` is a shared global, mutating the timeout per-test would race the parallel suite. The mechanism is covered by helper-level tests instead.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean; `cargo fmt` — applied
- New unit tests: `StatementTimeoutMs::new`; `with_connection_timeout` (bounds + reverts, no leak); `ambient_statement_timeout_scope_bounds_with_connection`
- `source .env && ./run_tests.sh` — **627 passed, 0 failed** (+ admin CLI tests)
- No migration / `schema.rs` / endpoint-schema change → OpenAPI regen not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)