### PR TITLE
Add docs-backed template guide tests

### DIFF
--- a/docs/template_guide.md
+++ b/docs/template_guide.md
@@ -268,15 +268,19 @@ Composition rules:
 
 Template:
 
+<!-- doc-example: template-guide/plain/template -->
+
 ```text
 Report scope: {{ meta.scope.kind }}
 Rows: {{ meta.count }}
 
 {% for item in items %}- {{ item.name }} owned by {{ item.data.owner }}
-{% endfor %}
+{% endfor -%}
 ```
 
 Rendered output:
+
+<!-- doc-example: template-guide/plain/output -->
 
 ```text
 Report scope: objects_in_class
@@ -290,12 +294,16 @@ Rows: 2
 
 Template:
 
+<!-- doc-example: template-guide/html/template -->
+
 ```html
 <h1>Server report</h1>
 <ul>{% for item in items %}<li><strong>{{ item.name }}</strong> - {{ item.data.hostname }}</li>{% endfor %}</ul>
 ```
 
 Rendered output:
+
+<!-- doc-example: template-guide/html/output -->
 
 ```html
 <h1>Server report</h1>
@@ -308,13 +316,17 @@ Interpolated values are HTML-escaped automatically for `text/html` output.
 
 Template:
 
+<!-- doc-example: template-guide/csv/template -->
+
 ```csv
 name,owner,hostname
 {% for item in items %}{{ item.name }},{{ item.data.owner }},{{ item.data.hostname }}
-{% endfor %}
+{% endfor -%}
 ```
 
 Rendered output:
+
+<!-- doc-example: template-guide/csv/output -->
 
 ```csv
 name,owner,hostname
@@ -337,13 +349,17 @@ Given item data like:
 
 Template:
 
+<!-- doc-example: template-guide/nested-array/template -->
+
 ```text
 {% for item in items %}{{ item.name }}
 {% for tag in item.data.tags %}  - {{ tag }}
-{% endfor %}{% endfor %}
+{% endfor %}{% endfor -%}
 ```
 
 Rendered output:
+
+<!-- doc-example: template-guide/nested-array/output -->
 
 ```text
 srv-app-01
@@ -457,9 +473,11 @@ Missing values are controlled by `missing_data_policy` on the report request.
 
 Example template:
 
+<!-- doc-example: template-guide/missing-data/template -->
+
 ```text
 {% for item in items %}{{ item.name }} owner={{ item.data.primary_contact }}
-{% endfor %}
+{% endfor -%}
 ```
 
 If `primary_contact` does not exist:
@@ -471,12 +489,16 @@ If `primary_contact` does not exist:
 
 Rendered output with `null`:
 
+<!-- doc-example: template-guide/missing-data/null-output -->
+
 ```text
 srv-app-01 owner=null
 srv-db-01 owner=null
 ```
 
 Rendered output with `omit`:
