### PR TITLE
Split outbound HTTP and template helpers into crates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@
 - Model methods should stay thin and delegate persistence-heavy work to backend traits.
 - Use `BackendContext` for APIs that should accept either `DbPool` or wrappers such as `web::Data<DbPool>`.
 - Put multi-step database writes in `with_transaction`; use `with_connection` for single reads, single writes, and non-atomic database work.
+- Workspace crates should expose small, explicit interfaces with private fields. Prefer typed request/builder APIs over long positional argument lists when callers must provide several settings.
+- Keep workspace crate boundaries clean of app-specific errors, global config, Actix, Diesel, and task persistence unless the crate explicitly owns that layer.
+- Avoid leaking third-party implementation types from workspace crate APIs unless they are the intentional integration surface. Use crate-owned structs, builders, traits, and errors at boundaries where practical.
+- Use typestate builders when they prevent meaningful invalid call order or missing required data; otherwise prefer a simpler builder with validating terminal methods.
 
 ## API Conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,6 +1458,8 @@ dependencies = [
  "futures",
  "futures-util",
  "hmac",
+ "hubuum-outbound-http",
+ "hubuum-templates",
  "iai-callgrind",
  "ipnet",
  "jsonschema",
@@ -1483,6 +1485,25 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
+]
+
+[[package]]
+name = "hubuum-outbound-http"
+version = "0.0.1"
+dependencies = [
+ "ipnet",
+ "reqwest 0.12.28",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "hubuum-templates"
+version = "0.0.1"
+dependencies = [
+ "chrono",
+ "minijinja",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["web-programming::http-server"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[workspace]
+members = ["crates/hubuum-outbound-http", "crates/hubuum-templates"]
+
 [dependencies]
 actix-rt = "2"
 actix-service = "2"
@@ -41,6 +44,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"
 hmac = "0.13"
+hubuum-outbound-http = { path = "crates/hubuum-outbound-http" }
+hubuum-templates = { path = "crates/hubuum-templates" }
 minijinja = { version = "2", features = ["loader", "fuel"] }
 tokio = { version = "1", features = ["sync", "macros", "rt-multi-thread", "net", "io-util"] }
 tracing = "0.1"

--- a/crates/hubuum-outbound-http/Cargo.toml
+++ b/crates/hubuum-outbound-http/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "hubuum-outbound-http"
+version = "0.0.1"
+edition = "2024"
+description = "Hardened outbound HTTP helpers for Hubuum."
+license = "MIT"
+repository = "https://github.com/hubuum/hubuum"
+
+[dependencies]
+ipnet = "2.12"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+serde_json = "1"
+tokio = { version = "1", features = ["net"] }

--- a/crates/hubuum-outbound-http/src/lib.rs
+++ b/crates/hubuum-outbound-http/src/lib.rs
@@ -1,0 +1,545 @@
+//! Hardened outbound HTTP primitives shared by Hubuum integrations.
+//!
+//! This crate owns the reusable security boundary for outbound calls: HTTPS-only
+//! URL validation, embedded credential rejection, DNS resolution with IP
+//! screening, resolver pinning, redirect refusal, response body caps, timeout
+//! application, and sensitive response-header redaction.
+//!
+//! It intentionally does not own Hubuum-specific concerns such as auth secret
+//! resolution, task/result persistence, API error types, permissions, template
+//! rendering, or global app configuration. Callers pass concrete request
+//! settings in explicitly and map `OutboundHttpError` into their public error
+//! surface.
+//!
+//! The `dangerous_*` request toggles exist for tightly scoped test/internal
+//! callers and should not be enabled from production paths.
+
+use std::fmt;
+use std::net::{IpAddr, SocketAddr};
+use std::time::{Duration, Instant};
+
+use ipnet::IpNet;
+use reqwest::Url;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+
+#[derive(Debug)]
+pub enum OutboundHttpError {
+    InvalidUrl,
+    NonHttpsUrl,
+    EmbeddedCredentials,
+    MissingHost,
+    MissingKnownPort,
+    DnsResolution { host: String },
+    EmptyDnsResolution { host: String },
+    DisallowedAddress { host: String, address: IpAddr },
+    ClientBuild(String),
+    ResponseRead(String),
+    Timeout,
+    Connect,
+    Request(String),
+    InvalidHeaderName { name: String },
+    InvalidHeaderValue { name: String },
+}
+
+impl fmt::Display for OutboundHttpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidUrl => write!(f, "outbound URL is invalid"),
+            Self::NonHttpsUrl => write!(f, "outbound URLs must use https"),
+            Self::EmbeddedCredentials => {
+                write!(f, "outbound URLs must not contain embedded credentials")
+            }
+            Self::MissingHost => write!(f, "outbound URL is missing a host"),
+            Self::MissingKnownPort => write!(f, "outbound URL is missing a known port"),
+            Self::DnsResolution { host } => write!(f, "failed to resolve outbound host '{host}'"),
+            Self::EmptyDnsResolution { host } => {
+                write!(f, "outbound host '{host}' did not resolve to any address")
+            }
+            Self::DisallowedAddress { host, address } => write!(
+                f,
+                "outbound host '{host}' resolves to a disallowed address ({address})"
+            ),
+            Self::ClientBuild(error) => write!(f, "HTTP client error: {error}"),
+            Self::ResponseRead(error) => write!(f, "failed reading outbound response: {error}"),
+            Self::Timeout => write!(f, "outbound call timed out"),
+            Self::Connect => write!(f, "outbound connection failed"),
+            Self::Request(error) => write!(f, "outbound call failed: {error}"),
+            Self::InvalidHeaderName { name } => write!(f, "invalid outbound header name: {name}"),
+            Self::InvalidHeaderValue { name } => {
+                write!(f, "invalid outbound header value for {name}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for OutboundHttpError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutboundMethod {
+    Get,
+    Post,
+    Patch,
+    Delete,
+}
+
+impl OutboundMethod {
+    fn as_reqwest(self) -> reqwest::Method {
+        match self {
+            OutboundMethod::Get => reqwest::Method::GET,
+            OutboundMethod::Post => reqwest::Method::POST,
+            OutboundMethod::Patch => reqwest::Method::PATCH,
+            OutboundMethod::Delete => reqwest::Method::DELETE,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutboundUrlParts {
+    url: Url,
+    host: String,
+    port: u16,
+}
+
+impl OutboundUrlParts {
+    pub fn url(&self) -> &str {
+        self.url.as_str()
+    }
+
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+pub fn validate_outbound_url(url: &str) -> Result<OutboundUrlParts, OutboundHttpError> {
+    if url.is_empty() || url.chars().any(|ch| ch.is_whitespace() || ch.is_control()) {
+        return Err(OutboundHttpError::InvalidUrl);
+    }
+
+    let parsed = Url::parse(url).map_err(|_| OutboundHttpError::InvalidUrl)?;
+
+    if parsed.scheme() != "https" {
+        return Err(OutboundHttpError::NonHttpsUrl);
+    }
+
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(OutboundHttpError::EmbeddedCredentials);
+    }
+
+    let host = parsed
+        .host_str()
+        .filter(|host| !host.is_empty())
+        .ok_or(OutboundHttpError::MissingHost)?
+        .to_string();
+
+    let port = parsed
+        .port_or_known_default()
+        .ok_or(OutboundHttpError::MissingKnownPort)?;
+
+    Ok(OutboundUrlParts {
+        url: parsed,
+        host,
+        port,
+    })
+}
+
+fn blocked_outbound_nets() -> &'static [IpNet] {
+    use std::sync::OnceLock;
+    static NETS: OnceLock<Vec<IpNet>> = OnceLock::new();
+    NETS.get_or_init(|| {
+        [
+            "0.0.0.0/8",
+            "10.0.0.0/8",
+            "100.64.0.0/10",
+            "127.0.0.0/8",
+            "169.254.0.0/16",
+            "172.16.0.0/12",
+            "192.0.0.0/24",
+            "192.0.2.0/24",
+            "192.168.0.0/16",
+            "198.18.0.0/15",
+            "198.51.100.0/24",
+            "203.0.113.0/24",
+            "224.0.0.0/4",
+            "240.0.0.0/4",
+            "255.255.255.255/32",
+            "::/128",
+            "::1/128",
+            "::ffff:0:0/96",
+            "64:ff9b::/96",
+            "100::/64",
+            "2001:db8::/32",
+            "fc00::/7",
+            "fe80::/10",
+            "ff00::/8",
+        ]
+        .iter()
+        .map(|net| net.parse().expect("static blocked net must parse"))
+        .collect()
+    })
+}
+
+pub fn ip_blocked(ip: IpAddr) -> bool {
+    let ip = match ip {
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => IpAddr::V4(v4),
+            None => IpAddr::V6(v6),
+        },
+        other => other,
+    };
+
+    blocked_outbound_nets().iter().any(|net| match (net, ip) {
+        (IpNet::V4(net), IpAddr::V4(addr)) => net.contains(&addr),
+        (IpNet::V6(net), IpAddr::V6(addr)) => net.contains(&addr),
+        _ => false,
+    })
+}
+
+pub async fn screen_host(
+    host: &str,
+    port: u16,
+    allow_private_targets: bool,
+    dangerous_allow_localhost: bool,
+) -> Result<Vec<SocketAddr>, OutboundHttpError> {
+    if dangerous_allow_localhost && host.eq_ignore_ascii_case("localhost") {
+        return Ok(vec![SocketAddr::from(([127, 0, 0, 1], port))]);
+    }
+
+    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|_| OutboundHttpError::DnsResolution {
+            host: host.to_string(),
+        })?
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(OutboundHttpError::EmptyDnsResolution {
+            host: host.to_string(),
+        });
+    }
+
+    if !allow_private_targets && let Some(blocked) = addrs.iter().find(|addr| ip_blocked(addr.ip()))
+    {
+        return Err(OutboundHttpError::DisallowedAddress {
+            host: host.to_string(),
+            address: blocked.ip(),
+        });
+    }
+
+    Ok(addrs)
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct OutboundHeaders {
+    inner: HeaderMap,
+}
+
+impl OutboundHeaders {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, name: &str, value: &str) -> Result<(), OutboundHttpError> {
+        let header_name = HeaderName::from_bytes(name.as_bytes()).map_err(|_| {
+            OutboundHttpError::InvalidHeaderName {
+                name: name.to_string(),
+            }
+        })?;
+        let header_value =
+            HeaderValue::from_str(value).map_err(|_| OutboundHttpError::InvalidHeaderValue {
+                name: name.to_string(),
+            })?;
+        self.inner.insert(header_name, header_value);
+        Ok(())
+    }
+
+    fn into_inner(self) -> HeaderMap {
+        self.inner
+    }
+}
+
+pub struct OutboundRequest {
+    method: OutboundMethod,
+    url: String,
+    headers: OutboundHeaders,
+    body: Option<String>,
+    timeout: Duration,
+    max_response_bytes: usize,
+    allow_private_targets: bool,
+    dangerous_accept_invalid_certs: bool,
+    dangerous_allow_localhost: bool,
+}
+
+impl OutboundRequest {
+    pub fn new(method: OutboundMethod, url: impl Into<String>, timeout: Duration) -> Self {
+        Self {
+            method,
+            url: url.into(),
+            headers: OutboundHeaders::new(),
+            body: None,
+            timeout,
+            max_response_bytes: 64 * 1024,
+            allow_private_targets: false,
+            dangerous_accept_invalid_certs: false,
+            dangerous_allow_localhost: false,
+        }
+    }
+
+    pub fn headers(mut self, headers: OutboundHeaders) -> Self {
+        self.headers = headers;
+        self
+    }
+
+    pub fn body(mut self, body: Option<String>) -> Self {
+        self.body = body;
+        self
+    }
+
+    pub fn max_response_bytes(mut self, max_response_bytes: usize) -> Self {
+        self.max_response_bytes = max_response_bytes;
+        self
+    }
+
+    pub fn allow_private_targets(mut self, allow_private_targets: bool) -> Self {
+        self.allow_private_targets = allow_private_targets;
+        self
+    }
+
+    pub fn dangerous_accept_invalid_certs(mut self, dangerous_accept_invalid_certs: bool) -> Self {
+        self.dangerous_accept_invalid_certs = dangerous_accept_invalid_certs;
+        self
+    }
+
+    pub fn dangerous_allow_localhost(mut self, dangerous_allow_localhost: bool) -> Self {
+        self.dangerous_allow_localhost = dangerous_allow_localhost;
+        self
+    }
+
+    pub async fn send(self) -> Result<OutboundResponse, OutboundHttpError> {
+        execute(self).await
+    }
+}
+
+#[derive(Debug)]
+pub struct OutboundResponse {
+    status_code: u16,
+    status_display: String,
+    success: bool,
+    headers: serde_json::Value,
+    body_preview: String,
+    duration_ms: i32,
+    url: String,
+}
+
+impl OutboundResponse {
+    pub fn status_code(&self) -> u16 {
+        self.status_code
+    }
+
+    pub fn status_display(&self) -> &str {
+        &self.status_display
+    }
+
+    pub fn is_success(&self) -> bool {
+        self.success
+    }
+
+    pub fn headers(&self) -> &serde_json::Value {
+        &self.headers
+    }
+
+    pub fn body_preview(&self) -> &str {
+        &self.body_preview
+    }
+
+    pub fn duration_ms(&self) -> i32 {
+        self.duration_ms
+    }
+
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+async fn execute(request: OutboundRequest) -> Result<OutboundResponse, OutboundHttpError> {
+    let url_parts = validate_outbound_url(&request.url)?;
+    let screened_addrs = screen_host(
+        &url_parts.host,
+        url_parts.port,
+        request.allow_private_targets,
+        request.dangerous_allow_localhost,
+    )
+    .await?;
+
+    let client_builder = reqwest::Client::builder()
+        .timeout(request.timeout)
+        .redirect(reqwest::redirect::Policy::none())
+        .resolve_to_addrs(&url_parts.host, &screened_addrs);
+    let client_builder = if request.dangerous_accept_invalid_certs {
+        client_builder.danger_accept_invalid_certs(true)
+    } else {
+        client_builder
+    };
+    let client = client_builder
+        .build()
+        .map_err(|error| OutboundHttpError::ClientBuild(error.to_string()))?;
+
+    let mut request_builder = client
+        .request(request.method.as_reqwest(), url_parts.url.clone())
+        .headers(request.headers.into_inner());
+    if let Some(body) = request.body {
+        request_builder = request_builder.body(body);
+    }
+
+    let start = Instant::now();
+    let response = request_builder.send().await.map_err(map_reqwest_error)?;
+    let status = response.status();
+    let headers = headers_to_json(response.headers());
+    let body_preview = read_capped_body(response, request.max_response_bytes).await?;
+    let duration_ms = i32::try_from(start.elapsed().as_millis()).unwrap_or(i32::MAX);
+
+    Ok(OutboundResponse {
+        status_code: status.as_u16(),
+        status_display: status.to_string(),
+        success: status.is_success(),
+        headers,
+        body_preview,
+        duration_ms,
+        url: url_parts.url.to_string(),
+    })
+}
+
+async fn read_capped_body(
+    mut response: reqwest::Response,
+    limit: usize,
+) -> Result<String, OutboundHttpError> {
+    let mut buffer: Vec<u8> = Vec::new();
+    while buffer.len() < limit {
+        match response
+            .chunk()
+            .await
+            .map_err(|error| OutboundHttpError::ResponseRead(error.to_string()))?
+        {
+            Some(chunk) => {
+                let remaining = limit - buffer.len();
+                let take = remaining.min(chunk.len());
+                buffer.extend_from_slice(&chunk[..take]);
+            }
+            None => break,
+        }
+    }
+    Ok(String::from_utf8_lossy(&buffer).replace('\0', "\u{FFFD}"))
+}
+
+fn is_sensitive_response_header(name: &str) -> bool {
+    const SENSITIVE: [&str; 6] = [
+        "set-cookie",
+        "set-cookie2",
+        "authorization",
+        "proxy-authorization",
+        "www-authenticate",
+        "proxy-authenticate",
+    ];
+    SENSITIVE.contains(&name.to_ascii_lowercase().as_str())
+}
+
+fn headers_to_json(headers: &HeaderMap) -> serde_json::Value {
+    let mut object = serde_json::Map::new();
+    for (name, value) in headers {
+        if is_sensitive_response_header(name.as_str()) {
+            object.insert(
+                name.to_string(),
+                serde_json::Value::String("[redacted]".to_string()),
+            );
+        } else if let Ok(value) = value.to_str() {
+            object.insert(
+                name.to_string(),
+                serde_json::Value::String(value.to_string()),
+            );
+        }
+    }
+    serde_json::Value::Object(object)
+}
+
+fn map_reqwest_error(error: reqwest::Error) -> OutboundHttpError {
+    if error.is_timeout() {
+        OutboundHttpError::Timeout
+    } else if error.is_connect() {
+        OutboundHttpError::Connect
+    } else {
+        OutboundHttpError::Request(error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outbound_urls_must_be_https() {
+        let parts = validate_outbound_url("https://example.com/hook").unwrap();
+        assert_eq!(parts.url(), "https://example.com/hook");
+        assert_eq!(parts.host, "example.com");
+        assert_eq!(parts.port, 443);
+
+        let custom_port = validate_outbound_url("https://example.com:8443/hook").unwrap();
+        assert_eq!(custom_port.url(), "https://example.com:8443/hook");
+        assert_eq!(custom_port.port, 8443);
+
+        assert!(matches!(
+            validate_outbound_url("http://example.com/hook"),
+            Err(OutboundHttpError::NonHttpsUrl)
+        ));
+        assert!(validate_outbound_url("https://").is_err());
+        assert!(validate_outbound_url("ftp://example.com").is_err());
+        assert!(validate_outbound_url("https://example.com /hook").is_err());
+    }
+
+    #[test]
+    fn outbound_urls_reject_embedded_credentials() {
+        assert!(matches!(
+            validate_outbound_url("https://user:pass@example.com/hook"),
+            Err(OutboundHttpError::EmbeddedCredentials)
+        ));
+        assert!(matches!(
+            validate_outbound_url("https://user@example.com/hook"),
+            Err(OutboundHttpError::EmbeddedCredentials)
+        ));
+        assert!(matches!(
+            validate_outbound_url("https://example.com@127.0.0.1/hook"),
+            Err(OutboundHttpError::EmbeddedCredentials)
+        ));
+    }
+
+    #[test]
+    fn private_and_internal_ips_are_blocked() {
+        use std::net::{Ipv4Addr, Ipv6Addr};
+
+        assert!(ip_blocked(IpAddr::V4(Ipv4Addr::LOCALHOST)));
+        assert!(ip_blocked(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5))));
+        assert!(ip_blocked(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
+        assert!(ip_blocked(IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254))));
+        assert!(ip_blocked(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+        assert!(ip_blocked("fd00::1".parse::<IpAddr>().unwrap()));
+        assert!(ip_blocked("::ffff:127.0.0.1".parse::<IpAddr>().unwrap()));
+
+        assert!(!ip_blocked(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+        assert!(!ip_blocked(
+            "2606:4700:4700::1111".parse::<IpAddr>().unwrap()
+        ));
+    }
+
+    #[test]
+    fn sensitive_response_headers_are_redacted() {
+        let mut headers = HeaderMap::new();
+        headers.insert("set-cookie", "secret=1".parse().unwrap());
+        headers.insert("x-request-id", "abc".parse().unwrap());
+
+        let json = headers_to_json(&headers);
+        assert_eq!(json["set-cookie"], "[redacted]");
+        assert_eq!(json["x-request-id"], "abc");
+    }
+}

--- a/crates/hubuum-templates/Cargo.toml
+++ b/crates/hubuum-templates/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "hubuum-templates"
+version = "0.0.1"
+edition = "2024"
+description = "Bounded MiniJinja template helpers for Hubuum."
+license = "MIT"
+repository = "https://github.com/hubuum/hubuum"
+
+[dependencies]
+chrono = "0.4"
+minijinja = { version = "2", features = ["fuel"] }
+serde_json = "1"

--- a/crates/hubuum-templates/src/lib.rs
+++ b/crates/hubuum-templates/src/lib.rs
@@ -1,0 +1,431 @@
+//! Bounded MiniJinja helpers shared by Hubuum templating surfaces.
+//!
+//! This crate owns the reusable template execution boundary: fuel and recursion
+//! limits, simple validation/rendering helpers, and the curated filters/functions
+//! that should behave consistently across reports, remote targets, webhook
+//! sinks, and future template consumers.
+//!
+//! It intentionally does not own Hubuum-specific concerns such as report
+//! database models, namespace template loading, permission checks, report output
+//! persistence, API error types, or global app configuration. Callers pass
+//! `TemplateLimits` explicitly, usually through `prepare_template`, and may
+//! provide an optional missing-value recorder callback when they need
+//! app-specific warning collection.
+
+use std::fmt;
+
+use minijinja::value::Value;
+use minijinja::{Environment, Error as MiniJinjaError, ErrorKind as MiniJinjaErrorKind, State};
+
+pub type MissingValueRecorder = fn(MissingValue);
+
+pub fn prepare_template(source: &str) -> PreparedTemplate<'_> {
+    PreparedTemplate::new(source)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingValue {
+    template_name: String,
+    path: Option<String>,
+}
+
+impl MissingValue {
+    pub fn new(template_name: impl Into<String>, path: Option<String>) -> Self {
+        Self {
+            template_name: template_name.into(),
+            path,
+        }
+    }
+
+    pub fn template_name(&self) -> &str {
+        &self.template_name
+    }
+
+    pub fn path(&self) -> Option<&str> {
+        self.path.as_deref()
+    }
+
+    pub fn into_path(self) -> Option<String> {
+        self.path
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct TemplateLimits {
+    recursion_limit: usize,
+    fuel: u64,
+}
+
+impl TemplateLimits {
+    pub fn new(recursion_limit: usize, fuel: u64) -> Self {
+        Self {
+            recursion_limit,
+            fuel,
+        }
+    }
+
+    pub fn recursion_limit(self) -> usize {
+        self.recursion_limit
+    }
+
+    pub fn fuel(self) -> u64 {
+        self.fuel
+    }
+}
+
+#[derive(Debug)]
+pub struct TemplateError {
+    message: String,
+    source: Option<MiniJinjaError>,
+}
+
+impl TemplateError {
+    fn validation(source: MiniJinjaError) -> Self {
+        Self {
+            message: source.to_string(),
+            source: Some(source),
+        }
+    }
+
+    fn render(source: MiniJinjaError) -> Self {
+        Self {
+            message: source.to_string(),
+            source: Some(source),
+        }
+    }
+
+    fn missing_limit(name: &str) -> Self {
+        Self {
+            message: format!("template {name} limit is not configured"),
+            source: None,
+        }
+    }
+}
+
+impl fmt::Display for TemplateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for TemplateError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|source| source as &(dyn std::error::Error + 'static))
+    }
+}
+
+pub struct PreparedTemplate<'source> {
+    source: &'source str,
+    recursion_limit: Option<usize>,
+    fuel: Option<u64>,
+}
+
+impl<'source> PreparedTemplate<'source> {
+    fn new(source: &'source str) -> Self {
+        Self {
+            source,
+            recursion_limit: None,
+            fuel: None,
+        }
+    }
+
+    pub fn limits(mut self, limits: TemplateLimits) -> Self {
+        self.recursion_limit = Some(limits.recursion_limit());
+        self.fuel = Some(limits.fuel());
+        self
+    }
+
+    pub fn limit_recursion(mut self, recursion_limit: usize) -> Self {
+        self.recursion_limit = Some(recursion_limit);
+        self
+    }
+
+    pub fn limit_fuel(mut self, fuel: u64) -> Self {
+        self.fuel = Some(fuel);
+        self
+    }
+
+    pub fn context<'context>(
+        self,
+        context: &'context serde_json::Value,
+    ) -> PreparedTemplateRender<'source, 'context> {
+        PreparedTemplateRender {
+            template: self,
+            context,
+        }
+    }
+
+    pub fn validate(self) -> Result<(), TemplateError> {
+        let limits = self.limits_or_error()?;
+        bounded_environment(limits)
+            .template_from_str(self.source)
+            .map(|_| ())
+            .map_err(TemplateError::validation)
+    }
+
+    fn limits_or_error(&self) -> Result<TemplateLimits, TemplateError> {
+        let recursion_limit = self
+            .recursion_limit
+            .ok_or_else(|| TemplateError::missing_limit("recursion"))?;
+        let fuel = self
+            .fuel
+            .ok_or_else(|| TemplateError::missing_limit("fuel"))?;
+        Ok(TemplateLimits::new(recursion_limit, fuel))
+    }
+}
+
+pub struct PreparedTemplateRender<'source, 'context> {
+    template: PreparedTemplate<'source>,
+    context: &'context serde_json::Value,
+}
+
+impl PreparedTemplateRender<'_, '_> {
+    pub fn render(self) -> Result<String, TemplateError> {
+        let limits = self.template.limits_or_error()?;
+        bounded_environment(limits)
+            .template_from_str(self.template.source)
+            .and_then(|compiled| compiled.render(self.context))
+            .map_err(TemplateError::render)
+    }
+}
+
+fn bounded_environment(limits: TemplateLimits) -> Environment<'static> {
+    let mut env = Environment::new();
+    env.set_recursion_limit(limits.recursion_limit);
+    env.set_fuel(Some(limits.fuel));
+    register_curated_helpers(&mut env, None);
+    env
+}
+
+pub fn register_curated_helpers(
+    env: &mut Environment<'static>,
+    missing_value_recorder: Option<MissingValueRecorder>,
+) {
+    env.add_filter("csv_cell", csv_cell_filter);
+    env.add_filter("tojson", tojson_filter);
+    env.add_filter(
+        "default_if_empty",
+        move |state: &State<'_, '_>, value: Value, fallback: Value| {
+            default_if_empty_filter(state, value, fallback, missing_value_recorder)
+        },
+    );
+    env.add_filter("format_datetime", format_datetime_filter);
+    env.add_filter("join_nonempty", join_nonempty_filter);
+    env.add_function(
+        "coalesce",
+        move |state: &State<'_, '_>, values: minijinja::value::Rest<Value>| {
+            coalesce_function(state, values, missing_value_recorder)
+        },
+    );
+}
+
+pub fn csv_cell_filter(value: Value) -> String {
+    let rendered = if value.is_none() || value.is_undefined() {
+        String::new()
+    } else {
+        value.to_string()
+    };
+    let guarded = if csv_cell_needs_formula_guard(&rendered) {
+        format!("'{rendered}")
+    } else {
+        rendered
+    };
+    if guarded.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", guarded.replace('"', "\"\""))
+    } else {
+        guarded
+    }
+}
+
+fn csv_cell_needs_formula_guard(rendered: &str) -> bool {
+    match rendered.chars().next() {
+        Some('\t' | '\r' | '\n') => true,
+        Some(_) => rendered
+            .trim_start_matches([' ', '\t'])
+            .starts_with(['=', '+', '-', '@']),
+        None => false,
+    }
+}
+
+fn tojson_filter(value: Value) -> Result<String, MiniJinjaError> {
+    serde_json::to_string(&value).map_err(|error| {
+        MiniJinjaError::new(
+            MiniJinjaErrorKind::InvalidOperation,
+            "unable to serialize template value as JSON",
+        )
+        .with_source(error)
+    })
+}
+
+fn default_if_empty_filter(
+    state: &State<'_, '_>,
+    value: Value,
+    fallback: Value,
+    missing_value_recorder: Option<MissingValueRecorder>,
+) -> Value {
+    if value.is_undefined()
+        && let Some(record) = missing_value_recorder
+    {
+        record(MissingValue::new(state.name(), None));
+    }
+    if value_is_missing_or_empty(&value) {
+        fallback
+    } else {
+        value
+    }
+}
+
+fn format_datetime_filter(value: Value, format: Option<String>) -> Result<String, MiniJinjaError> {
+    let format = format.unwrap_or_else(|| "iso".to_string());
+    let raw = match value.as_str() {
+        Some(raw) if !raw.trim().is_empty() => raw.trim(),
+        _ if value.is_none() || value.is_undefined() => return Ok(String::new()),
+        _ => {
+            return Err(MiniJinjaError::new(
+                MiniJinjaErrorKind::InvalidOperation,
+                "format_datetime expects an RFC3339 or Hubuum timestamp string",
+            ));
+        }
+    };
+
+    let parsed = parse_template_datetime(raw).ok_or_else(|| {
+        MiniJinjaError::new(
+            MiniJinjaErrorKind::InvalidOperation,
+            format!("Unable to parse '{raw}' as a supported datetime"),
+        )
+    })?;
+
+    Ok(match format.as_str() {
+        "iso" => parsed.to_rfc3339(),
+        "date" => parsed.format("%Y-%m-%d").to_string(),
+        "datetime" => parsed.format("%Y-%m-%d %H:%M:%S").to_string(),
+        "time" => parsed.format("%H:%M:%S").to_string(),
+        other => {
+            return Err(MiniJinjaError::new(
+                MiniJinjaErrorKind::InvalidOperation,
+                format!("Unsupported datetime format '{other}'"),
+            ));
+        }
+    })
+}
+
+fn join_nonempty_filter(value: Value, sep: Option<String>) -> Result<String, MiniJinjaError> {
+    let joiner = sep.unwrap_or_else(|| ", ".to_string());
+    let items = value.try_iter().map_err(|_| {
+        MiniJinjaError::new(
+            MiniJinjaErrorKind::InvalidOperation,
+            "join_nonempty expects a list-like value",
+        )
+    })?;
+
+    Ok(items
+        .filter(|item| !value_is_missing_or_empty(item))
+        .map(|item| item.to_string())
+        .filter(|item| !item.is_empty())
+        .collect::<Vec<_>>()
+        .join(&joiner))
+}
+
+fn coalesce_function(
+    state: &State<'_, '_>,
+    values: minijinja::value::Rest<Value>,
+    missing_value_recorder: Option<MissingValueRecorder>,
+) -> Value {
+    if values.iter().any(Value::is_undefined)
+        && let Some(record) = missing_value_recorder
+    {
+        record(MissingValue::new(state.name(), None));
+    }
+    values
+        .iter()
+        .find(|value| !value_is_missing_or_empty(value))
+        .cloned()
+        .unwrap_or(Value::UNDEFINED)
+}
+
+fn value_is_missing_or_empty(value: &Value) -> bool {
+    if value.is_undefined() || value.is_none() {
+        return true;
+    }
+
+    if let Some(text) = value.as_str() {
+        return text.is_empty();
+    }
+
+    matches!(value.len(), Some(0))
+}
+
+fn parse_template_datetime(raw: &str) -> Option<chrono::DateTime<chrono::FixedOffset>> {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .or_else(|| {
+            chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S")
+                .ok()
+                .and_then(|value| {
+                    chrono::FixedOffset::east_opt(0)
+                        .map(|offset| value.and_utc().with_timezone(&offset))
+                })
+        })
+        .or_else(|| {
+            chrono::NaiveDate::parse_from_str(raw, "%Y-%m-%d")
+                .ok()
+                .and_then(|value| value.and_hms_opt(0, 0, 0))
+                .and_then(|value| {
+                    chrono::FixedOffset::east_opt(0)
+                        .map(|offset| value.and_utc().with_timezone(&offset))
+                })
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn csv_cell_neutralizes_formula_injection() {
+        assert_eq!(
+            csv_cell_filter(Value::from("=HYPERLINK(\"http://evil\")")),
+            "\"'=HYPERLINK(\"\"http://evil\"\")\""
+        );
+        assert_eq!(csv_cell_filter(Value::from("@SUM(A1:A9)")), "'@SUM(A1:A9)");
+        assert_eq!(csv_cell_filter(Value::from("+1+1")), "'+1+1");
+        assert_eq!(csv_cell_filter(Value::from("-2+3")), "'-2+3");
+        assert_eq!(csv_cell_filter(Value::from("  =1+1")), "'  =1+1");
+        assert_eq!(csv_cell_filter(Value::from("\t=1+1")), "'\t=1+1");
+        assert_eq!(csv_cell_filter(Value::from("\rdata")), "\"'\rdata\"");
+        assert_eq!(csv_cell_filter(Value::from("plain value")), "plain value");
+        assert_eq!(csv_cell_filter(Value::from("a,b")), "\"a,b\"");
+        assert_eq!(csv_cell_filter(Value::from("3.14")), "3.14");
+    }
+
+    #[test]
+    fn render_template_supports_curated_filters() {
+        let context = serde_json::json!({ "object": { "data": { "host": "h1" } } });
+        let rendered = prepare_template("{{ object.data | tojson }}")
+            .limit_recursion(64)
+            .limit_fuel(50_000)
+            .context(&context)
+            .render()
+            .unwrap();
+        assert_eq!(rendered, "{\"host\":\"h1\"}");
+    }
+
+    #[test]
+    fn render_template_is_fuel_bounded() {
+        let context = serde_json::json!({});
+        let error = prepare_template("{% for _ in range(1000000000) %}x{% endfor %}")
+            .limit_recursion(64)
+            .limit_fuel(100)
+            .context(&context)
+            .render()
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("fuel")
+                || error.to_string().contains("operation")
+                || error.to_string().contains("limit")
+        );
+    }
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -8741,6 +8741,16 @@
               "null"
             ]
           },
+          "class_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/HubuumClassID"
+              }
+            ]
+          },
           "description": {
             "type": "string"
           },
@@ -9481,6 +9491,13 @@
               "string",
               "null"
             ]
+          },
+          "class_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
           },
           "created_at": {
             "type": "string",
@@ -10778,6 +10795,13 @@
               "string",
               "null"
             ]
