### PR TITLE
Stabilize retention purge tests

### DIFF
--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -7,8 +7,6 @@
 
 #![cfg(test)]
 
-use std::sync::OnceLock;
-
 use diesel::prelude::*;
 use rstest::rstest;
 use uuid::Uuid;
@@ -48,17 +46,13 @@ use crate::models::{
     UpdateReportTemplate, UpdateUser,
 };
 use crate::schema::events::dsl::events;
-use crate::tests::{TestScope, create_test_user, test_scope};
+use crate::tests::{
+    TestMutex, TestScope, create_test_user, lock_test_mutex, test_mutex, test_scope,
+};
 use crate::traits::{CanDelete, CanSave, CanUpdate, PermissionController};
 
-static EVENT_DELIVERY_TEST_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
-
-async fn event_delivery_test_lock() -> tokio::sync::MutexGuard<'static, ()> {
-    EVENT_DELIVERY_TEST_LOCK
-        .get_or_init(|| tokio::sync::Mutex::new(()))
-        .lock()
-        .await
-}
+static EVENT_DELIVERY_TEST_LOCK: TestMutex = test_mutex();
+static EVENT_RETENTION_TEST_LOCK: TestMutex = test_mutex();
 
 /// Count event rows for a given `event_id` (0 or 1, since `event_id` is UNIQUE).
 fn count_events_for(conn: &mut PgConnection, target: Uuid) -> i64 {
@@ -538,6 +532,7 @@ async fn ordinary_event_delete_is_rejected_by_append_only_trigger() {
 
 #[actix_web::test]
 async fn event_retention_purge_deletes_old_events_through_guarded_path() {
+    let _lock = lock_test_mutex(&EVENT_RETENTION_TEST_LOCK).await;
     let scope = test_scope();
     let old_event = insert_namespace_created_event_at(
         &scope,
@@ -562,6 +557,7 @@ async fn event_retention_purge_deletes_old_events_through_guarded_path() {
 
 #[actix_web::test]
 async fn event_retention_purge_keeps_events_pending_fanout() {
+    let _lock = lock_test_mutex(&EVENT_RETENTION_TEST_LOCK).await;
     let scope = test_scope();
     let old_event = insert_namespace_created_event_at(
         &scope,
@@ -585,6 +581,7 @@ async fn event_retention_purge_keeps_events_pending_fanout() {
 
 #[actix_web::test]
 async fn event_retention_purge_keeps_events_with_active_deliveries() {
+    let _lock = lock_test_mutex(&EVENT_RETENTION_TEST_LOCK).await;
     let scope = test_scope();
     let fixture = scope.with_namespace().await;
     create_namespace_event_subscription(&scope, fixture.namespace.id, "retention_active", true)
@@ -612,6 +609,7 @@ async fn event_retention_purge_keeps_events_with_active_deliveries() {
 
 #[actix_web::test]
 async fn event_retention_purge_deletes_old_terminal_deliveries_without_deleting_event() {
+    let _lock = lock_test_mutex(&EVENT_RETENTION_TEST_LOCK).await;
     let scope = test_scope();
     let fixture = scope.with_namespace().await;
     let subscription_id = create_namespace_event_subscription(
@@ -664,7 +662,7 @@ async fn event_retention_purge_deletes_old_terminal_deliveries_without_deleting_
 
 #[actix_web::test]
 async fn event_delivery_worker_marks_successful_delivery_succeeded() {
-    let _lock = event_delivery_test_lock().await;
+    let _lock = lock_test_mutex(&EVENT_DELIVERY_TEST_LOCK).await;
     let scope = test_scope();
     let fixture = scope.with_namespace().await;
     create_namespace_event_subscription(&scope, fixture.namespace.id, "delivery_success", true)
@@ -693,7 +691,7 @@ async fn event_delivery_worker_marks_successful_delivery_succeeded() {
 
 #[actix_web::test]
 async fn event_delivery_worker_retries_with_backoff_then_marks_dead() {
-    let _lock = event_delivery_test_lock().await;
+    let _lock = lock_test_mutex(&EVENT_DELIVERY_TEST_LOCK).await;
     let scope = test_scope();
     let fixture = scope.with_namespace().await;
     create_namespace_event_subscription(&scope, fixture.namespace.id, "delivery_retry", true).await;
@@ -740,7 +738,7 @@ async fn event_delivery_worker_retries_with_backoff_then_marks_dead() {
 
 #[actix_web::test]
 async fn event_delivery_claims_expired_in_flight_rows_again() {
-    let _lock = event_delivery_test_lock().await;
+    let _lock = lock_test_mutex(&EVENT_DELIVERY_TEST_LOCK).await;
     let scope = test_scope();
     let fixture = scope.with_namespace().await;
     create_namespace_event_subscription(&scope, fixture.namespace.id, "delivery_reclaim", true)
@@ -775,7 +773,7 @@ async fn event_delivery_claims_expired_in_flight_rows_again() {
 
 #[actix_web::test]
 async fn event_delivery_failed_mark_respects_claim_token() {
-    let _lock = event_delivery_test_lock().await;
+    let _lock = lock_test_mutex(&EVENT_DELIVERY_TEST_LOCK).await;
     let scope = test_scope();
     let fixture = scope.with_namespace().await;
     create_namespace_event_subscription(&scope, fixture.namespace.id, "delivery_claim_token", true)

--- a/src/middlewares/rate_limit.rs
+++ b/src/middlewares/rate_limit.rs
@@ -4,6 +4,8 @@ use ipnet::{Ipv4Net, Ipv6Net};
 use crate::config::{AppConfig, LoginRateLimitConfig, login_rate_limit_config};
 use crate::middlewares::client_allowlist::{ProxyTrust, extract_client_ip_from_http_request};
 
+#[cfg(test)]
+use crate::tests::{TestMutex, test_mutex};
 use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
 use std::sync::LazyLock;
@@ -313,8 +315,7 @@ pub(crate) async fn clear_all() -> usize {
 /// Serializes tests that touch the process-global limiter state (auth login tests and the
 /// admin `/meta/login-rate-limit` tests) so they do not observe each other's failures.
 #[cfg(test)]
-pub(crate) static LOGIN_RATE_LIMIT_TEST_LOCK: LazyLock<Mutex<()>> =
-    LazyLock::new(|| Mutex::new(()));
+pub(crate) static LOGIN_RATE_LIMIT_TEST_LOCK: TestMutex = test_mutex();
 
 #[cfg(test)]
 pub(crate) async fn reset_login_rate_limit_for_tests() {

--- a/src/tests/api/meta.rs
+++ b/src/tests/api/meta.rs
@@ -11,7 +11,7 @@ mod tests {
     };
     use crate::tests::api_operations::{delete_request, get_request};
     use crate::tests::asserts::assert_response_status;
-    use crate::tests::{TestContext, test_context};
+    use crate::tests::{TestContext, lock_test_mutex, test_context};
 
     const LOGIN_RATE_LIMIT_ENDPOINT: &str = "/api/v0/meta/login-rate-limit";
 
@@ -57,7 +57,7 @@ mod tests {
     async fn test_login_rate_limit_meta_endpoint_returns_config(
         #[future(awt)] test_context: TestContext,
     ) {
-        let _guard = LOGIN_RATE_LIMIT_TEST_LOCK.lock().await;
+        let _guard = lock_test_mutex(&LOGIN_RATE_LIMIT_TEST_LOCK).await;
         reset_login_rate_limit_for_tests().await;
         let context = test_context;
 
@@ -97,7 +97,7 @@ mod tests {
     #[rstest]
     #[actix_web::test]
     async fn test_login_rate_limit_release_entry(#[future(awt)] test_context: TestContext) {
-        let _guard = LOGIN_RATE_LIMIT_TEST_LOCK.lock().await;
+        let _guard = lock_test_mutex(&LOGIN_RATE_LIMIT_TEST_LOCK).await;
         reset_login_rate_limit_for_tests().await;
         let context = test_context;
 
@@ -168,7 +168,7 @@ mod tests {
     async fn test_login_rate_limit_filter_by_scope_and_query(
         #[future(awt)] test_context: TestContext,
     ) {
-        let _guard = LOGIN_RATE_LIMIT_TEST_LOCK.lock().await;
+        let _guard = lock_test_mutex(&LOGIN_RATE_LIMIT_TEST_LOCK).await;
         reset_login_rate_limit_for_tests().await;
         let context = test_context;
 
@@ -228,7 +228,7 @@ mod tests {
     #[rstest]
     #[actix_web::test]
     async fn test_login_rate_limit_clear_all(#[future(awt)] test_context: TestContext) {
-        let _guard = LOGIN_RATE_LIMIT_TEST_LOCK.lock().await;
+        let _guard = lock_test_mutex(&LOGIN_RATE_LIMIT_TEST_LOCK).await;
         reset_login_rate_limit_for_tests().await;
         let context = test_context;
 

--- a/src/tests/api/v1/auth.rs
+++ b/src/tests/api/v1/auth.rs
@@ -7,12 +7,11 @@ mod tests {
         LOGIN_RATE_LIMIT_TEST_LOCK, reset_login_rate_limit_for_tests,
     };
     use crate::models::user::LoginUser;
-    use crate::tests::{create_test_admin, create_test_user};
+    use crate::tests::{TestMutexGuard, create_test_admin, create_test_user, lock_test_mutex};
     use crate::{api, assert_not_contains};
     use actix_web::http::header;
     use actix_web::{App, http::StatusCode, test, web, web::Data};
     use diesel::prelude::*;
-    use tokio::sync::MutexGuard;
 
     const LOGIN_ENDPOINT: &str = "/api/v0/auth/login";
     const LOGOUT_ENDPOINT: &str = "/api/v0/auth/logout";
@@ -21,8 +20,8 @@ mod tests {
     const LOGOUT_SPECIFIC_TOKEN: &str = "/api/v0/auth/logout/token";
     const VALIDATE_TOKEN_ENDPOINT: &str = "/api/v0/auth/validate";
 
-    async fn lock_auth_test_state() -> MutexGuard<'static, ()> {
-        LOGIN_RATE_LIMIT_TEST_LOCK.lock().await
+    async fn lock_auth_test_state() -> TestMutexGuard {
+        lock_test_mutex(&LOGIN_RATE_LIMIT_TEST_LOCK).await
     }
 
     #[actix_web::test]

--- a/src/tests/api/v1/reports.rs
+++ b/src/tests/api/v1/reports.rs
@@ -20,7 +20,9 @@ mod tests {
     use crate::tests::api::v1::classes::tests::{cleanup, create_test_classes};
     use crate::tests::api_operations::{get_request, post_request_with_headers};
     use crate::tests::asserts::{assert_response_status, header_value};
-    use crate::tests::{TestContext, create_test_user, test_context};
+    use crate::tests::{
+        TestContext, TestMutex, create_test_user, lock_test_mutex, test_context, test_mutex,
+    };
     use crate::traits::{CanSave, CanUpdate};
     const REPORTS_ENDPOINT: &str = "/api/v1/reports";
 
@@ -28,8 +30,7 @@ mod tests {
     /// outputs: one runs the global `purge_expired_report_outputs`, the other needs its expired
     /// row to survive until it has queried it. They cannot safely interleave; every other test in
     /// the suite remains free to run in parallel.
-    static EXPIRED_OUTPUT_PURGE_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
-        std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+    static EXPIRED_OUTPUT_PURGE_LOCK: TestMutex = test_mutex();
 
     async fn wait_for_task(
         context: &TestContext,
@@ -1497,7 +1498,7 @@ mod tests {
 
         // Hold the purge lock from here: the global purge below must not race the expired-output
         // test, which relies on its own expired row surviving.
-        let _purge_guard = EXPIRED_OUTPUT_PURGE_LOCK.lock().await;
+        let _purge_guard = lock_test_mutex(&EXPIRED_OUTPUT_PURGE_LOCK).await;
 
         crate::db::with_connection(&context.pool, |conn| {
             use crate::schema::report_task_outputs::dsl::{
@@ -1602,7 +1603,7 @@ mod tests {
 
         // Hold the purge lock so the cleanup test's global purge cannot delete our expired row
         // out from under the assertions below.
-        let _purge_guard = EXPIRED_OUTPUT_PURGE_LOCK.lock().await;
+        let _purge_guard = lock_test_mutex(&EXPIRED_OUTPUT_PURGE_LOCK).await;
 
         // Fixed, whole-second timestamp in the past: deterministically expired and round-trips
         // through Postgres' microsecond-resolution `timestamp` column without precision loss.

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -32,11 +32,23 @@ use crate::utilities::auth::generate_random_password;
 
 use crate::traits::{CanDelete, CanSave};
 use std::sync::LazyLock;
+use tokio::sync::{Mutex, MutexGuard};
 
 static POOL: LazyLock<DbPool> = LazyLock::new(|| {
     let config = get_config().unwrap();
     init_pool(&config.database_url, 20)
 });
+
+pub type TestMutex = LazyLock<Mutex<()>>;
+pub type TestMutexGuard = MutexGuard<'static, ()>;
+
+pub const fn test_mutex() -> TestMutex {
+    LazyLock::new(|| Mutex::new(()))
+}
+
+pub async fn lock_test_mutex(mutex: &'static TestMutex) -> TestMutexGuard {
+    mutex.lock().await
+}
 
 #[derive(Clone)]
 pub struct NamespaceFixture {


### PR DESCRIPTION
## Summary
- add a shared async test mutex helper for tests that must serialize process-global cleanup/state
- serialize retention purge tests so global terminal-delivery cleanup cannot race their setup/assertions
- migrate existing event delivery, login rate-limit, and report purge test locks to the shared helper

## Verification
- source .env && ./run_tests.sh --bin hubuum-server event_retention_purge
- source .env && ./run_tests.sh
- cargo clippy --all-targets -- -D warnings
- cargo fmt --check