### PR TITLE
Trim test_old_directional_class_routes_removed: drop incidental GET /{id}/relations case

### DIFF
--- a/src/tests/api/v1/relations.rs
+++ b/src/tests/api/v1/relations.rs
@@ -561,13 +561,11 @@ mod tests {
         cleanup(&classes).await;
     }
 
-    // The old directional class-relation routes are gone. A stale URL that collides with a current
-    // route expecting a numeric segment (here `/{class_id}/{object_id}`) is rejected as a `400`
-    // because the literal segment is not a valid id; the deeper paths match no route and are a plain
-    // `404`. Either way the old endpoint no longer serves. `{first}`/`{second}` are substituted with
-    // the fixture class ids since rstest cases cannot reference runtime values.
+    // The old directional class-relation transitive routes are gone; these deeper
+    // paths match no route and return a plain `404`. `{first}`/`{second}` are
+    // substituted with the fixture class ids since rstest cases cannot reference
+    // runtime values.
     #[rstest]
-    #[case::get_relations("{first}/relations", StatusCode::BAD_REQUEST)]
     #[case::transitive("{first}/relations/transitive/", StatusCode::NOT_FOUND)]
     #[case::transitive_to_class(
         "{first}/relations/transitive/class/{second}",


### PR DESCRIPTION
Closes #63.

## Context

`test_old_directional_class_routes_removed` (in `src/tests/api/v1/relations.rs`) guards that the directional class-relation routes removed in #29 stay removed.

## Problem

The `GET /{id}/relations` case no longer tests what it claims. After the `PathConfig` error handler landed, invalid path ids return `400` instead of actix's default `404`, so `GET /classes/{id}/relations` passes only because `"relations"` collides with the current `/{class_id}/{object_id}` route and is rejected as a non-numeric object id — an incidental `400`, not a genuine "removed route" guard.

That assertion is fragile: if a legitimate `GET /{id}/relations` is ever added (e.g. a shortcut for the relations list, which today lives at `GET /classes/{id}/related/relations`), this case fails for an unrelated reason.

The two `transitive` cases are fine — those paths match no route, so the `404` is a genuine guard.

## Change

- Drop the `get_relations` `400` case.
- Keep the two `transitive` `404` cases.
- Tighten the surrounding comment to describe only the remaining cases.

Nothing is lost: the relations-list capability lives at `GET /api/v1/classes/{class_id}/related/relations` (`get_related_class_relations`).

## Validation

- `test_old_directional_class_routes_removed` (both remaining cases) passes via `run_tests.sh` on a fresh migrated DB.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt -- --check` clean.
- Test-only change; no OpenAPI regen needed.