### PR TITLE
Add structured JSON logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,6 +403,7 @@ jobs:
           push: false
           build-args: |
             CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release
+            HUBUUM_BUILD_GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -773,6 +774,7 @@ jobs:
             org.opencontainers.image.version=${{ github.ref_name }}
           build-args: |
             CARGO_BUILD_FLAGS=${{ matrix.variant.build_args }} --locked --release
+            HUBUUM_BUILD_GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -868,6 +870,7 @@ jobs:
             org.opencontainers.image.version=${{ github.ref_name }}
           build-args: |
             CARGO_BUILD_FLAGS=${{ matrix.variant.build_args }} --locked --release
+            HUBUUM_BUILD_GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,9 +74,11 @@ RUN awk ' \
     ' Cargo.toml > Cargo.toml.docker && mv Cargo.toml.docker Cargo.toml
 
 # Build the real application (dependencies are cached)
+ARG HUBUUM_BUILD_GIT_SHA="unknown"
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/src/hubuum/target \
+    HUBUUM_BUILD_GIT_SHA="${HUBUUM_BUILD_GIT_SHA}" \
     cargo build ${CARGO_BUILD_FLAGS} --bin hubuum-server --bin hubuum-admin && \
     cp target/release/hubuum-server /tmp/ && \
     cp target/release/hubuum-admin /tmp/

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ resolved from the right of the `[X-Forwarded-For..., peer]` hop chain, so attack
 
 - `HUBUUM_TOKEN_LIFETIME_HOURS` controls bearer token lifetime and defaults to `24`.
 
+### Logging
+
+Hubuum writes newline-delimited JSON logs. Set `HUBUUM_LOG_LEVEL` to control verbosity; see
+[docs/logging.md](docs/logging.md) for fields, request correlation, authorization events, and
+`jq` recipes.
+
 ### Login Rate Limiting
 
 Login throttling is layered across three scopes - per `(username, IP)`, per IP, and per

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,107 @@
+# Structured Logging
+
+Hubuum writes newline-delimited JSON logs only. There is no text formatter toggle; configure verbosity with `HUBUUM_LOG_LEVEL`.
+
+## Configuration
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `HUBUUM_LOG_LEVEL` | `info` | Minimum log level: `trace`, `debug`, `info`, `warn`, or `error` |
+
+## Common Fields
+
+Every log record includes:
+
+| Field | Description |
+| ----- | ----------- |
+| `time` | UTC timestamp in RFC 3339 format with millisecond precision |
+| `severity` | Log level as `TRACE`, `DEBUG`, `INFO`, `WARN`, or `ERROR` |
+| `message` | Stable event message |
+
+Request-scoped records also include `request_id` and, when supplied by the client, `correlation_id`. Authenticated requests record `principal` on the request span after bearer token resolution.
+
+## Request Logs
+
+Request completion is the canonical HTTP request log event. Actix's default text request logger is disabled to avoid duplicate unstructured logs.
+
+Completion records include:
+
+| Field | Description |
+| ----- | ----------- |
+| `message` | `request complete` |
+| `method` | HTTP method |
+| `path` | Request path without query string |
+| `status` | HTTP response status |
+| `client_ip` | Resolved client IP when available |
+| `elapsed_ms` | Request duration in whole milliseconds |
+
+Severity is derived from the outcome:
+
+| Outcome | Severity |
+| ------- | -------- |
+| `2xx` and `3xx` | `INFO` |
+| `4xx` | `WARN` |
+| `5xx` and service errors | `ERROR` |
+
+Clients may send `X-Correlation-ID`; Hubuum echoes it as `x-correlation-id`. Hubuum always returns `x-request-id`.
+
+## Operation And Authorization Logs
+
+Domain mutation logs are emitted from the audit event writer at `INFO`. They use the audit catalog labels:
+
+| Field | Description |
+| ----- | ----------- |
+| `operation` | `mutation` |
+| `entity_type` | Catalog entity label, such as `namespace` |
+| `action` | Catalog action label, such as `created` |
+| `entity_id` | Entity identifier when available |
+| `actor_principal_id` | Acting principal when available |
+
+Read helpers log at `DEBUG` for code paths that opt in to operation read logging.
+
+Authorization decision logs use:
+
+| Decision | Severity |
+| -------- | -------- |
+| Grant | `DEBUG` |
+| Denial | `WARN` |
+
+Authorization records include `event_type=authorization`, `decision`, `principal_id`, requested `permissions`, `namespace_count` when known, and a short `reason`.
+
+## Sensitive Data Rules
+
+Do not log secrets or high-volume payloads. In particular, logs must not include bearer tokens, token hashes, password hashes, sink secrets, raw `Authorization` headers, request bodies, response bodies, audit `before` or `after` snapshots, or remote target secret material.
+
+Prefer stable identifiers, catalog labels, counts, and short reason strings over raw payload data.
+
+## jq Recipes
+
+Pretty-print logs:
+
+```bash
+jq . hubuum.log
+```
+
+Show failed requests:
+
+```bash
+jq 'select(.message == "request complete" and (.status >= 500 or .severity == "ERROR"))' hubuum.log
+```
+
+Trace one request:
+
+```bash
+jq 'select(.request_id == "REPLACE-WITH-REQUEST-ID")' hubuum.log
+```
+
+Trace a client-supplied correlation ID:
+
+```bash
+jq 'select(.correlation_id == "REPLACE-WITH-CORRELATION-ID")' hubuum.log
+```
+
+List authorization denials:
+
+```bash
+jq 'select(.event_type == "authorization" and .decision == "deny")' hubuum.log
+```

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,6 +1,6 @@
 # Structured Logging
 
-Hubuum writes newline-delimited JSON logs only. There is no text formatter toggle; configure verbosity with `HUBUUM_LOG_LEVEL`.
+Hubuum writes newline-delimited JSON logs only. JSON is the stable operational interface for containers, collectors, and command-line tooling; there is no text formatter toggle. Configure verbosity with `HUBUUM_LOG_LEVEL`.
 
 ## Configuration
 
@@ -18,7 +18,9 @@ Every log record includes:
 | `severity` | Log level as `TRACE`, `DEBUG`, `INFO`, `WARN`, or `ERROR` |
 | `message` | Stable event message |
 
-Request-scoped records also include `request_id` and, when supplied by the client, `correlation_id`. Authenticated requests record `principal` on the request span after bearer token resolution.
+Request-scoped records also include `request_id` and, when accepted from the client, `correlation_id`. Authenticated requests record `principal_id` on the request span after bearer token resolution.
+
+The server emits one `server startup` record at `INFO` after binding succeeds. It includes the package version, build Git SHA, bind address, TLS state, worker counts, database and authorization backends, log format and level, and the number of enabled event sinks. Release and container builds populate `git_sha`; local builds report `unknown` unless `HUBUUM_BUILD_GIT_SHA` is set while compiling.
 
 ## Request Logs
 
@@ -34,6 +36,7 @@ Completion records include:
 | `status` | HTTP response status |
 | `client_ip` | Resolved client IP when available |
 | `elapsed_ms` | Request duration in whole milliseconds |
+| `error` | Present when a downstream service error ended the request |
 
 Severity is derived from the outcome:
 
@@ -41,24 +44,26 @@ Severity is derived from the outcome:
 | ------- | -------- |
 | `2xx` and `3xx` | `INFO` |
 | `4xx` | `WARN` |
-| `5xx` and service errors | `ERROR` |
+| `5xx` | `ERROR` |
 
-Clients may send `X-Correlation-ID`; Hubuum echoes it as `x-correlation-id`. Hubuum always returns `x-request-id`.
+Hubuum applies the status-to-severity mapping to downstream service errors as well as normal responses. Early middleware rejections, including client-allowlist denials, are returned as responses so they receive the same completion event and `x-request-id` header as handler responses.
+
+Clients may send `X-Correlation-ID`. Accepted values are 1 to 128 visible ASCII bytes without whitespace. Hubuum echoes accepted values as `x-correlation-id`; invalid values are ignored without logging or echoing the supplied value. Hubuum always returns `x-request-id`.
 
 ## Operation And Authorization Logs
 
-Domain mutation-recorded logs are emitted from the audit event writer at `INFO`. They mean Hubuum inserted an audit event row in the current database transaction; if a later step rolls the transaction back, the audit row and the domain mutation are rolled back together even though the log line has already been written. These logs use the audit catalog labels:
+Domain mutation logs are queued by the audit event writer and emitted at `INFO` only after the surrounding database transaction commits. Failed and rolled-back transactions discard their queued mutation logs. These logs use the audit catalog labels:
 
 | Field | Description |
 | ----- | ----------- |
-| `operation` | `mutation_recorded` |
-| `mutation_phase` | `recorded` |
+| `operation` | `mutation_committed` |
+| `mutation_phase` | `committed` |
 | `entity_type` | Catalog entity label, such as `collection` |
 | `action` | Catalog action label, such as `created` |
 | `entity_id` | Entity identifier when available |
 | `actor_principal_id` | Acting principal when available |
 
-Read helpers log at `DEBUG` for code paths that opt in to operation read logging.
+Service list/get paths log at `DEBUG`. The audit-event query path additionally uses the standardized `operation=read` helper with optional catalog entity, action, and entity ID filters.
 
 Authorization decision logs use:
 
@@ -67,11 +72,11 @@ Authorization decision logs use:
 | Grant | `DEBUG` |
 | Denial | `WARN` |
 
-Authorization records include `event_type=authorization`, `decision`, `principal_id`, requested `permissions` as a JSON array, nullable `collection_count`, and a short `reason`.
+Authorization records include `event_type=authorization`, `decision`, `principal_id`, requested `permissions` as a JSON array, derived `action` and `entity_type` when the requested permissions share them, nullable `collection_id` and `collection_count`, and a short `reason`.
 
 ## Sensitive Data Rules
 
-Do not log secrets or high-volume payloads. In particular, logs must not include bearer tokens, token hashes, password hashes, sink secrets, raw `Authorization` headers, request bodies, response bodies, audit `before` or `after` snapshots, or remote target secret material.
+Do not log secrets or high-volume payloads. In particular, logs must not include bearer tokens or token fragments, token hashes, password hashes, sink secrets, raw `Authorization` headers, request bodies, response bodies, audit `before` or `after` snapshots, or remote target secret material.
 
 Prefer stable identifiers, catalog labels, counts, and short reason strings over raw payload data.
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -47,11 +47,12 @@ Clients may send `X-Correlation-ID`; Hubuum echoes it as `x-correlation-id`. Hub
 
 ## Operation And Authorization Logs
 
-Domain mutation logs are emitted from the audit event writer at `INFO`. They use the audit catalog labels:
+Domain mutation-recorded logs are emitted from the audit event writer at `INFO`. They mean Hubuum inserted an audit event row in the current database transaction; if a later step rolls the transaction back, the audit row and the domain mutation are rolled back together even though the log line has already been written. These logs use the audit catalog labels:
 
 | Field | Description |
 | ----- | ----------- |
-| `operation` | `mutation` |
+| `operation` | `mutation_recorded` |
+| `mutation_phase` | `recorded` |
 | `entity_type` | Catalog entity label, such as `namespace` |
 | `action` | Catalog action label, such as `created` |
 | `entity_id` | Entity identifier when available |
@@ -66,7 +67,7 @@ Authorization decision logs use:
 | Grant | `DEBUG` |
 | Denial | `WARN` |
 
-Authorization records include `event_type=authorization`, `decision`, `principal_id`, requested `permissions`, `namespace_count` when known, and a short `reason`.
+Authorization records include `event_type=authorization`, `decision`, `principal_id`, requested `permissions` as a JSON array, nullable `namespace_count`, and a short `reason`.
 
 ## Sensitive Data Rules
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -53,7 +53,7 @@ Domain mutation-recorded logs are emitted from the audit event writer at `INFO`.
 | ----- | ----------- |
 | `operation` | `mutation_recorded` |
 | `mutation_phase` | `recorded` |
-| `entity_type` | Catalog entity label, such as `namespace` |
+| `entity_type` | Catalog entity label, such as `collection` |
 | `action` | Catalog action label, such as `created` |
 | `entity_id` | Entity identifier when available |
 | `actor_principal_id` | Acting principal when available |
@@ -67,7 +67,7 @@ Authorization decision logs use:
 | Grant | `DEBUG` |
 | Denial | `WARN` |
 
-Authorization records include `event_type=authorization`, `decision`, `principal_id`, requested `permissions` as a JSON array, nullable `namespace_count`, and a short `reason`.
+Authorization records include `event_type=authorization`, `decision`, `principal_id`, requested `permissions` as a JSON array, nullable `collection_count`, and a short `reason`.
 
 ## Sensitive Data Rules
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -24,8 +24,10 @@ Probe paths bypass the client IP allowlist so platform health checks are not rej
 | `HUBUUM_LOG_LEVEL` | `info` | JSON log verbosity (`trace`, `debug`, `info`, `warn`, `error`) |
 | `HUBUUM_ACTIX_WORKERS` | Detected CPU count | Number of Actix worker threads |
 
-Logs are newline-delimited JSON only and are configured through `HUBUUM_LOG_LEVEL`; see
-[Structured Logging](logging.md) for fields and examples.
+Logs are newline-delimited JSON only and are configured through `HUBUUM_LOG_LEVEL`. Release
+builds include their Git SHA in the structured startup event; local builders may set
+`HUBUUM_BUILD_GIT_SHA` at compile time. See [Structured Logging](logging.md) for fields and
+examples.
 
 ### Access Control Configuration
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -21,8 +21,11 @@ Probe paths bypass the client IP allowlist so platform health checks are not rej
 | ------- | ------- | ----------- |
 | `HUBUUM_BIND_IP` | `127.0.0.1` | IP address the server binds to |
 | `HUBUUM_BIND_PORT` | `8080` | Port the server listens on |
