### PR TITLE
Return HubuumClassID/HubuumObjectID from class/object accessors

### DIFF
--- a/src/api/v1/handlers/mod.rs
+++ b/src/api/v1/handlers/mod.rs
@@ -25,7 +25,7 @@ where
     C: SelfAccessors<HubuumClass>,
     O: SelfAccessors<HubuumObject> + ClassAccessors<HubuumClass>,
 {
-    let object_class_id = object.class_id(pool).await?;
+    let object_class_id = object.class_id(pool).await?.id();
 
     if object_class_id != class.id() {
         debug!(

--- a/src/db/traits/namespace/relations.rs
+++ b/src/db/traits/namespace/relations.rs
@@ -10,6 +10,8 @@ impl GetNamespace<(Namespace, Namespace)> for HubuumClassRelation {
         use crate::schema::namespaces::dsl::{id as namespace_id, namespaces};
 
         let (from_id, to_id) = self.class_id(pool).await?;
+        // Work with raw ids at the Diesel boundary.
+        let (from_id, to_id) = (from_id.id(), to_id.id());
 
         let namespace_list = with_connection(pool, |conn| {
             hubuumclass
@@ -47,6 +49,8 @@ impl GetNamespace<(Namespace, Namespace)> for NewHubuumClassRelation {
         use crate::schema::namespaces::dsl::{id as namespace_id, namespaces};
 
         let (from_id, to_id) = self.class_id(pool).await?;
+        // Work with raw ids at the Diesel boundary.
+        let (from_id, to_id) = (from_id.id(), to_id.id());
 
         let namespace_list = with_connection(pool, |conn| {
             hubuumclass
@@ -84,6 +88,8 @@ impl GetNamespace<(Namespace, Namespace)> for HubuumObjectRelation {
         use crate::schema::namespaces::dsl::{id as namespace_id, namespaces};
 
         let (from_id, to_id) = self.object_id(pool).await?;
+        // Work with raw ids at the Diesel boundary.
+        let (from_id, to_id) = (from_id.id(), to_id.id());
 
         let namespace_list = with_connection(pool, |conn| {
             hubuumobject
@@ -121,6 +127,8 @@ impl GetNamespace<(Namespace, Namespace)> for NewHubuumObjectRelation {
         use crate::schema::namespaces::dsl::{id as namespace_id, namespaces};
 
         let (from_id, to_id) = self.object_id(pool).await?;
+        // Work with raw ids at the Diesel boundary.
+        let (from_id, to_id) = (from_id.id(), to_id.id());
 
         let namespace_list = with_connection(pool, |conn| {
             hubuumobject
@@ -158,6 +166,8 @@ impl GetNamespace<(Namespace, Namespace)> for HubuumObjectRelationID {
         use crate::schema::namespaces::dsl::{id as namespace_id, namespaces};
 
         let (from_id, to_id) = self.object_id(pool).await?;
+        // Work with raw ids at the Diesel boundary.
+        let (from_id, to_id) = (from_id.id(), to_id.id());
 
         let namespace_list = with_connection(pool, |conn| {
             hubuumobject

--- a/src/models/traits/class.rs
+++ b/src/models/traits/class.rs
@@ -63,8 +63,8 @@ impl InstanceAdapter<HubuumClass> for HubuumClass {
 }
 
 impl ClassAdapter for HubuumClass {
-    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.id)
+    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<HubuumClassID, ApiError> {
+        HubuumClassID::new(self.id)
     }
 
     async fn class_adapter(&self, _pool: &DbPool) -> Result<HubuumClass, ApiError> {
@@ -98,8 +98,8 @@ impl InstanceAdapter<HubuumClass> for HubuumClassID {
 }
 
 impl ClassAdapter for HubuumClassID {
-    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.id())
+    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<HubuumClassID, ApiError> {
+        Ok(*self)
     }
 
     async fn class_adapter(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {

--- a/src/models/traits/class_relation.rs
+++ b/src/models/traits/class_relation.rs
@@ -6,10 +6,10 @@ use crate::errors::ApiError;
 
 use crate::models::search::{FilterField, SortParam};
 use crate::models::{
-    ClassGraphRow, HubuumClass, HubuumClassRelation, HubuumClassRelationID,
-    HubuumClassRelationTransitive, HubuumClassWithPath, HubuumObject, HubuumObjectRelation,
-    HubuumObjectRelationID, Namespace, NamespaceID, NewHubuumClassRelation, NewHubuumObjectRelation,
-    ObjectGraphRow, RelatedObjectGraphRow,
+    ClassGraphRow, HubuumClass, HubuumClassID, HubuumClassRelation, HubuumClassRelationID,
+    HubuumClassRelationTransitive, HubuumClassWithPath, HubuumObject, HubuumObjectID,
+    HubuumObjectRelation, HubuumObjectRelationID, Namespace, NamespaceID, NewHubuumClassRelation,
+    NewHubuumObjectRelation, ObjectGraphRow, RelatedObjectGraphRow,
 };
 use crate::traits::accessors::{
     ClassAdapter, IdAccessor, InstanceAdapter, NamespaceAdapter, ObjectAdapter,
@@ -139,14 +139,20 @@ impl NamespaceAdapter<(Namespace, Namespace), (NamespaceID, NamespaceID)> for Hu
     }
 }
 
-impl ClassAdapter<(HubuumClass, HubuumClass), (i32, i32)> for HubuumClassRelation {
+impl ClassAdapter<(HubuumClass, HubuumClass), (HubuumClassID, HubuumClassID)> for HubuumClassRelation {
     async fn class_adapter(&self, pool: &DbPool) -> Result<(HubuumClass, HubuumClass), ApiError> {
         use crate::db::traits::GetClass;
         self.class_from_backend(pool).await
     }
 
-    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<(i32, i32), ApiError> {
-        Ok((self.from_hubuum_class_id, self.to_hubuum_class_id))
+    async fn class_id_adapter(
+        &self,
+        _pool: &DbPool,
+    ) -> Result<(HubuumClassID, HubuumClassID), ApiError> {
+        Ok((
+            HubuumClassID::new(self.from_hubuum_class_id)?,
+            HubuumClassID::new(self.to_hubuum_class_id)?,
+        ))
     }
 }
 
@@ -163,29 +169,38 @@ impl NamespaceAdapter<(Namespace, Namespace), (NamespaceID, NamespaceID)> for Hu
     }
 }
 
-impl ClassAdapter<(HubuumClass, HubuumClass), (i32, i32)> for HubuumClassRelationID {
+impl ClassAdapter<(HubuumClass, HubuumClass), (HubuumClassID, HubuumClassID)> for HubuumClassRelationID {
     async fn class_adapter(&self, pool: &DbPool) -> Result<(HubuumClass, HubuumClass), ApiError> {
         use crate::db::traits::GetClass;
         self.class_from_backend(pool).await
     }
 
-    async fn class_id_adapter(&self, pool: &DbPool) -> Result<(i32, i32), ApiError> {
+    async fn class_id_adapter(
+        &self,
+        pool: &DbPool,
+    ) -> Result<(HubuumClassID, HubuumClassID), ApiError> {
         self.instance(pool).await?.class_id(pool).await
     }
 }
 
-impl ClassAdapter<(HubuumClass, HubuumClass), (i32, i32)> for NewHubuumClassRelation {
+impl ClassAdapter<(HubuumClass, HubuumClass), (HubuumClassID, HubuumClassID)> for NewHubuumClassRelation {
     async fn class_adapter(&self, pool: &DbPool) -> Result<(HubuumClass, HubuumClass), ApiError> {
         use crate::db::traits::GetClass;
         self.class_from_backend(pool).await
     }
 
-    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<(i32, i32), ApiError> {
-        Ok((self.from_hubuum_class_id, self.to_hubuum_class_id))
+    async fn class_id_adapter(
+        &self,
+        _pool: &DbPool,
+    ) -> Result<(HubuumClassID, HubuumClassID), ApiError> {
+        Ok((
+            HubuumClassID::new(self.from_hubuum_class_id)?,
+            HubuumClassID::new(self.to_hubuum_class_id)?,
+        ))
     }
 }
 
-impl ObjectAdapter<(HubuumObject, HubuumObject), (i32, i32)> for NewHubuumObjectRelation {
+impl ObjectAdapter<(HubuumObject, HubuumObject), (HubuumObjectID, HubuumObjectID)> for NewHubuumObjectRelation {
     async fn object_adapter(
         &self,
         pool: &DbPool,
@@ -194,12 +209,18 @@ impl ObjectAdapter<(HubuumObject, HubuumObject), (i32, i32)> for NewHubuumObject
         self.object_from_backend(pool).await
     }
 
-    async fn object_id_adapter(&self, _pool: &DbPool) -> Result<(i32, i32), ApiError> {
-        Ok((self.from_hubuum_object_id, self.to_hubuum_object_id))
+    async fn object_id_adapter(
+        &self,
+        _pool: &DbPool,
+    ) -> Result<(HubuumObjectID, HubuumObjectID), ApiError> {
+        Ok((
+            HubuumObjectID::new(self.from_hubuum_object_id)?,
+            HubuumObjectID::new(self.to_hubuum_object_id)?,
+        ))
     }
 }
 
-impl ObjectAdapter<(HubuumObject, HubuumObject), (i32, i32)> for HubuumObjectRelationID {
+impl ObjectAdapter<(HubuumObject, HubuumObject), (HubuumObjectID, HubuumObjectID)> for HubuumObjectRelationID {
     async fn object_adapter(
         &self,
         pool: &DbPool,
@@ -208,12 +229,15 @@ impl ObjectAdapter<(HubuumObject, HubuumObject), (i32, i32)> for HubuumObjectRel
         self.object_from_backend(pool).await
     }
 
-    async fn object_id_adapter(&self, pool: &DbPool) -> Result<(i32, i32), ApiError> {
+    async fn object_id_adapter(
+        &self,
+        pool: &DbPool,
+    ) -> Result<(HubuumObjectID, HubuumObjectID), ApiError> {
         self.instance(pool).await?.object_id(pool).await
     }
 }
 
-impl ObjectAdapter<(HubuumObject, HubuumObject), (i32, i32)> for HubuumObjectRelation {
+impl ObjectAdapter<(HubuumObject, HubuumObject), (HubuumObjectID, HubuumObjectID)> for HubuumObjectRelation {
     async fn object_adapter(
         &self,
         pool: &DbPool,
@@ -222,8 +246,14 @@ impl ObjectAdapter<(HubuumObject, HubuumObject), (i32, i32)> for HubuumObjectRel
         self.object_from_backend(pool).await
     }
 
-    async fn object_id_adapter(&self, _pool: &DbPool) -> Result<(i32, i32), ApiError> {
-        Ok((self.from_hubuum_object_id, self.to_hubuum_object_id))
+    async fn object_id_adapter(
+        &self,
+        _pool: &DbPool,
+    ) -> Result<(HubuumObjectID, HubuumObjectID), ApiError> {
+        Ok((
+            HubuumObjectID::new(self.from_hubuum_object_id)?,
+            HubuumObjectID::new(self.to_hubuum_object_id)?,
+        ))
     }
 }
 

--- a/src/models/traits/object.rs
+++ b/src/models/traits/object.rs
@@ -5,7 +5,7 @@ use crate::db::traits::object::{
 };
 use crate::errors::ApiError;
 
-use crate::models::class::HubuumClass;
+use crate::models::class::{HubuumClass, HubuumClassID};
 use crate::models::namespace::{Namespace, NamespaceID};
 use crate::models::object::{
     HubuumObject, HubuumObjectID, HubuumObjectWithPath, NewHubuumObject, UpdateHubuumObject,
@@ -158,8 +158,8 @@ impl ClassAdapter for HubuumObject {
         self.lookup_object_class(pool).await
     }
 
-    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.hubuum_class_id)
+    async fn class_id_adapter(&self, _pool: &DbPool) -> Result<HubuumClassID, ApiError> {
+        HubuumClassID::new(self.hubuum_class_id)
     }
 }
 
@@ -193,8 +193,8 @@ impl ClassAdapter for HubuumObjectID {
         self.lookup_object_class(pool).await
     }
 
-    async fn class_id_adapter(&self, pool: &DbPool) -> Result<i32, ApiError> {
-        Ok(self.class(pool).await?.id)
+    async fn class_id_adapter(&self, pool: &DbPool) -> Result<HubuumClassID, ApiError> {
+        HubuumClassID::new(self.class(pool).await?.id)
     }
 }
 

--- a/src/traits/accessors.rs
+++ b/src/traits/accessors.rs
@@ -2,7 +2,9 @@
 
 use crate::db::DbPool;
 use crate::errors::ApiError;
-use crate::models::{HubuumClass, HubuumObject, Namespace, NamespaceID};
+use crate::models::{
+    HubuumClass, HubuumClassID, HubuumObject, HubuumObjectID, Namespace, NamespaceID,
+};
 
 use super::context::BackendContext;
 
@@ -130,7 +132,7 @@ where
 ///
 /// As with [`NamespaceAccessors`], this trait lets entity and identifier types share a common
 /// class lookup interface while keeping backend-specific loading in internal adapters.
-pub trait ClassAccessors<C = HubuumClass, I = i32> {
+pub trait ClassAccessors<C = HubuumClass, I = HubuumClassID> {
     /// Return the class instance for this value.
     async fn class<B>(&self, backend: &B) -> Result<C, ApiError>
     where
@@ -143,7 +145,7 @@ pub trait ClassAccessors<C = HubuumClass, I = i32> {
 }
 
 #[doc(hidden)]
-pub(crate) trait ClassAdapter<C = HubuumClass, I = i32> {
+pub(crate) trait ClassAdapter<C = HubuumClass, I = HubuumClassID> {
     async fn class_adapter(&self, pool: &DbPool) -> Result<C, ApiError>;
     async fn class_id_adapter(&self, pool: &DbPool) -> Result<I, ApiError>;
 }
@@ -184,7 +186,7 @@ where
 ///
 /// This follows the same pattern as the other accessor traits, including relation cases where the
 /// returned object or identifier type may be a tuple rather than a single value.
-pub trait ObjectAccessors<O = HubuumObject, I = i32> {
+pub trait ObjectAccessors<O = HubuumObject, I = HubuumObjectID> {
     #[allow(dead_code)]
     /// Return the object instance for this value.
     async fn object<B>(&self, backend: &B) -> Result<O, ApiError>
@@ -198,7 +200,7 @@ pub trait ObjectAccessors<O = HubuumObject, I = i32> {
 }
 
 #[doc(hidden)]
-pub(crate) trait ObjectAdapter<O = HubuumObject, I = i32> {
+pub(crate) trait ObjectAdapter<O = HubuumObject, I = HubuumObjectID> {
     #[allow(dead_code)]
     async fn object_adapter(&self, pool: &DbPool) -> Result<O, ApiError>;
     async fn object_id_adapter(&self, pool: &DbPool) -> Result<I, ApiError>;


### PR DESCRIPTION
Stacked on #62 (base branch `harden-id-newtypes-57`).

Finishes the symmetry started for namespace ids in #62: the class/object id accessors now return the validated newtypes instead of bare `i32`, so a class or object id can't be passed around unchecked any more than a namespace id can.

## Changes
- `ClassAdapter::class_id_adapter` / `ClassAccessors::class_id` → `HubuumClassID` (default type param flipped from `i32`).
- `ObjectAdapter::object_id_adapter` / `ObjectAccessors::object_id` → `HubuumObjectID`.
- Tuple relation variants → `(HubuumClassID, HubuumClassID)` / `(HubuumObjectID, HubuumObjectID)`.
- `HubuumClass`/`HubuumObject` and the `*ID` implementors construct via `XID::new`; the relation `*ID` variants delegate through `instance(..)`.
- Callers unwrap to the raw id at the persistence boundary with `.id()` — the namespace relation lookups convert the tuple immediately after fetching; `check_if_object_in_class` compares as `i32`.

## Verification
- `cargo clippy --all-targets -- -D warnings` — clean
- `source .env && ./run_tests.sh` — 645 passed, 0 failed
- `docs/openapi.json` — no drift (these are internal adapter traits; path params are still documented as `i32`)

> Note: review/merge after #62, or merge #62 first and I'll retarget this onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)