### PR TITLE
Harden ID newtypes and return NamespaceID from accessors (#57)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9154,7 +9154,8 @@
       },
       "ReportTemplateID": {
         "type": "integer",
-        "format": "int32"
+        "format": "int32",
+        "description": "Identifier wrapper for a [`ReportTemplate`]."
       },
       "ReportTemplateKind": {
         "type": "string",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,4 @@
-use actix_web::web;
+use actix_web::web::{self, PathConfig};
 
 pub mod handlers;
 pub mod openapi;
@@ -6,6 +6,10 @@ pub mod routes;
 pub mod v1;
 
 pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.service(web::scope("api/v1").configure(v1::routes::config))
+    // Map path-parameter extraction errors (e.g. an invalid id newtype) to `400` instead of
+    // actix's default `404`. Registered here so both the production app and the test harness, which
+    // share this `configure`, get the same edge behavior.
+    cfg.app_data(PathConfig::default().error_handler(crate::errors::path_error_handler))
+        .service(web::scope("api/v1").configure(v1::routes::config))
         .service(web::scope("api/v0").configure(routes::config));
 }

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -243,7 +243,7 @@ async fn create_class(
         class_name = class_data.name
     );
 
-    let namespace = NamespaceID(class_data.namespace_id);
+    let namespace = NamespaceID::new(class_data.namespace_id)?;
     can!(&pool, user, [Permissions::CreateClass], namespace);
 
     let class = class_data
@@ -337,7 +337,7 @@ async fn update_class(
             &pool,
             user,
             [Permissions::CreateClass],
-            NamespaceID(target_namespace_id)
+            NamespaceID::new(target_namespace_id)?
         );
     }
 
