### PR TITLE
Harden authentication and bound expensive workloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/hubuum-outbound-http/src/lib.rs
+++ b/crates/hubuum-outbound-http/src/lib.rs
@@ -14,13 +14,34 @@
 //! The `dangerous_*` request toggles exist for tightly scoped test/internal
 //! callers and should not be enabled from production paths.
 
+use std::collections::HashMap;
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
 use ipnet::IpNet;
 use reqwest::Url;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+
+const MAX_CACHED_CLIENTS: usize = 128;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ClientCacheKey {
+    host: String,
+    addresses: Vec<SocketAddr>,
+    accept_invalid_certs: bool,
+}
+
+struct CachedClient {
+    client: reqwest::Client,
+    last_used: u64,
+}
+
+static CLIENT_CACHE: LazyLock<Mutex<HashMap<ClientCacheKey, CachedClient>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static CLIENT_CACHE_CLOCK: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug)]
 pub enum OutboundHttpError {
@@ -366,29 +387,25 @@ impl OutboundResponse {
 
 async fn execute(request: OutboundRequest) -> Result<OutboundResponse, OutboundHttpError> {
     let url_parts = validate_outbound_url(&request.url)?;
-    let screened_addrs = screen_host(
+    let mut screened_addrs = screen_host(
         &url_parts.host,
         url_parts.port,
         request.allow_private_targets,
         request.dangerous_allow_localhost,
     )
     .await?;
+    screened_addrs.sort_unstable();
+    screened_addrs.dedup();
 
-    let client_builder = reqwest::Client::builder()
-        .timeout(request.timeout)
-        .redirect(reqwest::redirect::Policy::none())
-        .resolve_to_addrs(&url_parts.host, &screened_addrs);
-    let client_builder = if request.dangerous_accept_invalid_certs {
-        client_builder.danger_accept_invalid_certs(true)
-    } else {
-        client_builder
-    };
-    let client = client_builder
-        .build()
-        .map_err(|error| OutboundHttpError::ClientBuild(error.to_string()))?;
+    let client = cached_client(
+        &url_parts.host,
+        &screened_addrs,
+        request.dangerous_accept_invalid_certs,
+    )?;
 
     let mut request_builder = client
         .request(request.method.as_reqwest(), url_parts.url.clone())
+        .timeout(request.timeout)
         .headers(request.headers.into_inner());
     if let Some(body) = request.body {
         request_builder = request_builder.body(body);
@@ -410,6 +427,54 @@ async fn execute(request: OutboundRequest) -> Result<OutboundResponse, OutboundH
         duration_ms,
         url: url_parts.url.to_string(),
     })
+}
+
+fn cached_client(
+    host: &str,
+    addresses: &[SocketAddr],
+    accept_invalid_certs: bool,
+) -> Result<reqwest::Client, OutboundHttpError> {
+    let key = ClientCacheKey {
+        host: host.to_ascii_lowercase(),
+        addresses: addresses.to_vec(),
+        accept_invalid_certs,
+    };
+    let now = CLIENT_CACHE_CLOCK.fetch_add(1, Ordering::Relaxed);
+    let mut cache = CLIENT_CACHE
+        .lock()
+        .map_err(|_| OutboundHttpError::ClientBuild("client cache lock poisoned".to_string()))?;
+
+    if let Some(entry) = cache.get_mut(&key) {
+        entry.last_used = now;
+        return Ok(entry.client.clone());
+    }
+
+    let mut builder = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .resolve_to_addrs(host, addresses);
+    if accept_invalid_certs {
+        builder = builder.danger_accept_invalid_certs(true);
+    }
+    let client = builder
+        .build()
+        .map_err(|error| OutboundHttpError::ClientBuild(error.to_string()))?;
+
+    if cache.len() >= MAX_CACHED_CLIENTS
+        && let Some(stalest) = cache
+            .iter()
+            .min_by_key(|(_, entry)| entry.last_used)
+            .map(|(key, _)| key.clone())
+    {
+        cache.remove(&stalest);
+    }
+    cache.insert(
+        key,
+        CachedClient {
+            client: client.clone(),
+            last_used: now,
+        },
+    );
+    Ok(client)
 }
 
 async fn read_capped_body(
@@ -541,5 +606,18 @@ mod tests {
         let json = headers_to_json(&headers);
         assert_eq!(json["set-cookie"], "[redacted]");
         assert_eq!(json["x-request-id"], "abc");
+    }
+
+    #[test]
+    fn clients_are_reused_only_for_identical_dns_and_tls_policy() {
+        CLIENT_CACHE.lock().unwrap().clear();
+        let first_addresses = ["93.184.216.34:443".parse().unwrap()];
+
+        cached_client("example.com", &first_addresses, false).unwrap();
+        cached_client("EXAMPLE.COM", &first_addresses, false).unwrap();
+        assert_eq!(CLIENT_CACHE.lock().unwrap().len(), 1);
+
+        cached_client("example.com", &first_addresses, true).unwrap();
+        assert_eq!(CLIENT_CACHE.lock().unwrap().len(), 2);
     }
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -671,7 +671,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes",
-        "description": "Auto-generated documentation for GET /api/v1/classes. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1Classes",
         "parameters": [
           {
@@ -700,6 +700,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -716,7 +725,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -1015,7 +1024,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id Trailing",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdTrailing",
         "parameters": [
           {
@@ -1054,6 +1063,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -1070,7 +1088,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -1351,7 +1369,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id History",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/history. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/history. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdHistory",
         "parameters": [
           {
@@ -1390,6 +1408,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -1406,7 +1433,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -1631,7 +1658,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id Objects By Object Id Related Objects",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/objects/{object_id}/related/objects. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/objects/{object_id}/related/objects. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdObjectsByObjectIdRelatedObjects",
         "parameters": [
           {
@@ -1698,6 +1725,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -1714,7 +1750,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -1772,7 +1808,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id Objects By Object Id Related Relations",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/objects/{object_id}/related/relations. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/objects/{object_id}/related/relations. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdObjectsByObjectIdRelatedRelations",
         "parameters": [
           {
@@ -1821,6 +1857,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -1837,7 +1882,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -1895,7 +1940,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id Permissions",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/permissions. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/permissions. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdPermissions",
         "parameters": [
           {
@@ -1934,6 +1979,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -1950,7 +2004,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -1998,7 +2052,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id Related Classes",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/related/classes. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/related/classes. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdRelatedClasses",
         "parameters": [
           {
@@ -2037,6 +2091,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -2053,7 +2116,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -2180,7 +2243,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id Related Relations",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/related/relations. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/related/relations. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdRelatedRelations",
         "parameters": [
           {
@@ -2219,6 +2282,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -2235,7 +2307,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -3092,7 +3164,7 @@
           "classes"
         ],
         "summary": "Get Api V1 Classes By Class Id By Object Id History",
-        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/{object_id}/history. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/classes/{class_id}/{object_id}/history. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ClassesByClassIdByObjectIdHistory",
         "parameters": [
           {
@@ -3141,6 +3213,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -3157,7 +3238,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -3313,7 +3394,7 @@
           "collections"
         ],
         "summary": "Get Api V1 Collections",
-        "description": "Auto-generated documentation for GET /api/v1/collections. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/collections. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1Collections",
         "parameters": [
           {
@@ -3342,6 +3423,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -3358,7 +3448,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -4342,7 +4432,7 @@
           "collections"
         ],
         "summary": "List all groups that have any permissions on a collection",
-        "description": "Auto-generated documentation for GET /api/v1/collections/{collection_id}/has_permissions/{permission}. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/collections/{collection_id}/has_permissions/{permission}. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1CollectionsByCollectionIdHasPermissionsByPermission",
         "parameters": [
           {
@@ -4390,6 +4480,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -4406,7 +4505,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -4454,7 +4553,7 @@
           "collections"
         ],
         "summary": "Get Api V1 Collections By Collection Id History",
-        "description": "Auto-generated documentation for GET /api/v1/collections/{collection_id}/history. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/collections/{collection_id}/history. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1CollectionsByCollectionIdHistory",
         "parameters": [
           {
@@ -4493,6 +4592,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -4509,7 +4617,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -4754,7 +4862,7 @@
           "collections"
         ],
         "summary": "List all groups who have permissions for a collection",
-        "description": "Auto-generated documentation for GET /api/v1/collections/{collection_id}/permissions. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/collections/{collection_id}/permissions. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1CollectionsByCollectionIdPermissions",
         "parameters": [
           {
@@ -4793,6 +4901,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -4809,7 +4926,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -5495,7 +5612,7 @@
           "collections"
         ],
         "summary": "List all permissions for a principal on a collection",
-        "description": "Auto-generated documentation for GET /api/v1/collections/{collection_id}/permissions/principal/{principal_id}. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/collections/{collection_id}/permissions/principal/{principal_id}. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1CollectionsByCollectionIdPermissionsPrincipalByPrincipalId",
         "parameters": [
           {
@@ -5544,6 +5661,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -5560,7 +5686,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -6478,7 +6604,7 @@
           "export-templates"
         ],
         "summary": "Get Api V1 Export Templates",
-        "description": "Auto-generated documentation for GET /api/v1/export-templates. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/export-templates. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ExportTemplates",
         "parameters": [
           {
@@ -6507,6 +6633,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -6523,7 +6658,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -7127,7 +7262,7 @@
           "export-templates"
         ],
         "summary": "Get Api V1 Export Templates By Template Id History",
-        "description": "Auto-generated documentation for GET /api/v1/export-templates/{template_id}/history. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/export-templates/{template_id}/history. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1ExportTemplatesByTemplateIdHistory",
         "parameters": [
           {
@@ -7166,6 +7301,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -7182,7 +7326,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -7548,7 +7692,7 @@
           "groups"
         ],
         "summary": "Get Api V1 Iam Groups",
-        "description": "Auto-generated documentation for GET /api/v1/iam/groups. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/iam/groups. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1IamGroups",
         "parameters": [
           {
@@ -7577,6 +7721,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -7593,7 +7746,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -8068,7 +8221,7 @@
           "groups"
         ],
         "summary": "Get Api V1 Iam Groups By Group Id Members",
-        "description": "Auto-generated documentation for GET /api/v1/iam/groups/{group_id}/members. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/iam/groups/{group_id}/members. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1IamGroupsByGroupIdMembers",
         "parameters": [
           {
@@ -8107,6 +8260,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -8123,7 +8285,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -8330,7 +8492,7 @@
           "principals"
         ],
         "summary": "Get Api V1 Iam Me Groups",
-        "description": "Auto-generated documentation for GET /api/v1/iam/me/groups. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/iam/me/groups. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1IamMeGroups",
         "parameters": [
           {
@@ -8359,6 +8521,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -8375,7 +8546,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -8643,7 +8814,7 @@
           "principals"
         ],
         "summary": "Get Api V1 Iam Me Tokens",
-        "description": "Auto-generated documentation for GET /api/v1/iam/me/tokens. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/iam/me/tokens. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1IamMeTokens",
         "parameters": [
           {
@@ -8672,6 +8843,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -8688,7 +8868,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -8736,7 +8916,7 @@
           "principals"
         ],
         "summary": "Get Api V1 Iam Principals By Principal Id Groups",
-        "description": "Auto-generated documentation for GET /api/v1/iam/principals/{principal_id}/groups. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/iam/principals/{principal_id}/groups. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1IamPrincipalsByPrincipalIdGroups",
         "parameters": [
           {
@@ -8775,6 +8955,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -8791,7 +8980,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -9179,7 +9368,7 @@
           "principals"
         ],
         "summary": "Get Api V1 Iam Principals By Principal Id Tokens",
-        "description": "Auto-generated documentation for GET /api/v1/iam/principals/{principal_id}/tokens. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/iam/principals/{principal_id}/tokens. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1IamPrincipalsByPrincipalIdTokens",
         "parameters": [
           {
@@ -9218,6 +9407,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -9234,7 +9432,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -9441,7 +9639,7 @@
           "service-accounts"
         ],
         "summary": "Get Api V1 Iam Service Accounts",
-        "description": "Auto-generated documentation for GET /api/v1/iam/service-accounts. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/iam/service-accounts. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1IamServiceAccounts",
         "parameters": [
           {
@@ -9470,6 +9668,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -9486,7 +9693,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -9874,7 +10081,7 @@
           "users"
         ],
         "summary": "Get Api V1 Iam Users",
-        "description": "Auto-generated documentation for GET /api/v1/iam/users. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/iam/users. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1IamUsers",
         "parameters": [
           {
@@ -9903,6 +10110,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -9919,7 +10135,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -10684,7 +10900,7 @@
           "relations"
         ],
         "summary": "Get Api V1 Relations Classes",
-        "description": "Auto-generated documentation for GET /api/v1/relations/classes. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/relations/classes. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1RelationsClasses",
         "parameters": [
           {
@@ -10713,6 +10929,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -10729,7 +10954,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -10951,7 +11176,7 @@
           "relations"
         ],
         "summary": "Get Api V1 Relations Objects",
-        "description": "Auto-generated documentation for GET /api/v1/relations/objects. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/relations/objects. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1RelationsObjects",
         "parameters": [
           {
@@ -10980,6 +11205,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -10996,7 +11230,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -11343,7 +11577,7 @@
           "remote-targets"
         ],
         "summary": "Get Api V1 Remote Targets By Remote Target Id History",
-        "description": "Auto-generated documentation for GET /api/v1/remote-targets/{remote_target_id}/history. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/remote-targets/{remote_target_id}/history. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1RemoteTargetsByRemoteTargetIdHistory",
         "parameters": [
           {
@@ -11382,6 +11616,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -11398,7 +11641,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {
@@ -12252,7 +12495,7 @@
           "tasks"
         ],
         "summary": "Get Api V1 Tasks",
-        "description": "Auto-generated documentation for GET /api/v1/tasks. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header, and the next page cursor is returned in the `X-Next-Cursor` response header.",
+        "description": "Auto-generated documentation for GET /api/v1/tasks. Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `X-Total-Count` response header unless `include_total=false`, and the next page cursor is returned in the `X-Next-Cursor` response header.",
         "operationId": "getApiV1Tasks",
         "parameters": [
           {
@@ -12310,6 +12553,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_total",
+            "in": "query",
+            "description": "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -12326,7 +12578,7 @@
                 "schema": {
                   "type": "string"
                 },
-                "description": "Exact total number of results matching the current filter set, independent of cursor pagination."
+                "description": "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
               }
             },
             "content": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10518,6 +10518,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many active import tasks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -106,6 +106,7 @@ Parameters:
 - `limit`: maximum number of items to return
 - `sort`: page order
 - `cursor`: opaque token returned by a previous response
+- `include_total`: whether to run the exact count query and return `X-Total-Count`; defaults to `true`
 
 Limits:
 
@@ -115,7 +116,8 @@ Limits:
 Behavior:
 
 - the current page is returned as a JSON array
-- every paginated response includes `X-Total-Count` with the exact number of matching results
+- by default, paginated responses include `X-Total-Count` with the exact number of matching results
+- set `include_total=false` to skip that count query on latency-sensitive requests; `X-Total-Count` is then omitted
 - if another page exists, the response includes `X-Next-Cursor`
 - send that cursor back unchanged to fetch the next page
 - if `X-Next-Cursor` is absent, there is no next page

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -43,8 +43,9 @@ Probe paths bypass the client IP allowlist so platform health checks are not rej
 | -------- | ------- | ----------- |
 | `HUBUUM_DATABASE_URL` | `postgres://localhost` | PostgreSQL connection URL |
 | `HUBUUM_DB_POOL_SIZE` | `10` | Maximum number of database connections in the pool |
+| `HUBUUM_DB_POOL_ACQUIRE_TIMEOUT_MS` | `2000` | Maximum wait for a free pooled connection before failing the request |
 | `HUBUUM_SKIP_MIGRATIONS` | `false` | If true, the container waits for the database but does not run Diesel migrations on startup |
-| `HUBUUM_DB_STATEMENT_TIMEOUT_MS` | `0` | Pool-global Postgres `statement_timeout` in ms (`0` disables). Cancels any query exceeding it server-side; applies to **all** DB work, not just exports |
+| `HUBUUM_DB_STATEMENT_TIMEOUT_MS` | `30000` | Pool-global Postgres `statement_timeout` in ms (`0` disables). Cancels any query exceeding it server-side; applies to **all** DB work, not just exports |
 
 ### Task System Configuration
 
@@ -52,6 +53,7 @@ Probe paths bypass the client IP allowlist so platform health checks are not rej
 | -------- | ------- | ----------- |
 | `HUBUUM_TASK_WORKERS` | About half the detected CPU count, minimum `1` | Number of background task workers |
 | `HUBUUM_TASK_POLL_INTERVAL_MS` | `200` | Idle polling interval for background task workers |
+| `HUBUUM_IMPORT_MAX_ACTIVE_TASKS_PER_USER` | `100` | Maximum queued, validating, or running import tasks one user may have at once |
 
 ### Event And Audit Configuration
 

--- a/docs/temporal_history.md
+++ b/docs/temporal_history.md
@@ -389,9 +389,10 @@ Returns all historical versions for a specific entity, ordered newest-first by d
 - `?sort=history_id` - Sort order (default: `history_id` descending for newest-first; ordering is chronological via the monotonic history_id)
 - `?limit=N` - Number of results per page (default: 50, max: 500)
 - `?cursor=<opaque>` - Pagination cursor from `X-Next-Cursor` header
+- `?include_total=false` - Skip the exact count query and omit `X-Total-Count`
 
 **Response Headers:**
-- `X-Total-Count` - Total number of history rows for this entity
+- `X-Total-Count` - Total number of history rows for this entity (omitted when `include_total=false`)
 - `X-Next-Cursor` - Opaque cursor for the next page (omitted on last page)
 
 **Response Body:**

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,12 +17,12 @@ wait_for_db() {
     echo "Waiting for database to be ready..."
     if should_skip_migrations; then
         while ! psql "$HUBUUM_DATABASE_URL" -c 'SELECT 1' >/dev/null 2>&1; do
-            echo "Database @ $HUBUUM_DATABASE_URL is unavailable - sleeping"
+            echo "Database is unavailable - sleeping"
             sleep 1
         done
     else
         while ! diesel database setup --migration-dir /migrations --database-url "$HUBUUM_DATABASE_URL"; do
-            echo "Database @ $HUBUUM_DATABASE_URL is unavailable - sleeping"
+            echo "Database is unavailable - sleeping"
             sleep 1
         done
     fi

--- a/src/api/handlers/auth.rs
+++ b/src/api/handlers/auth.rs
@@ -4,7 +4,7 @@ use crate::db::DbPool;
 use crate::errors::ApiError;
 use crate::extractors::{AdminAccess, Authenticated, ManagementAccess};
 use crate::middlewares::rate_limit::{
-    clear_login_failures, client_ip_for_request, login_is_rate_limited, record_login_failure,
+    LoginAttemptOutcome, begin_login_attempt, client_ip_for_request, finish_login_attempt,
 };
 use crate::models::{LOCAL_IDENTITY_SCOPE, LoginUser, Token, UserID};
 use actix_web::{HttpRequest, Responder, get, post, web};
@@ -48,7 +48,7 @@ pub async fn login(
     let client_ip = client_ip_for_request(&req);
     let client_ip_log = client_ip.map(|ip| ip.to_string());
 
-    if login_is_rate_limited(&identity_scope, &name, client_ip).await {
+    let Some(login_permit) = begin_login_attempt(&identity_scope, &name, client_ip).await else {
         warn!(
             message = "Login throttled",
             identity_scope = identity_scope,
@@ -58,20 +58,23 @@ pub async fn login(
         return Err(ApiError::TooManyRequests(
             "Too many login attempts. Please try again later.".to_string(),
         ));
-    }
+    };
 
     debug!(message = "Login started", user = name);
     let user = match crate::auth::login(&pool, login).await {
         Ok(user) => user,
         Err(e) => {
-            if let ApiError::Unauthorized(_) = &e {
-                record_login_failure(&identity_scope, &name, client_ip).await;
-            }
+            let outcome = if matches!(e, ApiError::Unauthorized(_)) {
+                LoginAttemptOutcome::Failed
+            } else {
+                LoginAttemptOutcome::Aborted
+            };
+            finish_login_attempt(login_permit, outcome).await;
             return Err(e);
         }
     };
 
-    clear_login_failures(&identity_scope, &name, client_ip).await;
+    finish_login_attempt(login_permit, LoginAttemptOutcome::Succeeded).await;
 
     let token_generation_result = user.create_token(&pool).await;
 

--- a/src/api/handlers/probes.rs
+++ b/src/api/handlers/probes.rs
@@ -5,7 +5,7 @@ use utoipa::ToSchema;
 
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::db::{DbPool, with_connection};
+use crate::db::{DbPool, with_connection_async};
 use crate::errors::ApiError;
 
 #[derive(Serialize, ToSchema)]
@@ -45,12 +45,11 @@ pub async fn healthz() -> impl Responder {
 )]
 #[get("/readyz")]
 pub async fn readyz(pool: web::Data<DbPool>) -> Result<impl Responder, ApiError> {
-    with_connection(&pool, |conn| {
+    with_connection_async(pool.get_ref().clone(), |conn| {
         diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>("1")).get_result::<i32>(conn)
     })
-    .map_err(|err| {
-        ApiError::ServiceUnavailable(format!("Database readiness check failed: {err}"))
-    })?;
+    .await
+    .map_err(|_| ApiError::ServiceUnavailable("Database is not ready".to_string()))?;
 
     Ok(ApiResponse::new(ProbeResponse::ok("ready"), StatusCode::OK))
 }

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -571,10 +571,16 @@ fn add_cursor_pagination_docs(operation: &mut Operation) {
         "Opaque cursor returned in the X-Next-Cursor response header from a previous page. Supply it unchanged to fetch the next page.",
         Type::String,
     );
+    ensure_query_parameter(
+        parameters,
+        "include_total",
+        "Whether to execute an exact count query and return X-Total-Count. Defaults to true; set false on latency-sensitive requests that do not need the count.",
+        Type::Boolean,
+    );
 
     if let Some(description) = operation.description.as_mut() {
         let pagination_text = format!(
-            " Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `{TOTAL_COUNT_HEADER}` response header, and the next page cursor is returned in the `{NEXT_CURSOR_HEADER}` response header."
+            " Supports cursor pagination through the `limit`, `sort`, and `cursor` query parameters. The exact total hit count is returned in the `{TOTAL_COUNT_HEADER}` response header unless `include_total=false`, and the next page cursor is returned in the `{NEXT_CURSOR_HEADER}` response header."
         );
         if !description.contains(NEXT_CURSOR_HEADER) {
             description.push_str(&pagination_text);
@@ -645,7 +651,7 @@ fn add_total_count_header(response: &mut RefOr<utoipa::openapi::response::Respon
         .or_insert_with(|| {
             let mut header = Header::default();
             header.description = Some(
-                "Exact total number of results matching the current filter set, independent of cursor pagination."
+            "Exact total number of results matching the current filter set, independent of cursor pagination. Omitted when include_total=false."
                     .to_string(),
             );
             header

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -206,9 +206,12 @@ async fn get_classes(
 
     debug!(message = "Listing classes", user_id = user.id());
 
-    let total_count = user
-        .count_classes(&pool, count_query_options(&params), requestor.scopes())
-        .await?;
+    let total_count = if params.include_total {
+        user.count_classes(&pool, count_query_options(&params), requestor.scopes())
+            .await?
+    } else {
+        crate::pagination::SKIPPED_TOTAL_COUNT
+    };
     let search_params = prepare_db_pagination::<HubuumClassExpanded>(&params)?;
     let classes = user
         .search_classes(&pool, search_params, requestor.scopes())
@@ -462,19 +465,23 @@ async fn get_class_permissions(
     );
 
     let target_collection_id = class.collection_id(&pool).await?;
-    let count_params = count_query_options(&params);
-    let total_count = crate::models::collection::count_groups_on_paginated(
-        &pool,
-        target_collection_id,
-        vec![
-            Permissions::CreateClass,
-            Permissions::UpdateClass,
-            Permissions::ReadClass,
-            Permissions::DeleteClass,
-        ],
-        &count_params,
-    )
-    .await?;
+    let total_count = if params.include_total {
+        let count_params = count_query_options(&params);
+        crate::models::collection::count_groups_on_paginated(
+            &pool,
+            target_collection_id,
+            vec![
+                Permissions::CreateClass,
+                Permissions::UpdateClass,
+                Permissions::ReadClass,
+                Permissions::DeleteClass,
+            ],
+            &count_params,
+        )
+        .await?
+    } else {
+        crate::pagination::SKIPPED_TOTAL_COUNT
+    };
     let search_params = prepare_db_pagination::<GroupPermission>(&params)?;
     let permissions = groups_on_paginated(
         &pool,
@@ -826,9 +833,12 @@ async fn get_objects_in_class(
         query = query_string
     );
 
-    let total_count = user
-        .count_objects(&pool, count_query_options(&params), requestor.scopes())
-        .await?;
+    let total_count = if params.include_total {
+        user.count_objects(&pool, count_query_options(&params), requestor.scopes())
+            .await?
+    } else {
+        crate::pagination::SKIPPED_TOTAL_COUNT
+    };
     let search_params = prepare_db_pagination::<HubuumObject>(&params)?;
     let objects = user
         .search_objects(&pool, search_params, requestor.scopes())
@@ -1517,7 +1527,7 @@ async fn get_class_history(
     let search_params = prepare_db_pagination::<crate::models::HubuumClassHistory>(&params)?;
     let (rows, total_count) =
         class_history_paginated_with_total_count(entity_id, &pool, &search_params).await?;
-    if require_history && total_count == 0 {
+    if require_history && rows.is_empty() && params.cursor.is_none() {
         return Err(ApiError::NotFound(format!("class {entity_id} not found")));
     }
 
@@ -1651,7 +1661,7 @@ async fn get_object_history(
     let (rows, total_count) =
         object_history_paginated_with_total_count(entity_id, class_id.id(), &pool, &search_params)
             .await?;
-    if require_history && total_count == 0 {
+    if require_history && rows.is_empty() && params.cursor.is_none() {
         return Err(ApiError::NotFound(format!("object {entity_id} not found")));
     }
 

--- a/src/api/v1/handlers/collections.rs
+++ b/src/api/v1/handlers/collections.rs
@@ -55,9 +55,12 @@ pub async fn get_collections(
         Err(e) => return Err(e),
     };
 
-    let total_count = user
-        .count_collections(&pool, count_query_options(&params), requestor.scopes())
-        .await?;
+    let total_count = if params.include_total {
+        user.count_collections(&pool, count_query_options(&params), requestor.scopes())
+            .await?
+    } else {
+        crate::pagination::SKIPPED_TOTAL_COUNT
+    };
     let search_params = prepare_db_pagination::<Collection>(&params)?;
     let result = user
         .search_collections(&pool, search_params, requestor.scopes())
@@ -889,7 +892,7 @@ pub async fn get_collection_principal_permissions(
         )
         .await?;
 
-    if total_count == 0 {
+    if permissions.is_empty() && query_options.cursor.is_none() {
         return Err(ApiError::NotFound("No permissions found".to_string()));
     }
 
@@ -1037,7 +1040,7 @@ pub async fn get_collection_history(
     let search_params = prepare_db_pagination::<crate::models::CollectionHistory>(&params)?;
     let (rows, total_count) =
         collection_history_paginated_with_total_count(entity_id, &pool, &search_params).await?;
-    if require_history && total_count == 0 {
+    if require_history && rows.is_empty() && params.cursor.is_none() {
         return Err(ApiError::NotFound(format!(
             "collection {entity_id} not found"
         )));

--- a/src/api/v1/handlers/export_templates.rs
+++ b/src/api/v1/handlers/export_templates.rs
@@ -381,7 +381,7 @@ pub async fn get_template_history(
     let (rows, total_count) =
         export_template_history_paginated_with_total_count(entity_id, &pool, &search_params)
             .await?;
-    if require_history && total_count == 0 {
+    if require_history && rows.is_empty() && params.cursor.is_none() {
         return Err(ApiError::NotFound(format!(
             "template {entity_id} not found"
         )));

--- a/src/api/v1/handlers/exports.rs
+++ b/src/api/v1/handlers/exports.rs
@@ -437,28 +437,10 @@ async fn find_or_create_export_task(
     payload: serde_json::Value,
     request_hash_value: String,
 ) -> Result<TaskRecord, ApiError> {
-    let request_hash_for_match = request_hash_value.clone();
-    let matches_request = |task: &TaskRecord| {
-        task.kind == TaskKind::Export.as_str()
-            && task.request_hash.as_deref() == Some(request_hash_for_match.as_str())
-    };
-
-    if let Some(key) = idempotency_key.as_deref()
-        && let Some(existing) = TaskRecord::find_by_idempotency(pool, submitted_by, key).await?
-    {
-        if matches_request(&existing) {
-            return Ok(existing);
-        }
-
-        return Err(ApiError::Conflict(format!(
-            "Idempotency-Key '{key}' is already in use for a different task submission"
-        )));
-    }
-
-    match (TaskCreateRequest {
+    (TaskCreateRequest {
         kind: TaskKind::Export,
         submitted_by,
-        idempotency_key: idempotency_key.clone(),
+        idempotency_key,
         request_hash: Some(request_hash_value),
         request_payload: payload,
         total_items: 1,
@@ -466,25 +448,8 @@ async fn find_or_create_export_task(
         submitted_token_scoped: snapshot.scoped,
         submitted_token_scopes: snapshot.scopes,
     })
-    .create_with_active_export_limit(pool, max_active_export_tasks_per_user())
+    .create_idempotently_with_active_limit(pool, max_active_export_tasks_per_user())
     .await
-    {
-        Ok(task) => Ok(task),
-        Err(ApiError::Conflict(_)) => {
-            if let Some(key) = idempotency_key.as_deref()
-                && let Some(existing) =
-                    TaskRecord::find_by_idempotency(pool, submitted_by, key).await?
-                && matches_request(&existing)
-            {
-                return Ok(existing);
-            }
-
-            Err(ApiError::Conflict(
-                "Idempotency-Key is already in use for a different task submission".to_string(),
-            ))
-        }
-        Err(error) => Err(error),
-    }
 }
 
 pub(crate) async fn execute_export_task(

--- a/src/api/v1/handlers/groups.rs
+++ b/src/api/v1/handlers/groups.rs
@@ -52,9 +52,12 @@ pub async fn get_groups(
         params = ?params
     );
 
-    let total_count = user
-        .count_groups(&pool, count_query_options(&params))
-        .await?;
+    let total_count = if params.include_total {
+        user.count_groups(&pool, count_query_options(&params))
+            .await?
+    } else {
+        crate::pagination::SKIPPED_TOTAL_COUNT
+    };
     let search_params = prepare_db_pagination::<Group>(&params)?;
     let groups = user.search_groups(&pool, search_params).await?;
     let result = GroupResponse::from_groups(&pool, groups).await?;
@@ -257,8 +260,12 @@ pub async fn get_group_members(
         requestor = requestor.user.id
     );
 
-    let count_params = count_query_options(&params);
-    let total_count = group.count_members_paginated(&pool, &count_params).await?;
+    let total_count = if params.include_total {
+        let count_params = count_query_options(&params);
+        group.count_members_paginated(&pool, &count_params).await?
+    } else {
+        crate::pagination::SKIPPED_TOTAL_COUNT
+    };
     let search_params = prepare_db_pagination::<Principal>(&params)?;
     let members = group.members_paginated(&pool, &search_params).await?;
 

--- a/src/api/v1/handlers/imports.rs
+++ b/src/api/v1/handlers/imports.rs
@@ -3,6 +3,7 @@ use actix_web::{HttpRequest, Responder, get, http::StatusCode, post, web};
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
+use crate::config::{DEFAULT_IMPORT_MAX_ACTIVE_TASKS_PER_USER, get_config};
 use crate::db::DbPool;
 use crate::db::traits::task::{TaskBackend, TaskCreateRequest, TaskScopeSnapshot};
 use crate::errors::ApiError;
@@ -26,30 +27,10 @@ async fn find_or_create_import_task(
     request_hash: String,
     total_items: i32,
 ) -> Result<TaskRecord, ApiError> {
-    let request_hash_for_match = request_hash.clone();
-    let matches_request = |task: &TaskRecord| {
-        task.kind == TaskKind::Import.as_str()
-            && task.request_hash.as_deref() == Some(request_hash_for_match.as_str())
-    };
-
-    if let Some(key) = idempotency_key.as_deref()
-        && let Some(existing) = TaskRecord::find_by_idempotency(pool, submitted_by, key).await?
-    {
-        if matches_request(&existing) {
-            return Ok(existing);
-        }
-
-        return Err(ApiError::Conflict(format!(
-            "Idempotency-Key '{key}' is already in use for a different task submission"
-        )));
-    }
-
-    let create_idempotency_key = idempotency_key.clone();
-
-    match (TaskCreateRequest {
+    (TaskCreateRequest {
         kind: TaskKind::Import,
         submitted_by,
-        idempotency_key: create_idempotency_key,
+        idempotency_key,
         request_hash: Some(request_hash),
         request_payload: payload,
         total_items,
@@ -57,25 +38,8 @@ async fn find_or_create_import_task(
         submitted_token_scoped: snapshot.scoped,
         submitted_token_scopes: snapshot.scopes,
     })
-    .create_generic(pool)
+    .create_idempotently_with_active_limit(pool, max_active_import_tasks_per_user())
     .await
-    {
-        Ok(task) => Ok(task),
-        Err(ApiError::Conflict(_)) => {
-            if let Some(key) = idempotency_key.as_deref()
-                && let Some(existing) =
-                    TaskRecord::find_by_idempotency(pool, submitted_by, key).await?
-                && matches_request(&existing)
-            {
-                return Ok(existing);
-            }
-
-            Err(ApiError::Conflict(
-                "Idempotency-Key is already in use for a different task submission".to_string(),
-            ))
-        }
-        Err(err) => Err(err),
-    }
 }
 
 #[utoipa::path(
@@ -88,6 +52,7 @@ async fn find_or_create_import_task(
         (status = 202, description = "Import task accepted", body = TaskResponse),
         (status = 400, description = "Bad request", body = ApiErrorResponse),
         (status = 409, description = "Conflict", body = ApiErrorResponse),
+        (status = 429, description = "Too many active import tasks", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse)
     )
 )]
@@ -131,6 +96,12 @@ pub async fn create_import(
         response,
         api_locations::task(task.id)?,
     ))
+}
+
+fn max_active_import_tasks_per_user() -> usize {
+    get_config()
+        .map(|config| config.import_max_active_tasks_per_user)
+        .unwrap_or(DEFAULT_IMPORT_MAX_ACTIVE_TASKS_PER_USER)
 }
 
 #[utoipa::path(

--- a/src/api/v1/handlers/remote_targets.rs
+++ b/src/api/v1/handlers/remote_targets.rs
@@ -433,7 +433,7 @@ pub async fn get_remote_target_history(
     let search_params = prepare_db_pagination::<crate::models::RemoteTargetHistory>(&params)?;
     let (rows, total_count) =
         remote_target_history_paginated_with_total_count(entity_id, &pool, &search_params).await?;
-    if require_history && total_count == 0 {
+    if require_history && rows.is_empty() && params.cursor.is_none() {
         return Err(ApiError::NotFound(format!(
             "remote target {entity_id} not found"
         )));

--- a/src/api/v1/handlers/remote_targets.rs
+++ b/src/api/v1/handlers/remote_targets.rs
@@ -358,34 +358,15 @@ async fn find_or_create_remote_call_task(
     payload: serde_json::Value,
 ) -> Result<crate::models::TaskRecord, ApiError> {
     let hash = request_hash(&payload)?;
-    let request_hash_for_match = hash.clone();
-    let matches_request = |task: &crate::models::TaskRecord| {
-        task.kind == TaskKind::RemoteCall.as_str()
-            && task.request_hash.as_deref() == Some(request_hash_for_match.as_str())
-    };
-
-    if let Some(key) = idempotency_key.as_deref()
-        && let Some(existing) =
-            crate::models::TaskRecord::find_by_idempotency(pool, submitted_by, key).await?
-    {
-        if matches_request(&existing) {
-            return Ok(existing);
-        }
-        return Err(ApiError::Conflict(format!(
-            "Idempotency-Key '{key}' is already in use for a different task submission"
-        )));
-    }
 
     info!(
         message = "Creating remote call task",
         submitted_by = submitted_by
     );
-    let create_idempotency_key = idempotency_key.clone();
-
-    match (TaskCreateRequest {
+    (TaskCreateRequest {
         kind: TaskKind::RemoteCall,
         submitted_by,
-        idempotency_key: create_idempotency_key,
+        idempotency_key,
         request_hash: Some(hash),
         request_payload: payload,
         total_items: 1,
@@ -393,25 +374,8 @@ async fn find_or_create_remote_call_task(
         submitted_token_scoped: snapshot.scoped,
         submitted_token_scopes: snapshot.scopes,
     })
-    .create_with_active_remote_call_limit(pool, max_active_remote_call_tasks_per_user())
+    .create_idempotently_with_active_limit(pool, max_active_remote_call_tasks_per_user())
     .await
-    {
-        Ok(task) => Ok(task),
-        Err(ApiError::Conflict(_)) => {
-            if let Some(key) = idempotency_key.as_deref()
-                && let Some(existing) =
-                    crate::models::TaskRecord::find_by_idempotency(pool, submitted_by, key).await?
-                && matches_request(&existing)
-            {
-                return Ok(existing);
-            }
-
-            Err(ApiError::Conflict(
-                "Idempotency-Key is already in use for a different task submission".to_string(),
-            ))
-        }
-        Err(error) => Err(error),
-    }
 }
 
 fn max_active_remote_call_tasks_per_user() -> usize {

--- a/src/api/v1/handlers/search.rs
+++ b/src/api/v1/handlers/search.rs
@@ -112,7 +112,7 @@ pub async fn stream_search(
                 events.push(sse_event(
                     "error",
                     &UnifiedSearchErrorEvent {
-                        message: error.to_string(),
+                        message: error.public_message().to_string(),
                     },
                 )?);
 

--- a/src/api/v1/handlers/service_accounts.rs
+++ b/src/api/v1/handlers/service_accounts.rs
@@ -130,13 +130,17 @@ pub async fn list_service_accounts(
 
     // Authorization is applied in SQL (admin sees all; otherwise owner-group
     // membership), so this is a single paginated query, not a per-row scan.
-    let total_count = count_manageable_service_accounts(
-        &pool,
-        &requestor.user,
-        is_admin,
-        count_query_options(&params),
-    )
-    .await?;
+    let total_count = if params.include_total {
+        count_manageable_service_accounts(
+            &pool,
+            &requestor.user,
+            is_admin,
+            count_query_options(&params),
+        )
+        .await?
+    } else {
+        crate::pagination::SKIPPED_TOTAL_COUNT
+    };
     let search_params = prepare_db_pagination::<ServiceAccountWithName>(&params)?;
     let accounts =
         search_manageable_service_accounts(&pool, &requestor.user, is_admin, search_params).await?;

--- a/src/api/v1/handlers/users.rs
+++ b/src/api/v1/handlers/users.rs
@@ -40,9 +40,12 @@ pub async fn get_users(
 
     debug!(message = "User list requested", requestor = user.id);
 
-    let total_count = user
-        .count_users(&pool, count_query_options(&params))
-        .await?;
+    let total_count = if params.include_total {
+        user.count_users(&pool, count_query_options(&params))
+            .await?
+    } else {
+        crate::pagination::SKIPPED_TOTAL_COUNT
+    };
     let search_params = prepare_db_pagination::<UserWithName>(&params)?;
     let result = user.search_users(&pool, search_params).await?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,7 @@ pub const DEFAULT_EVENT_RETENTION_PURGE_BATCH_SIZE: usize = 1_000;
 pub const DEFAULT_EVENT_RETENTION_FILE_ARCHIVE_ENABLED: bool = false;
 pub const DEFAULT_EXPORT_OUTPUT_RETENTION_HOURS: i64 = 24 * 7;
 pub const DEFAULT_EXPORT_OUTPUT_CLEANUP_INTERVAL_SECONDS: u64 = 300;
+pub const DEFAULT_IMPORT_MAX_ACTIVE_TASKS_PER_USER: usize = 100;
 pub const DEFAULT_EXPORT_MAX_ACTIVE_TASKS_PER_USER: usize = 100;
 pub const DEFAULT_REMOTE_CALL_MAX_ACTIVE_TASKS_PER_USER: usize = 100;
 pub const DEFAULT_EXPORT_TEMPLATE_RECURSION_LIMIT: usize = 64;
@@ -47,7 +48,8 @@ pub const DEFAULT_EXPORT_STAGE_TIMEOUT_MS: u64 = 10_000;
 pub const DEFAULT_REMOTE_CALL_TIMEOUT_MS: u64 = 10_000;
 pub const DEFAULT_REMOTE_CALL_MAX_RESPONSE_BYTES: usize = 262_144;
 pub const DEFAULT_REMOTE_CALL_ALLOW_PRIVATE_TARGETS: bool = false;
-pub const DEFAULT_DB_STATEMENT_TIMEOUT_MS: u64 = 0;
+pub const DEFAULT_DB_STATEMENT_TIMEOUT_MS: u64 = 30_000;
+pub const DEFAULT_DB_POOL_ACQUIRE_TIMEOUT_MS: u64 = 2_000;
 pub const DEFAULT_EXPORT_DB_STATEMENT_TIMEOUT_MS: u64 = 0;
 pub const DEFAULT_TOKEN_LIFETIME_HOURS: i64 = 24;
 pub const DEFAULT_LOGIN_RATE_LIMIT_ENABLED: bool = true;
@@ -335,6 +337,14 @@ pub struct AppConfig {
     )]
     pub export_output_cleanup_interval_seconds: u64,
 
+    /// Maximum queued/validating/running import tasks one user may have at once.
+    #[clap(
+        long,
+        env = "HUBUUM_IMPORT_MAX_ACTIVE_TASKS_PER_USER",
+        default_value_t = DEFAULT_IMPORT_MAX_ACTIVE_TASKS_PER_USER
+    )]
+    pub import_max_active_tasks_per_user: usize,
+
     /// Maximum queued/validating/running export tasks one user may have at once.
     #[clap(
         long,
@@ -438,7 +448,7 @@ pub struct AppConfig {
     /// work - exports, imports, admin commands, health/auth queries, and
     /// migrations sharing the pool - not just export stages. Postgres cancels any
     /// statement exceeding it server-side, which frees the connection (a genuine
-    /// in-flight timeout). Disabled by default to preserve existing behavior.
+    /// in-flight timeout).
     #[clap(
         long,
         env = "HUBUUM_DB_STATEMENT_TIMEOUT_MS",
@@ -462,6 +472,14 @@ pub struct AppConfig {
         default_value_t = DEFAULT_EXPORT_DB_STATEMENT_TIMEOUT_MS
     )]
     pub export_db_statement_timeout_ms: u64,
+
+    /// Maximum time to wait for a free database connection from the pool.
+    #[clap(
+        long,
+        env = "HUBUUM_DB_POOL_ACQUIRE_TIMEOUT_MS",
+        default_value_t = DEFAULT_DB_POOL_ACQUIRE_TIMEOUT_MS
+    )]
+    pub db_pool_acquire_timeout_ms: u64,
 
     /// Number of DB connections in the pool
     #[clap(long, env = "HUBUUM_DB_POOL_SIZE", default_value_t = 10)]
@@ -792,6 +810,12 @@ impl AppConfig {
             ));
         }
 
+        if self.import_max_active_tasks_per_user == 0 {
+            return Err(ApiError::BadRequest(
+                "import_max_active_tasks_per_user must be greater than 0".to_string(),
+            ));
+        }
+
         if self.export_max_active_tasks_per_user == 0 {
             return Err(ApiError::BadRequest(
                 "export_max_active_tasks_per_user must be greater than 0".to_string(),
@@ -849,6 +873,12 @@ impl AppConfig {
         if self.db_pool_size == 0 {
             return Err(ApiError::BadRequest(
                 "db_pool_size must be greater than 0".to_string(),
+            ));
+        }
+
+        if self.db_pool_acquire_timeout_ms == 0 {
+            return Err(ApiError::BadRequest(
+                "db_pool_acquire_timeout_ms must be greater than 0".to_string(),
             ));
         }
 
@@ -1223,6 +1253,10 @@ fn get_config_from_env() -> Result<AppConfig, ApiError> {
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(DEFAULT_EXPORT_OUTPUT_CLEANUP_INTERVAL_SECONDS),
+        import_max_active_tasks_per_user: env::var("HUBUUM_IMPORT_MAX_ACTIVE_TASKS_PER_USER")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_IMPORT_MAX_ACTIVE_TASKS_PER_USER),
         export_max_active_tasks_per_user: env::var("HUBUUM_EXPORT_MAX_ACTIVE_TASKS_PER_USER")
             .ok()
             .and_then(|value| value.parse().ok())
@@ -1273,6 +1307,10 @@ fn get_config_from_env() -> Result<AppConfig, ApiError> {
             .ok()
             .and_then(|value| value.parse().ok())
             .unwrap_or(DEFAULT_EXPORT_DB_STATEMENT_TIMEOUT_MS),
+        db_pool_acquire_timeout_ms: env::var("HUBUUM_DB_POOL_ACQUIRE_TIMEOUT_MS")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_DB_POOL_ACQUIRE_TIMEOUT_MS),
         db_pool_size: env_or_default("HUBUUM_DB_POOL_SIZE", "2")
             .parse()
             .unwrap_or(5),
@@ -1522,16 +1560,17 @@ mod tests {
     use clap::Parser;
 
     use super::{
-        AppConfig, DEFAULT_EVENT_DELIVERY_BATCH_SIZE, DEFAULT_EVENT_DELIVERY_LOCK_TIMEOUT_MS,
-        DEFAULT_EVENT_DELIVERY_MAX_ATTEMPTS, DEFAULT_EVENT_DELIVERY_POLL_INTERVAL_MS,
-        DEFAULT_EVENT_DELIVERY_RETENTION_DAYS, DEFAULT_EVENT_DELIVERY_RETRY_BACKOFF_BASE_MS,
-        DEFAULT_EVENT_DELIVERY_RETRY_BACKOFF_MAX_MS, DEFAULT_EVENT_DELIVERY_TRANSPORT_TIMEOUT_MS,
-        DEFAULT_EVENT_DELIVERY_WORKERS, DEFAULT_EVENT_FANOUT_BATCH_SIZE,
-        DEFAULT_EVENT_FANOUT_LOCK_TIMEOUT_MS, DEFAULT_EVENT_FANOUT_POLL_INTERVAL_MS,
-        DEFAULT_EVENT_FANOUT_WORKERS, DEFAULT_EVENT_RETENTION_DAYS,
-        DEFAULT_EVENT_RETENTION_FILE_ARCHIVE_ENABLED, DEFAULT_EVENT_RETENTION_PURGE_BATCH_SIZE,
-        DEFAULT_EVENT_RETENTION_PURGE_ENABLED, DEFAULT_EVENT_RETENTION_PURGE_INTERVAL_SECONDS,
-        DEFAULT_EXPORT_MAX_ACTIVE_TASKS_PER_USER, DEFAULT_EXPORT_MAX_OUTPUT_BYTES,
+        AppConfig, DEFAULT_DB_POOL_ACQUIRE_TIMEOUT_MS, DEFAULT_EVENT_DELIVERY_BATCH_SIZE,
+        DEFAULT_EVENT_DELIVERY_LOCK_TIMEOUT_MS, DEFAULT_EVENT_DELIVERY_MAX_ATTEMPTS,
+        DEFAULT_EVENT_DELIVERY_POLL_INTERVAL_MS, DEFAULT_EVENT_DELIVERY_RETENTION_DAYS,
+        DEFAULT_EVENT_DELIVERY_RETRY_BACKOFF_BASE_MS, DEFAULT_EVENT_DELIVERY_RETRY_BACKOFF_MAX_MS,
+        DEFAULT_EVENT_DELIVERY_TRANSPORT_TIMEOUT_MS, DEFAULT_EVENT_DELIVERY_WORKERS,
+        DEFAULT_EVENT_FANOUT_BATCH_SIZE, DEFAULT_EVENT_FANOUT_LOCK_TIMEOUT_MS,
+        DEFAULT_EVENT_FANOUT_POLL_INTERVAL_MS, DEFAULT_EVENT_FANOUT_WORKERS,
+        DEFAULT_EVENT_RETENTION_DAYS, DEFAULT_EVENT_RETENTION_FILE_ARCHIVE_ENABLED,
+        DEFAULT_EVENT_RETENTION_PURGE_BATCH_SIZE, DEFAULT_EVENT_RETENTION_PURGE_ENABLED,
+        DEFAULT_EVENT_RETENTION_PURGE_INTERVAL_SECONDS, DEFAULT_EXPORT_MAX_ACTIVE_TASKS_PER_USER,
+        DEFAULT_EXPORT_MAX_OUTPUT_BYTES, DEFAULT_IMPORT_MAX_ACTIVE_TASKS_PER_USER,
         DEFAULT_LOGIN_RATE_LIMIT_MAX_ATTEMPTS, DEFAULT_LOGIN_RATE_LIMIT_WINDOW_SECONDS,
         DEFAULT_PAGE_LIMIT, DEFAULT_REMOTE_CALL_MAX_ACTIVE_TASKS_PER_USER,
         DEFAULT_TASK_POLL_INTERVAL_MS, DEFAULT_TOKEN_LIFETIME_HOURS, MAX_PAGE_LIMIT, TEST_ENV_LOCK,
@@ -2037,6 +2076,58 @@ mod tests {
 
         assert_eq!(parsed.export_max_active_tasks_per_user, 7);
         assert_eq!(loaded.export_max_active_tasks_per_user, 7);
+    }
+
+    #[test]
+    fn import_max_active_tasks_per_user_is_loaded_and_validated() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _guard = EnvVarGuard::set("HUBUUM_IMPORT_MAX_ACTIVE_TASKS_PER_USER", Some("7"));
+
+        let parsed = AppConfig::try_parse_from(["hubuum-server"]).unwrap();
+        let loaded = get_config_from_env().unwrap();
+        assert_eq!(parsed.import_max_active_tasks_per_user, 7);
+        assert_eq!(loaded.import_max_active_tasks_per_user, 7);
+
+        drop(_guard);
+        let _guard = EnvVarGuard::set("HUBUUM_IMPORT_MAX_ACTIVE_TASKS_PER_USER", None);
+        assert_eq!(
+            get_config_from_env()
+                .unwrap()
+                .import_max_active_tasks_per_user,
+            DEFAULT_IMPORT_MAX_ACTIVE_TASKS_PER_USER
+        );
+
+        drop(_guard);
+        let _guard = EnvVarGuard::set("HUBUUM_IMPORT_MAX_ACTIVE_TASKS_PER_USER", Some("0"));
+        assert_eq!(
+            get_config_from_env().unwrap_err().to_string(),
+            "import_max_active_tasks_per_user must be greater than 0"
+        );
+    }
+
+    #[test]
+    fn db_pool_acquire_timeout_is_loaded_and_validated() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _guard = EnvVarGuard::set("HUBUUM_DB_POOL_ACQUIRE_TIMEOUT_MS", Some("750"));
+
+        let parsed = AppConfig::try_parse_from(["hubuum-server"]).unwrap();
+        let loaded = get_config_from_env().unwrap();
+        assert_eq!(parsed.db_pool_acquire_timeout_ms, 750);
+        assert_eq!(loaded.db_pool_acquire_timeout_ms, 750);
+
+        drop(_guard);
+        let _guard = EnvVarGuard::set("HUBUUM_DB_POOL_ACQUIRE_TIMEOUT_MS", None);
+        assert_eq!(
+            get_config_from_env().unwrap().db_pool_acquire_timeout_ms,
+            DEFAULT_DB_POOL_ACQUIRE_TIMEOUT_MS
+        );
+
+        drop(_guard);
+        let _guard = EnvVarGuard::set("HUBUUM_DB_POOL_ACQUIRE_TIMEOUT_MS", Some("0"));
+        assert_eq!(
+            get_config_from_env().unwrap_err().to_string(),
+            "db_pool_acquire_timeout_ms must be greater than 0"
+        );
     }
 
     #[test]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -5,6 +5,7 @@ use diesel::PgConnection;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::Pool;
 use diesel::r2d2::PooledConnection;
+use std::time::Duration;
 
 use tracing::debug;
 
@@ -134,6 +135,57 @@ where
     with_connection_timeout(pool, ambient_statement_timeout(), f)
 }
 
+/// Run synchronous Diesel work on Tokio's blocking pool so an Actix worker can
+/// continue serving unrelated requests while waiting for a connection or Postgres.
+/// New async request paths should prefer this helper until the Diesel backend is
+/// migrated fully to `diesel-async`.
+pub async fn with_connection_async<F, R, E>(pool: DbPool, f: F) -> Result<R, ApiError>
+where
+    F: FnOnce(&mut PgConnection) -> Result<R, E> + Send + 'static,
+    R: Send + 'static,
+    E: Send + 'static,
+    ApiError: From<E>,
+{
+    let statement_timeout = ambient_statement_timeout();
+    let actor = ambient_actor();
+    if tokio::runtime::Handle::try_current().is_err() {
+        // CLI and unit-test callers may drive these async domain APIs with a
+        // runtime-agnostic executor. There is no Actix worker to protect there.
+        return with_connection_context(&pool, statement_timeout, actor, f);
+    }
+    tokio::task::spawn_blocking(move || with_connection_context(&pool, statement_timeout, actor, f))
+        .await
+        .map_err(|error| {
+            ApiError::InternalServerError(format!("Database blocking task failed: {error}"))
+        })?
+}
+
+fn with_connection_context<F, R, E>(
+    pool: &DbPool,
+    statement_timeout: Option<StatementTimeoutMs>,
+    actor: Option<i32>,
+    f: F,
+) -> Result<R, ApiError>
+where
+    F: FnOnce(&mut PgConnection) -> Result<R, E>,
+    ApiError: From<E>,
+{
+    let mut conn = acquire_connection(pool)?;
+    if statement_timeout.is_none() && actor.is_none() {
+        f(&mut conn).map_err(ApiError::from)
+    } else {
+        conn.transaction::<R, ApiError, _>(|conn| {
+            if let Some(statement_timeout) = statement_timeout {
+                set_local_statement_timeout(conn, statement_timeout)?;
+            }
+            if let Some(actor) = actor {
+                set_local_actor(conn, actor)?;
+            }
+            f(conn).map_err(ApiError::from)
+        })
+    }
+}
+
 /// Return an updated row, or fetch the current row when a temporal no-op trigger
 /// suppressed an unchanged `UPDATE`.
 ///
@@ -182,21 +234,7 @@ where
     F: FnOnce(&mut PgConnection) -> Result<R, E>,
     ApiError: From<E>,
 {
-    let actor = ambient_actor();
-    let mut conn = acquire_connection(pool)?;
-    if statement_timeout.is_none() && actor.is_none() {
-        f(&mut conn).map_err(ApiError::from)
-    } else {
-        conn.transaction::<R, ApiError, _>(|conn| {
-            if let Some(statement_timeout) = statement_timeout {
-                set_local_statement_timeout(conn, statement_timeout)?;
-            }
-            if let Some(actor) = actor {
-                set_local_actor(conn, actor)?;
-            }
-            f(conn).map_err(ApiError::from)
-        })
-    }
+    with_connection_context(pool, statement_timeout, ambient_actor(), f)
 }
 
 /// Run database work inside a SQL transaction on a single pooled connection.
@@ -244,18 +282,43 @@ pub fn init_pool(database_url: &str, max_size: u32) -> DbPool {
     // health/auth queries), not just export stages. 0 = disabled.
     let statement_timeout_ms = crate::config::get_config()
         .map(|config| config.db_statement_timeout_ms)
-        .unwrap_or(0);
-    init_pool_with_statement_timeout(database_url, max_size, statement_timeout_ms)
+        .unwrap_or(crate::config::DEFAULT_DB_STATEMENT_TIMEOUT_MS);
+    let acquire_timeout_ms = crate::config::get_config()
+        .map(|config| config.db_pool_acquire_timeout_ms)
+        .unwrap_or(crate::config::DEFAULT_DB_POOL_ACQUIRE_TIMEOUT_MS);
+    init_pool_with_timeouts(
+        database_url,
+        max_size,
+        statement_timeout_ms,
+        acquire_timeout_ms,
+    )
 }
 
 /// Build a pool with an explicit Postgres `statement_timeout` (in milliseconds)
 /// applied to every connection on acquisition. A value of 0 disables the
 /// timeout. Exposed so tests can exercise the customizer without mutating the
 /// global config.
+// The server binary compiles this module directly as well as through the library;
+// this explicit-timeout constructor is consumed by the admin binary and DB tests.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn init_pool_with_statement_timeout(
     database_url: &str,
     max_size: u32,
     statement_timeout_ms: u64,
+) -> DbPool {
+    init_pool_with_timeouts(
+        database_url,
+        max_size,
+        statement_timeout_ms,
+        crate::config::DEFAULT_DB_POOL_ACQUIRE_TIMEOUT_MS,
+    )
+}
+
+fn init_pool_with_timeouts(
+    database_url: &str,
+    max_size: u32,
+    statement_timeout_ms: u64,
+    acquire_timeout_ms: u64,
 ) -> DbPool {
     let database_url_components = DatabaseUrlComponents::new(database_url);
 
@@ -278,7 +341,9 @@ pub fn init_pool_with_statement_timeout(
 
     let manager = ConnectionManager::<PgConnection>::new(database_url);
 
-    let mut builder = Pool::builder().max_size(max_size);
+    let mut builder = Pool::builder()
+        .max_size(max_size)
+        .connection_timeout(Duration::from_millis(acquire_timeout_ms));
     if statement_timeout_ms > 0 {
         builder = builder.connection_customizer(Box::new(StatementTimeoutCustomizer {
             statement_timeout_ms,

--- a/src/db/traits/active_tokens.rs
+++ b/src/db/traits/active_tokens.rs
@@ -123,7 +123,9 @@ async fn active_tokens_by_principal_id_paginated_with_total_count(
     };
 
     let base_query = build_query()?;
-    let total_count = with_connection(pool, |conn| base_query.count().get_result::<i64>(conn))?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+        with_connection(pool, |conn| base_query.count().get_result::<i64>(conn))
+    })?;
 
     let mut base_query = build_query()?;
     crate::apply_query_options!(base_query, query_options, PrincipalToken);

--- a/src/db/traits/authz.rs
+++ b/src/db/traits/authz.rs
@@ -18,7 +18,7 @@ use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::sql_types::Integer;
 
-use crate::db::{DbPool, with_connection};
+use crate::db::{DbPool, with_connection, with_connection_async};
 use crate::errors::ApiError;
 use crate::models::identity::LOCAL_IDENTITY_SCOPE;
 use crate::models::permissions::Permissions;
@@ -106,7 +106,8 @@ pub trait AuthzSubject: PrincipalIdAccessor {
         use diesel::dsl::{exists, select};
         let pid = self.principal_id();
         let scope = self.admin_identity_scope().await?;
-        let is_in_group = with_connection(pool, |conn| {
+        let group_name = groupname_queried.to_string();
+        let is_in_group = with_connection_async(pool.clone(), move |conn| {
             select(exists(
                 group_memberships::table
                     .inner_join(groups::table)
@@ -115,11 +116,12 @@ pub trait AuthzSubject: PrincipalIdAccessor {
                             .on(groups::identity_scope_id.eq(identity_scopes::id)),
                     )
                     .filter(group_memberships::principal_id.eq(pid))
-                    .filter(groups::groupname.eq(groupname_queried))
+                    .filter(groups::groupname.eq(group_name))
                     .filter(identity_scopes::name.eq(scope)),
             ))
             .get_result(conn)
-        })?;
+        })
+        .await?;
         Ok(is_in_group)
     }
 

--- a/src/db/traits/collection/permissions.rs
+++ b/src/db/traits/collection/permissions.rs
@@ -166,7 +166,9 @@ pub async fn principal_on_paginated_with_total_count_from_backend<
     };
 
     let query = build_query()?;
-    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
+    })?;
 
     let mut query = build_query()?;
     crate::apply_query_options!(query, query_options, GroupPermission);
@@ -424,7 +426,9 @@ pub async fn groups_can_on_paginated_with_total_count_from_backend(
     };
 
     let query = build_query()?;
-    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
+    })?;
 
     let mut query = build_query()?;
     crate::apply_query_options!(query, query_options, Group);
@@ -591,7 +595,9 @@ pub async fn groups_on_paginated_with_total_count_from_backend<T: CollectionAcce
     };
 
     let query = build_query()?;
-    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
+    })?;
 
     let mut query = build_query()?;
     crate::apply_query_options!(query, query_options, GroupPermission);

--- a/src/db/traits/event_delivery.rs
+++ b/src/db/traits/event_delivery.rs
@@ -313,7 +313,9 @@ pub async fn list_event_deliveries_with_total_count(
     query_options: &QueryOptions,
 ) -> Result<(Vec<EventDelivery>, i64), ApiError> {
     let query = build_event_delivery_query(query_options)?;
-    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
+    })?;
     let mut query = build_event_delivery_query(query_options)?;
     crate::apply_query_options!(query, query_options, EventDelivery);
     let deliveries = with_connection(pool, |conn| query.load::<EventDelivery>(conn))?;

--- a/src/db/traits/event_subscription.rs
+++ b/src/db/traits/event_subscription.rs
@@ -415,7 +415,9 @@ pub(crate) async fn list_event_sink_rows_with_total_count(
     query_options: &QueryOptions,
 ) -> Result<(Vec<EventSinkRow>, i64), ApiError> {
     let query = build_event_sink_query(query_options)?;
-    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
+    })?;
     let mut query = build_event_sink_query(query_options)?;
     apply_query_options!(query, query_options, EventSink);
     let rows = with_connection(pool, |conn| query.load::<EventSinkRow>(conn))?;
@@ -452,7 +454,9 @@ pub(crate) async fn list_event_subscription_rows_with_total_count(
     query_options: &QueryOptions,
 ) -> Result<(Vec<EventSubscriptionRow>, i64), ApiError> {
     let base = build_event_subscription_query(collection, query_options)?;
-    let total_count = with_connection(pool, |conn| base.count().get_result::<i64>(conn))?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+        with_connection(pool, |conn| base.count().get_result::<i64>(conn))
+    })?;
     let mut query = build_event_subscription_query(collection, query_options)?;
     apply_query_options!(query, query_options, EventSubscription);
     let rows = with_connection(pool, |conn| query.load::<EventSubscriptionRow>(conn))?;

--- a/src/db/traits/events.rs
+++ b/src/db/traits/events.rs
@@ -29,7 +29,9 @@ pub async fn list_events_with_total_count(
     query_options: &QueryOptions,
 ) -> Result<(Vec<EventResponse>, i64), ApiError> {
     let query = build_event_query(accessible_collection_ids, include_collection_less, filters)?;
-    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
+    })?;
 
     let mut query = build_event_query(accessible_collection_ids, include_collection_less, filters)?;
     apply_query_options!(query, query_options, EventResponse);

--- a/src/db/traits/export_template.rs
+++ b/src/db/traits/export_template.rs
@@ -404,7 +404,9 @@ pub(crate) async fn list_rows_with_total_count(
     query_options: &QueryOptions,
 ) -> Result<(Vec<ExportTemplateRow>, i64), ApiError> {
     let query = build_list_query(allowed_collection_ids, query_options)?;
-    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
+    })?;
 
     let mut query = build_list_query(allowed_collection_ids, query_options)?;
     crate::apply_query_options!(query, query_options, ExportTemplate);

--- a/src/db/traits/history.rs
+++ b/src/db/traits/history.rs
@@ -37,11 +37,13 @@ macro_rules! history_db_fns {
         ) -> Result<(Vec<$ty>, i64), $crate::errors::ApiError> {
             use diesel::prelude::*;
             use $($schema)::+::dsl::*;
-            let total = $crate::db::with_connection(pool, |conn| {
-                $($schema)::+::table
-                    .filter(id.eq(entity_id))
-                    .count()
-                    .get_result::<i64>(conn)
+            let total = $crate::pagination::exact_count_or_skipped(query_options, || {
+                $crate::db::with_connection(pool, |conn| {
+                    $($schema)::+::table
+                        .filter(id.eq(entity_id))
+                        .count()
+                        .get_result::<i64>(conn)
+                })
             })?;
             let mut query = $($schema)::+::table.into_boxed().filter(id.eq(entity_id));
             $crate::apply_query_options!(query, query_options, $ty);
@@ -106,12 +108,14 @@ pub async fn object_history_paginated_with_total_count(
 ) -> Result<(Vec<crate::models::HubuumObjectHistory>, i64), ApiError> {
     use crate::schema::hubuumobject_history::dsl as history;
 
-    let total = with_connection(pool, |conn| {
-        history::hubuumobject_history
-            .filter(history::id.eq(object_id))
-            .filter(history::hubuum_class_id.eq(class_id))
-            .count()
-            .get_result::<i64>(conn)
+    let total = crate::pagination::exact_count_or_skipped(query_options, || {
+        with_connection(pool, |conn| {
+            history::hubuumobject_history
+                .filter(history::id.eq(object_id))
+                .filter(history::hubuum_class_id.eq(class_id))
+                .count()
+                .get_result::<i64>(conn)
+        })
     })?;
     let mut query = history::hubuumobject_history
         .into_boxed()

--- a/src/db/traits/is_active.rs
+++ b/src/db/traits/is_active.rs
@@ -4,7 +4,7 @@ use tracing::warn;
 
 use crate::db::traits::Status;
 use crate::db::traits::active_tokens::{active_token_predicate, active_tokens_cutoff};
-use crate::db::{DbPool, with_connection};
+use crate::db::{DbPool, with_connection_async};
 use crate::errors::ApiError;
 use crate::models::{PrincipalToken, Token};
 
@@ -39,7 +39,7 @@ impl Status<PrincipalToken> for Token {
         let now = chrono::Utc::now().naive_utc().trunc_subsecs(6);
         let cutoff = active_tokens_cutoff();
 
-        let result = with_connection(pool, |conn| {
+        let result = with_connection_async(pool.clone(), move |conn| {
             tokens
                 .filter(token.eq(&token_hash))
                 .filter(active_token_predicate(now, cutoff))
@@ -50,7 +50,8 @@ impl Status<PrincipalToken> for Token {
                 )))
                 .first::<PrincipalToken>(conn)
                 .optional()
-        });
+        })
+        .await;
 
         let mut valid_token = match result {
             Ok(Some(valid_token)) => valid_token,
@@ -76,11 +77,12 @@ impl Status<PrincipalToken> for Token {
             // Best-effort telemetry: a failure to advance `last_used_at` must
             // never fail an otherwise-valid request.
             let token_id_value = valid_token.id;
-            let updated = with_connection(pool, |conn| {
+            let updated = with_connection_async(pool.clone(), move |conn| {
                 diesel::update(tokens.filter(token_id.eq(token_id_value)))
                     .set(last_used_at.eq(now))
                     .execute(conn)
-            });
+            })
+            .await;
             // Reflect the advance in the returned row (the SELECT above read the
             // prior value), so callers observe an accurate `last_used_at`.
             if updated.is_ok() {

--- a/src/db/traits/remote_target.rs
+++ b/src/db/traits/remote_target.rs
@@ -269,7 +269,9 @@ pub(crate) async fn list_rows_with_total_count(
     query_options: &QueryOptions,
 ) -> Result<(Vec<RemoteTargetRow>, i64), ApiError> {
     let query = build_list_query(allowed_collection_ids, query_options)?;
-    let total_count = with_connection(pool, |conn| query.count().get_result::<i64>(conn))?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
+    })?;
 
     let mut query = build_list_query(allowed_collection_ids, query_options)?;
     apply_query_options!(query, query_options, RemoteTarget);

--- a/src/db/traits/task.rs
+++ b/src/db/traits/task.rs
@@ -2,6 +2,7 @@ use chrono::Utc;
 use diesel::PgConnection;
 use diesel::prelude::*;
 use diesel::sql_types::{BigInt, Bool};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing::info;
 
 use crate::apply_query_options;
@@ -708,20 +709,36 @@ pub(crate) fn executable_task_kind_values() -> [&'static str; 3] {
     ]
 }
 
+static NEXT_TASK_KIND: AtomicUsize = AtomicUsize::new(0);
+
+fn task_kind_claim_order(start: usize) -> [&'static str; 3] {
+    let kinds = executable_task_kind_values();
+    std::array::from_fn(|offset| kinds[(start + offset) % kinds.len()])
+}
+
 pub async fn claim_next_queued_task(pool: &DbPool) -> Result<Option<TaskRecord>, ApiError> {
     use crate::schema::tasks::dsl::{created_at, id, kind, started_at, status, tasks, updated_at};
 
     let record = with_transaction(pool, |conn| -> Result<Option<TaskRecord>, ApiError> {
-        let Some(task_id_value) = tasks
-            .filter(status.eq(TaskStatus::Queued.as_str()))
-            .filter(kind.eq_any(executable_task_kind_values()))
-            .order(created_at.asc())
-            .for_update()
-            .skip_locked()
-            .select(id)
-            .first::<i32>(conn)
-            .optional()?
-        else {
+        let task_kinds = executable_task_kind_values();
+        let first_kind = NEXT_TASK_KIND.fetch_add(1, Ordering::Relaxed) % task_kinds.len();
+        let claim_order = task_kind_claim_order(first_kind);
+        let mut selected_task_id = None;
+        for selected_kind in claim_order {
+            selected_task_id = tasks
+                .filter(status.eq(TaskStatus::Queued.as_str()))
+                .filter(kind.eq(selected_kind))
+                .order(created_at.asc())
+                .for_update()
+                .skip_locked()
+                .select(id)
+                .first::<i32>(conn)
+                .optional()?;
+            if selected_task_id.is_some() {
+                break;
+            }
+        }
+        let Some(task_id_value) = selected_task_id else {
             return Ok(None);
         };
 
@@ -766,38 +783,51 @@ pub async fn claim_next_queued_task(pool: &DbPool) -> Result<Option<TaskRecord>,
 }
 
 impl TaskCreateRequest {
-    /// Queue this task (with its initial "queued" event) in a single transaction.
-    pub async fn create_generic(self, pool: &DbPool) -> Result<TaskRecord, ApiError> {
-        let task = with_transaction(pool, |conn| -> Result<TaskRecord, ApiError> {
-            insert_queued_task_with_event(conn, self)
-        })?;
-
-        log_task_queued(&task);
-
-        Ok(task)
-    }
-
-    /// Queue this export task, rejecting it with `429` if the submitter already has
-    /// `max_active_export_tasks` queued/validating/running exports. Capacity is checked under a
-    /// per-user advisory lock so concurrent submissions cannot race past the limit.
-    pub async fn create_with_active_export_limit(
+    /// Return an existing task for an identical idempotent submission or create a
+    /// new one under the per-user active-task limit. The post-conflict lookup
+    /// closes the race between concurrent requests carrying the same key.
+    pub async fn create_idempotently_with_active_limit(
         self,
         pool: &DbPool,
-        max_active_export_tasks: usize,
+        max_active_tasks: usize,
     ) -> Result<TaskRecord, ApiError> {
-        self.create_with_active_kind_limit(pool, TaskKind::Export, max_active_export_tasks)
-            .await
-    }
+        let kind = self.kind;
+        let submitted_by = self.submitted_by;
+        let idempotency_key = self.idempotency_key.clone();
+        let request_hash = self.request_hash.clone();
+        let matches_request =
+            |task: &TaskRecord| task.kind == kind.as_str() && task.request_hash == request_hash;
 
-    /// Queue this remote call task, rejecting it with `429` if the submitter already has
-    /// `max_active_remote_call_tasks` queued/validating/running remote calls.
-    pub async fn create_with_active_remote_call_limit(
-        self,
-        pool: &DbPool,
-        max_active_remote_call_tasks: usize,
-    ) -> Result<TaskRecord, ApiError> {
-        self.create_with_active_kind_limit(pool, TaskKind::RemoteCall, max_active_remote_call_tasks)
+        if let Some(key) = idempotency_key.as_deref()
+            && let Some(existing) = TaskRecord::find_by_idempotency(pool, submitted_by, key).await?
+        {
+            if matches_request(&existing) {
+                return Ok(existing);
+            }
+            return Err(ApiError::Conflict(format!(
+                "Idempotency-Key '{key}' is already in use for a different task submission"
+            )));
+        }
+
+        match self
+            .create_with_active_kind_limit(pool, kind, max_active_tasks)
             .await
+        {
+            Ok(task) => Ok(task),
+            Err(ApiError::Conflict(_)) => {
+                if let Some(key) = idempotency_key.as_deref()
+                    && let Some(existing) =
+                        TaskRecord::find_by_idempotency(pool, submitted_by, key).await?
+                    && matches_request(&existing)
+                {
+                    return Ok(existing);
+                }
+                Err(ApiError::Conflict(
+                    "Idempotency-Key is already in use for a different task submission".to_string(),
+                ))
+            }
+            Err(error) => Err(error),
+        }
     }
 
     async fn create_with_active_kind_limit(
@@ -953,7 +983,10 @@ mod tests {
     use std::sync::mpsc;
     use std::thread;
 
-    use super::{TaskBackend, TaskCreateRequest, claim_next_queued_task, task_capacity_lock_key};
+    use super::{
+        TaskBackend, TaskCreateRequest, claim_next_queued_task, task_capacity_lock_key,
+        task_kind_claim_order,
+    };
     use crate::db::traits::user::DeleteUserRecord;
     use crate::db::with_transaction;
     use crate::errors::ApiError;
@@ -984,6 +1017,20 @@ mod tests {
             fallback_key,
             task_capacity_lock_key(user_id, TaskKind::Reindex)
         );
+    }
+
+    #[test]
+    fn task_claim_order_rotates_every_executable_kind_to_the_front() {
+        assert_eq!(
+            task_kind_claim_order(0),
+            [
+                TaskKind::Import.as_str(),
+                TaskKind::Export.as_str(),
+                TaskKind::RemoteCall.as_str(),
+            ]
+        );
+        assert_eq!(task_kind_claim_order(1)[0], TaskKind::Export.as_str());
+        assert_eq!(task_kind_claim_order(2)[0], TaskKind::RemoteCall.as_str());
     }
 
     #[test]
@@ -1124,7 +1171,7 @@ mod tests {
                 request_payload: serde_json::json!({"export": "first"}),
                 total_items: 1,
             }
-            .create_with_active_export_limit(&context.pool, 1),
+            .create_idempotently_with_active_limit(&context.pool, 1),
         )
         .unwrap();
 
@@ -1142,13 +1189,46 @@ mod tests {
                 request_payload: serde_json::json!({"export": "second"}),
                 total_items: 1,
             }
-            .create_with_active_export_limit(&context.pool, 1),
+            .create_idempotently_with_active_limit(&context.pool, 1),
         )
         .unwrap_err();
 
         match error {
             ApiError::TooManyRequests(message) => {
                 assert!(message.contains("Too many active export tasks for user"));
+            }
+            other => panic!("expected TooManyRequests, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_import_task_active_limit_blocks_new_work_for_same_user() {
+        let context = block_on(TestContext::new());
+        let create_request = |suffix: &str| TaskCreateRequest {
+            kind: TaskKind::Import,
+            submitted_by: context.admin_user.id,
+            submitted_token_id: None,
+            submitted_token_scoped: false,
+            submitted_token_scopes: serde_json::json!([]),
+            idempotency_key: Some(context.scoped_name(&format!("import-cap-{suffix}"))),
+            request_hash: Some(context.scoped_name(&format!("import-cap-{suffix}-hash"))),
+            request_payload: serde_json::json!({"import": suffix}),
+            total_items: 1,
+        };
+
+        let first = block_on(
+            create_request("first").create_idempotently_with_active_limit(&context.pool, 1),
+        )
+        .unwrap();
+        assert_eq!(first.status, TaskStatus::Queued.as_str());
+
+        let error = block_on(
+            create_request("second").create_idempotently_with_active_limit(&context.pool, 1),
+        )
+        .unwrap_err();
+        match error {
+            ApiError::TooManyRequests(message) => {
+                assert!(message.contains("Too many active import tasks for user"));
             }
             other => panic!("expected TooManyRequests, got {other:?}"),
         }
@@ -1179,7 +1259,7 @@ mod tests {
                 request_payload: payload.clone(),
                 total_items: 1,
             }
-            .create_with_active_remote_call_limit(&context.pool, 1),
+            .create_idempotently_with_active_limit(&context.pool, 1),
         )
         .unwrap();
 
@@ -1197,7 +1277,7 @@ mod tests {
                 request_payload: payload,
                 total_items: 1,
             }
-            .create_with_active_remote_call_limit(&context.pool, 1),
+            .create_idempotently_with_active_limit(&context.pool, 1),
         )
         .unwrap_err();
 

--- a/src/db/traits/task.rs
+++ b/src/db/traits/task.rs
@@ -141,12 +141,14 @@ pub trait TaskBackend: TaskIdentifier {
             .unwrap_or(false);
         let cursor_id = decode_task_event_cursor_id(query_options)?;
 
-        let total_count = with_connection(pool, |conn| {
-            events
-                .filter(entity_type.eq(EntityType::Task.as_str()))
-                .filter(entity_id.eq(Some(task_id_value)))
-                .count()
-                .get_result::<i64>(conn)
+        let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+            with_connection(pool, |conn| {
+                events
+                    .filter(entity_type.eq(EntityType::Task.as_str()))
+                    .filter(entity_id.eq(Some(task_id_value)))
+                    .count()
+                    .get_result::<i64>(conn)
+            })
         })?;
 
         let items = with_connection(pool, |conn| {
@@ -199,11 +201,13 @@ pub trait TaskBackend: TaskIdentifier {
             .unwrap_or(false);
         let cursor_id = decode_int_history_cursor_id(query_options)?;
 
-        let total_count = with_connection(pool, |conn| {
-            import_task_results
-                .filter(task_id.eq(task_id_value))
-                .count()
-                .get_result::<i64>(conn)
+        let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+            with_connection(pool, |conn| {
+                import_task_results
+                    .filter(task_id.eq(task_id_value))
+                    .count()
+                    .get_result::<i64>(conn)
+            })
         })?;
 
         let items = with_connection(pool, |conn| {
@@ -515,10 +519,12 @@ pub async fn list_tasks_with_total_count(
     status_filter: Option<&str>,
     query_options: &QueryOptions,
 ) -> Result<(Vec<TaskRecord>, i64), ApiError> {
-    let total_count = with_connection(pool, |conn| {
-        build_task_query(submitted_by_filter, kind_filter, status_filter)
-            .count()
-            .get_result::<i64>(conn)
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+        with_connection(pool, |conn| {
+            build_task_query(submitted_by_filter, kind_filter, status_filter)
+                .count()
+                .get_result::<i64>(conn)
+        })
     })?;
 
     let items = with_connection(pool, |conn| -> Result<Vec<TaskRecord>, ApiError> {
@@ -1109,6 +1115,7 @@ mod tests {
                         sort: Vec::new(),
                         limit: None,
                         cursor: None,
+                        include_total: true,
                     },
                 ),
         )

--- a/src/db/traits/user/auth.rs
+++ b/src/db/traits/user/auth.rs
@@ -81,18 +81,22 @@ impl User {
         use crate::schema::principals;
         use crate::schema::users;
 
-        with_connection(pool, |conn| {
+        let pool = pool.clone();
+        let name = name_arg.to_string();
+        let scope = scope_arg.to_string();
+        crate::db::with_connection_async(pool, move |conn| {
             users::table
                 .inner_join(principals::table.on(users::id.eq(principals::id)))
                 .inner_join(
                     identity_scopes::table
                         .on(principals::identity_scope_id.eq(identity_scopes::id)),
                 )
-                .filter(principals::name.eq(name_arg))
-                .filter(identity_scopes::name.eq(scope_arg))
+                .filter(principals::name.eq(name))
+                .filter(identity_scopes::name.eq(scope))
                 .select(users::all_columns)
                 .first::<User>(conn)
         })
+        .await
     }
 
     /// Set a new password for a user.

--- a/src/db/traits/user/membership.rs
+++ b/src/db/traits/user/membership.rs
@@ -80,7 +80,9 @@ where
         };
 
         let base_query = build_query()?;
-        let total_count = with_connection(pool, |conn| base_query.count().get_result::<i64>(conn))?;
+        let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
+            with_connection(pool, |conn| base_query.count().get_result::<i64>(conn))
+        })?;
 
         let mut base_query = build_query()?.select(groups::all_columns());
         crate::apply_query_options!(base_query, query_options, Group);

--- a/src/db/traits/user/search.rs
+++ b/src/db/traits/user/search.rs
@@ -807,16 +807,17 @@ pub trait UserSearchBackend: UserCollectionAccessors {
                     operator: class_param.operator.clone(),
                     value: class_param.value.clone(),
                 };
-                let query_options = QueryOptions {
+                let class_query_options = QueryOptions {
                     filters: vec![qparam],
                     sort: vec![],
                     limit: None,
                     cursor: None,
+                    include_total: true,
                 };
                 let classes = self
                     .search_classes_from_backend_with_admin_status(
                         pool,
-                        query_options,
+                        class_query_options,
                         is_admin,
                         scopes,
                     )
@@ -830,7 +831,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
                         user_id = self.principal_id(),
                         result = "No class IDs found, returning empty result"
                     );
-                    return Ok((vec![], 0));
+                    return Ok((
+                        vec![],
+                        crate::pagination::known_count_or_skipped(&query_options, 0),
+                    ));
                 }
 
                 debug!(
@@ -911,12 +915,14 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         };
 
         let base_query = build_query()?;
-        let total_count = with_connection(pool, |conn| {
-            base_query
-                .select(class_relation_id)
-                .distinct()
-                .count()
-                .get_result::<i64>(conn)
+        let total_count = crate::pagination::exact_count_or_skipped(&query_options, || {
+            with_connection(pool, |conn| {
+                base_query
+                    .select(class_relation_id)
+                    .distinct()
+                    .count()
+                    .get_result::<i64>(conn)
+            })
         })?;
 
         let mut base_query = build_query()?;
@@ -1045,12 +1051,14 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         };
 
         let base_query = build_query()?;
-        let total_count = with_connection(pool, |conn| {
-            base_query
-                .select(relation_id)
-                .distinct()
-                .count()
-                .get_result::<i64>(conn)
+        let total_count = crate::pagination::exact_count_or_skipped(&query_options, || {
+            with_connection(pool, |conn| {
+                base_query
+                    .select(relation_id)
+                    .distinct()
+                    .count()
+                    .get_result::<i64>(conn)
+            })
         })?;
 
         let mut base_query = build_query()?;
@@ -1238,15 +1246,20 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         )
         .await?
         else {
-            return Ok((vec![], 0));
+            return Ok((
+                vec![],
+                crate::pagination::known_count_or_skipped(&query_options, 0),
+            ));
         };
         let total_count_spec = base_spec.clone().into_count_query("related_classes_count");
         let spec = apply_raw_sql_pagination::<ClassGraphRow>(base_spec, &query_options)?;
 
-        let total_count = with_connection(pool, |conn| {
-            bind_raw_sql_query!(total_count_spec)
-                .get_result::<CountRow>(conn)
-                .map(|row| row.count)
+        let total_count = crate::pagination::exact_count_or_skipped(&query_options, || {
+            with_connection(pool, |conn| {
+                bind_raw_sql_query!(total_count_spec)
+                    .get_result::<CountRow>(conn)
+                    .map(|row| row.count)
+            })
         })?;
 
         let query = bind_raw_sql_query!(spec.clone());
@@ -1409,12 +1422,14 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         };
 
         let base_query = build_query()?;
-        let total_count = with_connection(pool, |conn| {
-            base_query
-                .select(relation_id)
-                .distinct()
-                .count()
-                .get_result::<i64>(conn)
+        let total_count = crate::pagination::exact_count_or_skipped(&query_options, || {
+            with_connection(pool, |conn| {
+                base_query
+                    .select(relation_id)
+                    .distinct()
+                    .count()
+                    .get_result::<i64>(conn)
+            })
         })?;
 
         let mut base_query = build_query()?;
@@ -1563,12 +1578,14 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         };
 
         let base_query = build_query()?;
-        let total_count = with_connection(pool, |conn| {
-            base_query
-                .select(relation_id)
-                .distinct()
-                .count()
-                .get_result::<i64>(conn)
+        let total_count = crate::pagination::exact_count_or_skipped(&query_options, || {
+            with_connection(pool, |conn| {
+                base_query
+                    .select(relation_id)
+                    .distinct()
+                    .count()
+                    .get_result::<i64>(conn)
+            })
         })?;
 
         let mut base_query = build_query()?;
@@ -1765,15 +1782,20 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         )
         .await?
         else {
-            return Ok((vec![], 0));
+            return Ok((
+                vec![],
+                crate::pagination::known_count_or_skipped(&query_options, 0),
+            ));
         };
         let total_count_spec = base_spec.clone().into_count_query("related_objects_count");
         let spec = apply_raw_sql_pagination::<RelatedObjectGraphRow>(base_spec, &query_options)?;
 
-        let total_count = with_connection(pool, |conn| {
-            bind_raw_sql_query!(total_count_spec)
-                .get_result::<CountRow>(conn)
-                .map(|row| row.count)
+        let total_count = crate::pagination::exact_count_or_skipped(&query_options, || {
+            with_connection(pool, |conn| {
+                bind_raw_sql_query!(total_count_spec)
+                    .get_result::<CountRow>(conn)
+                    .map(|row| row.count)
+            })
         })?;
 
         let query = bind_raw_sql_query!(spec.clone());

--- a/src/db/traits/user/unified_search.rs
+++ b/src/db/traits/user/unified_search.rs
@@ -1,15 +1,126 @@
-use diesel::dsl::sql;
 use diesel::prelude::*;
-use diesel::sql_types::{Bool, Text};
+use diesel::sql_query;
+use diesel::sql_types::{BigInt, Bool, Integer, Text};
 
-use crate::db::traits::user::LoadPermittedCollections;
-use crate::db::{DbPool, with_connection};
+use crate::db::traits::authz::{AuthzSubject, scope_allows};
+use crate::db::{DbPool, with_connection_async};
 use crate::errors::ApiError;
 use crate::models::traits::ExpandCollectionFromMap;
 use crate::models::traits::user::UserCollectionAccessors;
 use crate::models::{
-    Collection, HubuumClass, HubuumClassExpanded, HubuumObject, Permissions, UnifiedSearchSpec,
+    Collection, HubuumClass, HubuumClassExpanded, HubuumObject, Permissions,
+    UnifiedSearchCursorToken, UnifiedSearchSpec,
 };
+
+const COLLECTION_SEARCH_SQL: &str = r#"
+    SELECT c.id, c.name, c.description, c.created_at, c.updated_at,
+           c.parent_collection_id
+    FROM collections c
+    CROSS JOIN LATERAL (
+        SELECT CASE
+            WHEN lower(c.name) = lower($1) THEN 0
+            WHEN lower(c.name) LIKE lower($1) || '%' THEN 1
+            WHEN lower(c.name) LIKE '%' || lower($1) || '%' THEN 2
+            WHEN lower(c.description) LIKE '%' || lower($1) || '%' THEN 3
+            ELSE 4
+        END AS search_rank
+    ) ranked
+    WHERE (c.name ILIKE '%' || $1 || '%' OR c.description ILIKE '%' || $1 || '%')
+      AND ($2 OR EXISTS (
+          SELECT 1
+          FROM permissions p
+          JOIN group_memberships gm ON gm.group_id = p.group_id
+          JOIN collection_closure cc ON cc.ancestor_collection_id = p.collection_id
+          WHERE gm.principal_id = $3
+            AND cc.descendant_collection_id = c.id
+            AND p.has_read_collection
+      ))
+      AND ($4 OR (ranked.search_rank, lower(c.name), c.id) > ($5, $6, $7))
+    ORDER BY ranked.search_rank, lower(c.name), c.id
+    LIMIT $8
+"#;
+
+const CLASS_SEARCH_SQL: &str = r#"
+    SELECT c.id, c.name, c.collection_id, c.json_schema, c.validate_schema,
+           c.description, c.created_at, c.updated_at
+    FROM hubuumclass c
+    CROSS JOIN LATERAL (
+        SELECT CASE
+            WHEN lower(c.name) = lower($1) THEN 0
+            WHEN lower(c.name) LIKE lower($1) || '%' THEN 1
+            WHEN lower(c.name) LIKE '%' || lower($1) || '%' THEN 2
+            WHEN lower(c.description) LIKE '%' || lower($1) || '%' THEN 3
+            WHEN $2 AND lower(coalesce(c.json_schema::text, ''))
+                LIKE '%' || lower($1) || '%' THEN 4
+            ELSE 5
+        END AS search_rank
+    ) ranked
+    WHERE (
+          c.name ILIKE '%' || $1 || '%'
+          OR c.description ILIKE '%' || $1 || '%'
+          OR ($2 AND lower(coalesce(c.json_schema::text, '')) LIKE '%' || lower($1) || '%')
+      )
+      AND ($3 OR EXISTS (
+          SELECT 1
+          FROM permissions p
+          JOIN group_memberships gm ON gm.group_id = p.group_id
+          JOIN collection_closure cc ON cc.ancestor_collection_id = p.collection_id
+          WHERE gm.principal_id = $4
+            AND cc.descendant_collection_id = c.collection_id
+            AND p.has_read_collection
+            AND p.has_read_class
+      ))
+      AND ($5 OR (ranked.search_rank, lower(c.name), c.id) > ($6, $7, $8))
+    ORDER BY ranked.search_rank, lower(c.name), c.id
+    LIMIT $9
+"#;
+
+const OBJECT_SEARCH_SQL: &str = r#"
+    SELECT o.id, o.name, o.collection_id, o.hubuum_class_id, o.data,
+           o.description, o.created_at, o.updated_at
+    FROM hubuumobject o
+    CROSS JOIN LATERAL (
+        SELECT CASE
+            WHEN lower(o.name) = lower($1) THEN 0
+            WHEN lower(o.name) LIKE lower($1) || '%' THEN 1
+            WHEN lower(o.name) LIKE '%' || lower($1) || '%' THEN 2
+            WHEN lower(o.description) LIKE '%' || lower($1) || '%' THEN 3
+            WHEN $2 AND jsonb_to_tsvector('simple', o.data, '["string"]')
+                @@ plainto_tsquery('simple', $1) THEN 4
+            ELSE 5
+        END AS search_rank
+    ) ranked
+    WHERE (
+          o.name ILIKE '%' || $1 || '%'
+          OR o.description ILIKE '%' || $1 || '%'
+          OR ($2 AND jsonb_to_tsvector('simple', o.data, '["string"]')
+              @@ plainto_tsquery('simple', $1))
+      )
+      AND ($3 OR EXISTS (
+          SELECT 1
+          FROM permissions p
+          JOIN group_memberships gm ON gm.group_id = p.group_id
+          JOIN collection_closure cc ON cc.ancestor_collection_id = p.collection_id
+          WHERE gm.principal_id = $4
+            AND cc.descendant_collection_id = o.collection_id
+            AND p.has_read_collection
+            AND p.has_read_object
+      ))
+      AND ($5 OR (ranked.search_rank, lower(o.name), o.id) > ($6, $7, $8))
+    ORDER BY ranked.search_rank, lower(o.name), o.id
+    LIMIT $9
+"#;
+
+fn bounded_limit(limit: usize) -> i64 {
+    i64::try_from(limit.saturating_add(1)).unwrap_or(i64::MAX)
+}
+
+fn cursor_values(cursor: Option<&UnifiedSearchCursorToken>) -> (bool, i32, String, i32) {
+    match cursor {
+        Some(cursor) => (false, cursor.rank, cursor.name.clone(), cursor.id),
+        None => (true, 0, String::new(), 0),
+    }
+}
 
 pub trait UnifiedSearchBackend: UserCollectionAccessors {
     async fn search_unified_collections_from_backend(
@@ -18,30 +129,30 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
         params: &UnifiedSearchSpec,
         scopes: Option<&[Permissions]>,
     ) -> Result<Vec<Collection>, ApiError> {
-        use crate::schema::collections::dsl as collection_dsl;
-
-        let collections =
-            permitted_collections(self, pool, &[Permissions::ReadCollection], scopes).await?;
-        if collections.is_empty() {
-            return Ok(vec![]);
+        if !scope_allows(scopes, &[Permissions::ReadCollection]) {
+            return Ok(Vec::new());
         }
 
-        let collection_ids = collections
-            .into_iter()
-            .map(|collection| collection.id)
-            .collect::<Vec<_>>();
-        let pattern = format!("%{}%", params.query);
+        let is_unscoped_admin = AuthzSubject::is_admin(self, pool).await? && scopes.is_none();
+        let principal_id = self.principal_id();
+        let query = params.query.clone();
+        let (no_cursor, cursor_rank, cursor_name, cursor_id) =
+            cursor_values(params.collection_cursor.as_ref());
+        let limit = bounded_limit(params.limit_per_kind);
 
-        with_connection(pool, |conn| {
-            collection_dsl::collections
-                .filter(collection_dsl::id.eq_any(collection_ids))
-                .filter(
-                    collection_dsl::name
-                        .ilike(pattern.clone())
-                        .or(collection_dsl::description.ilike(pattern.clone())),
-                )
+        with_connection_async(pool.clone(), move |conn| {
+            sql_query(COLLECTION_SEARCH_SQL)
+                .bind::<Text, _>(query)
+                .bind::<Bool, _>(is_unscoped_admin)
+                .bind::<Integer, _>(principal_id)
+                .bind::<Bool, _>(no_cursor)
+                .bind::<Integer, _>(cursor_rank)
+                .bind::<Text, _>(cursor_name)
+                .bind::<Integer, _>(cursor_id)
+                .bind::<BigInt, _>(limit)
                 .load::<Collection>(conn)
         })
+        .await
     }
 
     async fn search_unified_classes_from_backend(
@@ -50,53 +161,55 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
         params: &UnifiedSearchSpec,
         scopes: Option<&[Permissions]>,
     ) -> Result<Vec<HubuumClassExpanded>, ApiError> {
-        use crate::schema::hubuumclass::dsl as class_dsl;
-
-        let collections = permitted_collections(
-            self,
-            pool,
-            &[Permissions::ReadCollection, Permissions::ReadClass],
+        if !scope_allows(
             scopes,
-        )
-        .await?;
-        if collections.is_empty() {
-            return Ok(vec![]);
+            &[Permissions::ReadCollection, Permissions::ReadClass],
+        ) {
+            return Ok(Vec::new());
         }
 
-        let collection_map = collections
+        let is_unscoped_admin = AuthzSubject::is_admin(self, pool).await? && scopes.is_none();
+        let principal_id = self.principal_id();
+        let query = params.query.clone();
+        let search_schema = params.search_class_schema;
+        let (no_cursor, cursor_rank, cursor_name, cursor_id) =
+            cursor_values(params.class_cursor.as_ref());
+        let limit = bounded_limit(params.limit_per_kind);
+
+        let classes = with_connection_async(pool.clone(), move |conn| {
+            sql_query(CLASS_SEARCH_SQL)
+                .bind::<Text, _>(query)
+                .bind::<Bool, _>(search_schema)
+                .bind::<Bool, _>(is_unscoped_admin)
+                .bind::<Integer, _>(principal_id)
+                .bind::<Bool, _>(no_cursor)
+                .bind::<Integer, _>(cursor_rank)
+                .bind::<Text, _>(cursor_name)
+                .bind::<Integer, _>(cursor_id)
+                .bind::<BigInt, _>(limit)
+                .load::<HubuumClass>(conn)
+        })
+        .await?;
+
+        if classes.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let collection_ids = classes
             .iter()
-            .cloned()
+            .map(|class| class.collection_id)
+            .collect::<Vec<_>>();
+        let collections = with_connection_async(pool.clone(), move |conn| {
+            use crate::schema::collections::dsl::{collections, id};
+            collections
+                .filter(id.eq_any(collection_ids))
+                .load::<Collection>(conn)
+        })
+        .await?;
+        let collection_map = collections
+            .into_iter()
             .map(|collection| (collection.id, collection))
             .collect::<std::collections::HashMap<_, _>>();
-        let collection_ids = collection_map.keys().copied().collect::<Vec<_>>();
-        let pattern = format!("%{}%", params.query);
-
-        let classes = with_connection(pool, |conn| {
-            let mut query = class_dsl::hubuumclass
-                .filter(class_dsl::collection_id.eq_any(collection_ids))
-                .into_boxed();
-
-            if params.search_class_schema {
-                query = query.filter(
-                    class_dsl::name
-                        .ilike(pattern.clone())
-                        .or(class_dsl::description.ilike(pattern.clone()))
-                        .or(sql::<Bool>(
-                            "lower(coalesce(json_schema::text, '')) LIKE '%' || lower(",
-                        )
-                        .bind::<Text, _>(params.query.clone())
-                        .sql(") || '%'")),
-                );
-            } else {
-                query = query.filter(
-                    class_dsl::name
-                        .ilike(pattern.clone())
-                        .or(class_dsl::description.ilike(pattern.clone())),
-                );
-            }
-
-            query.load::<HubuumClass>(conn)
-        })?;
 
         Ok(classes.expand_collection_from_map(&collection_map))
     }
@@ -107,68 +220,36 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
         params: &UnifiedSearchSpec,
         scopes: Option<&[Permissions]>,
     ) -> Result<Vec<HubuumObject>, ApiError> {
-        use crate::schema::hubuumobject::dsl as object_dsl;
-
-        let collections = permitted_collections(
-            self,
-            pool,
-            &[Permissions::ReadCollection, Permissions::ReadObject],
+        if !scope_allows(
             scopes,
-        )
-        .await?;
-        if collections.is_empty() {
-            return Ok(vec![]);
+            &[Permissions::ReadCollection, Permissions::ReadObject],
+        ) {
+            return Ok(Vec::new());
         }
 
-        let collection_ids = collections
-            .into_iter()
-            .map(|collection| collection.id)
-            .collect::<Vec<_>>();
-        let pattern = format!("%{}%", params.query);
+        let is_unscoped_admin = AuthzSubject::is_admin(self, pool).await? && scopes.is_none();
+        let principal_id = self.principal_id();
+        let query = params.query.clone();
+        let search_data = params.search_object_data;
+        let (no_cursor, cursor_rank, cursor_name, cursor_id) =
+            cursor_values(params.object_cursor.as_ref());
+        let limit = bounded_limit(params.limit_per_kind);
 
-        with_connection(pool, |conn| {
-            let mut query = object_dsl::hubuumobject
-                .filter(object_dsl::collection_id.eq_any(collection_ids))
-                .into_boxed();
-
-            if params.search_object_data {
-                query = query.filter(
-                    object_dsl::name
-                        .ilike(pattern.clone())
-                        .or(object_dsl::description.ilike(pattern.clone()))
-                        .or(
-                            sql::<Bool>(
-                                "jsonb_to_tsvector('simple', data, '[\"string\"]') @@ plainto_tsquery('simple', ",
-                            )
-                            .bind::<Text, _>(params.query.clone())
-                            .sql(")"),
-                        ),
-                );
-            } else {
-                query = query.filter(
-                    object_dsl::name
-                        .ilike(pattern.clone())
-                        .or(object_dsl::description.ilike(pattern.clone())),
-                );
-            }
-
-            query.load::<HubuumObject>(conn)
+        with_connection_async(pool.clone(), move |conn| {
+            sql_query(OBJECT_SEARCH_SQL)
+                .bind::<Text, _>(query)
+                .bind::<Bool, _>(search_data)
+                .bind::<Bool, _>(is_unscoped_admin)
+                .bind::<Integer, _>(principal_id)
+                .bind::<Bool, _>(no_cursor)
+                .bind::<Integer, _>(cursor_rank)
+                .bind::<Text, _>(cursor_name)
+                .bind::<Integer, _>(cursor_id)
+                .bind::<BigInt, _>(limit)
+                .load::<HubuumObject>(conn)
         })
-    }
-}
-
-async fn permitted_collections<T>(
-    user: &T,
-    pool: &DbPool,
-    permissions: &[Permissions],
-    scopes: Option<&[Permissions]>,
-) -> Result<Vec<Collection>, ApiError>
-where
-    T: UserCollectionAccessors + ?Sized,
-{
-    let permissions = permissions.to_vec();
-    user.load_collections_with_permissions(pool, &permissions, scopes)
         .await
+    }
 }
 
 impl<T: ?Sized> UnifiedSearchBackend for T where T: UserCollectionAccessors {}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,6 +10,9 @@ use std::num::ParseIntError;
 
 use tracing::{debug, error};
 
+const PUBLIC_INTERNAL_ERROR: &str = "An internal error occurred";
+const PUBLIC_SERVICE_UNAVAILABLE: &str = "Service temporarily unavailable";
+
 // Exit codes for startup/initialization failures.
 // These help shell scripts and orchestration systems determine the failure mode.
 pub const EXIT_CODE_GENERIC_ERROR: i32 = 1; // Non-specific/generic errors
@@ -91,6 +94,30 @@ impl ApiError {
             _ => EXIT_CODE_GENERIC_ERROR,
         }
     }
+
+    /// Message safe to expose over any public transport, including response
+    /// bodies and streaming events.
+    pub fn public_message(&self) -> &str {
+        match self {
+            ApiError::InternalServerError(_)
+            | ApiError::DatabaseError(_)
+            | ApiError::DbConnectionError(_)
+            | ApiError::HashError(_) => PUBLIC_INTERNAL_ERROR,
+            ApiError::ServiceUnavailable(_) => PUBLIC_SERVICE_UNAVAILABLE,
+            ApiError::Unauthorized(message)
+            | ApiError::Forbidden(message)
+            | ApiError::NotAcceptable(message)
+            | ApiError::PayloadTooLarge(message)
+            | ApiError::Conflict(message)
+            | ApiError::TooManyRequests(message)
+            | ApiError::NotFound(message)
+            | ApiError::Gone(message)
+            | ApiError::BadRequest(message)
+            | ApiError::OperatorMismatch(message)
+            | ApiError::InvalidIntegerRange(message)
+            | ApiError::ValidationError(message) => message,
+        }
+    }
 }
 
 impl fmt::Display for ApiError {
@@ -125,8 +152,9 @@ impl ResponseError for ApiError {
             }
             ApiError::TooManyRequests(message) => HttpResponse::TooManyRequests()
                 .json(json!({ "error": "Too Many Requests", "message": message })),
-            ApiError::ServiceUnavailable(message) => HttpResponse::ServiceUnavailable()
-                .json(json!({ "error": "Service Unavailable", "message": message })),
+            ApiError::ServiceUnavailable(_) => HttpResponse::ServiceUnavailable().json(
+                json!({ "error": "Service Unavailable", "message": PUBLIC_SERVICE_UNAVAILABLE }),
+            ),
             ApiError::Forbidden(message) => {
                 HttpResponse::Forbidden().json(json!({ "error": "Forbidden", "message": message }))
             }
@@ -134,16 +162,14 @@ impl ResponseError for ApiError {
                 .json(json!({ "error": "Not Acceptable", "message": message })),
             ApiError::PayloadTooLarge(message) => HttpResponse::PayloadTooLarge()
                 .json(json!({ "error": "Payload Too Large", "message": message })),
-            ApiError::InternalServerError(message) => HttpResponse::InternalServerError()
-                .json(json!({ "error": "Internal Server Error", "message": message })),
+            ApiError::InternalServerError(_)
+            | ApiError::DbConnectionError(_)
+            | ApiError::DatabaseError(_)
+            | ApiError::HashError(_) => HttpResponse::InternalServerError().json(
+                json!({ "error": "Internal Server Error", "message": PUBLIC_INTERNAL_ERROR }),
+            ),
             ApiError::Unauthorized(message) => HttpResponse::Unauthorized()
                 .json(json!({ "error": "Unauthorized", "message": message })),
-            ApiError::DbConnectionError(message) => HttpResponse::InternalServerError()
-                .json(json!({ "error": "Database Connection Error", "message": message })),
-            ApiError::DatabaseError(message) => HttpResponse::InternalServerError()
-                .json(json!({ "error": "Database Error", "message": message })),
-            ApiError::HashError(message) => HttpResponse::InternalServerError()
-                .json(json!({ "error": "Hash Error", "message": message })),
             ApiError::NotFound(message) => {
                 HttpResponse::NotFound().json(json!({ "error": "Not Found", "message": message }))
             }
@@ -398,5 +424,38 @@ mod tests {
             ApiError::ServiceUnavailable("test".to_string()).status_code(),
             StatusCode::SERVICE_UNAVAILABLE
         );
+    }
+
+    #[actix_web::test]
+    async fn internal_error_responses_do_not_expose_details() {
+        use actix_web::body::to_bytes;
+
+        for error in [
+            ApiError::InternalServerError("secret internal path".to_string()),
+            ApiError::DatabaseError("password=database-secret".to_string()),
+            ApiError::DbConnectionError("postgres://user:secret@db/app".to_string()),
+            ApiError::HashError("hash implementation detail".to_string()),
+        ] {
+            let response = error.error_response();
+            let body = to_bytes(response.into_body()).await.unwrap();
+            let body = std::str::from_utf8(&body).unwrap();
+            assert!(body.contains(PUBLIC_INTERNAL_ERROR));
+            assert!(!body.contains("secret"));
+            assert!(!body.contains("implementation detail"));
+        }
+    }
+
+    #[actix_web::test]
+    async fn service_unavailable_response_does_not_expose_details() {
+        use actix_web::body::to_bytes;
+
+        let response = ApiError::ServiceUnavailable(
+            "database host db.internal.example rejected password".to_string(),
+        )
+        .error_response();
+        let body = to_bytes(response.into_body()).await.unwrap();
+        let body = std::str::from_utf8(&body).unwrap();
+        assert!(body.contains(PUBLIC_SERVICE_UNAVAILABLE));
+        assert!(!body.contains("db.internal.example"));
     }
 }

--- a/src/events/delivery.rs
+++ b/src/events/delivery.rs
@@ -4,6 +4,7 @@ use std::thread;
 use std::time::Duration;
 
 use actix_rt::time::sleep;
+use futures_util::StreamExt;
 use tokio::sync::Notify;
 use tracing::{error, info};
 
@@ -30,6 +31,8 @@ static EVENT_DELIVERY_NOTIFICATION_WAKEUPS: AtomicU64 = AtomicU64::new(0);
 static EVENT_DELIVERY_POLL_WAKEUPS: AtomicU64 = AtomicU64::new(0);
 static DEFAULT_SINK_RESOLVER: std::sync::LazyLock<DefaultSinkResolver> =
     std::sync::LazyLock::new(DefaultSinkResolver::default);
+
+const EVENT_DELIVERY_MAX_CONCURRENCY_PER_WORKER: usize = 8;
 
 fn get_event_delivery_notify() -> &'static Notify {
     EVENT_DELIVERY_NOTIFY.get_or_init(Notify::new)
@@ -78,11 +81,14 @@ pub async fn process_event_delivery_batch(
     resolver: &dyn SinkResolver,
 ) -> Result<usize, ApiError> {
     let deliveries = claim_event_deliveries(pool, settings).await?;
-    let mut processed = 0;
-
-    for claimed in deliveries {
-        process_claimed_event_delivery(pool, settings, resolver, claimed).await?;
-        processed += 1;
+    let processed = deliveries.len();
+    let results = futures_util::stream::iter(deliveries)
+        .map(|claimed| process_claimed_event_delivery(pool, settings, resolver, claimed))
+        .buffer_unordered(EVENT_DELIVERY_MAX_CONCURRENCY_PER_WORKER)
+        .collect::<Vec<_>>()
+        .await;
+    for result in results {
+        result?;
     }
 
     Ok(processed)

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,7 @@ async fn main() -> std::io::Result<()> {
         db_pool_size = config.db_pool_size,
     );
 
+    utilities::auth::initialize_dummy_password_hash();
     let pool = init_pool(&config.database_url, config.db_pool_size);
 
     if let Err(e) = utilities::init::init(pool.clone()).await {
@@ -123,15 +124,17 @@ async fn main() -> std::io::Result<()> {
 
     let server = HttpServer::new(move || {
         let app = App::new()
+            .wrap(from_fn(middlewares::actor_context))
+            .wrap(Logger::default())
+            .wrap(middlewares::TracingMiddleware::new_with_trust(
+                proxy_trust.clone(),
+            ))
+            // Actix runs the last registered middleware first. Reject disallowed
+            // clients before bearer-token resolution can touch the database.
             .wrap(middlewares::ClientAllowlistMiddleware::new_with_trust(
                 client_allowlist.clone(),
                 proxy_trust.clone(),
             ))
-            .wrap(middlewares::TracingMiddleware::new_with_trust(
-                proxy_trust.clone(),
-            ))
-            .wrap(Logger::default())
-            .wrap(from_fn(middlewares::actor_context))
             .app_data(Data::new(app_config.clone()))
             .app_data(Data::new(pool.clone()))
             .app_data(JsonConfig::default().error_handler(json_error_handler))

--- a/src/middlewares/actor_context.rs
+++ b/src/middlewares/actor_context.rs
@@ -25,6 +25,13 @@ fn bearer_token(req: &ServiceRequest) -> Option<Token> {
     header.strip_prefix("Bearer ").map(|s| Token(s.to_string()))
 }
 
+fn is_public_path(path: &str) -> bool {
+    matches!(path, "/healthz" | "/readyz" | "/api/v0/auth/login")
+        || path.starts_with("/api-doc/")
+        || path == "/swagger-ui"
+        || path.starts_with("/swagger-ui/")
+}
+
 async fn resolve_auth(req: &ServiceRequest) -> ResolvedAuth {
     let token = match bearer_token(req) {
         Some(token) => token,
@@ -47,7 +54,11 @@ pub async fn actor_context(
     req: ServiceRequest,
     next: Next<impl MessageBody + 'static>,
 ) -> Result<ServiceResponse<BoxBody>, Error> {
-    let resolved = resolve_auth(&req).await;
+    let resolved = if is_public_path(req.path()) {
+        ResolvedAuth::Missing
+    } else {
+        resolve_auth(&req).await
+    };
     let actor = match &resolved {
         ResolvedAuth::Authenticated { token_meta, .. } => Some(token_meta.principal_id),
         _ => None,
@@ -55,4 +66,25 @@ pub async fn actor_context(
     req.extensions_mut().insert(resolved);
     let res = with_actor_scope(actor, next.call(req)).await?;
     Ok(res.map_into_boxed_body())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_public_path;
+
+    #[test]
+    fn public_paths_skip_authentication_resolution() {
+        for path in [
+            "/healthz",
+            "/readyz",
+            "/api/v0/auth/login",
+            "/api-doc/openapi.json",
+            "/swagger-ui",
+            "/swagger-ui/index.html",
+        ] {
+            assert!(is_public_path(path), "expected {path} to be public");
+        }
+        assert!(!is_public_path("/api/v0/auth/logout"));
+        assert!(!is_public_path("/api/v1/classes"));
+    }
 }

--- a/src/middlewares/rate_limit.rs
+++ b/src/middlewares/rate_limit.rs
@@ -21,6 +21,8 @@ struct ScopeState {
     attempts: VecDeque<Instant>,
     locked_until: Option<Instant>,
     lockout_level: u32,
+    in_flight: usize,
+    last_activity_at: Option<Instant>,
 }
 
 impl ScopeState {
@@ -72,6 +74,7 @@ impl ScopeState {
         self.prune(now, window);
         self.reset_escalation_if_cooled_off(now, window);
         self.attempts.push_back(now);
+        self.last_activity_at = Some(now);
         if self.attempts.len() >= threshold {
             self.trigger_lockout(now, cfg);
         }
@@ -82,7 +85,7 @@ impl ScopeState {
     /// elapses, so pruning does not discard escalation that `reset_escalation_if_cooled_off`
     /// would otherwise preserve (and reset only after a genuine cool-off).
     fn is_active(&self, now: Instant, window: Duration) -> bool {
-        if !self.attempts.is_empty() || self.is_locked(now) {
+        if !self.attempts.is_empty() || self.is_locked(now) || self.in_flight > 0 {
             return true;
         }
         match self.locked_until {
@@ -95,11 +98,14 @@ impl ScopeState {
     /// the stalest entry for eviction; locked entries sort as "freshest" (their expiry is
     /// in the future) and are therefore protected from premature eviction.
     fn last_activity(&self) -> Option<Instant> {
-        match (self.attempts.back().copied(), self.locked_until) {
-            (Some(attempt), Some(lock)) => Some(attempt.max(lock)),
-            (Some(attempt), None) => Some(attempt),
-            (None, lock) => lock,
-        }
+        [
+            self.attempts.back().copied(),
+            self.locked_until,
+            self.last_activity_at,
+        ]
+        .into_iter()
+        .flatten()
+        .max()
     }
 }
 
@@ -191,9 +197,10 @@ fn prune_login_attempts_map(
     });
 }
 
-fn evict_stalest_login_attempt_key(attempts_by_key: &mut HashMap<String, ScopeState>) {
+fn evict_stalest_login_attempt_key(attempts_by_key: &mut HashMap<String, ScopeState>) -> bool {
     let stalest_key = attempts_by_key
         .iter()
+        .filter(|(_, state)| state.in_flight == 0)
         .filter_map(|(key, state)| state.last_activity().map(|last| (key.clone(), last)))
         .min_by_key(|(_, last)| *last)
         .map(|(key, _)| key);
@@ -204,7 +211,122 @@ fn evict_stalest_login_attempt_key(attempts_by_key: &mut HashMap<String, ScopeSt
             message = "Evicted stalest login limiter entry to enforce key cap",
             max_tracked_keys = MAX_LOGIN_ATTEMPT_KEYS
         );
+        true
+    } else {
+        false
     }
+}
+
+/// Reservation for a login attempt. Applicable scope budgets are reserved before
+/// password verification starts so concurrent requests cannot all pass the limiter
+/// check before any of them records a failure.
+pub(crate) struct LoginAttemptPermit {
+    scopes: Vec<(String, usize)>,
+    user_ip_key: String,
+    enabled: bool,
+}
+
+pub(crate) enum LoginAttemptOutcome {
+    Succeeded,
+    Failed,
+    Aborted,
+}
+
+/// Atomically check every applicable scope and reserve capacity for one login.
+/// Returns `None` when a scope is locked or has enough failures and concurrent
+/// verifications to reach its threshold.
+pub(crate) async fn begin_login_attempt(
+    identity_scope: &str,
+    username: &str,
+    client_ip: Option<IpAddr>,
+) -> Option<LoginAttemptPermit> {
+    let cfg = login_rate_limit_config();
+    let scopes = scopes_for(identity_scope, username, client_ip, &cfg);
+    let user_ip_key = user_ip_key(identity_scope, username, &ip_label(client_ip));
+    if !cfg.enabled {
+        return Some(LoginAttemptPermit {
+            scopes,
+            user_ip_key,
+            enabled: false,
+        });
+    }
+
+    let now = Instant::now();
+    let window = Duration::from_secs(cfg.window_seconds);
+    let mut guard = LOGIN_ATTEMPTS.lock().await;
+    prune_login_attempts_map(&mut guard, now, window);
+
+    let unavailable = scopes.iter().any(|(key, threshold)| {
+        guard.get(key).is_some_and(|state| {
+            state.is_locked(now)
+                || state.attempts.len().saturating_add(state.in_flight) >= *threshold
+        })
+    });
+    if unavailable {
+        return None;
+    }
+
+    let missing_scopes = scopes
+        .iter()
+        .filter(|(key, _)| !guard.contains_key(key))
+        .count();
+    while guard.len().saturating_add(missing_scopes) > MAX_LOGIN_ATTEMPT_KEYS {
+        if !evict_stalest_login_attempt_key(&mut guard) {
+            return None;
+        }
+    }
+
+    for (key, _) in &scopes {
+        let state = guard.entry(key.clone()).or_default();
+        state.in_flight = state.in_flight.saturating_add(1);
+        state.last_activity_at = Some(now);
+    }
+
+    Some(LoginAttemptPermit {
+        scopes,
+        user_ip_key,
+        enabled: true,
+    })
+}
+
+/// Release a login reservation and update all applicable scope budgets in the same
+/// critical section. Internal authentication errors release capacity without counting
+/// as credential failures.
+pub(crate) async fn finish_login_attempt(permit: LoginAttemptPermit, outcome: LoginAttemptOutcome) {
+    if !permit.enabled {
+        return;
+    }
+
+    let cfg = login_rate_limit_config();
+    let now = Instant::now();
+    let window = Duration::from_secs(cfg.window_seconds);
+    let mut guard = LOGIN_ATTEMPTS.lock().await;
+
+    for (key, threshold) in &permit.scopes {
+        if let Some(state) = guard.get_mut(key) {
+            state.in_flight = state.in_flight.saturating_sub(1);
+            state.last_activity_at = Some(now);
+            if matches!(outcome, LoginAttemptOutcome::Failed) {
+                state.register_failure(now, *threshold, &cfg);
+            }
+        }
+    }
+
+    if matches!(outcome, LoginAttemptOutcome::Succeeded) {
+        let should_remove = if let Some(state) = guard.get_mut(&permit.user_ip_key) {
+            state.attempts.clear();
+            state.locked_until = None;
+            state.lockout_level = 0;
+            state.in_flight == 0
+        } else {
+            false
+        };
+        if should_remove {
+            guard.remove(&permit.user_ip_key);
+        }
+    }
+
+    prune_login_attempts_map(&mut guard, now, window);
 }
 
 /// Resolve the trustworthy client IP for a login request, honoring the configured proxy
@@ -218,27 +340,9 @@ pub(crate) fn client_ip_for_request(req: &HttpRequest) -> Option<IpAddr> {
     extract_client_ip_from_http_request(req, &policy)
 }
 
-/// Whether the login request is currently throttled by any applicable scope.
-pub(crate) async fn login_is_rate_limited(
-    identity_scope: &str,
-    username: &str,
-    client_ip: Option<IpAddr>,
-) -> bool {
-    let cfg = login_rate_limit_config();
-    if !cfg.enabled {
-        return false;
-    }
-
-    let now = Instant::now();
-    let guard = LOGIN_ATTEMPTS.lock().await;
-
-    scopes_for(identity_scope, username, client_ip, &cfg)
-        .iter()
-        .any(|(key, _)| guard.get(key).is_some_and(|state| state.is_locked(now)))
-}
-
 /// Record a failed login attempt across all applicable scopes, applying lockouts with
 /// exponential backoff when a scope crosses its threshold.
+#[cfg(test)]
 pub(crate) async fn record_login_failure(
     identity_scope: &str,
     username: &str,
@@ -257,25 +361,13 @@ pub(crate) async fn record_login_failure(
         if !guard.contains_key(&key) && guard.len() >= MAX_LOGIN_ATTEMPT_KEYS {
             prune_login_attempts_map(&mut guard, now, window);
             if guard.len() >= MAX_LOGIN_ATTEMPT_KEYS {
-                evict_stalest_login_attempt_key(&mut guard);
+                let _ = evict_stalest_login_attempt_key(&mut guard);
             }
         }
 
         let state = guard.entry(key).or_default();
         state.register_failure(now, threshold, &cfg);
     }
-}
-
-/// Clear the per-(user, IP) failure state after a successful login. The per-IP and
-/// per-subnet budgets are intentionally left intact: one user's success must not reset
-/// the spray/distributed counters for the whole host or network.
-pub(crate) async fn clear_login_failures(
-    identity_scope: &str,
-    username: &str,
-    client_ip: Option<IpAddr>,
-) {
-    let key = user_ip_key(identity_scope, username, &ip_label(client_ip));
-    LOGIN_ATTEMPTS.lock().await.remove(&key);
 }
 
 /// A point-in-time view of one tracked rate-limit scope, for the admin observability API.
@@ -504,7 +596,7 @@ mod tests {
         locked.trigger_lockout(now, &config);
         map.insert("locked".to_string(), locked);
 
-        evict_stalest_login_attempt_key(&mut map);
+        assert!(evict_stalest_login_attempt_key(&mut map));
 
         assert!(!map.contains_key("stale"));
         assert!(map.contains_key("locked"));
@@ -560,5 +652,37 @@ mod tests {
         assert!(map.contains_key("cooling"));
         assert_eq!(map["cooling"].lockout_level, 2);
         assert!(!map.contains_key("cooled"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_attempts_reserve_capacity_atomically() {
+        let _guard = LOGIN_RATE_LIMIT_TEST_LOCK.lock().await;
+        reset_login_rate_limit_for_tests().await;
+        let config = login_rate_limit_config();
+        assert!(config.enabled);
+
+        let mut permits = Vec::new();
+        for _ in 0..config.max_attempts {
+            permits.push(
+                begin_login_attempt("local", "atomic-limit-user", None)
+                    .await
+                    .expect("capacity below the threshold should be reserved"),
+            );
+        }
+        assert!(
+            begin_login_attempt("local", "atomic-limit-user", None)
+                .await
+                .is_none()
+        );
+
+        for permit in permits {
+            finish_login_attempt(permit, LoginAttemptOutcome::Aborted).await;
+        }
+        assert!(
+            begin_login_attempt("local", "atomic-limit-user", None)
+                .await
+                .is_some()
+        );
+        reset_login_rate_limit_for_tests().await;
     }
 }

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -7,7 +7,7 @@ use crate::errors::ApiError;
 use crate::schema::hubuumclass;
 use crate::traits::BackendContext;
 
-#[derive(Serialize, Deserialize, Queryable, Clone, PartialEq, Debug, ToSchema)]
+#[derive(Serialize, Deserialize, Queryable, QueryableByName, Clone, PartialEq, Debug, ToSchema)]
 #[diesel(table_name = hubuumclass )]
 pub struct HubuumClass {
     pub id: i32,

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -17,7 +17,17 @@ use crate::models::{Permission, Permissions};
 use crate::models::traits::GroupAccessors;
 use crate::traits::{BackendContext, CollectionAccessors};
 
-#[derive(Serialize, Deserialize, Queryable, PartialEq, Debug, Clone, Selectable, ToSchema)]
+#[derive(
+    Serialize,
+    Deserialize,
+    Queryable,
+    QueryableByName,
+    PartialEq,
+    Debug,
+    Clone,
+    Selectable,
+    ToSchema,
+)]
 #[diesel(table_name = collections)]
 pub struct Collection {
     pub id: i32,

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -814,6 +814,7 @@ mod tests {
                 sort: vec![],
                 limit: None,
                 cursor: None,
+                include_total: true,
             },
         )
         .await

--- a/src/models/export_template.rs
+++ b/src/models/export_template.rs
@@ -427,7 +427,10 @@ impl ExportTemplate {
         query_options: &QueryOptions,
     ) -> Result<(Vec<ExportTemplate>, i64), ApiError> {
         if allowed_collection_ids.is_empty() {
-            return Ok((Vec::new(), 0));
+            return Ok((
+                Vec::new(),
+                crate::pagination::known_count_or_skipped(query_options, 0),
+            ));
         }
 
         let (rows, total_count) =

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use chrono::NaiveDateTime;
 use diesel::expression::{AppearsOnTable, Expression, SelectableExpression, ValidGrouping};
 use diesel::pg::Pg;
@@ -1000,21 +999,6 @@ pub trait QueryParamsExt {
     /// * A PermissionsList of Permissions or ApiError::BadRequest if the permissions are invalid
     fn permissions(&self) -> Result<PermissionsList<Permissions>, ApiError>;
 
-    /// ## Get a sorted list of collection ids from a list of parsed query parameters
-    ///
-    /// Iterate over the parsed query parameters and filter out the ones that are collections,
-    /// defined as having the `field` set as "collections". For each value of each parsed query
-    /// parameter, attempt to parse it into a list integers via [`parse_integer_list`].
-    ///
-    /// If the value is not a valid list of integers, return an ApiError::BadRequest.
-    ///
-    /// Note that the result is sorted and that duplicates are removed.
-    ///
-    /// ### Returns
-    ///
-    /// * A vector of integers or ApiError::BadRequest if any of the collection values are invalid
-    fn collections(&self) -> Result<Vec<i32>, ApiError>;
-
     /// ## Get a list of all JSON Schema elements in a list of parsed query parameters
     ///
     /// Iterate over the parsed query parameters and filter out the ones that are JSON Schemas,
@@ -1093,27 +1077,6 @@ impl QueryParamsExt for Vec<ParsedQueryParam> {
         }
         Ok(PermissionsList::new(unique_permissions))
     }
-    /// ## Get a sorted list of collection ids from a list of parsed query parameters
-    ///
-    /// Iterate over the parsed query parameters and filter out the ones that are collections,
-    /// defined as having the `field` set as "collections". For each value of a matching parsed query
-    /// parameter, attempt to parse it into a list of integers via [`parse_integer_list`].
-    ///
-    /// If any value is not a valid list of integers, return an ApiError::BadRequest.
-    fn collections(&self) -> Result<Vec<i32>, ApiError> {
-        let mut collection_ids = vec![];
-
-        for p in self.iter() {
-            if p.field == FilterField::Collections {
-                collection_ids.extend(p.value.as_integer()?);
-            }
-        }
-
-        collection_ids.sort_unstable();
-        collection_ids.dedup();
-        Ok(collection_ids)
-    }
-
     /// ## Get a list of all JSON schema entries in a list of parsed query parameters
     ///
     /// Iterate over the parsed query parameters and filter out the ones that are JSON Schemas,
@@ -1235,17 +1198,6 @@ impl Operator {
                 | Operator::ContainsIp
                 | Operator::OverlapsNetwork
                 | Operator::InetEquals
-        )
-    }
-
-    fn is_json_structure_operator(&self) -> bool {
-        matches!(
-            self,
-            Operator::In
-                | Operator::All
-                | Operator::ArrayLength
-                | Operator::HasKey
-                | Operator::IsNull
         )
     }
 }
@@ -1471,13 +1423,6 @@ pub enum SQLMappedType {
     None,
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub struct JsonbFieldType {
-    pub value: String,
-    pub mapping: SQLMappedType,
-    pub operator: Operator,
-}
-
 /// ## Get the type of a field within a JSON schema
 ///
 /// This function takes a JSON schema and a key, and returns the type of the field at that key.
@@ -1540,6 +1485,7 @@ pub struct JsonbFieldType {
 /// * "address,city" -> Some(SQLMappedType::String)
 /// * "address,zip" -> Some(SQLMappedType::Numeric)
 ///
+#[cfg(test)]
 fn get_jsonb_field_type_from_json_schema(
     schema: &serde_json::Value,
     key: &str,

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -40,6 +40,7 @@ pub fn parse_query_parameter_with_passthrough(
     let mut sort = Vec::new();
     let mut limit = None;
     let mut cursor = None;
+    let mut include_total = None;
     let mut passthrough = HashMap::<String, Vec<String>>::new();
     let passthrough_keys = passthrough_keys.iter().copied().collect::<HashSet<_>>();
 
@@ -50,6 +51,7 @@ pub fn parse_query_parameter_with_passthrough(
                 sort,
                 limit,
                 cursor,
+                include_total: true,
             },
             passthrough,
         ));
@@ -80,6 +82,13 @@ pub fn parse_query_parameter_with_passthrough(
                 cursor = Some(value);
             }
 
+            "include_total" => {
+                if include_total.is_some() {
+                    return Err(ApiError::BadRequest("duplicate include_total".into()));
+                }
+                include_total = Some(value.as_boolean()?);
+            }
+
             // SORT / ORDER BY: e.g. sort=created_at,-name,email.desc
             "sort" | "order_by" => {
                 for piece in value.split(',') {
@@ -107,6 +116,7 @@ pub fn parse_query_parameter_with_passthrough(
             sort,
             limit,
             cursor,
+            include_total: include_total.unwrap_or(true),
         },
         passthrough,
     ))
@@ -213,6 +223,9 @@ pub struct QueryOptions {
     pub sort: Vec<SortParam>,
     pub limit: Option<usize>,
     pub cursor: Option<String>,
+    /// Whether list endpoints should execute an exact count query and return
+    /// `X-Total-Count`. Defaults to true for API compatibility.
+    pub include_total: bool,
 }
 
 /// ## A struct that represents a filter field
@@ -2684,6 +2697,19 @@ mod test {
         assert_eq!(query_options.sort[0].field, FilterField::Id);
         assert!(query_options.sort[0].descending);
         assert_eq!(query_options.cursor, Some("test-cursor".to_string()));
+    }
+
+    #[test]
+    fn parse_query_parameter_supports_total_count_opt_out() {
+        let options = parse_query_parameter("include_total=false").unwrap();
+        assert!(!options.include_total);
+
+        let defaults = parse_query_parameter("").unwrap();
+        assert!(defaults.include_total);
+
+        let duplicate =
+            parse_query_parameter("include_total=true&include_total=false").unwrap_err();
+        assert_eq!(duplicate.to_string(), "duplicate include_total");
     }
 
     #[test]

--- a/src/models/traits/user.rs
+++ b/src/models/traits/user.rs
@@ -476,6 +476,7 @@ mod test {
             sort: vec![],
             limit: None,
             cursor: None,
+            include_total: true,
         }
     }
 
@@ -611,6 +612,7 @@ mod test {
                     sort: vec![],
                     limit: None,
                     cursor: None,
+                    include_total: true,
                 },
                 None,
             )

--- a/src/models/unified_search.rs
+++ b/src/models/unified_search.rs
@@ -11,6 +11,8 @@ use crate::pagination::{page_limits, validate_page_limit_with_max};
 use crate::traits::BackendContext;
 use crate::utilities::extensions::CustomStringExtensions;
 
+const MAX_UNIFIED_SEARCH_QUERY_LENGTH: usize = 256;
+
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ToSchema, Hash,
 )]
@@ -74,6 +76,10 @@ pub struct UnifiedSearchSpec {
     pub query: String,
     pub search_class_schema: bool,
     pub search_object_data: bool,
+    pub limit_per_kind: usize,
+    pub collection_cursor: Option<UnifiedSearchCursorToken>,
+    pub class_cursor: Option<UnifiedSearchCursorToken>,
+    pub object_cursor: Option<UnifiedSearchCursorToken>,
 }
 
 #[derive(Default)]
@@ -112,6 +118,10 @@ impl From<&UnifiedSearchQuery> for UnifiedSearchSpec {
             query: value.query.clone(),
             search_class_schema: value.search_class_schema,
             search_object_data: value.search_object_data,
+            limit_per_kind: value.limit_per_kind,
+            collection_cursor: value.collection_cursor.clone(),
+            class_cursor: value.class_cursor.clone(),
+            object_cursor: value.object_cursor.clone(),
         }
     }
 }
@@ -204,6 +214,11 @@ fn parse_required_query(value: &str) -> Result<String, ApiError> {
     let trimmed = value.trim().to_string();
     if trimmed.is_empty() {
         return Err(ApiError::BadRequest("q must not be empty".to_string()));
+    }
+    if trimmed.chars().count() > MAX_UNIFIED_SEARCH_QUERY_LENGTH {
+        return Err(ApiError::BadRequest(format!(
+            "q must be at most {MAX_UNIFIED_SEARCH_QUERY_LENGTH} characters"
+        )));
     }
     Ok(trimmed)
 }
@@ -562,32 +577,38 @@ where
     S: crate::traits::Search + ?Sized,
 {
     let search_spec = params.search_spec();
-    let collections = if params.includes(UnifiedSearchKind::Collection) {
-        search_collections(user, backend, params, &search_spec, scopes).await?
-    } else {
-        SearchPage {
-            items: vec![],
-            next: None,
+    let collections_future = async {
+        if params.includes(UnifiedSearchKind::Collection) {
+            search_collections(user, backend, params, &search_spec, scopes).await
+        } else {
+            Ok(SearchPage {
+                items: vec![],
+                next: None,
+            })
         }
     };
-
-    let classes = if params.includes(UnifiedSearchKind::Class) {
-        search_classes(user, backend, params, &search_spec, scopes).await?
-    } else {
-        SearchPage {
-            items: vec![],
-            next: None,
+    let classes_future = async {
+        if params.includes(UnifiedSearchKind::Class) {
+            search_classes(user, backend, params, &search_spec, scopes).await
+        } else {
+            Ok(SearchPage {
+                items: vec![],
+                next: None,
+            })
         }
     };
-
-    let objects = if params.includes(UnifiedSearchKind::Object) {
-        search_objects(user, backend, params, &search_spec, scopes).await?
-    } else {
-        SearchPage {
-            items: vec![],
-            next: None,
+    let objects_future = async {
+        if params.includes(UnifiedSearchKind::Object) {
+            search_objects(user, backend, params, &search_spec, scopes).await
+        } else {
+            Ok(SearchPage {
+                items: vec![],
+                next: None,
+            })
         }
     };
+    let (collections, classes, objects) =
+        tokio::try_join!(collections_future, classes_future, objects_future)?;
 
     Ok(UnifiedSearchResponse {
         query: params.query.clone(),
@@ -708,6 +729,10 @@ mod tests {
                 query: "server".to_string(),
                 search_class_schema: true,
                 search_object_data: true,
+                limit_per_kind: 5,
+                collection_cursor: None,
+                class_cursor: parsed.class_cursor.clone(),
+                object_cursor: None,
             }
         );
     }
@@ -716,6 +741,13 @@ mod tests {
     fn parse_unified_search_rejects_unknown_parameter() {
         let error = parse_unified_search_query("q=server&foo=bar").unwrap_err();
         assert_eq!(error.to_string(), "Invalid query parameter: 'foo'");
+    }
+
+    #[test]
+    fn parse_unified_search_rejects_oversized_query() {
+        let query = "a".repeat(MAX_UNIFIED_SEARCH_QUERY_LENGTH + 1);
+        let error = parse_unified_search_query(&format!("q={query}")).unwrap_err();
+        assert_eq!(error.to_string(), "q must be at most 256 characters");
     }
 
     #[test]

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -547,6 +547,13 @@ impl LoginUser {
             match User::get_by_name_in_scope(backend.db_pool(), identity_scope, &self.name).await {
                 Ok(user) => user,
                 Err(_) => {
+                    // Keep unknown-user and wrong-password paths comparable: both execute
+                    // one Argon2 verification before returning the same public error.
+                    let password = self.password.clone();
+                    let _ = tokio::task::spawn_blocking(move || {
+                        crate::utilities::auth::verify_dummy_password(&password)
+                    })
+                    .await;
                     warn!(message = "Login failed (user not found)", user = self.name);
                     return Err(auth_failure());
                 }
@@ -561,19 +568,33 @@ impl LoginUser {
             return Err(auth_failure());
         };
 
-        match crate::utilities::auth::verify_password(plaintext_password, hashed_password) {
-            Ok(true) => Ok(user),
-            Ok(false) => {
+        let plaintext_password = plaintext_password.clone();
+        let hashed_password = hashed_password.clone();
+        let verification = tokio::task::spawn_blocking(move || {
+            crate::utilities::auth::verify_password(&plaintext_password, &hashed_password)
+        })
+        .await;
+
+        match verification {
+            Ok(Ok(true)) => Ok(user),
+            Ok(Ok(false)) => {
                 warn!(
                     message = "Login failed (password mismatch)",
                     user = self.name
                 );
                 Err(auth_failure())
             }
-
-            Err(e) => {
+            Ok(Err(e)) => {
                 error!(
                     message = "Login failed (hashing error)",
+                    user = self.name,
+                    error = e.to_string()
+                );
+                Err(auth_failure())
+            }
+            Err(e) => {
+                error!(
+                    message = "Login failed (password worker error)",
                     user = self.name,
                     error = e.to_string()
                 );

--- a/src/pagination/mod.rs
+++ b/src/pagination/mod.rs
@@ -12,6 +12,26 @@ pub use crate::traits::pagination::{
 
 pub const NEXT_CURSOR_HEADER: &str = "X-Next-Cursor";
 pub const TOTAL_COUNT_HEADER: &str = "X-Total-Count";
+pub const SKIPPED_TOTAL_COUNT: i64 = -1;
+
+pub fn exact_count_or_skipped(
+    query_options: &QueryOptions,
+    count: impl FnOnce() -> Result<i64, ApiError>,
+) -> Result<i64, ApiError> {
+    if query_options.include_total {
+        count()
+    } else {
+        Ok(SKIPPED_TOTAL_COUNT)
+    }
+}
+
+pub fn known_count_or_skipped(query_options: &QueryOptions, count: i64) -> i64 {
+    if query_options.include_total {
+        count
+    } else {
+        SKIPPED_TOTAL_COUNT
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CursorPageRequest {
@@ -130,7 +150,9 @@ pub fn pagination_headers(
     total_count: i64,
 ) -> HashMap<String, String> {
     let mut headers = HashMap::new();
-    headers.insert(TOTAL_COUNT_HEADER.to_string(), total_count.to_string());
+    if total_count != SKIPPED_TOTAL_COUNT {
+        headers.insert(TOTAL_COUNT_HEADER.to_string(), total_count.to_string());
+    }
     if let Some(cursor) = next_cursor.as_ref() {
         headers.insert(NEXT_CURSOR_HEADER.to_string(), cursor.clone());
     }
@@ -533,6 +555,7 @@ mod tests {
                 sort: vec![],
                 limit: Some(2),
                 cursor: None,
+                include_total: true,
             },
         )
         .unwrap();
@@ -552,6 +575,7 @@ mod tests {
             sort: vec![],
             limit: Some(2),
             cursor: first_page.next_cursor.clone(),
+            include_total: true,
         })
         .unwrap();
 
@@ -568,6 +592,7 @@ mod tests {
                 sort: vec![],
                 limit: Some(2),
                 cursor: first_page.next_cursor,
+                include_total: true,
             },
         )
         .unwrap();
@@ -601,6 +626,7 @@ mod tests {
                 }],
                 limit: Some(2),
                 cursor: None,
+                include_total: true,
             },
         )
         .unwrap();
@@ -625,6 +651,7 @@ mod tests {
             }],
             limit: None,
             cursor: None,
+            include_total: true,
         })
         .unwrap();
 
@@ -632,6 +659,25 @@ mod tests {
         assert_eq!(prepared.sort.len(), 2);
         assert_eq!(prepared.sort[0].field, FilterField::Username);
         assert_eq!(prepared.sort[1].field, FilterField::Id);
+    }
+
+    #[test]
+    fn exact_total_count_can_be_skipped() {
+        let options = QueryOptions {
+            filters: vec![],
+            sort: vec![],
+            limit: None,
+            cursor: None,
+            include_total: false,
+        };
+        let count = exact_count_or_skipped(&options, || {
+            panic!("count query must not execute when include_total is false")
+        })
+        .unwrap();
+        assert_eq!(count, SKIPPED_TOTAL_COUNT);
+
+        let headers = pagination_headers(&None, count);
+        assert!(!headers.contains_key(TOTAL_COUNT_HEADER));
     }
 
     #[test]

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -356,6 +356,7 @@ fn test_process_one_task_marks_claimed_task_failed_when_execution_setup_errors()
                     sort: Vec::new(),
                     limit: None,
                     cursor: None,
+                    include_total: true,
                 },
             ))
             .unwrap();

--- a/src/tests/api/meta.rs
+++ b/src/tests/api/meta.rs
@@ -257,6 +257,18 @@ mod tests {
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
         let body: Value = test::read_body_json(resp).await;
-        assert_eq!(body["tracked_entries"], 0);
+        let entries = body["entries"].as_array().unwrap();
+        let cleared_identifiers = [
+            "meta-clear-user|203.0.113.66",
+            "203.0.113.66",
+            "203.0.113.0/24",
+        ];
+        assert!(
+            entries.iter().all(|entry| {
+                let identifier = entry["identifier"].as_str().unwrap();
+                !cleared_identifiers.contains(&identifier)
+            }),
+            "clear-all should remove every scope created by this test: {entries:?}",
+        );
     }
 }

--- a/src/tests/api/v1/collections.rs
+++ b/src/tests/api/v1/collections.rs
@@ -5,7 +5,7 @@ mod tests {
         Permission, Permissions, UpdateCollection,
     };
 
-    use crate::pagination::NEXT_CURSOR_HEADER;
+    use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER};
     use crate::tests::api_operations::{
         delete_request, get_request, patch_request, post_request, put_request,
     };
@@ -988,6 +988,34 @@ mod tests {
         CollectionFixture::cleanup_all(&created_collections)
             .await
             .unwrap();
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_api_collections_can_skip_exact_total_count(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let created = create_collections(&context, "api_collections_skip_total", 3).await;
+        let ids = created
+            .iter()
+            .map(|fixture| fixture.collection.id.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let resp = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("{COLLECTION_ENDPOINT}/?id={ids}&limit=2&sort=id&include_total=false"),
+        )
+        .await;
+        let resp = assert_response_status(resp, http::StatusCode::OK).await;
+        assert!(resp.headers().get(TOTAL_COUNT_HEADER).is_none());
+        assert!(resp.headers().get(NEXT_CURSOR_HEADER).is_some());
+        let page: Vec<Collection> = test::read_body_json(resp).await;
+        assert_eq!(page.len(), 2);
+
+        CollectionFixture::cleanup_all(&created).await.unwrap();
     }
 
     #[rstest]

--- a/src/tests/api/v1/service_accounts.rs
+++ b/src/tests/api/v1/service_accounts.rs
@@ -27,6 +27,9 @@ mod tests {
     use crate::db::with_connection;
     use crate::errors::ApiError;
     use crate::events::{Action, EntityType};
+    use crate::middlewares::rate_limit::{
+        LOGIN_RATE_LIMIT_TEST_LOCK, reset_login_rate_limit_for_tests,
+    };
     use crate::models::Collection;
     use crate::models::collection::user_can_on_any;
     use crate::models::principal::load_principal_by_id;
@@ -41,7 +44,7 @@ mod tests {
     use crate::tests::asserts::assert_response_status;
     use crate::tests::{
         TestContext, create_test_group, create_test_service_account, create_test_user,
-        ensure_admin_group, scoped_token, service_account_token,
+        ensure_admin_group, lock_test_mutex, scoped_token, service_account_token,
     };
     use crate::traits::PermissionController;
     use crate::utilities::auth::generate_random_password;
@@ -56,6 +59,8 @@ mod tests {
     /// password-login — the login endpoint returns a generic 401.
     #[actix_web::test]
     async fn test_service_account_cannot_password_login() {
+        let _guard = lock_test_mutex(&LOGIN_RATE_LIMIT_TEST_LOCK).await;
+        reset_login_rate_limit_for_tests().await;
         let context = TestContext::new().await;
         let pool = context.pool.clone();
 

--- a/src/tests/search/classes.rs
+++ b/src/tests/search/classes.rs
@@ -82,6 +82,7 @@ mod test {
                 sort: vec![],
                 limit: None,
                 cursor: None,
+                include_total: true,
             };
 
             let hits = context

--- a/src/tests/search/classrelations.rs
+++ b/src/tests/search/classrelations.rs
@@ -154,6 +154,7 @@ mod test {
             sort: vec![],
             limit: None,
             cursor: None,
+            include_total: true,
         };
 
         let result = context

--- a/src/utilities/auth.rs
+++ b/src/utilities/auth.rs
@@ -9,8 +9,24 @@ use argon2::{
 
 use rand::{RngExt, distr::Alphanumeric, rng};
 use sha2::{Digest, Sha512};
+use std::sync::LazyLock;
 
 use tracing::debug;
+
+static DUMMY_PASSWORD_HASH: LazyLock<String> = LazyLock::new(|| {
+    hash_password("hubuum-dummy-password-verification-target")
+        .expect("the built-in dummy password must be hashable")
+});
+
+/// Initialize the dummy verifier used to make unknown-user login attempts perform
+/// the same expensive password-hash work as wrong-password attempts.
+pub fn initialize_dummy_password_hash() {
+    LazyLock::force(&DUMMY_PASSWORD_HASH);
+}
+
+pub fn verify_dummy_password(password: &str) -> Result<bool, argon2::Error> {
+    verify_password(password, &DUMMY_PASSWORD_HASH)
+}
 
 /// Hash a plaintext password.
 pub fn hash_password(password: &str) -> Result<String, Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary

- sanitize public database/internal errors and remove credential-bearing startup logging
- harden login admission, unknown-user password verification, middleware ordering, and blocking password work
- bound import admission, database waits, unified search, event delivery, and pagination count costs
- consolidate race-safe idempotent task submission across import, export, and remote tasks
- preserve outbound SSRF/DNS screening while reusing HTTP clients
- move request-critical authentication, readiness, and search database work off Actix workers
- update crossbeam-epoch and clean up unused search code
- add include_total=false so clients can skip exact pagination counts

## Async database work

This is an incremental async-safe migration rather than a full diesel-async conversion. It adds a task-local-aware blocking database helper and migrates request-critical authentication, readiness, authorization, and search operations off Actix worker threads. Database statement and pool-acquisition timeouts are configurable.

## Verification

- source .env && ./run_tests.sh: 864 passed, 2 ignored; admin CLI 2 passed; doctests 2 passed
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- Markdown lint for all Markdown files
- OpenAPI regenerated and validated
- cargo audit reports zero vulnerabilities; two allowed dev-only unmaintained warnings remain through the current iai-callgrind dependency tree

## Follow-up

Deferred container runtime, Compose-default, and build-bootstrap hardening is tracked in #114.