+          },
+          "class_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
           },
           "description": {
             "type": [

--- a/docs/remote_targets.md
+++ b/docs/remote_targets.md
@@ -65,6 +65,7 @@ Example:
 ```json
 {
   "namespace_id": 12,
+  "class_id": 34,
   "name": "create-ticket",
   "description": "Create a ticket for the object",
   "method": "post",
@@ -89,6 +90,7 @@ Fields:
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `namespace_id` | integer | yes | Namespace that owns the target and controls permissions. |
+| `class_id` | integer or null | required for object targets | Class scope for targets whose `allowed_subject_types` includes `object`. Must belong to `namespace_id`. Must be null or omitted for non-object targets. |
 | `name` | string | yes | Unique with `namespace_id`. |
 | `description` | string | yes | Human-readable description. |
 | `method` | string | yes | One of `get`, `post`, `patch`, `delete`. |
@@ -302,9 +304,9 @@ Supported subject shapes:
 { "type": "object_relation", "relation_id": 90 }
 ```
 
-For object subjects, `class_id` must match the object's class. The subject type must be listed in
-the target's `allowed_subject_types`, and the target namespace must be one of the subject
-namespaces. Disabled targets return `400 Bad Request`.
+For object subjects, `class_id` must match the object's class and the remote target's persisted
+`class_id`. The subject type must be listed in the target's `allowed_subject_types`, and the target
+namespace must be one of the subject namespaces. Disabled targets return `400 Bad Request`.
 
 On success, Hubuum creates a queued task and returns `202 Accepted`:
 

--- a/migrations/2026-06-22-000001_remote_targets/up.sql
+++ b/migrations/2026-06-22-000001_remote_targets/up.sql
@@ -31,6 +31,7 @@ $$;
 CREATE TABLE remote_targets (
     id SERIAL PRIMARY KEY,
     namespace_id INT REFERENCES namespaces (id) ON DELETE CASCADE NOT NULL,
+    class_id INT REFERENCES hubuumclass (id) ON DELETE CASCADE NULL,
     name VARCHAR NOT NULL,
     description VARCHAR NOT NULL DEFAULT '',
     method VARCHAR NOT NULL CHECK (method IN ('get', 'post', 'patch', 'delete')),
@@ -47,6 +48,7 @@ CREATE TABLE remote_targets (
     CHECK (timeout_ms > 0),
     CHECK (jsonb_typeof(headers_template) = 'object'),
     CHECK (jsonb_typeof(auth_config) = 'object'),
+    CHECK (NOT (allowed_subject_types ? 'object') OR class_id IS NOT NULL),
     CHECK (remote_target_subject_types_valid(allowed_subject_types))
 );
 
@@ -68,6 +70,7 @@ CREATE TABLE remote_call_results (
 );
 
 CREATE INDEX idx_remote_targets_namespace_id ON remote_targets(namespace_id);
+CREATE INDEX idx_remote_targets_class_id ON remote_targets(class_id);
 CREATE INDEX idx_remote_targets_enabled ON remote_targets(enabled);
 CREATE INDEX idx_remote_call_results_target_id ON remote_call_results(target_id);
 CREATE INDEX idx_remote_call_results_subject ON remote_call_results(subject_type, subject_id);

--- a/src/api/v1/handlers/remote_targets.rs
+++ b/src/api/v1/handlers/remote_targets.rs
@@ -14,7 +14,7 @@ use crate::errors::ApiError;
 use crate::extractors::UserAccess;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
-    NamespaceID, NewRemoteTarget, Permissions, RemoteTarget, RemoteTargetID,
+    HubuumClassID, NamespaceID, NewRemoteTarget, Permissions, RemoteTarget, RemoteTargetID,
     RemoteTargetInvokeRequest, StoredRemoteCallTaskPayload, TaskKind, UpdateRemoteTarget,
     authorize_remote_invocation,
 };
@@ -22,7 +22,7 @@ use crate::pagination::prepare_db_pagination;
 use crate::tasks::{
     ensure_task_worker_running, idempotency_key_from_headers, kick_task_worker, request_hash,
 };
-use crate::traits::NamespaceAccessors;
+use crate::traits::{ClassAccessors, NamespaceAccessors};
 use crate::utilities::response::{
     json_response, json_response_created, json_response_with_header, paginated_json_response,
 };
@@ -57,6 +57,12 @@ pub async fn create_remote_target(
         [Permissions::CreateRemoteTarget],
         target.namespace_id
     );
+    validate_remote_target_class_scope(
+        &pool,
+        target.namespace_id.id(),
+        target.class_id.map(HubuumClassID::id),
+    )
+    .await?;
 
     let created: RemoteTarget = target
         .into_row()?
@@ -175,6 +181,16 @@ pub async fn patch_remote_target(
     if let Some(namespace_id) = update.namespace_id {
         can!(&pool, user, [Permissions::CreateRemoteTarget], namespace_id);
     }
+    let effective_namespace_id = update
+        .namespace_id
+        .map(NamespaceID::id)
+        .unwrap_or(existing.namespace_id);
+    let effective_class_id = match update.class_id {
+        Some(Some(class_id)) => Some(class_id.id()),
+        Some(None) => None,
+        None => existing.class_id,
+    };
+    validate_remote_target_class_scope(&pool, effective_namespace_id, effective_class_id).await?;
 
     let row = update.into_row(&existing)?;
     let updated: RemoteTarget = row
@@ -182,6 +198,23 @@ pub async fn patch_remote_target(
         .await?
         .try_into()?;
     Ok(json_response(updated, StatusCode::OK))
+}
+
+async fn validate_remote_target_class_scope(
+    pool: &DbPool,
+    namespace_id: i32,
+    class_id: Option<i32>,
+) -> Result<(), ApiError> {
+    let Some(class_id) = class_id else {
+        return Ok(());
+    };
+    let class = HubuumClassID::new(class_id)?.class(pool).await?;
+    if class.namespace_id != namespace_id {
+        return Err(ApiError::BadRequest(
+            "class_id must belong to the remote target namespace".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 #[utoipa::path(

--- a/src/db/traits/remote_target.rs
+++ b/src/db/traits/remote_target.rs
@@ -101,7 +101,8 @@ fn build_list_query<'a>(
     query_options: &'a QueryOptions,
 ) -> Result<crate::schema::remote_targets::BoxedQuery<'a, diesel::pg::Pg>, ApiError> {
     use crate::schema::remote_targets::dsl::{
-        created_at, description, id, method, name, namespace_id, remote_targets, updated_at,
+        class_id, created_at, description, id, method, name, namespace_id, remote_targets,
+        updated_at,
     };
 
     let mut query = remote_targets
@@ -117,6 +118,7 @@ fn build_list_query<'a>(
             FilterField::NamespaceId | FilterField::Namespaces => {
                 numeric_search!(query, param, operator, namespace_id)
             }
+            FilterField::ClassId => numeric_search!(query, param, operator, class_id),
             FilterField::Kind => string_search!(query, param, operator, method),
             FilterField::CreatedAt => date_search!(query, param, operator, created_at),
             FilterField::UpdatedAt => date_search!(query, param, operator, updated_at),

--- a/src/models/remote_target.rs
+++ b/src/models/remote_target.rs
@@ -1,9 +1,8 @@
-use std::net::IpAddr;
 use std::str::FromStr;
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
-use ipnet::IpNet;
+use hubuum_templates::prepare_template;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -128,6 +127,7 @@ pub enum RemoteAuthConfig {
 pub(crate) struct RemoteTargetRow {
     pub id: i32,
     pub namespace_id: i32,
+    pub class_id: Option<i32>,
     pub name: String,
     pub description: String,
     pub method: String,
@@ -146,6 +146,7 @@ pub(crate) struct RemoteTargetRow {
 pub struct RemoteTarget {
     pub id: i32,
     pub namespace_id: i32,
+    pub class_id: Option<i32>,
     pub name: String,
     pub description: String,
     pub method: RemoteHttpMethod,
@@ -163,6 +164,7 @@ pub struct RemoteTarget {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct NewRemoteTarget {
     pub namespace_id: NamespaceID,
+    pub class_id: Option<HubuumClassID>,
     pub name: String,
     pub description: String,
     pub method: RemoteHttpMethod,
@@ -182,6 +184,13 @@ pub struct NewRemoteTarget {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct UpdateRemoteTarget {
     pub namespace_id: Option<NamespaceID>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_double_option"
+    )]
+    #[schema(value_type = Option<i32>)]
+    pub class_id: Option<Option<HubuumClassID>>,
     pub name: Option<String>,
     pub description: Option<String>,
     pub method: Option<RemoteHttpMethod>,
@@ -204,6 +213,7 @@ pub struct UpdateRemoteTarget {
 #[diesel(table_name = remote_targets)]
 pub(crate) struct NewRemoteTargetRow {
     pub namespace_id: i32,
+    pub class_id: Option<i32>,
     pub name: String,
     pub description: String,
     pub method: String,
@@ -220,6 +230,7 @@ pub(crate) struct NewRemoteTargetRow {
 #[diesel(table_name = remote_targets)]
 pub(crate) struct UpdateRemoteTargetRow {
     pub namespace_id: Option<i32>,
+    pub class_id: Option<Option<i32>>,
     pub name: Option<String>,
     pub description: Option<String>,
     pub method: Option<String>,
@@ -448,6 +459,7 @@ impl TryFrom<RemoteTargetRow> for RemoteTarget {
         Ok(Self {
             id: row.id,
             namespace_id: row.namespace_id,
+            class_id: row.class_id,
             name: row.name,
             description: row.description,
             method: RemoteHttpMethod::from_str(&row.method)?,
@@ -467,6 +479,7 @@ impl TryFrom<RemoteTargetRow> for RemoteTarget {
 impl NewRemoteTarget {
     pub(crate) fn into_row(self) -> Result<NewRemoteTargetRow, ApiError> {
         validate_target_parts(
+            self.class_id.map(HubuumClassID::id),
             &self.url_template,
             &self.headers_template,
             self.body_template.as_deref(),
@@ -477,6 +490,7 @@ impl NewRemoteTarget {
 
         Ok(NewRemoteTargetRow {
             namespace_id: self.namespace_id.id(),
+            class_id: self.class_id.map(HubuumClassID::id),
             name: self.name,
             description: self.description,
             method: self.method.as_str().to_string(),
@@ -494,6 +508,7 @@ impl NewRemoteTarget {
 impl UpdateRemoteTarget {
     pub fn is_empty(&self) -> bool {
         self.namespace_id.is_none()
+            && self.class_id.is_none()
             && self.name.is_none()
             && self.description.is_none()
             && self.method.is_none()
@@ -531,8 +546,14 @@ impl UpdateRemoteTarget {
             .clone()
             .unwrap_or_else(|| existing.allowed_subject_types.clone());
         let timeout_ms = self.timeout_ms.unwrap_or(existing.timeout_ms);
+        let class_id = match self.class_id {
+            Some(Some(class_id)) => Some(class_id.id()),
+            Some(None) => None,
+            None => existing.class_id,
+        };
 
         validate_target_parts(
+            class_id,
             &url_template,
             &headers_template,
             body_template.as_deref(),
@@ -543,6 +564,9 @@ impl UpdateRemoteTarget {
 
         Ok(UpdateRemoteTargetRow {
             namespace_id: self.namespace_id.map(NamespaceID::id),
+            class_id: self
+                .class_id
+                .map(|class_id| class_id.map(HubuumClassID::id)),
             name: self.name,
             description: self.description,
             method: self.method.map(|method| method.as_str().to_string()),
@@ -561,6 +585,7 @@ impl UpdateRemoteTarget {
 }
 
 pub fn validate_target_parts(
+    class_id: Option<i32>,
     url_template: &str,
     headers_template: &serde_json::Value,
     body_template: Option<&str>,
@@ -585,7 +610,24 @@ pub fn validate_target_parts(
     validate_header_templates(headers_template)?;
     validate_auth_config(auth_config)?;
     validate_allowed_subject_types(allowed_subject_types)?;
+    validate_class_scope(class_id, allowed_subject_types)?;
     Ok(())
+}
+
+pub fn validate_class_scope(
+    class_id: Option<i32>,
+    allowed_subject_types: &[RemoteTargetSubjectType],
+) -> Result<(), ApiError> {
+    let allows_objects = allowed_subject_types.contains(&RemoteTargetSubjectType::Object);
+    match (allows_objects, class_id) {
+        (true, None) => Err(ApiError::BadRequest(
+            "class_id is required when allowed_subject_types includes 'object'".to_string(),
+        )),
+        (false, Some(_)) => Err(ApiError::BadRequest(
+            "class_id is only valid when allowed_subject_types includes 'object'".to_string(),
+        )),
+        _ => Ok(()),
+    }
 }
 
 pub fn validate_allowed_subject_types(
@@ -640,6 +682,13 @@ pub async fn authorize_remote_invocation(
             "Remote target does not allow '{}' subjects",
             resolved.subject_type.as_str()
         )));
+    }
+    if let RemoteInvocationSubject::Object { class_id, .. } = subject
+        && target.class_id != Some(class_id.id())
+    {
+        return Err(ApiError::NotFound(
+            "Remote target not found for invocation subject class".to_string(),
+        ));
     }
     if !resolved
         .namespaces
@@ -789,119 +838,6 @@ fn unique_namespaces(namespaces: Vec<Namespace>) -> Vec<Namespace> {
         .collect()
 }
 
-/// Host and port extracted from a validated outbound remote target URL.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OutboundUrlParts {
-    pub url: reqwest::Url,
-    pub host: String,
-    pub port: u16,
-}
-
-/// Validate a fully rendered outbound URL and return its host/port.
-///
-/// Enforces that the URL parses, uses the `https` scheme, carries no embedded
-/// credentials, and names a host. The returned host/port feed the worker's
-/// SSRF address screening before the outbound call is made.
-pub fn validate_rendered_remote_url(url: &str) -> Result<OutboundUrlParts, ApiError> {
-    if url.is_empty() || url.chars().any(|ch| ch.is_whitespace() || ch.is_control()) {
-        return Err(ApiError::BadRequest(
-            "remote target URL is invalid".to_string(),
-        ));
-    }
-
-    let parsed = reqwest::Url::parse(url)
-        .map_err(|_| ApiError::BadRequest("remote target URL is invalid".to_string()))?;
-
-    if parsed.scheme() != "https" {
-        return Err(ApiError::BadRequest(
-            "remote target URLs must use https".to_string(),
-        ));
-    }
-
-    if !parsed.username().is_empty() || parsed.password().is_some() {
-        return Err(ApiError::BadRequest(
-            "remote target URLs must not contain embedded credentials".to_string(),
-        ));
-    }
-
-    let host = parsed
-        .host_str()
-        .filter(|host| !host.is_empty())
-        .ok_or_else(|| ApiError::BadRequest("remote target URL is missing a host".to_string()))?
-        .to_string();
-
-    let port = parsed.port_or_known_default().ok_or_else(|| {
-        ApiError::BadRequest("remote target URL is missing a known port".to_string())
-    })?;
-
-    Ok(OutboundUrlParts {
-        url: parsed,
-        host,
-        port,
-    })
-}
-
-/// IP networks that must never be reachable as remote targets unless explicitly
-/// allowed via configuration. Covers loopback, RFC1918, link-local, carrier-grade
-/// NAT, cloud metadata, unique-local, documentation, and other non-global ranges.
-fn blocked_outbound_nets() -> &'static [IpNet] {
-    use std::sync::OnceLock;
-    static NETS: OnceLock<Vec<IpNet>> = OnceLock::new();
-    NETS.get_or_init(|| {
-        [
-            // IPv4
-            "0.0.0.0/8",
-            "10.0.0.0/8",
-            "100.64.0.0/10",
-            "127.0.0.0/8",
-            "169.254.0.0/16",
-            "172.16.0.0/12",
-            "192.0.0.0/24",
-            "192.0.2.0/24",
-            "192.168.0.0/16",
-            "198.18.0.0/15",
-            "198.51.100.0/24",
-            "203.0.113.0/24",
-            "224.0.0.0/4",
-            "240.0.0.0/4",
-            "255.255.255.255/32",
-            // IPv6
-            "::/128",
-            "::1/128",
-            "::ffff:0:0/96",
-            "64:ff9b::/96",
-            "100::/64",
-            "2001:db8::/32",
-            "fc00::/7",
-            "fe80::/10",
-            "ff00::/8",
-        ]
-        .iter()
-        .map(|net| net.parse().expect("static blocked net must parse"))
-        .collect()
-    })
-}
-
-/// Returns true when an outbound remote call to `ip` must be refused (SSRF guard).
-///
-/// IPv4-mapped IPv6 addresses are unwrapped so an attacker cannot smuggle a private
-/// IPv4 address through an IPv6 literal.
-pub fn remote_target_ip_blocked(ip: IpAddr) -> bool {
-    let ip = match ip {
-        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
-            Some(v4) => IpAddr::V4(v4),
-            None => IpAddr::V6(v6),
-        },
-        other => other,
-    };
-
-    blocked_outbound_nets().iter().any(|net| match (net, ip) {
-        (IpNet::V4(net), IpAddr::V4(addr)) => net.contains(&addr),
-        (IpNet::V6(net), IpAddr::V6(addr)) => net.contains(&addr),
-        _ => false,
-    })
-}
-
 fn validate_header_templates(value: &serde_json::Value) -> Result<(), ApiError> {
     let object = value.as_object().ok_or_else(|| {
         ApiError::BadRequest("headers_template must be a JSON object".to_string())
@@ -957,19 +893,12 @@ fn validate_auth_config(auth_config: &RemoteAuthConfig) -> Result<(), ApiError> 
 }
 
 fn validate_template(label: &str, source: &str) -> Result<(), ApiError> {
-    let mut env = build_remote_template_validation_environment();
-    crate::utilities::reporting::register_curated_helpers(&mut env);
-    env.template_from_str(source)
-        .map(|_| ())
-        .map_err(|error| ApiError::BadRequest(format!("Invalid {label}: {error}")))
-}
-
-fn build_remote_template_validation_environment() -> minijinja::Environment<'static> {
-    let mut env = minijinja::Environment::new();
     let (recursion_limit, fuel) = remote_template_limits();
-    env.set_recursion_limit(recursion_limit);
-    env.set_fuel(Some(fuel));
-    env
+    prepare_template(source)
+        .limit_recursion(recursion_limit)
+        .limit_fuel(fuel)
+        .validate()
+        .map_err(|error| ApiError::BadRequest(format!("Invalid {label}: {error}")))
 }
 
 fn remote_template_limits() -> (usize, u64) {
@@ -1109,70 +1038,10 @@ mod tests {
     }
 
     #[test]
-    fn rendered_remote_urls_must_be_https() {
-        let parts = validate_rendered_remote_url("https://example.com/hook").unwrap();
-        assert_eq!(parts.url.host_str(), Some(parts.host.as_str()));
-        assert_eq!(parts.url.port_or_known_default(), Some(parts.port));
-        assert_eq!(parts.host, "example.com");
-        assert_eq!(parts.port, 443);
-
-        let custom_port = validate_rendered_remote_url("https://example.com:8443/hook").unwrap();
-        assert_eq!(custom_port.url.host_str(), Some(custom_port.host.as_str()));
-        assert_eq!(
-            custom_port.url.port_or_known_default(),
-            Some(custom_port.port)
-        );
-        assert_eq!(custom_port.port, 8443);
-
-        assert!(validate_rendered_remote_url("http://example.com/hook").is_err());
-        assert!(validate_rendered_remote_url("https://").is_err());
-        assert!(validate_rendered_remote_url("ftp://example.com").is_err());
-        assert!(validate_rendered_remote_url("https://example.com /hook").is_err());
-    }
-
-    #[test]
-    fn rendered_remote_urls_reject_embedded_credentials() {
-        assert!(validate_rendered_remote_url("https://user:pass@example.com/hook").is_err());
-        assert!(validate_rendered_remote_url("https://user@example.com/hook").is_err());
-        assert!(validate_rendered_remote_url("https://example.com@127.0.0.1/hook").is_err());
-    }
-
-    #[test]
-    fn private_and_internal_ips_are_blocked() {
-        use std::net::{Ipv4Addr, Ipv6Addr};
-
-        // Blocked: loopback, RFC1918, link-local / cloud metadata, ULA, mapped v4.
-        assert!(remote_target_ip_blocked(IpAddr::V4(Ipv4Addr::LOCALHOST)));
-        assert!(remote_target_ip_blocked(IpAddr::V4(Ipv4Addr::new(
-            10, 0, 0, 5
-        ))));
-        assert!(remote_target_ip_blocked(IpAddr::V4(Ipv4Addr::new(
-            192, 168, 1, 1
-        ))));
-        assert!(remote_target_ip_blocked(IpAddr::V4(Ipv4Addr::new(
-            169, 254, 169, 254
-        ))));
-        assert!(remote_target_ip_blocked(IpAddr::V6(Ipv6Addr::LOCALHOST)));
-        assert!(remote_target_ip_blocked(
-            "fd00::1".parse::<IpAddr>().unwrap()
-        ));
-        assert!(remote_target_ip_blocked(
-            "::ffff:127.0.0.1".parse::<IpAddr>().unwrap()
-        ));
-
-        // Allowed: genuinely global addresses.
-        assert!(!remote_target_ip_blocked(IpAddr::V4(Ipv4Addr::new(
-            8, 8, 8, 8
-        ))));
-        assert!(!remote_target_ip_blocked(
-            "2606:4700:4700::1111".parse::<IpAddr>().unwrap()
-        ));
-    }
-
-    #[test]
     fn target_parts_validate_templates_and_auth_references() {
         assert!(
             validate_target_parts(
+                Some(1),
                 "https://example.com/{{ object.id }}",
                 &serde_json::json!({ "X-Object": "{{ object.name }}" }),
                 Some("{\"id\": {{ object.id }}}"),
@@ -1187,6 +1056,7 @@ mod tests {
 
         assert!(
             validate_target_parts(
+                Some(1),
                 "https://example.com/{{",
                 &serde_json::json!({}),
                 None,
@@ -1198,6 +1068,7 @@ mod tests {
         );
         assert!(
             validate_target_parts(
+                Some(1),
                 "https://example.com",
                 &serde_json::json!([]),
                 None,
@@ -1209,6 +1080,7 @@ mod tests {
         );
         assert!(
             validate_target_parts(
+                Some(1),
                 "https://example.com",
                 &serde_json::json!({ "Invalid Header": "{{ object.id }}" }),
                 None,
@@ -1220,6 +1092,7 @@ mod tests {
         );
         assert!(
             validate_target_parts(
+                Some(1),
                 "https://example.com",
                 &serde_json::json!({}),
                 None,
@@ -1239,6 +1112,7 @@ mod tests {
         // The `tojson` filter is documented for remote targets; validation must accept it.
         assert!(
             validate_target_parts(
+                Some(1),
                 "https://example.com/{{ object.id }}",
                 &serde_json::json!({ "X-Object": "{{ object.name }}" }),
                 Some("{\"data\": {{ object.data | tojson }}}"),
@@ -1248,6 +1122,24 @@ mod tests {
             )
             .is_ok()
         );
+    }
+
+    #[test]
+    fn object_targets_require_class_scope() {
+        assert!(
+            validate_class_scope(None, &[RemoteTargetSubjectType::Object])
+                .unwrap_err()
+                .to_string()
+                .contains("class_id is required")
+        );
+        assert!(
+            validate_class_scope(Some(1), &[RemoteTargetSubjectType::Class])
+                .unwrap_err()
+                .to_string()
+                .contains("class_id is only valid")
+        );
+        assert!(validate_class_scope(Some(1), &[RemoteTargetSubjectType::Object]).is_ok());
+        assert!(validate_class_scope(None, &[RemoteTargetSubjectType::Class]).is_ok());
     }
 
     #[test]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -156,6 +156,7 @@ diesel::table! {
     remote_targets (id) {
         id -> Int4,
         namespace_id -> Int4,
+        class_id -> Nullable<Int4>,
         name -> Varchar,
         description -> Varchar,
         method -> Varchar,
@@ -285,6 +286,7 @@ diesel::joinable!(permissions -> groups (group_id));
 diesel::joinable!(permissions -> namespaces (namespace_id));
 diesel::joinable!(remote_call_results -> remote_targets (target_id));
 diesel::joinable!(remote_call_results -> tasks (task_id));
+diesel::joinable!(remote_targets -> hubuumclass (class_id));
 diesel::joinable!(remote_targets -> namespaces (namespace_id));
 diesel::joinable!(report_task_outputs -> tasks (task_id));
 diesel::joinable!(report_templates -> hubuumclass (class_id));

--- a/src/tasks/remote_call.rs
+++ b/src/tasks/remote_call.rs
@@ -1,8 +1,9 @@
-use std::net::SocketAddr;
-use std::time::Instant;
-
 use base64::Engine;
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use hubuum_outbound_http::{
+    OutboundHeaders, OutboundHttpError, OutboundMethod, OutboundRequest, validate_outbound_url,
+};
+use hubuum_templates::prepare_template;
+use std::time::Instant;
 use tracing::warn;
 
 use crate::config::{
@@ -18,7 +19,6 @@ use crate::models::{
     NewRemoteCallResult, NewTaskEventRecord, RemoteAuthConfig, RemoteHttpMethod,
     RemoteInvocationBodyOverride, RemoteInvocationParameters, RemoteTemplateContext,
     StoredRemoteCallTaskPayload, TaskRecord, TaskStatus, User, authorize_remote_invocation,
-    remote_target_ip_blocked, validate_rendered_remote_url,
 };
 
 pub(super) async fn execute_remote_call_task(
@@ -91,6 +91,15 @@ struct RemoteExecutionOutcome {
     event_data: Option<serde_json::Value>,
 }
 
+struct RemoteFailureContext<'a> {
+    pool: &'a DbPool,
+    task_id: i32,
+    target_id: i32,
+    subject_type: &'a str,
+    subject_id: i32,
+    method: &'a str,
+}
+
 async fn execute_remote_call(
     pool: &DbPool,
     task_id: i32,
@@ -107,8 +116,22 @@ async fn execute_remote_call(
     )?;
 
     let rendered_url = render_template("url_template", &target.url_template, &context)?;
-    let url_parts = validate_rendered_remote_url(&rendered_url)?;
-    let screened_addrs = screen_outbound_host(&url_parts.host, url_parts.port).await?;
+    let start = Instant::now();
+    let failure_context = RemoteFailureContext {
+        pool,
+        task_id,
+        target_id: target.id,
+        subject_type: resolved.subject_type.as_str(),
+        subject_id: resolved.subject_id,
+        method: target.method.as_str(),
+    };
+    let normalized_rendered_url = match validate_outbound_url(&rendered_url) {
+        Ok(parts) => parts.url().to_string(),
+        Err(error) => {
+            return record_remote_call_failure(&failure_context, rendered_url, 0, error).await;
+        }
+    };
+
     let rendered_headers = render_headers(&target.headers_template, &context)?;
     let rendered_body = target
         .body_template
@@ -120,40 +143,40 @@ async fn execute_remote_call(
     apply_auth(&mut headers, &target.auth_config)?;
 
     let timeout_ms = bounded_timeout_ms(target.timeout_ms);
-    // Never follow redirects: a 3xx could otherwise bounce the call to a non-https
-    // scheme or an internal address that bypassed the initial SSRF screening.
-    // Pin DNS to the addresses we already screened so the host cannot rebind to a
-    // private address between our check and the connection.
-    let client_builder = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_millis(timeout_ms))
-        .redirect(reqwest::redirect::Policy::none())
-        .resolve_to_addrs(&url_parts.host, &screened_addrs);
-    #[cfg(test)]
-    let client_builder = client_builder.danger_accept_invalid_certs(true);
-    let client = client_builder
-        .build()
-        .map_err(|error| ApiError::InternalServerError(format!("HTTP client error: {error}")))?;
-
-    let mut request_builder = client
-        .request(reqwest_method(target.method), url_parts.url.clone())
-        .headers(headers);
-    if let Some(body) = rendered_body {
-        request_builder = request_builder.body(body);
-    }
-
-    let start = Instant::now();
-    let response_result = request_builder.send().await;
     let preview_limit = get_config()
         .map(|config| config.remote_call_max_response_bytes)
         .unwrap_or(DEFAULT_REMOTE_CALL_MAX_RESPONSE_BYTES);
+    let allow_private_targets = get_config()
+        .map(|config| config.remote_call_allow_private_targets)
+        .unwrap_or(DEFAULT_REMOTE_CALL_ALLOW_PRIVATE_TARGETS);
+
+    #[cfg(test)]
+    let dangerous_accept_invalid_certs = true;
+    #[cfg(not(test))]
+    let dangerous_accept_invalid_certs = false;
+    #[cfg(test)]
+    let dangerous_allow_localhost = true;
+    #[cfg(not(test))]
+    let dangerous_allow_localhost = false;
+
+    let response_result = OutboundRequest::new(
+        outbound_method(target.method),
+        normalized_rendered_url.clone(),
+        std::time::Duration::from_millis(timeout_ms),
+    )
+    .headers(headers)
+    .body(rendered_body)
+    .max_response_bytes(preview_limit)
+    .allow_private_targets(allow_private_targets)
+    .dangerous_accept_invalid_certs(dangerous_accept_invalid_certs)
+    .dangerous_allow_localhost(dangerous_allow_localhost)
+    .send()
+    .await;
 
     match response_result {
         Ok(response) => {
-            let status = response.status();
-            let response_headers = headers_to_json(response.headers());
-            let body_preview = read_capped_body(response, preview_limit).await?;
-            let duration_ms = i32::try_from(start.elapsed().as_millis()).unwrap_or(i32::MAX);
-            let success = status.is_success();
+            let status = response.status_display();
+            let success = response.is_success();
             insert_remote_call_result(
                 pool,
                 NewRemoteCallResult {
@@ -162,11 +185,11 @@ async fn execute_remote_call(
                     subject_type: resolved.subject_type.as_str().to_string(),
                     subject_id: resolved.subject_id,
                     method: target.method.as_str().to_string(),
-                    rendered_url: url_parts.url.to_string(),
-                    response_status: Some(i32::from(status.as_u16())),
-                    response_headers: Some(response_headers),
-                    response_body_preview: Some(body_preview),
-                    duration_ms,
+                    rendered_url: response.url().to_string(),
+                    response_status: Some(i32::from(response.status_code())),
+                    response_headers: Some(response.headers().clone()),
+                    response_body_preview: Some(response.body_preview().to_string()),
+                    duration_ms: response.duration_ms(),
                     success,
                     error: (!success).then(|| format!("Remote returned HTTP {status}")),
                 },
@@ -182,39 +205,55 @@ async fn execute_remote_call(
                 success,
                 summary,
                 event_data: Some(serde_json::json!({
-                    "status": i32::from(status.as_u16()),
-                    "duration_ms": duration_ms,
+                    "status": i32::from(response.status_code()),
+                    "duration_ms": response.duration_ms(),
                 })),
             })
         }
         Err(error) => {
             let duration_ms = i32::try_from(start.elapsed().as_millis()).unwrap_or(i32::MAX);
-            let message = sanitize_reqwest_error(error);
-            insert_remote_call_result(
-                pool,
-                NewRemoteCallResult {
-                    task_id,
-                    target_id: Some(target.id),
-                    subject_type: resolved.subject_type.as_str().to_string(),
-                    subject_id: resolved.subject_id,
-                    method: target.method.as_str().to_string(),
-                    rendered_url: url_parts.url.to_string(),
-                    response_status: None,
-                    response_headers: None,
-                    response_body_preview: None,
-                    duration_ms,
-                    success: false,
-                    error: Some(message.clone()),
-                },
+            record_remote_call_failure(
+                &failure_context,
+                normalized_rendered_url,
+                duration_ms,
+                error,
             )
-            .await?;
-            Ok(RemoteExecutionOutcome {
-                success: false,
-                summary: message,
-                event_data: Some(serde_json::json!({ "duration_ms": duration_ms })),
-            })
+            .await
         }
     }
+}
+
+async fn record_remote_call_failure(
+    context: &RemoteFailureContext<'_>,
+    rendered_url: String,
+    duration_ms: i32,
+    error: OutboundHttpError,
+) -> Result<RemoteExecutionOutcome, ApiError> {
+    let api_error = outbound_error_to_api_error(error);
+    let message = crate::tasks::helpers::sanitize_error_for_storage(&api_error);
+    insert_remote_call_result(
+        context.pool,
+        NewRemoteCallResult {
+            task_id: context.task_id,
+            target_id: Some(context.target_id),
+            subject_type: context.subject_type.to_string(),
+            subject_id: context.subject_id,
+            method: context.method.to_string(),
+            rendered_url,
+            response_status: None,
+            response_headers: None,
+            response_body_preview: None,
+            duration_ms,
+            success: false,
+            error: Some(message.clone()),
+        },
+    )
+    .await?;
+    Ok(RemoteExecutionOutcome {
+        success: false,
+        summary: message,
+        event_data: Some(serde_json::json!({ "duration_ms": duration_ms })),
+    })
 }
 
 async fn finalize_remote_task(
@@ -264,19 +303,13 @@ fn render_template(
     template: &str,
     context: &serde_json::Value,
 ) -> Result<String, ApiError> {
-    let env = build_remote_template_environment();
-    env.template_from_str(template)
-        .and_then(|compiled| compiled.render(context))
-        .map_err(|error| ApiError::BadRequest(format!("Failed rendering {label}: {error}")))
-}
-
-fn build_remote_template_environment() -> minijinja::Environment<'static> {
-    let mut env = minijinja::Environment::new();
     let (recursion_limit, fuel) = remote_template_limits();
-    env.set_recursion_limit(recursion_limit);
-    env.set_fuel(Some(fuel));
-    crate::utilities::reporting::register_curated_helpers(&mut env);
-    env
+    prepare_template(template)
+        .limit_recursion(recursion_limit)
+        .limit_fuel(fuel)
+        .context(context)
+        .render()
+        .map_err(|error| ApiError::BadRequest(format!("Failed rendering {label}: {error}")))
 }
 
 fn remote_template_limits() -> (usize, u64) {
@@ -296,8 +329,8 @@ fn remote_template_limits() -> (usize, u64) {
 fn render_headers(
     headers_template: &serde_json::Value,
     context: &serde_json::Value,
-) -> Result<HeaderMap, ApiError> {
-    let mut headers = HeaderMap::new();
+) -> Result<OutboundHeaders, ApiError> {
+    let mut headers = OutboundHeaders::new();
     let object = headers_template.as_object().ok_or_else(|| {
         ApiError::BadRequest("headers_template must be a JSON object".to_string())
     })?;
@@ -305,53 +338,50 @@ fn render_headers(
         let value = value.as_str().ok_or_else(|| {
             ApiError::BadRequest("header template values must be strings".to_string())
         })?;
-        let name = HeaderName::from_bytes(name.as_bytes())
-            .map_err(|_| ApiError::BadRequest(format!("Invalid header name: {name}")))?;
         let rendered = render_template("header template", value, context)?;
-        let value = HeaderValue::from_str(&rendered)
-            .map_err(|_| ApiError::BadRequest(format!("Invalid header value for {name}")))?;
-        headers.insert(name, value);
+        headers
+            .insert(name, &rendered)
+            .map_err(outbound_error_to_bad_request)?;
     }
     Ok(headers)
 }
 
-fn apply_auth(headers: &mut HeaderMap, auth_config: &RemoteAuthConfig) -> Result<(), ApiError> {
+fn apply_auth(
+    headers: &mut OutboundHeaders,
+    auth_config: &RemoteAuthConfig,
+) -> Result<(), ApiError> {
     match auth_config {
         RemoteAuthConfig::None => Ok(()),
         RemoteAuthConfig::BearerSecret { secret } => {
             let value = format!("Bearer {}", resolve_secret(secret)?);
-            headers.insert(
-                reqwest::header::AUTHORIZATION,
-                HeaderValue::from_str(&value).map_err(|_| {
-                    ApiError::BadRequest("Resolved bearer secret is not a valid header".to_string())
-                })?,
-            );
+            headers.insert("authorization", &value).map_err(|_| {
+                ApiError::BadRequest("Resolved bearer secret is not a valid header".to_string())
+            })?;
             Ok(())
         }
         RemoteAuthConfig::BasicSecret { username, secret } => {
             let raw = format!("{}:{}", username, resolve_secret(secret)?);
             let encoded = base64::engine::general_purpose::STANDARD.encode(raw);
-            headers.insert(
-                reqwest::header::AUTHORIZATION,
-                HeaderValue::from_str(&format!("Basic {encoded}")).map_err(|_| {
+            headers
+                .insert("authorization", &format!("Basic {encoded}"))
+                .map_err(|_| {
                     ApiError::BadRequest("Resolved basic secret is not a valid header".to_string())
-                })?,
-            );
+                })?;
             Ok(())
         }
         RemoteAuthConfig::ApiKeySecret { header, secret } => {
-            let name = HeaderName::from_bytes(header.as_bytes()).map_err(|_| {
-                ApiError::BadRequest(format!("Invalid API key header name: {header}"))
-            })?;
             let value = resolve_secret(secret)?;
-            headers.insert(
-                name,
-                HeaderValue::from_str(&value).map_err(|_| {
-                    ApiError::BadRequest(
+            headers
+                .insert(header, &value)
+                .map_err(|error| match error {
+                    OutboundHttpError::InvalidHeaderName { .. } => {
+                        ApiError::BadRequest(format!("Invalid API key header name: {header}"))
+                    }
+                    OutboundHttpError::InvalidHeaderValue { .. } => ApiError::BadRequest(
                         "Resolved API key secret is not a valid header".to_string(),
-                    )
-                })?,
-            );
+                    ),
+                    other => ApiError::BadRequest(outbound_error_to_api_message(other)),
+                })?;
             Ok(())
         }
     }
@@ -366,12 +396,12 @@ fn resolve_secret(secret: &str) -> Result<String, ApiError> {
     })
 }
 
-fn reqwest_method(method: RemoteHttpMethod) -> reqwest::Method {
+fn outbound_method(method: RemoteHttpMethod) -> OutboundMethod {
     match method {
-        RemoteHttpMethod::Get => reqwest::Method::GET,
-        RemoteHttpMethod::Post => reqwest::Method::POST,
-        RemoteHttpMethod::Patch => reqwest::Method::PATCH,
-        RemoteHttpMethod::Delete => reqwest::Method::DELETE,
+        RemoteHttpMethod::Get => OutboundMethod::Get,
+        RemoteHttpMethod::Post => OutboundMethod::Post,
+        RemoteHttpMethod::Patch => OutboundMethod::Patch,
+        RemoteHttpMethod::Delete => OutboundMethod::Delete,
     }
 }
 
@@ -390,111 +420,57 @@ fn bounded_timeout_ms(timeout_ms: i32) -> u64 {
     requested.min(cap)
 }
 
-/// Resolve `host` and reject the call if any resolved address is private/internal,
-/// unless the deployment has opted in via `remote_call_allow_private_targets`.
-/// Returns the screened socket addresses so the caller can pin reqwest's resolver
-/// to exactly these IPs (defeating DNS rebinding).
-async fn screen_outbound_host(host: &str, port: u16) -> Result<Vec<SocketAddr>, ApiError> {
-    #[cfg(test)]
-    if host.eq_ignore_ascii_case("localhost") {
-        // Tests use localhost for the HTTPS success path; the SSRF guard test uses
-        // 127.0.0.1 directly so loopback screening still has coverage.
-        return Ok(vec![SocketAddr::from(([127, 0, 0, 1], port))]);
-    }
-
-    let allow_private = get_config()
-        .map(|config| config.remote_call_allow_private_targets)
-        .unwrap_or(DEFAULT_REMOTE_CALL_ALLOW_PRIVATE_TARGETS);
-
-    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host, port))
-        .await
-        .map_err(|_| {
-            ApiError::BadRequest(format!("Failed to resolve remote target host '{host}'"))
-        })?
-        .collect();
-
-    if addrs.is_empty() {
-        return Err(ApiError::BadRequest(format!(
-            "Remote target host '{host}' did not resolve to any address"
-        )));
-    }
-
-    if !allow_private
-        && let Some(blocked) = addrs
-            .iter()
-            .find(|addr| remote_target_ip_blocked(addr.ip()))
-    {
-        return Err(ApiError::BadRequest(format!(
-            "Remote target host '{host}' resolves to a disallowed address ({})",
-            blocked.ip()
-        )));
-    }
-
-    Ok(addrs)
-}
-
-/// Read at most `limit` bytes of the response body, stopping early so an oversized
-/// or hostile response cannot exhaust worker memory.
-async fn read_capped_body(
-    mut response: reqwest::Response,
-    limit: usize,
-) -> Result<String, ApiError> {
-    let mut buffer: Vec<u8> = Vec::new();
-    while buffer.len() < limit {
-        match response.chunk().await.map_err(|error| {
-            ApiError::InternalServerError(format!("Failed reading remote response: {error}"))
-        })? {
-            Some(chunk) => {
-                let remaining = limit - buffer.len();
-                let take = remaining.min(chunk.len());
-                buffer.extend_from_slice(&chunk[..take]);
-            }
-            None => break,
+fn outbound_error_to_api_message(error: OutboundHttpError) -> String {
+    match error {
+        OutboundHttpError::InvalidUrl => "remote target URL is invalid".to_string(),
+        OutboundHttpError::NonHttpsUrl => "remote target URLs must use https".to_string(),
+        OutboundHttpError::EmbeddedCredentials => {
+            "remote target URLs must not contain embedded credentials".to_string()
+        }
+        OutboundHttpError::MissingHost => "remote target URL is missing a host".to_string(),
+        OutboundHttpError::MissingKnownPort => {
+            "remote target URL is missing a known port".to_string()
+        }
+        OutboundHttpError::DnsResolution { host } => {
+            format!("Failed to resolve remote target host '{host}'")
+        }
+        OutboundHttpError::EmptyDnsResolution { host } => {
+            format!("Remote target host '{host}' did not resolve to any address")
+        }
+        OutboundHttpError::DisallowedAddress { host, address } => {
+            format!("Remote target host '{host}' resolves to a disallowed address ({address})")
+        }
+        OutboundHttpError::ClientBuild(error) => format!("HTTP client error: {error}"),
+        OutboundHttpError::ResponseRead(error) => {
+            format!("Failed reading remote response: {error}")
+        }
+        OutboundHttpError::Timeout => "Remote call timed out".to_string(),
+        OutboundHttpError::Connect => "Remote connection failed".to_string(),
+        OutboundHttpError::Request(error) => format!("Remote call failed: {error}"),
+        OutboundHttpError::InvalidHeaderName { name } => format!("Invalid header name: {name}"),
+        OutboundHttpError::InvalidHeaderValue { name } => {
+            format!("Invalid header value for {name}")
         }
     }
-    Ok(String::from_utf8_lossy(&buffer).replace('\0', "\u{FFFD}"))
 }
 
-/// Response headers that may carry secrets the remote echoes back; their values are
-/// redacted before storage so they are never persisted in `remote_call_results`.
-fn is_sensitive_response_header(name: &str) -> bool {
-    const SENSITIVE: [&str; 6] = [
-        "set-cookie",
-        "set-cookie2",
-        "authorization",
-        "proxy-authorization",
-        "www-authenticate",
-        "proxy-authenticate",
-    ];
-    SENSITIVE.contains(&name.to_ascii_lowercase().as_str())
-}
-
-fn headers_to_json(headers: &HeaderMap) -> serde_json::Value {
-    let mut object = serde_json::Map::new();
-    for (name, value) in headers {
-        if is_sensitive_response_header(name.as_str()) {
-            object.insert(
-                name.to_string(),
-                serde_json::Value::String("[redacted]".to_string()),
-            );
-        } else if let Ok(value) = value.to_str() {
-            object.insert(
-                name.to_string(),
-                serde_json::Value::String(value.to_string()),
-            );
-        }
-    }
-    serde_json::Value::Object(object)
-}
-
-fn sanitize_reqwest_error(error: reqwest::Error) -> String {
-    if error.is_timeout() {
-        "Remote call timed out".to_string()
-    } else if error.is_connect() {
-        "Remote connection failed".to_string()
+fn outbound_error_to_api_error(error: OutboundHttpError) -> ApiError {
+    let internal = matches!(
+        &error,
+        OutboundHttpError::ClientBuild(_)
+            | OutboundHttpError::ResponseRead(_)
+            | OutboundHttpError::Request(_)
+    );
+    let message = outbound_error_to_api_message(error);
+    if internal {
+        ApiError::InternalServerError(message)
     } else {
-        format!("Remote call failed: {error}")
+        ApiError::BadRequest(message)
     }
+}
+
+fn outbound_error_to_bad_request(error: OutboundHttpError) -> ApiError {
+    ApiError::BadRequest(outbound_error_to_api_message(error))
 }
 
 #[cfg(test)]
@@ -525,6 +501,30 @@ mod tests {
             error.to_string().contains("fuel")
                 || error.to_string().contains("operation")
                 || error.to_string().contains("limit")
+        );
+    }
+
+    #[test]
+    fn internal_outbound_errors_are_sanitized_for_storage() {
+        let error = outbound_error_to_api_error(OutboundHttpError::ResponseRead(
+            "transport failure for https://example.com/secret".to_string(),
+        ));
+
+        assert!(matches!(error, ApiError::InternalServerError(_)));
+        assert_eq!(
+            crate::tasks::helpers::sanitize_error_for_storage(&error),
+            "An internal error occurred"
+        );
+    }
+
+    #[test]
+    fn user_actionable_outbound_errors_remain_visible_for_storage() {
+        let error = outbound_error_to_api_error(OutboundHttpError::NonHttpsUrl);
+
+        assert!(matches!(error, ApiError::BadRequest(_)));
+        assert_eq!(
+            crate::tasks::helpers::sanitize_error_for_storage(&error),
+            "Invalid input: remote target URLs must use https"
         );
     }
 }

--- a/src/tests/api/v1/remote_targets.rs
+++ b/src/tests/api/v1/remote_targets.rs
@@ -68,9 +68,44 @@ mod tests {
         )
     }
 
-    fn target_payload(namespace_id: i32, name: &str, url_template: &str) -> serde_json::Value {
+    async fn create_object_in_namespace(
+        context: &TestContext,
+        namespace_id: i32,
+        label: &str,
+    ) -> (i32, i32) {
+        let class = NewHubuumClass {
+            name: context.scoped_name(&format!("{label}-class")),
+            description: "remote target alternate class".to_string(),
+            namespace_id,
+            json_schema: None,
+            validate_schema: Some(false),
+        }
+        .save(&context.pool)
+        .await
+        .unwrap();
+        let object = NewHubuumObject {
+            name: context.scoped_name(&format!("{label}-object")),
+            description: "remote target alternate object".to_string(),
+            namespace_id,
+            hubuum_class_id: class.id,
+            data: serde_json::json!({"hostname": "other-host"}),
+        }
+        .save(&context.pool)
+        .await
+        .unwrap();
+
+        (class.id, object.id)
+    }
+
+    fn target_payload(
+        namespace_id: i32,
+        class_id: i32,
+        name: &str,
+        url_template: &str,
+    ) -> serde_json::Value {
         target_payload_with_subjects(
             namespace_id,
+            Some(class_id),
             name,
             url_template,
             serde_json::json!(["object"]),
@@ -79,12 +114,14 @@ mod tests {
 
     fn target_payload_with_subjects(
         namespace_id: i32,
+        class_id: Option<i32>,
         name: &str,
         url_template: &str,
         allowed_subject_types: serde_json::Value,
     ) -> serde_json::Value {
         serde_json::json!({
             "namespace_id": namespace_id,
+            "class_id": class_id,
             "name": name,
             "description": "test target",
             "method": "post",
@@ -189,6 +226,7 @@ mod tests {
     async fn create_target(
         context: &TestContext,
         namespace_id: i32,
+        class_id: i32,
         name: &str,
         url_template: &str,
     ) -> RemoteTarget {
@@ -196,7 +234,7 @@ mod tests {
             &context.pool,
             &context.admin_token,
             RT_ENDPOINT,
-            target_payload(namespace_id, name, url_template),
+            target_payload(namespace_id, class_id, name, url_template),
         )
         .await;
         let resp = assert_response_status(resp, StatusCode::CREATED).await;
@@ -320,11 +358,12 @@ mod tests {
     #[actix_web::test]
     async fn crud_lifecycle_as_admin() {
         let context = TestContext::new().await;
-        let (namespace_id, _class_id, _object_id) = setup_object(&context, "rt_crud").await;
+        let (namespace_id, class_id, _object_id) = setup_object(&context, "rt_crud").await;
 
         // Create
         let create = serde_json::json!({
             "namespace_id": namespace_id,
+            "class_id": class_id,
             "name": "crud-target",
             "description": "created",
             "method": "post",
@@ -394,7 +433,7 @@ mod tests {
     #[actix_web::test]
     async fn create_requires_create_permission() {
         let context = TestContext::new().await;
-        let (namespace_id, _, _) = setup_object(&context, "rt_perm").await;
+        let (namespace_id, class_id, _) = setup_object(&context, "rt_perm").await;
 
         // Normal user with no permission is forbidden.
         let resp = post_request(
@@ -403,6 +442,7 @@ mod tests {
             RT_ENDPOINT,
             target_payload(
                 namespace_id,
+                class_id,
                 "perm-target",
                 "https://service.example.com/hook",
             ),
@@ -436,6 +476,7 @@ mod tests {
             RT_ENDPOINT,
             target_payload(
                 namespace_id,
+                class_id,
                 "perm-target",
                 "https://service.example.com/hook",
             ),
@@ -447,14 +488,19 @@ mod tests {
     #[actix_web::test]
     async fn create_rejects_invalid_template_and_secret() {
         let context = TestContext::new().await;
-        let (namespace_id, _, _) = setup_object(&context, "rt_invalid").await;
+        let (namespace_id, class_id, _) = setup_object(&context, "rt_invalid").await;
 
         // Broken minijinja template.
         let resp = post_request(
             &context.pool,
             &context.admin_token,
             RT_ENDPOINT,
-            target_payload(namespace_id, "bad-template", "https://x.example.com/{{"),
+            target_payload(
+                namespace_id,
+                class_id,
+                "bad-template",
+                "https://x.example.com/{{",
+            ),
         )
         .await;
         assert_response_status(resp, StatusCode::BAD_REQUEST).await;
@@ -462,6 +508,7 @@ mod tests {
         // Auth secret reference with an illegal character.
         let payload = serde_json::json!({
             "namespace_id": namespace_id,
+            "class_id": class_id,
             "name": "bad-secret",
             "description": "test",
             "method": "get",
@@ -476,7 +523,7 @@ mod tests {
     #[actix_web::test]
     async fn create_rejects_empty_or_duplicate_allowed_subject_types() {
         let context = TestContext::new().await;
-        let (namespace_id, _, _) = setup_object(&context, "rt_subject_validation").await;
+        let (namespace_id, class_id, _) = setup_object(&context, "rt_subject_validation").await;
 
         let resp = post_request(
             &context.pool,
@@ -484,6 +531,7 @@ mod tests {
             RT_ENDPOINT,
             target_payload_with_subjects(
                 namespace_id,
+                None,
                 "empty-subjects",
                 "https://x.example.com/hook",
                 serde_json::json!([]),
@@ -498,6 +546,7 @@ mod tests {
             RT_ENDPOINT,
             target_payload_with_subjects(
                 namespace_id,
+                Some(class_id),
                 "duplicate-subjects",
                 "https://x.example.com/hook",
                 serde_json::json!(["object", "object"]),
@@ -508,15 +557,60 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn create_object_target_requires_class_scope_in_target_namespace() {
+        let context = TestContext::new().await;
+        let (namespace_id, _class_id, _) = setup_object(&context, "rt_class_scope").await;
+        let (other_namespace_id, other_class_id, _) =
+            setup_object(&context, "rt_class_scope_other").await;
+
+        let payload_without_class = serde_json::json!({
+            "namespace_id": namespace_id,
+            "name": "object-without-class",
+            "description": "test",
+            "method": "post",
+            "url_template": "https://x.example.com/hook",
+            "allowed_subject_types": ["object"],
+        });
+        let resp = post_request(
+            &context.pool,
+            &context.admin_token,
+            RT_ENDPOINT,
+            payload_without_class,
+        )
+        .await;
+        assert_response_status(resp, StatusCode::BAD_REQUEST).await;
+
+        let payload_with_foreign_class = serde_json::json!({
+            "namespace_id": namespace_id,
+            "class_id": other_class_id,
+            "name": "object-with-foreign-class",
+            "description": "test",
+            "method": "post",
+            "url_template": "https://x.example.com/hook",
+            "allowed_subject_types": ["object"],
+        });
+        assert_ne!(namespace_id, other_namespace_id);
+        let resp = post_request(
+            &context.pool,
+            &context.admin_token,
+            RT_ENDPOINT,
+            payload_with_foreign_class,
+        )
+        .await;
+        assert_response_status(resp, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[actix_web::test]
     async fn move_requires_create_on_target_namespace() {
         let context = TestContext::new().await;
-        let (source_ns, _, _) = setup_object(&context, "rt_move_src").await;
+        let (source_ns, class_id, _) = setup_object(&context, "rt_move_src").await;
         let target_namespace = context.namespace_fixture("rt_move_dst").await;
         let target_ns = target_namespace.namespace.id;
 
         let created = create_target(
             &context,
             source_ns,
+            class_id,
             "move-target",
             "https://x.example.com/h",
         )
@@ -543,7 +637,11 @@ mod tests {
             .await
             .unwrap();
 
-        let move_payload = serde_json::json!({ "namespace_id": target_ns });
+        let move_payload = serde_json::json!({
+            "namespace_id": target_ns,
+            "class_id": null,
+            "allowed_subject_types": ["namespace"],
+        });
         let resp = patch_request(
             &context.pool,
             &user_token,
@@ -583,6 +681,7 @@ mod tests {
         let target = create_target(
             &context,
             namespace_id,
+            class_id,
             "invoke-target",
             "https://127.0.0.1/hook",
         )
@@ -615,6 +714,7 @@ mod tests {
             RT_ENDPOINT,
             target_payload_with_subjects(
                 namespace_id,
+                None,
                 "scope-subject-target",
                 "https://127.0.0.1/hook",
                 serde_json::json!(["namespace", "class"]),
@@ -654,6 +754,7 @@ mod tests {
             RT_ENDPOINT,
             target_payload_with_subjects(
                 namespace_id,
+                None,
                 "class-only-target",
                 "https://x.example.com/hook",
                 serde_json::json!(["class"]),
@@ -674,12 +775,41 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn invoke_object_requires_target_class_scope() {
+        let context = TestContext::new().await;
+        let (namespace_id, target_class_id, _target_object_id) =
+            setup_object(&context, "rt_target_class").await;
+        let (other_class_id, other_object_id) =
+            create_object_in_namespace(&context, namespace_id, "rt_other_class").await;
+        assert_ne!(target_class_id, other_class_id);
+
+        let target = create_target(
+            &context,
+            namespace_id,
+            target_class_id,
+            "class-scoped-object-target",
+            "https://x.example.com/h",
+        )
+        .await;
+
+        let resp = post_request(
+            &context.pool,
+            &context.admin_token,
+            &invoke_endpoint(target.id),
+            object_invoke_body(other_class_id, other_object_id),
+        )
+        .await;
+        assert_response_status(resp, StatusCode::NOT_FOUND).await;
+    }
+
+    #[actix_web::test]
     async fn invoke_rejects_non_object_parameters_and_body_override() {
         let context = TestContext::new().await;
         let (namespace_id, class_id, object_id) = setup_object(&context, "rt_newtypes").await;
         let target = create_target(
             &context,
             namespace_id,
+            class_id,
             "newtype-target",
             "https://x.example.com/h",
         )
@@ -721,6 +851,7 @@ mod tests {
         let (namespace_id, class_id, object_id) = setup_object(&context, "rt_success").await;
         let payload = serde_json::json!({
             "namespace_id": namespace_id,
+            "class_id": class_id,
             "name": "success-target",
             "description": "test",
             "method": "post",
@@ -793,6 +924,7 @@ mod tests {
         let target = create_target(
             &context,
             namespace_id,
+            class_id,
             "nul-preview-target",
             &format!("https://localhost:{port}/hook"),
         )
@@ -832,6 +964,7 @@ mod tests {
         let (namespace_id, class_id, object_id) = setup_object(&context, "rt_disabled").await;
         let payload = serde_json::json!({
             "namespace_id": namespace_id,
+            "class_id": class_id,
             "name": "disabled-target",
             "description": "test",
             "method": "post",
@@ -860,6 +993,7 @@ mod tests {
             setup_object(&context, "rt_disabled_forbidden").await;
         let payload = serde_json::json!({
             "namespace_id": namespace_id,
+            "class_id": class_id,
             "name": "disabled-forbidden-target",
             "description": "test",
             "method": "post",
@@ -884,10 +1018,11 @@ mod tests {
     #[actix_web::test]
     async fn invoke_class_mismatch_returns_404() {
         let context = TestContext::new().await;
-        let (namespace_id, _class_id, object_id) = setup_object(&context, "rt_mismatch").await;
+        let (namespace_id, class_id, object_id) = setup_object(&context, "rt_mismatch").await;
         let target = create_target(
             &context,
             namespace_id,
+            class_id,
             "mismatch-target",
             "https://x.example.com/h",
         )
@@ -911,6 +1046,7 @@ mod tests {
         let target = create_target(
             &context,
             namespace_id,
+            class_id,
             "exec-target",
             "https://x.example.com/h",
         )
@@ -958,6 +1094,7 @@ mod tests {
             RT_ENDPOINT,
             target_payload_with_subjects(
                 from_namespace_id,
+                None,
                 "relation-target",
                 "https://127.0.0.1/hook",
                 serde_json::json!(["class_relation", "object_relation"]),
@@ -1002,6 +1139,7 @@ mod tests {
             RT_ENDPOINT,
             target_payload_with_subjects(
                 from_namespace_id,
+                None,
                 "relation-read-target",
                 "https://127.0.0.1/hook",
                 serde_json::json!(["object_relation"]),
@@ -1079,6 +1217,7 @@ mod tests {
             RT_ENDPOINT,
             target_payload_with_subjects(
                 unrelated_namespace.namespace.id,
+                None,
                 "relation-unrelated-target",
                 "https://x.example.com/hook",
                 serde_json::json!(["object_relation"]),
@@ -1105,6 +1244,7 @@ mod tests {
         let target = create_target(
             &context,
             namespace_id,
+            class_id,
             "idem-target",
             "https://127.0.0.1/hook",
         )
@@ -1175,6 +1315,7 @@ mod tests {
         let target = create_target(
             &context,
             namespace_id,
+            class_id,
             "idem-concurrent-target",
             "https://127.0.0.1/hook",
         )

--- a/src/utilities/reporting.rs
+++ b/src/utilities/reporting.rs
@@ -6,11 +6,13 @@ use std::io::{self, Write};
 use std::num::NonZeroUsize;
 use std::sync::{Arc, OnceLock, RwLock};
 
+use hubuum_templates::{
+    MissingValue, MissingValueRecorder, TemplateLimits, register_curated_helpers,
+};
 use lru::LruCache;
 use minijinja::value::Value;
 use minijinja::{
-    AutoEscape, Environment, Error as MiniJinjaError, ErrorKind as MiniJinjaErrorKind, State,
-    UndefinedBehavior, escape_formatter,
+    AutoEscape, Environment, Error as MiniJinjaError, UndefinedBehavior, escape_formatter,
 };
 
 use crate::config::get_config;
@@ -89,10 +91,7 @@ pub fn validate_template_with_limits(
         namespace_templates,
         content_type,
         ReportMissingDataPolicy::Omit,
-        TemplateLimits {
-            recursion_limit,
-            fuel,
-        },
+        TemplateLimits::new(recursion_limit, fuel),
     )?;
 
     env.env
@@ -188,10 +187,7 @@ pub fn render_template(
                 namespace_templates,
                 content_type,
                 missing_data_policy,
-                TemplateLimits {
-                    recursion_limit,
-                    fuel,
-                },
+                TemplateLimits::new(recursion_limit, fuel),
             )?);
             let mut cache = template_env_cache()
                 .write()
@@ -281,14 +277,6 @@ fn namespace_signature(
     }
 }
 
-/// Recursion and fuel bounds for a MiniJinja environment, bundled so `build_environment`
-/// stays within a sensible argument count.
-#[derive(Debug, Clone, Copy)]
-struct TemplateLimits {
-    recursion_limit: usize,
-    fuel: u64,
-}
-
 fn build_environment(
     template_name: &str,
     template_source: &str,
@@ -308,8 +296,8 @@ fn build_environment(
 
     env.set_keep_trailing_newline(true);
     env.set_undefined_behavior(undefined_behavior(missing_data_policy));
-    env.set_recursion_limit(limits.recursion_limit);
-    env.set_fuel(Some(limits.fuel));
+    env.set_recursion_limit(limits.recursion_limit());
+    env.set_fuel(Some(limits.fuel()));
     env.set_auto_escape_callback(move |_| match content_type {
         ReportContentType::TextHtml => AutoEscape::Html,
         _ => AutoEscape::None,
@@ -325,7 +313,10 @@ fn build_environment(
         }
         Ok(template_map.get(name).cloned())
     });
-    register_curated_helpers(&mut env);
+    register_curated_helpers(
+        &mut env,
+        Some(record_missing_value_warning as MissingValueRecorder),
+    );
     env.add_template_owned(template_name.to_string(), template_source.to_string())
         .map_err(|error| template_error("Template load failed", error))?;
 
@@ -418,7 +409,7 @@ fn format_nullable_value(
     replacement: Option<&str>,
 ) -> Result<(), MiniJinjaError> {
     if value.is_undefined() {
-        record_missing_value_warning(state, None);
+        record_missing_value_warning(MissingValue::new(state.name(), None));
         if let Some(replacement) = replacement {
             out.write_str(replacement)?;
         }
@@ -433,176 +424,6 @@ fn format_nullable_value(
     }
 
     escape_formatter(out, state, value)
-}
-
-/// Register the curated MiniJinja filters/functions shared by every Hubuum
-/// templating surface (reports and remote targets). Keeping a single registrar
-/// means validation and execution accept the same template syntax — e.g. the
-/// `tojson` filter documented for remote targets is available wherever templates
-/// render. The missing-value helpers degrade to no-ops when no report warning
-/// capture is active, so they are safe to use outside report rendering.
-pub(crate) fn register_curated_helpers(env: &mut Environment<'static>) {
-    env.add_filter("csv_cell", csv_cell_filter);
-    env.add_filter("tojson", tojson_filter);
-    env.add_filter("default_if_empty", default_if_empty_filter);
-    env.add_filter("format_datetime", format_datetime_filter);
-    env.add_filter("join_nonempty", join_nonempty_filter);
-    env.add_function("coalesce", coalesce_function);
-}
-
-fn csv_cell_filter(value: Value) -> String {
-    let rendered = if value.is_none() || value.is_undefined() {
-        String::new()
-    } else {
-        value.to_string()
-    };
-    let guarded = if csv_cell_needs_formula_guard(&rendered) {
-        // Neutralize spreadsheet formula injection: Excel/Sheets/LibreOffice
-        // interpret a cell that begins with a formula trigger as a formula.
-        // Prefixing a single quote forces the cell to be treated as text.
-        format!("'{rendered}")
-    } else {
-        rendered
-    };
-    if guarded.contains([',', '"', '\n', '\r']) {
-        format!("\"{}\"", guarded.replace('"', "\"\""))
-    } else {
-        guarded
-    }
-}
-
-/// Returns true when a CSV cell would be interpreted as a formula by a
-/// spreadsheet application and therefore must be neutralized.
-///
-/// Leading spaces and tabs are ignored by spreadsheets when deciding whether a
-/// cell is a formula, so we look past leading spaces/tabs for the trigger
-/// characters `=`, `+`, `-`, `@`. A cell that itself begins with a control
-/// character (tab, CR, LF) is also treated as dangerous.
-fn csv_cell_needs_formula_guard(rendered: &str) -> bool {
-    match rendered.chars().next() {
-        Some('\t' | '\r' | '\n') => true,
-        Some(_) => rendered
-            .trim_start_matches([' ', '\t'])
-            .starts_with(['=', '+', '-', '@']),
-        None => false,
-    }
-}
-
-fn tojson_filter(value: Value) -> Result<String, MiniJinjaError> {
-    serde_json::to_string(&value).map_err(|error| {
-        MiniJinjaError::new(
-            MiniJinjaErrorKind::InvalidOperation,
-            "unable to serialize template value as JSON",
-        )
-        .with_source(error)
-    })
-}
-
-fn default_if_empty_filter(state: &State<'_, '_>, value: Value, fallback: Value) -> Value {
-    if value.is_undefined() {
-        record_missing_value_warning(state, None);
-    }
-    if value_is_missing_or_empty(&value) {
-        fallback
-    } else {
-        value
-    }
-}
-
-fn format_datetime_filter(value: Value, format: Option<String>) -> Result<String, MiniJinjaError> {
-    let format = format.unwrap_or_else(|| "iso".to_string());
-    let raw = match value.as_str() {
-        Some(raw) if !raw.trim().is_empty() => raw.trim(),
-        _ if value.is_none() || value.is_undefined() => return Ok(String::new()),
-        _ => {
-            return Err(MiniJinjaError::new(
-                MiniJinjaErrorKind::InvalidOperation,
-                "format_datetime expects an RFC3339 or Hubuum timestamp string",
-            ));
-        }
-    };
-
-    let parsed = parse_template_datetime(raw).ok_or_else(|| {
-        MiniJinjaError::new(
-            MiniJinjaErrorKind::InvalidOperation,
-            format!("Unable to parse '{raw}' as a supported datetime"),
-        )
-    })?;
-
-    Ok(match format.as_str() {
-        "iso" => parsed.to_rfc3339(),
-        "date" => parsed.format("%Y-%m-%d").to_string(),
-        "datetime" => parsed.format("%Y-%m-%d %H:%M:%S").to_string(),
-        "time" => parsed.format("%H:%M:%S").to_string(),
-        other => {
-            return Err(MiniJinjaError::new(
-                MiniJinjaErrorKind::InvalidOperation,
-                format!("Unsupported datetime format '{other}'"),
-            ));
-        }
-    })
-}
-
-fn join_nonempty_filter(value: Value, sep: Option<String>) -> Result<String, MiniJinjaError> {
-    let joiner = sep.unwrap_or_else(|| ", ".to_string());
-    let items = value.try_iter().map_err(|_| {
-        MiniJinjaError::new(
-            MiniJinjaErrorKind::InvalidOperation,
-            "join_nonempty expects a list-like value",
-        )
-    })?;
-
-    Ok(items
-        .filter(|item| !value_is_missing_or_empty(item))
-        .map(|item| item.to_string())
-        .filter(|item| !item.is_empty())
-        .collect::<Vec<_>>()
-        .join(&joiner))
-}
-
-fn coalesce_function(state: &State<'_, '_>, values: minijinja::value::Rest<Value>) -> Value {
-    if values.iter().any(Value::is_undefined) {
-        record_missing_value_warning(state, None);
-    }
-    values
-        .iter()
-        .find(|value| !value_is_missing_or_empty(value))
-        .cloned()
-        .unwrap_or(Value::UNDEFINED)
-}
-
-fn value_is_missing_or_empty(value: &Value) -> bool {
-    if value.is_undefined() || value.is_none() {
-        return true;
-    }
-
-    if let Some(text) = value.as_str() {
-        return text.is_empty();
-    }
-
-    matches!(value.len(), Some(0))
-}
-
-fn parse_template_datetime(raw: &str) -> Option<chrono::DateTime<chrono::FixedOffset>> {
-    chrono::DateTime::parse_from_rfc3339(raw)
-        .ok()
-        .or_else(|| {
-            chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S")
-                .ok()
-                .and_then(|value| {
-                    chrono::FixedOffset::east_opt(0)
-                        .map(|offset| value.and_utc().with_timezone(&offset))
-                })
-        })
-        .or_else(|| {
-            chrono::NaiveDate::parse_from_str(raw, "%Y-%m-%d")
-                .ok()
-                .and_then(|value| value.and_hms_opt(0, 0, 0))
-                .and_then(|value| {
-                    chrono::FixedOffset::east_opt(0)
-                        .map(|offset| value.and_utc().with_timezone(&offset))
-                })
-        })
 }
 
 fn template_error(prefix: &str, error: MiniJinjaError) -> ApiError {
@@ -625,13 +446,14 @@ fn finish_template_warning_capture() -> Vec<ReportWarning> {
     })
 }
 
-fn record_missing_value_warning(state: &State<'_, '_>, path: Option<String>) {
+fn record_missing_value_warning(missing: MissingValue) {
     TEMPLATE_WARNING_CAPTURE.with(|capture| {
         let mut capture = capture.borrow_mut();
         let Some(capture) = capture.as_mut() else {
             return;
         };
-        let template_name = state.name().to_string();
+        let template_name = missing.template_name().to_string();
+        let path = missing.into_path();
         let key = (template_name.clone(), path.clone());
         if capture.missing_value_keys.contains(&key) {
             return;
@@ -723,28 +545,6 @@ mod tests {
 
         assert_eq!(rendered, "srv-01=alice\nsrv-02=bob\n");
         assert!(warnings.is_empty());
-    }
-
-    #[test]
-    fn csv_cell_neutralizes_formula_injection() {
-        // Leading formula triggers are prefixed with a quote so a spreadsheet
-        // treats the cell as text rather than evaluating it.
-        assert_eq!(
-            csv_cell_filter(Value::from("=HYPERLINK(\"http://evil\")")),
-            "\"'=HYPERLINK(\"\"http://evil\"\")\""
-        );
-        assert_eq!(csv_cell_filter(Value::from("@SUM(A1:A9)")), "'@SUM(A1:A9)");
-        assert_eq!(csv_cell_filter(Value::from("+1+1")), "'+1+1");
-        assert_eq!(csv_cell_filter(Value::from("-2+3")), "'-2+3");
-        // Spreadsheets ignore leading spaces/tabs when detecting a formula.
-        assert_eq!(csv_cell_filter(Value::from("  =1+1")), "'  =1+1");
-        assert_eq!(csv_cell_filter(Value::from("\t=1+1")), "'\t=1+1");
-        // Leading control characters are dangerous on their own.
-        assert_eq!(csv_cell_filter(Value::from("\rdata")), "\"'\rdata\"");
-        // Ordinary values are left untouched (still RFC-4180 quoted as needed).
-        assert_eq!(csv_cell_filter(Value::from("plain value")), "plain value");
-        assert_eq!(csv_cell_filter(Value::from("a,b")), "\"a,b\"");
-        assert_eq!(csv_cell_filter(Value::from("3.14")), "3.14");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add the internal hubuum-outbound-http workspace crate for hardened outbound HTTP behavior
- move URL validation, DNS/IP screening, resolver pinning, redirect refusal, response caps, and response-header redaction out of remote target internals
- expose outbound HTTP through crate-owned method, header, request, and response types with a builder-style send path
- add the internal hubuum-templates workspace crate for bounded MiniJinja validation/rendering and curated helper registration
- expose template rendering through a prepared-template builder so callers pass context and limits without long positional calls
- wire reports and remote targets through the shared template helper crate while keeping app-specific report caching, loaders, permissions, warnings, and API error mapping in the main crate
- preserve task-storage sanitization by mapping outbound crate errors to ApiError at the remote-call boundary before storing failures
- add persisted class scope for object-capable remote targets so object invocations must match both the request class_id and the target class_id
- document the workspace-crate API guidance in AGENTS.md: private fields, small explicit interfaces, builder APIs where useful, typestate only when it prevents real invalid states, and no third-party leaks unless intentional

Refs #88

## Verification
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test --no-run
- cargo test -p hubuum-outbound-http
- cargo test -p hubuum-templates
- cargo test tasks::remote_call::tests
- cargo run --quiet --bin hubuum-openapi > docs/openapi.json
- source .env && ./run_tests.sh

Note: diesel print-schema against the configured long-lived database was not useful because that database has not applied this branch migration yet; the fresh migrated test database path is covered by ./run_tests.sh.