@@ -426,7 +426,7 @@ async fn get_class_permissions(
     let count_params = count_query_options(&params);
     let total_count = crate::models::namespace::count_groups_on_paginated(
         &pool,
-        NamespaceID(nid),
+        nid,
         vec![
             Permissions::CreateClass,
             Permissions::UpdateClass,
@@ -439,7 +439,7 @@ async fn get_class_permissions(
     let search_params = prepare_db_pagination::<GroupPermission>(&params)?;
     let permissions = groups_on_paginated(
         &pool,
-        NamespaceID(nid),
+        nid,
         vec![
             Permissions::CreateClass,
             Permissions::UpdateClass,
@@ -540,10 +540,7 @@ async fn create_class_relation(
         reverse_template_alias: partial_relation.reverse_template_alias.clone(),
     };
 
-    let ids = relation
-        .namespace_id(&pool)
-        .await
-        .map(|(id0, id1)| (NamespaceID(id0), NamespaceID(id1)))?;
+    let ids = relation.namespace_id(&pool).await?;
     can!(
         &pool,
         user,
@@ -601,10 +598,7 @@ async fn delete_class_relation(
 
     let relation = relation_id.instance(&pool).await?;
 
-    let ids = relation_id
-        .namespace_id(&pool)
-        .await
-        .map(|(id0, id1)| (NamespaceID(id0), NamespaceID(id1)))?;
+    let ids = relation_id.namespace_id(&pool).await?;
 
     can!(
         &pool,

--- a/src/api/v1/handlers/groups.rs
+++ b/src/api/v1/handlers/groups.rs
@@ -185,7 +185,7 @@ pub async fn delete_group(
 ) -> Result<impl Responder, ApiError> {
     debug!(
         message = "Group delete requested",
-        target = group_id.0,
+        target = group_id.id(),
         requestor = requestor.user.id
     );
 

--- a/src/api/v1/handlers/mod.rs
+++ b/src/api/v1/handlers/mod.rs
@@ -25,7 +25,7 @@ where
     C: SelfAccessors<HubuumClass>,
     O: SelfAccessors<HubuumObject> + ClassAccessors<HubuumClass>,
 {
-    let object_class_id = object.class_id(pool).await?;
+    let object_class_id = object.class_id(pool).await?.id();
 
     if object_class_id != class.id() {
         debug!(

--- a/src/api/v1/handlers/namespaces.rs
+++ b/src/api/v1/handlers/namespaces.rs
@@ -651,7 +651,7 @@ pub async fn get_namespace_user_permissions(
         message = "Namespace user permissions list requested",
         requestor = requestor.user.username,
         namespace_id = namespace_id.id(),
-        user_id = user_id.0
+        user_id = user_id.id()
     );
 
     let namespace = namespace_id.instance(&pool).await?;
@@ -665,7 +665,7 @@ pub async fn get_namespace_user_permissions(
     let search_params = prepare_db_pagination::<GroupPermission>(&query_options)?;
     let (permissions, total_count) = crate::models::namespace::user_on_paginated_with_total_count(
         &pool,
-        user_id.clone(),
+        user_id,
         namespace.clone(),
         &search_params,
     )

--- a/src/api/v1/handlers/relations.rs
+++ b/src/api/v1/handlers/relations.rs
@@ -5,7 +5,7 @@ use crate::extractors::UserAccess;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
     HubuumClassRelation, HubuumClassRelationID, HubuumObjectRelation, HubuumObjectRelationID,
-    NamespaceID, NewHubuumClassRelation, NewHubuumObjectRelation, Permissions,
+    NewHubuumClassRelation, NewHubuumObjectRelation, Permissions,
 };
 use crate::pagination::prepare_db_pagination;
 

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -344,7 +344,7 @@ async fn prepare_report_runtime(
 
     let namespace_templates = match &template {
         Some(template) => {
-            NamespaceID(template.namespace_id)
+            NamespaceID::new(template.namespace_id)?
                 .report_templates(pool, None)
                 .await?
         }
@@ -380,7 +380,7 @@ async fn resolve_template(
         pool,
         user.clone(),
         [Permissions::ReadTemplate],
-        NamespaceID(template.namespace_id)
+        NamespaceID::new(template.namespace_id)?
     );
 
     Ok(Some(template))
@@ -1144,7 +1144,7 @@ async fn build_template_items(
             Ok((hydrated_items, None))
         }
         ReportScopeKind::RelatedObjects => {
-            let source_object = HubuumObjectID(runtime.report.scope.object_id_required()?)
+            let source_object = HubuumObjectID::new(runtime.report.scope.object_id_required()?)?
                 .instance(pool)
                 .await?;
             let source = object_with_root_path(&source_object);
@@ -1986,8 +1986,8 @@ async fn execute_scope(
             to_json_items(user.search_object_relations(pool, query_options).await?)?
         }
         ReportScopeKind::RelatedObjects => {
-            let class_id = HubuumClassID(scope.class_id_required()?);
-            let object_id = HubuumObjectID(scope.object_id_required()?);
+            let class_id = HubuumClassID::new(scope.class_id_required()?)?;
+            let object_id = HubuumObjectID::new(scope.object_id_required()?)?;
             check_if_object_in_class(pool, &class_id, &object_id).await?;
             let source_object = object_id.instance(pool).await?;
             can!(pool, user.clone(), [Permissions::ReadObject], source_object);

--- a/src/api/v1/handlers/templates.rs
+++ b/src/api/v1/handlers/templates.rs
@@ -54,7 +54,7 @@ pub async fn create_template(
         &pool,
         user,
         [Permissions::CreateTemplate],
-        NamespaceID(template.namespace_id)
+        NamespaceID::new(template.namespace_id)?
     );
 
     let created = template.save(&pool).await?;
@@ -143,7 +143,7 @@ pub async fn get_template(
         &pool,
         user,
         [Permissions::ReadTemplate],
-        NamespaceID(template.namespace_id)
+        NamespaceID::new(template.namespace_id)?
     );
 
     Ok(json_response(template, StatusCode::OK))
@@ -192,7 +192,7 @@ pub async fn run_template_report(
         &pool,
         user.clone(),
         [Permissions::ReadTemplate],
-        NamespaceID(template.namespace_id)
+        NamespaceID::new(template.namespace_id)?
     );
 
     let report = template.build_report_request(run)?;
@@ -256,7 +256,7 @@ pub async fn patch_template(
         &pool,
         user.clone(),
         [Permissions::UpdateTemplate],
-        NamespaceID(existing.namespace_id)
+        NamespaceID::new(existing.namespace_id)?
     );
 
     if let Some(target_namespace) = update.namespace_id
@@ -266,7 +266,7 @@ pub async fn patch_template(
             &pool,
             user,
             [Permissions::CreateTemplate],
-            NamespaceID(target_namespace)
+            NamespaceID::new(target_namespace)?
         );
     }
 
@@ -311,7 +311,7 @@ pub async fn delete_template(
         &pool,
         user,
         [Permissions::DeleteTemplate],
-        NamespaceID(template.namespace_id)
+        NamespaceID::new(template.namespace_id)?
     );
 
     template_id.delete(&pool).await?;

--- a/src/api/v1/handlers/users.rs
+++ b/src/api/v1/handlers/users.rs
@@ -258,7 +258,7 @@ pub async fn delete_user(
 ) -> Result<impl Responder, ApiError> {
     debug!(
         message = "User delete requested",
-        target = user_id.0,
+        target = user_id.id(),
         requestor = requestor.user.id
     );
 

--- a/src/db/traits/class.rs
+++ b/src/db/traits/class.rs
@@ -25,7 +25,7 @@ impl GetClass for HubuumClassID {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id};
         with_connection(pool, |conn| -> Result<HubuumClass, diesel::result::Error> {
             let class = hubuumclass
-                .filter(id.eq(self.0))
+                .filter(id.eq(self.id()))
                 .first::<HubuumClass>(conn)?;
             Ok(class)
         })
@@ -65,7 +65,7 @@ impl GetClass<(HubuumClass, HubuumClass)> for HubuumClassRelationID {
             pool,
             |conn| -> Result<(HubuumClass, HubuumClass), diesel::result::Error> {
                 let relation = hubuumclass_relation
-                    .filter(rel_id.eq(self.0))
+                    .filter(rel_id.eq(self.id()))
                     .first::<HubuumClassRelation>(conn)?;
 
                 let from_class = hubuumclass

--- a/src/db/traits/group.rs
+++ b/src/db/traits/group.rs
@@ -15,7 +15,7 @@ impl LoadGroupRecord for GroupID {
         use crate::schema::groups::dsl::{groups, id};
 
         with_connection(pool, |conn| {
-            groups.filter(id.eq(self.0)).first::<Group>(conn)
+            groups.filter(id.eq(self.id())).first::<Group>(conn)
         })
     }
 }
@@ -29,7 +29,7 @@ impl DeleteGroupRecord for GroupID {
         use crate::schema::groups::dsl::{groups, id};
 
         with_connection(pool, |conn| {
-            diesel::delete(groups.filter(id.eq(self.0))).execute(conn)
+            diesel::delete(groups.filter(id.eq(self.id()))).execute(conn)
         })
     }
 }

--- a/src/db/traits/namespace/permissions.rs
+++ b/src/db/traits/namespace/permissions.rs
@@ -85,7 +85,7 @@ pub async fn user_on_from_backend<T: NamespaceAccessors>(
     use crate::schema::groups::dsl::{groups, id as group_table_id};
     use crate::schema::permissions::dsl::{group_id, namespace_id, permissions};
 
-    let namespace_target_id = namespace_ref.namespace_id(pool).await?;
+    let namespace_target_id = namespace_ref.namespace_id(pool).await?.id();
     let group_ids_subquery = user_id.group_ids_subquery_from_backend();
     let rows = with_connection(pool, |conn| {
         groups
@@ -113,7 +113,7 @@ pub async fn user_on_paginated_with_total_count_from_backend<T: NamespaceAccesso
     };
     use crate::{date_search, numeric_search, string_search};
 
-    let namespace_target_id = namespace_ref.namespace_id(pool).await?;
+    let namespace_target_id = namespace_ref.namespace_id(pool).await?.id();
     let build_query = || -> Result<_, ApiError> {
         let group_ids_subquery = user_id.group_ids_subquery_from_backend();
         let mut query = groups
@@ -215,7 +215,7 @@ pub async fn group_can_on_from_backend<T: NamespaceAccessors>(
     let base_query = permissions
         .into_boxed()
         .filter(group_id.eq(gid))
-        .filter(namespace_id.eq(namespace_ref.namespace_id(pool).await?));
+        .filter(namespace_id.eq(namespace_ref.namespace_id(pool).await?.id()));
 
     let filtered_query = permission_type.create_boxed_filter(base_query, true);
     let result = with_connection(pool, |conn| filtered_query.execute(conn))?;
@@ -315,7 +315,7 @@ pub async fn groups_on_from_backend<T: NamespaceAccessors>(
     };
     use crate::{date_search, numeric_search};
 
-    let namespace_target_id = namespace_ref.namespace_id(pool).await?;
+    let namespace_target_id = namespace_ref.namespace_id(pool).await?.id();
     let query_params = query_options.filters;
 
     let mut permission_filters = query_params.permissions()?;
@@ -418,7 +418,7 @@ pub async fn groups_on_paginated_with_total_count_from_backend<T: NamespaceAcces
     };
     use crate::{date_search, numeric_search, string_search};
 
-    let namespace_target_id = namespace_ref.namespace_id(pool).await?;
+    let namespace_target_id = namespace_ref.namespace_id(pool).await?.id();
     let mut permission_filters = query_options.filters.permissions()?;
     permission_filters.ensure_contains(&permissions_filter);
 

--- a/src/db/traits/namespace/records.rs
+++ b/src/db/traits/namespace/records.rs
@@ -19,7 +19,7 @@ impl DeleteNamespaceRecord for NamespaceID {
         use crate::schema::namespaces::dsl::{id, namespaces};
 
         with_connection(pool, |conn| {
-            diesel::delete(namespaces.filter(id.eq(self.0))).execute(conn)
+            diesel::delete(namespaces.filter(id.eq(self.id()))).execute(conn)
         })?;
         Ok(())
     }

--- a/src/db/traits/namespace/relations.rs
+++ b/src/db/traits/namespace/relations.rs
@@ -10,6 +10,8 @@ impl GetNamespace<(Namespace, Namespace)> for HubuumClassRelation {
         use crate::schema::namespaces::dsl::{id as namespace_id, namespaces};
 
         let (from_id, to_id) = self.class_id(pool).await?;
+        // Work with raw ids at the Diesel boundary.
+        let (from_id, to_id) = (from_id.id(), to_id.id());
 
         let namespace_list = with_connection(pool, |conn| {
             hubuumclass
@@ -47,6 +49,8 @@ impl GetNamespace<(Namespace, Namespace)> for NewHubuumClassRelation {
         use crate::schema::namespaces::dsl::{id as namespace_id, namespaces};
 
         let (from_id, to_id) = self.class_id(pool).await?;
+        // Work with raw ids at the Diesel boundary.
+        let (from_id, to_id) = (from_id.id(), to_id.id());
 
         let namespace_list = with_connection(pool, |conn| {
             hubuumclass
@@ -84,6 +88,8 @@ impl GetNamespace<(Namespace, Namespace)> for HubuumObjectRelation {
         use crate::schema::namespaces::dsl::{id as namespace_id, namespaces};
 
         let (from_id, to_id) = self.object_id(pool).await?;
+        // Work with raw ids at the Diesel boundary.
+        let (from_id, to_id) = (from_id.id(), to_id.id());
 
         let namespace_list = with_connection(pool, |conn| {
             hubuumobject
@@ -121,6 +127,8 @@ impl GetNamespace<(Namespace, Namespace)> for NewHubuumObjectRelation {
         use crate::schema::namespaces::dsl::{id as namespace_id, namespaces};
 
         let (from_id, to_id) = self.object_id(pool).await?;
+        // Work with raw ids at the Diesel boundary.
+        let (from_id, to_id) = (from_id.id(), to_id.id());
 
         let namespace_list = with_connection(pool, |conn| {
             hubuumobject
@@ -158,6 +166,8 @@ impl GetNamespace<(Namespace, Namespace)> for HubuumObjectRelationID {
         use crate::schema::namespaces::dsl::{id as namespace_id, namespaces};
 
         let (from_id, to_id) = self.object_id(pool).await?;
+        // Work with raw ids at the Diesel boundary.
+        let (from_id, to_id) = (from_id.id(), to_id.id());
 
         let namespace_list = with_connection(pool, |conn| {
             hubuumobject

--- a/src/db/traits/object.rs
+++ b/src/db/traits/object.rs
@@ -24,7 +24,7 @@ impl GetObject<(HubuumObject, HubuumObject)> for HubuumObjectRelationID {
 
         let objects = with_connection(pool, |conn| {
             obj_rel::hubuumobject_relation
-                .filter(obj_rel::id.eq(self.0))
+                .filter(obj_rel::id.eq(self.id()))
                 .inner_join(
                     obj::hubuumobject.on(obj::id
                         .eq(obj_rel::from_hubuum_object_id)
@@ -116,7 +116,7 @@ impl LoadObjectRecord for HubuumObjectID {
 
         with_connection(pool, |conn| {
             hubuumobject
-                .filter(id.eq(self.0))
+                .filter(id.eq(self.id()))
                 .first::<HubuumObject>(conn)
         })
     }
@@ -164,7 +164,7 @@ pub trait ValidateObjectRecord {
 
 impl ValidateObjectRecord for HubuumObject {
     async fn validate_object_record(&self, pool: &DbPool) -> Result<(), ApiError> {
-        let class = HubuumClassID(self.hubuum_class_id).class(pool).await?;
+        let class = HubuumClassID::new(self.hubuum_class_id)?.class(pool).await?;
 
         if class.validate_schema
             && let Some(ref schema) = class.json_schema
@@ -177,7 +177,7 @@ impl ValidateObjectRecord for HubuumObject {
 
 impl ValidateObjectRecord for NewHubuumObject {
     async fn validate_object_record(&self, pool: &DbPool) -> Result<(), ApiError> {
-        let class = HubuumClassID(self.hubuum_class_id).class(pool).await?;
+        let class = HubuumClassID::new(self.hubuum_class_id)?.class(pool).await?;
 
         if self.namespace_id != class.namespace_id {
             return Err(ApiError::BadRequest(format!(
@@ -198,9 +198,9 @@ impl ValidateObjectRecord for NewHubuumObject {
 impl ValidateObjectRecord for (&UpdateHubuumObject, i32) {
     async fn validate_object_record(&self, pool: &DbPool) -> Result<(), ApiError> {
         let (update_obj, object_id) = self;
-        let original = HubuumObjectID(*object_id).instance(pool).await?;
+        let original = HubuumObjectID::new(*object_id)?.instance(pool).await?;
         let merged = original.merge_update(update_obj);
-        let class = HubuumClassID(merged.hubuum_class_id).class(pool).await?;
+        let class = HubuumClassID::new(merged.hubuum_class_id)?.class(pool).await?;
 
         if merged.namespace_id != class.namespace_id {
             return Err(ApiError::BadRequest(format!(

--- a/src/db/traits/permissions.rs
+++ b/src/db/traits/permissions.rs
@@ -31,7 +31,7 @@ pub trait PermissionControllerBackend: Serialize + NamespaceAccessors {
         let group_id_subquery = user.group_ids_subquery_from_backend();
         let mut base_query = lookup_table
             .into_boxed()
-            .filter(namespace_id_field.eq(self.namespace_id(pool).await?))
+            .filter(namespace_id_field.eq(self.namespace_id(pool).await?.id()))
             .filter(group_id_field.eq_any(group_id_subquery));
 
         for permission in permissions_requested {
@@ -53,7 +53,7 @@ pub trait PermissionControllerBackend: Serialize + NamespaceAccessors {
     ) -> Result<Permission, ApiError> {
         use crate::schema::permissions::dsl::*;
 
-        let nid = self.namespace_id(pool).await?;
+        let nid = self.namespace_id(pool).await?.id();
 
         with_transaction(pool, |conn| -> Result<Permission, ApiError> {
             let existing_entry = permissions
@@ -235,7 +235,7 @@ pub trait PermissionControllerBackend: Serialize + NamespaceAccessors {
     ) -> Result<Permission, ApiError> {
         use crate::schema::permissions::dsl::*;
 
-        let nid = self.namespace_id(pool).await?;
+        let nid = self.namespace_id(pool).await?.id();
 
         with_transaction(pool, |conn| -> Result<Permission, ApiError> {
             permissions
@@ -336,7 +336,7 @@ pub trait PermissionControllerBackend: Serialize + NamespaceAccessors {
     ) -> Result<(), ApiError> {
         use crate::schema::permissions::dsl::*;
 
-        let namespace_id_for_revoke = self.namespace_id(pool).await?;
+        let namespace_id_for_revoke = self.namespace_id(pool).await?.id();
         with_connection(pool, |conn| {
             diesel::delete(permissions)
                 .filter(namespace_id.eq(namespace_id_for_revoke))

--- a/src/db/traits/relations.rs
+++ b/src/db/traits/relations.rs
@@ -655,7 +655,7 @@ impl LoadClassRelationRecord for HubuumClassRelationID {
 
         with_connection(pool, |conn| {
             hubuumclass_relation
-                .filter(id.eq(self.0))
+                .filter(id.eq(self.id()))
                 .first::<HubuumClassRelation>(conn)
         })
     }
@@ -681,7 +681,7 @@ impl DeleteClassRelationRecord for HubuumClassRelationID {
         use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
 
         with_connection(pool, |conn| {
-            diesel::delete(hubuumclass_relation.filter(id.eq(self.0))).execute(conn)
+            diesel::delete(hubuumclass_relation.filter(id.eq(self.id()))).execute(conn)
         })?;
         Ok(())
     }
@@ -752,7 +752,7 @@ impl LoadObjectRelationRecord for HubuumObjectRelationID {
 
         with_connection(pool, |conn| {
             hubuumobject_relation
-                .filter(id.eq(self.0))
+                .filter(id.eq(self.id()))
                 .first::<HubuumObjectRelation>(conn)
         })
     }
@@ -778,7 +778,7 @@ impl DeleteObjectRelationRecord for HubuumObjectRelationID {
         use crate::schema::hubuumobject_relation::dsl::{hubuumobject_relation, id};
 
         with_connection(pool, |conn| {
-            diesel::delete(hubuumobject_relation.filter(id.eq(self.0))).execute(conn)
+            diesel::delete(hubuumobject_relation.filter(id.eq(self.id()))).execute(conn)
         })?;
         Ok(())
     }
@@ -804,7 +804,7 @@ impl SaveObjectRelationRecord for NewHubuumObjectRelation {
             ));
         }
 
-        let obj1 = match HubuumObjectID(self.from_hubuum_object_id)
+        let obj1 = match HubuumObjectID::new(self.from_hubuum_object_id)?
             .instance(pool)
             .await
         {
@@ -816,7 +816,7 @@ impl SaveObjectRelationRecord for NewHubuumObjectRelation {
             }
         };
 
-        let obj2 = match HubuumObjectID(self.to_hubuum_object_id)
+        let obj2 = match HubuumObjectID::new(self.to_hubuum_object_id)?
             .instance(pool)
             .await
         {

--- a/src/db/traits/report_template.rs
+++ b/src/db/traits/report_template.rs
@@ -11,6 +11,7 @@ use diesel::prelude::*;
 
 use crate::db::{DbPool, with_connection};
 use crate::errors::ApiError;
+use crate::models::namespace::NamespaceID;
 use crate::models::report_template::{
     NewReportTemplateRow, ReportTemplate, ReportTemplateID, ReportTemplateRow,
     UpdateReportTemplateRow,
@@ -108,19 +109,26 @@ impl DeleteReportTemplateRecord for ReportTemplateID {
 
 /// Look up the namespace id of the report template identified by this id.
 pub(crate) trait ReportTemplateNamespaceLookup {
-    async fn lookup_report_template_namespace_id(&self, pool: &DbPool) -> Result<i32, ApiError>;
+    async fn lookup_report_template_namespace_id(
+        &self,
+        pool: &DbPool,
+    ) -> Result<NamespaceID, ApiError>;
 }
 
 impl ReportTemplateNamespaceLookup for ReportTemplateID {
-    async fn lookup_report_template_namespace_id(&self, pool: &DbPool) -> Result<i32, ApiError> {
+    async fn lookup_report_template_namespace_id(
+        &self,
+        pool: &DbPool,
+    ) -> Result<NamespaceID, ApiError> {
         use crate::schema::report_templates::dsl::{id, namespace_id, report_templates};
 
-        with_connection(pool, |conn| {
+        let raw = with_connection(pool, |conn| {
             report_templates
                 .filter(id.eq(self.id()))
                 .select(namespace_id)
                 .first::<i32>(conn)
-        })
+        })?;
+        NamespaceID::new(raw)
     }
 }
 

--- a/src/db/traits/user/auth.rs
+++ b/src/db/traits/user/auth.rs
@@ -134,7 +134,7 @@ impl DeleteUserRecord for UserID {
         use crate::schema::users::dsl::{id, users};
 
         with_connection(pool, |conn| {
-            diesel::delete(users.filter(id.eq(self.0))).execute(conn)
+            diesel::delete(users.filter(id.eq(self.id()))).execute(conn)
         })
     }
 }
@@ -201,6 +201,6 @@ impl LoadUserRecord for UserID {
     async fn load_user_record(&self, pool: &DbPool) -> Result<User, ApiError> {
         use crate::schema::users::dsl::{id, users};
 
-        with_connection(pool, |conn| users.filter(id.eq(self.0)).first::<User>(conn))
+        with_connection(pool, |conn| users.filter(id.eq(self.id())).first::<User>(conn))
     }
 }

--- a/src/db/traits/user/permissions.rs
+++ b/src/db/traits/user/permissions.rs
@@ -40,7 +40,7 @@ pub trait UserPermissions: SelfAccessors<User> + GroupAccessors + GroupMembershi
         let group_id_subquery = self.group_ids_subquery_from_backend();
 
         let namespace_ids: HashSet<i32> = stream::iter(namespaces)
-            .map(|ns| async move { ns.namespace_id(pool).await })
+            .map(|ns| async move { ns.namespace_id(pool).await.map(|nid| nid.id()) })
             // Batch the futures into groups of 5, to avoid overwhelming the database
             .buffered(5)
             .try_collect()

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -261,6 +261,14 @@ pub fn json_error_handler(err: JsonPayloadError, _: &HttpRequest) -> actix_web::
     ApiError::BadRequest(error_message).into()
 }
 
+/// Ensure that path-parameter errors are reported as a bad request rather than actix's default
+/// `404`. The validating `Deserialize` impls on the id newtypes already surface a clear message
+/// (e.g. "Invalid namespace id '0': must be a positive integer"); this maps that to a `400` so an
+/// invalid id is rejected at the edge as the contract promises.
+pub fn path_error_handler(err: actix_web::error::PathError, _: &HttpRequest) -> actix_web::Error {
+    ApiError::BadRequest(err.to_string()).into()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -77,10 +77,10 @@ macro_rules! can {
             $pool,
             vec![$($perm),+],
             vec![
-                // This should be fairly cheap. We're just getting the namespace ID for each object.
-                // which is a field lookup and convertinng it to NamespaceID directly. There is no
-                // database interaction here but the trait definition requires the pool to be passed.
-                $(NamespaceID($namespace.namespace_id($pool).await?)),+
+                // This should be fairly cheap. We're just getting the namespace ID for each object,
+                // which is a field lookup returning a `NamespaceID`. There is no database interaction
+                // here but the trait definition requires the pool to be passed.
+                $($namespace.namespace_id($pool).await?),+
             ]
         ).await?
     }};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -610,3 +610,72 @@ macro_rules! bind_transitive_filter_params {
             .bind::<diesel::sql_types::Bool, _>($filter.path_negated)
     }};
 }
+
+/// ## Declare an `i32`-backed id newtype with a validating constructor.
+///
+/// Generates the tuple struct (with a private field), a validating `new` that rejects
+/// non-positive ids, an `id()` accessor for the rare persistence boundaries that still operate on
+/// the raw `i32`, and a `Deserialize` impl routed through `new` so an invalid id is rejected at
+/// the API edge with a clear `400` rather than surfacing later as a confusing lookup miss.
+///
+/// `new` and `id` are deliberately *inherent* rather than trait methods: an `id()` on a shared
+/// trait would collide with [`SelfAccessors::id`](crate::traits::SelfAccessors::id), and a trait
+/// constructor would have to expose an unchecked `from_raw`, defeating the private field.
+///
+/// ### Arguments
+///
+/// * `noun` - human-readable name used in the validation error, e.g. `"namespace id"`.
+///
+/// ### Example
+///
+/// ```ignore
+/// int_id_newtype! {
+///     /// Identifier for a namespace.
+///     pub struct NamespaceID;
+///     noun = "namespace id";
+/// }
+/// ```
+#[macro_export]
+macro_rules! int_id_newtype {
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident;
+        noun = $noun:literal $(;)?
+    ) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq, utoipa::ToSchema)]
+        $vis struct $name(i32);
+
+        impl $name {
+            #[doc = concat!("Validating constructor: ", $noun, "s are positive integers.")]
+            ///
+            /// Constructing through `new` (and the `Deserialize` impl, which routes through it)
+            /// means an invalid id is rejected at the edge with a clear `400` rather than
+            /// surfacing later as a confusing lookup miss.
+            pub fn new(id: i32) -> Result<Self, $crate::errors::ApiError> {
+                if id <= 0 {
+                    return Err($crate::errors::ApiError::BadRequest(format!(
+                        concat!("Invalid ", $noun, " '{id}': must be a positive integer"),
+                        id = id
+                    )));
+                }
+                Ok(Self(id))
+            }
+
+            /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
+            pub fn id(self) -> i32 {
+                self.0
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let id = <i32 as serde::Deserialize>::deserialize(deserializer)?;
+                Self::new(id).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -55,8 +55,37 @@ pub struct HubuumClassWithPath {
     pub path: Vec<i32>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
-pub struct HubuumClassID(pub i32);
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
+pub struct HubuumClassID(i32);
+
+impl HubuumClassID {
+    /// Validating constructor: class ids are positive integers. Constructing through `new` (and the
+    /// `Deserialize` impl, which routes through it) means an invalid id is rejected at the edge with
+    /// a clear `400` rather than surfacing later as a confusing lookup miss.
+    pub fn new(id: i32) -> Result<Self, ApiError> {
+        if id <= 0 {
+            return Err(ApiError::BadRequest(format!(
+                "Invalid class id '{id}': must be a positive integer"
+            )));
+        }
+        Ok(Self(id))
+    }
+
+    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
+    pub fn id(self) -> i32 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for HubuumClassID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let id = i32::deserialize(deserializer)?;
+        HubuumClassID::new(id).map_err(serde::de::Error::custom)
+    }
+}
 
 /// A normalized set of class ids: deduplicated, sorted ascending, and guaranteed positive.
 ///
@@ -171,7 +200,7 @@ pub mod tests {
         let class = create_class(&pool, &namespace.namespace, class_name).await;
 
         assert_eq!(
-            class.namespace_id(&pool).await.unwrap(),
+            class.namespace_id(&pool).await.unwrap().id(),
             namespace.namespace.id
         );
         assert_eq!(class.name, class_name);

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -55,36 +55,10 @@ pub struct HubuumClassWithPath {
     pub path: Vec<i32>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
-pub struct HubuumClassID(i32);
-
-impl HubuumClassID {
-    /// Validating constructor: class ids are positive integers. Constructing through `new` (and the
-    /// `Deserialize` impl, which routes through it) means an invalid id is rejected at the edge with
-    /// a clear `400` rather than surfacing later as a confusing lookup miss.
-    pub fn new(id: i32) -> Result<Self, ApiError> {
-        if id <= 0 {
-            return Err(ApiError::BadRequest(format!(
-                "Invalid class id '{id}': must be a positive integer"
-            )));
-        }
-        Ok(Self(id))
-    }
-
-    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
-    pub fn id(self) -> i32 {
-        self.0
-    }
-}
-
-impl<'de> Deserialize<'de> for HubuumClassID {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let id = i32::deserialize(deserializer)?;
-        HubuumClassID::new(id).map_err(serde::de::Error::custom)
-    }
+crate::int_id_newtype! {
+    /// Identifier wrapper for a [`HubuumClass`].
+    pub struct HubuumClassID;
+    noun = "class id";
 }
 
 /// A normalized set of class ids: deduplicated, sorted ascending, and guaranteed positive.

--- a/src/models/group.rs
+++ b/src/models/group.rs
@@ -21,8 +21,37 @@ use crate::traits::{
 
 use crate::db::DbPool;
 
-#[derive(Serialize, Deserialize, ToSchema)]
-pub struct GroupID(pub i32);
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
+pub struct GroupID(i32);
+
+impl GroupID {
+    /// Validating constructor: group ids are positive integers. Constructing through `new` (and the
+    /// `Deserialize` impl, which routes through it) means an invalid id is rejected at the edge with
+    /// a clear `400` rather than surfacing later as a confusing lookup miss.
+    pub fn new(id: i32) -> Result<Self, ApiError> {
+        if id <= 0 {
+            return Err(ApiError::BadRequest(format!(
+                "Invalid group id '{id}': must be a positive integer"
+            )));
+        }
+        Ok(Self(id))
+    }
+
+    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
+    pub fn id(self) -> i32 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for GroupID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let id = i32::deserialize(deserializer)?;
+        GroupID::new(id).map_err(serde::de::Error::custom)
+    }
+}
 
 impl IdAccessor for GroupID {
     fn accessor_id(&self) -> i32 {

--- a/src/models/group.rs
+++ b/src/models/group.rs
@@ -21,36 +21,10 @@ use crate::traits::{
 
 use crate::db::DbPool;
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
-pub struct GroupID(i32);
-
-impl GroupID {
-    /// Validating constructor: group ids are positive integers. Constructing through `new` (and the
-    /// `Deserialize` impl, which routes through it) means an invalid id is rejected at the edge with
-    /// a clear `400` rather than surfacing later as a confusing lookup miss.
-    pub fn new(id: i32) -> Result<Self, ApiError> {
-        if id <= 0 {
-            return Err(ApiError::BadRequest(format!(
-                "Invalid group id '{id}': must be a positive integer"
-            )));
-        }
-        Ok(Self(id))
-    }
-
-    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
-    pub fn id(self) -> i32 {
-        self.0
-    }
-}
-
-impl<'de> Deserialize<'de> for GroupID {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let id = i32::deserialize(deserializer)?;
-        GroupID::new(id).map_err(serde::de::Error::custom)
-    }
+crate::int_id_newtype! {
+    /// Identifier wrapper for a [`Group`].
+    pub struct GroupID;
+    noun = "group id";
 }
 
 impl IdAccessor for GroupID {

--- a/src/models/namespace.rs
+++ b/src/models/namespace.rs
@@ -28,36 +28,10 @@ pub struct Namespace {
     pub updated_at: chrono::NaiveDateTime,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
-pub struct NamespaceID(i32);
-
-impl NamespaceID {
-    /// Validating constructor: namespace ids are positive integers. Constructing through `new` (and
-    /// the `Deserialize` impl, which routes through it) means an invalid id is rejected at the edge
-    /// with a clear `400` rather than surfacing later as a confusing lookup miss.
-    pub fn new(id: i32) -> Result<Self, ApiError> {
-        if id <= 0 {
-            return Err(ApiError::BadRequest(format!(
-                "Invalid namespace id '{id}': must be a positive integer"
-            )));
-        }
-        Ok(Self(id))
-    }
-
-    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
-    pub fn id(self) -> i32 {
-        self.0
-    }
-}
-
-impl<'de> Deserialize<'de> for NamespaceID {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let id = i32::deserialize(deserializer)?;
-        NamespaceID::new(id).map_err(serde::de::Error::custom)
-    }
+crate::int_id_newtype! {
+    /// Identifier wrapper for a [`Namespace`].
+    pub struct NamespaceID;
+    noun = "namespace id";
 }
 
 #[derive(Serialize, Deserialize, Clone, AsChangeset, ToSchema)]

--- a/src/models/namespace.rs
+++ b/src/models/namespace.rs
@@ -28,8 +28,37 @@ pub struct Namespace {
     pub updated_at: chrono::NaiveDateTime,
 }
 
-#[derive(Serialize, Debug, Deserialize, Copy, Clone, ToSchema)]
-pub struct NamespaceID(pub i32);
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
+pub struct NamespaceID(i32);
+
+impl NamespaceID {
+    /// Validating constructor: namespace ids are positive integers. Constructing through `new` (and
+    /// the `Deserialize` impl, which routes through it) means an invalid id is rejected at the edge
+    /// with a clear `400` rather than surfacing later as a confusing lookup miss.
+    pub fn new(id: i32) -> Result<Self, ApiError> {
+        if id <= 0 {
+            return Err(ApiError::BadRequest(format!(
+                "Invalid namespace id '{id}': must be a positive integer"
+            )));
+        }
+        Ok(Self(id))
+    }
+
+    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
+    pub fn id(self) -> i32 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for NamespaceID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let id = i32::deserialize(deserializer)?;
+        NamespaceID::new(id).map_err(serde::de::Error::custom)
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone, AsChangeset, ToSchema)]
 #[schema(example = update_namespace_example)]

--- a/src/models/object.rs
+++ b/src/models/object.rs
@@ -55,36 +55,10 @@ pub struct UpdateHubuumObject {
     pub description: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
-pub struct HubuumObjectID(i32);
-
-impl HubuumObjectID {
-    /// Validating constructor: object ids are positive integers. Constructing through `new` (and the
-    /// `Deserialize` impl, which routes through it) means an invalid id is rejected at the edge with
-    /// a clear `400` rather than surfacing later as a confusing lookup miss.
-    pub fn new(id: i32) -> Result<Self, ApiError> {
-        if id <= 0 {
-            return Err(ApiError::BadRequest(format!(
-                "Invalid object id '{id}': must be a positive integer"
-            )));
-        }
-        Ok(Self(id))
-    }
-
-    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
-    pub fn id(self) -> i32 {
-        self.0
-    }
-}
-
-impl<'de> Deserialize<'de> for HubuumObjectID {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let id = i32::deserialize(deserializer)?;
-        HubuumObjectID::new(id).map_err(serde::de::Error::custom)
-    }
+crate::int_id_newtype! {
+    /// Identifier wrapper for a [`HubuumObject`].
+    pub struct HubuumObjectID;
+    noun = "object id";
 }
 
 // For objects per class.

--- a/src/models/object.rs
+++ b/src/models/object.rs
@@ -55,8 +55,37 @@ pub struct UpdateHubuumObject {
     pub description: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema)]
-pub struct HubuumObjectID(pub i32);
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
+pub struct HubuumObjectID(i32);
+
+impl HubuumObjectID {
+    /// Validating constructor: object ids are positive integers. Constructing through `new` (and the
+    /// `Deserialize` impl, which routes through it) means an invalid id is rejected at the edge with
+    /// a clear `400` rather than surfacing later as a confusing lookup miss.
+    pub fn new(id: i32) -> Result<Self, ApiError> {
+        if id <= 0 {
+            return Err(ApiError::BadRequest(format!(
+                "Invalid object id '{id}': must be a positive integer"
+            )));
+        }
+        Ok(Self(id))
+    }
+
+    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
+    pub fn id(self) -> i32 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for HubuumObjectID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let id = i32::deserialize(deserializer)?;
+        HubuumObjectID::new(id).map_err(serde::de::Error::custom)
+    }
+}
 
 // For objects per class.
 #[derive(QueryableByName, Debug, Serialize, Deserialize, ToSchema)]

--- a/src/models/relation.rs
+++ b/src/models/relation.rs
@@ -4,40 +4,13 @@ use diesel::sql_types::{Array, Bool, Integer, Jsonb, Nullable, Text, Timestamp};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::errors::ApiError;
 use crate::models::{HubuumClassWithPath, HubuumObjectWithPath};
 use crate::{schema::hubuumclass_relation, schema::hubuumobject_relation};
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
-pub struct HubuumClassRelationID(i32);
-
-impl HubuumClassRelationID {
-    /// Validating constructor: class-relation ids are positive integers. Constructing through `new`
-    /// (and the `Deserialize` impl, which routes through it) means an invalid id is rejected at the
-    /// edge with a clear `400` rather than surfacing later as a confusing lookup miss.
-    pub fn new(id: i32) -> Result<Self, ApiError> {
-        if id <= 0 {
-            return Err(ApiError::BadRequest(format!(
-                "Invalid class relation id '{id}': must be a positive integer"
-            )));
-        }
-        Ok(Self(id))
-    }
-
-    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
-    pub fn id(self) -> i32 {
-        self.0
-    }
-}
-
-impl<'de> Deserialize<'de> for HubuumClassRelationID {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let id = i32::deserialize(deserializer)?;
-        HubuumClassRelationID::new(id).map_err(serde::de::Error::custom)
-    }
+crate::int_id_newtype! {
+    /// Identifier wrapper for a [`HubuumClassRelation`].
+    pub struct HubuumClassRelationID;
+    noun = "class relation id";
 }
 
 #[derive(Debug, Serialize, Deserialize, Queryable, Clone, PartialEq, Eq, ToSchema)]
@@ -72,36 +45,10 @@ pub struct NewHubuumClassRelationFromClass {
     pub reverse_template_alias: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
-pub struct HubuumObjectRelationID(i32);
-
-impl HubuumObjectRelationID {
-    /// Validating constructor: object-relation ids are positive integers. Constructing through
-    /// `new` (and the `Deserialize` impl, which routes through it) means an invalid id is rejected
-    /// at the edge with a clear `400` rather than surfacing later as a confusing lookup miss.
-    pub fn new(id: i32) -> Result<Self, ApiError> {
-        if id <= 0 {
-            return Err(ApiError::BadRequest(format!(
-                "Invalid object relation id '{id}': must be a positive integer"
-            )));
-        }
-        Ok(Self(id))
-    }
-
-    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
-    pub fn id(self) -> i32 {
-        self.0
-    }
-}
-
-impl<'de> Deserialize<'de> for HubuumObjectRelationID {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let id = i32::deserialize(deserializer)?;
-        HubuumObjectRelationID::new(id).map_err(serde::de::Error::custom)
-    }
+crate::int_id_newtype! {
+    /// Identifier wrapper for a [`HubuumObjectRelation`].
+    pub struct HubuumObjectRelationID;
+    noun = "object relation id";
 }
 
 #[derive(Debug, Serialize, Deserialize, Queryable, Clone, Copy, PartialEq, Eq, ToSchema)]

--- a/src/models/relation.rs
+++ b/src/models/relation.rs
@@ -4,11 +4,41 @@ use diesel::sql_types::{Array, Bool, Integer, Jsonb, Nullable, Text, Timestamp};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+use crate::errors::ApiError;
 use crate::models::{HubuumClassWithPath, HubuumObjectWithPath};
 use crate::{schema::hubuumclass_relation, schema::hubuumobject_relation};
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct HubuumClassRelationID(pub i32);
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
+pub struct HubuumClassRelationID(i32);
+
+impl HubuumClassRelationID {
+    /// Validating constructor: class-relation ids are positive integers. Constructing through `new`
+    /// (and the `Deserialize` impl, which routes through it) means an invalid id is rejected at the
+    /// edge with a clear `400` rather than surfacing later as a confusing lookup miss.
+    pub fn new(id: i32) -> Result<Self, ApiError> {
+        if id <= 0 {
+            return Err(ApiError::BadRequest(format!(
+                "Invalid class relation id '{id}': must be a positive integer"
+            )));
+        }
+        Ok(Self(id))
+    }
+
+    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
+    pub fn id(self) -> i32 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for HubuumClassRelationID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let id = i32::deserialize(deserializer)?;
+        HubuumClassRelationID::new(id).map_err(serde::de::Error::custom)
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize, Queryable, Clone, PartialEq, Eq, ToSchema)]
 #[diesel(table_name = hubuumclass_relation)]
@@ -42,8 +72,37 @@ pub struct NewHubuumClassRelationFromClass {
     pub reverse_template_alias: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct HubuumObjectRelationID(pub i32);
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
+pub struct HubuumObjectRelationID(i32);
+
+impl HubuumObjectRelationID {
+    /// Validating constructor: object-relation ids are positive integers. Constructing through
+    /// `new` (and the `Deserialize` impl, which routes through it) means an invalid id is rejected
+    /// at the edge with a clear `400` rather than surfacing later as a confusing lookup miss.
+    pub fn new(id: i32) -> Result<Self, ApiError> {
+        if id <= 0 {
+            return Err(ApiError::BadRequest(format!(
+                "Invalid object relation id '{id}': must be a positive integer"
+            )));
+        }
+        Ok(Self(id))
+    }
+
+    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
+    pub fn id(self) -> i32 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for HubuumObjectRelationID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let id = i32::deserialize(deserializer)?;
+        HubuumObjectRelationID::new(id).map_err(serde::de::Error::custom)
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize, Queryable, Clone, Copy, PartialEq, Eq, ToSchema)]
 #[diesel(table_name = hubuumobject_relation)]

--- a/src/models/report_template.rs
+++ b/src/models/report_template.rs
@@ -445,7 +445,7 @@ pub trait NamespaceReportTemplates: NamespaceAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        let namespace_id = self.namespace_id(backend).await?;
+        let namespace_id = self.namespace_id(backend).await?.id();
         let rows = crate::db::traits::report_template::load_rows_in_namespace(
             backend.db_pool(),
             namespace_id,
@@ -480,7 +480,7 @@ impl SaveAdapter for NewReportTemplate {
             },
         )
         .await?;
-        let namespace_templates = NamespaceID(new_row.namespace_id)
+        let namespace_templates = NamespaceID::new(new_row.namespace_id)?
             .report_templates(pool, None)
             .await?;
         validate_template(
@@ -571,7 +571,7 @@ async fn apply_report_template_update(
         },
     )
     .await?;
-    let namespace_templates = NamespaceID(target_namespace_id)
+    let namespace_templates = NamespaceID::new(target_namespace_id)?
         .report_templates(pool, Some(template_id))
         .await?;
     validate_template(
@@ -933,22 +933,25 @@ impl InstanceAdapter<ReportTemplate> for ReportTemplateID {
 
 impl NamespaceAdapter for ReportTemplate {
     async fn namespace_adapter(&self, pool: &DbPool) -> Result<Namespace, ApiError> {
-        NamespaceID(self.namespace_id).namespace_adapter(pool).await
+        NamespaceID::new(self.namespace_id)?
+            .namespace_adapter(pool)
+            .await
     }
 
-    async fn namespace_id_adapter(&self, _pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.namespace_id)
+    async fn namespace_id_adapter(&self, _pool: &DbPool) -> Result<NamespaceID, ApiError> {
+        NamespaceID::new(self.namespace_id)
     }
 }
 
 impl NamespaceAdapter for ReportTemplateID {
     async fn namespace_adapter(&self, pool: &DbPool) -> Result<Namespace, ApiError> {
-        NamespaceID(self.namespace_id_adapter(pool).await?)
+        self.namespace_id_adapter(pool)
+            .await?
             .namespace_adapter(pool)
             .await
     }
 
-    async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<i32, ApiError> {
+    async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<NamespaceID, ApiError> {
         self.lookup_report_template_namespace_id(pool).await
     }
 }

--- a/src/models/report_template.rs
+++ b/src/models/report_template.rs
@@ -97,36 +97,10 @@ pub struct ReportTemplate {
     pub updated_at: chrono::NaiveDateTime,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
-pub struct ReportTemplateID(i32);
-
-impl ReportTemplateID {
-    /// Validating constructor: report-template ids are positive integers. Constructing through
-    /// `new` (and the `Deserialize` impl, which routes through it) means an invalid id is rejected
-    /// at the edge with a clear `400` rather than surfacing later as a confusing lookup miss.
-    pub fn new(id: i32) -> Result<Self, ApiError> {
-        if id <= 0 {
-            return Err(ApiError::BadRequest(format!(
-                "Invalid report template id '{id}': must be a positive integer"
-            )));
-        }
-        Ok(Self(id))
-    }
-
-    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
-    pub fn id(self) -> i32 {
-        self.0
-    }
-}
-
-impl<'de> Deserialize<'de> for ReportTemplateID {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let id = i32::deserialize(deserializer)?;
-        ReportTemplateID::new(id).map_err(serde::de::Error::custom)
-    }
+crate::int_id_newtype! {
+    /// Identifier wrapper for a [`ReportTemplate`].
+    pub struct ReportTemplateID;
+    noun = "report template id";
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -117,36 +117,10 @@ impl From<TaskResultCounts> for (i32, i32, i32) {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
-pub struct TaskID(i32);
-
-impl TaskID {
-    /// Validating constructor: task ids are positive integers. Constructing through `new` (and the
-    /// `Deserialize` impl, which routes through it) means an invalid id is rejected at the edge with
-    /// a clear `400` rather than surfacing later as a confusing lookup miss.
-    pub fn new(id: i32) -> Result<Self, ApiError> {
-        if id <= 0 {
-            return Err(ApiError::BadRequest(format!(
-                "Invalid task id '{id}': must be a positive integer"
-            )));
-        }
-        Ok(Self(id))
-    }
-
-    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
-    pub fn id(self) -> i32 {
-        self.0
-    }
-}
-
-impl<'de> Deserialize<'de> for TaskID {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let id = i32::deserialize(deserializer)?;
-        TaskID::new(id).map_err(serde::de::Error::custom)
-    }
+crate::int_id_newtype! {
+    /// Identifier wrapper for a task.
+    pub struct TaskID;
+    noun = "task id";
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]

--- a/src/models/traits/class.rs
+++ b/src/models/traits/class.rs
@@ -63,8 +63,8 @@ impl InstanceAdapter<HubuumClass> for HubuumClass {
 }
 
 impl ClassAdapter for HubuumClass {
-    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.id)
+    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<HubuumClassID, ApiError> {
+        HubuumClassID::new(self.id)
     }
 
     async fn class_adapter(&self, _pool: &DbPool) -> Result<HubuumClass, ApiError> {
@@ -98,8 +98,8 @@ impl InstanceAdapter<HubuumClass> for HubuumClassID {
 }
 
 impl ClassAdapter for HubuumClassID {
-    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.id())
+    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<HubuumClassID, ApiError> {
+        Ok(*self)
     }
 
     async fn class_adapter(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {

--- a/src/models/traits/class.rs
+++ b/src/models/traits/class.rs
@@ -84,6 +84,9 @@ impl NamespaceAdapter for HubuumClass {
 
 impl IdAccessor for HubuumClassID {
     fn accessor_id(&self) -> i32 {
+        // Deref to the owned (Copy) value on purpose: with a `&self` receiver, `self.id()`
+        // binds to the `SelfAccessors::id` trait method, which calls back into `accessor_id`
+        // and recurses. The inherent `id` is only selected on an owned receiver.
         (*self).id()
     }
 }

--- a/src/models/traits/class.rs
+++ b/src/models/traits/class.rs
@@ -8,7 +8,9 @@ use crate::db::traits::class::{
 use crate::errors::ApiError;
 use crate::traits::crud::{DeleteAdapter, SaveAdapter, UpdateAdapter};
 
-use crate::models::{HubuumClass, HubuumClassID, Namespace, NewHubuumClass, UpdateHubuumClass};
+use crate::models::{
+    HubuumClass, HubuumClassID, Namespace, NamespaceID, NewHubuumClass, UpdateHubuumClass,
+};
 
 impl SaveAdapter for HubuumClass {
     type Output = HubuumClass;
@@ -75,14 +77,14 @@ impl NamespaceAdapter for HubuumClass {
         self.lookup_class_namespace(pool).await
     }
 
-    async fn namespace_id_adapter(&self, _pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.namespace_id)
+    async fn namespace_id_adapter(&self, _pool: &DbPool) -> Result<NamespaceID, ApiError> {
+        NamespaceID::new(self.namespace_id)
     }
 }
 
 impl IdAccessor for HubuumClassID {
     fn accessor_id(&self) -> i32 {
-        self.0
+        (*self).id()
     }
 }
 
@@ -94,7 +96,7 @@ impl InstanceAdapter<HubuumClass> for HubuumClassID {
 
 impl ClassAdapter for HubuumClassID {
     async fn class_id_adapter(&self, _pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.0)
+        Ok(self.id())
     }
 
     async fn class_adapter(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
@@ -107,8 +109,8 @@ impl NamespaceAdapter for HubuumClassID {
         self.lookup_class_namespace(pool).await
     }
 
-    async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.namespace(pool).await?.id)
+    async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<NamespaceID, ApiError> {
+        NamespaceID::new(self.namespace(pool).await?.id)
     }
 }
 

--- a/src/models/traits/class_relation.rs
+++ b/src/models/traits/class_relation.rs
@@ -22,6 +22,9 @@ use crate::traits::{
 
 impl IdAccessor for HubuumClassRelationID {
     fn accessor_id(&self) -> i32 {
+        // Deref to the owned (Copy) value on purpose: with a `&self` receiver, `self.id()`
+        // binds to the `SelfAccessors::id` trait method, which calls back into `accessor_id`
+        // and recurses. The inherent `id` is only selected on an owned receiver.
         (*self).id()
     }
 }

--- a/src/models/traits/class_relation.rs
+++ b/src/models/traits/class_relation.rs
@@ -8,7 +8,7 @@ use crate::models::search::{FilterField, SortParam};
 use crate::models::{
     ClassGraphRow, HubuumClass, HubuumClassRelation, HubuumClassRelationID,
     HubuumClassRelationTransitive, HubuumClassWithPath, HubuumObject, HubuumObjectRelation,
-    HubuumObjectRelationID, Namespace, NewHubuumClassRelation, NewHubuumObjectRelation,
+    HubuumObjectRelationID, Namespace, NamespaceID, NewHubuumClassRelation, NewHubuumObjectRelation,
     ObjectGraphRow, RelatedObjectGraphRow,
 };
 use crate::traits::accessors::{
@@ -22,7 +22,7 @@ use crate::traits::{
 
 impl IdAccessor for HubuumClassRelationID {
     fn accessor_id(&self) -> i32 {
-        self.0
+        (*self).id()
     }
 }
 
@@ -63,61 +63,76 @@ impl DeleteAdapter for HubuumClassRelationID {
     }
 }
 
-impl NamespaceAdapter<(Namespace, Namespace), (i32, i32)> for NewHubuumClassRelation {
+impl NamespaceAdapter<(Namespace, Namespace), (NamespaceID, NamespaceID)> for NewHubuumClassRelation {
     async fn namespace_adapter(&self, pool: &DbPool) -> Result<(Namespace, Namespace), ApiError> {
         use crate::db::traits::GetNamespace;
         self.namespace_from_backend(pool).await
     }
 
-    async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<(i32, i32), ApiError> {
+    async fn namespace_id_adapter(
+        &self,
+        pool: &DbPool,
+    ) -> Result<(NamespaceID, NamespaceID), ApiError> {
         let (ns1, ns2) = self.namespace(pool).await?;
-        Ok((ns1.id, ns2.id))
+        Ok((NamespaceID::new(ns1.id)?, NamespaceID::new(ns2.id)?))
     }
 }
 
-impl NamespaceAdapter<(Namespace, Namespace), (i32, i32)> for NewHubuumObjectRelation {
+impl NamespaceAdapter<(Namespace, Namespace), (NamespaceID, NamespaceID)> for NewHubuumObjectRelation {
     async fn namespace_adapter(&self, pool: &DbPool) -> Result<(Namespace, Namespace), ApiError> {
         use crate::db::traits::GetNamespace;
         self.namespace_from_backend(pool).await
     }
 
-    async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<(i32, i32), ApiError> {
+    async fn namespace_id_adapter(
+        &self,
+        pool: &DbPool,
+    ) -> Result<(NamespaceID, NamespaceID), ApiError> {
         let (ns1, ns2) = self.namespace(pool).await?;
-        Ok((ns1.id, ns2.id))
+        Ok((NamespaceID::new(ns1.id)?, NamespaceID::new(ns2.id)?))
     }
 }
 
-impl NamespaceAdapter<(Namespace, Namespace), (i32, i32)> for HubuumObjectRelationID {
+impl NamespaceAdapter<(Namespace, Namespace), (NamespaceID, NamespaceID)> for HubuumObjectRelationID {
     async fn namespace_adapter(&self, pool: &DbPool) -> Result<(Namespace, Namespace), ApiError> {
         self.instance(pool).await?.namespace(pool).await
     }
 
-    async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<(i32, i32), ApiError> {
+    async fn namespace_id_adapter(
+        &self,
+        pool: &DbPool,
+    ) -> Result<(NamespaceID, NamespaceID), ApiError> {
         self.instance(pool).await?.namespace_id(pool).await
     }
 }
 
-impl NamespaceAdapter<(Namespace, Namespace), (i32, i32)> for HubuumObjectRelation {
+impl NamespaceAdapter<(Namespace, Namespace), (NamespaceID, NamespaceID)> for HubuumObjectRelation {
     async fn namespace_adapter(&self, pool: &DbPool) -> Result<(Namespace, Namespace), ApiError> {
         use crate::db::traits::GetNamespace;
         self.namespace_from_backend(pool).await
     }
 
-    async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<(i32, i32), ApiError> {
+    async fn namespace_id_adapter(
+        &self,
+        pool: &DbPool,
+    ) -> Result<(NamespaceID, NamespaceID), ApiError> {
         let (ns1, ns2) = self.namespace(pool).await?;
-        Ok((ns1.id, ns2.id))
+        Ok((NamespaceID::new(ns1.id)?, NamespaceID::new(ns2.id)?))
     }
 }
 
-impl NamespaceAdapter<(Namespace, Namespace), (i32, i32)> for HubuumClassRelation {
+impl NamespaceAdapter<(Namespace, Namespace), (NamespaceID, NamespaceID)> for HubuumClassRelation {
     async fn namespace_adapter(&self, pool: &DbPool) -> Result<(Namespace, Namespace), ApiError> {
         use crate::db::traits::GetNamespace;
         self.namespace_from_backend(pool).await
     }
 
-    async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<(i32, i32), ApiError> {
+    async fn namespace_id_adapter(
+        &self,
+        pool: &DbPool,
+    ) -> Result<(NamespaceID, NamespaceID), ApiError> {
         let (ns1, ns2) = self.namespace(pool).await?;
-        Ok((ns1.id, ns2.id))
+        Ok((NamespaceID::new(ns1.id)?, NamespaceID::new(ns2.id)?))
     }
 }
 
@@ -132,12 +147,15 @@ impl ClassAdapter<(HubuumClass, HubuumClass), (i32, i32)> for HubuumClassRelatio
     }
 }
 
-impl NamespaceAdapter<(Namespace, Namespace), (i32, i32)> for HubuumClassRelationID {
+impl NamespaceAdapter<(Namespace, Namespace), (NamespaceID, NamespaceID)> for HubuumClassRelationID {
     async fn namespace_adapter(&self, pool: &DbPool) -> Result<(Namespace, Namespace), ApiError> {
         self.instance(pool).await?.namespace(pool).await
     }
 
-    async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<(i32, i32), ApiError> {
+    async fn namespace_id_adapter(
+        &self,
+        pool: &DbPool,
+    ) -> Result<(NamespaceID, NamespaceID), ApiError> {
         self.instance(pool).await?.namespace_id(pool).await
     }
 }

--- a/src/models/traits/class_relation.rs
+++ b/src/models/traits/class_relation.rs
@@ -6,10 +6,10 @@ use crate::errors::ApiError;
 
 use crate::models::search::{FilterField, SortParam};
 use crate::models::{
-    ClassGraphRow, HubuumClass, HubuumClassRelation, HubuumClassRelationID,
-    HubuumClassRelationTransitive, HubuumClassWithPath, HubuumObject, HubuumObjectRelation,
-    HubuumObjectRelationID, Namespace, NamespaceID, NewHubuumClassRelation, NewHubuumObjectRelation,
-    ObjectGraphRow, RelatedObjectGraphRow,
+    ClassGraphRow, HubuumClass, HubuumClassID, HubuumClassRelation, HubuumClassRelationID,
+    HubuumClassRelationTransitive, HubuumClassWithPath, HubuumObject, HubuumObjectID,
+    HubuumObjectRelation, HubuumObjectRelationID, Namespace, NamespaceID, NewHubuumClassRelation,
+    NewHubuumObjectRelation, ObjectGraphRow, RelatedObjectGraphRow,
 };
 use crate::traits::accessors::{
     ClassAdapter, IdAccessor, InstanceAdapter, NamespaceAdapter, ObjectAdapter,
@@ -139,14 +139,20 @@ impl NamespaceAdapter<(Namespace, Namespace), (NamespaceID, NamespaceID)> for Hu
     }
 }
 
-impl ClassAdapter<(HubuumClass, HubuumClass), (i32, i32)> for HubuumClassRelation {
+impl ClassAdapter<(HubuumClass, HubuumClass), (HubuumClassID, HubuumClassID)> for HubuumClassRelation {
     async fn class_adapter(&self, pool: &DbPool) -> Result<(HubuumClass, HubuumClass), ApiError> {
         use crate::db::traits::GetClass;
         self.class_from_backend(pool).await
     }
 
-    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<(i32, i32), ApiError> {
-        Ok((self.from_hubuum_class_id, self.to_hubuum_class_id))
+    async fn class_id_adapter(
+        &self,
+        _pool: &DbPool,
+    ) -> Result<(HubuumClassID, HubuumClassID), ApiError> {
+        Ok((
+            HubuumClassID::new(self.from_hubuum_class_id)?,
+            HubuumClassID::new(self.to_hubuum_class_id)?,
+        ))
     }
 }
 
@@ -163,29 +169,38 @@ impl NamespaceAdapter<(Namespace, Namespace), (NamespaceID, NamespaceID)> for Hu
     }
 }
 
-impl ClassAdapter<(HubuumClass, HubuumClass), (i32, i32)> for HubuumClassRelationID {
+impl ClassAdapter<(HubuumClass, HubuumClass), (HubuumClassID, HubuumClassID)> for HubuumClassRelationID {
     async fn class_adapter(&self, pool: &DbPool) -> Result<(HubuumClass, HubuumClass), ApiError> {
         use crate::db::traits::GetClass;
         self.class_from_backend(pool).await
     }
 
-    async fn class_id_adapter(&self, pool: &DbPool) -> Result<(i32, i32), ApiError> {
+    async fn class_id_adapter(
+        &self,
+        pool: &DbPool,
+    ) -> Result<(HubuumClassID, HubuumClassID), ApiError> {
         self.instance(pool).await?.class_id(pool).await
     }
 }
 
-impl ClassAdapter<(HubuumClass, HubuumClass), (i32, i32)> for NewHubuumClassRelation {
+impl ClassAdapter<(HubuumClass, HubuumClass), (HubuumClassID, HubuumClassID)> for NewHubuumClassRelation {
     async fn class_adapter(&self, pool: &DbPool) -> Result<(HubuumClass, HubuumClass), ApiError> {
         use crate::db::traits::GetClass;
         self.class_from_backend(pool).await
     }
 
-    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<(i32, i32), ApiError> {
-        Ok((self.from_hubuum_class_id, self.to_hubuum_class_id))
+    async fn class_id_adapter(
+        &self,
+        _pool: &DbPool,
+    ) -> Result<(HubuumClassID, HubuumClassID), ApiError> {
+        Ok((
+            HubuumClassID::new(self.from_hubuum_class_id)?,
+            HubuumClassID::new(self.to_hubuum_class_id)?,
+        ))
     }
 }
 
-impl ObjectAdapter<(HubuumObject, HubuumObject), (i32, i32)> for NewHubuumObjectRelation {
+impl ObjectAdapter<(HubuumObject, HubuumObject), (HubuumObjectID, HubuumObjectID)> for NewHubuumObjectRelation {
     async fn object_adapter(
         &self,
         pool: &DbPool,
@@ -194,12 +209,18 @@ impl ObjectAdapter<(HubuumObject, HubuumObject), (i32, i32)> for NewHubuumObject
         self.object_from_backend(pool).await
     }
 
-    async fn object_id_adapter(&self, _pool: &DbPool) -> Result<(i32, i32), ApiError> {
-        Ok((self.from_hubuum_object_id, self.to_hubuum_object_id))
+    async fn object_id_adapter(
+        &self,
+        _pool: &DbPool,
+    ) -> Result<(HubuumObjectID, HubuumObjectID), ApiError> {
+        Ok((
+            HubuumObjectID::new(self.from_hubuum_object_id)?,
+            HubuumObjectID::new(self.to_hubuum_object_id)?,
+        ))
     }
 }
 
-impl ObjectAdapter<(HubuumObject, HubuumObject), (i32, i32)> for HubuumObjectRelationID {
+impl ObjectAdapter<(HubuumObject, HubuumObject), (HubuumObjectID, HubuumObjectID)> for HubuumObjectRelationID {
     async fn object_adapter(
         &self,
         pool: &DbPool,
@@ -208,12 +229,15 @@ impl ObjectAdapter<(HubuumObject, HubuumObject), (i32, i32)> for HubuumObjectRel
         self.object_from_backend(pool).await
     }
 
-    async fn object_id_adapter(&self, pool: &DbPool) -> Result<(i32, i32), ApiError> {
+    async fn object_id_adapter(
+        &self,
+        pool: &DbPool,
+    ) -> Result<(HubuumObjectID, HubuumObjectID), ApiError> {
         self.instance(pool).await?.object_id(pool).await
     }
 }
 
-impl ObjectAdapter<(HubuumObject, HubuumObject), (i32, i32)> for HubuumObjectRelation {
+impl ObjectAdapter<(HubuumObject, HubuumObject), (HubuumObjectID, HubuumObjectID)> for HubuumObjectRelation {
     async fn object_adapter(
         &self,
         pool: &DbPool,
@@ -222,8 +246,14 @@ impl ObjectAdapter<(HubuumObject, HubuumObject), (i32, i32)> for HubuumObjectRel
         self.object_from_backend(pool).await
     }
 
-    async fn object_id_adapter(&self, _pool: &DbPool) -> Result<(i32, i32), ApiError> {
-        Ok((self.from_hubuum_object_id, self.to_hubuum_object_id))
+    async fn object_id_adapter(
+        &self,
+        _pool: &DbPool,
+    ) -> Result<(HubuumObjectID, HubuumObjectID), ApiError> {
+        Ok((
+            HubuumObjectID::new(self.from_hubuum_object_id)?,
+            HubuumObjectID::new(self.to_hubuum_object_id)?,
+        ))
     }
 }
 

--- a/src/models/traits/namespace.rs
+++ b/src/models/traits/namespace.rs
@@ -80,6 +80,9 @@ impl NamespaceAdapter for Namespace {
 
 impl IdAccessor for NamespaceID {
     fn accessor_id(&self) -> i32 {
+        // Deref to the owned (Copy) value on purpose: with a `&self` receiver, `self.id()`
+        // binds to the `SelfAccessors::id` trait method, which calls back into `accessor_id`
+        // and recurses. The inherent `id` is only selected on an owned receiver.
         (*self).id()
     }
 }

--- a/src/models/traits/namespace.rs
+++ b/src/models/traits/namespace.rs
@@ -73,14 +73,14 @@ impl NamespaceAdapter for Namespace {
         Ok(self.clone())
     }
 
-    async fn namespace_id_adapter(&self, _pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.id)
+    async fn namespace_id_adapter(&self, _pool: &DbPool) -> Result<NamespaceID, ApiError> {
+        NamespaceID::new(self.id)
     }
 }
 
 impl IdAccessor for NamespaceID {
     fn accessor_id(&self) -> i32 {
-        self.0
+        (*self).id()
     }
 }
 
@@ -91,8 +91,8 @@ impl InstanceAdapter<Namespace> for NamespaceID {
 }
 
 impl NamespaceAdapter for NamespaceID {
-    async fn namespace_id_adapter(&self, _pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.0)
+    async fn namespace_id_adapter(&self, _pool: &DbPool) -> Result<NamespaceID, ApiError> {
+        Ok(*self)
     }
 
     async fn namespace_adapter(&self, pool: &DbPool) -> Result<Namespace, ApiError> {
@@ -114,7 +114,7 @@ impl NewNamespace {
     where
         C: BackendContext + ?Sized,
     {
-        self.save_namespace_for_group_record(backend.db_pool(), assignee.0)
+        self.save_namespace_for_group_record(backend.db_pool(), assignee.id())
             .await
     }
 

--- a/src/models/traits/object.rs
+++ b/src/models/traits/object.rs
@@ -5,7 +5,7 @@ use crate::db::traits::object::{
 };
 use crate::errors::ApiError;
 
-use crate::models::class::HubuumClass;
+use crate::models::class::{HubuumClass, HubuumClassID};
 use crate::models::namespace::{Namespace, NamespaceID};
 use crate::models::object::{
     HubuumObject, HubuumObjectID, HubuumObjectWithPath, NewHubuumObject, UpdateHubuumObject,
@@ -158,8 +158,8 @@ impl ClassAdapter for HubuumObject {
         self.lookup_object_class(pool).await
     }
 
-    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.hubuum_class_id)
+    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<HubuumClassID, ApiError> {
+        HubuumClassID::new(self.hubuum_class_id)
     }
 }
 
@@ -193,8 +193,8 @@ impl ClassAdapter for HubuumObjectID {
         self.lookup_object_class(pool).await
     }
 
-    async fn class_id_adapter(&self, pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.class(pool).await?.id)
+    async fn class_id_adapter(&self, pool: &DbPool) -> Result<HubuumClassID, ApiError> {
+        HubuumClassID::new(self.class(pool).await?.id)
     }
 }
 

--- a/src/models/traits/object.rs
+++ b/src/models/traits/object.rs
@@ -6,7 +6,7 @@ use crate::db::traits::object::{
 use crate::errors::ApiError;
 
 use crate::models::class::HubuumClass;
-use crate::models::namespace::Namespace;
+use crate::models::namespace::{Namespace, NamespaceID};
 use crate::models::object::{
     HubuumObject, HubuumObjectID, HubuumObjectWithPath, NewHubuumObject, UpdateHubuumObject,
 };
@@ -148,8 +148,8 @@ impl NamespaceAdapter for HubuumObject {
         self.lookup_object_namespace(pool).await
     }
 
-    async fn namespace_id_adapter(&self, _pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.namespace_id)
+    async fn namespace_id_adapter(&self, _pool: &DbPool) -> Result<NamespaceID, ApiError> {
+        NamespaceID::new(self.namespace_id)
     }
 }
 
@@ -165,7 +165,7 @@ impl ClassAdapter for HubuumObject {
 
 impl IdAccessor for HubuumObjectID {
     fn accessor_id(&self) -> i32 {
-        self.0
+        (*self).id()
     }
 }
 
@@ -180,8 +180,8 @@ impl NamespaceAdapter for HubuumObjectID {
         self.lookup_object_namespace(pool).await
     }
 
-    async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.namespace(pool).await?.id)
+    async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<NamespaceID, ApiError> {
+        NamespaceID::new(self.namespace(pool).await?.id)
     }
 }
 

--- a/src/models/traits/object.rs
+++ b/src/models/traits/object.rs
@@ -165,6 +165,9 @@ impl ClassAdapter for HubuumObject {
 
 impl IdAccessor for HubuumObjectID {
     fn accessor_id(&self) -> i32 {
+        // Deref to the owned (Copy) value on purpose: with a `&self` receiver, `self.id()`
+        // binds to the `SelfAccessors::id` trait method, which calls back into `accessor_id`
+        // and recurses. The inherent `id` is only selected on an owned receiver.
         (*self).id()
     }
 }

--- a/src/models/traits/object_relation.rs
+++ b/src/models/traits/object_relation.rs
@@ -14,7 +14,7 @@ use crate::traits::crud::{DeleteAdapter, SaveAdapter};
 
 impl IdAccessor for HubuumObjectRelationID {
     fn accessor_id(&self) -> i32 {
-        self.0
+        (*self).id()
     }
 }
 

--- a/src/models/traits/object_relation.rs
+++ b/src/models/traits/object_relation.rs
@@ -14,6 +14,9 @@ use crate::traits::crud::{DeleteAdapter, SaveAdapter};
 
 impl IdAccessor for HubuumObjectRelationID {
     fn accessor_id(&self) -> i32 {
+        // Deref to the owned (Copy) value on purpose: with a `&self` receiver, `self.id()`
+        // binds to the `SelfAccessors::id` trait method, which calls back into `accessor_id`
+        // and recurses. The inherent `id` is only selected on an owned receiver.
         (*self).id()
     }
 }

--- a/src/models/traits/output.rs
+++ b/src/models/traits/output.rs
@@ -32,7 +32,9 @@ impl ExpandNamespace<HubuumClassExpanded> for HubuumClass {
     where
         C: BackendContext + ?Sized,
     {
-        let namespace = NamespaceID(self.namespace_id).instance(backend).await?;
+        let namespace = NamespaceID::new(self.namespace_id)?
+            .instance(backend)
+            .await?;
 
         Ok(HubuumClassExpanded {
             id: self.id,

--- a/src/models/traits/user.rs
+++ b/src/models/traits/user.rs
@@ -487,6 +487,9 @@ impl InstanceAdapter<User> for User {
 
 impl IdAccessor for UserID {
     fn accessor_id(&self) -> i32 {
+        // Deref to the owned (Copy) value on purpose: with a `&self` receiver, `self.id()`
+        // binds to the `SelfAccessors::id` trait method, which calls back into `accessor_id`
+        // and recurses. The inherent `id` is only selected on an owned receiver.
         (*self).id()
     }
 }

--- a/src/models/traits/user.rs
+++ b/src/models/traits/user.rs
@@ -379,8 +379,10 @@ impl UserNamespaceAccessors for UserID {}
 impl GroupAccessors for User {}
 impl GroupAccessors for UserID {}
 
-impl GroupAccessors for &User {}
-impl GroupAccessors for &UserID {}
+// `&T` gets `GroupAccessors` wherever `T` is a user accessor, mirroring the blanket reference impls
+// for the adapter traits in `crate::traits::accessors`. This subsumes the explicit `&User` /
+// `&UserID` impls that previously had to be written out one type at a time.
+impl<T> GroupAccessors for &T where T: IdAccessor + InstanceAdapter<User> {}
 
 impl Search for User {}
 impl Search for UserID {}
@@ -485,7 +487,7 @@ impl InstanceAdapter<User> for User {
 
 impl IdAccessor for UserID {
     fn accessor_id(&self) -> i32 {
-        self.0
+        (*self).id()
     }
 }
 
@@ -545,7 +547,7 @@ mod test {
             name: "test_user_namespace_listing".to_string(),
             description: "Test namespace".to_string(),
         }
-        .save_and_grant_all_to(&context.pool, GroupID(test_group_1.id))
+        .save_and_grant_all_to(&context.pool, GroupID::new(test_group_1.id).unwrap())
         .await
         .unwrap();
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -184,8 +184,37 @@ impl NewUser {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-pub struct UserID(pub i32);
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct UserID(i32);
+
+impl UserID {
+    /// Validating constructor: user ids are positive integers. Constructing through `new` (and the
+    /// `Deserialize` impl, which routes through it) means an invalid id is rejected at the edge with
+    /// a clear `400` rather than surfacing later as a confusing lookup miss.
+    pub fn new(id: i32) -> Result<Self, ApiError> {
+        if id <= 0 {
+            return Err(ApiError::BadRequest(format!(
+                "Invalid user id '{id}': must be a positive integer"
+            )));
+        }
+        Ok(Self(id))
+    }
+
+    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
+    pub fn id(self) -> i32 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for UserID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let id = i32::deserialize(deserializer)?;
+        UserID::new(id).map_err(serde::de::Error::custom)
+    }
+}
 
 impl UserID {
     pub async fn user<C>(&self, backend: &C) -> Result<User, ApiError>

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -184,36 +184,10 @@ impl NewUser {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
-pub struct UserID(i32);
-
-impl UserID {
-    /// Validating constructor: user ids are positive integers. Constructing through `new` (and the
-    /// `Deserialize` impl, which routes through it) means an invalid id is rejected at the edge with
-    /// a clear `400` rather than surfacing later as a confusing lookup miss.
-    pub fn new(id: i32) -> Result<Self, ApiError> {
-        if id <= 0 {
-            return Err(ApiError::BadRequest(format!(
-                "Invalid user id '{id}': must be a positive integer"
-            )));
-        }
-        Ok(Self(id))
-    }
-
-    /// The underlying id. Use at persistence boundaries that still operate on the raw `i32`.
-    pub fn id(self) -> i32 {
-        self.0
-    }
-}
-
-impl<'de> Deserialize<'de> for UserID {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let id = i32::deserialize(deserializer)?;
-        UserID::new(id).map_err(serde::de::Error::custom)
-    }
+crate::int_id_newtype! {
+    /// Identifier wrapper for a [`User`].
+    pub struct UserID;
+    noun = "user id";
 }
 
 impl UserID {

--- a/src/tasks/planning.rs
+++ b/src/tasks/planning.rs
@@ -66,8 +66,9 @@ async fn ensure_namespace_permission_cached(
         return result.clone();
     }
 
+    let namespace = NamespaceID::new(namespace_id).map_err(|err| err.to_string())?;
     let result = user
-        .can(pool, vec![permission], vec![NamespaceID(namespace_id)])
+        .can(pool, vec![permission], vec![namespace])
         .await
         .map_err(|err| err.to_string());
     state.namespace_permission_cache.insert(key, result.clone());

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -163,7 +163,7 @@ async fn process_claimed_task(pool: &DbPool, task: &TaskRecord) -> Result<(), Ap
     let submitted_by = task.submitted_by.ok_or_else(|| {
         ApiError::BadRequest("Submitting user is no longer available for this task".to_string())
     })?;
-    let submitted_by = UserID(submitted_by).user(pool).await?;
+    let submitted_by = UserID::new(submitted_by)?.user(pool).await?;
 
     info!(
         message = "Dispatching task execution",

--- a/src/tests/api/v1/classes.rs
+++ b/src/tests/api/v1/classes.rs
@@ -64,11 +64,11 @@ pub mod tests {
     pub async fn cleanup(classes: &ClassFixture) {
         let namespaces = classes
             .iter()
-            .map(|c| NamespaceID(c.namespace_id))
+            .map(|c| NamespaceID::new(c.namespace_id).unwrap())
             .collect::<Vec<NamespaceID>>();
 
         for ns in namespaces {
-            assert_eq!(ns.0, classes.namespace.namespace.id);
+            assert_eq!(ns.id(), classes.namespace.namespace.id);
         }
 
         classes.cleanup().await.unwrap();

--- a/src/tests/api/v1/namespaces.rs
+++ b/src/tests/api/v1/namespaces.rs
@@ -181,6 +181,32 @@ mod tests {
         let _ = assert_response_status(resp, http::StatusCode::NOT_FOUND).await;
     }
 
+    // Invalid namespace ids are refused during path extraction (`NamespaceID`'s validating
+    // `Deserialize` plus the `PathConfig` error handler), so the request is rejected at the edge
+    // with a `400` rather than surfacing as a confusing lookup miss further in. Covers
+    // non-positive values rejected by `new` and non-integer segments rejected while parsing `i32`.
+    #[rstest]
+    #[case::zero("0")]
+    #[case::negative_one("-1")]
+    #[case::i32_min("-2147483648")]
+    #[case::non_numeric("abc")]
+    #[case::non_integer("1.5")]
+    #[actix_web::test]
+    async fn test_invalid_namespace_id_in_path_is_rejected(
+        #[future(awt)] test_context: TestContext,
+        #[case] invalid_id: &str,
+    ) {
+        let context = test_context;
+
+        let resp = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("{NAMESPACE_ENDPOINT}/{invalid_id}"),
+        )
+        .await;
+        let _ = assert_response_status(resp, http::StatusCode::BAD_REQUEST).await;
+    }
+
     #[rstest]
     #[actix_web::test]
     async fn test_api_namespace_permissions(#[future(awt)] test_context: TestContext) {

--- a/src/tests/api/v1/relations.rs
+++ b/src/tests/api/v1/relations.rs
@@ -781,7 +781,7 @@ mod tests {
 
         let (classes, relations) =
             create_classes_and_relations(&context, "get_class_relation_with_permissions").await;
-        let namespace = NamespaceID(classes[0].namespace_id)
+        let namespace = NamespaceID::new(classes[0].namespace_id).unwrap()
             .instance(&context.pool)
             .await
             .unwrap();
@@ -1869,7 +1869,7 @@ mod tests {
         let _ = create_object_relation(&context.pool, &objects[0], &objects[4], &class_relation_15)
             .await;
 
-        let namespace = NamespaceID(classes[0].namespace_id)
+        let namespace = NamespaceID::new(classes[0].namespace_id).unwrap()
             .instance(&context.pool)
             .await
             .unwrap();
@@ -1985,7 +1985,7 @@ mod tests {
         )
         .await;
 
-        let visible_namespace = NamespaceID(visible_classes[0].namespace_id)
+        let visible_namespace = NamespaceID::new(visible_classes[0].namespace_id).unwrap()
             .instance(&context.pool)
             .await
             .unwrap();

--- a/src/tests/api/v1/relations.rs
+++ b/src/tests/api/v1/relations.rs
@@ -561,24 +561,41 @@ mod tests {
         cleanup(&classes).await;
     }
 
+    // The old directional class-relation routes are gone. A stale URL that collides with a current
+    // route expecting a numeric segment (here `/{class_id}/{object_id}`) is rejected as a `400`
+    // because the literal segment is not a valid id; the deeper paths match no route and are a plain
+    // `404`. Either way the old endpoint no longer serves. `{first}`/`{second}` are substituted with
+    // the fixture class ids since rstest cases cannot reference runtime values.
     #[rstest]
+    #[case::get_relations("{first}/relations", StatusCode::BAD_REQUEST)]
+    #[case::transitive("{first}/relations/transitive/", StatusCode::NOT_FOUND)]
+    #[case::transitive_to_class(
+        "{first}/relations/transitive/class/{second}",
+        StatusCode::NOT_FOUND
+    )]
     #[actix_web::test]
-    async fn test_old_directional_class_routes_removed(#[future(awt)] test_context: TestContext) {
+    async fn test_old_directional_class_routes_removed(
+        #[future(awt)] test_context: TestContext,
+        #[case] path_template: &str,
+        #[case] expected: StatusCode,
+    ) {
         let context = test_context;
-        let classes = create_test_classes(&context, "old_directional_class_routes_removed").await;
+        // Cases share the run's test database, so derive a unique fixture prefix per case to avoid
+        // class-name collisions.
+        let prefix = format!(
+            "old_directional_class_routes_removed_{}",
+            path_template.replace(['/', '{', '}', '.'], "_")
+        );
+        let classes = create_test_classes(&context, &prefix).await;
         let _ = create_relation(&context.pool, &classes[0], &classes[1]).await;
 
-        for endpoint in [
-            format!("/api/v1/classes/{}/relations", classes[0].id),
-            format!("/api/v1/classes/{}/relations/transitive/", classes[0].id),
-            format!(
-                "/api/v1/classes/{}/relations/transitive/class/{}",
-                classes[0].id, classes[1].id
-            ),
-        ] {
-            let resp = get_request(&context.pool, &context.admin_token, &endpoint).await;
-            let _ = assert_response_status(resp, StatusCode::NOT_FOUND).await;
-        }
+        let suffix = path_template
+            .replace("{first}", &classes[0].id.to_string())
+            .replace("{second}", &classes[1].id.to_string());
+        let endpoint = format!("/api/v1/classes/{suffix}");
+
+        let resp = get_request(&context.pool, &context.admin_token, &endpoint).await;
+        let _ = assert_response_status(resp, expected).await;
 
         cleanup(&classes).await;
     }

--- a/src/tests/api/v1/users.rs
+++ b/src/tests/api/v1/users.rs
@@ -205,7 +205,7 @@ mod tests {
         assert_eq!(patched_user.username, test_user.username);
         assert_eq!(patched_user.email, test_user.email);
 
-        let stored_user = UserID(test_user.id).user(&context.pool).await.unwrap();
+        let stored_user = UserID::new(test_user.id).unwrap().user(&context.pool).await.unwrap();
         assert_ne!(stored_user.password, test_user.password);
         LoginUser {
             username: test_user.username,

--- a/src/tests/id_newtypes.rs
+++ b/src/tests/id_newtypes.rs
@@ -1,0 +1,51 @@
+//! Validation invariants shared by every `int_id_newtype!`-generated id newtype.
+//!
+//! All id newtypes are produced by the same macro, so one test over the full set guards the
+//! contract: positive ids round-trip, non-positive ids are rejected, and `Deserialize` routes
+//! through the validating constructor so `web::Path<XID>` rejects invalid ids at the API edge.
+
+use crate::errors::ApiError;
+use crate::models::{
+    GroupID, HubuumClassID, HubuumClassRelationID, HubuumObjectID, HubuumObjectRelationID,
+    NamespaceID, ReportTemplateID, TaskID, UserID,
+};
+
+macro_rules! assert_id_newtype_validates {
+    ($($t:ty),+ $(,)?) => {{
+        $(
+            // Positive ids round-trip through `new` / `id`.
+            assert_eq!(<$t>::new(1).unwrap().id(), 1, "{}::new(1)", stringify!($t));
+            assert_eq!(<$t>::new(i32::MAX).unwrap().id(), i32::MAX);
+
+            // Non-positive ids are rejected with a 400-class error.
+            for invalid in [0, -1, i32::MIN] {
+                let err = <$t>::new(invalid).unwrap_err();
+                assert!(
+                    matches!(err, ApiError::BadRequest(_)),
+                    "{}::new({invalid}) should be BadRequest, got {err:?}",
+                    stringify!($t)
+                );
+            }
+
+            // `Deserialize` routes through `new`, so an invalid path/body id never produces a value.
+            assert_eq!(serde_json::from_str::<$t>("7").unwrap().id(), 7);
+            assert!(serde_json::from_str::<$t>("0").is_err());
+            assert!(serde_json::from_str::<$t>("-3").is_err());
+        )+
+    }};
+}
+
+#[test]
+fn all_id_newtypes_reject_invalid_ids() {
+    assert_id_newtype_validates!(
+        HubuumObjectID,
+        HubuumClassID,
+        HubuumClassRelationID,
+        HubuumObjectRelationID,
+        UserID,
+        NamespaceID,
+        GroupID,
+        ReportTemplateID,
+        TaskID,
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8,6 +8,7 @@ pub mod api_operations;
 pub mod asserts;
 pub mod client_allowlist;
 pub mod constants;
+pub mod id_newtypes;
 pub mod search;
 pub mod validation;
 

--- a/src/tests/search/classes.rs
+++ b/src/tests/search/classes.rs
@@ -35,7 +35,7 @@ mod test {
                     name: namespace_name,
                     description: namespace_description,
                 }
-                .save_and_grant_all_to(&context.pool, GroupID(admin_group.id))
+                .save_and_grant_all_to(&context.pool, GroupID::new(admin_group.id).unwrap())
                 .await
                 .unwrap(),
             );

--- a/src/tests/search/classrelations.rs
+++ b/src/tests/search/classrelations.rs
@@ -24,7 +24,7 @@ mod test {
             description: crname.clone(),
         };
         let namespace = namespace
-            .save_and_grant_all_to(pool, GroupID(admin_group.id))
+            .save_and_grant_all_to(pool, GroupID::new(admin_group.id).unwrap())
             .await
             .unwrap();
 

--- a/src/traits/accessors.rs
+++ b/src/traits/accessors.rs
@@ -2,7 +2,9 @@
 
 use crate::db::DbPool;
 use crate::errors::ApiError;
-use crate::models::{HubuumClass, HubuumObject, Namespace, NamespaceID};
+use crate::models::{
+    HubuumClass, HubuumClassID, HubuumObject, HubuumObjectID, Namespace, NamespaceID,
+};
 
 use super::context::BackendContext;
 
@@ -130,7 +132,7 @@ where
 ///
 /// As with [`NamespaceAccessors`], this trait lets entity and identifier types share a common
 /// class lookup interface while keeping backend-specific loading in internal adapters.
-pub trait ClassAccessors<C = HubuumClass, I = i32> {
+pub trait ClassAccessors<C = HubuumClass, I = HubuumClassID> {
     /// Return the class instance for this value.
     async fn class<B>(&self, backend: &B) -> Result<C, ApiError>
     where
@@ -143,7 +145,7 @@ pub trait ClassAccessors<C = HubuumClass, I = i32> {
 }
 
 #[doc(hidden)]
-pub(crate) trait ClassAdapter<C = HubuumClass, I = i32> {
+pub(crate) trait ClassAdapter<C = HubuumClass, I = HubuumClassID> {
     async fn class_adapter(&self, pool: &DbPool) -> Result<C, ApiError>;
     async fn class_id_adapter(&self, pool: &DbPool) -> Result<I, ApiError>;
 }
@@ -184,7 +186,7 @@ where
 ///
 /// This follows the same pattern as the other accessor traits, including relation cases where the
 /// returned object or identifier type may be a tuple rather than a single value.
-pub trait ObjectAccessors<O = HubuumObject, I = i32> {
+pub trait ObjectAccessors<O = HubuumObject, I = HubuumObjectID> {
     #[allow(dead_code)]
     /// Return the object instance for this value.
     async fn object<B>(&self, backend: &B) -> Result<O, ApiError>
@@ -198,7 +200,7 @@ pub trait ObjectAccessors<O = HubuumObject, I = i32> {
 }
 
 #[doc(hidden)]
-pub(crate) trait ObjectAdapter<O = HubuumObject, I = i32> {
+pub(crate) trait ObjectAdapter<O = HubuumObject, I = HubuumObjectID> {
     #[allow(dead_code)]
     async fn object_adapter(&self, pool: &DbPool) -> Result<O, ApiError>;
     async fn object_id_adapter(&self, pool: &DbPool) -> Result<I, ApiError>;

--- a/src/traits/accessors.rs
+++ b/src/traits/accessors.rs
@@ -2,7 +2,7 @@
 
 use crate::db::DbPool;
 use crate::errors::ApiError;
-use crate::models::{HubuumClass, HubuumObject, Namespace};
+use crate::models::{HubuumClass, HubuumObject, Namespace, NamespaceID};
 
 use super::context::BackendContext;
 
@@ -76,7 +76,7 @@ where
 /// This allows both direct entities and identifier wrappers to expose a common namespace lookup
 /// API without pushing Diesel details into the public trait surface.
 #[allow(async_fn_in_trait)]
-pub trait NamespaceAccessors<N = Namespace, I = i32> {
+pub trait NamespaceAccessors<N = Namespace, I = NamespaceID> {
     /// Return the namespace instance for this value.
     async fn namespace<C>(&self, backend: &C) -> Result<N, ApiError>
     where
@@ -89,7 +89,7 @@ pub trait NamespaceAccessors<N = Namespace, I = i32> {
 }
 
 #[doc(hidden)]
-pub(crate) trait NamespaceAdapter<N = Namespace, I = i32> {
+pub(crate) trait NamespaceAdapter<N = Namespace, I = NamespaceID> {
     async fn namespace_adapter(&self, pool: &DbPool) -> Result<N, ApiError>;
     async fn namespace_id_adapter(&self, pool: &DbPool) -> Result<I, ApiError>;
 }


### PR DESCRIPTION
Closes #57.

Brings the remaining ID newtypes up to the standard set by `ReportTemplateID` / `TaskID`, makes the namespace **and** class/object id accessors return their newtypes instead of bare `i32`, then extracts the now-uniform boilerplate into a macro and locks the behavior down with tests.

## 1. Hardened newtypes
For `HubuumObjectID`, `HubuumClassID`, `HubuumClassRelationID`, `HubuumObjectRelationID`, `UserID`, `NamespaceID`, `GroupID`:
- private field,
- validating `new(i32) -> Result<Self, ApiError>` rejecting ids `<= 0`,
- `Deserialize` routed through `new()` so `web::Path<XID>` rejects invalid ids at the edge,
- an `id()` accessor.

Construction sites use `XID::new(..)` (`?` in fallible paths, `.unwrap()` in tests); field reads use `.id()`.

## 2. Accessors return newtypes (symmetry)
`namespace_id`, `class_id`, and `object_id` accessors — across `NamespaceAdapter`/`ClassAdapter`/`ObjectAdapter` and their `*Accessors` counterparts, including the tuple relation variants and the report-template backend lookup — now return `NamespaceID` / `HubuumClassID` / `HubuumObjectID` (and `(XID, XID)` for relations) instead of bare `i32`. Diesel filters convert to the raw id at the persistence boundary via `.id()`; the `can!` macro no longer re-wraps with `NamespaceID(..)`.

## 3. `int_id_newtype!` macro
All nine id newtypes (the seven above plus `ReportTemplateID`/`TaskID`) now share a single `int_id_newtype!` declaration that generates the struct, derives, validating `new`, `id()`, and the `Deserialize` impl. `new`/`id` stay **inherent** rather than on a shared trait: an `id()` on a trait would collide with `SelfAccessors::id`, and a trait constructor would have to expose an unchecked `from_raw`, defeating the private field.

## 4. Invalid path ids now return `400`
The issue promises invalid ids are rejected at the edge with a clear `400`, but actix's default `web::Path` error maps to `404`. Added a `PathConfig` error handler (mirroring the existing `JsonConfig` one), registered in the shared `api::config` so prod and tests both get it.

## Cleanup
- Collapsed the explicit `GroupAccessors for &User` / `&UserID` impls into a blanket `impl<T> GroupAccessors for &T`.

## Tests
- Consolidated validation test over all nine newtypes (positive round-trips, non-positive rejected as `BadRequest`, `Deserialize` rejects invalid).
- Route-level rstest cases asserting `web::Path<NamespaceID>` rejects `0`, `-1`, `i32::MIN`, non-numeric, and non-integer with `400`.
- `test_old_directional_class_routes_removed` updated to rstest cases for the new statuses (follow-up cleanup tracked in #63).

## Notes / footgun fixed
`IdAccessor::accessor_id` for the cross-module impls returns `(*self).id()`, not `self.id()`. With a `&self` receiver, `self.id()` binds to the `SelfAccessors::id` trait method (whose `&XID` receiver matches before the by-value inherent `id`), which calls back into `accessor_id` and recurses (caught by a stack overflow in `test_bidirectional_transitive_class_relations`). Dereferencing to the owned `Copy` value selects the inherent accessor.

## Follow-ups
- #63 — trim the incidental case in `test_old_directional_class_routes_removed`.

## Verification
- `cargo clippy --all-targets -- -D warnings` — clean
- `source .env && ./run_tests.sh` — 645 passed, 0 failed
- `docs/openapi.json` regenerated — no drift (only earlier delta was a schema description from new doc comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)