+
+<!-- doc-example: template-guide/missing-data/omit-output -->
 
 ```text
 srv-app-01 owner=

--- a/src/tests/docs_examples.rs
+++ b/src/tests/docs_examples.rs
@@ -1,0 +1,118 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocExampleBlock {
+    pub label: String,
+    pub language: String,
+    pub body: String,
+}
+
+pub fn extract_labeled_blocks(markdown: &str) -> Result<Vec<DocExampleBlock>, String> {
+    let mut blocks = Vec::new();
+    let mut pending_label = None;
+    let mut lines = markdown.lines();
+
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim();
+        if let Some(label) = trimmed
+            .strip_prefix("<!-- doc-example:")
+            .and_then(|rest| rest.strip_suffix("-->"))
+        {
+            let label = label.trim();
+            if label.is_empty() {
+                return Err("doc-example label must not be empty".to_string());
+            }
+            if pending_label.replace(label.to_string()).is_some() {
+                return Err(format!(
+                    "doc-example label {label:?} appeared before the previous label had a block"
+                ));
+            }
+            continue;
+        }
+
+        if let Some(fence_info) = trimmed.strip_prefix("```") {
+            let Some(label) = pending_label.take() else {
+                continue;
+            };
+            let language = fence_info
+                .split_whitespace()
+                .next()
+                .unwrap_or_default()
+                .to_string();
+            if language.is_empty() {
+                return Err(format!(
+                    "doc-example block {label:?} must declare a fenced code language"
+                ));
+            }
+
+            let mut body = String::new();
+            let mut closed = false;
+            for block_line in lines.by_ref() {
+                if block_line.trim() == "```" {
+                    closed = true;
+                    break;
+                }
+                body.push_str(block_line);
+                body.push('\n');
+            }
+            if !closed {
+                return Err(format!(
+                    "doc-example block {label:?} is missing a closing fence"
+                ));
+            }
+            blocks.push(DocExampleBlock {
+                label,
+                language,
+                body,
+            });
+        }
+    }
+
+    if let Some(label) = pending_label {
+        return Err(format!(
+            "doc-example label {label:?} was not followed by a fenced code block"
+        ));
+    }
+
+    Ok(blocks)
+}
+
+pub fn required_labeled_block(markdown: &str, label: &str) -> Result<DocExampleBlock, String> {
+    extract_labeled_blocks(markdown)?
+        .into_iter()
+        .find(|block| block.label == label)
+        .ok_or_else(|| format!("missing doc-example block {label:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_labeled_blocks, required_labeled_block};
+
+    #[test]
+    fn extracts_explicitly_labeled_fenced_blocks() {
+        let markdown = r#"
+Before
+
+<!-- doc-example: guide/example/template -->
+```text
+hello
+```
+
+```text
+ignored
+```
+"#;
+
+        let blocks = extract_labeled_blocks(markdown).unwrap();
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].label, "guide/example/template");
+        assert_eq!(blocks[0].language, "text");
+        assert_eq!(blocks[0].body, "hello\n");
+    }
+
+    #[test]
+    fn reports_missing_required_blocks_clearly() {
+        let error = required_labeled_block("", "guide/missing").unwrap_err();
+
+        assert!(error.contains("guide/missing"));
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8,6 +8,7 @@ pub mod api_operations;
 pub mod asserts;
 pub mod client_allowlist;
 pub mod constants;
+pub mod docs_examples;
 pub mod id_newtypes;
 pub mod search;
 pub mod temporal;

--- a/src/utilities/reporting.rs
+++ b/src/utilities/reporting.rs
@@ -471,6 +471,9 @@ fn record_missing_value_warning(missing: MissingValue) {
 mod tests {
     use super::*;
     use crate::models::{ReportScopeKind, ReportTemplateKind};
+    use crate::tests::docs_examples::required_labeled_block;
+
+    const TEMPLATE_GUIDE: &str = include_str!("../../docs/template_guide.md");
 
     #[test]
     fn limited_string_writer_accumulates_under_limit() {
@@ -515,6 +518,167 @@ mod tests {
             created_at: now,
             updated_at: now,
         }
+    }
+
+    fn template_guide_context() -> serde_json::Value {
+        serde_json::json!({
+            "items": [
+                {
+                    "id": 101,
+                    "name": "srv-app-01",
+                    "description": "Application server",
+                    "namespace_id": 7,
+                    "hubuum_class_id": 42,
+                    "data": {
+                        "owner": "alice",
+                        "hostname": "srv-app-01.example.org",
+                        "environment": "prod",
+                        "tags": ["prod", "app"]
+                    }
+                },
+                {
+                    "id": 102,
+                    "name": "srv-db-01",
+                    "description": "Database server",
+                    "namespace_id": 7,
+                    "hubuum_class_id": 42,
+                    "data": {
+                        "owner": "bob",
+                        "hostname": "srv-db-01.example.org",
+                        "environment": "prod",
+                        "tags": ["prod", "db"]
+                    }
+                }
+            ],
+            "meta": {
+                "count": 2,
+                "truncated": false,
+                "scope": {
+                    "kind": "objects_in_class",
+                    "class_id": 42,
+                    "object_id": null
+                },
+                "content_type": "text/plain"
+            },
+            "warnings": [],
+            "request": {
+                "scope": {
+                    "kind": "objects_in_class",
+                    "class_id": 42,
+                    "object_id": null
+                },
+                "query": "name__contains=srv-&sort=name"
+            }
+        })
+    }
+
+    fn template_guide_block(label: &str) -> String {
+        required_labeled_block(TEMPLATE_GUIDE, label).unwrap().body
+    }
+
+    fn assert_template_guide_example(
+        name: &str,
+        content_type: ReportContentType,
+        missing_data_policy: ReportMissingDataPolicy,
+    ) -> (String, Vec<ReportWarning>) {
+        let template = template(
+            100,
+            10,
+            &format!("{name}.txt"),
+            content_type,
+            &template_guide_block(&format!("template-guide/{name}/template")),
+        );
+
+        render_template(
+            &template,
+            &[],
+            &template_guide_context(),
+            content_type,
+            missing_data_policy,
+            usize::MAX,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn template_guide_plain_text_example_matches_renderer() {
+        let (rendered, warnings) = assert_template_guide_example(
+            "plain",
+            ReportContentType::TextPlain,
+            ReportMissingDataPolicy::Strict,
+        );
+
+        assert_eq!(
+            rendered,
+            template_guide_block("template-guide/plain/output")
+        );
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn template_guide_html_example_matches_renderer() {
+        let (rendered, warnings) = assert_template_guide_example(
+            "html",
+            ReportContentType::TextHtml,
+            ReportMissingDataPolicy::Strict,
+        );
+
+        assert_eq!(rendered, template_guide_block("template-guide/html/output"));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn template_guide_csv_example_matches_renderer() {
+        let (rendered, warnings) = assert_template_guide_example(
+            "csv",
+            ReportContentType::TextCsv,
+            ReportMissingDataPolicy::Strict,
+        );
+
+        assert_eq!(rendered, template_guide_block("template-guide/csv/output"));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn template_guide_nested_array_example_matches_renderer() {
+        let (rendered, warnings) = assert_template_guide_example(
+            "nested-array",
+            ReportContentType::TextPlain,
+            ReportMissingDataPolicy::Strict,
+        );
+
+        assert_eq!(
+            rendered,
+            template_guide_block("template-guide/nested-array/output")
+        );
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn template_guide_missing_data_policy_examples_match_renderer() {
+        let (null_rendered, null_warnings) = assert_template_guide_example(
+            "missing-data",
+            ReportContentType::TextPlain,
+            ReportMissingDataPolicy::Null,
+        );
+        let (omit_rendered, omit_warnings) = assert_template_guide_example(
+            "missing-data",
+            ReportContentType::TextPlain,
+            ReportMissingDataPolicy::Omit,
+        );
+
+        assert_eq!(
+            null_rendered,
+            template_guide_block("template-guide/missing-data/null-output")
+        );
+        assert_eq!(
+            omit_rendered,
+            template_guide_block("template-guide/missing-data/omit-output")
+        );
+        assert_eq!(null_warnings.len(), 1);
+        assert_eq!(omit_warnings.len(), 1);
+        assert_eq!(null_warnings[0].code, "template_missing_value");
+        assert_eq!(omit_warnings[0].code, "template_missing_value");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a reusable test helper for extracting explicitly labeled Markdown code fences
- label the machine-testable examples in docs/template_guide.md
- verify plain text, HTML, CSV, nested array, and missing-data-policy examples against the report template renderer

Closes #19