-| `HUBUUM_LOG_LEVEL` | `info` | Logging level (trace, debug, info, warn, error) |
+| `HUBUUM_LOG_LEVEL` | `info` | JSON log verbosity (`trace`, `debug`, `info`, `warn`, `error`) |
 | `HUBUUM_ACTIX_WORKERS` | Detected CPU count | Number of Actix worker threads |
+
+Logs are newline-delimited JSON only and are configured through `HUBUUM_LOG_LEVEL`; see
+[Structured Logging](logging.md) for fields and examples.
 
 ### Access Control Configuration
 

--- a/src/api/handlers/auth.rs
+++ b/src/api/handlers/auth.rs
@@ -113,12 +113,7 @@ pub async fn login(
         }
     };
 
-    debug!(
-        message = "Login successful",
-        name = name,
-        user_id = user.id,
-        token = token.obfuscate()
-    );
+    debug!(message = "Login successful", name = name, user_id = user.id,);
 
     Ok(ApiResponse::ok(LoginResponse::new(token.get_token())))
 }
@@ -141,18 +136,14 @@ pub async fn logout(
 ) -> Result<impl Responder, ApiError> {
     let token = requestor.token;
 
-    debug!(message = "Logging out token.", token = token.obfuscate());
+    debug!(message = "token logout requested");
 
     let result = token.delete(&pool).await;
 
     match result {
         Ok(_) => Ok(ApiResponse::message("Logout successful.")),
         Err(e) => {
-            warn!(
-                message = "Logout failed",
-                token_used = token.obfuscate(),
-                error = e.to_string()
-            );
+            warn!(message = "Logout failed", error = e.to_string());
             Err(ApiError::InternalServerError(
                 "Internal authentication failure".to_string(),
             ))
@@ -188,7 +179,6 @@ pub async fn logout_all(
         Err(e) => {
             warn!(
                 message = "Logout of all tokens failed",
-                token_used = user_access.token.obfuscate(),
                 user_id = user_access.user.id,
                 error = e.to_string()
             );
@@ -218,7 +208,7 @@ pub async fn logout_token(
     token: web::Json<LogoutTokenRequest>,
 ) -> Result<impl Responder, ApiError> {
     let token = Token(token.into_inner().token);
-    debug!(message = "Logging out token {}.", token = token.obfuscate());
+    debug!(message = "administrative token logout requested");
 
     let result = token.delete(&pool).await;
 
@@ -227,8 +217,6 @@ pub async fn logout_token(
         Err(e) => {
             warn!(
                 message = "Logout of token failed",
-                token_used = token.obfuscate(),
-                token_target = user_access.token.obfuscate(),
                 user_id = user_access.user.id,
                 error = e.to_string()
             );
@@ -281,7 +269,6 @@ pub async fn logout_other(
         Err(e) => {
             warn!(
                 message = "Logout of other tokens failed",
-                token_used = admin_access.token.obfuscate(),
                 user_id = admin_access.user.id,
                 error = e.to_string()
             );
@@ -307,7 +294,6 @@ pub async fn validate_token(user_access: Authenticated) -> Result<impl Responder
     debug!(
         message = "Token validation successful",
         principal_id = user_access.principal.id,
-        token = user_access.token.obfuscate()
     );
 
     Ok(ApiResponse::message("Token is valid."))

--- a/src/bin/admin.rs
+++ b/src/bin/admin.rs
@@ -1,7 +1,5 @@
 use clap::Parser;
 use std::collections::BTreeMap;
-use std::process::exit;
-use tracing::warn;
 
 use hubuum::config::{
     DEFAULT_DB_STATEMENT_TIMEOUT_MS, DEFAULT_EXPORT_TEMPLATE_FUEL,
@@ -226,11 +224,12 @@ async fn export_template_health(pool: DbPool) -> Result<(), ApiError> {
 
 fn init_logging(log_level: &str) {
     if !is_valid_log_level(log_level) {
-        warn!("Invalid log level: {}", log_level);
-        exit(EXIT_CODE_CONFIG_ERROR);
+        fatal_error(
+            &format!("Invalid log level: {log_level}"),
+            EXIT_CODE_CONFIG_ERROR,
+        );
     }
     if let Err(err) = logger::init_json_logging(log_level) {
-        warn!("{}", err);
-        exit(EXIT_CODE_CONFIG_ERROR);
+        fatal_error(&err, EXIT_CODE_CONFIG_ERROR);
     }
 }

--- a/src/bin/admin.rs
+++ b/src/bin/admin.rs
@@ -2,9 +2,6 @@ use clap::Parser;
 use std::collections::BTreeMap;
 use std::process::exit;
 use tracing::warn;
-use tracing_subscriber::{
-    filter::EnvFilter, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
-};
 
 use hubuum::config::{
     DEFAULT_DB_STATEMENT_TIMEOUT_MS, DEFAULT_EXPORT_TEMPLATE_FUEL,
@@ -228,23 +225,12 @@ async fn export_template_health(pool: DbPool) -> Result<(), ApiError> {
 }
 
 fn init_logging(log_level: &str) {
-    let filter = if is_valid_log_level(log_level) {
-        EnvFilter::try_new(log_level).unwrap_or_else(|_e| {
-            warn!("Error parsing log level: {}", log_level);
-            exit(EXIT_CODE_CONFIG_ERROR);
-        })
-    } else {
+    if !is_valid_log_level(log_level) {
         warn!("Invalid log level: {}", log_level);
         exit(EXIT_CODE_CONFIG_ERROR);
-    };
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .json()
-                .with_span_events(FmtSpan::CLOSE)
-                .event_format(logger::HubuumLoggingFormat),
-        )
-        .init();
+    }
+    if let Err(err) = logger::init_json_logging(log_level) {
+        warn!("{}", err);
+        exit(EXIT_CODE_CONFIG_ERROR);
+    }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -423,15 +423,17 @@ where
     let statement_timeout = ambient_statement_timeout();
     let actor = ambient_actor();
     let mut conn = acquire_connection(pool).await?;
-    conn.transaction::<R, ApiError, _>(async move |conn| {
-        if let Some(statement_timeout) = statement_timeout {
-            set_local_statement_timeout(conn, statement_timeout).await?;
-        }
-        if let Some(actor) = actor {
-            set_local_actor(conn, actor).await?;
-        }
-        f(conn).await.map_err(ApiError::from)
-    })
+    crate::logger::defer_operation_mutation_logs_until_commit(conn.transaction::<R, ApiError, _>(
+        async move |conn| {
+            if let Some(statement_timeout) = statement_timeout {
+                set_local_statement_timeout(conn, statement_timeout).await?;
+            }
+            if let Some(actor) = actor {
+                set_local_actor(conn, actor).await?;
+            }
+            f(conn).await.map_err(ApiError::from)
+        },
+    ))
     .await
 }
 

--- a/src/db/traits/event_subscription.rs
+++ b/src/db/traits/event_subscription.rs
@@ -452,6 +452,21 @@ pub(crate) async fn list_event_sink_rows_with_total_count(
     Ok((rows, total_count))
 }
 
+pub async fn enabled_event_sink_count(pool: &DbPool) -> Result<i64, ApiError> {
+    use diesel::dsl::count_star;
+
+    use crate::schema::event_sinks::dsl::{enabled, event_sinks};
+
+    with_connection(pool, async |conn| {
+        event_sinks
+            .filter(enabled.eq(true))
+            .select(count_star())
+            .first::<i64>(conn)
+            .await
+    })
+    .await
+}
+
 fn build_event_sink_query(
     query_options: &QueryOptions,
 ) -> Result<crate::schema::event_sinks::BoxedQuery<'static, diesel::pg::Pg>, ApiError> {

--- a/src/db/traits/events.rs
+++ b/src/db/traits/events.rs
@@ -28,7 +28,7 @@ pub async fn list_events_with_total_count(
     filters: &EventListFilters,
     query_options: &QueryOptions,
 ) -> Result<(Vec<EventResponse>, i64), ApiError> {
-    crate::logger::log_operation_read(filters.entity_type, filters.action, filters.entity_id, None);
+    crate::logger::log_operation_read(filters.entity_type, filters.action, filters.entity_id);
 
     let query = build_event_query(accessible_collection_ids, include_collection_less, filters)?;
     let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {

--- a/src/db/traits/events.rs
+++ b/src/db/traits/events.rs
@@ -28,6 +28,8 @@ pub async fn list_events_with_total_count(
     filters: &EventListFilters,
     query_options: &QueryOptions,
 ) -> Result<(Vec<EventResponse>, i64), ApiError> {
+    crate::logger::log_operation_read(filters.entity_type, filters.action, filters.entity_id, None);
+
     let query = build_event_query(accessible_collection_ids, include_collection_less, filters)?;
     let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
         with_connection(pool, async |conn| {

--- a/src/db/traits/is_active.rs
+++ b/src/db/traits/is_active.rs
@@ -29,7 +29,6 @@ impl Status<PrincipalToken> for Token {
         };
 
         let token_hash = self.storage_hash();
-        let token_preview = self.obfuscate();
         // Truncate to microseconds: Postgres `timestamp` columns store microsecond
         // resolution, so the value we persist below and reflect back in-memory must
         // be truncated to match what a subsequent read returns. Otherwise the
@@ -57,14 +56,11 @@ impl Status<PrincipalToken> for Token {
         let mut valid_token = match result {
             Ok(Some(valid_token)) => valid_token,
             Ok(None) => {
-                warn!(
-                    "Invalid token {}: not found, revoked, expired, or disabled.",
-                    token_preview
-                );
+                warn!(message = "invalid token", reason = "not_active");
                 return Err(ApiError::Unauthorized("Invalid token".to_string()));
             }
             Err(e) => {
-                warn!("Invalid token {}: {}", token_preview, e);
+                warn!(message = "token validation failed", error = %e);
                 return Err(ApiError::Unauthorized("Invalid token".to_string()));
             }
         };

--- a/src/db/traits/user/permissions.rs
+++ b/src/db/traits/user/permissions.rs
@@ -37,14 +37,20 @@ pub trait UserPermissions: AuthzSubject {
 
         // Fail-closed scope pre-filter, before the admin bypass.
         if !scope_allows(scopes, &requested) {
-            crate::logger::log_authorization_denial(principal_id, &requested, None, "token_scope");
+            crate::logger::log_authorization_denial(
+                principal_id,
+                &requested,
+                None,
+                None,
+                "token_scope",
+            );
             return Err(ApiError::Forbidden(
                 "Token scope does not permit the requested action".to_string(),
             ));
         }
 
         if AuthzSubject::is_admin(self, pool).await? {
-            crate::logger::log_authorization_grant(principal_id, &requested, None, "admin");
+            crate::logger::log_authorization_grant(principal_id, &requested, None, None, "admin");
             return Ok(());
         }
 
@@ -70,6 +76,9 @@ pub trait UserPermissions: AuthzSubject {
             .try_collect()
             .await?;
         let collection_count = collection_ids.len();
+        let collection_id = (collection_count == 1)
+            .then(|| collection_ids.iter().next().copied())
+            .flatten();
 
         let mut base_query = lookup_table
             .inner_join(closure_table.on(collection_id_field.eq(ancestor_collection_id)))
@@ -97,6 +106,7 @@ pub trait UserPermissions: AuthzSubject {
                 principal_id,
                 &requested,
                 Some(collection_count),
+                collection_id,
                 "permissions",
             );
             Ok(())
@@ -105,6 +115,7 @@ pub trait UserPermissions: AuthzSubject {
                 principal_id,
                 &requested,
                 Some(collection_count),
+                collection_id,
                 "permissions",
             );
             Err(ApiError::Forbidden(

--- a/src/db/traits/user/permissions.rs
+++ b/src/db/traits/user/permissions.rs
@@ -44,7 +44,7 @@ pub trait UserPermissions: AuthzSubject {
         }
 
         if AuthzSubject::is_admin(self, pool).await? {
-            crate::logger::log_authorization_grant(principal_id, &requested, 0, "admin");
+            crate::logger::log_authorization_grant(principal_id, &requested, None, "admin");
             return Ok(());
         }
 
@@ -96,7 +96,7 @@ pub trait UserPermissions: AuthzSubject {
             crate::logger::log_authorization_grant(
                 principal_id,
                 &requested,
-                collection_count,
+                Some(collection_count),
                 "permissions",
             );
             Ok(())

--- a/src/db/traits/user/permissions.rs
+++ b/src/db/traits/user/permissions.rs
@@ -33,15 +33,18 @@ pub trait UserPermissions: AuthzSubject {
         use std::collections::HashSet;
 
         let requested: Vec<Permissions> = permissions.into_iter().collect();
+        let principal_id = self.principal_id();
 
         // Fail-closed scope pre-filter, before the admin bypass.
         if !scope_allows(scopes, &requested) {
+            crate::logger::log_authorization_denial(principal_id, &requested, None, "token_scope");
             return Err(ApiError::Forbidden(
                 "Token scope does not permit the requested action".to_string(),
             ));
         }
 
         if AuthzSubject::is_admin(self, pool).await? {
+            crate::logger::log_authorization_grant(principal_id, &requested, 0, "admin");
             return Ok(());
         }
 
@@ -66,6 +69,7 @@ pub trait UserPermissions: AuthzSubject {
             .buffered(5)
             .try_collect()
             .await?;
+        let collection_count = collection_ids.len();
 
         let mut base_query = lookup_table
             .inner_join(closure_table.on(collection_id_field.eq(ancestor_collection_id)))
@@ -74,8 +78,8 @@ pub trait UserPermissions: AuthzSubject {
             .filter(group_id_field.eq_any(group_id_subquery));
 
         // Apply all permission filters
-        for perm in requested {
-            crate::apply_permission_filter!(base_query, perm, true);
+        for perm in &requested {
+            crate::apply_permission_filter!(base_query, *perm, true);
         }
 
         // Count the number of distinct collections that match all criteria
@@ -88,9 +92,21 @@ pub trait UserPermissions: AuthzSubject {
         .await?;
 
         // Check if the count of matching collections equals the number of input collections
-        if matching_collections_count as usize == collection_ids.len() {
+        if matching_collections_count as usize == collection_count {
+            crate::logger::log_authorization_grant(
+                principal_id,
+                &requested,
+                collection_count,
+                "permissions",
+            );
             Ok(())
         } else {
+            crate::logger::log_authorization_denial(
+                principal_id,
+                &requested,
+                Some(collection_count),
+                "permissions",
+            );
             Err(ApiError::Forbidden(
                 "User does not have the required permissions".to_string(),
             ))

--- a/src/events/db.rs
+++ b/src/events/db.rs
@@ -29,6 +29,16 @@ pub async fn emit_event(
         .values(new_event)
         .get_result::<Event>(conn)
         .await?;
+    if let (Ok(entity_type), Ok(action)) = (event.entity_type(), event.action()) {
+        crate::logger::log_operation_mutation(
+            entity_type,
+            action,
+            event.entity_id,
+            event.actor_user_id,
+            event.request_id,
+            event.correlation_id.as_deref(),
+        );
+    }
     super::notify_event_fanout(conn).await?;
     Ok(event)
 }

--- a/src/extractors/mod.rs
+++ b/src/extractors/mod.rs
@@ -46,7 +46,6 @@ pub struct UserAccess {
 
 /// A human admin with a valid, unscoped token.
 pub struct AdminAccess {
-    pub token: Token,
     pub user: User,
 }
 
@@ -61,7 +60,6 @@ pub struct AdminOrSelfAccess {
 /// Per-operation authorization (admin or owner-group) is decided in the handler.
 /// Scoped automation tokens can never manage SAs, users, groups, or credentials.
 pub struct ManagementAccess {
-    pub token: Token,
     pub user: User,
 }
 
@@ -271,7 +269,7 @@ impl FromRequest for ManagementAccess {
                 Some(token_meta) => human_unscoped_user_from_meta(&pool, token_meta).await?,
                 None => human_unscoped_user(&pool, &token).await?,
             };
-            Ok(ManagementAccess { token, user })
+            Ok(ManagementAccess { user })
         }
         .boxed_local()
     }
@@ -297,7 +295,7 @@ impl FromRequest for AdminAccess {
             };
 
             if user.is_admin(&pool).await? {
-                Ok(AdminAccess { token, user })
+                Ok(AdminAccess { user })
             } else {
                 Err(ApiError::Forbidden("Permission denied".to_string()))
             }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -8,9 +8,6 @@ use tracing_subscriber::fmt::format::{FormatEvent, FormatFields, Writer};
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
-use serde::ser::{SerializeMap, Serializer};
-use tracing_serde::AsSerde;
-
 use crate::events::{Action, EntityType};
 use crate::models::Permissions;
 
@@ -76,6 +73,10 @@ pub fn log_authorization_grant(
     namespace_count: Option<usize>,
     reason: &'static str,
 ) {
+    if !tracing::enabled!(tracing::Level::DEBUG) {
+        return;
+    }
+
     let permissions = permissions
         .iter()
         .map(ToString::to_string)
@@ -86,7 +87,7 @@ pub fn log_authorization_grant(
         event_type = "authorization",
         decision = "grant",
         principal_id,
-        permissions_json = permissions,
+        permissions,
         namespace_count,
         reason,
     );
@@ -108,130 +109,82 @@ pub fn log_authorization_denial(
         event_type = "authorization",
         decision = "deny",
         principal_id,
-        permissions_json = permissions,
+        permissions,
         namespace_count,
         reason,
     );
 }
 
-fn json_field_name(field_name: &str) -> Option<&str> {
-    field_name.strip_suffix("_json")
+fn structured_json_field_name(field_name: &str) -> Option<&'static str> {
+    match field_name {
+        "permissions" => Some("permissions"),
+        _ => None,
+    }
 }
 
-fn serialize_entry<S, V>(
-    serializer_map: &mut S,
+fn json_aware_value(field_name: &str, value: serde_json::Value) -> (String, serde_json::Value) {
+    match (structured_json_field_name(field_name), value.as_str()) {
+        (Some(target_field_name), Some(value)) => match serde_json::from_str(value) {
+            Ok(value) => (target_field_name.to_string(), value),
+            Err(_) => (
+                target_field_name.to_string(),
+                serde_json::Value::String(value.to_string()),
+            ),
+        },
+        (Some(target_field_name), None) => (target_field_name.to_string(), value),
+        (None, _) => (field_name.to_string(), value),
+    }
+}
+
+fn insert_json_aware_value(
+    fields: &mut serde_json::Map<String, serde_json::Value>,
     field_name: &str,
-    value: &V,
-) -> Result<(), S::Error>
-where
-    S: SerializeMap,
-    V: serde::Serialize + ?Sized,
-{
-    serializer_map.serialize_entry(field_name, value)
+    value: serde_json::Value,
+) {
+    let (field_name, value) = json_aware_value(field_name, value);
+    fields.insert(field_name, value);
 }
 
-fn serialize_json_aware_str_entry<S>(
-    serializer_map: &mut S,
-    field_name: &str,
-    value: &str,
-) -> Result<(), S::Error>
-where
-    S: SerializeMap,
-{
-    let Some(stripped_field_name) = json_field_name(field_name) else {
-        return serializer_map.serialize_entry(field_name, value);
-    };
-
-    match serde_json::from_str::<serde_json::Value>(value) {
-        Ok(value) => serializer_map.serialize_entry(stripped_field_name, &value),
-        Err(_) => serializer_map.serialize_entry(stripped_field_name, value),
-    }
+struct JsonFieldVisitor<'a> {
+    fields: &'a mut serde_json::Map<String, serde_json::Value>,
 }
 
-fn serialize_json_aware_value_entry<S>(
-    serializer_map: &mut S,
-    field_name: &str,
-    value: &serde_json::Value,
-) -> Result<(), S::Error>
-where
-    S: SerializeMap,
-{
-    match (json_field_name(field_name), value.as_str()) {
-        (Some(stripped_field_name), Some(value)) => {
-            match serde_json::from_str::<serde_json::Value>(value) {
-                Ok(value) => serializer_map.serialize_entry(stripped_field_name, &value),
-                Err(_) => serializer_map.serialize_entry(stripped_field_name, value),
-            }
-        }
-        (Some(stripped_field_name), None) => {
-            serializer_map.serialize_entry(stripped_field_name, value)
-        }
-        (None, _) => serializer_map.serialize_entry(field_name, value),
-    }
-}
-
-struct JsonFieldVisitor<S: SerializeMap> {
-    serializer: S,
-    state: Result<(), S::Error>,
-}
-
-impl<S> JsonFieldVisitor<S>
-where
-    S: SerializeMap,
-{
-    fn new(serializer: S) -> Self {
-        Self {
-            serializer,
-            state: Ok(()),
-        }
-    }
-
-    fn take_serializer(self) -> Result<S, S::Error> {
-        self.state.map(|_| self.serializer)
-    }
-
-    fn record_entry<V>(&mut self, field: &Field, value: &V)
-    where
-        V: serde::Serialize + ?Sized,
-    {
-        if self.state.is_ok() {
-            self.state = serialize_entry(&mut self.serializer, field.name(), value);
-        }
+impl JsonFieldVisitor<'_> {
+    fn record_value(&mut self, field: &Field, value: serde_json::Value) {
+        insert_json_aware_value(self.fields, field.name(), value);
     }
 
     fn record_str_entry(&mut self, field: &Field, value: &str) {
-        if self.state.is_ok() {
-            self.state = serialize_json_aware_str_entry(&mut self.serializer, field.name(), value);
-        }
+        self.record_value(field, serde_json::Value::String(value.to_string()));
     }
 }
 
-impl<S> Visit for JsonFieldVisitor<S>
-where
-    S: SerializeMap,
-{
+impl Visit for JsonFieldVisitor<'_> {
     fn record_bool(&mut self, field: &Field, value: bool) {
-        self.record_entry(field, &value);
+        self.record_value(field, serde_json::Value::Bool(value));
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
-        self.record_entry(field, &value);
+        self.record_value(field, serde_json::Value::Number(value.into()));
     }
 
     fn record_u64(&mut self, field: &Field, value: u64) {
-        self.record_entry(field, &value);
+        self.record_value(field, serde_json::Value::Number(value.into()));
     }
 
     fn record_i128(&mut self, field: &Field, value: i128) {
-        self.record_entry(field, &value.to_string());
+        self.record_value(field, serde_json::Value::String(value.to_string()));
     }
 
     fn record_u128(&mut self, field: &Field, value: u128) {
-        self.record_entry(field, &value.to_string());
+        self.record_value(field, serde_json::Value::String(value.to_string()));
     }
 
     fn record_f64(&mut self, field: &Field, value: f64) {
-        self.record_entry(field, &value);
+        let value = serde_json::Number::from_f64(value)
+            .map(serde_json::Value::Number)
+            .unwrap_or_else(|| serde_json::Value::String(value.to_string()));
+        self.record_value(field, value);
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
@@ -239,13 +192,7 @@ where
     }
 
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        if self.state.is_ok() {
-            self.state = serialize_entry(
-                &mut self.serializer,
-                field.name(),
-                &format_args!("{value:?}"),
-            );
-        }
+        self.record_value(field, serde_json::Value::String(format!("{value:?}")));
     }
 }
 
@@ -264,47 +211,36 @@ where
         S: Subscriber + for<'a> LookupSpan<'a>,
     {
         let meta = event.metadata();
-
-        let mut s = Vec::<u8>::new();
-        let mut serializer = serde_json::Serializer::new(&mut s);
-        let mut serializer_map = serializer
-            .serialize_map(None)
-            .map_err(|_| std::fmt::Error)?;
+        let mut fields = serde_json::Map::new();
 
         let timestamp = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-        serializer_map
-            .serialize_entry("time", &timestamp)
-            .map_err(|_| std::fmt::Error)?;
-        serializer_map
-            .serialize_entry("severity", &meta.level().as_serde())
-            .map_err(|_| std::fmt::Error)?;
+        fields.insert("time".to_string(), serde_json::Value::String(timestamp));
+        fields.insert(
+            "severity".to_string(),
+            serde_json::Value::String(meta.level().to_string()),
+        );
 
         if let Some(leaf_span) = ctx.lookup_current() {
             for span in leaf_span.scope().from_root() {
                 let ext = span.extensions();
                 if let Some(data) = ext.get::<FormattedFields<N>>()
-                    && let Ok(serde_json::Value::Object(fields)) =
+                    && let Ok(serde_json::Value::Object(span_fields)) =
                         serde_json::from_str::<serde_json::Value>(data)
                 {
-                    for (field_name, value) in fields {
-                        serialize_json_aware_value_entry(&mut serializer_map, &field_name, &value)
-                            .map_err(|_| std::fmt::Error)?;
+                    for (field_name, value) in span_fields {
+                        insert_json_aware_value(&mut fields, &field_name, value);
                     }
                 }
             }
         }
 
-        let mut visitor = JsonFieldVisitor::new(serializer_map);
+        let mut visitor = JsonFieldVisitor {
+            fields: &mut fields,
+        };
         event.record(&mut visitor);
 
-        visitor
-            .take_serializer()
-            .map_err(|_| std::fmt::Error)?
-            .end()
-            .map_err(|_| std::fmt::Error)?;
-
-        let s_str = std::str::from_utf8(&s).map_err(|_| std::fmt::Error)?;
-        writer.write_str(s_str)?;
+        let line = serde_json::to_string(&fields).map_err(|_| std::fmt::Error)?;
+        writer.write_str(&line)?;
         writeln!(writer)
     }
 }
@@ -320,10 +256,13 @@ pub(crate) mod test_support {
     }
 
     impl JsonLogWriter {
-        pub(crate) fn output(&self) -> Vec<serde_json::Value> {
+        pub(crate) fn raw_output(&self) -> String {
             let bytes = self.lines.lock().expect("writer lock").clone();
-            String::from_utf8(bytes)
-                .expect("utf8 logs")
+            String::from_utf8(bytes).expect("utf8 logs")
+        }
+
+        pub(crate) fn output(&self) -> Vec<serde_json::Value> {
+            self.raw_output()
                 .lines()
                 .map(|line| serde_json::from_str(line).expect("json log line"))
                 .collect()
@@ -366,6 +305,19 @@ mod tests {
     use test_support::JsonLogWriter;
     use tracing::{info, info_span};
     use tracing_subscriber::layer::SubscriberExt;
+
+    fn capture_raw_logs(run: impl FnOnce()) -> String {
+        let writer = JsonLogWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(writer.clone())
+                .event_format(HubuumLoggingFormat),
+        );
+
+        tracing::subscriber::with_default(subscriber, run);
+        writer.raw_output()
+    }
 
     fn capture_logs(run: impl FnOnce()) -> Vec<serde_json::Value> {
         let writer = JsonLogWriter::default();
@@ -419,11 +371,12 @@ mod tests {
     }
 
     #[test]
-    fn logging_format_serializes_json_suffixed_fields_as_json_values() {
+    fn logging_format_serializes_explicit_structured_fields_as_json_values() {
         let logs = capture_logs(|| {
             info!(
                 message = "structured field",
-                permissions_json = "[\"ReadCollection\",\"UpdateCollection\"]",
+                permissions = "[\"ReadCollection\",\"UpdateCollection\"]",
+                unrelated_json = "{\"kept\":\"literal\"}",
             );
         });
 
@@ -432,7 +385,7 @@ mod tests {
             event["permissions"],
             json!(["ReadCollection", "UpdateCollection"])
         );
-        assert!(event.get("permissions_json").is_none());
+        assert_eq!(event["unrelated_json"], "{\"kept\":\"literal\"}");
     }
 
     #[test]
@@ -502,5 +455,34 @@ mod tests {
         assert_eq!(event["correlation_id"], "operation-correlation");
         assert!(event.get("before").is_none());
         assert!(event.get("after").is_none());
+    }
+
+    #[test]
+    fn event_fields_override_span_fields_without_duplicate_json_keys() {
+        let request_id = uuid::Uuid::new_v4();
+        let raw_logs = capture_raw_logs(|| {
+            let span = info_span!(
+                "request",
+                request_id = "span-request",
+                correlation_id = "span-correlation"
+            );
+            let _guard = span.enter();
+            log_operation_mutation(
+                EntityType::Namespace,
+                Action::Created,
+                Some(9),
+                Some(12),
+                Some(request_id),
+                Some("event-correlation"),
+            );
+        });
+
+        let line = raw_logs.lines().next().expect("raw log line");
+        assert_eq!(line.matches("\"request_id\"").count(), 1);
+        assert_eq!(line.matches("\"correlation_id\"").count(), 1);
+
+        let event: serde_json::Value = serde_json::from_str(line).expect("json log line");
+        assert_eq!(event["request_id"], request_id.to_string());
+        assert_eq!(event["correlation_id"], "event-correlation");
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+
+use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
 use tracing_subscriber::fmt::FmtContext;
 use tracing_subscriber::fmt::FormattedFields;
@@ -39,8 +42,9 @@ pub fn log_operation_mutation(
     correlation_id: Option<&str>,
 ) {
     tracing::info!(
-        message = "operation mutation",
-        operation = "mutation",
+        message = "operation mutation recorded",
+        operation = "mutation_recorded",
+        mutation_phase = "recorded",
         entity_type = entity_type.as_str(),
         action = action.as_str(),
         entity_id,
@@ -54,7 +58,6 @@ pub fn log_operation_read(
     entity_type: Option<EntityType>,
     action: Option<Action>,
     entity_id: Option<i32>,
-    actor_principal_id: Option<i32>,
 ) {
     let entity_type = entity_type.map(EntityType::as_str);
     let action = action.map(Action::as_str);
@@ -64,14 +67,13 @@ pub fn log_operation_read(
         entity_type,
         action,
         entity_id,
-        actor_principal_id,
     );
 }
 
 pub fn log_authorization_grant(
     principal_id: i32,
     permissions: &[Permissions],
-    namespace_count: usize,
+    namespace_count: Option<usize>,
     reason: &'static str,
 ) {
     let permissions = permissions
@@ -84,7 +86,7 @@ pub fn log_authorization_grant(
         event_type = "authorization",
         decision = "grant",
         principal_id,
-        permissions,
+        permissions_json = permissions,
         namespace_count,
         reason,
     );
@@ -106,10 +108,145 @@ pub fn log_authorization_denial(
         event_type = "authorization",
         decision = "deny",
         principal_id,
-        permissions,
+        permissions_json = permissions,
         namespace_count,
         reason,
     );
+}
+
+fn json_field_name(field_name: &str) -> Option<&str> {
+    field_name.strip_suffix("_json")
+}
+
+fn serialize_entry<S, V>(
+    serializer_map: &mut S,
+    field_name: &str,
+    value: &V,
+) -> Result<(), S::Error>
+where
+    S: SerializeMap,
+    V: serde::Serialize + ?Sized,
+{
+    serializer_map.serialize_entry(field_name, value)
+}
+
+fn serialize_json_aware_str_entry<S>(
+    serializer_map: &mut S,
+    field_name: &str,
+    value: &str,
+) -> Result<(), S::Error>
+where
+    S: SerializeMap,
+{
+    let Some(stripped_field_name) = json_field_name(field_name) else {
+        return serializer_map.serialize_entry(field_name, value);
+    };
+
+    match serde_json::from_str::<serde_json::Value>(value) {
+        Ok(value) => serializer_map.serialize_entry(stripped_field_name, &value),
+        Err(_) => serializer_map.serialize_entry(stripped_field_name, value),
+    }
+}
+
+fn serialize_json_aware_value_entry<S>(
+    serializer_map: &mut S,
+    field_name: &str,
+    value: &serde_json::Value,
+) -> Result<(), S::Error>
+where
+    S: SerializeMap,
+{
+    match (json_field_name(field_name), value.as_str()) {
+        (Some(stripped_field_name), Some(value)) => {
+            match serde_json::from_str::<serde_json::Value>(value) {
+                Ok(value) => serializer_map.serialize_entry(stripped_field_name, &value),
+                Err(_) => serializer_map.serialize_entry(stripped_field_name, value),
+            }
+        }
+        (Some(stripped_field_name), None) => {
+            serializer_map.serialize_entry(stripped_field_name, value)
+        }
+        (None, _) => serializer_map.serialize_entry(field_name, value),
+    }
+}
+
+struct JsonFieldVisitor<S: SerializeMap> {
+    serializer: S,
+    state: Result<(), S::Error>,
+}
+
+impl<S> JsonFieldVisitor<S>
+where
+    S: SerializeMap,
+{
+    fn new(serializer: S) -> Self {
+        Self {
+            serializer,
+            state: Ok(()),
+        }
+    }
+
+    fn take_serializer(self) -> Result<S, S::Error> {
+        self.state.map(|_| self.serializer)
+    }
+
+    fn record_entry<V>(&mut self, field: &Field, value: &V)
+    where
+        V: serde::Serialize + ?Sized,
+    {
+        if self.state.is_ok() {
+            self.state = serialize_entry(&mut self.serializer, field.name(), value);
+        }
+    }
+
+    fn record_str_entry(&mut self, field: &Field, value: &str) {
+        if self.state.is_ok() {
+            self.state = serialize_json_aware_str_entry(&mut self.serializer, field.name(), value);
+        }
+    }
+}
+
+impl<S> Visit for JsonFieldVisitor<S>
+where
+    S: SerializeMap,
+{
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.record_entry(field, &value);
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.record_entry(field, &value);
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.record_entry(field, &value);
+    }
+
+    fn record_i128(&mut self, field: &Field, value: i128) {
+        self.record_entry(field, &value.to_string());
+    }
+
+    fn record_u128(&mut self, field: &Field, value: u128) {
+        self.record_entry(field, &value.to_string());
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.record_entry(field, &value);
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.record_str_entry(field, value);
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if self.state.is_ok() {
+            self.state = serialize_entry(
+                &mut self.serializer,
+                field.name(),
+                &format_args!("{value:?}"),
+            );
+        }
+    }
 }
 
 impl<S, N> FormatEvent<S, N> for HubuumLoggingFormat
@@ -149,16 +286,15 @@ where
                     && let Ok(serde_json::Value::Object(fields)) =
                         serde_json::from_str::<serde_json::Value>(data)
                 {
-                    for field in fields {
-                        serializer_map
-                            .serialize_entry(&field.0, &field.1)
+                    for (field_name, value) in fields {
+                        serialize_json_aware_value_entry(&mut serializer_map, &field_name, &value)
                             .map_err(|_| std::fmt::Error)?;
                     }
                 }
             }
         }
 
-        let mut visitor = tracing_serde::SerdeMapVisitor::new(serializer_map);
+        let mut visitor = JsonFieldVisitor::new(serializer_map);
         event.record(&mut visitor);
 
         visitor
@@ -226,6 +362,7 @@ pub(crate) mod test_support {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
     use test_support::JsonLogWriter;
     use tracing::{info, info_span};
     use tracing_subscriber::layer::SubscriberExt;
@@ -282,6 +419,23 @@ mod tests {
     }
 
     #[test]
+    fn logging_format_serializes_json_suffixed_fields_as_json_values() {
+        let logs = capture_logs(|| {
+            info!(
+                message = "structured field",
+                permissions_json = "[\"ReadCollection\",\"UpdateCollection\"]",
+            );
+        });
+
+        let event = logs.first().expect("log event");
+        assert_eq!(
+            event["permissions"],
+            json!(["ReadCollection", "UpdateCollection"])
+        );
+        assert!(event.get("permissions_json").is_none());
+    }
+
+    #[test]
     fn test_logging_format_handles_special_characters() {
         let logs = capture_logs(|| {
             info!(
@@ -298,7 +452,7 @@ mod tests {
     #[test]
     fn authorization_helpers_log_grant_and_denial_levels() {
         let logs = capture_logs(|| {
-            log_authorization_grant(12, &[Permissions::ReadCollection], 1, "permissions");
+            log_authorization_grant(12, &[Permissions::ReadCollection], Some(1), "permissions");
             log_authorization_denial(12, &[Permissions::UpdateCollection], Some(1), "permissions");
         });
 
@@ -309,7 +463,7 @@ mod tests {
         assert_eq!(grant["severity"], "DEBUG");
         assert_eq!(grant["event_type"], "authorization");
         assert_eq!(grant["principal_id"], 12);
-        assert_eq!(grant["permissions"], "[\"ReadCollection\"]");
+        assert_eq!(grant["permissions"], json!(["ReadCollection"]));
 
         let denial = logs
             .iter()
@@ -318,7 +472,7 @@ mod tests {
         assert_eq!(denial["severity"], "WARN");
         assert_eq!(denial["event_type"], "authorization");
         assert_eq!(denial["principal_id"], 12);
-        assert_eq!(denial["permissions"], "[\"UpdateCollection\"]");
+        assert_eq!(denial["permissions"], json!(["UpdateCollection"]));
     }
 
     #[test]
@@ -337,7 +491,9 @@ mod tests {
 
         let event = logs.first().expect("operation event");
         assert_eq!(event["severity"], "INFO");
-        assert_eq!(event["operation"], "mutation");
+        assert_eq!(event["message"], "operation mutation recorded");
+        assert_eq!(event["operation"], "mutation_recorded");
+        assert_eq!(event["mutation_phase"], "recorded");
         assert_eq!(event["entity_type"], "namespace");
         assert_eq!(event["action"], "created");
         assert_eq!(event["entity_id"], 9);

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -70,7 +70,7 @@ pub fn log_operation_read(
 pub fn log_authorization_grant(
     principal_id: i32,
     permissions: &[Permissions],
-    namespace_count: Option<usize>,
+    collection_count: Option<usize>,
     reason: &'static str,
 ) {
     if !tracing::enabled!(tracing::Level::DEBUG) {
@@ -88,7 +88,7 @@ pub fn log_authorization_grant(
         decision = "grant",
         principal_id,
         permissions,
-        namespace_count,
+        collection_count,
         reason,
     );
 }
@@ -96,7 +96,7 @@ pub fn log_authorization_grant(
 pub fn log_authorization_denial(
     principal_id: i32,
     permissions: &[Permissions],
-    namespace_count: Option<usize>,
+    collection_count: Option<usize>,
     reason: &'static str,
 ) {
     let permissions = permissions
@@ -110,7 +110,7 @@ pub fn log_authorization_denial(
         decision = "deny",
         principal_id,
         permissions,
-        namespace_count,
+        collection_count,
         reason,
     );
 }
@@ -433,7 +433,7 @@ mod tests {
         let request_id = uuid::Uuid::new_v4();
         let logs = capture_logs(|| {
             log_operation_mutation(
-                EntityType::Namespace,
+                EntityType::Collection,
                 Action::Created,
                 Some(9),
                 Some(12),
@@ -447,7 +447,7 @@ mod tests {
         assert_eq!(event["message"], "operation mutation recorded");
         assert_eq!(event["operation"], "mutation_recorded");
         assert_eq!(event["mutation_phase"], "recorded");
-        assert_eq!(event["entity_type"], "namespace");
+        assert_eq!(event["entity_type"], "collection");
         assert_eq!(event["action"], "created");
         assert_eq!(event["entity_id"], 9);
         assert_eq!(event["actor_principal_id"], 12);
@@ -468,7 +468,7 @@ mod tests {
             );
             let _guard = span.enter();
             log_operation_mutation(
-                EntityType::Namespace,
+                EntityType::Collection,
                 Action::Created,
                 Some(9),
                 Some(12),

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{cell::RefCell, fmt, future::Future};
 
 use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
@@ -15,6 +15,36 @@ pub struct HubuumLoggingFormat;
 
 impl HubuumLoggingFormat {}
 
+#[derive(Clone, Debug)]
+struct OperationMutationLog {
+    entity_type: EntityType,
+    action: Action,
+    entity_id: Option<i32>,
+    actor_principal_id: Option<i32>,
+    request_id: Option<uuid::Uuid>,
+    correlation_id: Option<String>,
+}
+
+impl OperationMutationLog {
+    fn emit(self) {
+        tracing::info!(
+            message = "operation mutation committed",
+            operation = "mutation_committed",
+            mutation_phase = "committed",
+            entity_type = self.entity_type.as_str(),
+            action = self.action.as_str(),
+            entity_id = self.entity_id,
+            actor_principal_id = self.actor_principal_id,
+            request_id = self.request_id.map(|id| id.to_string()),
+            correlation_id = self.correlation_id.as_deref(),
+        );
+    }
+}
+
+tokio::task_local! {
+    static DEFERRED_OPERATION_MUTATIONS: RefCell<Vec<OperationMutationLog>>;
+}
+
 pub fn init_json_logging(log_level: &str) -> Result<(), String> {
     let filter = EnvFilter::try_new(log_level)
         .map_err(|err| format!("Error parsing log level '{log_level}': {err}"))?;
@@ -30,6 +60,12 @@ pub fn init_json_logging(log_level: &str) -> Result<(), String> {
         .map_err(|err| format!("Failed to initialize logging: {err}"))
 }
 
+pub fn build_git_sha() -> &'static str {
+    option_env!("HUBUUM_BUILD_GIT_SHA")
+        .or(option_env!("GITHUB_SHA"))
+        .unwrap_or("unknown")
+}
+
 pub fn log_operation_mutation(
     entity_type: EntityType,
     action: Action,
@@ -38,17 +74,42 @@ pub fn log_operation_mutation(
     request_id: Option<uuid::Uuid>,
     correlation_id: Option<&str>,
 ) {
-    tracing::info!(
-        message = "operation mutation recorded",
-        operation = "mutation_recorded",
-        mutation_phase = "recorded",
-        entity_type = entity_type.as_str(),
-        action = action.as_str(),
+    let operation = OperationMutationLog {
+        entity_type,
+        action,
         entity_id,
         actor_principal_id,
-        request_id = request_id.map(|id| id.to_string()),
-        correlation_id,
-    );
+        request_id,
+        correlation_id: correlation_id.map(ToOwned::to_owned),
+    };
+    if DEFERRED_OPERATION_MUTATIONS
+        .try_with(|operations| operations.borrow_mut().push(operation.clone()))
+        .is_err()
+    {
+        operation.emit();
+    }
+}
+
+pub(crate) async fn defer_operation_mutation_logs_until_commit<F, R, E>(future: F) -> Result<R, E>
+where
+    F: Future<Output = Result<R, E>>,
+{
+    if DEFERRED_OPERATION_MUTATIONS.try_with(|_| ()).is_ok() {
+        return future.await;
+    }
+
+    DEFERRED_OPERATION_MUTATIONS
+        .scope(RefCell::new(Vec::new()), async move {
+            let result = future.await;
+            let operations = DEFERRED_OPERATION_MUTATIONS.with(RefCell::take);
+            if result.is_ok() {
+                for operation in operations {
+                    operation.emit();
+                }
+            }
+            result
+        })
+        .await
 }
 
 pub fn log_operation_read(
@@ -71,12 +132,14 @@ pub fn log_authorization_grant(
     principal_id: i32,
     permissions: &[Permissions],
     collection_count: Option<usize>,
+    collection_id: Option<i32>,
     reason: &'static str,
 ) {
     if !tracing::enabled!(tracing::Level::DEBUG) {
         return;
     }
 
+    let (action, entity_type) = authorization_operation_fields_for(permissions);
     let permissions = permissions
         .iter()
         .map(ToString::to_string)
@@ -89,6 +152,9 @@ pub fn log_authorization_grant(
         principal_id,
         permissions,
         collection_count,
+        collection_id,
+        action,
+        entity_type,
         reason,
     );
 }
@@ -97,8 +163,10 @@ pub fn log_authorization_denial(
     principal_id: i32,
     permissions: &[Permissions],
     collection_count: Option<usize>,
+    collection_id: Option<i32>,
     reason: &'static str,
 ) {
+    let (action, entity_type) = authorization_operation_fields_for(permissions);
     let permissions = permissions
         .iter()
         .map(ToString::to_string)
@@ -111,8 +179,28 @@ pub fn log_authorization_denial(
         principal_id,
         permissions,
         collection_count,
+        collection_id,
+        action,
+        entity_type,
         reason,
     );
+}
+
+fn authorization_operation_fields_for(
+    permissions: &[Permissions],
+) -> (Option<&'static str>, Option<&'static str>) {
+    let first = permissions.first().copied();
+    let action = first.map(Permissions::operation_action).filter(|action| {
+        permissions
+            .iter()
+            .all(|permission| permission.operation_action() == *action)
+    });
+    let entity_type = first.map(Permissions::entity_type).filter(|entity_type| {
+        permissions
+            .iter()
+            .all(|permission| permission.entity_type() == *entity_type)
+    });
+    (action, entity_type)
 }
 
 fn structured_json_field_name(field_name: &str) -> Option<&'static str> {
@@ -213,13 +301,6 @@ where
         let meta = event.metadata();
         let mut fields = serde_json::Map::new();
 
-        let timestamp = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-        fields.insert("time".to_string(), serde_json::Value::String(timestamp));
-        fields.insert(
-            "severity".to_string(),
-            serde_json::Value::String(meta.level().to_string()),
-        );
-
         if let Some(leaf_span) = ctx.lookup_current() {
             for span in leaf_span.scope().from_root() {
                 let ext = span.extensions();
@@ -238,6 +319,13 @@ where
             fields: &mut fields,
         };
         event.record(&mut visitor);
+
+        let timestamp = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        fields.insert("time".to_string(), serde_json::Value::String(timestamp));
+        fields.insert(
+            "severity".to_string(),
+            serde_json::Value::String(meta.level().to_string()),
+        );
 
         let line = serde_json::to_string(&fields).map_err(|_| std::fmt::Error)?;
         writer.write_str(&line)?;
@@ -357,7 +445,7 @@ mod tests {
                 "request",
                 request_id = "request-1",
                 correlation_id = "correlation-1",
-                principal = 42
+                principal_id = 42
             );
             let _guard = span.enter();
             info!(message = "inside request");
@@ -366,7 +454,7 @@ mod tests {
         let event = logs.first().expect("log event");
         assert_eq!(event["request_id"], "request-1");
         assert_eq!(event["correlation_id"], "correlation-1");
-        assert_eq!(event["principal"], 42);
+        assert_eq!(event["principal_id"], 42);
         assert_eq!(event["message"], "inside request");
     }
 
@@ -405,8 +493,20 @@ mod tests {
     #[test]
     fn authorization_helpers_log_grant_and_denial_levels() {
         let logs = capture_logs(|| {
-            log_authorization_grant(12, &[Permissions::ReadCollection], Some(1), "permissions");
-            log_authorization_denial(12, &[Permissions::UpdateCollection], Some(1), "permissions");
+            log_authorization_grant(
+                12,
+                &[Permissions::ReadCollection],
+                Some(1),
+                Some(4),
+                "permissions",
+            );
+            log_authorization_denial(
+                12,
+                &[Permissions::UpdateCollection],
+                Some(1),
+                Some(4),
+                "permissions",
+            );
         });
 
         let grant = logs
@@ -417,6 +517,9 @@ mod tests {
         assert_eq!(grant["event_type"], "authorization");
         assert_eq!(grant["principal_id"], 12);
         assert_eq!(grant["permissions"], json!(["ReadCollection"]));
+        assert_eq!(grant["action"], "read");
+        assert_eq!(grant["entity_type"], "collection");
+        assert_eq!(grant["collection_id"], 4);
 
         let denial = logs
             .iter()
@@ -426,6 +529,9 @@ mod tests {
         assert_eq!(denial["event_type"], "authorization");
         assert_eq!(denial["principal_id"], 12);
         assert_eq!(denial["permissions"], json!(["UpdateCollection"]));
+        assert_eq!(denial["action"], "update");
+        assert_eq!(denial["entity_type"], "collection");
+        assert_eq!(denial["collection_id"], 4);
     }
 
     #[test]
@@ -444,9 +550,9 @@ mod tests {
 
         let event = logs.first().expect("operation event");
         assert_eq!(event["severity"], "INFO");
-        assert_eq!(event["message"], "operation mutation recorded");
-        assert_eq!(event["operation"], "mutation_recorded");
-        assert_eq!(event["mutation_phase"], "recorded");
+        assert_eq!(event["message"], "operation mutation committed");
+        assert_eq!(event["operation"], "mutation_committed");
+        assert_eq!(event["mutation_phase"], "committed");
         assert_eq!(event["entity_type"], "collection");
         assert_eq!(event["action"], "created");
         assert_eq!(event["entity_id"], 9);
@@ -484,5 +590,61 @@ mod tests {
         let event: serde_json::Value = serde_json::from_str(line).expect("json log line");
         assert_eq!(event["request_id"], request_id.to_string());
         assert_eq!(event["correlation_id"], "event-correlation");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn deferred_mutation_logs_are_emitted_after_success() {
+        let writer = JsonLogWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(writer.clone())
+                .event_format(HubuumLoggingFormat),
+        );
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let result: Result<(), ()> = defer_operation_mutation_logs_until_commit(async {
+            log_operation_mutation(
+                EntityType::Collection,
+                Action::Created,
+                Some(9),
+                Some(12),
+                None,
+                None,
+            );
+            Ok(())
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(writer.output().len(), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn deferred_mutation_logs_are_discarded_after_failure() {
+        let writer = JsonLogWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(writer.clone())
+                .event_format(HubuumLoggingFormat),
+        );
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let result: Result<(), ()> = defer_operation_mutation_logs_until_commit(async {
+            log_operation_mutation(
+                EntityType::Collection,
+                Action::Created,
+                Some(9),
+                Some(12),
+                None,
+                None,
+            );
+            Err(())
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert!(writer.output().is_empty());
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -3,13 +3,114 @@ use tracing_subscriber::fmt::FmtContext;
 use tracing_subscriber::fmt::FormattedFields;
 use tracing_subscriber::fmt::format::{FormatEvent, FormatFields, Writer};
 use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 use serde::ser::{SerializeMap, Serializer};
 use tracing_serde::AsSerde;
 
+use crate::events::{Action, EntityType};
+use crate::models::Permissions;
+
 pub struct HubuumLoggingFormat;
 
 impl HubuumLoggingFormat {}
+
+pub fn init_json_logging(log_level: &str) -> Result<(), String> {
+    let filter = EnvFilter::try_new(log_level)
+        .map_err(|err| format!("Error parsing log level '{log_level}': {err}"))?;
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .event_format(HubuumLoggingFormat),
+        )
+        .try_init()
+        .map_err(|err| format!("Failed to initialize logging: {err}"))
+}
+
+pub fn log_operation_mutation(
+    entity_type: EntityType,
+    action: Action,
+    entity_id: Option<i32>,
+    actor_principal_id: Option<i32>,
+    request_id: Option<uuid::Uuid>,
+    correlation_id: Option<&str>,
+) {
+    tracing::info!(
+        message = "operation mutation",
+        operation = "mutation",
+        entity_type = entity_type.as_str(),
+        action = action.as_str(),
+        entity_id,
+        actor_principal_id,
+        request_id = request_id.map(|id| id.to_string()),
+        correlation_id,
+    );
+}
+
+pub fn log_operation_read(
+    entity_type: Option<EntityType>,
+    action: Option<Action>,
+    entity_id: Option<i32>,
+    actor_principal_id: Option<i32>,
+) {
+    let entity_type = entity_type.map(EntityType::as_str);
+    let action = action.map(Action::as_str);
+    tracing::debug!(
+        message = "operation read",
+        operation = "read",
+        entity_type,
+        action,
+        entity_id,
+        actor_principal_id,
+    );
+}
+
+pub fn log_authorization_grant(
+    principal_id: i32,
+    permissions: &[Permissions],
+    namespace_count: usize,
+    reason: &'static str,
+) {
+    let permissions = permissions
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    let permissions = serde_json::to_string(&permissions).unwrap_or_else(|_| "[]".to_string());
+    tracing::debug!(
+        message = "authorization granted",
+        event_type = "authorization",
+        decision = "grant",
+        principal_id,
+        permissions,
+        namespace_count,
+        reason,
+    );
+}
+
+pub fn log_authorization_denial(
+    principal_id: i32,
+    permissions: &[Permissions],
+    namespace_count: Option<usize>,
+    reason: &'static str,
+) {
+    let permissions = permissions
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    let permissions = serde_json::to_string(&permissions).unwrap_or_else(|_| "[]".to_string());
+    tracing::warn!(
+        message = "authorization denied",
+        event_type = "authorization",
+        decision = "deny",
+        principal_id,
+        permissions,
+        namespace_count,
+        reason,
+    );
+}
 
 impl<S, N> FormatEvent<S, N> for HubuumLoggingFormat
 where
@@ -73,69 +174,177 @@ where
 }
 
 #[cfg(test)]
+pub(crate) mod test_support {
+    use std::io;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    pub(crate) struct JsonLogWriter {
+        lines: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl JsonLogWriter {
+        pub(crate) fn output(&self) -> Vec<serde_json::Value> {
+            let bytes = self.lines.lock().expect("writer lock").clone();
+            String::from_utf8(bytes)
+                .expect("utf8 logs")
+                .lines()
+                .map(|line| serde_json::from_str(line).expect("json log line"))
+                .collect()
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for JsonLogWriter {
+        type Writer = JsonLogWriterGuard;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            JsonLogWriterGuard {
+                lines: Arc::clone(&self.lines),
+            }
+        }
+    }
+
+    pub(crate) struct JsonLogWriterGuard {
+        lines: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl io::Write for JsonLogWriterGuard {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.lines
+                .lock()
+                .expect("writer lock")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
-    use tracing::info;
-    use tracing_subscriber::fmt::format::FmtSpan;
+    use test_support::JsonLogWriter;
+    use tracing::{info, info_span};
     use tracing_subscriber::layer::SubscriberExt;
-    use tracing_subscriber::util::SubscriberInitExt;
 
-    #[test]
-    fn test_logging_format_handles_simple_event() {
-        // Test that basic logging works without panicking
-        // We use a writer that discards output to avoid polluting test output
+    fn capture_logs(run: impl FnOnce()) -> Vec<serde_json::Value> {
+        let writer = JsonLogWriter::default();
         let subscriber = tracing_subscriber::registry().with(
             tracing_subscriber::fmt::layer()
                 .json()
-                .with_writer(std::io::sink) // Discard output
-                .with_span_events(FmtSpan::CLOSE)
+                .with_writer(writer.clone())
                 .event_format(HubuumLoggingFormat),
         );
 
-        let _guard = subscriber.set_default();
-
-        // This should not panic
-        info!("Test message");
+        tracing::subscriber::with_default(subscriber, run);
+        writer.output()
     }
 
     #[test]
-    fn test_logging_format_handles_event_with_fields() {
-        // Test that logging with structured fields works
-        let subscriber = tracing_subscriber::registry().with(
-            tracing_subscriber::fmt::layer()
-                .json()
-                .with_writer(std::io::sink) // Discard output
-                .with_span_events(FmtSpan::CLOSE)
-                .event_format(HubuumLoggingFormat),
-        );
+    fn logging_format_emits_json_fields() {
+        let logs = capture_logs(|| {
+            info!(
+                message = "Test with fields",
+                user_id = 123,
+                action = "test_action"
+            );
+        });
 
-        let _guard = subscriber.set_default();
+        let event = logs.first().expect("log event");
+        assert_eq!(event["severity"], "INFO");
+        assert_eq!(event["message"], "Test with fields");
+        assert_eq!(event["user_id"], 123);
+        assert_eq!(event["action"], "test_action");
+        assert!(event["time"].as_str().expect("timestamp").ends_with('Z'));
+    }
 
-        // This should not panic even with multiple fields
-        info!(
-            message = "Test with fields",
-            user_id = 123,
-            action = "test_action"
-        );
+    #[test]
+    fn logging_format_inherits_span_fields() {
+        let logs = capture_logs(|| {
+            let span = info_span!(
+                "request",
+                request_id = "request-1",
+                correlation_id = "correlation-1",
+                principal = 42
+            );
+            let _guard = span.enter();
+            info!(message = "inside request");
+        });
+
+        let event = logs.first().expect("log event");
+        assert_eq!(event["request_id"], "request-1");
+        assert_eq!(event["correlation_id"], "correlation-1");
+        assert_eq!(event["principal"], 42);
+        assert_eq!(event["message"], "inside request");
     }
 
     #[test]
     fn test_logging_format_handles_special_characters() {
-        // Test that special characters don't cause panics
-        let subscriber = tracing_subscriber::registry().with(
-            tracing_subscriber::fmt::layer()
-                .json()
-                .with_writer(std::io::sink) // Discard output
-                .with_span_events(FmtSpan::CLOSE)
-                .event_format(HubuumLoggingFormat),
-        );
+        let logs = capture_logs(|| {
+            info!(
+                message = "Test with \"quotes\" and \n newlines",
+                path = "/some/path/with\\backslashes"
+            );
+        });
 
-        let _guard = subscriber.set_default();
+        let event = logs.first().expect("log event");
+        assert_eq!(event["message"], "Test with \"quotes\" and \n newlines");
+        assert_eq!(event["path"], "/some/path/with\\backslashes");
+    }
 
-        // This should handle various special characters without panicking
-        info!(
-            message = "Test with \"quotes\" and \n newlines",
-            path = "/some/path/with\\backslashes"
-        );
+    #[test]
+    fn authorization_helpers_log_grant_and_denial_levels() {
+        let logs = capture_logs(|| {
+            log_authorization_grant(12, &[Permissions::ReadCollection], 1, "permissions");
+            log_authorization_denial(12, &[Permissions::UpdateCollection], Some(1), "permissions");
+        });
+
+        let grant = logs
+            .iter()
+            .find(|event| event["decision"] == "grant")
+            .expect("grant event");
+        assert_eq!(grant["severity"], "DEBUG");
+        assert_eq!(grant["event_type"], "authorization");
+        assert_eq!(grant["principal_id"], 12);
+        assert_eq!(grant["permissions"], "[\"ReadCollection\"]");
+
+        let denial = logs
+            .iter()
+            .find(|event| event["decision"] == "deny")
+            .expect("denial event");
+        assert_eq!(denial["severity"], "WARN");
+        assert_eq!(denial["event_type"], "authorization");
+        assert_eq!(denial["principal_id"], 12);
+        assert_eq!(denial["permissions"], "[\"UpdateCollection\"]");
+    }
+
+    #[test]
+    fn operation_mutation_helper_uses_catalog_labels_without_payloads() {
+        let request_id = uuid::Uuid::new_v4();
+        let logs = capture_logs(|| {
+            log_operation_mutation(
+                EntityType::Namespace,
+                Action::Created,
+                Some(9),
+                Some(12),
+                Some(request_id),
+                Some("operation-correlation"),
+            );
+        });
+
+        let event = logs.first().expect("operation event");
+        assert_eq!(event["severity"], "INFO");
+        assert_eq!(event["operation"], "mutation");
+        assert_eq!(event["entity_type"], "namespace");
+        assert_eq!(event["action"], "created");
+        assert_eq!(event["entity_id"], 9);
+        assert_eq!(event["actor_principal_id"], 12);
+        assert_eq!(event["request_id"], request_id.to_string());
+        assert_eq!(event["correlation_id"], "operation-correlation");
+        assert!(event.get("before").is_none());
+        assert!(event.get("after").is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,6 @@ async fn main() -> std::io::Result<()> {
     let server = HttpServer::new(move || {
         let app = App::new()
             .wrap(from_fn(middlewares::actor_context))
-            .wrap(Logger::default())
             .wrap(middlewares::TracingMiddleware::new_with_trust(
                 proxy_trust.clone(),
             ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use utoipa::OpenApi;
 #[cfg(feature = "swagger-ui")]
 use utoipa_swagger_ui::SwaggerUi;
 
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use crate::api::openapi::openapi_json as openapi_json_handler;
 use crate::config::{get_config, token_hash_key_is_ephemeral};
@@ -77,18 +77,6 @@ async fn main() -> std::io::Result<()> {
         );
     }
 
-    debug!(
-        message = "Starting server",
-        bind_ip = %config.bind_ip,
-        port = config.port,
-        ssl = config.tls_cert_path.is_some() && config.tls_key_path.is_some(),
-        log_level = %config.log_level,
-        actix_workers = config.actix_workers,
-        task_workers = config.task_workers,
-        task_poll_interval_ms = config.task_poll_interval_ms,
-        db_pool_size = config.db_pool_size,
-    );
-
     utilities::auth::initialize_dummy_password_hash();
     let pool = init_pool(&config.database_url, config.db_pool_size);
 
@@ -98,6 +86,18 @@ async fn main() -> std::io::Result<()> {
             EXIT_CODE_INIT_ERROR,
         );
     }
+
+    let active_event_sinks =
+        match db::traits::event_subscription::enabled_event_sink_count(&pool).await {
+            Ok(count) => Some(count),
+            Err(error) => {
+                warn!(
+                    message = "failed to count active event sinks for startup metadata",
+                    error = %error,
+                );
+                None
+            }
+        };
 
     ensure_task_worker_running(pool.clone());
     ensure_event_fanout_worker_running(pool.clone());
@@ -111,13 +111,13 @@ async fn main() -> std::io::Result<()> {
     let server = HttpServer::new(move || {
         let app = App::new()
             .wrap(from_fn(middlewares::actor_context))
-            .wrap(middlewares::TracingMiddleware::new_with_trust(
-                proxy_trust.clone(),
-            ))
             // Actix runs the last registered middleware first. Reject disallowed
             // clients before bearer-token resolution can touch the database.
             .wrap(middlewares::ClientAllowlistMiddleware::new_with_trust(
                 client_allowlist.clone(),
+                proxy_trust.clone(),
+            ))
+            .wrap(middlewares::TracingMiddleware::new_with_trust(
                 proxy_trust.clone(),
             ))
             .app_data(Data::new(app_config.clone()))
@@ -159,11 +159,25 @@ async fn main() -> std::io::Result<()> {
             "TLS key specified but certificate is missing. Please provide both --tls-cert-path and --tls-key-path",
             EXIT_CODE_TLS_ERROR,
         ),
-        _ => {
-            info!("Server binding to http://{}", bind_address);
-            server.bind(bind_address)?
-        }
+        _ => server.bind(&bind_address)?,
     };
+
+    info!(
+        message = "server startup",
+        version = env!("CARGO_PKG_VERSION"),
+        git_sha = logger::build_git_sha(),
+        bind_address = bind_address.as_str(),
+        tls = config.tls_cert_path.is_some() && config.tls_key_path.is_some(),
+        log_format = "json",
+        log_level = config.log_level.as_str(),
+        actix_workers = config.actix_workers,
+        task_workers = config.task_workers,
+        event_fanout_workers = config.event_fanout_workers,
+        event_delivery_workers = config.event_delivery_workers,
+        db_backend = "postgresql",
+        authorization_backend = "database_permissions",
+        active_event_sinks,
+    );
 
     server.workers(config.actix_workers).run().await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,13 +20,7 @@ mod tls;
 mod traits;
 mod utilities;
 
-use actix_web::{
-    App, HttpServer,
-    middleware::{Logger, from_fn},
-    web,
-    web::Data,
-    web::JsonConfig,
-};
+use actix_web::{App, HttpServer, middleware::from_fn, web, web::Data, web::JsonConfig};
 use db::init_pool;
 #[cfg(feature = "swagger-ui")]
 use utoipa::OpenApi;
@@ -34,9 +28,6 @@ use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
 use tracing::{debug, info, warn};
-use tracing_subscriber::{
-    filter::EnvFilter, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
-};
 
 use crate::api::openapi::openapi_json as openapi_json_handler;
 use crate::config::{get_config, token_hash_key_is_ephemeral};
@@ -69,29 +60,15 @@ async fn main() -> std::io::Result<()> {
             EXIT_CODE_CONFIG_ERROR,
         ),
     };
-    let filter = if is_valid_log_level(&config.log_level) {
-        EnvFilter::try_new(&config.log_level).unwrap_or_else(|_e| {
-            fatal_error(
-                &format!("Error parsing log level: {}", &config.log_level),
-                EXIT_CODE_CONFIG_ERROR,
-            )
-        })
-    } else {
+    if !is_valid_log_level(&config.log_level) {
         fatal_error(
             &format!("Invalid log level: {}", config.log_level),
             EXIT_CODE_CONFIG_ERROR,
-        )
-    };
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .json()
-                .with_span_events(FmtSpan::CLOSE)
-                .event_format(logger::HubuumLoggingFormat),
-        )
-        .init();
+        );
+    }
+    if let Err(err) = logger::init_json_logging(&config.log_level) {
+        fatal_error(&err, EXIT_CODE_CONFIG_ERROR);
+    }
 
     if token_hash_key_is_ephemeral() {
         warn!(

--- a/src/middlewares/actor_context.rs
+++ b/src/middlewares/actor_context.rs
@@ -6,6 +6,7 @@ use actix_web::{Error, HttpMessage};
 
 use crate::db::traits::Status;
 use crate::db::{DbPool, with_actor_scope};
+use crate::middlewares::tracing::record_principal_on_current_span;
 use crate::models::token::{PrincipalToken, Token};
 
 /// Outcome of resolving the bearer token once per request. Stored in request
@@ -63,6 +64,9 @@ pub async fn actor_context(
         ResolvedAuth::Authenticated { token_meta, .. } => Some(token_meta.principal_id),
         _ => None,
     };
+    if let Some(principal_id) = actor {
+        record_principal_on_current_span(principal_id);
+    }
     req.extensions_mut().insert(resolved);
     let res = with_actor_scope(actor, next.call(req)).await?;
     Ok(res.map_into_boxed_body())

--- a/src/middlewares/client_allowlist.rs
+++ b/src/middlewares/client_allowlist.rs
@@ -1,6 +1,6 @@
 use actix_service::{Service, Transform};
 use actix_web::{
-    Error, HttpRequest, dev::ServiceRequest, dev::ServiceResponse, error::ErrorForbidden,
+    Error, HttpRequest, HttpResponse, body::EitherBody, dev::ServiceRequest, dev::ServiceResponse,
     http::header::HeaderMap,
 };
 use futures_util::future::{self, LocalBoxFuture, Ready};
@@ -73,7 +73,7 @@ where
     S::Future: 'static,
     B: 'static,
 {
-    type Response = ServiceResponse<B>;
+    type Response = ServiceResponse<EitherBody<B>>;
     type Error = Error;
     type Transform = ClientAllowlistMiddlewareService<S>;
     type InitError = ();
@@ -99,7 +99,7 @@ where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
     B: 'static,
 {
-    type Response = ServiceResponse<B>;
+    type Response = ServiceResponse<EitherBody<B>>;
     type Error = Error;
     type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -109,20 +109,30 @@ where
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
         if is_probe_path(req.path()) {
-            return Box::pin(self.service.call(req));
+            let fut = self.service.call(req);
+            return Box::pin(async move { fut.await.map(ServiceResponse::map_into_left_body) });
         }
 
         let client_ip = extract_client_ip(&req, &self.proxy_trust);
 
         match client_ip {
-            Some(ip) if self.allowlist.allows(ip) => Box::pin(self.service.call(req)),
+            Some(ip) if self.allowlist.allows(ip) => {
+                let fut = self.service.call(req);
+                Box::pin(async move { fut.await.map(ServiceResponse::map_into_left_body) })
+            }
             Some(ip) => {
                 warn!(message = "Rejected request from disallowed IP", client_ip = %ip);
-                Box::pin(async { Err(ErrorForbidden("Client not allowed")) })
+                let response = req
+                    .into_response(HttpResponse::Forbidden().body("Client not allowed"))
+                    .map_into_right_body();
+                Box::pin(async { Ok(response) })
             }
             None => {
                 warn!(message = "Rejected request with missing client IP");
-                Box::pin(async { Err(ErrorForbidden("Client not allowed")) })
+                let response = req
+                    .into_response(HttpResponse::Forbidden().body("Client not allowed"))
+                    .map_into_right_body();
+                Box::pin(async { Ok(response) })
             }
         }
     }

--- a/src/middlewares/tracing.rs
+++ b/src/middlewares/tracing.rs
@@ -1,8 +1,7 @@
 use actix_service::{Service, Transform};
 use actix_web::{
     Error, HttpMessage,
-    dev::ServiceRequest,
-    dev::ServiceResponse,
+    dev::{ServiceRequest, ServiceResponse},
     http::header::{HeaderName, HeaderValue},
 };
 use futures_util::future::{self, LocalBoxFuture, Ready};
@@ -17,9 +16,38 @@ use super::client_allowlist::{ProxyTrust, extract_client_ip};
 
 const CORRELATION_ID: HeaderName = HeaderName::from_static("x-correlation-id");
 const REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
+const MAX_CORRELATION_ID_LEN: usize = 128;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CorrelationId(String);
+
+impl CorrelationId {
+    fn from_request(req: &ServiceRequest) -> Result<Option<Self>, &'static str> {
+        let Some(value) = req.headers().get(&CORRELATION_ID) else {
+            return Ok(None);
+        };
+        let value = value
+            .to_str()
+            .map_err(|_| "correlation ID must contain visible ASCII characters")?;
+        if value.is_empty() {
+            return Err("correlation ID must not be empty");
+        }
+        if value.len() > MAX_CORRELATION_ID_LEN {
+            return Err("correlation ID exceeds 128 bytes");
+        }
+        if !value.bytes().all(|byte| byte.is_ascii_graphic()) {
+            return Err("correlation ID must contain visible ASCII characters without whitespace");
+        }
+        Ok(Some(Self(value.to_string())))
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
 
 pub(crate) fn record_principal_on_current_span(principal_id: i32) {
-    Span::current().record("principal", principal_id);
+    Span::current().record("principal_id", principal_id);
 }
 
 fn elapsed_millis(start_time: Instant) -> u64 {
@@ -96,21 +124,24 @@ where
         let request_id = Uuid::new_v4();
         let request_id_s = request_id.to_string();
 
-        // Extract the correlation ID from the request headers, could be None
-        let correlation_id = req
-            .headers()
-            .get(&CORRELATION_ID)
-            .and_then(|hv| hv.to_str().ok())
-            .map(str::to_string);
+        let (correlation_id, invalid_correlation_reason) = match CorrelationId::from_request(&req) {
+            Ok(correlation_id) => (correlation_id, None),
+            Err(reason) => (None, Some(reason)),
+        };
         let span = span!(
             Level::INFO,
             "request",
             request_id = %request_id_s,
             correlation_id = field::Empty,
-            principal = field::Empty
+            principal_id = field::Empty
         );
-        if let Some(correlation_id) = correlation_id.as_deref() {
-            span.record("correlation_id", correlation_id);
+        if let Some(correlation_id) = correlation_id.as_ref() {
+            span.record("correlation_id", correlation_id.as_str());
+        }
+        if let Some(reason) = invalid_correlation_reason {
+            span.in_scope(|| {
+                tracing::warn!(message = "invalid correlation ID ignored", reason);
+            });
         }
 
         let method = req.method().to_string();
@@ -120,12 +151,14 @@ where
         req.extensions_mut()
             .insert(RequestProvenance::new_with_client_ip(
                 request_id,
-                correlation_id.clone(),
+                correlation_id
+                    .as_ref()
+                    .map(|correlation_id| correlation_id.as_str().to_string()),
                 client_ip,
             ));
 
         let start_time = Instant::now();
-        let fut = self.service.call(req);
+        let fut = span.in_scope(|| self.service.call(req));
 
         Box::pin(
             async move {
@@ -133,14 +166,29 @@ where
                     Ok(res) => res,
                     Err(err) => {
                         let elapsed_ms = elapsed_millis(start_time);
-                        error!(
-                            message = "request complete",
-                            method = method.as_str(),
-                            path = path.as_str(),
-                            client_ip = client_ip_s.as_deref(),
-                            elapsed_ms,
-                            error = %err,
-                        );
+                        let status = err.as_response_error().status_code();
+                        let status_code = status.as_u16();
+                        if status.is_server_error() {
+                            error!(
+                                message = "request complete",
+                                method = method.as_str(),
+                                path = path.as_str(),
+                                status = status_code,
+                                client_ip = client_ip_s.as_deref(),
+                                elapsed_ms,
+                                error = %err,
+                            );
+                        } else {
+                            warn!(
+                                message = "request complete",
+                                method = method.as_str(),
+                                path = path.as_str(),
+                                status = status_code,
+                                client_ip = client_ip_s.as_deref(),
+                                elapsed_ms,
+                                error = %err,
+                            );
+                        }
                         return Err(err);
                     }
                 };
@@ -156,6 +204,7 @@ where
                     res.headers_mut().insert(
                         CORRELATION_ID,
                         correlation_id
+                            .as_str()
                             .parse()
                             .unwrap_or_else(|_| HeaderValue::from_static("<failed>")),
                     );

--- a/src/middlewares/tracing.rs
+++ b/src/middlewares/tracing.rs
@@ -8,7 +8,7 @@ use actix_web::{
 use futures_util::future::{self, LocalBoxFuture, Ready};
 use std::task::{Context, Poll};
 use std::time::Instant;
-use tracing::{Instrument, Level, info, span};
+use tracing::{Instrument, Level, Span, error, field, info, span, warn};
 use uuid::Uuid;
 
 use crate::events::RequestProvenance;
@@ -17,6 +17,18 @@ use super::client_allowlist::{ProxyTrust, extract_client_ip};
 
 const CORRELATION_ID: HeaderName = HeaderName::from_static("x-correlation-id");
 const REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
+
+pub(crate) fn record_principal_on_current_span(principal_id: i32) {
+    Span::current().record("principal", principal_id);
+}
+
+fn elapsed_millis(start_time: Instant) -> u64 {
+    start_time
+        .elapsed()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
 
 // Middleware factory
 #[derive(Clone)]
@@ -90,8 +102,16 @@ where
             .get(&CORRELATION_ID)
             .and_then(|hv| hv.to_str().ok())
             .map(str::to_string);
-        let correlation_id_log_value = correlation_id.as_deref().unwrap_or_default();
-        let span = span!(Level::INFO, "request", request_id = %request_id_s, correlation_id = correlation_id_log_value);
+        let span = span!(
+            Level::INFO,
+            "request",
+            request_id = %request_id_s,
+            correlation_id = field::Empty,
+            principal = field::Empty
+        );
+        if let Some(correlation_id) = correlation_id.as_deref() {
+            span.record("correlation_id", correlation_id);
+        }
 
         let method = req.method().to_string();
         let path = req.path().to_string();
@@ -105,25 +125,73 @@ where
             ));
 
         let start_time = Instant::now();
-        info!(request_id = %request_id_s, correlation_id = correlation_id_log_value, message = "Request start", method = &method, path = &path, client_ip = client_ip_s.as_deref());
-
         let fut = self.service.call(req);
 
         Box::pin(
             async move {
-                let mut res = fut.await?;
+                let mut res = match fut.await {
+                    Ok(res) => res,
+                    Err(err) => {
+                        let elapsed_ms = elapsed_millis(start_time);
+                        error!(
+                            message = "request complete",
+                            method = method.as_str(),
+                            path = path.as_str(),
+                            client_ip = client_ip_s.as_deref(),
+                            elapsed_ms,
+                            error = %err,
+                        );
+                        return Err(err);
+                    }
+                };
 
                 // Add the request ID and correlation ID to the response headers
-                res.headers_mut().insert(REQUEST_ID, request_id_s.parse().unwrap_or_else(|_| HeaderValue::from_static("<failed>")));
+                res.headers_mut().insert(
+                    REQUEST_ID,
+                    request_id_s
+                        .parse()
+                        .unwrap_or_else(|_| HeaderValue::from_static("<failed>")),
+                );
                 if let Some(correlation_id) = correlation_id {
                     res.headers_mut().insert(
                         CORRELATION_ID,
-                        correlation_id.parse().unwrap_or_else(|_| HeaderValue::from_static("<failed>")),
+                        correlation_id
+                            .parse()
+                            .unwrap_or_else(|_| HeaderValue::from_static("<failed>")),
                     );
                 }
 
-                let elapsed_time = start_time.elapsed();
-                info!(message = "Request end", method = &method, path = &path, client_ip = client_ip_s.as_deref(), run_time = ?elapsed_time);
+                let elapsed_ms = elapsed_millis(start_time);
+                let status = res.status();
+                let status_code = status.as_u16();
+                if status.is_server_error() {
+                    error!(
+                        message = "request complete",
+                        method = method.as_str(),
+                        path = path.as_str(),
+                        status = status_code,
+                        client_ip = client_ip_s.as_deref(),
+                        elapsed_ms,
+                    );
+                } else if status.is_client_error() {
+                    warn!(
+                        message = "request complete",
+                        method = method.as_str(),
+                        path = path.as_str(),
+                        status = status_code,
+                        client_ip = client_ip_s.as_deref(),
+                        elapsed_ms,
+                    );
+                } else {
+                    info!(
+                        message = "request complete",
+                        method = method.as_str(),
+                        path = path.as_str(),
+                        status = status_code,
+                        client_ip = client_ip_s.as_deref(),
+                        elapsed_ms,
+                    );
+                }
 
                 Ok(res)
             }

--- a/src/models/permissions.rs
+++ b/src/models/permissions.rs
@@ -123,6 +123,74 @@ impl Permissions {
             _ => Err(ApiError::BadRequest(format!("Invalid permission: '{s}'"))),
         }
     }
+
+    pub fn operation_action(self) -> &'static str {
+        match self {
+            Self::ReadCollection
+            | Self::ReadClass
+            | Self::ReadObject
+            | Self::ReadClassRelation
+            | Self::ReadObjectRelation
+            | Self::ReadTemplate
+            | Self::ReadRemoteTarget
+            | Self::ReadAudit => "read",
+            Self::CreateClass
+            | Self::CreateObject
+            | Self::CreateClassRelation
+            | Self::CreateObjectRelation
+            | Self::CreateTemplate
+            | Self::CreateRemoteTarget => "create",
+            Self::UpdateCollection
+            | Self::UpdateClass
+            | Self::UpdateObject
+            | Self::UpdateClassRelation
+            | Self::UpdateObjectRelation
+            | Self::UpdateTemplate
+            | Self::UpdateRemoteTarget => "update",
+            Self::DeleteCollection
+            | Self::DeleteClass
+            | Self::DeleteObject
+            | Self::DeleteClassRelation
+            | Self::DeleteObjectRelation
+            | Self::DeleteTemplate
+            | Self::DeleteRemoteTarget => "delete",
+            Self::DelegateCollection => "delegate",
+            Self::ExecuteRemoteTarget => "execute",
+            Self::ManageEventSubscription => "manage",
+        }
+    }
+
+    pub fn entity_type(self) -> &'static str {
+        match self {
+            Self::ReadCollection
+            | Self::UpdateCollection
+            | Self::DeleteCollection
+            | Self::DelegateCollection => "collection",
+            Self::CreateClass | Self::ReadClass | Self::UpdateClass | Self::DeleteClass => "class",
+            Self::CreateObject | Self::ReadObject | Self::UpdateObject | Self::DeleteObject => {
+                "object"
+            }
+            Self::CreateClassRelation
+            | Self::ReadClassRelation
+            | Self::UpdateClassRelation
+            | Self::DeleteClassRelation => "class_relation",
+            Self::CreateObjectRelation
+            | Self::ReadObjectRelation
+            | Self::UpdateObjectRelation
+            | Self::DeleteObjectRelation => "object_relation",
+            Self::ReadTemplate
+            | Self::CreateTemplate
+            | Self::UpdateTemplate
+            | Self::DeleteTemplate => "export_template",
+            Self::ReadRemoteTarget
+            | Self::CreateRemoteTarget
+            | Self::UpdateRemoteTarget
+            | Self::DeleteRemoteTarget
+            | Self::ExecuteRemoteTarget => "remote_target",
+            Self::ReadAudit => "audit_event",
+            Self::ManageEventSubscription => "event_subscription",
+        }
+    }
 }
 impl Display for Permissions {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/tests/api/v1/request_and_correlation.rs
+++ b/src/tests/api/v1/request_and_correlation.rs
@@ -8,13 +8,15 @@ mod tests {
         test, web,
     };
     use serde_json::json;
+    use std::str::FromStr;
     use tracing_subscriber::layer::SubscriberExt;
 
+    use crate::config::ClientAllowlist;
     use crate::events::RequestProvenance;
     use crate::logger::{HubuumLoggingFormat, test_support::JsonLogWriter};
-    use crate::middlewares::TracingMiddleware;
     use crate::middlewares::actor_context;
     use crate::middlewares::tracing::record_principal_on_current_span;
+    use crate::middlewares::{ClientAllowlistMiddleware, TracingMiddleware};
     use crate::tests::api_operations::get_request_with_correlation;
     use crate::tests::asserts::assert_response_status;
     use crate::tests::{TestContext, test_context};
@@ -22,15 +24,20 @@ mod tests {
     const ENDPOINT: &str = "/api/v1/classes/";
 
     #[rstest]
-    #[case::with_correlation_id(Some("test-correlation-id"))]
-    #[case::with_empty_correlation_id(Some(""))]
-    #[case::with_long_correlation_id(Some(
-        "test-correlation-id-long with spaces & weird characters"
-    ))]
-    #[case::without_correlation_id(None)]
+    #[case::with_correlation_id(Some("test-correlation-id"), true)]
+    #[case::with_empty_correlation_id(Some(""), false)]
+    #[case::with_whitespace_correlation_id(Some("correlation id"), false)]
+    #[case::with_overlong_correlation_id(
+        Some(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ),
+        false
+    )]
+    #[case::without_correlation_id(None, false)]
     #[actix_web::test]
     async fn test_with_correlation_id(
         #[case] correlation_target: Option<&str>,
+        #[case] echoed: bool,
         #[future(awt)] test_context: TestContext,
     ) {
         let resp = get_request_with_correlation(
@@ -43,14 +50,14 @@ mod tests {
 
         let resp = assert_response_status(resp, StatusCode::OK).await;
 
-        match correlation_target {
-            Some(correlation_id) => {
+        match (correlation_target, echoed) {
+            (Some(correlation_id), true) => {
                 assert_eq!(
                     resp.headers().get("x-correlation-id"),
                     Some(&HeaderValue::from_str(correlation_id).unwrap())
                 );
             }
-            None => {
+            _ => {
                 assert!(resp.headers().get("x-correlation-id").is_none());
             }
         }
@@ -187,7 +194,7 @@ mod tests {
             .iter()
             .find(|event| event["message"] == "request complete")
             .expect("request completion log");
-        assert_eq!(event["principal"], 77);
+        assert_eq!(event["principal_id"], 77);
     }
 
     #[actix_web::test]
@@ -218,6 +225,40 @@ mod tests {
             .iter()
             .find(|event| event["message"] == "request complete")
             .expect("request completion log");
-        assert_eq!(event["principal"], test_context.admin_user.id);
+        assert_eq!(event["principal_id"], test_context.admin_user.id);
+    }
+
+    #[actix_web::test]
+    async fn production_middleware_stack_traces_allowlist_rejections() {
+        let (writer, _guard) = capture_request_logs();
+        let app = test::init_service(
+            App::new()
+                .wrap(actix_web::middleware::from_fn(actor_context))
+                .wrap(ClientAllowlistMiddleware::new(
+                    ClientAllowlist::from_str("10.0.0.0/24").expect("allowlist"),
+                ))
+                .wrap(TracingMiddleware::new())
+                .route("/denied", web::get().to(ok_handler)),
+        )
+        .await;
+
+        let resp = test::TestRequest::get()
+            .uri("/denied")
+            .peer_addr("192.0.2.10:8000".parse().expect("peer address"))
+            .send_request(&app)
+            .await;
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert!(resp.headers().get("x-request-id").is_some());
+
+        let event = writer
+            .output()
+            .into_iter()
+            .find(|event| event["message"] == "request complete")
+            .expect("request completion log");
+        assert_eq!(event["severity"], "WARN");
+        assert_eq!(event["status"], StatusCode::FORBIDDEN.as_u16());
+        assert_eq!(event["path"], "/denied");
+        assert!(event["request_id"].as_str().is_some());
     }
 }

--- a/src/tests/api/v1/request_and_correlation.rs
+++ b/src/tests/api/v1/request_and_correlation.rs
@@ -13,6 +13,7 @@ mod tests {
     use crate::events::RequestProvenance;
     use crate::logger::{HubuumLoggingFormat, test_support::JsonLogWriter};
     use crate::middlewares::TracingMiddleware;
+    use crate::middlewares::actor_context;
     use crate::middlewares::tracing::record_principal_on_current_span;
     use crate::tests::api_operations::get_request_with_correlation;
     use crate::tests::asserts::assert_response_status;
@@ -187,5 +188,36 @@ mod tests {
             .find(|event| event["message"] == "request complete")
             .expect("request completion log");
         assert_eq!(event["principal"], 77);
+    }
+
+    #[actix_web::test]
+    async fn production_middleware_stack_records_authenticated_principal_on_request_logs() {
+        let test_context = TestContext::new().await;
+        let (writer, _guard) = capture_request_logs();
+        let app = test::init_service(
+            App::new()
+                .wrap(actix_web::middleware::from_fn(actor_context))
+                .wrap(TracingMiddleware::new())
+                .app_data(test_context.pool.clone())
+                .route("/principal", web::get().to(ok_handler)),
+        )
+        .await;
+
+        let resp = test::TestRequest::get()
+            .insert_header((
+                actix_web::http::header::AUTHORIZATION,
+                format!("Bearer {}", test_context.admin_token),
+            ))
+            .uri("/principal")
+            .send_request(&app)
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let logs = writer.output();
+        let event = logs
+            .iter()
+            .find(|event| event["message"] == "request complete")
+            .expect("request completion log");
+        assert_eq!(event["principal"], test_context.admin_user.id);
     }
 }

--- a/src/tests/api/v1/request_and_correlation.rs
+++ b/src/tests/api/v1/request_and_correlation.rs
@@ -8,9 +8,12 @@ mod tests {
         test, web,
     };
     use serde_json::json;
+    use tracing_subscriber::layer::SubscriberExt;
 
     use crate::events::RequestProvenance;
+    use crate::logger::{HubuumLoggingFormat, test_support::JsonLogWriter};
     use crate::middlewares::TracingMiddleware;
+    use crate::middlewares::tracing::record_principal_on_current_span;
     use crate::tests::api_operations::get_request_with_correlation;
     use crate::tests::asserts::assert_response_status;
     use crate::tests::{TestContext, test_context};
@@ -90,5 +93,99 @@ mod tests {
 
         assert_eq!(body["request_id"], response_request_id);
         assert_eq!(body["correlation_id"], "context-correlation");
+    }
+
+    fn capture_request_logs() -> (JsonLogWriter, tracing::dispatcher::DefaultGuard) {
+        let writer = JsonLogWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(writer.clone())
+                .event_format(HubuumLoggingFormat),
+        );
+        let guard = tracing::subscriber::set_default(subscriber);
+        (writer, guard)
+    }
+
+    async fn ok_handler() -> HttpResponse {
+        HttpResponse::Ok().finish()
+    }
+
+    async fn bad_request_handler() -> HttpResponse {
+        HttpResponse::BadRequest().finish()
+    }
+
+    async fn server_error_handler() -> HttpResponse {
+        HttpResponse::InternalServerError().finish()
+    }
+
+    async fn principal_handler() -> HttpResponse {
+        record_principal_on_current_span(77);
+        HttpResponse::Ok().finish()
+    }
+
+    #[rstest]
+    #[case::success("/ok", StatusCode::OK, "INFO")]
+    #[case::client_error("/bad-request", StatusCode::BAD_REQUEST, "WARN")]
+    #[case::server_error("/server-error", StatusCode::INTERNAL_SERVER_ERROR, "ERROR")]
+    #[actix_web::test]
+    async fn tracing_middleware_logs_request_completion_by_status(
+        #[case] path: &str,
+        #[case] expected_status: StatusCode,
+        #[case] expected_severity: &str,
+    ) {
+        let (writer, _guard) = capture_request_logs();
+        let app = test::init_service(
+            App::new()
+                .wrap(TracingMiddleware::new())
+                .route("/ok", web::get().to(ok_handler))
+                .route("/bad-request", web::get().to(bad_request_handler))
+                .route("/server-error", web::get().to(server_error_handler)),
+        )
+        .await;
+
+        let resp = test::TestRequest::get()
+            .insert_header(("x-correlation-id", "request-log-correlation"))
+            .uri(path)
+            .send_request(&app)
+            .await;
+        assert_eq!(resp.status(), expected_status);
+
+        let logs = writer.output();
+        let event = logs
+            .iter()
+            .find(|event| event["message"] == "request complete")
+            .expect("request completion log");
+        assert_eq!(event["severity"], expected_severity);
+        assert_eq!(event["method"], "GET");
+        assert_eq!(event["path"], path);
+        assert_eq!(event["status"], expected_status.as_u16());
+        assert_eq!(event["correlation_id"], "request-log-correlation");
+        assert!(event["request_id"].as_str().is_some());
+        assert!(event["elapsed_ms"].as_u64().is_some());
+    }
+
+    #[actix_web::test]
+    async fn tracing_middleware_includes_recorded_principal_on_request_logs() {
+        let (writer, _guard) = capture_request_logs();
+        let app = test::init_service(
+            App::new()
+                .wrap(TracingMiddleware::new())
+                .route("/principal", web::get().to(principal_handler)),
+        )
+        .await;
+
+        let resp = test::TestRequest::get()
+            .uri("/principal")
+            .send_request(&app)
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let logs = writer.output();
+        let event = logs
+            .iter()
+            .find(|event| event["message"] == "request complete")
+            .expect("request completion log");
+        assert_eq!(event["principal"], 77);
     }
 }

--- a/src/tests/api_operations.rs
+++ b/src/tests/api_operations.rs
@@ -35,12 +35,14 @@ pub async fn get_request_with_correlation(
             .uri(endpoint)
             .send_request(&app)
             .await
+            .map_into_boxed_body()
     } else {
         test::TestRequest::get()
             .insert_header(create_token_header(token))
             .uri(endpoint)
             .send_request(&app)
             .await
+            .map_into_boxed_body()
     }
 }
 
@@ -81,7 +83,10 @@ where
         req = req.insert_header((name, value));
     }
 
-    req.set_json(&content).send_request(&app).await
+    req.set_json(&content)
+        .send_request(&app)
+        .await
+        .map_into_boxed_body()
 }
 
 pub async fn post_request<T>(
@@ -117,6 +122,7 @@ pub async fn delete_request(
         .uri(endpoint)
         .send_request(&app)
         .await
+        .map_into_boxed_body()
 }
 
 pub async fn patch_request<T>(
@@ -145,6 +151,7 @@ where
         .set_json(&content) // Make sure to reference content
         .send_request(&app)
         .await
+        .map_into_boxed_body()
 }
 
 pub async fn put_request<T>(
@@ -173,4 +180,5 @@ where
         .set_json(&content)
         .send_request(&app)
         .await
+        .map_into_boxed_body()
 }

--- a/src/tests/api_operations.rs
+++ b/src/tests/api_operations.rs
@@ -16,10 +16,10 @@ pub async fn get_request_with_correlation(
 ) -> actix_web::dev::ServiceResponse {
     let app = test::init_service(
         App::new()
-            .wrap(TracingMiddleware::new())
             .wrap(actix_web::middleware::from_fn(
                 crate::middlewares::actor_context,
             ))
+            .wrap(TracingMiddleware::new())
             .app_data(Data::new(pool.clone()))
             .configure(prod_api::config),
     )
@@ -64,10 +64,10 @@ where
 {
     let app = test::init_service(
         App::new()
-            .wrap(TracingMiddleware::new())
             .wrap(actix_web::middleware::from_fn(
                 crate::middlewares::actor_context,
             ))
+            .wrap(TracingMiddleware::new())
             .app_data(Data::new(pool.clone()))
             .configure(prod_api::config),
     )
@@ -103,10 +103,10 @@ pub async fn delete_request(
 ) -> actix_web::dev::ServiceResponse {
     let app = test::init_service(
         App::new()
-            .wrap(TracingMiddleware::new())
             .wrap(actix_web::middleware::from_fn(
                 crate::middlewares::actor_context,
             ))
+            .wrap(TracingMiddleware::new())
             .app_data(Data::new(pool.clone()))
             .configure(prod_api::config),
     )
@@ -130,10 +130,10 @@ where
 {
     let app = test::init_service(
         App::new()
-            .wrap(TracingMiddleware::new())
             .wrap(actix_web::middleware::from_fn(
                 crate::middlewares::actor_context,
             ))
+            .wrap(TracingMiddleware::new())
             .app_data(Data::new(pool.clone()))
             .configure(prod_api::config),
     )
@@ -158,10 +158,10 @@ where
 {
     let app = test::init_service(
         App::new()
-            .wrap(TracingMiddleware::new())
             .wrap(actix_web::middleware::from_fn(
                 crate::middlewares::actor_context,
             ))
+            .wrap(TracingMiddleware::new())
             .app_data(Data::new(pool.clone()))
             .configure(prod_api::config),
     )

--- a/src/tests/client_allowlist.rs
+++ b/src/tests/client_allowlist.rs
@@ -60,13 +60,8 @@ mod tests {
             .insert_header(("x-forwarded-for", "192.168.1.10"))
             .to_request();
 
-        let resp = test::try_call_service(&app, req).await;
-        assert!(resp.is_err());
-        let err = resp.unwrap_err();
-        assert_eq!(
-            err.error_response().status(),
-            actix_web::http::StatusCode::FORBIDDEN
-        );
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
     }
 
     #[actix_web::test]
@@ -89,12 +84,8 @@ mod tests {
             .insert_header(("x-forwarded-for", "10.0.0.42"))
             .to_request();
 
-        let resp = test::try_call_service(&app, req).await;
-        assert!(resp.is_err());
-        assert_eq!(
-            resp.unwrap_err().error_response().status(),
-            actix_web::http::StatusCode::FORBIDDEN
-        );
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
     }
 
     #[actix_web::test]
@@ -138,8 +129,8 @@ mod tests {
             .insert_header(("x-forwarded-for", "10.0.0.42"))
             .to_request();
 
-        let resp = test::try_call_service(&app, req).await;
-        assert!(resp.is_err());
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
     }
 
     #[actix_web::test]

--- a/tests/admin_cli.rs
+++ b/tests/admin_cli.rs
@@ -17,6 +17,18 @@ fn admin_help_exposes_reset_password() {
 }
 
 #[test]
+fn invalid_log_level_is_reported_before_logging_is_initialized() {
+    let output = Command::new(admin_binary())
+        .args(["--log-level", "not-a-level"])
+        .output()
+        .expect("hubuum-admin with an invalid log level should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Invalid log level: not-a-level"));
+}
+
+#[test]
 fn reset_password_does_not_parse_server_config_arguments() {
     let output = Command::new(admin_binary())
         .args([


### PR DESCRIPTION
## Summary

- centralize newline-delimited JSON logging for the server and admin CLI; JSON is the only supported operational log format
- make request tracing the outermost production middleware so normal responses, service errors, and early allowlist rejections receive request IDs and status-aware completion records
- validate client correlation IDs before echoing or recording them and propagate authenticated `principal_id` consistently
- emit mutation-complete records only after successful transaction commit, with stable audit-catalog entity/action labels
- enrich authorization decisions with action, entity, collection, permission, and reason context while removing token fragments from operational logs
- emit one structured startup record with version/build SHA, listener/TLS state, worker/backend configuration, and active event-sink count
- document the conventions and pass the build Git SHA into published container builds

Fixes #86

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `source .env && ./run_tests.sh` (941 unit/API tests, 2 CLI tests, and 2 doctests passed; 2 pre-existing tests ignored)
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`
