### PR TITLE
Add health and readiness probes

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7302,6 +7302,60 @@
           }
         ]
       }
+    },
+    "/healthz": {
+      "get": {
+        "tags": [
+          "probes"
+        ],
+        "summary": "Get Healthz",
+        "description": "Auto-generated documentation for GET /healthz.",
+        "operationId": "getHealthz",
+        "responses": {
+          "200": {
+            "description": "Process is alive",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProbeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/readyz": {
+      "get": {
+        "tags": [
+          "probes"
+        ],
+        "summary": "Get Readyz",
+        "description": "Auto-generated documentation for GET /readyz.",
+        "operationId": "getReadyz",
+        "responses": {
+          "200": {
+            "description": "Service is ready to receive traffic",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProbeResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service is not ready",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -9141,6 +9195,17 @@
           "DeleteRemoteTarget",
           "ExecuteRemoteTarget"
         ]
+      },
+      "ProbeResponse": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string"
+          }
+        }
       },
       "RelatedClassGraph": {
         "type": "object",

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -4,6 +4,17 @@
 
 Hubuum can be configured using environment variables or command-line arguments. All environment variables have the prefix `HUBUUM_`.
 
+### Health Probes
+
+Hubuum exposes unauthenticated probe endpoints for container schedulers and load balancers:
+
+| Endpoint | Purpose |
+| -------- | ------- |
+| `/healthz` | Liveness probe. Returns `200 OK` when the process can serve HTTP. Does not touch the database. |
+| `/readyz` | Readiness probe. Returns `200 OK` only after a simple database query succeeds. Returns `503 Service Unavailable` when the service should not receive traffic. |
+
+Probe paths bypass the client IP allowlist so platform health checks are not rejected before reaching the handler.
+
 ### Server Configuration
 
 | Variable | Default | Description |

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -1,2 +1,3 @@
 pub mod auth;
 pub mod meta;
+pub mod probes;

--- a/src/api/handlers/probes.rs
+++ b/src/api/handlers/probes.rs
@@ -1,0 +1,56 @@
+use actix_web::{Responder, get, http::StatusCode, web};
+use diesel::RunQueryDsl;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::api::openapi::ApiErrorResponse;
+use crate::db::{DbPool, with_connection};
+use crate::errors::ApiError;
+use crate::utilities::response::json_response;
+
+#[derive(Serialize, ToSchema)]
+pub struct ProbeResponse {
+    status: String,
+}
+
+impl ProbeResponse {
+    fn ok(status: &str) -> Self {
+        Self {
+            status: status.to_string(),
+        }
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/healthz",
+    tag = "probes",
+    responses(
+        (status = 200, description = "Process is alive", body = ProbeResponse)
+    )
+)]
+#[get("/healthz")]
+pub async fn healthz() -> impl Responder {
+    json_response(ProbeResponse::ok("ok"), StatusCode::OK)
+}
+
+#[utoipa::path(
+    get,
+    path = "/readyz",
+    tag = "probes",
+    responses(
+        (status = 200, description = "Service is ready to receive traffic", body = ProbeResponse),
+        (status = 503, description = "Service is not ready", body = ApiErrorResponse)
+    )
+)]
+#[get("/readyz")]
+pub async fn readyz(pool: web::Data<DbPool>) -> Result<impl Responder, ApiError> {
+    with_connection(&pool, |conn| {
+        diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>("1")).get_result::<i32>(conn)
+    })
+    .map_err(|err| {
+        ApiError::ServiceUnavailable(format!("Database readiness check failed: {err}"))
+    })?;
+
+    Ok(json_response(ProbeResponse::ok("ready"), StatusCode::OK))
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -10,6 +10,8 @@ pub fn config(cfg: &mut web::ServiceConfig) {
     // actix's default `404`. Registered here so both the production app and the test harness, which
     // share this `configure`, get the same edge behavior.
     cfg.app_data(PathConfig::default().error_handler(crate::errors::path_error_handler))
+        .service(handlers::probes::healthz)
+        .service(handlers::probes::readyz)
         .service(web::scope("api/v1").configure(v1::routes::config))
         .service(web::scope("api/v0").configure(routes::config));
 }

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -1,4 +1,4 @@
-use crate::api::handlers::{auth, meta};
+use crate::api::handlers::{auth, meta, probes};
 use crate::api::v1::handlers::{
     classes, groups, imports, namespaces, relations, remote_targets, reports, search, tasks,
     templates, users,
@@ -44,6 +44,8 @@ use utoipa::{Modify, OpenApi, ToSchema};
     ),
     servers((url = "/", description = "Current deployment base URL")),
     paths(
+        probes::healthz,
+        probes::readyz,
         meta::get_db_state,
         meta::get_object_and_class_count,
         meta::get_task_queue_state,
@@ -144,6 +146,7 @@ use utoipa::{Modify, OpenApi, ToSchema};
         schemas(
             ApiErrorResponse,
             MessageResponse,
+            probes::ProbeResponse,
             LoginResponse,
             CountsResponse,
             meta::DbStateResponse,
@@ -685,6 +688,8 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         let expected_paths = [
+            "/healthz",
+            "/readyz",
             "/api/v0/auth/login",
             "/api/v0/auth/logout",
             "/api/v0/auth/logout_all",
@@ -886,8 +891,10 @@ mod tests {
                     "description is empty for {method} {path}"
                 );
 
+                let is_public_probe =
+                    matches!(path.as_str(), "/healthz" | "/readyz") && method == "get";
                 let is_login = path == "/api/v0/auth/login" && method == "post";
-                if !is_login {
+                if !is_login && !is_public_probe {
                     let security = operation
                         .get("security")
                         .and_then(Value::as_array)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -61,6 +61,7 @@ pub enum ApiError {
     DatabaseError(String),
     Conflict(String),
     TooManyRequests(String),
+    ServiceUnavailable(String),
     NotFound(String),
     Gone(String),
     DbConnectionError(String),
@@ -100,6 +101,7 @@ impl fmt::Display for ApiError {
             ApiError::Gone(message) => write!(f, "{message}"),
             ApiError::Conflict(message) => write!(f, "{message}"),
             ApiError::TooManyRequests(message) => write!(f, "{message}"),
+            ApiError::ServiceUnavailable(message) => write!(f, "{message}"),
             ApiError::Forbidden(message) => write!(f, "{message}"),
             ApiError::InternalServerError(message) => write!(f, "{message}"),
             ApiError::Unauthorized(message) => write!(f, "{message}"),
@@ -123,6 +125,8 @@ impl ResponseError for ApiError {
             }
             ApiError::TooManyRequests(message) => HttpResponse::TooManyRequests()
                 .json(json!({ "error": "Too Many Requests", "message": message })),
+            ApiError::ServiceUnavailable(message) => HttpResponse::ServiceUnavailable()
+                .json(json!({ "error": "Service Unavailable", "message": message })),
             ApiError::Forbidden(message) => {
                 HttpResponse::Forbidden().json(json!({ "error": "Forbidden", "message": message }))
             }
@@ -161,6 +165,7 @@ impl ResponseError for ApiError {
         match self {
             ApiError::Conflict(_) => StatusCode::CONFLICT,
             ApiError::TooManyRequests(_) => StatusCode::TOO_MANY_REQUESTS,
+            ApiError::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
             ApiError::Forbidden(_) => StatusCode::FORBIDDEN,
             ApiError::NotAcceptable(_) => StatusCode::NOT_ACCEPTABLE,
             ApiError::PayloadTooLarge(_) => StatusCode::PAYLOAD_TOO_LARGE,
@@ -387,6 +392,11 @@ mod tests {
         assert_eq!(
             ApiError::TooManyRequests("test".to_string()).status_code(),
             StatusCode::TOO_MANY_REQUESTS
+        );
+
+        assert_eq!(
+            ApiError::ServiceUnavailable("test".to_string()).status_code(),
+            StatusCode::SERVICE_UNAVAILABLE
         );
     }
 }

--- a/src/middlewares/client_allowlist.rs
+++ b/src/middlewares/client_allowlist.rs
@@ -108,6 +108,10 @@ where
     }
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
+        if is_probe_path(req.path()) {
+            return Box::pin(self.service.call(req));
+        }
+
         let client_ip = extract_client_ip(&req, &self.proxy_trust);
 
         match client_ip {
@@ -122,6 +126,10 @@ where
             }
         }
     }
+}
+
+fn is_probe_path(path: &str) -> bool {
+    matches!(path, "/healthz" | "/readyz")
 }
 
 /// Extract the client IP from the request

--- a/src/tasks/helpers.rs
+++ b/src/tasks/helpers.rs
@@ -73,6 +73,7 @@ pub(super) fn sanitize_error_for_storage(err: &ApiError) -> String {
             "Database operation failed".to_string()
         }
         ApiError::InternalServerError(_) => "An internal error occurred".to_string(),
+        ApiError::ServiceUnavailable(_) => "Service unavailable".to_string(),
         ApiError::HashError(_) => "Hashing operation failed".to_string(),
         ApiError::Unauthorized(msg) => format!("Unauthorized: {}", msg),
         ApiError::TooManyRequests(msg) => format!("Too many requests: {}", msg),

--- a/src/tests/api/mod.rs
+++ b/src/tests/api/mod.rs
@@ -1,2 +1,3 @@
 pub mod meta;
+pub mod probes;
 pub mod v1;

--- a/src/tests/api/probes.rs
+++ b/src/tests/api/probes.rs
@@ -1,0 +1,36 @@
+use actix_web::{App, http::StatusCode, test, web::Data};
+use serde_json::Value;
+
+use crate::api as prod_api;
+use crate::tests::POOL;
+
+#[actix_web::test]
+async fn test_healthz_returns_ok_without_database_pool() {
+    let app = test::init_service(App::new().configure(prod_api::config)).await;
+
+    let req = test::TestRequest::get().uri("/healthz").to_request();
+    let response = test::call_service(&app, req).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = test::read_body_json(response).await;
+    assert_eq!(body["status"], "ok");
+}
+
+#[actix_web::test]
+async fn test_readyz_checks_database_connectivity() {
+    let app = test::init_service(
+        App::new()
+            .app_data(Data::new(POOL.clone()))
+            .configure(prod_api::config),
+    )
+    .await;
+
+    let req = test::TestRequest::get().uri("/readyz").to_request();
+    let response = test::call_service(&app, req).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = test::read_body_json(response).await;
+    assert_eq!(body["status"], "ready");
+}

--- a/src/tests/client_allowlist.rs
+++ b/src/tests/client_allowlist.rs
@@ -163,6 +163,27 @@ mod tests {
         assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
     }
 
+    #[actix_web::test]
+    async fn test_probe_paths_bypass_client_allowlist() {
+        let app = test::init_service(
+            App::new()
+                .wrap(ClientAllowlistMiddleware::new_with_trust(
+                    ClientAllowlist::from_str("10.0.0.0/24").unwrap(),
+                    ProxyTrust::peer_only(),
+                ))
+                .route("/healthz", web::get().to(ok_handler)),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/healthz")
+            .peer_addr("192.168.1.100:9000".parse().unwrap())
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+    }
+
     // Unit tests for ClientAllowlist logic (no actix-web involved)
     #[cfg(test)]
     mod allowlist_unit_tests {


### PR DESCRIPTION
## Summary

- Add unauthenticated `/healthz` and `/readyz` endpoints for distributed/container platform probes.
- Make `/readyz` run a simple database query and return `503 Service Unavailable` when readiness fails.
- Let probe paths bypass the client IP allowlist so scheduler/load-balancer health checks can reach them.
- Document the endpoints and regenerate OpenAPI.

## Tests

- `source .env && cargo test probes`
- `source .env && cargo test client_allowlist`
- `source .env && cargo test openapi_operations_have_metadata_unique_operation_ids_and_security`
- `source .env && cargo test openapi_operations_resolve_to_mounted_routes`
- `source .env && cargo test openapi_paths_match_mounted_routes`
- `cargo clippy --all-targets -- -D warnings`
- `source .env && ./run_tests.sh`

Related to #92.