### PR TITLE
Add IAM "me" endpoints for user identity and token management

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3162,6 +3162,259 @@
         ]
       }
     },
+    "/api/v1/iam/me": {
+      "get": {
+        "tags": [
+          "principals"
+        ],
+        "summary": "Get Api V1 Iam Me",
+        "description": "Auto-generated documentation for GET /api/v1/iam/me.",
+        "operationId": "getApiV1IamMe",
+        "responses": {
+          "200": {
+            "description": "Current authenticated principal and token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/v1/iam/me/groups": {
+      "get": {
+        "tags": [
+          "principals"
+        ],
+        "summary": "Get Api V1 Iam Me Groups",
+        "description": "Auto-generated documentation for GET /api/v1/iam/me/groups. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "operationId": "getApiV1IamMeGroups",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of items to return. Defaults to 100. Maximum is 250.",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort fields. Cursor pagination uses the requested sort order and appends a stable tie-breaker automatically.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor returned in the X-Next-Cursor response header from a previous page. Supply it unchanged to fetch the next page.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Groups the current principal belongs to The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "headers": {
+              "X-Next-Cursor": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Group"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/v1/iam/me/permissions": {
+      "get": {
+        "tags": [
+          "principals"
+        ],
+        "summary": "Get Api V1 Iam Me Permissions",
+        "description": "Auto-generated documentation for GET /api/v1/iam/me/permissions.",
+        "operationId": "getApiV1IamMePermissions",
+        "responses": {
+          "200": {
+            "description": "Current principal effective permissions per namespace, grouped by granting group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PrincipalNamespacePermissions"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/v1/iam/me/tokens": {
+      "get": {
+        "tags": [
+          "principals"
+        ],
+        "summary": "Get Api V1 Iam Me Tokens",
+        "description": "Auto-generated documentation for GET /api/v1/iam/me/tokens. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "operationId": "getApiV1IamMeTokens",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of items to return. Defaults to 100. Maximum is 250.",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort fields. Cursor pagination uses the requested sort order and appends a stable tie-breaker automatically.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor returned in the X-Next-Cursor response header from a previous page. Supply it unchanged to fetch the next page.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current human user's active token metadata The response body contains the current page items as a JSON array. Use the `X-Total-Count` header for the exact number of matching results. Use the `X-Next-Cursor` header, when present, to request the next page.",
+            "headers": {
+              "X-Next-Cursor": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Opaque cursor for the next page. This header is omitted when there are no more results."
+              },
+              "X-Total-Count": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PrincipalTokenMetadata"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/v1/iam/principals/{principal_id}/groups": {
       "get": {
         "tags": [
@@ -8115,6 +8368,62 @@
           "total_objects": 42
         }
       },
+      "CurrentTokenMetadata": {
+        "type": "object",
+        "required": [
+          "id",
+          "issued",
+          "scoped"
+        ],
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "expires_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "issued": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_used_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "scoped": {
+            "type": "boolean"
+          },
+          "scopes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Permissions"
+            }
+          }
+        }
+      },
       "DbStateResponse": {
         "type": "object",
         "required": [
@@ -9177,6 +9486,21 @@
         "properties": {
           "token": {
             "type": "string"
+          }
+        }
+      },
+      "MeResponse": {
+        "type": "object",
+        "required": [
+          "principal",
+          "token"
+        ],
+        "properties": {
+          "principal": {
+            "$ref": "#/components/schemas/PrincipalMemberResponse"
+          },
+          "token": {
+            "$ref": "#/components/schemas/CurrentTokenMetadata"
           }
         }
       },

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -1,7 +1,7 @@
 use crate::api::handlers::{auth, meta, probes};
 use crate::api::v1::handlers::{
-    classes, groups, imports, namespaces, principals, relations, remote_targets, reports, search,
-    service_accounts, tasks, templates, users,
+    classes, groups, imports, me, namespaces, principals, relations, remote_targets, reports,
+    search, service_accounts, tasks, templates, users,
 };
 use crate::models::{
     ClassKey, Group, GroupKey, GroupPermission, HubuumClass, HubuumClassExpanded,
@@ -83,6 +83,10 @@ use utoipa::{Modify, OpenApi, ToSchema};
         principals::revoke_token,
         principals::list_principal_groups,
         principals::list_principal_permissions,
+        me::get_me,
+        me::list_my_tokens,
+        me::list_my_groups,
+        me::list_my_permissions,
         namespaces::get_namespaces,
         namespaces::create_namespace,
         namespaces::get_namespace,
@@ -181,6 +185,8 @@ use utoipa::{Modify, OpenApi, ToSchema};
             principals::NewTokenRequest,
             principals::GroupGrant,
             principals::PrincipalNamespacePermissions,
+            me::CurrentTokenMetadata,
+            me::MeResponse,
             Group,
             NewGroup,
             UpdateGroup,
@@ -412,6 +418,8 @@ fn is_cursor_paginated_get(path: &str, method: &str) -> bool {
             path,
             "/api/v1/iam/users"
                 | "/api/v1/iam/service-accounts"
+                | "/api/v1/iam/me/tokens"
+                | "/api/v1/iam/me/groups"
                 | "/api/v1/iam/principals/{principal_id}/tokens"
                 | "/api/v1/iam/principals/{principal_id}/groups"
                 | "/api/v1/iam/groups"
@@ -730,6 +738,10 @@ mod tests {
             "/api/v1/iam/service-accounts",
             "/api/v1/iam/service-accounts/{service_account_id}",
             "/api/v1/iam/service-accounts/{service_account_id}/disable",
+            "/api/v1/iam/me",
+            "/api/v1/iam/me/tokens",
+            "/api/v1/iam/me/groups",
+            "/api/v1/iam/me/permissions",
             "/api/v1/iam/principals/{principal_id}/tokens",
             "/api/v1/iam/principals/{principal_id}/tokens/{token_id}/revoke",
             "/api/v1/iam/principals/{principal_id}/groups",

--- a/src/api/v1/handlers/imports.rs
+++ b/src/api/v1/handlers/imports.rs
@@ -113,10 +113,8 @@ pub async fn create_import(
     let payload = serde_json::to_value(&import_request)?;
     let hash = request_hash(&payload)?;
     let idempotency_key = idempotency_key_from_headers(req.headers())?;
-    let snapshot = TaskScopeSnapshot::from_request(
-        Some(requestor.token_meta.id),
-        requestor.scopes(),
-    );
+    let snapshot =
+        TaskScopeSnapshot::from_request(Some(requestor.token_meta.id), requestor.scopes());
 
     let task = find_or_create_import_task(
         &pool,

--- a/src/api/v1/handlers/me.rs
+++ b/src/api/v1/handlers/me.rs
@@ -1,0 +1,154 @@
+use actix_web::{HttpRequest, Responder, get, http::StatusCode, routes, web};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::api::openapi::ApiErrorResponse;
+use crate::api::v1::handlers::principals::{
+    PrincipalNamespacePermissions, principal_permissions_response,
+};
+use crate::db::DbPool;
+use crate::db::traits::ActiveTokens;
+use crate::errors::ApiError;
+use crate::extractors::{Authenticated, ManagementAccess};
+use crate::models::search::parse_query_parameter;
+use crate::models::{Group, Permissions, PrincipalMemberResponse, PrincipalToken};
+use crate::pagination::prepare_db_pagination;
+use crate::traits::GroupAccessors;
+use crate::utilities::response::{
+    json_response, paginated_json_mapped_response, paginated_json_response,
+};
+
+pub fn config(cfg: &mut web::ServiceConfig) {
+    cfg.service(get_me)
+        .service(list_my_tokens)
+        .service(list_my_groups)
+        .service(list_my_permissions);
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct CurrentTokenMetadata {
+    pub id: i32,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub issued: chrono::NaiveDateTime,
+    pub expires_at: Option<chrono::NaiveDateTime>,
+    pub last_used_at: Option<chrono::NaiveDateTime>,
+    pub scoped: bool,
+    pub scopes: Option<Vec<Permissions>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct MeResponse {
+    pub principal: PrincipalMemberResponse,
+    pub token: CurrentTokenMetadata,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/iam/me",
+    tag = "principals",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Current authenticated principal and token", body = MeResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse)
+    )
+)]
+#[routes]
+#[get("")]
+#[get("/")]
+pub async fn get_me(requestor: Authenticated) -> Result<impl Responder, ApiError> {
+    let token = CurrentTokenMetadata {
+        id: requestor.token_meta.id,
+        name: requestor.token_meta.name,
+        description: requestor.token_meta.description,
+        issued: requestor.token_meta.issued,
+        expires_at: requestor.token_meta.expires_at,
+        last_used_at: requestor.token_meta.last_used_at,
+        scoped: requestor.token_meta.scoped,
+        scopes: requestor.scopes,
+    };
+
+    Ok(json_response(
+        MeResponse {
+            principal: requestor.principal.into(),
+            token,
+        },
+        StatusCode::OK,
+    ))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/iam/me/tokens",
+    tag = "principals",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Current human user's active token metadata", body = [crate::models::PrincipalTokenMetadata]),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Forbidden", body = ApiErrorResponse)
+    )
+)]
+#[get("/tokens")]
+pub async fn list_my_tokens(
+    pool: web::Data<DbPool>,
+    requestor: ManagementAccess,
+    req: HttpRequest,
+) -> Result<impl Responder, ApiError> {
+    let params = parse_query_parameter(req.query_string())?;
+    let search_params = prepare_db_pagination::<PrincipalToken>(&params)?;
+    let (tokens, total_count) = requestor
+        .user
+        .tokens_paginated_with_total_count(&pool, &search_params)
+        .await?;
+
+    paginated_json_mapped_response(tokens, total_count, StatusCode::OK, &params, |tokens| {
+        tokens
+            .into_iter()
+            .map(crate::models::PrincipalTokenMetadata::from)
+            .collect()
+    })
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/iam/me/groups",
+    tag = "principals",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Groups the current principal belongs to", body = [Group]),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse)
+    )
+)]
+#[get("/groups")]
+pub async fn list_my_groups(
+    pool: web::Data<DbPool>,
+    requestor: Authenticated,
+    req: HttpRequest,
+) -> Result<impl Responder, ApiError> {
+    let params = parse_query_parameter(req.query_string())?;
+    let search_params = prepare_db_pagination::<Group>(&params)?;
+    let (groups, total_count) = requestor
+        .principal
+        .groups_paginated_with_total_count(&pool, &search_params)
+        .await?;
+    paginated_json_response(groups, total_count, StatusCode::OK, &params)
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/iam/me/permissions",
+    tag = "principals",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Current principal effective permissions per namespace, grouped by granting group", body = [PrincipalNamespacePermissions]),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse)
+    )
+)]
+#[get("/permissions")]
+pub async fn list_my_permissions(
+    pool: web::Data<DbPool>,
+    requestor: Authenticated,
+) -> Result<impl Responder, ApiError> {
+    let report = principal_permissions_response(&pool, &requestor.principal).await?;
+    Ok(json_response(report, StatusCode::OK))
+}

--- a/src/api/v1/handlers/mod.rs
+++ b/src/api/v1/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod classes;
 pub mod groups;
 pub mod imports;
+pub mod me;
 pub mod namespaces;
 pub mod principals;
 pub mod relations;

--- a/src/api/v1/handlers/principals.rs
+++ b/src/api/v1/handlers/principals.rs
@@ -75,6 +75,39 @@ async fn ensure_can_manage_principal(
     }
 }
 
+pub async fn principal_permissions_response(
+    pool: &DbPool,
+    principal: &impl AuthzSubject,
+) -> Result<Vec<PrincipalNamespacePermissions>, ApiError> {
+    let rows = principal_all_permissions(pool, principal).await?;
+
+    // Fold (namespace, group, permission-row) tuples into a per-namespace,
+    // per-group report. BTreeMap keeps namespaces in a stable id order; groups
+    // with no granted flags are dropped.
+    let mut by_namespace: BTreeMap<i32, PrincipalNamespacePermissions> = BTreeMap::new();
+    for (namespace, group, permission) in rows {
+        let permissions = permission.granted();
+        if permissions.is_empty() {
+            continue;
+        }
+        by_namespace
+            .entry(namespace.id)
+            .or_insert_with(|| PrincipalNamespacePermissions {
+                namespace_id: namespace.id,
+                namespace_name: namespace.name.clone(),
+                grants: Vec::new(),
+            })
+            .grants
+            .push(GroupGrant {
+                group_id: group.id,
+                groupname: group.groupname.clone(),
+                permissions,
+            });
+    }
+
+    Ok(by_namespace.into_values().collect())
+}
+
 #[utoipa::path(
     post,
     path = "/api/v1/iam/principals/{principal_id}/tokens",
@@ -290,32 +323,6 @@ pub async fn list_principal_permissions(
     let principal = pid.principal(&pool).await?;
     ensure_can_manage_principal(&pool, &requestor, &principal).await?;
 
-    let rows = principal_all_permissions(&pool, pid).await?;
-
-    // Fold (namespace, group, permission-row) tuples into a per-namespace,
-    // per-group report. BTreeMap keeps namespaces in a stable id order; groups
-    // with no granted flags are dropped.
-    let mut by_namespace: BTreeMap<i32, PrincipalNamespacePermissions> = BTreeMap::new();
-    for (namespace, group, permission) in rows {
-        let permissions = permission.granted();
-        if permissions.is_empty() {
-            continue;
-        }
-        by_namespace
-            .entry(namespace.id)
-            .or_insert_with(|| PrincipalNamespacePermissions {
-                namespace_id: namespace.id,
-                namespace_name: namespace.name.clone(),
-                grants: Vec::new(),
-            })
-            .grants
-            .push(GroupGrant {
-                group_id: group.id,
-                groupname: group.groupname.clone(),
-                permissions,
-            });
-    }
-
-    let report: Vec<PrincipalNamespacePermissions> = by_namespace.into_values().collect();
+    let report = principal_permissions_response(&pool, &pid).await?;
     Ok(json_response(report, StatusCode::OK))
 }

--- a/src/api/v1/handlers/principals.rs
+++ b/src/api/v1/handlers/principals.rs
@@ -75,7 +75,7 @@ async fn ensure_can_manage_principal(
     }
 }
 
-pub async fn principal_permissions_response(
+pub(crate) async fn principal_permissions_response(
     pool: &DbPool,
     principal: &impl AuthzSubject,
 ) -> Result<Vec<PrincipalNamespacePermissions>, ApiError> {

--- a/src/api/v1/handlers/remote_targets.rs
+++ b/src/api/v1/handlers/remote_targets.rs
@@ -305,10 +305,8 @@ pub async fn invoke_remote_target(
         parameters: invoke.parameters,
         body_override: invoke.body_override,
     })?;
-    let snapshot = TaskScopeSnapshot::from_request(
-        Some(requestor.token_meta.id),
-        requestor.scopes(),
-    );
+    let snapshot =
+        TaskScopeSnapshot::from_request(Some(requestor.token_meta.id), requestor.scopes());
     let task = find_or_create_remote_call_task(
         &pool,
         user.id,

--- a/src/api/v1/handlers/reports.rs
+++ b/src/api/v1/handlers/reports.rs
@@ -259,8 +259,7 @@ pub(crate) async fn submit_report_task<S: AuthzSubject>(
     validate_report_submission(&runtime)?;
     let task_payload = runtime_to_task_payload(&runtime)?;
 
-    let snapshot =
-        TaskScopeSnapshot::from_request(submitted_token_id, scopes);
+    let snapshot = TaskScopeSnapshot::from_request(submitted_token_id, scopes);
 
     find_or_create_report_task(
         pool,

--- a/src/api/v1/routes/mod.rs
+++ b/src/api/v1/routes/mod.rs
@@ -1,3 +1,4 @@
+use crate::api::v1::handlers::me;
 use actix_web::web;
 
 pub mod classes;
@@ -22,6 +23,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         .service(
             web::scope("/iam/principals").configure(crate::api::v1::handlers::principals::config),
         )
+        .service(web::scope("/iam/me").configure(me::config))
         .service(web::scope("/imports").configure(imports::config))
         .service(web::scope("/namespaces").configure(namespaces::config))
         .service(web::scope("/classes").configure(classes::config))

--- a/src/tests/api/v1/service_accounts.rs
+++ b/src/tests/api/v1/service_accounts.rs
@@ -17,6 +17,7 @@ mod tests {
     use rstest::rstest;
 
     use crate::api;
+    use crate::api::v1::handlers::me::MeResponse;
     use crate::db::traits::Status;
     use crate::db::traits::authz::scope_allows;
     use crate::db::traits::task::scope_snapshot_json;
@@ -30,10 +31,11 @@ mod tests {
     use crate::models::user::{LoginUser, NewUser};
     use crate::models::{
         NewServiceAccount, NewTaskRecord, Permissions, PrincipalID, PrincipalMemberResponse,
-        ServiceAccount, ServiceAccountID, ServiceAccountResponse, TaskID, TaskKind, TaskRecord,
-        TaskStatus,
+        PrincipalTokenMetadata, ServiceAccount, ServiceAccountID, ServiceAccountResponse, TaskID,
+        TaskKind, TaskRecord, TaskStatus,
     };
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
+    use crate::tests::asserts::assert_response_status;
     use crate::tests::{
         TestContext, create_test_group, create_test_service_account, create_test_user,
         ensure_admin_group, scoped_token, service_account_token,
@@ -42,6 +44,7 @@ mod tests {
     use crate::utilities::auth::generate_random_password;
 
     const LOGIN_ENDPOINT: &str = "/api/v0/auth/login";
+    const ME_ENDPOINT: &str = "/api/v1/iam/me";
     const PRINCIPALS_ENDPOINT: &str = "/api/v1/iam/principals";
 
     // ----- Batch 1: identity / subtype invariants -----
@@ -758,6 +761,104 @@ mod tests {
         .await;
 
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    /// `/iam/me` gives service-account consumers a path-id-free way to discover
+    /// their principal identity and current token metadata.
+    #[actix_web::test]
+    async fn test_me_route_works_for_service_account() {
+        let context = TestContext::new().await;
+        let pool = &context.pool;
+        let group = create_test_group(pool).await;
+        let sa = create_test_service_account(pool, &group, None).await;
+        let token = scoped_token(pool, sa.id, &[Permissions::ReadCollection]).await;
+
+        let resp = get_request(pool, &token, ME_ENDPOINT).await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let body: MeResponse = test::read_body_json(resp).await;
+
+        assert_eq!(body.principal.principal_id, sa.id);
+        assert_eq!(body.principal.kind, "service_account");
+        assert!(body.token.scoped);
+        assert_eq!(body.token.scopes, Some(vec![Permissions::ReadCollection]));
+    }
+
+    /// `/iam/me/groups` is self-service and accepts service-account tokens; it
+    /// returns only the authenticated principal's memberships.
+    #[actix_web::test]
+    async fn test_me_groups_route_works_for_service_account() {
+        let context = TestContext::new().await;
+        let pool = &context.pool;
+        let group = create_test_group(pool).await;
+        let other_group = create_test_group(pool).await;
+        let sa = create_test_service_account(pool, &group, None).await;
+        group.add_member(pool, &sa).await.unwrap();
+        let token = service_account_token(pool, &sa, None, None).await;
+
+        let resp = get_request(pool, &token, &format!("{ME_ENDPOINT}/groups")).await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let groups: Vec<crate::models::Group> = test::read_body_json(resp).await;
+        let ids: std::collections::HashSet<i32> = groups.iter().map(|g| g.id).collect();
+
+        assert!(ids.contains(&group.id));
+        assert!(!ids.contains(&other_group.id));
+    }
+
+    /// `/iam/me/permissions` is self-service for the authenticated principal and
+    /// reports effective namespace permissions through its group memberships.
+    #[actix_web::test]
+    async fn test_me_permissions_route_works_for_service_account() {
+        let context = TestContext::new().await;
+        let pool = &context.pool;
+        let fixture = context.with_namespace().await;
+        let sa = create_test_service_account(pool, &fixture.owner_group, None).await;
+        fixture.owner_group.add_member(pool, &sa).await.unwrap();
+        let token = service_account_token(pool, &sa, None, None).await;
+
+        let resp = get_request(pool, &token, &format!("{ME_ENDPOINT}/permissions")).await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let report: Vec<crate::api::v1::handlers::principals::PrincipalNamespacePermissions> =
+            test::read_body_json(resp).await;
+
+        assert!(
+            report
+                .iter()
+                .any(|entry| entry.namespace_id == fixture.namespace.id),
+            "self permissions should include the fixture namespace"
+        );
+    }
+
+    /// `/iam/me/tokens` is still a credential-management surface: human unscoped
+    /// callers can list their own tokens, while service-account tokens are rejected.
+    #[actix_web::test]
+    async fn test_me_tokens_route_is_human_unscoped_only_and_self_scoped() {
+        let context = TestContext::new().await;
+        let pool = &context.pool;
+        let group = create_test_group(pool).await;
+        let sa = create_test_service_account(pool, &group, None).await;
+        let sa_token = service_account_token(pool, &sa, None, None).await;
+
+        let denied = get_request(pool, &sa_token, &format!("{ME_ENDPOINT}/tokens")).await;
+        assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+
+        let visible = get_request(
+            pool,
+            &context.normal_token,
+            &format!("{ME_ENDPOINT}/tokens"),
+        )
+        .await;
+        let visible = assert_response_status(visible, StatusCode::OK).await;
+        let tokens: Vec<PrincipalTokenMetadata> = test::read_body_json(visible).await;
+
+        assert!(
+            tokens
+                .iter()
+                .all(|token| token.principal_id == context.normal_user.id)
+        );
+        assert!(
+            !tokens.is_empty(),
+            "normal user should see its own active token"
+        );
     }
 
     /// #29: the principal-shaped namespace effective-permission route works for a


### PR DESCRIPTION
This pull request introduces a new set of "me" endpoints under `/api/v1/iam/me` for authenticated users, allowing them to retrieve their own profile, tokens, groups, and permissions. It also refactors permission reporting logic for better code reuse and updates the OpenAPI documentation to reflect these changes.

**New "me" API endpoints:**

* Added the following endpoints for authenticated users:
  - `GET /api/v1/iam/me` for current principal and token metadata (`MeResponse`) [[1]](diffhunk://#diff-3f833dc3e592cbd68a680aba03b33162e8841c28ca0c27bdde5989e8ba2a4480R3165-R3417) [[2]](diffhunk://#diff-a1d6bee1039416da4005d326205c3d1a3cee9c16eedeee74343a686baa7e9729R1-R154)
  - `GET /api/v1/iam/me/tokens` for listing the user's active tokens with pagination [[1]](diffhunk://#diff-3f833dc3e592cbd68a680aba03b33162e8841c28ca0c27bdde5989e8ba2a4480R3165-R3417) [[2]](diffhunk://#diff-a1d6bee1039416da4005d326205c3d1a3cee9c16eedeee74343a686baa7e9729R1-R154)
  - `GET /api/v1/iam/me/groups` for listing the user's groups with pagination [[1]](diffhunk://#diff-3f833dc3e592cbd68a680aba03b33162e8841c28ca0c27bdde5989e8ba2a4480R3165-R3417) [[2]](diffhunk://#diff-a1d6bee1039416da4005d326205c3d1a3cee9c16eedeee74343a686baa7e9729R1-R154)
  - `GET /api/v1/iam/me/permissions` for listing the user's effective permissions [[1]](diffhunk://#diff-3f833dc3e592cbd68a680aba03b33162e8841c28ca0c27bdde5989e8ba2a4480R3165-R3417) [[2]](diffhunk://#diff-a1d6bee1039416da4005d326205c3d1a3cee9c16eedeee74343a686baa7e9729R1-R154)

**OpenAPI documentation updates:**

* Documented the new "me" endpoints and their schemas in `openapi.json`, including new schema definitions for `MeResponse` and `CurrentTokenMetadata` [[1]](diffhunk://#diff-3f833dc3e592cbd68a680aba03b33162e8841c28ca0c27bdde5989e8ba2a4480R3165-R3417) [[2]](diffhunk://#diff-3f833dc3e592cbd68a680aba03b33162e8841c28ca0c27bdde5989e8ba2a4480R8371-R8426) [[3]](diffhunk://#diff-3f833dc3e592cbd68a680aba03b33162e8841c28ca0c27bdde5989e8ba2a4480R9492-R9506).
* Registered the new endpoints and schemas in the OpenAPI configuration (`src/api/openapi.rs`) [[1]](diffhunk://#diff-a00c8e361c8c4fd7f4c2c56d0c54a6fd794e84a4c7d223bbbf23554abe5ff435L3-R4) [[2]](diffhunk://#diff-a00c8e361c8c4fd7f4c2c56d0c54a6fd794e84a4c7d223bbbf23554abe5ff435R86-R89) [[3]](diffhunk://#diff-a00c8e361c8c4fd7f4c2c56d0c54a6fd794e84a4c7d223bbbf23554abe5ff435R188-R189) [[4]](diffhunk://#diff-a00c8e361c8c4fd7f4c2c56d0c54a6fd794e84a4c7d223bbbf23554abe5ff435R741-R744) [[5]](diffhunk://#diff-a00c8e361c8c4fd7f4c2c56d0c54a6fd794e84a4c7d223bbbf23554abe5ff435R421-R422).

**Codebase improvements and refactoring:**

* Introduced the `me` module and handlers for the new endpoints (`src/api/v1/handlers/me.rs`, `src/api/v1/handlers/mod.rs`) [[1]](diffhunk://#diff-a1d6bee1039416da4005d326205c3d1a3cee9c16eedeee74343a686baa7e9729R1-R154) [[2]](diffhunk://#diff-6f36b13a77e97f4d95b70464aa07d557de4577557ee47fc4c917ac4924ed7bd2R4).
* Refactored permission reporting logic into a shared helper function `principal_permissions_response` for code reuse between principal and "me" endpoints (`src/api/v1/handlers/principals.rs`) [[1]](diffhunk://#diff-46c93f23b85dc2ee2d136183c8a95cd0d9795ebc2184ac26dbfb26db7c4af1ebR78-R110) [[2]](diffhunk://#diff-46c93f23b85dc2ee2d136183c8a95cd0d9795ebc2184ac26dbfb26db7c4af1ebL293-R326).
* Minor code style improvements for constructing `TaskScopeSnapshot` [[1]](diffhunk://#diff-63a396ec23ec75edd7dc4e3a0a26d1f9ffda1aa9a0e4db002ef54c227290aeabL116-R117) [[2]](diffhunk://#diff-b367083eb3be9a9a20c57ffcfdee677d4d86acdee66e71e755286161ca8a0fefL308-R309).

These changes make it easier for users to programmatically access their own identity and authorization details and improve maintainability by consolidating permission reporting logic.