### PR TITLE
Migrate PostgreSQL access to diesel-async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bb8"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457d7ed3f888dfd2c7af56d4975cade43c622f74bdcddfed6d4352f57acc6310"
+dependencies = [
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "tokio",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,9 +1297,23 @@ dependencies = [
  "downcast-rs",
  "itoa",
  "pq-sys",
- "r2d2",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "diesel-async"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd39af30158d444884f166fe4c58f35dc40ad71ad017bb59408a3448526ff4bd"
+dependencies = [
+ "bb8",
+ "diesel",
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -1442,6 +1468,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fancy-regex"
@@ -1700,7 +1732,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1989,6 +2021,7 @@ dependencies = [
  "clap",
  "criterion",
  "diesel",
+ "diesel-async",
  "futures",
  "futures-util",
  "hmac 0.13.0",
@@ -2009,16 +2042,18 @@ dependencies = [
  "minijinja",
  "openssl",
  "percent-encoding",
- "r2d2",
  "rand 0.10.1",
  "regex",
  "reqwest 0.12.28",
  "rstest",
  "rustls",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "tokio",
+ "tokio-postgres",
+ "tokio-postgres-rustls",
  "tokio-rustls",
  "toml",
  "tracing",
@@ -2662,6 +2697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,6 +2765,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2791,7 +2845,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -2929,6 +2983,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3120,6 +3192,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3205,6 +3296,35 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac 0.13.0",
+ "md-5",
+ "memchr",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3373,17 +3493,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "r2d2"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
-dependencies = [
- "log",
- "parking_lot",
- "scheduled-thread-pool",
-]
 
 [[package]]
 name = "rand"
@@ -3879,15 +3988,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scheduled-thread-pool"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
-dependencies = [
- "parking_lot",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4089,6 +4189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4144,6 +4250,17 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -4323,6 +4440,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4359,6 +4497,47 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.1",
+ "socket2 0.6.4",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
+dependencies = [
+ "const-oid 0.9.6",
+ "ring",
+ "rustls",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls",
+ "x509-cert",
 ]
 
 [[package]]
@@ -4595,6 +4774,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4605,6 +4790,21 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4776,12 +4976,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -4875,6 +5093,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]
@@ -5102,6 +5333,7 @@ dependencies = [
  "const-oid 0.9.6",
  "der",
  "spki",
+ "tls_codec",
 ]
 
 [[package]]
@@ -5196,6 +5428,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,18 +40,18 @@ clap = { version = "4", features = ["env", "derive"] }
 diesel = { version = "2", features = [
     "postgres",
     "serde_json",
-    "r2d2",
     "chrono",
     "64-column-tables",
     "uuid",
 ] }
+diesel-async = { version = "0.9.2", features = ["postgres", "bb8"] }
 ipnet = "2.12"
 futures = "0.3"
 futures-util = "0.3"
 jsonschema = "0"
-r2d2 = "0.8"
 rand = "0.10"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+rustls-platform-verifier = "0.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"
@@ -68,6 +68,8 @@ hubuum-events-core = { path = "crates/hubuum-events-core", features = ["schema"]
 hubuum-outbound-http = { path = "crates/hubuum-outbound-http" }
 minijinja = { version = "2", features = ["loader", "fuel"] }
 tokio = { version = "1", features = ["sync", "macros", "rt-multi-thread", "net", "io-util"] }
+tokio-postgres = "0.7"
+tokio-postgres-rustls = "0.13"
 tracing = "0.1"
 tracing-serde = "0"
 tracing-subscriber = { version = "0.3", features = [

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ curl -H "Authorization: Bearer <token>" http://localhost:8080/api/v1/iam/users
 - Remote target actions are documented in [docs/remote_targets.md](docs/remote_targets.md).
 - Event audit and delivery behavior is documented in [docs/events.md](docs/events.md).
 - Temporal history, actor capture, and GDPR anonymization are documented in [docs/temporal_history.md](docs/temporal_history.md).
+- Database pool sizing, observability, and load testing are documented in [docs/performance.md](docs/performance.md).
 
 ### Production Behavior
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -152,6 +152,20 @@ sudo ./scripts/install-single-host.sh \
   --database-url 'postgres://hubuum:secret@postgres.example.com:5432/hubuum?sslmode=require'
 ```
 
+Database TLS behavior follows the URL's `sslmode`:
+
+- `sslmode=disable` uses an unencrypted connection.
+- `sslmode=prefer` verifies the server certificate and hostname when the server
+  offers TLS, but permits plaintext when the server does not support TLS.
+- `sslmode=require` requires TLS and verifies the server certificate and
+  hostname.
+- URLs without `sslmode` disable TLS for `localhost` and IP loopback addresses.
+  Other hosts use the verified `prefer` behavior.
+
+The platform trust store is used by default. Set `PGSSLROOTCERT` to a PEM CA
+bundle for private certificate authorities, or to `system` to explicitly use
+the platform trust store.
+
 The database must already exist and be reachable from containers on the host. Avoid `localhost` in the URL unless Postgres is inside the same container; from a container, `localhost` means the API container itself.
 
 ## External Authentication Configuration

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13148,35 +13148,138 @@
       "DbStateResponse": {
         "type": "object",
         "required": [
+          "max_connections",
+          "total_connections",
           "available_connections",
           "idle_connections",
+          "in_use_connections",
+          "pending_acquisitions",
+          "acquisitions_started",
+          "acquisitions_direct",
+          "acquisitions_waited",
+          "acquisitions_timed_out",
+          "acquisition_wait_time_ms",
+          "connections_created",
+          "connections_closed_broken",
+          "connections_closed_invalid",
+          "connections_closed_max_lifetime",
+          "connections_closed_idle_timeout",
           "active_connections",
           "db_size"
         ],
         "properties": {
+          "acquisition_wait_time_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Cumulative time spent waiting for connections, in milliseconds.",
+            "minimum": 0
+          },
+          "acquisitions_direct": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Cumulative acquisitions completed without waiting.",
+            "minimum": 0
+          },
+          "acquisitions_started": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Cumulative connection acquisitions started.",
+            "minimum": 0
+          },
+          "acquisitions_timed_out": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Cumulative acquisitions that exceeded the acquisition timeout.",
+            "minimum": 0
+          },
+          "acquisitions_waited": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Cumulative acquisitions that waited for a connection.",
+            "minimum": 0
+          },
           "active_connections": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "Active PostgreSQL sessions reported by `pg_stat_activity`."
           },
           "available_connections": {
             "type": "integer",
             "format": "int32",
+            "description": "Remaining capacity: idle connections plus capacity to create connections.",
+            "minimum": 0
+          },
+          "connections_closed_broken": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Cumulative connections discarded because they were broken.",
+            "minimum": 0
+          },
+          "connections_closed_idle_timeout": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Cumulative connections closed after reaching the idle timeout.",
+            "minimum": 0
+          },
+          "connections_closed_invalid": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Cumulative connections discarded after checkout validation failed.",
+            "minimum": 0
+          },
+          "connections_closed_max_lifetime": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Cumulative connections closed after reaching their maximum lifetime.",
+            "minimum": 0
+          },
+          "connections_created": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Cumulative connections established by the pool.",
             "minimum": 0
           },
           "db_size": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "Current database size in bytes."
           },
           "idle_connections": {
             "type": "integer",
             "format": "int32",
+            "description": "Established connections currently waiting in the pool.",
+            "minimum": 0
+          },
+          "in_use_connections": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Established connections currently checked out of the pool.",
             "minimum": 0
           },
           "last_vacuum_time": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Most recent vacuum timestamp among user tables."
+          },
+          "max_connections": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Configured maximum number of connections in this process-local pool.",
+            "minimum": 0
+          },
+          "pending_acquisitions": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Connection acquisitions currently waiting to complete.",
+            "minimum": 0
+          },
+          "total_connections": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Connections currently managed by this process-local pool.",
+            "minimum": 0
           }
         }
       },

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,140 @@
+# Database Pool Tuning and Load Testing
+
+Hubuum uses one asynchronous bb8 PostgreSQL pool per server process. The pool
+is shared by HTTP handlers, task workers, event workers, retention work, and
+PostgreSQL notification listeners. Tune it as a database concurrency limit,
+not as a mirror of the Actix worker count.
+
+## Connection Budget
+
+Start with the PostgreSQL connection budget for one Hubuum instance:
+
+```text
+per_instance_budget =
+    floor(
+        (postgres_max_connections - reserved_connections - other_client_connections)
+        / hubuum_instance_count
+    )
+```
+
+Set `HUBUUM_DB_POOL_SIZE` no higher than that budget. Leave capacity for
+administration, migrations, monitoring, failover overlap, and non-Hubuum
+clients.
+
+Two event notification listeners normally hold pooled connections for the
+lifetime of the process: one for event fanout and one for event delivery. The
+remaining pool capacity serves requests and workers. For example, a pool size
+of `10` normally leaves up to `8` connections for concurrent query work.
+
+Avoid configuring a pool that can be fully consumed by listeners. A practical
+starting point is:
+
+```text
+pool_size >= long_lived_listener_connections + desired_concurrent_db_work
+```
+
+The pool is a deliberate backpressure boundary. More Actix or task workers do
+not require the same number of connections; they wait asynchronously when the
+pool is busy.
+
+## Relevant Settings
+
+- `HUBUUM_DB_POOL_SIZE` controls the maximum number of managed connections.
+  The default is `10`.
+- `HUBUUM_DB_POOL_ACQUIRE_TIMEOUT_MS` bounds how long work waits for a
+  connection. The default is `2000` ms. Keep it below the external request or
+  proxy timeout so overload fails predictably inside Hubuum.
+- `HUBUUM_DB_STATEMENT_TIMEOUT_MS` is the pool-global PostgreSQL statement
+  timeout. The default is `30000` ms. PostgreSQL cancels statements that exceed
+  it, freeing the connection for later work.
+- `HUBUUM_EXPORT_DB_STATEMENT_TIMEOUT_MS` can impose a lower export-only
+  statement timeout without shortening unrelated database work.
+
+The current bb8 defaults maintain no minimum idle count, validate a connection
+when it is checked out, close connections after a maximum lifetime of 30
+minutes, and close excess idle connections after 10 minutes.
+
+## Pool Observability
+
+An administrator can inspect `/api/v0/meta/db`. The response includes:
+
+- current maximum, total, idle, in-use, and available connection capacity;
+- current pending acquisitions;
+- cumulative direct, waited, and timed-out acquisitions;
+- cumulative acquisition wait time;
+- created connections and connections closed as broken, invalid, expired, or
+  idle.
+
+Use deltas between samples for rates. In particular:
+
+- sustained `pending_acquisitions` indicates saturation;
+- growth in `acquisitions_waited` is early evidence of contention;
+- any steady-state growth in `acquisitions_timed_out` means the pool or database
+  cannot serve the offered load within the configured acquisition timeout;
+- growth in `connections_closed_broken` can indicate transaction cancellation,
+  network instability, or database restarts.
+
+The PostgreSQL `active_connections` value is database-wide and is not the same
+as Hubuum's pool-local `in_use_connections`.
+
+## Repeatable Load Test
+
+The k6 scenario in [`load-tests/pool.js`](../load-tests/pool.js) drives a
+constant request arrival rate. Run it only against an isolated test deployment
+with production-like data and database latency.
+
+The test requires an API token. Avoid placing tokens in shell history or
+committed files; inject them through the environment used by the test runner.
+
+```bash
+HUBUUM_LOAD_BASE_URL="https://hubuum.test.example" \
+HUBUUM_LOAD_TOKEN="$TEST_ADMIN_TOKEN" \
+HUBUUM_LOAD_RATE="50" \
+HUBUUM_LOAD_DURATION="2m" \
+k6 run load-tests/pool.js
+```
+
+`HUBUUM_LOAD_PATHS` accepts `|`-separated paths. The default is a collection
+listing that skips the exact count query. A mixed read test can be run with:
+
+```bash
+HUBUUM_LOAD_PATHS="/api/v1/collections?limit=25&include_total=false|/api/v1/collections?limit=25&include_total=true|/api/v1/search?q=server" \
+HUBUUM_LOAD_RATE="100" \
+HUBUUM_LOAD_DURATION="5m" \
+k6 run load-tests/pool.js
+```
+
+Confirm every configured path and token manually before a long run. Permission
+failures and invalid paths count as failed requests.
+
+## Tuning Procedure
+
+1. Record `/api/v0/meta/db`, PostgreSQL CPU, locks, connection count, and query
+   latency before the run.
+2. Test pool sizes such as `5`, `10`, and `20`, subject to the per-instance
+   connection budget. Restart Hubuum between runs so cumulative counters reset.
+3. Keep the data set, instance count, request mix, arrival rate, and duration
+   fixed while comparing pool sizes.
+4. Record throughput, p50/p95/p99 latency, failed requests, pending
+   acquisitions, acquisition timeouts, and PostgreSQL saturation indicators.
+5. Increase the arrival rate until the service reaches its intended operating
+   limit, then run an overload case above that limit.
+6. Select the smallest pool that meets the latency target without steady-state
+   acquisition timeouts or unacceptable PostgreSQL saturation.
+
+The overload case should produce bounded errors after the acquisition timeout,
+not unbounded latency or process instability. Async database access prevents
+waiters from occupying blocking threads, but it does not make PostgreSQL
+queries faster or increase the database connection budget.
+
+## Transaction Cancellation
+
+If an async transaction future is cancelled, diesel-async marks a connection
+with an open or indeterminate transaction as broken. bb8 discards it instead of
+returning it to the pool, and PostgreSQL rolls the transaction back when the
+connection closes. This is safe but causes connection churn, visible through
+`connections_closed_broken` and `connections_created`.
+
+Server-side statement timeouts are preferable to cancelling an outer future:
+the query returns an error normally, allowing the transaction helper to execute
+its rollback path without replacing the connection.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -47,6 +47,9 @@ Probe paths bypass the client IP allowlist so platform health checks are not rej
 | `HUBUUM_SKIP_MIGRATIONS` | `false` | If true, the container waits for the database but does not run Diesel migrations on startup |
 | `HUBUUM_DB_STATEMENT_TIMEOUT_MS` | `30000` | Pool-global Postgres `statement_timeout` in ms (`0` disables). Cancels any query exceeding it server-side; applies to **all** DB work, not just exports |
 
+See [Database Pool Tuning and Load Testing](performance.md) for connection
+budgeting, pool observability, and a repeatable k6 scenario.
+
 ### Task System Configuration
 
 | Variable | Default | Description |

--- a/load-tests/pool.js
+++ b/load-tests/pool.js
@@ -1,0 +1,54 @@
+import http from "k6/http";
+import { check } from "k6";
+
+const baseUrl = (__ENV.HUBUUM_LOAD_BASE_URL || "http://127.0.0.1:8080").replace(/\/$/, "");
+const token = __ENV.HUBUUM_LOAD_TOKEN || "";
+const paths = (__ENV.HUBUUM_LOAD_PATHS || "/api/v1/collections?limit=25&include_total=false")
+  .split("|")
+  .map((path) => path.trim())
+  .filter(Boolean);
+
+const rate = Number.parseInt(__ENV.HUBUUM_LOAD_RATE || "50", 10);
+const preAllocatedVUs = Number.parseInt(__ENV.HUBUUM_LOAD_PREALLOCATED_VUS || "25", 10);
+const maxVUs = Number.parseInt(__ENV.HUBUUM_LOAD_MAX_VUS || "200", 10);
+
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    pool_pressure: {
+      executor: "constant-arrival-rate",
+      rate,
+      timeUnit: "1s",
+      duration: __ENV.HUBUUM_LOAD_DURATION || "2m",
+      preAllocatedVUs,
+      maxVUs,
+    },
+  },
+  thresholds: {
+    checks: ["rate>0.99"],
+    http_req_duration: ["p(95)<1000", "p(99)<2000"],
+    http_req_failed: ["rate<0.01"],
+  },
+};
+
+export function setup() {
+  if (!token) {
+    throw new Error("HUBUUM_LOAD_TOKEN must contain a test API token");
+  }
+  if (paths.length === 0 || paths.some((path) => !path.startsWith("/"))) {
+    throw new Error("HUBUUM_LOAD_PATHS must contain one or more absolute API paths");
+  }
+}
+
+export default function () {
+  const path = paths[__ITER % paths.length];
+  const response = http.get(`${baseUrl}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    tags: { endpoint: path.split("?", 1)[0] },
+    timeout: __ENV.HUBUUM_LOAD_REQUEST_TIMEOUT || "5s",
+  });
+
+  check(response, {
+    "response is successful": (result) => result.status >= 200 && result.status < 300,
+  });
+}

--- a/src/api/handlers/meta.rs
+++ b/src/api/handlers/meta.rs
@@ -12,9 +12,9 @@ use actix_web::{Responder, delete, get, http::StatusCode, web};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use diesel::QueryableByName;
-use diesel::RunQueryDsl;
 use diesel::sql_query;
 use diesel::sql_types::{BigInt, Nullable, Timestamp};
+use diesel_async::RunQueryDsl;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 use utoipa::ToSchema;
@@ -123,7 +123,11 @@ pub async fn get_db_state(
           pg_stat_user_tables;
     "#;
 
-    let results = match with_connection(&pool, |conn| sql_query(query).load::<DbState>(conn)) {
+    let results = match with_connection(&pool, async |conn| {
+        sql_query(query).load::<DbState>(conn).await
+    })
+    .await
+    {
         Ok(results) => results,
         Err(e) => {
             return Err(ApiError::InternalServerError(format!(
@@ -132,7 +136,7 @@ pub async fn get_db_state(
         }
     };
 
-    if let Some(row) = results.first() {
+    if let Some(row) = results.as_slice().first() {
         debug!(
             message = "DB state requested",
             requestor = requestor.user.id
@@ -221,8 +225,11 @@ pub async fn get_task_queue_state(
         FROM tasks;
     "#;
 
-    let results = with_connection(&pool, |conn| sql_query(query).load::<TaskQueueState>(conn))?;
-    let state = results.first().ok_or_else(|| {
+    let results = with_connection(&pool, async |conn| {
+        sql_query(query).load::<TaskQueueState>(conn).await
+    })
+    .await?;
+    let state = results.as_slice().first().ok_or_else(|| {
         ApiError::InternalServerError("Error getting state for the task queue".to_string())
     })?;
 

--- a/src/api/handlers/meta.rs
+++ b/src/api/handlers/meta.rs
@@ -21,10 +21,43 @@ use utoipa::ToSchema;
 
 #[derive(Serialize, Debug, ToSchema)]
 pub struct DbStateResponse {
+    /// Configured maximum number of connections in this process-local pool.
+    max_connections: u32,
+    /// Connections currently managed by this process-local pool.
+    total_connections: u32,
+    /// Remaining capacity: idle connections plus capacity to create connections.
     available_connections: u32,
+    /// Established connections currently waiting in the pool.
     idle_connections: u32,
+    /// Established connections currently checked out of the pool.
+    in_use_connections: u32,
+    /// Connection acquisitions currently waiting to complete.
+    pending_acquisitions: u64,
+    /// Cumulative connection acquisitions started.
+    acquisitions_started: u64,
+    /// Cumulative acquisitions completed without waiting.
+    acquisitions_direct: u64,
+    /// Cumulative acquisitions that waited for a connection.
+    acquisitions_waited: u64,
+    /// Cumulative acquisitions that exceeded the acquisition timeout.
+    acquisitions_timed_out: u64,
+    /// Cumulative time spent waiting for connections, in milliseconds.
+    acquisition_wait_time_ms: u64,
+    /// Cumulative connections established by the pool.
+    connections_created: u64,
+    /// Cumulative connections discarded because they were broken.
+    connections_closed_broken: u64,
+    /// Cumulative connections discarded after checkout validation failed.
+    connections_closed_invalid: u64,
+    /// Cumulative connections closed after reaching their maximum lifetime.
+    connections_closed_max_lifetime: u64,
+    /// Cumulative connections closed after reaching the idle timeout.
+    connections_closed_idle_timeout: u64,
+    /// Active PostgreSQL sessions reported by `pg_stat_activity`.
     active_connections: i64,
+    /// Current database size in bytes.
     db_size: i64,
+    /// Most recent vacuum timestamp among user tables.
     last_vacuum_time: Option<String>,
 }
 
@@ -112,8 +145,6 @@ pub async fn get_db_state(
     pool: web::Data<DbPool>,
     requestor: AdminAccess,
 ) -> Result<impl Responder, ApiError> {
-    let state = pool.state();
-
     let query = r#"
         SELECT
           (SELECT count(*) FROM pg_stat_activity WHERE state = 'active') AS active_connections,
@@ -137,14 +168,34 @@ pub async fn get_db_state(
     };
 
     if let Some(row) = results.as_slice().first() {
+        let state = pool.state();
+        let max_connections = pool.config().max_size;
+        let in_use_connections = state.connections.saturating_sub(state.idle_connections);
+        let available_connections = max_connections.saturating_sub(in_use_connections);
+        let acquisition_wait_time_ms =
+            u64::try_from(state.statistics.get_wait_time.as_millis()).unwrap_or(u64::MAX);
         debug!(
             message = "DB state requested",
             requestor = requestor.user.id
         );
 
         let response = DbStateResponse {
-            available_connections: state.connections,
+            max_connections,
+            total_connections: state.connections,
+            available_connections,
             idle_connections: state.idle_connections,
+            in_use_connections,
+            pending_acquisitions: state.statistics.pending_gets(),
+            acquisitions_started: state.statistics.get_started,
+            acquisitions_direct: state.statistics.get_direct,
+            acquisitions_waited: state.statistics.get_waited,
+            acquisitions_timed_out: state.statistics.get_timed_out,
+            acquisition_wait_time_ms,
+            connections_created: state.statistics.connections_created,
+            connections_closed_broken: state.statistics.connections_closed_broken,
+            connections_closed_invalid: state.statistics.connections_closed_invalid,
+            connections_closed_max_lifetime: state.statistics.connections_closed_max_lifetime,
+            connections_closed_idle_timeout: state.statistics.connections_closed_idle_timeout,
             active_connections: row.active_connections,
             db_size: row.db_size,
             last_vacuum_time: row.last_vacuum_time.map(|dt| dt.to_string()),

--- a/src/api/handlers/probes.rs
+++ b/src/api/handlers/probes.rs
@@ -1,5 +1,5 @@
 use actix_web::{Responder, get, http::StatusCode, web};
-use diesel::RunQueryDsl;
+use diesel_async::RunQueryDsl;
 use serde::Serialize;
 use utoipa::ToSchema;
 
@@ -45,8 +45,10 @@ pub async fn healthz() -> impl Responder {
 )]
 #[get("/readyz")]
 pub async fn readyz(pool: web::Data<DbPool>) -> Result<impl Responder, ApiError> {
-    with_connection_async(pool.get_ref().clone(), |conn| {
-        diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>("1")).get_result::<i32>(conn)
+    with_connection_async(pool.get_ref().clone(), async |conn| {
+        diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>("1"))
+            .get_result::<i32>(conn)
+            .await
     })
     .await
     .map_err(|_| ApiError::ServiceUnavailable("Database is not ready".to_string()))?;

--- a/src/api/v1/handlers/history.rs
+++ b/src/api/v1/handlers/history.rs
@@ -39,7 +39,7 @@ pub fn parse_as_of(query_string: &str) -> Result<DateTime<Utc>, ApiError> {
         crate::models::search::parse_query_parameter_with_passthrough(query_string, &["at"])?;
     let at = passthrough
         .get("at")
-        .and_then(|values| values.first())
+        .and_then(|values| values.as_slice().first())
         .ok_or_else(|| ApiError::BadRequest("missing required 'at' parameter".into()))?;
     DateTime::parse_from_rfc3339(at)
         .map(|dt| dt.with_timezone(&Utc))

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -333,7 +333,7 @@ pub async fn refresh_principal_if_needed(pool: &DbPool, principal_id: i32) -> Re
                         Ok(()) => Ok(()),
                         Err(AuthProviderRefreshError::Internal(err)) => Err(err),
                         Err(AuthProviderRefreshError::Provider(err)) => {
-                            match mark_external_sync_attempted(pool, principal_id) {
+                            match mark_external_sync_attempted(pool, principal_id).await {
                                 Err(mark_err) => Err(mark_err),
                                 Ok(()) => {
                                     if within_max_stale(

--- a/src/bin/admin.rs
+++ b/src/bin/admin.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use diesel::prelude::*;
 use std::collections::BTreeMap;
 use std::process::exit;
 use tracing::warn;
@@ -11,6 +10,7 @@ use hubuum::config::{
     DEFAULT_DB_STATEMENT_TIMEOUT_MS, DEFAULT_EXPORT_TEMPLATE_FUEL,
     DEFAULT_EXPORT_TEMPLATE_RECURSION_LIMIT,
 };
+use hubuum::db::prelude::*;
 use hubuum::db::{DbPool, init_pool_with_statement_timeout, with_connection};
 use hubuum::errors::{ApiError, EXIT_CODE_CONFIG_ERROR, fatal_error};
 use hubuum::logger;
@@ -166,9 +166,12 @@ struct TemplateHealthRow {
 }
 
 async fn export_template_health(pool: DbPool) -> Result<(), ApiError> {
-    let outputs = with_connection(&pool, |conn| {
-        export_task_outputs.load::<ExportTaskOutputRecord>(conn)
-    })?;
+    let outputs = with_connection(&pool, async |conn| {
+        export_task_outputs
+            .load::<ExportTaskOutputRecord>(conn)
+            .await
+    })
+    .await?;
 
     if outputs.is_empty() {
         println!("No stored export outputs found.");

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,24 +1,117 @@
 pub mod traits;
 
-use diesel::Connection;
-use diesel::PgConnection;
-use diesel::r2d2::ConnectionManager;
-use diesel::r2d2::Pool;
-use diesel::r2d2::PooledConnection;
+/// Diesel query-building traits paired with diesel-async's I/O traits.
+///
+/// Importing this prelude avoids bringing the synchronous `Connection` and
+/// `RunQueryDsl` traits into scope, which can otherwise make query execution
+/// ambiguous when an [`AsyncPgConnection`] is used.
+pub mod prelude {
+    pub use diesel::associations::{Associations, GroupedBy, Identifiable};
+    pub use diesel::deserialize::{Queryable, QueryableByName};
+    pub use diesel::expression::IntoSql as _;
+    pub use diesel::expression::functions::{declare_sql_function, define_sql_function};
+    pub use diesel::expression::{
+        AppearsOnTable, BoxableExpression, Expression, IntoSql, Selectable, SelectableExpression,
+        SelectableHelper,
+    };
+    pub use diesel::expression_methods::*;
+    pub use diesel::insertable::Insertable;
+    pub use diesel::query_builder::{AsChangeset, DecoratableTarget};
+    pub use diesel::query_dsl::{BelongingToDsl, CombineDsl, JoinOnDsl, QueryDsl};
+    pub use diesel::query_source::SizeRestrictedColumn as _;
+    pub use diesel::query_source::{Column, JoinTo, QuerySource, Table};
+    pub use diesel::result::{
+        ConnectionError, ConnectionResult, OptionalEmptyChangesetExtension, OptionalExtension,
+        QueryResult,
+    };
+    pub use diesel_async::{AsyncConnection, RunQueryDsl, SaveChangesDsl};
+}
+
+use diesel_async::pooled_connection::bb8::{Pool, PooledConnection};
+use diesel_async::pooled_connection::{AsyncDieselConnectionManager, ManagerConfig};
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use futures_util::FutureExt;
+use rustls::pki_types::{CertificateDer, pem::PemObject};
+use rustls::{ClientConfig, RootCertStore};
+use rustls_platform_verifier::BuilderVerifierExt;
+use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
 
 use tracing::debug;
 
-use crate::errors::{ApiError, EXIT_CODE_CONFIG_ERROR, EXIT_CODE_DATABASE_ERROR, fatal_error};
+use crate::errors::{ApiError, EXIT_CODE_CONFIG_ERROR, fatal_error};
 use crate::models::search::StatementTimeoutMs;
 use crate::utilities::db::DatabaseUrlComponents;
 
-pub type DbPool = Pool<ConnectionManager<PgConnection>>;
+pub type DbConnection = AsyncPgConnection;
+pub type DbPool = Pool<DbConnection>;
 
-fn acquire_connection(
-    pool: &DbPool,
-) -> Result<PooledConnection<ConnectionManager<PgConnection>>, ApiError> {
-    pool.get().map_err(ApiError::from)
+fn database_tls_config() -> Result<ClientConfig, diesel::result::ConnectionError> {
+    let builder = ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .map_err(|error| diesel::result::ConnectionError::BadConnection(error.to_string()))?;
+
+    let Some(root_cert_path) = std::env::var_os("PGSSLROOTCERT") else {
+        return builder
+            .with_platform_verifier()
+            .map(|builder| builder.with_no_client_auth())
+            .map_err(|error| diesel::result::ConnectionError::BadConnection(error.to_string()));
+    };
+
+    // PostgreSQL 17 accepts `PGSSLROOTCERT=system`; match that behavior by
+    // delegating to the platform verifier rather than treating it as a path.
+    if root_cert_path == "system" {
+        return builder
+            .with_platform_verifier()
+            .map(|builder| builder.with_no_client_auth())
+            .map_err(|error| diesel::result::ConnectionError::BadConnection(error.to_string()));
+    }
+
+    let certificates = CertificateDer::pem_file_iter(&root_cert_path)
+        .map_err(|error| diesel::result::ConnectionError::BadConnection(error.to_string()))?;
+    let mut roots = RootCertStore::empty();
+    let mut root_count = 0usize;
+    for certificate in certificates {
+        roots
+            .add(certificate.map_err(|error| {
+                diesel::result::ConnectionError::BadConnection(error.to_string())
+            })?)
+            .map_err(|error| diesel::result::ConnectionError::BadConnection(error.to_string()))?;
+        root_count += 1;
+    }
+    if root_count == 0 {
+        return Err(diesel::result::ConnectionError::BadConnection(format!(
+            "PGSSLROOTCERT contains no certificates: {}",
+            root_cert_path.to_string_lossy()
+        )));
+    }
+
+    Ok(builder.with_root_certificates(roots).with_no_client_auth())
+}
+
+/// Helper bound used to require that futures returned by higher-ranked async
+/// closures are `Send`. This mirrors diesel-async's transaction bound while
+/// keeping the helper private to the database adapter.
+#[doc(hidden)]
+pub trait SendAsyncFn<T, R>:
+    AsyncFnOnce(T) -> R + FnOnce(T) -> <Self as SendAsyncFn<T, R>>::Fut
+{
+    type Fut: Future<Output = R>;
+}
+
+impl<F, T, Fut, R> SendAsyncFn<T, R> for F
+where
+    F: AsyncFnOnce(T) -> R + FnOnce(T) -> Fut,
+    Fut: Future<Output = R>,
+{
+    type Fut = Fut;
+}
+
+async fn acquire_connection(pool: &DbPool) -> Result<PooledConnection<'_, DbConnection>, ApiError> {
+    pool.get().await.map_err(ApiError::from)
 }
 
 tokio::task_local! {
@@ -85,11 +178,11 @@ fn ambient_actor() -> Option<i32> {
 
 /// Apply a transaction-local `SET LOCAL hubuum.actor_id`. Bound, not formatted,
 /// mirroring [`set_local_statement_timeout`]. Reverts at COMMIT/ROLLBACK.
-fn set_local_actor(conn: &mut PgConnection, actor: i32) -> Result<(), diesel::result::Error> {
-    use diesel::RunQueryDsl;
+async fn set_local_actor(conn: &mut DbConnection, actor: i32) -> Result<(), diesel::result::Error> {
     diesel::sql_query("SELECT set_config('hubuum.actor_id', $1, true)")
         .bind::<diesel::sql_types::Text, _>(actor.to_string())
-        .execute(conn)?;
+        .execute(conn)
+        .await?;
     Ok(())
 }
 
@@ -98,14 +191,14 @@ fn set_local_actor(conn: &mut PgConnection, actor: i32) -> Result<(), diesel::re
 /// mirroring [`StatementTimeoutCustomizer`]. `set_config(name, value,
 /// is_local=true)` scopes the value to the current transaction, so it reverts
 /// automatically at COMMIT/ROLLBACK and never leaks back to the shared pool.
-fn set_local_statement_timeout(
-    conn: &mut PgConnection,
+async fn set_local_statement_timeout(
+    conn: &mut DbConnection,
     statement_timeout: StatementTimeoutMs,
 ) -> Result<(), diesel::result::Error> {
-    use diesel::RunQueryDsl;
     diesel::sql_query("SELECT set_config('statement_timeout', $1, true)")
         .bind::<diesel::sql_types::Text, _>(statement_timeout.as_millis().to_string())
-        .execute(conn)?;
+        .execute(conn)
+        .await?;
     Ok(())
 }
 
@@ -126,63 +219,63 @@ fn set_local_statement_timeout(
 ///
 /// Note: block closures that use `?` and end with `Ok(...)` may require an explicit closure
 /// return type, for example:
-/// `with_connection(pool, |conn| -> Result<_, diesel::result::Error> { ... })`
-pub fn with_connection<F, R, E>(pool: &DbPool, f: F) -> Result<R, ApiError>
+/// `with_connection(pool, async |conn| -> Result<_, diesel::result::Error> { ... }).await`
+pub async fn with_connection<F, R, E>(pool: &DbPool, f: F) -> Result<R, ApiError>
 where
-    F: FnOnce(&mut PgConnection) -> Result<R, E>,
+    F: for<'conn> AsyncFnOnce(&'conn mut DbConnection) -> Result<R, E>
+        + for<'conn> SendAsyncFn<&'conn mut DbConnection, Result<R, E>, Fut: Send>
+        + Send,
+    R: Send,
+    E: Send,
     ApiError: From<E>,
 {
-    with_connection_timeout(pool, ambient_statement_timeout(), f)
+    with_connection_timeout(pool, ambient_statement_timeout(), f).await
 }
 
-/// Run synchronous Diesel work on Tokio's blocking pool so an Actix worker can
-/// continue serving unrelated requests while waiting for a connection or Postgres.
-/// New async request paths should prefer this helper until the Diesel backend is
-/// migrated fully to `diesel-async`.
+/// Compatibility alias retained while callers migrate from the former
+/// `spawn_blocking` bridge. Both helpers now execute non-blocking database I/O.
 pub async fn with_connection_async<F, R, E>(pool: DbPool, f: F) -> Result<R, ApiError>
 where
-    F: FnOnce(&mut PgConnection) -> Result<R, E> + Send + 'static,
-    R: Send + 'static,
-    E: Send + 'static,
+    F: for<'conn> AsyncFnOnce(&'conn mut DbConnection) -> Result<R, E>
+        + for<'conn> SendAsyncFn<&'conn mut DbConnection, Result<R, E>, Fut: Send>
+        + Send,
+    R: Send,
+    E: Send,
     ApiError: From<E>,
 {
     let statement_timeout = ambient_statement_timeout();
     let actor = ambient_actor();
-    if tokio::runtime::Handle::try_current().is_err() {
-        // CLI and unit-test callers may drive these async domain APIs with a
-        // runtime-agnostic executor. There is no Actix worker to protect there.
-        return with_connection_context(&pool, statement_timeout, actor, f);
-    }
-    tokio::task::spawn_blocking(move || with_connection_context(&pool, statement_timeout, actor, f))
-        .await
-        .map_err(|error| {
-            ApiError::InternalServerError(format!("Database blocking task failed: {error}"))
-        })?
+    with_connection_context(&pool, statement_timeout, actor, f).await
 }
 
-fn with_connection_context<F, R, E>(
+async fn with_connection_context<F, R, E>(
     pool: &DbPool,
     statement_timeout: Option<StatementTimeoutMs>,
     actor: Option<i32>,
     f: F,
 ) -> Result<R, ApiError>
 where
-    F: FnOnce(&mut PgConnection) -> Result<R, E>,
+    F: for<'conn> AsyncFnOnce(&'conn mut DbConnection) -> Result<R, E>
+        + for<'conn> SendAsyncFn<&'conn mut DbConnection, Result<R, E>, Fut: Send>
+        + Send,
+    R: Send,
+    E: Send,
     ApiError: From<E>,
 {
-    let mut conn = acquire_connection(pool)?;
+    let mut conn = acquire_connection(pool).await?;
     if statement_timeout.is_none() && actor.is_none() {
-        f(&mut conn).map_err(ApiError::from)
+        f(&mut conn).await.map_err(ApiError::from)
     } else {
-        conn.transaction::<R, ApiError, _>(|conn| {
+        conn.transaction::<R, ApiError, _>(async move |conn| {
             if let Some(statement_timeout) = statement_timeout {
-                set_local_statement_timeout(conn, statement_timeout)?;
+                set_local_statement_timeout(conn, statement_timeout).await?;
             }
             if let Some(actor) = actor {
-                set_local_actor(conn, actor)?;
+                set_local_actor(conn, actor).await?;
             }
-            f(conn).map_err(ApiError::from)
+            f(conn).await.map_err(ApiError::from)
         })
+        .await
     }
 }
 
@@ -193,13 +286,13 @@ where
 /// `UPDATE ... RETURNING` therefore returns no row even though the target row
 /// still exists. Centralizing that fallback keeps update call sites from
 /// encoding trigger behavior themselves.
-pub fn updated_or_current<T, E>(
+pub async fn updated_or_current<T, E>(
     updated: Result<Option<T>, E>,
-    select_current: impl FnOnce() -> Result<T, E>,
+    select_current: impl AsyncFnOnce() -> Result<T, E>,
 ) -> Result<T, E> {
     match updated? {
         Some(row) => Ok(row),
-        None => select_current(),
+        None => select_current().await,
     }
 }
 
@@ -225,16 +318,20 @@ pub fn updated_or_current<T, E>(
 /// [`with_connection`]" guidance, but the transaction here exists solely to
 /// scope `SET LOCAL`, not for multi-statement atomicity, and is encapsulated in
 /// this one helper rather than imposed on callers.
-pub fn with_connection_timeout<F, R, E>(
+pub async fn with_connection_timeout<F, R, E>(
     pool: &DbPool,
     statement_timeout: Option<StatementTimeoutMs>,
     f: F,
 ) -> Result<R, ApiError>
 where
-    F: FnOnce(&mut PgConnection) -> Result<R, E>,
+    F: for<'conn> AsyncFnOnce(&'conn mut DbConnection) -> Result<R, E>
+        + for<'conn> SendAsyncFn<&'conn mut DbConnection, Result<R, E>, Fut: Send>
+        + Send,
+    R: Send,
+    E: Send,
     ApiError: From<E>,
 {
-    with_connection_context(pool, statement_timeout, ambient_actor(), f)
+    with_connection_context(pool, statement_timeout, ambient_actor(), f).await
 }
 
 /// Run database work inside a SQL transaction on a single pooled connection.
@@ -255,24 +352,29 @@ where
 /// As with [`with_connection`], the closure may return any error type `E` that converts into
 /// [`ApiError`]. Block closures that end with `Ok(...)` may need an explicit closure return type,
 /// for example:
-/// `with_transaction(pool, |conn| -> Result<_, ApiError> { ... })`
-pub fn with_transaction<F, R, E>(pool: &DbPool, f: F) -> Result<R, ApiError>
+/// `with_transaction(pool, async |conn| -> Result<_, ApiError> { ... }).await`
+pub async fn with_transaction<F, R, E>(pool: &DbPool, f: F) -> Result<R, ApiError>
 where
-    F: FnOnce(&mut PgConnection) -> Result<R, E>,
+    F: for<'conn> AsyncFnOnce(&'conn mut DbConnection) -> Result<R, E>
+        + for<'conn> SendAsyncFn<&'conn mut DbConnection, Result<R, E>, Fut: Send>
+        + Send,
+    R: Send,
+    E: Send,
     ApiError: From<E>,
 {
     let statement_timeout = ambient_statement_timeout();
     let actor = ambient_actor();
-    let mut conn = acquire_connection(pool)?;
-    conn.transaction::<R, ApiError, _>(|conn| {
+    let mut conn = acquire_connection(pool).await?;
+    conn.transaction::<R, ApiError, _>(async move |conn| {
         if let Some(statement_timeout) = statement_timeout {
-            set_local_statement_timeout(conn, statement_timeout)?;
+            set_local_statement_timeout(conn, statement_timeout).await?;
         }
         if let Some(actor) = actor {
-            set_local_actor(conn, actor)?;
+            set_local_actor(conn, actor).await?;
         }
-        f(conn).map_err(ApiError::from)
+        f(conn).await.map_err(ApiError::from)
     })
+    .await
 }
 
 pub fn init_pool(database_url: &str, max_size: u32) -> DbPool {
@@ -339,61 +441,60 @@ fn init_pool_with_timeouts(
         ),
     }
 
-    let manager = ConnectionManager::<PgConnection>::new(database_url);
+    let mut manager_config = ManagerConfig::<DbConnection>::default();
+    let tls_config = database_tls_config().unwrap_or_else(|error| {
+        fatal_error(
+            &format!("Failed to configure database TLS: {error}"),
+            EXIT_CODE_CONFIG_ERROR,
+        )
+    });
+    manager_config.custom_setup = Box::new(move |url| {
+        let tls_config = tls_config.clone();
+        async move {
+            // AsyncPgConnection::establish uses NoTls. Constructing it from a
+            // tokio-postgres TLS connection preserves support for the
+            // repository's documented sslmode=require production URLs and
+            // verifies both the certificate chain and database hostname.
+            let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_config);
+            let (client, connection) =
+                tokio_postgres::connect(url, tls).await.map_err(|error| {
+                    diesel::result::ConnectionError::BadConnection(error.to_string())
+                })?;
+            let mut conn = DbConnection::try_from_client_and_connection(client, connection).await?;
 
-    let mut builder = Pool::builder()
+            if statement_timeout_ms > 0 {
+                diesel::sql_query("SELECT set_config('statement_timeout', $1, false)")
+                    .bind::<diesel::sql_types::Text, _>(statement_timeout_ms.to_string())
+                    .execute(&mut conn)
+                    .await
+                    .map_err(|error| {
+                        diesel::result::ConnectionError::BadConnection(error.to_string())
+                    })?;
+            }
+            Ok(conn)
+        }
+        .boxed()
+    });
+    let manager =
+        AsyncDieselConnectionManager::<DbConnection>::new_with_config(database_url, manager_config);
+
+    let builder = Pool::builder()
         .max_size(max_size)
         .connection_timeout(Duration::from_millis(acquire_timeout_ms));
-    if statement_timeout_ms > 0 {
-        builder = builder.connection_customizer(Box::new(StatementTimeoutCustomizer {
-            statement_timeout_ms,
-        }));
-    }
 
-    match builder.build(manager) {
-        Ok(pool) => pool,
-        Err(e) => fatal_error(
-            &format!("Failed to create database pool: {}", e),
-            EXIT_CODE_DATABASE_ERROR,
-        ),
-    }
-}
-
-/// r2d2 connection customizer that applies a Postgres `statement_timeout` to
-/// each connection as it is acquired from the pool. Postgres cancels any
-/// statement exceeding this budget server-side and returns an error, which
-/// frees the (synchronous) connection - a genuine in-flight timeout, unlike a
-/// post-completion wall-clock check.
-#[derive(Debug)]
-struct StatementTimeoutCustomizer {
-    statement_timeout_ms: u64,
-}
-
-impl diesel::r2d2::CustomizeConnection<PgConnection, diesel::r2d2::Error>
-    for StatementTimeoutCustomizer
-{
-    fn on_acquire(&self, conn: &mut PgConnection) -> Result<(), diesel::r2d2::Error> {
-        use diesel::RunQueryDsl;
-        // `set_config(name, value, is_local=false)` sets the value for the
-        // session; a bare numeric string is interpreted as milliseconds. The
-        // value is bound rather than formatted into the SQL.
-        diesel::sql_query("SELECT set_config('statement_timeout', $1, false)")
-            .bind::<diesel::sql_types::Text, _>(self.statement_timeout_ms.to_string())
-            .execute(conn)
-            .map_err(diesel::r2d2::Error::QueryError)?;
-        Ok(())
-    }
+    // Pool construction remains synchronous for compatibility with the test
+    // fixture singleton. The first checkout establishes connections lazily;
+    // startup initialization immediately verifies connectivity.
+    builder.build_unchecked(manager)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::get_config;
-    use diesel::PgConnection;
+    use crate::db::prelude::*;
     use diesel::dsl::count_star;
     use diesel::insert_into;
-    use diesel::prelude::*;
-    use diesel::r2d2::{ConnectionManager, Pool};
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -408,24 +509,29 @@ mod tests {
         format!("{prefix}_{now}_{counter}")
     }
 
-    #[test]
-    fn test_init_pool() {
+    #[tokio::test]
+    async fn test_init_pool() {
         let config = get_config().expect("Failed to load config for test");
         let database_url = config.database_url.clone();
         let pool_size = config.db_pool_size;
         let pool = init_pool(&database_url, pool_size);
-        assert_eq!(pool.max_size(), pool_size);
+        assert_eq!(pool.config().max_size, pool_size);
     }
 
-    #[test]
-    fn statement_timeout_cancels_slow_queries() {
+    #[tokio::test]
+    async fn statement_timeout_cancels_slow_queries() {
         let config = get_config().expect("Failed to load config for test");
         let database_url = config.database_url.clone();
 
         // A tiny timeout must cancel a query that sleeps past the budget...
         let bounded = init_pool_with_statement_timeout(&database_url, 1, 50);
-        let mut conn = bounded.get().expect("failed to acquire bounded connection");
-        let slow = diesel::sql_query("SELECT pg_sleep(1)").execute(&mut conn);
+        let mut conn = bounded
+            .get()
+            .await
+            .expect("failed to acquire bounded connection");
+        let slow = diesel::sql_query("SELECT pg_sleep(1)")
+            .execute(&mut conn)
+            .await;
         assert!(
             slow.is_err(),
             "pg_sleep(1) should be cancelled by a 50ms statement_timeout"
@@ -436,23 +542,27 @@ mod tests {
         // connection was returned in a usable state.
         let mut conn = bounded
             .get()
+            .await
             .expect("failed to re-acquire bounded connection");
         diesel::sql_query("SELECT 1")
             .execute(&mut conn)
+            .await
             .expect("fast query should succeed under the timeout");
 
         // With the timeout disabled (0), the same sleep completes.
         let unbounded = init_pool_with_statement_timeout(&database_url, 1, 0);
         let mut conn = unbounded
             .get()
+            .await
             .expect("failed to acquire unbounded connection");
         diesel::sql_query("SELECT pg_sleep(0.1)")
             .execute(&mut conn)
+            .await
             .expect("pg_sleep should complete when statement_timeout is disabled");
     }
 
-    #[test]
-    fn statement_timeout_ms_new_treats_zero_as_disabled() {
+    #[tokio::test]
+    async fn statement_timeout_ms_new_treats_zero_as_disabled() {
         assert_eq!(StatementTimeoutMs::new(0), None);
         assert_eq!(
             StatementTimeoutMs::new(50).map(StatementTimeoutMs::as_millis),
@@ -460,17 +570,18 @@ mod tests {
         );
     }
 
-    #[test]
-    fn with_connection_timeout_bounds_and_reverts() {
+    #[tokio::test]
+    async fn with_connection_timeout_bounds_and_reverts() {
         let config = get_config().expect("Failed to load config for test");
         // Pool-global timeout disabled, so any cancellation must come from the
         // per-query `SET LOCAL` applied by `with_connection_timeout` itself.
         let pool = init_pool_with_statement_timeout(&config.database_url, 1, 0);
 
         // A tiny explicit timeout cancels a query that sleeps past the budget.
-        let slow = with_connection_timeout(&pool, StatementTimeoutMs::new(50), |conn| {
-            diesel::sql_query("SELECT pg_sleep(1)").execute(conn)
-        });
+        let slow = with_connection_timeout(&pool, StatementTimeoutMs::new(50), async |conn| {
+            diesel::sql_query("SELECT pg_sleep(1)").execute(conn).await
+        })
+        .await;
         assert!(
             slow.is_err(),
             "pg_sleep(1) should be cancelled by a 50ms per-query statement_timeout"
@@ -478,9 +589,12 @@ mod tests {
 
         // The `SET LOCAL` reverts with the transaction, so a later checkout that
         // passes `None` is unbounded again (proving no leak back to the pool).
-        with_connection_timeout(&pool, None, |conn| {
-            diesel::sql_query("SELECT pg_sleep(0.1)").execute(conn)
+        with_connection_timeout(&pool, None, async |conn| {
+            diesel::sql_query("SELECT pg_sleep(0.1)")
+                .execute(conn)
+                .await
         })
+        .await
         .expect("pg_sleep should complete when no per-query timeout is applied");
     }
 
@@ -493,9 +607,10 @@ mod tests {
 
         // Inside the scope, a plain `with_connection` call is bounded.
         let bounded = with_statement_timeout_scope(StatementTimeoutMs::new(50), async {
-            with_connection(&pool, |conn| {
-                diesel::sql_query("SELECT pg_sleep(1)").execute(conn)
+            with_connection(&pool, async |conn| {
+                diesel::sql_query("SELECT pg_sleep(1)").execute(conn).await
             })
+            .await
         })
         .await;
         assert!(
@@ -504,33 +619,21 @@ mod tests {
         );
 
         // Outside any scope, the ambient timeout is gone and slow work runs.
-        with_connection(&pool, |conn| {
-            diesel::sql_query("SELECT pg_sleep(0.1)").execute(conn)
+        with_connection(&pool, async |conn| {
+            diesel::sql_query("SELECT pg_sleep(0.1)")
+                .execute(conn)
+                .await
         })
+        .await
         .expect("with_connection outside a scope must not be bounded");
     }
 
-    #[test]
-    fn test_with_connection_returns_error_on_invalid_pool() {
-        // Create a pool with an invalid database URL to test error handling
-        let manager = ConnectionManager::<PgConnection>::new("postgres://invalid:5432/nonexistent");
-
-        // Try to build the pool - if this fails, we can't run the test
-        let pool = match Pool::builder()
-            .max_size(1)
-            .connection_timeout(std::time::Duration::from_millis(100))
-            .build(manager)
-        {
-            Ok(p) => p,
-            Err(_) => {
-                // Pool creation itself failed - this is acceptable for this test
-                // as we're testing error handling in general
-                return;
-            }
-        };
+    #[tokio::test]
+    async fn test_with_connection_returns_error_on_invalid_pool() {
+        let pool = init_pool_with_timeouts("postgres://invalid:5432/nonexistent", 1, 0, 100);
 
         // This should return an error, not panic
-        let result = with_connection(&pool, |_conn| Ok::<_, diesel::result::Error>(()));
+        let result = with_connection(&pool, async |_conn| Ok::<_, diesel::result::Error>(())).await;
 
         assert!(result.is_err());
 
@@ -543,26 +646,27 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_with_connection_success_path() {
+    #[tokio::test]
+    async fn test_with_connection_success_path() {
         let config = get_config().expect("Failed to load config for test");
         let pool = init_pool(&config.database_url, 1);
 
         // This should succeed
-        let result = with_connection(&pool, |_conn| Ok::<i32, diesel::result::Error>(42));
+        let result =
+            with_connection(&pool, async |_conn| Ok::<i32, diesel::result::Error>(42)).await;
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 42);
     }
 
-    #[test]
-    fn test_with_transaction_rolls_back_on_error() {
+    #[tokio::test]
+    async fn test_with_transaction_rolls_back_on_error() {
         let config = get_config().expect("Failed to load config for test");
         let pool = init_pool(&config.database_url, 1);
         let rollback_name = unique_group_name("with_tx_rollback");
 
         let result: Result<(), ApiError> =
-            with_transaction(&pool, |conn| -> Result<(), diesel::result::Error> {
+            with_transaction(&pool, async |conn| -> Result<(), diesel::result::Error> {
                 use crate::schema::groups::dsl::{description, groupname, groups};
 
                 insert_into(groups)
@@ -570,30 +674,35 @@ mod tests {
                         groupname.eq(&rollback_name),
                         description.eq("rollback-test"),
                     ))
-                    .execute(conn)?;
+                    .execute(conn)
+                    .await?;
 
                 insert_into(groups)
                     .values((
                         groupname.eq(&rollback_name),
                         description.eq("rollback-test-duplicate"),
                     ))
-                    .execute(conn)?;
+                    .execute(conn)
+                    .await?;
                 Ok(())
-            });
+            })
+            .await;
 
         assert!(
             matches!(result, Err(ApiError::Conflict(_))),
             "expected unique violation mapped to ApiError::Conflict, got {result:?}",
         );
 
-        let committed_rows = with_connection(&pool, |conn| {
+        let committed_rows = with_connection(&pool, async |conn| {
             use crate::schema::groups::dsl::{groupname, groups};
 
             groups
                 .filter(groupname.eq(&rollback_name))
                 .select(count_star())
                 .first::<i64>(conn)
+                .await
         })
+        .await
         .expect("Failed to count rows after rollback test");
 
         assert_eq!(
@@ -602,43 +711,48 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_with_transaction_commits_on_success() {
+    #[tokio::test]
+    async fn test_with_transaction_commits_on_success() {
         let config = get_config().expect("Failed to load config for test");
         let pool = init_pool(&config.database_url, 1);
         let first_name = unique_group_name("with_tx_commit_one");
         let second_name = unique_group_name("with_tx_commit_two");
 
         let result: Result<(), ApiError> =
-            with_transaction(&pool, |conn| -> Result<(), diesel::result::Error> {
+            with_transaction(&pool, async |conn| -> Result<(), diesel::result::Error> {
                 use crate::schema::groups::dsl::{description, groupname, groups};
 
                 insert_into(groups)
                     .values((groupname.eq(&first_name), description.eq("commit-test-one")))
-                    .execute(conn)?;
+                    .execute(conn)
+                    .await?;
 
                 insert_into(groups)
                     .values((
                         groupname.eq(&second_name),
                         description.eq("commit-test-two"),
                     ))
-                    .execute(conn)?;
+                    .execute(conn)
+                    .await?;
                 Ok(())
-            });
+            })
+            .await;
 
         assert!(
             result.is_ok(),
             "expected transaction commit, got {result:?}"
         );
 
-        let committed_rows = with_connection(&pool, |conn| {
+        let committed_rows = with_connection(&pool, async |conn| {
             use crate::schema::groups::dsl::{groupname, groups};
 
             groups
                 .filter(groupname.eq_any(vec![first_name.clone(), second_name.clone()]))
                 .select(count_star())
                 .first::<i64>(conn)
+                .await
         })
+        .await
         .expect("Failed to count rows after commit test");
 
         assert_eq!(
@@ -646,11 +760,13 @@ mod tests {
             "successful transaction should commit both rows",
         );
 
-        let _ = with_connection(&pool, |conn| {
+        let _ = with_connection(&pool, async |conn| {
             use crate::schema::groups::dsl::{groupname, groups};
 
             diesel::delete(groups.filter(groupname.eq_any(vec![first_name, second_name])))
                 .execute(conn)
-        });
+                .await
+        })
+        .await;
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -712,6 +712,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelled_transaction_is_discarded_and_rolled_back() {
+        let config = get_config().expect("Failed to load config for test");
+        let pool = init_pool(&config.database_url, 1);
+        let cancelled_name = unique_group_name("with_tx_cancelled");
+        let closed_broken_before = pool.state().statistics.connections_closed_broken;
+        let (inserted_tx, inserted_rx) = tokio::sync::oneshot::channel();
+        let transaction_pool = pool.clone();
+        let transaction_name = cancelled_name.clone();
+
+        let transaction_task = tokio::spawn(async move {
+            with_transaction(
+                &transaction_pool,
+                async move |conn| -> Result<(), diesel::result::Error> {
+                    use crate::schema::groups::dsl::{description, groupname, groups};
+
+                    insert_into(groups)
+                        .values((
+                            groupname.eq(&transaction_name),
+                            description.eq("cancelled-transaction-test"),
+                        ))
+                        .execute(conn)
+                        .await?;
+                    let _ = inserted_tx.send(());
+                    std::future::pending::<()>().await;
+                    Ok(())
+                },
+            )
+            .await
+        });
+
+        inserted_rx
+            .await
+            .expect("transaction task ended before inserting its marker");
+        transaction_task.abort();
+        let join_error = transaction_task
+            .await
+            .expect_err("transaction task should have been cancelled");
+        assert!(join_error.is_cancelled());
+
+        let state_after_cancel = pool.state();
+        assert!(
+            state_after_cancel.statistics.connections_closed_broken > closed_broken_before,
+            "the cancelled transaction connection must be discarded instead of pooled",
+        );
+
+        let persisted_rows = with_connection(&pool, async |conn| {
+            use crate::schema::groups::dsl::{groupname, groups};
+
+            groups
+                .filter(groupname.eq(&cancelled_name))
+                .select(count_star())
+                .first::<i64>(conn)
+                .await
+        })
+        .await
+        .expect("replacement connection should remain usable");
+
+        assert_eq!(
+            persisted_rows, 0,
+            "Postgres should roll back work from the discarded connection",
+        );
+    }
+
+    #[tokio::test]
     async fn test_with_transaction_commits_on_success() {
         let config = get_config().expect("Failed to load config for test");
         let pool = init_pool(&config.database_url, 1);

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -35,6 +35,7 @@ use rustls::pki_types::{CertificateDer, pem::PemObject};
 use rustls::{ClientConfig, RootCertStore};
 use rustls_platform_verifier::BuilderVerifierExt;
 use std::future::Future;
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -46,6 +47,43 @@ use crate::utilities::db::DatabaseUrlComponents;
 
 pub type DbConnection = AsyncPgConnection;
 pub type DbPool = Pool<DbConnection>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DatabaseTlsMode {
+    Disable,
+    Verify,
+}
+
+fn database_tls_mode(database_url: &str, host: &str) -> Result<DatabaseTlsMode, String> {
+    let mut explicit_mode = None;
+    if let Some((_, query)) = database_url.split_once('?') {
+        for (key, value) in query
+            .split('&')
+            .filter_map(|parameter| parameter.split_once('='))
+        {
+            if key.eq_ignore_ascii_case("sslmode") && explicit_mode.replace(value).is_some() {
+                return Err("PostgreSQL sslmode must not be repeated".to_string());
+            }
+        }
+    }
+
+    match explicit_mode {
+        Some("disable") => Ok(DatabaseTlsMode::Disable),
+        Some("prefer" | "require") => Ok(DatabaseTlsMode::Verify),
+        Some(mode) => Err(format!(
+            "Unsupported PostgreSQL sslmode '{mode}'; expected disable, prefer, or require"
+        )),
+        None if is_loopback_database_host(host) => Ok(DatabaseTlsMode::Disable),
+        None => Ok(DatabaseTlsMode::Verify),
+    }
+}
+
+fn is_loopback_database_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
+}
 
 fn database_tls_config() -> Result<ClientConfig, diesel::result::ConnectionError> {
     let builder = ClientConfig::builder_with_provider(Arc::new(
@@ -90,6 +128,26 @@ fn database_tls_config() -> Result<ClientConfig, diesel::result::ConnectionError
     }
 
     Ok(builder.with_root_certificates(roots).with_no_client_auth())
+}
+
+async fn establish_database_connection(
+    database_url: &str,
+    tls_config: Option<ClientConfig>,
+) -> Result<DbConnection, diesel::result::ConnectionError> {
+    let connection = if let Some(tls_config) = tls_config {
+        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_config);
+        let (client, connection) = tokio_postgres::connect(database_url, tls)
+            .await
+            .map_err(|error| diesel::result::ConnectionError::BadConnection(error.to_string()))?;
+        DbConnection::try_from_client_and_connection(client, connection).await?
+    } else {
+        let (client, connection) = tokio_postgres::connect(database_url, tokio_postgres::NoTls)
+            .await
+            .map_err(|error| diesel::result::ConnectionError::BadConnection(error.to_string()))?;
+        DbConnection::try_from_client_and_connection(client, connection).await?
+    };
+
+    Ok(connection)
 }
 
 /// Helper bound used to require that futures returned by higher-ranked async
@@ -422,9 +480,7 @@ fn init_pool_with_timeouts(
     statement_timeout_ms: u64,
     acquire_timeout_ms: u64,
 ) -> DbPool {
-    let database_url_components = DatabaseUrlComponents::new(database_url);
-
-    match database_url_components {
+    let database_host = match DatabaseUrlComponents::new(database_url) {
         Ok(components) => {
             debug!(
                 message = "Database URL parsed.",
@@ -434,33 +490,35 @@ fn init_pool_with_timeouts(
                 port = components.port,
                 database = components.database,
             );
+            components.host
         }
         Err(err) => fatal_error(
             &format!("Failed to parse database URL: {}", err),
             EXIT_CODE_CONFIG_ERROR,
         ),
-    }
+    };
 
-    let mut manager_config = ManagerConfig::<DbConnection>::default();
-    let tls_config = database_tls_config().unwrap_or_else(|error| {
+    let tls_mode = database_tls_mode(database_url, &database_host).unwrap_or_else(|error| {
         fatal_error(
             &format!("Failed to configure database TLS: {error}"),
             EXIT_CODE_CONFIG_ERROR,
         )
     });
+
+    let mut manager_config = ManagerConfig::<DbConnection>::default();
+    let tls_config = match tls_mode {
+        DatabaseTlsMode::Disable => None,
+        DatabaseTlsMode::Verify => Some(database_tls_config().unwrap_or_else(|error| {
+            fatal_error(
+                &format!("Failed to configure database TLS: {error}"),
+                EXIT_CODE_CONFIG_ERROR,
+            )
+        })),
+    };
     manager_config.custom_setup = Box::new(move |url| {
         let tls_config = tls_config.clone();
         async move {
-            // AsyncPgConnection::establish uses NoTls. Constructing it from a
-            // tokio-postgres TLS connection preserves support for the
-            // repository's documented sslmode=require production URLs and
-            // verifies both the certificate chain and database hostname.
-            let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_config);
-            let (client, connection) =
-                tokio_postgres::connect(url, tls).await.map_err(|error| {
-                    diesel::result::ConnectionError::BadConnection(error.to_string())
-                })?;
-            let mut conn = DbConnection::try_from_client_and_connection(client, connection).await?;
+            let mut conn = establish_database_connection(url, tls_config).await?;
 
             if statement_timeout_ms > 0 {
                 diesel::sql_query("SELECT set_config('statement_timeout', $1, false)")
@@ -495,6 +553,7 @@ mod tests {
     use crate::db::prelude::*;
     use diesel::dsl::count_star;
     use diesel::insert_into;
+    use rstest::rstest;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -507,6 +566,68 @@ mod tests {
             .as_nanos();
         let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
         format!("{prefix}_{now}_{counter}")
+    }
+
+    #[rstest]
+    #[case::localhost("localhost")]
+    #[case::ipv4("127.0.0.1")]
+    #[case::ipv6("::1")]
+    fn implicit_loopback_database_urls_disable_tls(#[case] host: &str) {
+        assert_eq!(
+            database_tls_mode("postgres://postgres@localhost/hubuum", host),
+            Ok(DatabaseTlsMode::Disable)
+        );
+    }
+
+    #[rstest]
+    #[case::local_require(
+        "postgres://postgres@localhost/hubuum?sslmode=require",
+        "localhost",
+        DatabaseTlsMode::Verify
+    )]
+    #[case::local_prefer(
+        "postgres://postgres@localhost/hubuum?sslmode=prefer",
+        "localhost",
+        DatabaseTlsMode::Verify
+    )]
+    #[case::remote_disable(
+        "postgres://postgres@db.example.com/hubuum?sslmode=disable",
+        "db.example.com",
+        DatabaseTlsMode::Disable
+    )]
+    #[case::remote_implicit(
+        "postgres://postgres@db.example.com/hubuum",
+        "db.example.com",
+        DatabaseTlsMode::Verify
+    )]
+    fn database_tls_mode_follows_url_and_host(
+        #[case] database_url: &str,
+        #[case] host: &str,
+        #[case] expected: DatabaseTlsMode,
+    ) {
+        assert_eq!(database_tls_mode(database_url, host), Ok(expected));
+    }
+
+    #[test]
+    fn unsupported_database_sslmode_is_rejected() {
+        let error = database_tls_mode(
+            "postgres://postgres@db.example.com/hubuum?sslmode=verify-full",
+            "db.example.com",
+        )
+        .unwrap_err();
+
+        assert!(error.contains("Unsupported PostgreSQL sslmode 'verify-full'"));
+    }
+
+    #[test]
+    fn repeated_database_sslmode_is_rejected() {
+        assert!(matches!(
+            database_tls_mode(
+                "postgres://postgres@db.example.com/hubuum?sslmode=require&sslmode=disable",
+                "db.example.com"
+            ),
+            Err(message) if message == "PostgreSQL sslmode must not be repeated"
+        ));
     }
 
     #[tokio::test]

--- a/src/db/traits/active_tokens.rs
+++ b/src/db/traits/active_tokens.rs
@@ -1,4 +1,5 @@
 use crate::config::token_lifetime_hours_i32;
+use crate::db::prelude::*;
 use crate::db::traits::ActiveTokens;
 use crate::db::{DbPool, with_connection};
 use crate::errors::ApiError;
@@ -6,7 +7,6 @@ use crate::models::PrincipalToken;
 use crate::models::search::{FilterField, QueryOptions};
 use crate::traits::PrincipalIdAccessor;
 use diesel::pg::Pg;
-use diesel::prelude::*;
 use diesel::sql_types::{Bool, Nullable};
 
 impl<S> ActiveTokens for S
@@ -76,12 +76,14 @@ async fn active_tokens_by_principal_id(
     let active_after = active_tokens_cutoff();
     let now = chrono::Utc::now().naive_utc();
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         tokens
             .filter(principal_id.eq(principal))
             .filter(active_token_predicate(now, active_after))
             .load::<PrincipalToken>(conn)
+            .await
     })
+    .await
 }
 
 async fn active_tokens_by_principal_id_paginated_with_total_count(
@@ -123,13 +125,20 @@ async fn active_tokens_by_principal_id_paginated_with_total_count(
     };
 
     let base_query = build_query()?;
-    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-        with_connection(pool, |conn| base_query.count().get_result::<i64>(conn))
-    })?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+        with_connection(pool, async |conn| {
+            base_query.count().get_result::<i64>(conn).await
+        })
+        .await
+    })
+    .await?;
 
     let mut base_query = build_query()?;
     crate::apply_query_options!(base_query, query_options, PrincipalToken);
-    let items = with_connection(pool, |conn| base_query.load::<PrincipalToken>(conn))?;
+    let items = with_connection(pool, async |conn| {
+        base_query.load::<PrincipalToken>(conn).await
+    })
+    .await?;
 
     Ok((items, total_count))
 }

--- a/src/db/traits/authz.rs
+++ b/src/db/traits/authz.rs
@@ -14,8 +14,8 @@
 //! extractor; task workers pass the scope snapshot persisted on the task; plain
 //! internal callers pass `None`.
 
+use crate::db::prelude::*;
 use diesel::pg::Pg;
-use diesel::prelude::*;
 use diesel::sql_types::Integer;
 
 use crate::db::{DbPool, with_connection, with_connection_async};
@@ -107,7 +107,7 @@ pub trait AuthzSubject: PrincipalIdAccessor {
         let pid = self.principal_id();
         let scope = self.admin_identity_scope().await?;
         let group_name = groupname_queried.to_string();
-        let is_in_group = with_connection_async(pool.clone(), move |conn| {
+        let is_in_group = with_connection_async(pool.clone(), async move |conn| {
             select(exists(
                 group_memberships::table
                     .inner_join(groups::table)
@@ -120,6 +120,7 @@ pub trait AuthzSubject: PrincipalIdAccessor {
                     .filter(identity_scopes::name.eq(scope)),
             ))
             .get_result(conn)
+            .await
         })
         .await?;
         Ok(is_in_group)
@@ -160,12 +161,14 @@ pub fn scope_allows(scopes: Option<&[Permissions]>, requested: &[Permissions]) -
 pub async fn load_token_scopes(pool: &DbPool, token_id: i32) -> Result<Vec<Permissions>, ApiError> {
     use crate::schema::token_scopes::dsl::{permission, token_id as ts_token_id, token_scopes};
 
-    let raw: Vec<String> = with_connection(pool, |conn| {
+    let raw: Vec<String> = with_connection(pool, async |conn| {
         token_scopes
             .filter(ts_token_id.eq(token_id))
             .select(permission)
             .load::<String>(conn)
-    })?;
+            .await
+    })
+    .await?;
 
     raw.iter().map(|s| Permissions::from_string(s)).collect()
 }

--- a/src/db/traits/class.rs
+++ b/src/db/traits/class.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 
 use crate::db::traits::GetClass;
 use crate::db::{DbPool, with_connection, with_transaction};
@@ -40,24 +40,34 @@ fn class_event(
 impl GetClass for HubuumClass {
     async fn class_from_backend(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id};
-        with_connection(pool, |conn| -> Result<HubuumClass, diesel::result::Error> {
-            let class = hubuumclass
-                .filter(id.eq(self.id))
-                .first::<HubuumClass>(conn)?;
-            Ok(class)
-        })
+        with_connection(
+            pool,
+            async |conn| -> Result<HubuumClass, diesel::result::Error> {
+                let class = hubuumclass
+                    .filter(id.eq(self.id))
+                    .first::<HubuumClass>(conn)
+                    .await?;
+                Ok(class)
+            },
+        )
+        .await
     }
 }
 
 impl GetClass for HubuumClassID {
     async fn class_from_backend(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id};
-        with_connection(pool, |conn| -> Result<HubuumClass, diesel::result::Error> {
-            let class = hubuumclass
-                .filter(id.eq(self.id()))
-                .first::<HubuumClass>(conn)?;
-            Ok(class)
-        })
+        with_connection(
+            pool,
+            async |conn| -> Result<HubuumClass, diesel::result::Error> {
+                let class = hubuumclass
+                    .filter(id.eq(self.id()))
+                    .first::<HubuumClass>(conn)
+                    .await?;
+                Ok(class)
+            },
+        )
+        .await
     }
 }
 
@@ -69,16 +79,19 @@ impl GetClass<(HubuumClass, HubuumClass)> for HubuumClassRelation {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id};
         with_connection(
             pool,
-            |conn| -> Result<(HubuumClass, HubuumClass), diesel::result::Error> {
+            async |conn| -> Result<(HubuumClass, HubuumClass), diesel::result::Error> {
                 let from_class = hubuumclass
                     .filter(id.eq(self.from_hubuum_class_id))
-                    .first::<HubuumClass>(conn)?;
+                    .first::<HubuumClass>(conn)
+                    .await?;
                 let to_class = hubuumclass
                     .filter(id.eq(self.to_hubuum_class_id))
-                    .first::<HubuumClass>(conn)?;
+                    .first::<HubuumClass>(conn)
+                    .await?;
                 Ok((from_class, to_class))
             },
         )
+        .await
     }
 }
 
@@ -92,20 +105,24 @@ impl GetClass<(HubuumClass, HubuumClass)> for HubuumClassRelationID {
 
         with_connection(
             pool,
-            |conn| -> Result<(HubuumClass, HubuumClass), diesel::result::Error> {
+            async |conn| -> Result<(HubuumClass, HubuumClass), diesel::result::Error> {
                 let relation = hubuumclass_relation
                     .filter(rel_id.eq(self.id()))
-                    .first::<HubuumClassRelation>(conn)?;
+                    .first::<HubuumClassRelation>(conn)
+                    .await?;
 
                 let from_class = hubuumclass
                     .filter(hid.eq(relation.from_hubuum_class_id))
-                    .first::<HubuumClass>(conn)?;
+                    .first::<HubuumClass>(conn)
+                    .await?;
                 let to_class = hubuumclass
                     .filter(hid.eq(relation.to_hubuum_class_id))
-                    .first::<HubuumClass>(conn)?;
+                    .first::<HubuumClass>(conn)
+                    .await?;
                 Ok((from_class, to_class))
             },
         )
+        .await
     }
 }
 
@@ -118,16 +135,19 @@ impl GetClass<(HubuumClass, HubuumClass)> for NewHubuumClassRelation {
 
         with_connection(
             pool,
-            |conn| -> Result<(HubuumClass, HubuumClass), diesel::result::Error> {
+            async |conn| -> Result<(HubuumClass, HubuumClass), diesel::result::Error> {
                 let from_class = hubuumclass
                     .filter(hid.eq(self.from_hubuum_class_id))
-                    .first::<HubuumClass>(conn)?;
+                    .first::<HubuumClass>(conn)
+                    .await?;
                 let to_class = hubuumclass
                     .filter(hid.eq(self.to_hubuum_class_id))
-                    .first::<HubuumClass>(conn)?;
+                    .first::<HubuumClass>(conn)
+                    .await?;
                 Ok((from_class, to_class))
             },
         )
+        .await
     }
 }
 
@@ -170,11 +190,13 @@ impl CreateClassRecord for NewHubuumClass {
     ) -> Result<HubuumClass, ApiError> {
         use crate::schema::hubuumclass::dsl::hubuumclass;
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             diesel::insert_into(hubuumclass)
                 .values(self)
                 .get_result(conn)
+                .await
         })
+        .await
     }
 
     async fn create_class_record(
@@ -188,10 +210,11 @@ impl CreateClassRecord for NewHubuumClass {
 
         use crate::schema::hubuumclass::dsl::hubuumclass;
 
-        with_transaction(pool, |conn| -> Result<HubuumClass, ApiError> {
+        with_transaction(pool, async |conn| -> Result<HubuumClass, ApiError> {
             let class = diesel::insert_into(hubuumclass)
                 .values(self)
-                .get_result::<HubuumClass>(conn)?;
+                .get_result::<HubuumClass>(conn)
+                .await?;
             let event = class_event(
                 &class,
                 Action::Created,
@@ -199,9 +222,10 @@ impl CreateClassRecord for NewHubuumClass {
                 format!("Class '{}' created", class.name),
             )?
             .with_after(class_snapshot(&class));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(class)
         })
+        .await
     }
 }
 
@@ -232,15 +256,18 @@ impl UpdateClassRecord for UpdateHubuumClass {
     ) -> Result<HubuumClass, ApiError> {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             crate::db::updated_or_current(
                 diesel::update(hubuumclass.filter(id.eq(class_id)))
                     .set(self)
                     .get_result(conn)
+                    .await
                     .optional(),
-                || hubuumclass.filter(id.eq(class_id)).first(conn),
+                async || hubuumclass.filter(id.eq(class_id)).first(conn).await,
             )
+            .await
         })
+        .await
     }
 
     async fn update_class_record(
@@ -257,13 +284,15 @@ impl UpdateClassRecord for UpdateHubuumClass {
 
         use crate::schema::hubuumclass::dsl::{hubuumclass, id};
 
-        with_transaction(pool, |conn| -> Result<HubuumClass, ApiError> {
+        with_transaction(pool, async |conn| -> Result<HubuumClass, ApiError> {
             let before = hubuumclass
                 .filter(id.eq(class_id))
-                .first::<HubuumClass>(conn)?;
+                .first::<HubuumClass>(conn)
+                .await?;
             let updated = diesel::update(hubuumclass.filter(id.eq(class_id)))
                 .set(self)
-                .get_result::<HubuumClass>(conn)?;
+                .get_result::<HubuumClass>(conn)
+                .await?;
             let event = class_event(
                 &updated,
                 Action::Updated,
@@ -272,9 +301,10 @@ impl UpdateClassRecord for UpdateHubuumClass {
             )?
             .with_before(class_snapshot(&before))
             .with_after(class_snapshot(&updated));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(updated)
         })
+        .await
     }
 }
 
@@ -295,9 +325,12 @@ impl DeleteClassRecord for HubuumClass {
     async fn delete_class_record_without_events(&self, pool: &DbPool) -> Result<(), ApiError> {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id};
 
-        with_connection(pool, |conn| {
-            diesel::delete(hubuumclass.filter(id.eq(self.id))).execute(conn)
-        })?;
+        with_connection(pool, async |conn| {
+            diesel::delete(hubuumclass.filter(id.eq(self.id)))
+                .execute(conn)
+                .await
+        })
+        .await?;
         Ok(())
     }
 
@@ -312,8 +345,10 @@ impl DeleteClassRecord for HubuumClass {
 
         use crate::schema::hubuumclass::dsl::{hubuumclass, id};
 
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
-            diesel::delete(hubuumclass.filter(id.eq(self.id))).execute(conn)?;
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
+            diesel::delete(hubuumclass.filter(id.eq(self.id)))
+                .execute(conn)
+                .await?;
             let event = class_event(
                 self,
                 Action::Deleted,
@@ -321,9 +356,10 @@ impl DeleteClassRecord for HubuumClass {
                 format!("Class '{}' deleted", self.name),
             )?
             .with_before(class_snapshot(self));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(())
         })
+        .await
     }
 }
 
@@ -335,11 +371,13 @@ impl ClassCollectionLookup for HubuumClass {
     async fn lookup_class_collection(&self, pool: &DbPool) -> Result<Collection, ApiError> {
         use crate::schema::collections::dsl::{collections, id};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             collections
                 .filter(id.eq(self.collection_id))
                 .first::<Collection>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -355,7 +393,10 @@ impl ClassCollectionLookup for HubuumClassID {
 pub async fn total_class_count_from_backend(pool: &DbPool) -> Result<i64, ApiError> {
     use crate::schema::hubuumclass::dsl::*;
 
-    with_connection(pool, |conn| hubuumclass.count().get_result::<i64>(conn))
+    with_connection(pool, async |conn| {
+        hubuumclass.count().get_result::<i64>(conn).await
+    })
+    .await
 }
 
 impl ClassIdSet {
@@ -369,12 +410,14 @@ impl ClassIdSet {
         }
 
         let ids = self.as_slice().to_vec();
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             hubuumclass
                 .filter(id.eq_any(ids))
                 .select((id, name))
                 .load::<(i32, String)>(conn)
+                .await
         })
+        .await
     }
 
     /// Load every class relation that touches a class in this set as either endpoint.
@@ -391,11 +434,13 @@ impl ClassIdSet {
         }
 
         let ids = self.as_slice().to_vec();
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             hubuumclass_relation
                 .filter(from_hubuum_class_id.eq_any(&ids))
                 .or_filter(to_hubuum_class_id.eq_any(&ids))
                 .load::<HubuumClassRelation>(conn)
+                .await
         })
+        .await
     }
 }

--- a/src/db/traits/collection/mod.rs
+++ b/src/db/traits/collection/mod.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use tracing::{debug, trace};
 
 use crate::db::traits::GetCollection;

--- a/src/db/traits/collection/permissions.rs
+++ b/src/db/traits/collection/permissions.rs
@@ -1,9 +1,10 @@
 use super::*;
 use crate::db::traits::authz::AuthzSubject;
+use diesel_async::RunQueryDsl;
 use std::collections::HashMap;
 
-fn build_effective_group_permissions(
-    conn: &mut diesel::PgConnection,
+async fn build_effective_group_permissions(
+    conn: &mut crate::db::DbConnection,
     target_collection_id: i32,
     rows: Vec<(i32, i32, Group, Permission)>,
 ) -> Result<Vec<EffectiveGroupPermission>, ApiError> {
@@ -15,7 +16,8 @@ fn build_effective_group_permissions(
 
     let target_collection = collections
         .filter(id.eq(target_collection_id))
-        .first::<Collection>(conn)?;
+        .first::<Collection>(conn)
+        .await?;
     let mut source_ids: Vec<i32> = rows
         .iter()
         .map(|(source_collection_id, _, _, _)| *source_collection_id)
@@ -24,7 +26,8 @@ fn build_effective_group_permissions(
     source_ids.dedup();
     let source_collections = collections
         .filter(id.eq_any(source_ids))
-        .load::<Collection>(conn)?
+        .load::<Collection>(conn)
+        .await?
         .into_iter()
         .map(|collection| (collection.id, collection))
         .collect::<HashMap<_, _>>();
@@ -57,7 +60,10 @@ fn build_effective_group_permissions(
 pub async fn total_collection_count_from_backend(pool: &DbPool) -> Result<i64, ApiError> {
     use crate::schema::collections::dsl::*;
 
-    with_connection(pool, |conn| collections.count().get_result::<i64>(conn))
+    with_connection(pool, async |conn| {
+        collections.count().get_result::<i64>(conn).await
+    })
+    .await
 }
 
 pub async fn principal_on_from_backend<S: AuthzSubject, T: CollectionAccessors>(
@@ -71,14 +77,16 @@ pub async fn principal_on_from_backend<S: AuthzSubject, T: CollectionAccessors>(
 
     let collection_target_id = collection_ref.collection_id(pool).await?.id();
     let group_ids_subquery = principal.group_ids_subquery();
-    let rows = with_connection(pool, |conn| {
+    let rows = with_connection(pool, async |conn| {
         groups
             .inner_join(permissions.on(group_table_id.eq(group_id)))
             .filter(collection_id.eq(collection_target_id))
             .filter(group_id.eq_any(group_ids_subquery))
             .select((groups::all_columns(), permissions::all_columns()))
             .load::<(Group, Permission)>(conn)
-    })?;
+            .await
+    })
+    .await?;
 
     Ok(rows.into_iter().map(GroupPermission::from_tuple).collect())
 }
@@ -95,7 +103,7 @@ pub async fn principal_all_permissions_from_backend<S: AuthzSubject>(
     use diesel::SelectableHelper;
 
     let group_ids_subquery = principal.group_ids_subquery();
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         permissions
             .inner_join(crate::schema::groups::table)
             .inner_join(crate::schema::collections::table)
@@ -106,7 +114,9 @@ pub async fn principal_all_permissions_from_backend<S: AuthzSubject>(
                 Permission::as_select(),
             ))
             .load::<(Collection, Group, Permission)>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn principal_on_paginated_with_total_count_from_backend<
@@ -166,13 +176,20 @@ pub async fn principal_on_paginated_with_total_count_from_backend<
     };
 
     let query = build_query()?;
-    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
-    })?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+        with_connection(pool, async |conn| {
+            query.count().get_result::<i64>(conn).await
+        })
+        .await
+    })
+    .await?;
 
     let mut query = build_query()?;
     crate::apply_query_options!(query, query_options, GroupPermission);
-    let rows = with_connection(pool, |conn| query.load::<(Group, Permission)>(conn))?;
+    let rows = with_connection(pool, async |conn| {
+        query.load::<(Group, Permission)>(conn).await
+    })
+    .await?;
 
     Ok((
         rows.into_iter().map(GroupPermission::from_tuple).collect(),
@@ -196,7 +213,7 @@ pub async fn effective_principal_on_from_backend<S: AuthzSubject, T: CollectionA
     let target_collection_id = collection_ref.collection_id(pool).await?.id();
     let group_ids_subquery = principal.group_ids_subquery();
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         let rows = groups
             .inner_join(permissions.on(group_table_id.eq(group_id)))
             .inner_join(collection_closure.on(permission_collection_id.eq(ancestor_collection_id)))
@@ -213,10 +230,12 @@ pub async fn effective_principal_on_from_backend<S: AuthzSubject, T: CollectionA
                 groups::all_columns(),
                 permissions::all_columns(),
             ))
-            .load::<(i32, i32, Group, Permission)>(conn)?;
+            .load::<(i32, i32, Group, Permission)>(conn)
+            .await?;
 
-        build_effective_group_permissions(conn, target_collection_id, rows)
+        build_effective_group_permissions(conn, target_collection_id, rows).await
     })
+    .await
 }
 
 pub async fn user_can_on_any_from_backend<U: GroupAccessors + AuthzSubject>(
@@ -243,9 +262,12 @@ pub async fn user_can_on_any_from_backend<U: GroupAccessors + AuthzSubject>(
     // The admin "all collections" fast path applies only to unscoped tokens; a
     // scoped admin token falls through to the scoped grant query below.
     if scopes.is_none() && AuthzSubject::is_admin(&user_id, pool).await? {
-        return with_connection(pool, |conn| {
-            crate::schema::collections::table.load::<Collection>(conn)
-        });
+        return with_connection(pool, async |conn| {
+            crate::schema::collections::table
+                .load::<Collection>(conn)
+                .await
+        })
+        .await;
     }
 
     let base_query = {
@@ -257,14 +279,16 @@ pub async fn user_can_on_any_from_backend<U: GroupAccessors + AuthzSubject>(
     };
 
     let filtered_query = permission_type.create_boxed_filter(base_query, true);
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         filtered_query
             .inner_join(collection_closure.on(permission_collection_id.eq(ancestor_collection_id)))
             .inner_join(collections.on(collection_table_id.eq(descendant_collection_id)))
             .select(collections::all_columns())
             .distinct()
             .load::<Collection>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn group_can_on_from_backend<T: CollectionAccessors>(
@@ -283,13 +307,15 @@ pub async fn group_can_on_from_backend<T: CollectionAccessors>(
     let base_query = permissions.filter(group_id.eq(gid)).into_boxed();
     let filtered_query = permission_type.create_boxed_filter(base_query, true);
     let target_collection_id = collection_ref.collection_id(pool).await?.id();
-    let result = with_connection(pool, |conn| {
+    let result = with_connection(pool, async |conn| {
         filtered_query
             .inner_join(collection_closure.on(permission_collection_id.eq(ancestor_collection_id)))
             .filter(descendant_collection_id.eq(target_collection_id))
             .count()
             .get_result::<i64>(conn)
-    })?;
+            .await
+    })
+    .await?;
 
     Ok(result != 0)
 }
@@ -307,7 +333,7 @@ pub async fn effective_group_on_from_backend(
         collection_id as permission_collection_id, group_id, permissions,
     };
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         let rows = groups
             .inner_join(permissions.on(group_table_id.eq(group_id)))
             .inner_join(collection_closure.on(permission_collection_id.eq(ancestor_collection_id)))
@@ -324,10 +350,12 @@ pub async fn effective_group_on_from_backend(
                 groups::all_columns(),
                 permissions::all_columns(),
             ))
-            .load::<(i32, i32, Group, Permission)>(conn)?;
+            .load::<(i32, i32, Group, Permission)>(conn)
+            .await?;
 
-        build_effective_group_permissions(conn, target_collection_id, rows)
+        build_effective_group_permissions(conn, target_collection_id, rows).await
     })
+    .await
 }
 
 pub async fn groups_can_on_from_backend(
@@ -346,25 +374,29 @@ pub async fn groups_can_on_from_backend(
     let base_query = permissions.into_boxed();
     let filtered_query = permission_type.create_boxed_filter(base_query, true);
 
-    let group_ids = with_connection(pool, |conn| {
+    let group_ids = with_connection(pool, async |conn| {
         filtered_query
             .inner_join(collection_closure.on(permission_collection_id.eq(ancestor_collection_id)))
             .filter(descendant_collection_id.eq(target_collection_id))
             .select(group_id)
             .distinct()
             .load::<i32>(conn)
-    })?;
+            .await
+    })
+    .await?;
 
     if group_ids.is_empty() {
         return Ok(Vec::new());
     }
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         groups
             .filter(group_table_id.eq_any(group_ids))
             .order(group_table_id.asc())
             .load::<Group>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn groups_can_on_paginated_with_total_count_from_backend(
@@ -426,13 +458,17 @@ pub async fn groups_can_on_paginated_with_total_count_from_backend(
     };
 
     let query = build_query()?;
-    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
-    })?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+        with_connection(pool, async |conn| {
+            query.count().get_result::<i64>(conn).await
+        })
+        .await
+    })
+    .await?;
 
     let mut query = build_query()?;
     crate::apply_query_options!(query, query_options, Group);
-    let items = with_connection(pool, |conn| query.load::<Group>(conn))?;
+    let items = with_connection(pool, async |conn| query.load::<Group>(conn).await).await?;
 
     Ok((items, total_count))
 }
@@ -514,12 +550,14 @@ pub async fn groups_on_from_backend<T: CollectionAccessors>(
         base_query = base_query.limit(limit as i64);
     }
 
-    let rows = with_connection(pool, |conn| {
+    let rows = with_connection(pool, async |conn| {
         base_query
             .inner_join(groups.on(group_table_id.eq(group_id)))
             .select((groups::all_columns(), permissions::all_columns()))
             .load::<(Group, Permission)>(conn)
-    })?;
+            .await
+    })
+    .await?;
 
     Ok(rows.into_iter().map(GroupPermission::from_tuple).collect())
 }
@@ -595,17 +633,23 @@ pub async fn groups_on_paginated_with_total_count_from_backend<T: CollectionAcce
     };
 
     let query = build_query()?;
-    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
-    })?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+        with_connection(pool, async |conn| {
+            query.count().get_result::<i64>(conn).await
+        })
+        .await
+    })
+    .await?;
 
     let mut query = build_query()?;
     crate::apply_query_options!(query, query_options, GroupPermission);
-    let rows = with_connection(pool, |conn| {
+    let rows = with_connection(pool, async |conn| {
         query
             .select((groups::all_columns(), permissions::all_columns()))
             .load::<(Group, Permission)>(conn)
-    })?;
+            .await
+    })
+    .await?;
 
     Ok((
         rows.into_iter().map(GroupPermission::from_tuple).collect(),
@@ -636,10 +680,12 @@ pub async fn group_on_from_backend(
 ) -> Result<Permission, ApiError> {
     use crate::schema::permissions::dsl::*;
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         permissions
             .filter(collection_id.eq(target_collection_id))
             .filter(group_id.eq(gid))
             .first::<Permission>(conn)
+            .await
     })
+    .await
 }

--- a/src/db/traits/collection/records.rs
+++ b/src/db/traits/collection/records.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
+use diesel_async::RunQueryDsl;
 
 fn collection_snapshot(collection: &Collection) -> serde_json::Value {
     serde_json::json!({
@@ -12,18 +13,21 @@ fn collection_snapshot(collection: &Collection) -> serde_json::Value {
     })
 }
 
-pub(crate) fn root_collection_id(conn: &mut diesel::PgConnection) -> Result<i32, ApiError> {
+pub(crate) async fn root_collection_id(
+    conn: &mut crate::db::DbConnection,
+) -> Result<i32, ApiError> {
     use crate::schema::collections::dsl::{collections, id, parent_collection_id};
 
     collections
         .filter(parent_collection_id.is_null())
         .select(id)
         .first::<i32>(conn)
+        .await
         .map_err(ApiError::from)
 }
 
-fn resolve_parent_collection_id(
-    conn: &mut diesel::PgConnection,
+async fn resolve_parent_collection_id(
+    conn: &mut crate::db::DbConnection,
     requested_parent_collection_id: Option<i32>,
 ) -> Result<i32, ApiError> {
     use crate::schema::collections::dsl::{collections, id};
@@ -33,15 +37,16 @@ fn resolve_parent_collection_id(
             collections
                 .filter(id.eq(parent_id))
                 .select(id)
-                .first::<i32>(conn)?;
+                .first::<i32>(conn)
+                .await?;
             Ok(parent_id)
         }
-        None => root_collection_id(conn),
+        None => root_collection_id(conn).await,
     }
 }
 
-fn validate_collection_can_be_deleted(
-    conn: &mut diesel::PgConnection,
+async fn validate_collection_can_be_deleted(
+    conn: &mut crate::db::DbConnection,
     target_collection_id: i32,
 ) -> Result<(), ApiError> {
     use crate::schema::collections::dsl::{collections, id, parent_collection_id};
@@ -49,7 +54,8 @@ fn validate_collection_can_be_deleted(
     let target_parent = collections
         .filter(id.eq(target_collection_id))
         .select(parent_collection_id)
-        .first::<Option<i32>>(conn)?;
+        .first::<Option<i32>>(conn)
+        .await?;
 
     if target_parent.is_none() {
         return Err(ApiError::Conflict(
@@ -60,7 +66,8 @@ fn validate_collection_can_be_deleted(
     let child_count = collections
         .filter(parent_collection_id.eq(target_collection_id))
         .count()
-        .get_result::<i64>(conn)?;
+        .get_result::<i64>(conn)
+        .await?;
 
     if child_count > 0 {
         return Err(ApiError::Conflict(
@@ -71,8 +78,8 @@ fn validate_collection_can_be_deleted(
     Ok(())
 }
 
-pub(crate) fn insert_collection_closure_rows(
-    conn: &mut diesel::PgConnection,
+pub(crate) async fn insert_collection_closure_rows(
+    conn: &mut crate::db::DbConnection,
     target_collection_id: i32,
     parent_id: i32,
 ) -> Result<(), ApiError> {
@@ -86,20 +93,22 @@ pub(crate) fn insert_collection_closure_rows(
     )
     .bind::<diesel::sql_types::Integer, _>(target_collection_id)
     .bind::<diesel::sql_types::Integer, _>(parent_id)
-    .execute(conn)?;
+    .execute(conn)
+    .await?;
 
     Ok(())
 }
 
-pub(crate) fn insert_collection_row_with_closure(
-    conn: &mut diesel::PgConnection,
+pub(crate) async fn insert_collection_row_with_closure(
+    conn: &mut crate::db::DbConnection,
     name_value: &str,
     description_value: &str,
     requested_parent_collection_id: Option<i32>,
 ) -> Result<Collection, ApiError> {
     use crate::schema::collections::dsl::{collections, parent_collection_id};
 
-    let resolved_parent_id = resolve_parent_collection_id(conn, requested_parent_collection_id)?;
+    let resolved_parent_id =
+        resolve_parent_collection_id(conn, requested_parent_collection_id).await?;
 
     let collection = diesel::insert_into(collections)
         .values((
@@ -107,15 +116,16 @@ pub(crate) fn insert_collection_row_with_closure(
             crate::schema::collections::description.eq(description_value),
             parent_collection_id.eq(resolved_parent_id),
         ))
-        .get_result::<Collection>(conn)?;
+        .get_result::<Collection>(conn)
+        .await?;
 
-    insert_collection_closure_rows(conn, collection.id, resolved_parent_id)?;
+    insert_collection_closure_rows(conn, collection.id, resolved_parent_id).await?;
 
     Ok(collection)
 }
 
-fn move_collection_closure_rows(
-    conn: &mut diesel::PgConnection,
+async fn move_collection_closure_rows(
+    conn: &mut crate::db::DbConnection,
     target_collection_id: i32,
     new_parent_collection_id: i32,
 ) -> Result<(), ApiError> {
@@ -137,7 +147,8 @@ fn move_collection_closure_rows(
          )",
     )
     .bind::<diesel::sql_types::Integer, _>(target_collection_id)
-    .execute(conn)?;
+    .execute(conn)
+    .await?;
 
     diesel::sql_query(
         "INSERT INTO collection_closure (ancestor_collection_id, descendant_collection_id, depth)
@@ -150,13 +161,14 @@ fn move_collection_closure_rows(
     )
     .bind::<diesel::sql_types::Integer, _>(target_collection_id)
     .bind::<diesel::sql_types::Integer, _>(new_parent_collection_id)
-    .execute(conn)?;
+    .execute(conn)
+    .await?;
 
     Ok(())
 }
 
-fn insert_collection_for_group(
-    conn: &mut diesel::PgConnection,
+async fn insert_collection_for_group(
+    conn: &mut crate::db::DbConnection,
     new_collection: &NewCollection,
     group_id: i32,
 ) -> Result<Collection, ApiError> {
@@ -167,7 +179,8 @@ fn insert_collection_for_group(
         &new_collection.name,
         &new_collection.description,
         new_collection.parent_collection_id,
-    )?;
+    )
+    .await?;
 
     let group_permission = crate::db::traits::permissions::new_permission_from_list(
         collection.id,
@@ -177,7 +190,8 @@ fn insert_collection_for_group(
 
     diesel::insert_into(permissions)
         .values(&group_permission)
-        .execute(conn)?;
+        .execute(conn)
+        .await?;
 
     Ok(collection)
 }
@@ -217,10 +231,13 @@ impl DeleteCollectionRecord for Collection {
     async fn delete_collection_record_without_events(&self, pool: &DbPool) -> Result<(), ApiError> {
         use crate::schema::collections::dsl::{collections, id};
 
-        with_connection(pool, |conn| -> Result<_, ApiError> {
-            validate_collection_can_be_deleted(conn, self.id)?;
-            Ok(diesel::delete(collections.filter(id.eq(self.id))).execute(conn)?)
-        })?;
+        with_connection(pool, async |conn| -> Result<_, ApiError> {
+            validate_collection_can_be_deleted(conn, self.id).await?;
+            Ok(diesel::delete(collections.filter(id.eq(self.id)))
+                .execute(conn)
+                .await?)
+        })
+        .await?;
         Ok(())
     }
 
@@ -235,9 +252,11 @@ impl DeleteCollectionRecord for Collection {
 
         use crate::schema::collections::dsl::{collections, id};
 
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
-            validate_collection_can_be_deleted(conn, self.id)?;
-            diesel::delete(collections.filter(id.eq(self.id))).execute(conn)?;
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
+            validate_collection_can_be_deleted(conn, self.id).await?;
+            diesel::delete(collections.filter(id.eq(self.id)))
+                .execute(conn)
+                .await?;
             let event = collection_event(
                 self,
                 Action::Deleted,
@@ -245,9 +264,10 @@ impl DeleteCollectionRecord for Collection {
                 format!("Collection '{}' deleted", self.name),
             )?
             .with_before(collection_snapshot(self));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(())
         })
+        .await
     }
 }
 
@@ -255,10 +275,13 @@ impl DeleteCollectionRecord for CollectionID {
     async fn delete_collection_record_without_events(&self, pool: &DbPool) -> Result<(), ApiError> {
         use crate::schema::collections::dsl::{collections, id};
 
-        with_connection(pool, |conn| -> Result<_, ApiError> {
-            validate_collection_can_be_deleted(conn, self.id())?;
-            Ok(diesel::delete(collections.filter(id.eq(self.id()))).execute(conn)?)
-        })?;
+        with_connection(pool, async |conn| -> Result<_, ApiError> {
+            validate_collection_can_be_deleted(conn, self.id()).await?;
+            Ok(diesel::delete(collections.filter(id.eq(self.id())))
+                .execute(conn)
+                .await?)
+        })
+        .await?;
         Ok(())
     }
 
@@ -273,12 +296,15 @@ impl DeleteCollectionRecord for CollectionID {
 
         use crate::schema::collections::dsl::{collections, id};
 
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let collection = collections
                 .filter(id.eq(self.id()))
-                .first::<Collection>(conn)?;
-            validate_collection_can_be_deleted(conn, collection.id)?;
-            diesel::delete(collections.filter(id.eq(collection.id))).execute(conn)?;
+                .first::<Collection>(conn)
+                .await?;
+            validate_collection_can_be_deleted(conn, collection.id).await?;
+            diesel::delete(collections.filter(id.eq(collection.id)))
+                .execute(conn)
+                .await?;
             let event = collection_event(
                 &collection,
                 Action::Deleted,
@@ -286,9 +312,10 @@ impl DeleteCollectionRecord for CollectionID {
                 format!("Collection '{}' deleted", collection.name),
             )?
             .with_before(collection_snapshot(&collection));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(())
         })
+        .await
     }
 }
 
@@ -319,16 +346,19 @@ impl UpdateCollectionRecord for UpdateCollection {
     ) -> Result<Collection, ApiError> {
         use crate::schema::collections::dsl::{collections, id};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             crate::db::updated_or_current(
                 diesel::update(collections)
                     .filter(id.eq(collection_id))
                     .set(self)
                     .get_result::<Collection>(conn)
+                    .await
                     .optional(),
-                || collections.filter(id.eq(collection_id)).first(conn),
+                async || collections.filter(id.eq(collection_id)).first(conn).await,
             )
+            .await
         })
+        .await
     }
 
     async fn update_collection_record(
@@ -345,13 +375,15 @@ impl UpdateCollectionRecord for UpdateCollection {
 
         use crate::schema::collections::dsl::{collections, id};
 
-        with_transaction(pool, |conn| -> Result<Collection, ApiError> {
+        with_transaction(pool, async |conn| -> Result<Collection, ApiError> {
             let before = collections
                 .filter(id.eq(collection_id))
-                .first::<Collection>(conn)?;
+                .first::<Collection>(conn)
+                .await?;
             let updated = diesel::update(collections.filter(id.eq(collection_id)))
                 .set(self)
-                .get_result::<Collection>(conn)?;
+                .get_result::<Collection>(conn)
+                .await?;
             let event = collection_event(
                 &updated,
                 Action::Updated,
@@ -360,9 +392,10 @@ impl UpdateCollectionRecord for UpdateCollection {
             )?
             .with_before(collection_snapshot(&before))
             .with_after(collection_snapshot(&updated));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(updated)
         })
+        .await
     }
 }
 
@@ -441,9 +474,10 @@ impl SaveCollectionForGroupRecord for NewCollection {
         pool: &DbPool,
         group_id: i32,
     ) -> Result<Collection, ApiError> {
-        with_transaction(pool, |conn| -> Result<Collection, ApiError> {
-            insert_collection_for_group(conn, self, group_id)
+        with_transaction(pool, async |conn| -> Result<Collection, ApiError> {
+            insert_collection_for_group(conn, self, group_id).await
         })
+        .await
     }
 
     async fn save_collection_for_group_record(
@@ -458,8 +492,8 @@ impl SaveCollectionForGroupRecord for NewCollection {
                 .await;
         };
 
-        with_transaction(pool, |conn| -> Result<Collection, ApiError> {
-            let collection = insert_collection_for_group(conn, self, group_id)?;
+        with_transaction(pool, async |conn| -> Result<Collection, ApiError> {
+            let collection = insert_collection_for_group(conn, self, group_id).await?;
 
             let event = collection_event(
                 &collection,
@@ -469,10 +503,11 @@ impl SaveCollectionForGroupRecord for NewCollection {
             )?
             .with_after(collection_snapshot(&collection))
             .with_metadata(serde_json::json!({ "assignee_group_id": group_id }));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
 
             Ok(collection)
         })
+        .await
     }
 }
 
@@ -483,12 +518,14 @@ pub async fn collection_children_from_backend<T: CollectionAccessors>(
     use crate::schema::collections::dsl::{collections, parent_collection_id};
 
     let target_collection_id = collection_ref.collection_id(pool).await?.id();
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         collections
             .filter(parent_collection_id.eq(target_collection_id))
             .order(crate::schema::collections::name.asc())
             .load::<Collection>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn collection_ancestors_from_backend<T: CollectionAccessors>(
@@ -501,7 +538,7 @@ pub async fn collection_ancestors_from_backend<T: CollectionAccessors>(
     use crate::schema::collections::dsl::{collections, id};
 
     let target_collection_id = collection_ref.collection_id(pool).await?.id();
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         collection_closure
             .inner_join(collections.on(id.eq(ancestor_collection_id)))
             .filter(descendant_collection_id.eq(target_collection_id))
@@ -509,7 +546,9 @@ pub async fn collection_ancestors_from_backend<T: CollectionAccessors>(
             .order(depth.asc())
             .select(collections::all_columns())
             .load::<Collection>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn move_collection_record_from_backend(
@@ -523,10 +562,11 @@ pub async fn move_collection_record_from_backend(
     };
     use crate::schema::collections::dsl::{collections, id, parent_collection_id};
 
-    with_transaction(pool, |conn| -> Result<Collection, ApiError> {
+    with_transaction(pool, async |conn| -> Result<Collection, ApiError> {
         let before = collections
             .filter(id.eq(target_collection_id))
-            .first::<Collection>(conn)?;
+            .first::<Collection>(conn)
+            .await?;
 
         if before.parent_collection_id.is_none() {
             return Err(ApiError::Conflict(
@@ -543,13 +583,15 @@ pub async fn move_collection_record_from_backend(
         collections
             .filter(id.eq(new_parent_collection_id))
             .select(id)
-            .first::<i32>(conn)?;
+            .first::<i32>(conn)
+            .await?;
 
         let new_parent_is_descendant = collection_closure
             .filter(ancestor_collection_id.eq(target_collection_id))
             .filter(descendant_collection_id.eq(new_parent_collection_id))
             .count()
-            .get_result::<i64>(conn)?
+            .get_result::<i64>(conn)
+            .await?
             > 0;
 
         if new_parent_is_descendant {
@@ -560,13 +602,15 @@ pub async fn move_collection_record_from_backend(
 
         diesel::update(collections.filter(id.eq(target_collection_id)))
             .set(parent_collection_id.eq(new_parent_collection_id))
-            .execute(conn)?;
+            .execute(conn)
+            .await?;
 
-        move_collection_closure_rows(conn, target_collection_id, new_parent_collection_id)?;
+        move_collection_closure_rows(conn, target_collection_id, new_parent_collection_id).await?;
 
         let updated = collections
             .filter(id.eq(target_collection_id))
-            .first::<Collection>(conn)?;
+            .first::<Collection>(conn)
+            .await?;
 
         if let Some(context) = context {
             let event = collection_event(
@@ -577,9 +621,10 @@ pub async fn move_collection_record_from_backend(
             )?
             .with_before(collection_snapshot(&before))
             .with_after(collection_snapshot(&updated));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
         }
 
         Ok(updated)
     })
+    .await
 }

--- a/src/db/traits/collection/relations.rs
+++ b/src/db/traits/collection/relations.rs
@@ -1,4 +1,5 @@
 use super::*;
+use diesel_async::RunQueryDsl;
 impl GetCollection<(Collection, Collection)> for HubuumClassRelation {
     async fn collection_from_backend(
         &self,
@@ -13,13 +14,15 @@ impl GetCollection<(Collection, Collection)> for HubuumClassRelation {
         // Work with raw ids at the Diesel boundary.
         let (from_id, to_id) = (from_id.id(), to_id.id());
 
-        let collection_list = with_connection(pool, |conn| {
+        let collection_list = with_connection(pool, async |conn| {
             hubuumclass
                 .filter(class_id.eq_any(&[from_id, to_id]))
                 .inner_join(collections.on(collection_id.eq(class_collection_id)))
                 .select(collections::all_columns())
                 .load::<Collection>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         if from_id == to_id && collection_list.len() == 1 {
             trace!("Found same collection for class relation, returning same collection twice");
@@ -52,13 +55,15 @@ impl GetCollection<(Collection, Collection)> for NewHubuumClassRelation {
         // Work with raw ids at the Diesel boundary.
         let (from_id, to_id) = (from_id.id(), to_id.id());
 
-        let collection_list = with_connection(pool, |conn| {
+        let collection_list = with_connection(pool, async |conn| {
             hubuumclass
                 .filter(class_id.eq_any(&[from_id, to_id]))
                 .inner_join(collections.on(collection_id.eq(class_collection_id)))
                 .select(collections::all_columns())
                 .load::<Collection>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         if collection_list.len() == 1 {
             trace!("Found same collection for class relation, returning same collection twice");
@@ -91,13 +96,15 @@ impl GetCollection<(Collection, Collection)> for HubuumObjectRelation {
         // Work with raw ids at the Diesel boundary.
         let (from_id, to_id) = (from_id.id(), to_id.id());
 
-        let collection_list = with_connection(pool, |conn| {
+        let collection_list = with_connection(pool, async |conn| {
             hubuumobject
                 .filter(object_id.eq_any(&[from_id, to_id]))
                 .inner_join(collections.on(collection_id.eq(object_collection_id)))
                 .select(collections::all_columns())
                 .load::<Collection>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         if collection_list.len() == 1 {
             trace!("Found same collection for object relation, returning same collection twice");
@@ -130,13 +137,15 @@ impl GetCollection<(Collection, Collection)> for NewHubuumObjectRelation {
         // Work with raw ids at the Diesel boundary.
         let (from_id, to_id) = (from_id.id(), to_id.id());
 
-        let collection_list = with_connection(pool, |conn| {
+        let collection_list = with_connection(pool, async |conn| {
             hubuumobject
                 .filter(object_id.eq_any(&[from_id, to_id]))
                 .inner_join(collections.on(collection_id.eq(object_collection_id)))
                 .select(collections::all_columns())
                 .load::<Collection>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         if collection_list.len() == 1 {
             trace!("Found same collection for object relation, returning same collection twice");
@@ -169,13 +178,15 @@ impl GetCollection<(Collection, Collection)> for HubuumObjectRelationID {
         // Work with raw ids at the Diesel boundary.
         let (from_id, to_id) = (from_id.id(), to_id.id());
 
-        let collection_list = with_connection(pool, |conn| {
+        let collection_list = with_connection(pool, async |conn| {
             hubuumobject
                 .filter(object_id.eq_any(&[from_id, to_id]))
                 .inner_join(collections.on(collection_id.eq(object_collection_id)))
                 .select(collections::all_columns())
                 .load::<Collection>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         if collection_list.len() == 1 {
             trace!("Found same collection for object relation, returning same collection twice");
@@ -196,16 +207,18 @@ impl GetCollection<(Collection, Collection)> for HubuumObjectRelationID {
 
 impl<S> GetCollection for S
 where
-    S: SelfAccessors<Collection>,
+    S: SelfAccessors<Collection> + Sync,
 {
     async fn collection_from_backend(&self, pool: &DbPool) -> Result<Collection, ApiError> {
         use crate::schema::collections::dsl::{collections, id};
 
-        let collection = with_connection(pool, |conn| {
+        let collection = with_connection(pool, async |conn| {
             collections
                 .filter(id.eq(self.id()))
                 .first::<Collection>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         Ok(collection)
     }

--- a/src/db/traits/event_delivery.rs
+++ b/src/db/traits/event_delivery.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
+use crate::db::prelude::*;
 use chrono::{Duration, Utc};
-use diesel::prelude::*;
 use uuid::Uuid;
 
 use crate::db::{DbPool, with_connection, with_transaction};
@@ -43,7 +43,7 @@ pub(crate) async fn claim_event_deliveries(
 
     with_transaction(
         pool,
-        |conn| -> Result<Vec<ClaimedEventDelivery>, ApiError> {
+        async |conn| -> Result<Vec<ClaimedEventDelivery>, ApiError> {
             let now = Utc::now().naive_utc();
             let delivery_ids = event_deliveries
                 .filter(
@@ -61,7 +61,8 @@ pub(crate) async fn claim_event_deliveries(
                 .skip_locked()
                 .limit(settings.batch_size as i64)
                 .select(id)
-                .load::<i64>(conn)?;
+                .load::<i64>(conn)
+                .await?;
 
             if delivery_ids.is_empty() {
                 return Ok(Vec::new());
@@ -78,11 +79,13 @@ pub(crate) async fn claim_event_deliveries(
                         )),
                         claim_token.eq(Some(claim)),
                     ))
-                    .get_results::<EventDelivery>(conn)?;
+                    .get_results::<EventDelivery>(conn)
+                    .await?;
 
-            load_claimed_delivery_contexts(conn, claimed_deliveries)
+            load_claimed_delivery_contexts(conn, claimed_deliveries).await
         },
     )
+    .await
 }
 
 #[cfg(test)]
@@ -95,47 +98,53 @@ pub(crate) async fn claim_event_delivery_by_id(
         claim_token, event_deliveries, id, locked_until, next_attempt_at, status,
     };
 
-    with_transaction(pool, |conn| -> Result<ClaimedEventDelivery, ApiError> {
-        let now = Utc::now().naive_utc();
-        let claim = Uuid::new_v4();
-        let delivery = diesel::update(
-            event_deliveries.filter(id.eq(delivery_id)).filter(
-                status
-                    .eq(EventDeliveryStatus::Pending.as_str())
-                    .or(status
-                        .eq(EventDeliveryStatus::Failed.as_str())
-                        .and(next_attempt_at.le(now)))
-                    .or(status
-                        .eq(EventDeliveryStatus::InFlight.as_str())
-                        .and(locked_until.lt(now))),
-            ),
-        )
-        .set((
-            status.eq(EventDeliveryStatus::InFlight.as_str()),
-            locked_until.eq(Some(
-                now + Duration::milliseconds(settings.lock_timeout_ms as i64),
-            )),
-            claim_token.eq(Some(claim)),
-        ))
-        .get_result::<EventDelivery>(conn)?;
+    with_transaction(
+        pool,
+        async |conn| -> Result<ClaimedEventDelivery, ApiError> {
+            let now = Utc::now().naive_utc();
+            let claim = Uuid::new_v4();
+            let delivery = diesel::update(
+                event_deliveries.filter(id.eq(delivery_id)).filter(
+                    status
+                        .eq(EventDeliveryStatus::Pending.as_str())
+                        .or(status
+                            .eq(EventDeliveryStatus::Failed.as_str())
+                            .and(next_attempt_at.le(now)))
+                        .or(status
+                            .eq(EventDeliveryStatus::InFlight.as_str())
+                            .and(locked_until.lt(now))),
+                ),
+            )
+            .set((
+                status.eq(EventDeliveryStatus::InFlight.as_str()),
+                locked_until.eq(Some(
+                    now + Duration::milliseconds(settings.lock_timeout_ms as i64),
+                )),
+                claim_token.eq(Some(claim)),
+            ))
+            .get_result::<EventDelivery>(conn)
+            .await?;
 
-        load_claimed_delivery_context(conn, delivery)
-    })
+            load_claimed_delivery_context(conn, delivery).await
+        },
+    )
+    .await
 }
 
 #[cfg(test)]
-fn load_claimed_delivery_context(
-    conn: &mut PgConnection,
+async fn load_claimed_delivery_context(
+    conn: &mut crate::db::DbConnection,
     delivery: EventDelivery,
 ) -> Result<ClaimedEventDelivery, ApiError> {
-    load_claimed_delivery_contexts(conn, vec![delivery])?
+    load_claimed_delivery_contexts(conn, vec![delivery])
+        .await?
         .into_iter()
         .next()
         .ok_or_else(|| ApiError::NotFound("Event delivery not found".to_string()))
 }
 
-fn load_claimed_delivery_contexts(
-    conn: &mut PgConnection,
+async fn load_claimed_delivery_contexts(
+    conn: &mut crate::db::DbConnection,
     deliveries: Vec<EventDelivery>,
 ) -> Result<Vec<ClaimedEventDelivery>, ApiError> {
     use crate::schema::{event_sinks, event_subscriptions, events};
@@ -155,13 +164,15 @@ fn load_claimed_delivery_contexts(
 
     let loaded_events = events::table
         .filter(events::id.eq_any(&event_ids))
-        .load::<Event>(conn)?
+        .load::<Event>(conn)
+        .await?
         .into_iter()
         .map(|event| (event.id, event))
         .collect::<HashMap<_, _>>();
     let loaded_subscriptions = event_subscriptions::table
         .filter(event_subscriptions::id.eq_any(&subscription_ids))
-        .load::<EventSubscriptionRow>(conn)?
+        .load::<EventSubscriptionRow>(conn)
+        .await?
         .into_iter()
         .map(|subscription| (subscription.id, subscription))
         .collect::<HashMap<_, _>>();
@@ -171,7 +182,8 @@ fn load_claimed_delivery_contexts(
         .collect::<Vec<_>>();
     let loaded_sinks = event_sinks::table
         .filter(event_sinks::id.eq_any(&sink_ids))
-        .load::<EventSinkRow>(conn)?
+        .load::<EventSinkRow>(conn)
+        .await?
         .into_iter()
         .map(|sink| (sink.id, sink))
         .collect::<HashMap<_, _>>();
@@ -214,7 +226,7 @@ pub async fn mark_event_delivery_succeeded(
         claim_token, event_deliveries, id, last_error, locked_until, status,
     };
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         diesel::update(
             event_deliveries
                 .filter(id.eq(delivery_id_value))
@@ -228,7 +240,9 @@ pub async fn mark_event_delivery_succeeded(
             last_error.eq::<Option<String>>(None),
         ))
         .get_result::<EventDelivery>(conn)
+        .await
     })
+    .await
 }
 
 pub async fn mark_event_delivery_failed(
@@ -256,7 +270,7 @@ pub async fn mark_event_delivery_failed(
         ) as i64);
     let error = truncate_delivery_error(error);
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         diesel::update(
             event_deliveries
                 .filter(id.eq(delivery.id))
@@ -272,7 +286,9 @@ pub async fn mark_event_delivery_failed(
             claim_token.eq::<Option<Uuid>>(None),
         ))
         .get_result::<EventDelivery>(conn)
+        .await
     })
+    .await
 }
 
 pub fn retry_backoff_ms(attempts: i32, base_ms: u64, max_ms: u64) -> u64 {
@@ -301,11 +317,13 @@ pub async fn load_event_delivery(
 ) -> Result<EventDelivery, ApiError> {
     use crate::schema::event_deliveries::dsl::{event_deliveries, id};
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         event_deliveries
             .filter(id.eq(delivery_id.id()))
             .first::<EventDelivery>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn list_event_deliveries_with_total_count(
@@ -313,12 +331,17 @@ pub async fn list_event_deliveries_with_total_count(
     query_options: &QueryOptions,
 ) -> Result<(Vec<EventDelivery>, i64), ApiError> {
     let query = build_event_delivery_query(query_options)?;
-    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
-    })?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+        with_connection(pool, async |conn| {
+            query.count().get_result::<i64>(conn).await
+        })
+        .await
+    })
+    .await?;
     let mut query = build_event_delivery_query(query_options)?;
     crate::apply_query_options!(query, query_options, EventDelivery);
-    let deliveries = with_connection(pool, |conn| query.load::<EventDelivery>(conn))?;
+    let deliveries =
+        with_connection(pool, async |conn| query.load::<EventDelivery>(conn).await).await?;
     Ok((deliveries, total_count))
 }
 
@@ -382,7 +405,7 @@ pub async fn release_event_delivery_for_retry(
 
     with_connection(
         pool,
-        |conn| -> Result<EventDelivery, diesel::result::Error> {
+        async |conn| -> Result<EventDelivery, diesel::result::Error> {
             let delivery = diesel::update(event_deliveries.filter(id.eq(delivery_id.id())).filter(
                 status.eq_any([
                     EventDeliveryStatus::Failed.as_str(),
@@ -396,11 +419,13 @@ pub async fn release_event_delivery_for_retry(
                 claim_token.eq::<Option<Uuid>>(None),
                 last_error.eq::<Option<String>>(None),
             ))
-            .get_result::<EventDelivery>(conn)?;
-            crate::events::notify_event_delivery(conn)?;
+            .get_result::<EventDelivery>(conn)
+            .await?;
+            crate::events::notify_event_delivery(conn).await?;
             Ok(delivery)
         },
     )
+    .await
 }
 
 pub async fn mark_event_delivery_dead(
@@ -411,7 +436,7 @@ pub async fn mark_event_delivery_dead(
         claim_token, event_deliveries, id, last_error, locked_until, status,
     };
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         diesel::update(
             event_deliveries
                 .filter(id.eq(delivery_id.id()))
@@ -424,5 +449,7 @@ pub async fn mark_event_delivery_dead(
             last_error.eq(Some("marked dead by operator".to_string())),
         ))
         .get_result::<EventDelivery>(conn)
+        .await
     })
+    .await
 }

--- a/src/db/traits/event_fanout.rs
+++ b/src/db/traits/event_fanout.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
+use crate::db::prelude::*;
 use chrono::{Duration, Utc};
-use diesel::prelude::*;
 use uuid::Uuid;
 
 #[cfg(test)]
@@ -38,7 +38,7 @@ pub async fn claim_events_for_fanout(
         return Ok(Vec::new());
     }
 
-    with_transaction(pool, |conn| -> Result<Vec<Event>, ApiError> {
+    with_transaction(pool, async |conn| -> Result<Vec<Event>, ApiError> {
         let now = Utc::now().naive_utc();
         let event_ids = events
             .filter(dispatched_at.is_null())
@@ -52,7 +52,8 @@ pub async fn claim_events_for_fanout(
             .skip_locked()
             .limit(settings.batch_size as i64)
             .select(id)
-            .load::<i64>(conn)?;
+            .load::<i64>(conn)
+            .await?;
 
         if event_ids.is_empty() {
             return Ok(Vec::new());
@@ -65,10 +66,12 @@ pub async fn claim_events_for_fanout(
                 fanout_locked_until.eq(Some(now + lock_timeout)),
                 fanout_claim_token.eq(Some(claim_token)),
             ))
-            .get_results::<Event>(conn)?;
+            .get_results::<Event>(conn)
+            .await?;
 
         Ok(claimed)
     })
+    .await
 }
 
 #[cfg(test)]
@@ -85,18 +88,20 @@ pub async fn fanout_events(pool: &DbPool, event_ids: &[i64]) -> Result<usize, Ap
         return Ok(0);
     }
 
-    with_transaction(pool, |conn| -> Result<usize, ApiError> {
+    with_transaction(pool, async |conn| -> Result<usize, ApiError> {
         let claimed_events = events
             .filter(id.eq_any(event_ids))
             .filter(dispatched_at.is_null())
             .order(id.asc())
-            .load::<Event>(conn)?;
+            .load::<Event>(conn)
+            .await?;
         if claimed_events.is_empty() {
             return Ok(0);
         }
 
         let candidate_collection_ids = candidate_subscription_collection_ids(&claimed_events);
-        let subscriptions = load_enabled_subscriptions(conn, &candidate_collection_ids)?
+        let subscriptions = load_enabled_subscriptions(conn, &candidate_collection_ids)
+            .await?
             .into_iter()
             .map(CompiledEventSubscription::try_from)
             .collect::<Result<Vec<_>, _>>()?;
@@ -105,7 +110,7 @@ pub async fn fanout_events(pool: &DbPool, event_ids: &[i64]) -> Result<usize, Ap
         for event in &claimed_events {
             let envelope = EventEnvelope::from(event.clone());
             let subscription_ids = matching_subscription_ids(&subscriptions, event, &envelope);
-            inserted += insert_delivery_rows(conn, event.id, &subscription_ids)?;
+            inserted += insert_delivery_rows(conn, event.id, &subscription_ids).await?;
             processed_event_ids.push(event.id);
         }
         let now = Utc::now().naive_utc();
@@ -115,17 +120,19 @@ pub async fn fanout_events(pool: &DbPool, event_ids: &[i64]) -> Result<usize, Ap
                 fanout_locked_until.eq::<Option<chrono::NaiveDateTime>>(None),
                 fanout_claim_token.eq::<Option<Uuid>>(None),
             ))
-            .execute(conn)?;
+            .execute(conn)
+            .await?;
         if inserted > 0 {
-            crate::events::notify_event_delivery(conn)?;
+            crate::events::notify_event_delivery(conn).await?;
         }
 
         Ok(inserted)
     })
+    .await
 }
 
-fn load_enabled_subscriptions(
-    conn: &mut PgConnection,
+async fn load_enabled_subscriptions(
+    conn: &mut crate::db::DbConnection,
     collection_ids: &[i32],
 ) -> Result<Vec<crate::models::event_subscription::EventSubscriptionRow>, ApiError> {
     use crate::schema::{event_sinks, event_subscriptions};
@@ -141,6 +148,7 @@ fn load_enabled_subscriptions(
         .filter(event_subscriptions::collection_id.eq_any(collection_ids))
         .select(event_subscriptions::all_columns)
         .load::<crate::models::event_subscription::EventSubscriptionRow>(conn)
+        .await
         .map_err(ApiError::from)
 }
 
@@ -221,8 +229,8 @@ fn subscription_collection_matches_event(
         || envelope.related_collection_ids().contains(&collection_id)
 }
 
-fn insert_delivery_rows(
-    conn: &mut PgConnection,
+async fn insert_delivery_rows(
+    conn: &mut crate::db::DbConnection,
     event_id_value: i64,
     subscription_ids: &[i32],
 ) -> Result<usize, ApiError> {
@@ -250,6 +258,7 @@ fn insert_delivery_rows(
         .on_conflict((event_id, subscription_id))
         .do_nothing()
         .execute(conn)
+        .await
         .map_err(ApiError::from)
 }
 
@@ -260,10 +269,12 @@ pub(crate) async fn count_event_deliveries_for_event(
 ) -> Result<i64, ApiError> {
     use crate::schema::event_deliveries::dsl::{event_deliveries, event_id};
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         event_deliveries
             .filter(event_id.eq(event_id_value))
             .count()
             .get_result::<i64>(conn)
+            .await
     })
+    .await
 }

--- a/src/db/traits/event_observability.rs
+++ b/src/db/traits/event_observability.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use diesel::sql_types::{BigInt, Bool, Integer, Nullable, Text};
 
 use crate::config::{
@@ -122,11 +122,11 @@ struct SubscriptionHealthRow {
 pub async fn load_event_delivery_health(
     pool: &DbPool,
 ) -> Result<EventDeliveryHealthResponse, ApiError> {
-    with_connection(pool, |conn| {
-        let fanout = load_fanout_health(conn)?;
-        let delivery = load_delivery_queue_health(conn)?;
-        let sinks = load_sink_health(conn)?;
-        let subscriptions = load_subscription_health(conn)?;
+    with_connection(pool, async |conn| {
+        let fanout = load_fanout_health(conn).await?;
+        let delivery = load_delivery_queue_health(conn).await?;
+        let sinks = load_sink_health(conn).await?;
+        let subscriptions = load_subscription_health(conn).await?;
 
         Ok::<EventDeliveryHealthResponse, ApiError>(EventDeliveryHealthResponse {
             fanout,
@@ -135,9 +135,12 @@ pub async fn load_event_delivery_health(
             subscriptions,
         })
     })
+    .await
 }
 
-fn load_fanout_health(conn: &mut PgConnection) -> Result<EventFanoutHealth, ApiError> {
+async fn load_fanout_health(
+    conn: &mut crate::db::DbConnection,
+) -> Result<EventFanoutHealth, ApiError> {
     let row = diesel::sql_query(
         r#"
         SELECT
@@ -161,7 +164,8 @@ fn load_fanout_health(conn: &mut PgConnection) -> Result<EventFanoutHealth, ApiE
         WHERE dispatched_at IS NULL
         "#,
     )
-    .get_result::<FanoutHealthRow>(conn)?;
+    .get_result::<FanoutHealthRow>(conn)
+    .await?;
 
     Ok(EventFanoutHealth {
         pending_events: row.pending_events,
@@ -172,8 +176,8 @@ fn load_fanout_health(conn: &mut PgConnection) -> Result<EventFanoutHealth, ApiE
     })
 }
 
-fn load_delivery_queue_health(
-    conn: &mut PgConnection,
+async fn load_delivery_queue_health(
+    conn: &mut crate::db::DbConnection,
 ) -> Result<EventDeliveryQueueHealth, ApiError> {
     let row = diesel::sql_query(
         r#"
@@ -210,7 +214,8 @@ fn load_delivery_queue_health(
         FROM event_deliveries
         "#,
     )
-    .get_result::<DeliveryQueueHealthRow>(conn)?;
+    .get_result::<DeliveryQueueHealthRow>(conn)
+    .await?;
 
     Ok(EventDeliveryQueueHealth {
         counts: status_counts(&row),
@@ -220,7 +225,9 @@ fn load_delivery_queue_health(
     })
 }
 
-fn load_sink_health(conn: &mut PgConnection) -> Result<Vec<EventSinkDeliveryHealth>, ApiError> {
+async fn load_sink_health(
+    conn: &mut crate::db::DbConnection,
+) -> Result<Vec<EventSinkDeliveryHealth>, ApiError> {
     let rows = diesel::sql_query(
         r#"
         SELECT
@@ -265,7 +272,8 @@ fn load_sink_health(conn: &mut PgConnection) -> Result<Vec<EventSinkDeliveryHeal
         ORDER BY s.id
         "#,
     )
-    .load::<SinkHealthRow>(conn)?;
+    .load::<SinkHealthRow>(conn)
+    .await?;
 
     Ok(rows
         .into_iter()
@@ -285,8 +293,8 @@ fn load_sink_health(conn: &mut PgConnection) -> Result<Vec<EventSinkDeliveryHeal
         .collect())
 }
 
-fn load_subscription_health(
-    conn: &mut PgConnection,
+async fn load_subscription_health(
+    conn: &mut crate::db::DbConnection,
 ) -> Result<Vec<EventSubscriptionDeliveryHealth>, ApiError> {
     let rows = diesel::sql_query(
         r#"
@@ -335,7 +343,8 @@ fn load_subscription_health(
         ORDER BY sub.id
         "#,
     )
-    .load::<SubscriptionHealthRow>(conn)?;
+    .load::<SubscriptionHealthRow>(conn)
+    .await?;
 
     Ok(rows
         .into_iter()

--- a/src/db/traits/event_retention.rs
+++ b/src/db/traits/event_retention.rs
@@ -1,5 +1,5 @@
+use crate::db::prelude::*;
 use chrono::{Duration, NaiveDateTime, Utc};
-use diesel::prelude::*;
 use diesel::sql_types::{Array, BigInt, Timestamp};
 
 use crate::db::{DbPool, with_connection, with_transaction};
@@ -35,21 +35,24 @@ pub async fn select_events_for_retention_purge(
     }
 
     let cutoff = Utc::now().naive_utc() - Duration::days(settings.event_retention_days);
-    let ids = with_connection(pool, |conn| {
-        select_event_ids_for_retention_purge(conn, cutoff, settings.batch_size)
-    })?;
+    let ids = with_connection(pool, async |conn| {
+        select_event_ids_for_retention_purge(conn, cutoff, settings.batch_size).await
+    })
+    .await?;
 
     if ids.is_empty() {
         return Ok(Vec::new());
     }
 
     use crate::schema::events::dsl::{events, id};
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         events
             .filter(id.eq_any(ids))
             .order(id.asc())
             .load::<Event>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn purge_event_retention_batch(
@@ -59,12 +62,12 @@ pub async fn purge_event_retention_batch(
 ) -> Result<EventRetentionPurgeSummary, ApiError> {
     with_transaction(
         pool,
-        |conn| -> Result<EventRetentionPurgeSummary, ApiError> {
+        async |conn| -> Result<EventRetentionPurgeSummary, ApiError> {
             let delivery_cutoff =
                 Utc::now().naive_utc() - Duration::days(settings.delivery_retention_days);
             let purged_terminal_deliveries =
-                purge_terminal_event_deliveries(conn, delivery_cutoff)?;
-            let purged_events = purge_events_by_id(conn, event_ids)?;
+                purge_terminal_event_deliveries(conn, delivery_cutoff).await?;
+            let purged_events = purge_events_by_id(conn, event_ids).await?;
 
             Ok(EventRetentionPurgeSummary {
                 purged_events,
@@ -72,6 +75,7 @@ pub async fn purge_event_retention_batch(
             })
         },
     )
+    .await
 }
 
 #[cfg(test)]
@@ -84,8 +88,8 @@ pub async fn purge_event_retention_without_archive(
     purge_event_retention_batch(pool, settings, &event_ids).await
 }
 
-fn select_event_ids_for_retention_purge(
-    conn: &mut PgConnection,
+async fn select_event_ids_for_retention_purge(
+    conn: &mut crate::db::DbConnection,
     cutoff: NaiveDateTime,
     batch_size: usize,
 ) -> Result<Vec<i64>, diesel::result::Error> {
@@ -106,11 +110,12 @@ fn select_event_ids_for_retention_purge(
     .bind::<Timestamp, _>(cutoff)
     .bind::<BigInt, _>(batch_size as i64)
     .load::<EventIdRow>(conn)
+    .await
     .map(|rows| rows.into_iter().map(|row| row.id).collect())
 }
 
-fn purge_terminal_event_deliveries(
-    conn: &mut PgConnection,
+async fn purge_terminal_event_deliveries(
+    conn: &mut crate::db::DbConnection,
     cutoff: NaiveDateTime,
 ) -> Result<usize, diesel::result::Error> {
     use crate::schema::event_deliveries::dsl::{event_deliveries, status, updated_at};
@@ -124,17 +129,20 @@ fn purge_terminal_event_deliveries(
             ])),
     )
     .execute(conn)
+    .await
 }
 
-fn purge_events_by_id(
-    conn: &mut PgConnection,
+async fn purge_events_by_id(
+    conn: &mut crate::db::DbConnection,
     event_ids: &[i64],
 ) -> Result<usize, diesel::result::Error> {
     if event_ids.is_empty() {
         return Ok(0);
     }
 
-    diesel::sql_query("SELECT set_config('events.allow_purge', 'on', true)").execute(conn)?;
+    diesel::sql_query("SELECT set_config('events.allow_purge', 'on', true)")
+        .execute(conn)
+        .await?;
     diesel::sql_query(
         "DELETE FROM events e
          WHERE e.id = ANY($1)
@@ -148,4 +156,5 @@ fn purge_events_by_id(
     )
     .bind::<Array<BigInt>, _>(event_ids)
     .execute(conn)
+    .await
 }

--- a/src/db/traits/event_subscription.rs
+++ b/src/db/traits/event_subscription.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use serde_json::json;
 
 use crate::apply_query_options;
@@ -20,11 +20,13 @@ impl LoadEventSinkRecord for EventSinkID {
     async fn load_event_sink_record(&self, pool: &DbPool) -> Result<EventSinkRow, ApiError> {
         use crate::schema::event_sinks::dsl::{event_sinks, id};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             event_sinks
                 .filter(id.eq(self.id()))
                 .first::<EventSinkRow>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -67,13 +69,15 @@ async fn insert_event_sink_record(
 ) -> Result<EventSinkRow, ApiError> {
     use crate::schema::event_sinks::dsl::event_sinks;
 
-    with_transaction(pool, |conn| -> Result<EventSinkRow, ApiError> {
+    with_transaction(pool, async |conn| -> Result<EventSinkRow, ApiError> {
         let created = diesel::insert_into(event_sinks)
             .values(row)
-            .get_result::<EventSinkRow>(conn)?;
-        emit_event_sink_audit(conn, Action::Created, event_context, None, &created)?;
+            .get_result::<EventSinkRow>(conn)
+            .await?;
+        emit_event_sink_audit(conn, Action::Created, event_context, None, &created).await?;
         Ok(created)
     })
+    .await
 }
 
 pub(crate) trait UpdateEventSinkRecord {
@@ -104,22 +108,26 @@ async fn update_event_sink_record_impl(
 ) -> Result<EventSinkRow, ApiError> {
     use crate::schema::event_sinks::dsl::{event_sinks, id};
 
-    with_transaction(pool, |conn| -> Result<EventSinkRow, ApiError> {
+    with_transaction(pool, async |conn| -> Result<EventSinkRow, ApiError> {
         let before = event_sinks
             .filter(id.eq(sink_id))
-            .first::<EventSinkRow>(conn)?;
+            .first::<EventSinkRow>(conn)
+            .await?;
         let updated = diesel::update(event_sinks.filter(id.eq(sink_id)))
             .set(row)
-            .get_result::<EventSinkRow>(conn)?;
+            .get_result::<EventSinkRow>(conn)
+            .await?;
         emit_event_sink_audit(
             conn,
             Action::Updated,
             event_context,
             Some(&before),
             &updated,
-        )?;
+        )
+        .await?;
         Ok(updated)
     })
+    .await
 }
 
 pub(crate) trait DeleteEventSinkRecord {
@@ -147,16 +155,19 @@ async fn delete_event_sink_record_impl(
 ) -> Result<(), ApiError> {
     use crate::schema::event_sinks::dsl::{event_sinks, id};
 
-    with_transaction(pool, |conn| -> Result<(), ApiError> {
+    with_transaction(pool, async |conn| -> Result<(), ApiError> {
         let before = event_sinks
             .filter(id.eq(sink_id.id()))
-            .first::<EventSinkRow>(conn)?;
-        emit_event_sink_audit(conn, Action::Deleted, event_context, Some(&before), &before)?;
+            .first::<EventSinkRow>(conn)
+            .await?;
+        emit_event_sink_audit(conn, Action::Deleted, event_context, Some(&before), &before).await?;
         diesel::delete(event_sinks.filter(id.eq(sink_id.id())))
             .execute(conn)
+            .await
             .map_err(ApiError::from)?;
         Ok(())
-    })?;
+    })
+    .await?;
     Ok(())
 }
 
@@ -174,11 +185,13 @@ impl LoadEventSubscriptionRecord for EventSubscriptionID {
     ) -> Result<EventSubscriptionRow, ApiError> {
         use crate::schema::event_subscriptions::dsl::{event_subscriptions, id};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             event_subscriptions
                 .filter(id.eq(self.id()))
                 .first::<EventSubscriptionRow>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -221,13 +234,19 @@ async fn insert_event_subscription_record(
 ) -> Result<EventSubscriptionRow, ApiError> {
     use crate::schema::event_subscriptions::dsl::event_subscriptions;
 
-    with_transaction(pool, |conn| -> Result<EventSubscriptionRow, ApiError> {
-        let created = diesel::insert_into(event_subscriptions)
-            .values(row)
-            .get_result::<EventSubscriptionRow>(conn)?;
-        emit_event_subscription_audit(conn, Action::Created, event_context, None, &created)?;
-        Ok(created)
-    })
+    with_transaction(
+        pool,
+        async |conn| -> Result<EventSubscriptionRow, ApiError> {
+            let created = diesel::insert_into(event_subscriptions)
+                .values(row)
+                .get_result::<EventSubscriptionRow>(conn)
+                .await?;
+            emit_event_subscription_audit(conn, Action::Created, event_context, None, &created)
+                .await?;
+            Ok(created)
+        },
+    )
+    .await
 }
 
 pub(crate) trait UpdateEventSubscriptionRecord {
@@ -259,22 +278,29 @@ async fn update_event_subscription_record_impl(
 ) -> Result<EventSubscriptionRow, ApiError> {
     use crate::schema::event_subscriptions::dsl::{event_subscriptions, id};
 
-    with_transaction(pool, |conn| -> Result<EventSubscriptionRow, ApiError> {
-        let before = event_subscriptions
-            .filter(id.eq(subscription_id))
-            .first::<EventSubscriptionRow>(conn)?;
-        let updated = diesel::update(event_subscriptions.filter(id.eq(subscription_id)))
-            .set(row)
-            .get_result::<EventSubscriptionRow>(conn)?;
-        emit_event_subscription_audit(
-            conn,
-            Action::Updated,
-            event_context,
-            Some(&before),
-            &updated,
-        )?;
-        Ok(updated)
-    })
+    with_transaction(
+        pool,
+        async |conn| -> Result<EventSubscriptionRow, ApiError> {
+            let before = event_subscriptions
+                .filter(id.eq(subscription_id))
+                .first::<EventSubscriptionRow>(conn)
+                .await?;
+            let updated = diesel::update(event_subscriptions.filter(id.eq(subscription_id)))
+                .set(row)
+                .get_result::<EventSubscriptionRow>(conn)
+                .await?;
+            emit_event_subscription_audit(
+                conn,
+                Action::Updated,
+                event_context,
+                Some(&before),
+                &updated,
+            )
+            .await?;
+            Ok(updated)
+        },
+    )
+    .await
 }
 
 pub(crate) trait DeleteEventSubscriptionRecord {
@@ -302,27 +328,25 @@ async fn delete_event_subscription_record_impl(
 ) -> Result<(), ApiError> {
     use crate::schema::event_subscriptions::dsl::{event_subscriptions, id};
 
-    with_transaction(pool, |conn| -> Result<(), ApiError> {
+    with_transaction(pool, async |conn| -> Result<(), ApiError> {
         let before = event_subscriptions
             .filter(id.eq(subscription_id.id()))
-            .first::<EventSubscriptionRow>(conn)?;
-        emit_event_subscription_audit(
-            conn,
-            Action::Deleted,
-            event_context,
-            Some(&before),
-            &before,
-        )?;
+            .first::<EventSubscriptionRow>(conn)
+            .await?;
+        emit_event_subscription_audit(conn, Action::Deleted, event_context, Some(&before), &before)
+            .await?;
         diesel::delete(event_subscriptions.filter(id.eq(subscription_id.id())))
             .execute(conn)
+            .await
             .map_err(ApiError::from)?;
         Ok(())
-    })?;
+    })
+    .await?;
     Ok(())
 }
 
-fn emit_event_sink_audit(
-    conn: &mut PgConnection,
+async fn emit_event_sink_audit(
+    conn: &mut crate::db::DbConnection,
     action: Action,
     event_context: Option<&EventContext>,
     before: Option<&EventSinkRow>,
@@ -347,12 +371,12 @@ fn emit_event_sink_audit(
         "kind": after.kind,
         "enabled": after.enabled,
     }));
-    emit_event(conn, &event)?;
+    emit_event(conn, &event).await?;
     Ok(())
 }
 
-fn emit_event_subscription_audit(
-    conn: &mut PgConnection,
+async fn emit_event_subscription_audit(
+    conn: &mut crate::db::DbConnection,
     action: Action,
     event_context: Option<&EventContext>,
     before: Option<&EventSubscriptionRow>,
@@ -379,7 +403,7 @@ fn emit_event_subscription_audit(
         "collection_id": after.collection_id,
         "enabled": after.enabled,
     }));
-    emit_event(conn, &event)?;
+    emit_event(conn, &event).await?;
     Ok(())
 }
 
@@ -415,12 +439,16 @@ pub(crate) async fn list_event_sink_rows_with_total_count(
     query_options: &QueryOptions,
 ) -> Result<(Vec<EventSinkRow>, i64), ApiError> {
     let query = build_event_sink_query(query_options)?;
-    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
-    })?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+        with_connection(pool, async |conn| {
+            query.count().get_result::<i64>(conn).await
+        })
+        .await
+    })
+    .await?;
     let mut query = build_event_sink_query(query_options)?;
     apply_query_options!(query, query_options, EventSink);
-    let rows = with_connection(pool, |conn| query.load::<EventSinkRow>(conn))?;
+    let rows = with_connection(pool, async |conn| query.load::<EventSinkRow>(conn).await).await?;
     Ok((rows, total_count))
 }
 
@@ -454,12 +482,19 @@ pub(crate) async fn list_event_subscription_rows_with_total_count(
     query_options: &QueryOptions,
 ) -> Result<(Vec<EventSubscriptionRow>, i64), ApiError> {
     let base = build_event_subscription_query(collection, query_options)?;
-    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-        with_connection(pool, |conn| base.count().get_result::<i64>(conn))
-    })?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+        with_connection(pool, async |conn| {
+            base.count().get_result::<i64>(conn).await
+        })
+        .await
+    })
+    .await?;
     let mut query = build_event_subscription_query(collection, query_options)?;
     apply_query_options!(query, query_options, EventSubscription);
-    let rows = with_connection(pool, |conn| query.load::<EventSubscriptionRow>(conn))?;
+    let rows = with_connection(pool, async |conn| {
+        query.load::<EventSubscriptionRow>(conn).await
+    })
+    .await?;
     Ok((rows, total_count))
 }
 

--- a/src/db/traits/events.rs
+++ b/src/db/traits/events.rs
@@ -1,5 +1,5 @@
+use crate::db::prelude::*;
 use diesel::dsl::sql;
-use diesel::prelude::*;
 use diesel::sql_types::Bool;
 
 use crate::apply_query_options;
@@ -29,13 +29,17 @@ pub async fn list_events_with_total_count(
     query_options: &QueryOptions,
 ) -> Result<(Vec<EventResponse>, i64), ApiError> {
     let query = build_event_query(accessible_collection_ids, include_collection_less, filters)?;
-    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
-    })?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+        with_connection(pool, async |conn| {
+            query.count().get_result::<i64>(conn).await
+        })
+        .await
+    })
+    .await?;
 
     let mut query = build_event_query(accessible_collection_ids, include_collection_less, filters)?;
     apply_query_options!(query, query_options, EventResponse);
-    let rows = with_connection(pool, |conn| query.load::<Event>(conn))?;
+    let rows = with_connection(pool, async |conn| query.load::<Event>(conn).await).await?;
     let rows = rows
         .into_iter()
         .map(|event| {

--- a/src/db/traits/export_template.rs
+++ b/src/db/traits/export_template.rs
@@ -7,7 +7,7 @@
 //! aggregate queries — which have no single owning instance — stay free functions, as elsewhere in
 //! this module. The model owns the domain<->row conversions and all validation.
 
-use diesel::prelude::*;
+use crate::db::prelude::*;
 
 use crate::db::{DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
@@ -53,11 +53,13 @@ impl LoadExportTemplateRecord for ExportTemplateID {
     ) -> Result<ExportTemplateRow, ApiError> {
         use crate::schema::export_templates::dsl::{export_templates, id};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             export_templates
                 .filter(id.eq(self.id()))
                 .first::<ExportTemplateRow>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -85,11 +87,13 @@ impl SaveExportTemplateRecord for NewExportTemplateRow {
     ) -> Result<ExportTemplateRow, ApiError> {
         use crate::schema::export_templates::dsl::export_templates;
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             diesel::insert_into(export_templates)
                 .values(self)
                 .get_result::<ExportTemplateRow>(conn)
+                .await
         })
+        .await
     }
 
     async fn save_export_template_record(
@@ -103,10 +107,11 @@ impl SaveExportTemplateRecord for NewExportTemplateRow {
 
         use crate::schema::export_templates::dsl::export_templates;
 
-        with_transaction(pool, |conn| -> Result<ExportTemplateRow, ApiError> {
+        with_transaction(pool, async |conn| -> Result<ExportTemplateRow, ApiError> {
             let row = diesel::insert_into(export_templates)
                 .values(self)
-                .get_result::<ExportTemplateRow>(conn)?;
+                .get_result::<ExportTemplateRow>(conn)
+                .await?;
             let event = export_template_event(
                 &row,
                 Action::Created,
@@ -114,9 +119,10 @@ impl SaveExportTemplateRecord for NewExportTemplateRow {
                 format!("Export template '{}' created", row.name()),
             )?
             .with_after(row.audit_snapshot());
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(row)
         })
+        .await
     }
 }
 
@@ -148,15 +154,23 @@ impl UpdateExportTemplateRecord for UpdateExportTemplateRow {
     ) -> Result<ExportTemplateRow, ApiError> {
         use crate::schema::export_templates::dsl::{export_templates, id};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             crate::db::updated_or_current(
                 diesel::update(export_templates.filter(id.eq(template_id)))
                     .set(self)
                     .get_result::<ExportTemplateRow>(conn)
+                    .await
                     .optional(),
-                || export_templates.filter(id.eq(template_id)).first(conn),
+                async || {
+                    export_templates
+                        .filter(id.eq(template_id))
+                        .first(conn)
+                        .await
+                },
             )
+            .await
         })
+        .await
     }
 
     async fn update_export_template_record(
@@ -173,13 +187,15 @@ impl UpdateExportTemplateRecord for UpdateExportTemplateRow {
 
         use crate::schema::export_templates::dsl::{export_templates, id};
 
-        with_transaction(pool, |conn| -> Result<ExportTemplateRow, ApiError> {
+        with_transaction(pool, async |conn| -> Result<ExportTemplateRow, ApiError> {
             let before = export_templates
                 .filter(id.eq(template_id))
-                .first::<ExportTemplateRow>(conn)?;
+                .first::<ExportTemplateRow>(conn)
+                .await?;
             let after = diesel::update(export_templates.filter(id.eq(template_id)))
                 .set(self)
-                .get_result::<ExportTemplateRow>(conn)?;
+                .get_result::<ExportTemplateRow>(conn)
+                .await?;
             let event = export_template_event(
                 &after,
                 Action::Updated,
@@ -188,9 +204,10 @@ impl UpdateExportTemplateRecord for UpdateExportTemplateRow {
             )?
             .with_before(before.audit_snapshot())
             .with_after(after.audit_snapshot());
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(after)
         })
+        .await
     }
 }
 
@@ -219,9 +236,12 @@ impl DeleteExportTemplateRecord for ExportTemplateID {
     ) -> Result<(), ApiError> {
         use crate::schema::export_templates::dsl::{export_templates, id};
 
-        with_connection(pool, |conn| {
-            diesel::delete(export_templates.filter(id.eq(self.id()))).execute(conn)
-        })?;
+        with_connection(pool, async |conn| {
+            diesel::delete(export_templates.filter(id.eq(self.id())))
+                .execute(conn)
+                .await
+        })
+        .await?;
 
         Ok(())
     }
@@ -239,11 +259,14 @@ impl DeleteExportTemplateRecord for ExportTemplateID {
 
         use crate::schema::export_templates::dsl::{export_templates, id};
 
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let before = export_templates
                 .filter(id.eq(self.id()))
-                .first::<ExportTemplateRow>(conn)?;
-            diesel::delete(export_templates.filter(id.eq(self.id()))).execute(conn)?;
+                .first::<ExportTemplateRow>(conn)
+                .await?;
+            diesel::delete(export_templates.filter(id.eq(self.id())))
+                .execute(conn)
+                .await?;
             let event = export_template_event(
                 &before,
                 Action::Deleted,
@@ -251,9 +274,10 @@ impl DeleteExportTemplateRecord for ExportTemplateID {
                 format!("Export template '{}' deleted", before.name()),
             )?
             .with_before(before.audit_snapshot());
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(())
         })
+        .await
     }
 }
 
@@ -272,12 +296,14 @@ impl ExportTemplateCollectionLookup for ExportTemplateID {
     ) -> Result<CollectionID, ApiError> {
         use crate::schema::export_templates::dsl::{collection_id, export_templates, id};
 
-        let raw = with_connection(pool, |conn| {
+        let raw = with_connection(pool, async |conn| {
             export_templates
                 .filter(id.eq(self.id()))
                 .select(collection_id)
                 .first::<i32>(conn)
-        })?;
+                .await
+        })
+        .await?;
         CollectionID::new(raw)
     }
 }
@@ -290,24 +316,26 @@ pub(crate) async fn load_rows_in_collection(
 ) -> Result<Vec<ExportTemplateRow>, ApiError> {
     use crate::schema::export_templates::dsl::{collection_id, export_templates, id};
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         let mut query = export_templates
             .into_boxed()
             .filter(collection_id.eq(target_collection_id));
         if let Some(exclude_template_id) = exclude_template_id {
             query = query.filter(id.ne(exclude_template_id));
         }
-        query.load::<ExportTemplateRow>(conn)
+        query.load::<ExportTemplateRow>(conn).await
     })
+    .await
 }
 
 /// Load every export-template row.
 pub(crate) async fn load_all_rows(pool: &DbPool) -> Result<Vec<ExportTemplateRow>, ApiError> {
     use crate::schema::export_templates::dsl::export_templates;
 
-    with_connection(pool, |conn| {
-        export_templates.load::<ExportTemplateRow>(conn)
+    with_connection(pool, async |conn| {
+        export_templates.load::<ExportTemplateRow>(conn).await
     })
+    .await
 }
 
 /// Whether a template with `target_name` already exists in the collection, optionally ignoring one
@@ -320,7 +348,7 @@ pub(crate) async fn name_conflict_exists(
 ) -> Result<bool, ApiError> {
     use crate::schema::export_templates::dsl::{collection_id, export_templates, id, name};
 
-    let existing = with_connection(pool, |conn| {
+    let existing = with_connection(pool, async |conn| {
         let mut query = export_templates
             .into_boxed()
             .filter(collection_id.eq(target_collection_id))
@@ -328,8 +356,9 @@ pub(crate) async fn name_conflict_exists(
         if let Some(exclude_template_id) = exclude_template_id {
             query = query.filter(id.ne(exclude_template_id));
         }
-        query.first::<ExportTemplateRow>(conn).optional()
-    })?;
+        query.first::<ExportTemplateRow>(conn).await.optional()
+    })
+    .await?;
 
     Ok(existing.is_some())
 }
@@ -341,13 +370,15 @@ pub(crate) async fn class_collection_id(
 ) -> Result<Option<i32>, ApiError> {
     use crate::schema::hubuumclass::dsl::{collection_id, hubuumclass, id};
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         hubuumclass
             .filter(id.eq(target_class_id))
             .select(collection_id)
             .first::<i32>(conn)
+            .await
             .optional()
     })
+    .await
 }
 
 /// Build the filtered (but unsorted, unpaginated) query for listing export templates within the
@@ -404,13 +435,20 @@ pub(crate) async fn list_rows_with_total_count(
     query_options: &QueryOptions,
 ) -> Result<(Vec<ExportTemplateRow>, i64), ApiError> {
     let query = build_list_query(allowed_collection_ids, query_options)?;
-    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
-    })?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+        with_connection(pool, async |conn| {
+            query.count().get_result::<i64>(conn).await
+        })
+        .await
+    })
+    .await?;
 
     let mut query = build_list_query(allowed_collection_ids, query_options)?;
     crate::apply_query_options!(query, query_options, ExportTemplate);
-    let rows = with_connection(pool, |conn| query.load::<ExportTemplateRow>(conn))?;
+    let rows = with_connection(pool, async |conn| {
+        query.load::<ExportTemplateRow>(conn).await
+    })
+    .await?;
 
     Ok((rows, total_count))
 }

--- a/src/db/traits/external_identity.rs
+++ b/src/db/traits/external_identity.rs
@@ -423,12 +423,14 @@ mod tests {
         .unwrap();
 
         assert_eq!(synced_after_subject_change.id, user.id);
-        let external_subject = with_connection(scope.pool.get_ref(), |conn| {
+        let external_subject = with_connection(scope.pool.get_ref(), async |conn| {
             principals::table
                 .find(user.id)
                 .select(principals::external_subject)
                 .first::<Option<String>>(conn)
+                .await
         })
+        .await
         .unwrap();
         assert_eq!(
             external_subject.as_deref(),

--- a/src/db/traits/external_identity.rs
+++ b/src/db/traits/external_identity.rs
@@ -1,8 +1,8 @@
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
 use hubuum_auth_core::AuthenticatedExternalUser;
 use std::collections::HashSet;
 
+use crate::db::prelude::*;
 use crate::db::traits::identity::ensure_identity_scope;
 use crate::db::{DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
@@ -24,7 +24,7 @@ pub async fn external_principal_state(
 ) -> Result<Option<ExternalPrincipalState>, ApiError> {
     use crate::schema::{identity_scopes, principals, users};
 
-    let row = with_connection(pool, |conn| {
+    let row = with_connection(pool, async |conn| {
         users::table
             .inner_join(principals::table.on(users::id.eq(principals::id)))
             .inner_join(
@@ -47,8 +47,10 @@ pub async fn external_principal_state(
                 Option<NaiveDateTime>,
                 String,
             )>(conn)
+            .await
             .optional()
-    })?;
+    })
+    .await?;
 
     let Some((
         provider,
@@ -77,17 +79,19 @@ pub async fn external_principal_state(
     }))
 }
 
-pub fn mark_external_sync_attempted(
+pub async fn mark_external_sync_attempted(
     pool: &DbPool,
     principal_id_value: i32,
 ) -> Result<(), ApiError> {
     use crate::schema::principals;
     let attempted_at = now();
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         diesel::update(principals::table.filter(principals::id.eq(principal_id_value)))
             .set(principals::last_sync_attempted_at.eq(attempted_at))
             .execute(conn)
-    })?;
+            .await
+    })
+    .await?;
     Ok(())
 }
 
@@ -103,7 +107,7 @@ pub async fn sync_external_user(
     let groups = authenticated.groups;
     let synced_group_count = groups.len();
 
-    with_transaction(pool, |conn| -> Result<User, ApiError> {
+    with_transaction(pool, async |conn| -> Result<User, ApiError> {
         use crate::schema::{group_membership_sources, group_memberships, groups as groups_table};
         use crate::schema::{principals, users};
 
@@ -112,6 +116,7 @@ pub async fn sync_external_user(
             .filter(principals::external_subject.eq(&profile.subject))
             .select(principals::all_columns)
             .first::<Principal>(conn)
+            .await
             .optional()?;
 
         let principal = if let Some(existing) = existing_by_subject {
@@ -125,7 +130,8 @@ pub async fn sync_external_user(
                         principals::last_sync_attempted_at.eq(sync_time),
                         principals::last_sync_success_at.eq(sync_time),
                     ))
-                    .get_result::<Principal>(conn)?
+                    .get_result::<Principal>(conn)
+                    .await?
             }
         } else {
             let inserted = diesel::insert_into(principals::table)
@@ -140,6 +146,7 @@ pub async fn sync_external_user(
                 ))
                 .on_conflict_do_nothing()
                 .get_result::<Principal>(conn)
+                .await
                 .optional()?;
 
             match inserted {
@@ -148,7 +155,8 @@ pub async fn sync_external_user(
                     let principal = principals::table
                         .filter(principals::identity_scope_id.eq(scope.id))
                         .filter(principals::name.eq(&profile.name))
-                        .first::<Principal>(conn)?;
+                        .first::<Principal>(conn)
+                        .await?;
                     if principal.provider_managed && principal.kind == PrincipalKind::Human.as_str()
                     {
                         principal
@@ -181,7 +189,8 @@ pub async fn sync_external_user(
                 users::proper_name.eq(&profile.proper_name),
                 users::email.eq(&profile.email),
             ))
-            .get_result::<User>(conn)?;
+            .get_result::<User>(conn)
+            .await?;
 
         diesel::update(principals::table.filter(principals::id.eq(principal.id)))
             .set((
@@ -190,7 +199,8 @@ pub async fn sync_external_user(
                 principals::last_sync_attempted_at.eq(sync_time),
                 principals::last_sync_success_at.eq(sync_time),
             ))
-            .execute(conn)?;
+            .execute(conn)
+            .await?;
 
         let mut synced_group_ids = Vec::new();
         for group in groups {
@@ -214,7 +224,8 @@ pub async fn sync_external_user(
                     groups_table::last_sync_attempted_at.eq(sync_time),
                     groups_table::last_sync_success_at.eq(sync_time),
                 ))
-                .get_result::<crate::models::Group>(conn)?;
+                .get_result::<crate::models::Group>(conn)
+                .await?;
             synced_group_ids.push(saved.id);
 
             diesel::insert_into(group_memberships::table)
@@ -223,7 +234,8 @@ pub async fn sync_external_user(
                     group_memberships::group_id.eq(saved.id),
                 ))
                 .on_conflict_do_nothing()
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
             let source_key = saved.external_key.clone().unwrap_or_default();
             diesel::insert_into(group_membership_sources::table)
                 .values((
@@ -234,7 +246,8 @@ pub async fn sync_external_user(
                     group_membership_sources::source_key.eq(&source_key),
                 ))
                 .on_conflict_do_nothing()
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
         }
 
         diesel::delete(
@@ -246,18 +259,21 @@ pub async fn sync_external_user(
                     group_membership_sources::group_id.eq_any(&synced_group_ids),
                 )),
         )
-        .execute(conn)?;
+        .execute(conn)
+        .await?;
 
         let retained: HashSet<i32> = group_membership_sources::table
             .filter(group_membership_sources::principal_id.eq(user.id))
             .select(group_membership_sources::group_id)
-            .load::<i32>(conn)?
+            .load::<i32>(conn)
+            .await?
             .into_iter()
             .collect();
         let current: Vec<i32> = group_memberships::table
             .filter(group_memberships::principal_id.eq(user.id))
             .select(group_memberships::group_id)
-            .load(conn)?;
+            .load(conn)
+            .await?;
         for group_id in current {
             if !retained.contains(&group_id) {
                 diesel::delete(
@@ -265,7 +281,8 @@ pub async fn sync_external_user(
                         .filter(group_memberships::principal_id.eq(user.id))
                         .filter(group_memberships::group_id.eq(group_id)),
                 )
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
             }
         }
 
@@ -289,10 +306,11 @@ pub async fn sync_external_user(
             "external_subject": profile.subject,
             "synced_group_count": synced_group_count,
         }));
-        emit_event(conn, &event)?;
+        emit_event(conn, &event).await?;
 
         Ok(user)
     })
+    .await
 }
 
 fn now() -> NaiveDateTime {
@@ -366,13 +384,15 @@ mod tests {
             renamed
         );
 
-        let principal_count = with_connection(scope.pool.get_ref(), |conn| {
+        let principal_count = with_connection(scope.pool.get_ref(), async |conn| {
             principals::table
                 .inner_join(identity_scopes::table)
                 .filter(identity_scopes::name.eq(&identity_scope))
                 .count()
                 .get_result::<i64>(conn)
+                .await
         })
+        .await
         .unwrap();
         assert_eq!(principal_count, 1);
     }
@@ -442,7 +462,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let first_group_id = group_id_by_external_key(scope.pool.get_ref(), &first_group_key);
+        let first_group_id = group_id_by_external_key(scope.pool.get_ref(), &first_group_key).await;
 
         let manual_group = NewGroup {
             identity_scope: None,
@@ -469,28 +489,33 @@ mod tests {
         )
         .await
         .unwrap();
-        let second_group_id = group_id_by_external_key(scope.pool.get_ref(), &second_group_key);
+        let second_group_id =
+            group_id_by_external_key(scope.pool.get_ref(), &second_group_key).await;
 
         assert_eq!(synced.id, user.id);
-        let memberships = with_connection(scope.pool.get_ref(), |conn| {
+        let memberships = with_connection(scope.pool.get_ref(), async |conn| {
             group_memberships::table
                 .filter(group_memberships::principal_id.eq(user.id))
                 .select(group_memberships::group_id)
                 .load::<i32>(conn)
+                .await
         })
+        .await
         .unwrap();
         assert!(memberships.contains(&manual_group.id));
         assert!(memberships.contains(&second_group_id));
         assert!(!memberships.contains(&first_group_id));
     }
 
-    fn group_id_by_external_key(pool: &DbPool, external_key: &str) -> i32 {
-        with_connection(pool, |conn| {
+    async fn group_id_by_external_key(pool: &DbPool, external_key: &str) -> i32 {
+        with_connection(pool, async |conn| {
             groups_table::table
                 .filter(groups_table::external_key.eq(external_key))
                 .select(groups_table::id)
                 .first::<i32>(conn)
+                .await
         })
+        .await
         .unwrap()
     }
 }

--- a/src/db/traits/group.rs
+++ b/src/db/traits/group.rs
@@ -1,7 +1,7 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 
 use crate::db::traits::identity::{identity_scope_by_name, identity_scope_id_by_name_conn};
-use crate::db::{DbPool, with_connection, with_transaction};
+use crate::db::{DbConnection, DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
 use crate::models::identity::{
@@ -47,33 +47,37 @@ fn user_group_metadata(principal_id: i32, group_id: i32) -> serde_json::Value {
     })
 }
 
-fn insert_effective_membership(
-    conn: &mut PgConnection,
+async fn insert_effective_membership(
+    conn: &mut DbConnection,
     principal: i32,
     group: i32,
 ) -> Result<PrincipalGroup, diesel::result::Error> {
     use crate::schema::group_memberships::dsl::group_memberships;
 
-    diesel::insert_into(group_memberships)
+    let inserted = diesel::insert_into(group_memberships)
         .values((
             crate::schema::group_memberships::principal_id.eq(principal),
             crate::schema::group_memberships::group_id.eq(group),
         ))
         .on_conflict_do_nothing()
         .get_result(conn)
-        .optional()?
-        .map_or_else(|| load_principal_group(conn, principal, group), Ok)
+        .await
+        .optional()?;
+    match inserted {
+        Some(membership) => Ok(membership),
+        None => load_principal_group(conn, principal, group).await,
+    }
 }
 
-fn insert_manual_membership_source(
-    conn: &mut PgConnection,
+async fn insert_manual_membership_source(
+    conn: &mut DbConnection,
     principal: i32,
     group: i32,
 ) -> Result<(), ApiError> {
     use crate::schema::group_membership_sources;
 
-    ensure_group_allows_local_write(conn, group)?;
-    let local_scope_id = identity_scope_id_by_name_conn(conn, LOCAL_IDENTITY_SCOPE)?;
+    ensure_group_allows_local_write(conn, group).await?;
+    let local_scope_id = identity_scope_id_by_name_conn(conn, LOCAL_IDENTITY_SCOPE).await?;
     diesel::insert_into(group_membership_sources::table)
         .values((
             group_membership_sources::principal_id.eq(principal),
@@ -83,19 +87,20 @@ fn insert_manual_membership_source(
             group_membership_sources::source_key.eq(""),
         ))
         .on_conflict_do_nothing()
-        .execute(conn)?;
+        .execute(conn)
+        .await?;
     Ok(())
 }
 
-fn remove_manual_membership_source(
-    conn: &mut PgConnection,
+async fn remove_manual_membership_source(
+    conn: &mut DbConnection,
     principal: i32,
     group: i32,
 ) -> Result<(), ApiError> {
     use crate::schema::{group_membership_sources, group_memberships};
 
-    ensure_group_allows_local_write(conn, group)?;
-    let local_scope_id = identity_scope_id_by_name_conn(conn, LOCAL_IDENTITY_SCOPE)?;
+    ensure_group_allows_local_write(conn, group).await?;
+    let local_scope_id = identity_scope_id_by_name_conn(conn, LOCAL_IDENTITY_SCOPE).await?;
     diesel::delete(
         group_membership_sources::table
             .filter(group_membership_sources::principal_id.eq(principal))
@@ -104,31 +109,38 @@ fn remove_manual_membership_source(
             .filter(group_membership_sources::source_scope_id.eq(local_scope_id))
             .filter(group_membership_sources::source_key.eq("")),
     )
-    .execute(conn)?;
+    .execute(conn)
+    .await?;
 
     let remaining = group_membership_sources::table
         .filter(group_membership_sources::principal_id.eq(principal))
         .filter(group_membership_sources::group_id.eq(group))
         .count()
-        .get_result::<i64>(conn)?;
+        .get_result::<i64>(conn)
+        .await?;
     if remaining == 0 {
         diesel::delete(
             group_memberships::table
                 .filter(group_memberships::principal_id.eq(principal))
                 .filter(group_memberships::group_id.eq(group)),
         )
-        .execute(conn)?;
+        .execute(conn)
+        .await?;
     }
     Ok(())
 }
 
-fn ensure_group_allows_local_write(conn: &mut PgConnection, group: i32) -> Result<(), ApiError> {
+async fn ensure_group_allows_local_write(
+    conn: &mut DbConnection,
+    group: i32,
+) -> Result<(), ApiError> {
     use crate::schema::groups::dsl::{groups, id, managed_by};
 
     let manager = groups
         .filter(id.eq(group))
         .select(managed_by)
-        .first::<String>(conn)?;
+        .first::<String>(conn)
+        .await?;
     if manager != LOCAL_PROVIDER_KIND {
         return Err(ApiError::Forbidden(
             "Provider-managed groups are read-only in Hubuum".to_string(),
@@ -141,9 +153,12 @@ pub trait LoadGroupRecord {
     async fn load_group_record(&self, pool: &DbPool) -> Result<Group, ApiError>;
 }
 
-pub fn count_group_records(pool: &DbPool) -> Result<i64, ApiError> {
+pub async fn count_group_records(pool: &DbPool) -> Result<i64, ApiError> {
     use crate::schema::groups::dsl::groups;
-    with_connection(pool, |conn| groups.count().get_result::<i64>(conn))
+    with_connection(pool, async |conn| {
+        groups.count().get_result::<i64>(conn).await
+    })
+    .await
 }
 
 pub async fn group_identity_scope_name(
@@ -151,22 +166,25 @@ pub async fn group_identity_scope_name(
     group_id_value: i32,
 ) -> Result<String, ApiError> {
     use crate::schema::{groups, identity_scopes};
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         groups::table
             .inner_join(identity_scopes::table)
             .filter(groups::id.eq(group_id_value))
             .select(identity_scopes::name)
             .first::<String>(conn)
+            .await
     })
+    .await
 }
 
 impl LoadGroupRecord for GroupID {
     async fn load_group_record(&self, pool: &DbPool) -> Result<Group, ApiError> {
         use crate::schema::groups::dsl::{groups, id};
 
-        with_connection(pool, |conn| {
-            groups.filter(id.eq(self.id())).first::<Group>(conn)
+        with_connection(pool, async |conn| {
+            groups.filter(id.eq(self.id())).first::<Group>(conn).await
         })
+        .await
     }
 }
 
@@ -187,10 +205,13 @@ impl DeleteGroupRecord for GroupID {
     async fn delete_group_record_without_events(&self, pool: &DbPool) -> Result<usize, ApiError> {
         use crate::schema::groups::dsl::{groups, id};
 
-        with_connection(pool, |conn| -> Result<usize, ApiError> {
-            ensure_group_allows_local_write(conn, self.id())?;
-            Ok(diesel::delete(groups.filter(id.eq(self.id()))).execute(conn)?)
+        with_connection(pool, async |conn| -> Result<usize, ApiError> {
+            ensure_group_allows_local_write(conn, self.id()).await?;
+            Ok(diesel::delete(groups.filter(id.eq(self.id())))
+                .execute(conn)
+                .await?)
         })
+        .await
     }
 
     async fn delete_group_record(
@@ -204,10 +225,12 @@ impl DeleteGroupRecord for GroupID {
 
         use crate::schema::groups::dsl::{groups, id};
 
-        with_transaction(pool, |conn| -> Result<usize, ApiError> {
-            let group = groups.filter(id.eq(self.id())).first::<Group>(conn)?;
-            ensure_group_allows_local_write(conn, group.id)?;
-            let deleted = diesel::delete(groups.filter(id.eq(self.id()))).execute(conn)?;
+        with_transaction(pool, async |conn| -> Result<usize, ApiError> {
+            let group = groups.filter(id.eq(self.id())).first::<Group>(conn).await?;
+            ensure_group_allows_local_write(conn, group.id).await?;
+            let deleted = diesel::delete(groups.filter(id.eq(self.id())))
+                .execute(conn)
+                .await?;
             let event = group_event(
                 &group,
                 Action::Deleted,
@@ -215,9 +238,10 @@ impl DeleteGroupRecord for GroupID {
                 format!("Group '{}' deleted", group.groupname),
             )?
             .with_before(group_snapshot(&group));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(deleted)
         })
+        .await
     }
 }
 
@@ -225,10 +249,13 @@ impl DeleteGroupRecord for Group {
     async fn delete_group_record_without_events(&self, pool: &DbPool) -> Result<usize, ApiError> {
         use crate::schema::groups::dsl::{groups, id};
 
-        with_connection(pool, |conn| -> Result<usize, ApiError> {
-            ensure_group_allows_local_write(conn, self.id)?;
-            Ok(diesel::delete(groups.filter(id.eq(self.id))).execute(conn)?)
+        with_connection(pool, async |conn| -> Result<usize, ApiError> {
+            ensure_group_allows_local_write(conn, self.id).await?;
+            Ok(diesel::delete(groups.filter(id.eq(self.id)))
+                .execute(conn)
+                .await?)
         })
+        .await
     }
 
     async fn delete_group_record(
@@ -242,10 +269,12 @@ impl DeleteGroupRecord for Group {
 
         use crate::schema::groups::dsl::{groups, id};
 
-        with_transaction(pool, |conn| -> Result<usize, ApiError> {
-            let before = groups.filter(id.eq(self.id)).first::<Group>(conn)?;
-            ensure_group_allows_local_write(conn, before.id)?;
-            let deleted = diesel::delete(groups.filter(id.eq(self.id))).execute(conn)?;
+        with_transaction(pool, async |conn| -> Result<usize, ApiError> {
+            let before = groups.filter(id.eq(self.id)).first::<Group>(conn).await?;
+            ensure_group_allows_local_write(conn, before.id).await?;
+            let deleted = diesel::delete(groups.filter(id.eq(self.id)))
+                .execute(conn)
+                .await?;
             let event = group_event(
                 &before,
                 Action::Deleted,
@@ -253,9 +282,10 @@ impl DeleteGroupRecord for Group {
                 format!("Group '{}' deleted", before.groupname),
             )?
             .with_before(group_snapshot(&before));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(deleted)
         })
+        .await
     }
 }
 
@@ -289,7 +319,7 @@ impl SaveGroupRecord for NewGroup {
         let scope = identity_scope_by_name(pool, scope_name).await?;
         let description = self.description.clone().unwrap_or_default();
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             diesel::insert_into(groups::table)
                 .values((
                     groups::identity_scope_id.eq(scope.id),
@@ -298,7 +328,9 @@ impl SaveGroupRecord for NewGroup {
                     groups::managed_by.eq(LOCAL_PROVIDER_KIND),
                 ))
                 .get_result::<Group>(conn)
+                .await
         })
+        .await
     }
 
     async fn save_group_record(
@@ -324,7 +356,7 @@ impl SaveGroupRecord for NewGroup {
         let scope = identity_scope_by_name(pool, scope_name).await?;
         let description = self.description.clone().unwrap_or_default();
 
-        with_transaction(pool, |conn| -> Result<Group, ApiError> {
+        with_transaction(pool, async |conn| -> Result<Group, ApiError> {
             let group = diesel::insert_into(groups::table)
                 .values((
                     groups::identity_scope_id.eq(scope.id),
@@ -332,7 +364,8 @@ impl SaveGroupRecord for NewGroup {
                     groups::description.eq(&description),
                     groups::managed_by.eq(LOCAL_PROVIDER_KIND),
                 ))
-                .get_result::<Group>(conn)?;
+                .get_result::<Group>(conn)
+                .await?;
             let event = group_event(
                 &group,
                 Action::Created,
@@ -340,9 +373,10 @@ impl SaveGroupRecord for NewGroup {
                 format!("Group '{}' created", group.groupname),
             )?
             .with_after(group_snapshot(&group));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(group)
         })
+        .await
     }
 }
 
@@ -373,12 +407,14 @@ impl UpdateGroupRecord for UpdateGroup {
     ) -> Result<Group, ApiError> {
         use crate::schema::groups::dsl::{groups, id};
 
-        with_connection(pool, |conn| -> Result<Group, ApiError> {
-            ensure_group_allows_local_write(conn, group_id)?;
+        with_connection(pool, async |conn| -> Result<Group, ApiError> {
+            ensure_group_allows_local_write(conn, group_id).await?;
             Ok(diesel::update(groups.filter(id.eq(group_id)))
                 .set(self)
-                .get_result::<Group>(conn)?)
+                .get_result::<Group>(conn)
+                .await?)
         })
+        .await
     }
 
     async fn update_group_record(
@@ -395,12 +431,13 @@ impl UpdateGroupRecord for UpdateGroup {
 
         use crate::schema::groups::dsl::{groups, id};
 
-        with_transaction(pool, |conn| -> Result<Group, ApiError> {
-            let before = groups.filter(id.eq(group_id)).first::<Group>(conn)?;
-            ensure_group_allows_local_write(conn, before.id)?;
+        with_transaction(pool, async |conn| -> Result<Group, ApiError> {
+            let before = groups.filter(id.eq(group_id)).first::<Group>(conn).await?;
+            ensure_group_allows_local_write(conn, before.id).await?;
             let after = diesel::update(groups.filter(id.eq(group_id)))
                 .set(self)
-                .get_result::<Group>(conn)?;
+                .get_result::<Group>(conn)
+                .await?;
             let event = group_event(
                 &after,
                 Action::Updated,
@@ -409,9 +446,10 @@ impl UpdateGroupRecord for UpdateGroup {
             )?
             .with_before(group_snapshot(&before))
             .with_after(group_snapshot(&after));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(after)
         })
+        .await
     }
 }
 
@@ -456,13 +494,15 @@ impl GroupMembersBackend for Group {
         use crate::schema::group_memberships::dsl::{group_id, group_memberships};
         use crate::schema::principals::dsl::principals;
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             group_memberships
                 .filter(group_id.eq(self.id))
                 .inner_join(principals)
                 .select(crate::schema::principals::all_columns)
                 .load::<Principal>(conn)
+                .await
         })
+        .await
     }
 
     async fn load_group_members_paginated(
@@ -499,7 +539,7 @@ impl GroupMembersBackend for Group {
 
         crate::apply_query_options!(base_query, query_options, Principal);
 
-        with_connection(pool, |conn| base_query.load::<Principal>(conn))
+        with_connection(pool, async |conn| base_query.load::<Principal>(conn).await).await
     }
 
     async fn count_group_members_paginated(
@@ -533,7 +573,10 @@ impl GroupMembersBackend for Group {
             }
         }
 
-        with_connection(pool, |conn| base_query.count().get_result::<i64>(conn))
+        with_connection(pool, async |conn| {
+            base_query.count().get_result::<i64>(conn).await
+        })
+        .await
     }
 
     async fn remove_group_member_from_backend_without_events(
@@ -541,10 +584,11 @@ impl GroupMembersBackend for Group {
         member_principal_id: i32,
         pool: &DbPool,
     ) -> Result<(), ApiError> {
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
-            remove_manual_membership_source(conn, member_principal_id, self.id)?;
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
+            remove_manual_membership_source(conn, member_principal_id, self.id).await?;
             Ok(())
-        })?;
+        })
+        .await?;
         Ok(())
     }
 
@@ -560,9 +604,11 @@ impl GroupMembersBackend for Group {
                 .await;
         };
 
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
-            let membership = load_principal_group(conn, member_principal_id, self.id).optional()?;
-            remove_manual_membership_source(conn, member_principal_id, self.id)?;
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
+            let membership = load_principal_group(conn, member_principal_id, self.id)
+                .await
+                .optional()?;
+            remove_manual_membership_source(conn, member_principal_id, self.id).await?;
 
             if let Some(membership) = membership {
                 let event = NewEvent::new(
@@ -579,11 +625,12 @@ impl GroupMembersBackend for Group {
                     membership.principal_id,
                     membership.group_id,
                 ));
-                emit_event(conn, &event)?;
+                emit_event(conn, &event).await?;
             }
 
             Ok(())
         })
+        .await
     }
 }
 
@@ -608,11 +655,13 @@ impl SavePrincipalGroupRecord for NewPrincipalGroup {
         &self,
         pool: &DbPool,
     ) -> Result<PrincipalGroup, ApiError> {
-        with_transaction(pool, |conn| -> Result<PrincipalGroup, ApiError> {
-            let membership = insert_effective_membership(conn, self.principal_id, self.group_id)?;
-            insert_manual_membership_source(conn, self.principal_id, self.group_id)?;
+        with_transaction(pool, async |conn| -> Result<PrincipalGroup, ApiError> {
+            let membership =
+                insert_effective_membership(conn, self.principal_id, self.group_id).await?;
+            insert_manual_membership_source(conn, self.principal_id, self.group_id).await?;
             Ok(membership)
         })
+        .await
     }
 
     async fn save_principal_group_record(
@@ -624,11 +673,13 @@ impl SavePrincipalGroupRecord for NewPrincipalGroup {
             return self.save_principal_group_record_without_events(pool).await;
         };
 
-        with_transaction(pool, |conn| -> Result<PrincipalGroup, ApiError> {
-            let already_present =
-                load_principal_group(conn, self.principal_id, self.group_id).optional()?;
-            let membership = insert_effective_membership(conn, self.principal_id, self.group_id)?;
-            insert_manual_membership_source(conn, self.principal_id, self.group_id)?;
+        with_transaction(pool, async |conn| -> Result<PrincipalGroup, ApiError> {
+            let already_present = load_principal_group(conn, self.principal_id, self.group_id)
+                .await
+                .optional()?;
+            let membership =
+                insert_effective_membership(conn, self.principal_id, self.group_id).await?;
+            insert_manual_membership_source(conn, self.principal_id, self.group_id).await?;
             match already_present {
                 None => {
                     let event = NewEvent::new(
@@ -645,12 +696,13 @@ impl SavePrincipalGroupRecord for NewPrincipalGroup {
                         membership.principal_id,
                         membership.group_id,
                     ));
-                    emit_event(conn, &event)?;
+                    emit_event(conn, &event).await?;
                     Ok(membership)
                 }
                 Some(_) => Ok(membership),
             }
         })
+        .await
     }
 }
 
@@ -659,11 +711,13 @@ impl SavePrincipalGroupRecord for PrincipalGroup {
         &self,
         pool: &DbPool,
     ) -> Result<PrincipalGroup, ApiError> {
-        with_transaction(pool, |conn| -> Result<PrincipalGroup, ApiError> {
-            let membership = insert_effective_membership(conn, self.principal_id, self.group_id)?;
-            insert_manual_membership_source(conn, self.principal_id, self.group_id)?;
+        with_transaction(pool, async |conn| -> Result<PrincipalGroup, ApiError> {
+            let membership =
+                insert_effective_membership(conn, self.principal_id, self.group_id).await?;
+            insert_manual_membership_source(conn, self.principal_id, self.group_id).await?;
             Ok(membership)
         })
+        .await
     }
 
     async fn save_principal_group_record(
@@ -675,9 +729,10 @@ impl SavePrincipalGroupRecord for PrincipalGroup {
             return self.save_principal_group_record_without_events(pool).await;
         };
 
-        with_transaction(pool, |conn| -> Result<PrincipalGroup, ApiError> {
-            let membership = insert_effective_membership(conn, self.principal_id, self.group_id)?;
-            insert_manual_membership_source(conn, self.principal_id, self.group_id)?;
+        with_transaction(pool, async |conn| -> Result<PrincipalGroup, ApiError> {
+            let membership =
+                insert_effective_membership(conn, self.principal_id, self.group_id).await?;
+            insert_manual_membership_source(conn, self.principal_id, self.group_id).await?;
             let event = NewEvent::new(
                 EntityType::UserGroup,
                 Action::Added,
@@ -692,14 +747,15 @@ impl SavePrincipalGroupRecord for PrincipalGroup {
                 membership.principal_id,
                 membership.group_id,
             ));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(membership)
         })
+        .await
     }
 }
 
-fn load_principal_group(
-    conn: &mut PgConnection,
+async fn load_principal_group(
+    conn: &mut crate::db::DbConnection,
     principal: i32,
     group: i32,
 ) -> Result<PrincipalGroup, diesel::result::Error> {
@@ -708,6 +764,7 @@ fn load_principal_group(
         .filter(principal_id.eq(principal))
         .filter(group_id.eq(group))
         .first::<PrincipalGroup>(conn)
+        .await
 }
 
 pub trait DeletePrincipalGroupRecord {
@@ -716,9 +773,10 @@ pub trait DeletePrincipalGroupRecord {
 
 impl DeletePrincipalGroupRecord for PrincipalGroup {
     async fn delete_principal_group_record(&self, pool: &DbPool) -> Result<(), ApiError> {
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
-            remove_manual_membership_source(conn, self.principal_id, self.group_id)
-        })?;
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
+            remove_manual_membership_source(conn, self.principal_id, self.group_id).await
+        })
+        .await?;
         Ok(())
     }
 }
@@ -731,11 +789,13 @@ impl PrincipalGroupPrincipalLookup for PrincipalGroup {
     async fn load_principal_group_principal(&self, pool: &DbPool) -> Result<Principal, ApiError> {
         use crate::schema::principals::dsl::{id, principals};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             principals
                 .filter(id.eq(self.principal_id))
                 .first::<Principal>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -747,8 +807,12 @@ impl PrincipalGroupGroupLookup for PrincipalGroup {
     async fn load_principal_group_group(&self, pool: &DbPool) -> Result<Group, ApiError> {
         use crate::schema::groups::dsl::{groups, id};
 
-        with_connection(pool, |conn| {
-            groups.filter(id.eq(self.group_id)).first::<Group>(conn)
+        with_connection(pool, async |conn| {
+            groups
+                .filter(id.eq(self.group_id))
+                .first::<Group>(conn)
+                .await
         })
+        .await
     }
 }

--- a/src/db/traits/history.rs
+++ b/src/db/traits/history.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
-use chrono::{DateTime, Utc};
-use diesel::prelude::*;
-
+use crate::db::prelude::*;
 use crate::db::{DbPool, with_connection};
 use crate::errors::ApiError;
 use crate::models::search::QueryOptions;
+use chrono::{DateTime, Utc};
 
 /// Batch-resolve a set of actor ids to principal names (anonymized users keep
 /// their tombstoned principal name; ids with no matching principal are absent).
@@ -19,12 +18,14 @@ pub async fn resolve_actor_usernames(
     if actor_ids.is_empty() {
         return Ok(HashMap::new());
     }
-    let rows: Vec<(i32, String)> = with_connection(pool, |conn| {
+    let rows: Vec<(i32, String)> = with_connection(pool, async |conn| {
         principals
             .filter(id.eq_any(&actor_ids))
             .select((id, name))
             .load(conn)
-    })?;
+            .await
+    })
+    .await?;
     Ok(rows.into_iter().collect())
 }
 
@@ -35,19 +36,23 @@ macro_rules! history_db_fns {
             pool: &$crate::db::DbPool,
             query_options: &$crate::models::search::QueryOptions,
         ) -> Result<(Vec<$ty>, i64), $crate::errors::ApiError> {
-            use diesel::prelude::*;
+            use $crate::db::prelude::*;
             use $($schema)::+::dsl::*;
-            let total = $crate::pagination::exact_count_or_skipped(query_options, || {
-                $crate::db::with_connection(pool, |conn| {
+            let total = $crate::pagination::exact_count_or_skipped(query_options, async || {
+                $crate::db::with_connection(pool, async |conn| {
                     $($schema)::+::table
                         .filter(id.eq(entity_id))
                         .count()
                         .get_result::<i64>(conn)
+                        .await
                 })
-            })?;
+                .await
+            }).await?;
             let mut query = $($schema)::+::table.into_boxed().filter(id.eq(entity_id));
             $crate::apply_query_options!(query, query_options, $ty);
-            let items = $crate::db::with_connection(pool, |conn| query.load::<$ty>(conn))?;
+            let items = $crate::db::with_connection(pool, async |conn| {
+                query.load::<$ty>(conn).await
+            }).await?;
             Ok((items, total))
         }
 
@@ -56,9 +61,9 @@ macro_rules! history_db_fns {
             at: chrono::DateTime<chrono::Utc>,
             pool: &$crate::db::DbPool,
         ) -> Result<Option<$ty>, $crate::errors::ApiError> {
-            use diesel::prelude::*;
+            use $crate::db::prelude::*;
             use $($schema)::+::dsl::*;
-            $crate::db::with_connection(pool, |conn| {
+            $crate::db::with_connection(pool, async |conn| {
                 $($schema)::+::table
                     .into_boxed()
                     .filter(id.eq(entity_id))
@@ -66,8 +71,10 @@ macro_rules! history_db_fns {
                     .filter(valid_to.is_null().or(valid_to.gt(at)))
                     .order(history_id.desc())
                     .first::<$ty>(conn)
+                    .await
                     .optional()
             })
+            .await
         }
     };
 }
@@ -108,23 +115,27 @@ pub async fn object_history_paginated_with_total_count(
 ) -> Result<(Vec<crate::models::HubuumObjectHistory>, i64), ApiError> {
     use crate::schema::hubuumobject_history::dsl as history;
 
-    let total = crate::pagination::exact_count_or_skipped(query_options, || {
-        with_connection(pool, |conn| {
+    let total = crate::pagination::exact_count_or_skipped(query_options, async || {
+        with_connection(pool, async |conn| {
             history::hubuumobject_history
                 .filter(history::id.eq(object_id))
                 .filter(history::hubuum_class_id.eq(class_id))
                 .count()
                 .get_result::<i64>(conn)
+                .await
         })
-    })?;
+        .await
+    })
+    .await?;
     let mut query = history::hubuumobject_history
         .into_boxed()
         .filter(history::id.eq(object_id))
         .filter(history::hubuum_class_id.eq(class_id));
     crate::apply_query_options!(query, query_options, crate::models::HubuumObjectHistory);
-    let items = with_connection(pool, |conn| {
-        query.load::<crate::models::HubuumObjectHistory>(conn)
-    })?;
+    let items = with_connection(pool, async |conn| {
+        query.load::<crate::models::HubuumObjectHistory>(conn).await
+    })
+    .await?;
     Ok((items, total))
 }
 
@@ -136,7 +147,7 @@ pub async fn object_as_of(
 ) -> Result<Option<crate::models::HubuumObjectHistory>, ApiError> {
     use crate::schema::hubuumobject_history::dsl as history;
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         history::hubuumobject_history
             .into_boxed()
             .filter(history::id.eq(object_id))
@@ -145,6 +156,8 @@ pub async fn object_as_of(
             .filter(history::valid_to.is_null().or(history::valid_to.gt(at)))
             .order(history::history_id.desc())
             .first::<crate::models::HubuumObjectHistory>(conn)
+            .await
             .optional()
     })
+    .await
 }

--- a/src/db/traits/identity.rs
+++ b/src/db/traits/identity.rs
@@ -1,13 +1,13 @@
-use diesel::prelude::*;
 use std::collections::{HashMap, HashSet};
 
-use crate::db::{DbPool, with_connection};
+use crate::db::prelude::*;
+use crate::db::{DbConnection, DbPool, with_connection};
 use crate::errors::ApiError;
 use crate::models::{IdentityScope, NewIdentityScope};
 use crate::schema::identity_scopes;
 
-pub(crate) fn identity_scope_id_by_name_conn(
-    conn: &mut PgConnection,
+pub(crate) async fn identity_scope_id_by_name_conn(
+    conn: &mut DbConnection,
     scope_name: &str,
 ) -> Result<i32, ApiError> {
     use crate::schema::identity_scopes::dsl::{identity_scopes as scopes, name};
@@ -15,6 +15,7 @@ pub(crate) fn identity_scope_id_by_name_conn(
         .filter(name.eq(scope_name))
         .select(identity_scopes::id)
         .first::<i32>(conn)
+        .await
         .map_err(ApiError::from)
 }
 
@@ -23,11 +24,13 @@ pub async fn identity_scope_by_name(
     scope_name: &str,
 ) -> Result<IdentityScope, ApiError> {
     use crate::schema::identity_scopes::dsl::{identity_scopes as scopes, name};
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         scopes
             .filter(name.eq(scope_name))
             .first::<IdentityScope>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn identity_scope_names_by_ids(
@@ -40,12 +43,14 @@ pub async fn identity_scope_names_by_ids(
 
     let unique_ids = scope_ids.iter().copied().collect::<HashSet<_>>();
     let query_ids = unique_ids.iter().copied().collect::<Vec<_>>();
-    let rows = with_connection(pool, |conn| {
+    let rows = with_connection(pool, async |conn| {
         identity_scopes::table
             .filter(identity_scopes::id.eq_any(&query_ids))
             .select((identity_scopes::id, identity_scopes::name))
             .load::<(i32, String)>(conn)
-    })?;
+            .await
+    })
+    .await?;
     if rows.len() != unique_ids.len() {
         return Err(ApiError::InternalServerError(
             "One or more identity scopes could not be resolved".to_string(),
@@ -61,7 +66,7 @@ pub async fn ensure_identity_scope(
     provider: &str,
 ) -> Result<IdentityScope, ApiError> {
     use crate::schema::identity_scopes::dsl::{identity_scopes as scopes, name};
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         diesel::insert_into(scopes)
             .values(NewIdentityScope {
                 name: scope_name,
@@ -71,5 +76,7 @@ pub async fn ensure_identity_scope(
             .do_update()
             .set(identity_scopes::provider_kind.eq(provider))
             .get_result::<IdentityScope>(conn)
+            .await
     })
+    .await
 }

--- a/src/db/traits/is_active.rs
+++ b/src/db/traits/is_active.rs
@@ -1,5 +1,5 @@
+use crate::db::prelude::*;
 use chrono::SubsecRound;
-use diesel::prelude::*;
 use tracing::warn;
 
 use crate::db::traits::Status;
@@ -39,7 +39,7 @@ impl Status<PrincipalToken> for Token {
         let now = chrono::Utc::now().naive_utc().trunc_subsecs(6);
         let cutoff = active_tokens_cutoff();
 
-        let result = with_connection_async(pool.clone(), move |conn| {
+        let result = with_connection_async(pool.clone(), async move |conn| {
             tokens
                 .filter(token.eq(&token_hash))
                 .filter(active_token_predicate(now, cutoff))
@@ -49,6 +49,7 @@ impl Status<PrincipalToken> for Token {
                         .filter(service_accounts::disabled_at.is_not_null()),
                 )))
                 .first::<PrincipalToken>(conn)
+                .await
                 .optional()
         })
         .await;
@@ -77,10 +78,11 @@ impl Status<PrincipalToken> for Token {
             // Best-effort telemetry: a failure to advance `last_used_at` must
             // never fail an otherwise-valid request.
             let token_id_value = valid_token.id;
-            let updated = with_connection_async(pool.clone(), move |conn| {
+            let updated = with_connection_async(pool.clone(), async move |conn| {
                 diesel::update(tokens.filter(token_id.eq(token_id_value)))
                     .set(last_used_at.eq(now))
                     .execute(conn)
+                    .await
             })
             .await;
             // Reflect the advance in the returned row (the SELECT above read the

--- a/src/db/traits/mod.rs
+++ b/src/db/traits/mod.rs
@@ -161,7 +161,6 @@ where
         query_options: &QueryOptions,
     ) -> Result<Vec<HubuumClassRelationTransitive>, ApiError> {
         use crate::pagination::{cursor_filter_sql, normalized_sorts, order_sql_clause};
-        use diesel::prelude::*;
         use diesel::sql_query;
         use diesel::sql_types::Integer;
 
@@ -195,7 +194,7 @@ where
             raw_sql.push_str(&format!("\nLIMIT {limit}"));
         }
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             let query = bind_transitive_filter_params!(
                 sql_query(raw_sql)
                     .bind::<Integer, _>(self.id())
@@ -203,8 +202,9 @@ where
                 filter
             );
 
-            query.load::<HubuumClassRelationTransitive>(conn)
+            diesel_async::RunQueryDsl::load::<HubuumClassRelationTransitive>(query, conn).await
         })
+        .await
     }
 
     // We typically end up searching, so this interface is rarely used.

--- a/src/db/traits/object.rs
+++ b/src/db/traits/object.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use diesel::sql_query;
 use jsonschema;
 use serde_json;
@@ -48,21 +48,25 @@ impl GetObject<(HubuumObject, HubuumObject)> for HubuumObjectRelationID {
         &self,
         pool: &DbPool,
     ) -> Result<(HubuumObject, HubuumObject), ApiError> {
+        use crate::db::prelude::*;
         use crate::schema::hubuumobject::dsl as obj;
         use crate::schema::hubuumobject_relation::dsl as obj_rel;
-        use diesel::prelude::*;
 
-        let objects = with_connection(pool, |conn| {
-            obj_rel::hubuumobject_relation
-                .filter(obj_rel::id.eq(self.id()))
-                .inner_join(
-                    obj::hubuumobject.on(obj::id
-                        .eq(obj_rel::from_hubuum_object_id)
-                        .or(obj::id.eq(obj_rel::to_hubuum_object_id))),
-                )
-                .select(obj::hubuumobject::all_columns())
-                .load::<HubuumObject>(conn)
-        })?;
+        let objects = with_connection(pool, async |conn| {
+            diesel_async::RunQueryDsl::load::<HubuumObject>(
+                obj_rel::hubuumobject_relation
+                    .filter(obj_rel::id.eq(self.id()))
+                    .inner_join(
+                        obj::hubuumobject.on(obj::id
+                            .eq(obj_rel::from_hubuum_object_id)
+                            .or(obj::id.eq(obj_rel::to_hubuum_object_id))),
+                    )
+                    .select(obj::hubuumobject::all_columns()),
+                conn,
+            )
+            .await
+        })
+        .await?;
 
         if objects.len() != 2 {
             return Err(ApiError::NotFound(
@@ -80,11 +84,13 @@ impl GetObject<(HubuumObject, HubuumObject)> for NewHubuumObjectRelation {
         pool: &DbPool,
     ) -> Result<(HubuumObject, HubuumObject), ApiError> {
         use crate::schema::hubuumobject::dsl::{hubuumobject, id};
-        let objects = with_connection(pool, |conn| {
+        let objects = with_connection(pool, async |conn| {
             hubuumobject
                 .filter(id.eq_any(vec![self.from_hubuum_object_id, self.to_hubuum_object_id]))
                 .load::<HubuumObject>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         if objects.len() != 2 {
             return Err(ApiError::NotFound(
@@ -104,21 +110,25 @@ impl GetObject<(HubuumObject, HubuumObject)> for HubuumObjectRelation {
         &self,
         pool: &DbPool,
     ) -> Result<(HubuumObject, HubuumObject), ApiError> {
+        use crate::db::prelude::*;
         use crate::schema::hubuumobject::dsl as obj;
         use crate::schema::hubuumobject_relation::dsl as obj_rel;
-        use diesel::prelude::*;
 
-        let objects = with_connection(pool, |conn| {
-            obj_rel::hubuumobject_relation
-                .filter(obj_rel::id.eq(self.id))
-                .inner_join(
-                    obj::hubuumobject.on(obj::id
-                        .eq(obj_rel::from_hubuum_object_id)
-                        .or(obj::id.eq(obj_rel::to_hubuum_object_id))),
-                )
-                .select(obj::hubuumobject::all_columns())
-                .load::<HubuumObject>(conn)
-        })?;
+        let objects = with_connection(pool, async |conn| {
+            diesel_async::RunQueryDsl::load::<HubuumObject>(
+                obj_rel::hubuumobject_relation
+                    .filter(obj_rel::id.eq(self.id))
+                    .inner_join(
+                        obj::hubuumobject.on(obj::id
+                            .eq(obj_rel::from_hubuum_object_id)
+                            .or(obj::id.eq(obj_rel::to_hubuum_object_id))),
+                    )
+                    .select(obj::hubuumobject::all_columns()),
+                conn,
+            )
+            .await
+        })
+        .await?;
 
         if objects.len() != 2 {
             return Err(ApiError::NotFound(
@@ -144,11 +154,13 @@ impl LoadObjectRecord for HubuumObjectID {
     async fn load_object_record(&self, pool: &DbPool) -> Result<HubuumObject, ApiError> {
         use crate::schema::hubuumobject::dsl::{hubuumobject, id};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             hubuumobject
                 .filter(id.eq(self.id()))
                 .first::<HubuumObject>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -175,11 +187,13 @@ impl CreateObjectRecord for NewHubuumObject {
     ) -> Result<HubuumObject, ApiError> {
         use crate::schema::hubuumobject::dsl::hubuumobject;
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             diesel::insert_into(hubuumobject)
                 .values(self)
                 .get_result::<HubuumObject>(conn)
+                .await
         })
+        .await
     }
 
     async fn create_object_record(
@@ -193,10 +207,11 @@ impl CreateObjectRecord for NewHubuumObject {
 
         use crate::schema::hubuumobject::dsl::hubuumobject;
 
-        with_transaction(pool, |conn| -> Result<HubuumObject, ApiError> {
+        with_transaction(pool, async |conn| -> Result<HubuumObject, ApiError> {
             let object = diesel::insert_into(hubuumobject)
                 .values(self)
-                .get_result::<HubuumObject>(conn)?;
+                .get_result::<HubuumObject>(conn)
+                .await?;
             let event = object_event(
                 &object,
                 Action::Created,
@@ -204,9 +219,10 @@ impl CreateObjectRecord for NewHubuumObject {
                 format!("Object '{}' created", object.name),
             )?
             .with_after(object_snapshot(&object));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(object)
         })
+        .await
     }
 }
 
@@ -401,16 +417,19 @@ impl UpdateObjectRecord for UpdateHubuumObject {
     ) -> Result<HubuumObject, ApiError> {
         use crate::schema::hubuumobject::dsl::{hubuumobject, id};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             crate::db::updated_or_current(
                 diesel::update(hubuumobject)
                     .filter(id.eq(object_id))
                     .set(self)
                     .get_result::<HubuumObject>(conn)
+                    .await
                     .optional(),
-                || hubuumobject.filter(id.eq(object_id)).first(conn),
+                async || hubuumobject.filter(id.eq(object_id)).first(conn).await,
             )
+            .await
         })
+        .await
     }
 
     async fn update_object_record(
@@ -427,13 +446,15 @@ impl UpdateObjectRecord for UpdateHubuumObject {
 
         use crate::schema::hubuumobject::dsl::{hubuumobject, id};
 
-        with_transaction(pool, |conn| -> Result<HubuumObject, ApiError> {
+        with_transaction(pool, async |conn| -> Result<HubuumObject, ApiError> {
             let before = hubuumobject
                 .filter(id.eq(object_id))
-                .first::<HubuumObject>(conn)?;
+                .first::<HubuumObject>(conn)
+                .await?;
             let updated = diesel::update(hubuumobject.filter(id.eq(object_id)))
                 .set(self)
-                .get_result::<HubuumObject>(conn)?;
+                .get_result::<HubuumObject>(conn)
+                .await?;
             let event = object_event(
                 &updated,
                 Action::Updated,
@@ -442,9 +463,10 @@ impl UpdateObjectRecord for UpdateHubuumObject {
             )?
             .with_before(object_snapshot(&before))
             .with_after(object_snapshot(&updated));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(updated)
         })
+        .await
     }
 }
 
@@ -465,9 +487,12 @@ impl DeleteObjectRecord for HubuumObject {
     async fn delete_object_record_without_events(&self, pool: &DbPool) -> Result<(), ApiError> {
         use crate::schema::hubuumobject::dsl::{hubuumobject, id};
 
-        with_connection(pool, |conn| {
-            diesel::delete(hubuumobject.filter(id.eq(self.id))).execute(conn)
-        })?;
+        with_connection(pool, async |conn| {
+            diesel::delete(hubuumobject.filter(id.eq(self.id)))
+                .execute(conn)
+                .await
+        })
+        .await?;
         Ok(())
     }
 
@@ -482,8 +507,10 @@ impl DeleteObjectRecord for HubuumObject {
 
         use crate::schema::hubuumobject::dsl::{hubuumobject, id};
 
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
-            diesel::delete(hubuumobject.filter(id.eq(self.id))).execute(conn)?;
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
+            diesel::delete(hubuumobject.filter(id.eq(self.id)))
+                .execute(conn)
+                .await?;
             let event = object_event(
                 self,
                 Action::Deleted,
@@ -491,9 +518,10 @@ impl DeleteObjectRecord for HubuumObject {
                 format!("Object '{}' deleted", self.name),
             )?
             .with_before(object_snapshot(self));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(())
         })
+        .await
     }
 }
 
@@ -505,11 +533,13 @@ impl ObjectCollectionLookup for HubuumObject {
     async fn lookup_object_collection(&self, pool: &DbPool) -> Result<Collection, ApiError> {
         use crate::schema::collections::dsl::{collections, id};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             collections
                 .filter(id.eq(self.collection_id))
                 .first::<Collection>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -530,11 +560,13 @@ impl ObjectClassLookup for HubuumObject {
     async fn lookup_object_class(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             hubuumclass
                 .filter(id.eq(self.hubuum_class_id))
                 .first::<HubuumClass>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -550,7 +582,10 @@ impl ObjectClassLookup for HubuumObjectID {
 pub async fn total_object_count_from_backend(pool: &DbPool) -> Result<i64, ApiError> {
     use crate::schema::hubuumobject::dsl::*;
 
-    with_connection(pool, |conn| hubuumobject.count().get_result::<i64>(conn))
+    with_connection(pool, async |conn| {
+        hubuumobject.count().get_result::<i64>(conn).await
+    })
+    .await
 }
 
 pub async fn objects_per_class_count_from_backend(
@@ -558,7 +593,8 @@ pub async fn objects_per_class_count_from_backend(
 ) -> Result<Vec<ObjectsByClass>, ApiError> {
     let raw_query =
         "SELECT hubuum_class_id, COUNT(*) as count FROM hubuumobject GROUP BY hubuum_class_id";
-    with_connection(pool, |conn| {
-        sql_query(raw_query).load::<ObjectsByClass>(conn)
+    with_connection(pool, async |conn| {
+        sql_query(raw_query).load::<ObjectsByClass>(conn).await
     })
+    .await
 }

--- a/src/db/traits/permissions.rs
+++ b/src/db/traits/permissions.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use serde::Serialize;
 
 use crate::db::{DbPool, with_connection, with_transaction};
@@ -301,8 +301,10 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
             base_query = permission.create_boxed_filter(base_query, true);
         }
 
-        let result: Option<Permission> =
-            with_connection(pool, |conn| base_query.first::<Permission>(conn).optional())?;
+        let result: Option<Permission> = with_connection(pool, async |conn| {
+            base_query.first::<Permission>(conn).await.optional()
+        })
+        .await?;
 
         Ok(result.is_some())
     }
@@ -318,11 +320,12 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
 
         let target_collection_id = self.collection_id(pool).await?.id();
 
-        with_transaction(pool, |conn| -> Result<Permission, ApiError> {
+        with_transaction(pool, async |conn| -> Result<Permission, ApiError> {
             let existing_entry = permissions
                 .filter(collection_id.eq(target_collection_id))
                 .filter(group_id.eq(group_id_for_grant))
                 .first::<Permission>(conn)
+                .await
                 .optional()?;
 
             match existing_entry {
@@ -467,7 +470,8 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
                         .filter(collection_id.eq(target_collection_id))
                         .filter(group_id.eq(group_id_for_grant))
                         .set(&update_perm)
-                        .get_result(conn)?)
+                        .get_result(conn)
+                        .await?)
                 }
                 None => {
                     let new_entry = NewPermission {
@@ -525,10 +529,12 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
 
                     Ok(diesel::insert_into(permissions)
                         .values(&new_entry)
-                        .get_result(conn)?)
+                        .get_result(conn)
+                        .await?)
                 }
             }
         })
+        .await
     }
 
     async fn apply_permissions_from_backend(
@@ -555,11 +561,12 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
         let target_collection_id = self.collection_id(pool).await?.id();
         let requested = permission_list.iter().copied().collect::<Vec<_>>();
 
-        with_transaction(pool, |conn| -> Result<Permission, ApiError> {
+        with_transaction(pool, async |conn| -> Result<Permission, ApiError> {
             let before = permissions
                 .filter(collection_id.eq(target_collection_id))
                 .filter(group_id.eq(group_id_for_grant))
                 .first::<Permission>(conn)
+                .await
                 .optional()?;
 
             let after = match before {
@@ -570,7 +577,8 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
                         .filter(collection_id.eq(target_collection_id))
                         .filter(group_id.eq(group_id_for_grant))
                         .set(&update_perm)
-                        .get_result::<Permission>(conn)?
+                        .get_result::<Permission>(conn)
+                        .await?
                 }
                 None => {
                     let new_entry = new_permission_from_list(
@@ -580,7 +588,8 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
                     );
                     diesel::insert_into(permissions)
                         .values(&new_entry)
-                        .get_result::<Permission>(conn)?
+                        .get_result::<Permission>(conn)
+                        .await?
                 }
             };
 
@@ -602,9 +611,10 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
             } else {
                 event
             };
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(after)
         })
+        .await
     }
 
     async fn revoke_permissions_from_backend_without_events(
@@ -617,11 +627,12 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
 
         let target_collection_id = self.collection_id(pool).await?.id();
 
-        with_transaction(pool, |conn| -> Result<Permission, ApiError> {
+        with_transaction(pool, async |conn| -> Result<Permission, ApiError> {
             permissions
                 .filter(collection_id.eq(target_collection_id))
                 .filter(group_id.eq(group_id_for_revoke))
-                .first::<Permission>(conn)?;
+                .first::<Permission>(conn)
+                .await?;
 
             let mut update_perm = UpdatePermission::default();
             for permission in permission_list.into_iter() {
@@ -726,8 +737,10 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
                 .filter(collection_id.eq(target_collection_id))
                 .filter(group_id.eq(group_id_for_revoke))
                 .set(&update_perm)
-                .get_result(conn)?)
+                .get_result(conn)
+                .await?)
         })
+        .await
     }
 
     async fn revoke_permissions_from_backend(
@@ -752,18 +765,20 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
         let target_collection_id = self.collection_id(pool).await?.id();
         let requested = permission_list.iter().copied().collect::<Vec<_>>();
 
-        with_transaction(pool, |conn| -> Result<Permission, ApiError> {
+        with_transaction(pool, async |conn| -> Result<Permission, ApiError> {
             let before = permissions
                 .filter(collection_id.eq(target_collection_id))
                 .filter(group_id.eq(group_id_for_revoke))
-                .first::<Permission>(conn)?;
+                .first::<Permission>(conn)
+                .await?;
 
             let update_perm = update_permission_for_revoke(&permission_list);
             let after = diesel::update(permissions)
                 .filter(collection_id.eq(target_collection_id))
                 .filter(group_id.eq(group_id_for_revoke))
                 .set(&update_perm)
-                .get_result::<Permission>(conn)?;
+                .get_result::<Permission>(conn)
+                .await?;
 
             let event = permission_event(
                 &after,
@@ -778,9 +793,10 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
             )?
             .with_before(permission_snapshot(&before))
             .with_after(permission_snapshot(&after));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(after)
         })
+        .await
     }
 
     async fn revoke_all_from_backend_without_events(
@@ -791,12 +807,14 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
         use crate::schema::permissions::dsl::*;
 
         let collection_id_for_revoke = self.collection_id(pool).await?.id();
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             diesel::delete(permissions)
                 .filter(collection_id.eq(collection_id_for_revoke))
                 .filter(group_id.eq(group_id_for_revoke))
                 .execute(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         Ok(())
     }
@@ -816,17 +834,19 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
         use crate::schema::permissions::dsl::*;
 
         let collection_id_for_revoke = self.collection_id(pool).await?.id();
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let before = permissions
                 .filter(collection_id.eq(collection_id_for_revoke))
                 .filter(group_id.eq(group_id_for_revoke))
                 .first::<Permission>(conn)
+                .await
                 .optional()?;
 
             diesel::delete(permissions)
                 .filter(collection_id.eq(collection_id_for_revoke))
                 .filter(group_id.eq(group_id_for_revoke))
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
 
             if let Some(before) = before {
                 let requested = before.granted();
@@ -842,11 +862,12 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
                     None,
                 )?
                 .with_before(permission_snapshot(&before));
-                emit_event(conn, &event)?;
+                emit_event(conn, &event).await?;
             }
 
             Ok(())
         })
+        .await
     }
 }
 

--- a/src/db/traits/principal.rs
+++ b/src/db/traits/principal.rs
@@ -1,20 +1,19 @@
-use diesel::prelude::*;
-
 use hubuum_events_core::EventContext;
 use serde_json::json;
 
-use crate::db::{DbPool, with_connection, with_transaction};
+use crate::db::prelude::*;
+use crate::db::{DbConnection, DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, NewEvent, emit_event};
 use crate::models::{NewPrincipal, Principal, PrincipalKind, PrincipalSettings, User};
 
 pub trait InsertPrincipalRecord {
     /// Insert the principal row and return it (principal-first id allocation).
-    fn insert(&self, conn: &mut PgConnection) -> Result<Principal, ApiError>;
+    async fn insert(&self, conn: &mut DbConnection) -> Result<Principal, ApiError>;
 }
 
 impl InsertPrincipalRecord for NewPrincipal<'_> {
-    fn insert(&self, conn: &mut PgConnection) -> Result<Principal, ApiError> {
+    async fn insert(&self, conn: &mut DbConnection) -> Result<Principal, ApiError> {
         use crate::schema::principals;
 
         diesel::insert_into(principals::table)
@@ -24,6 +23,7 @@ impl InsertPrincipalRecord for NewPrincipal<'_> {
                 principals::name.eq(self.name),
             ))
             .get_result::<Principal>(conn)
+            .await
             .map_err(ApiError::from)
     }
 }
@@ -33,11 +33,13 @@ pub async fn load_principal_by_id(
     principal_id_value: i32,
 ) -> Result<Principal, ApiError> {
     use crate::schema::principals::dsl::{id, principals as principals_table};
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         principals_table
             .filter(id.eq(principal_id_value))
             .first::<Principal>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn load_principal_settings(
@@ -46,12 +48,14 @@ pub async fn load_principal_settings(
 ) -> Result<PrincipalSettings, ApiError> {
     use crate::schema::principals::dsl::{id, principals as principals_table, settings};
 
-    let value = with_connection(pool, |conn| {
+    let value = with_connection(pool, async |conn| {
         principals_table
             .filter(id.eq(principal_id_value))
             .select(settings)
             .first::<serde_json::Value>(conn)
-    })?;
+            .await
+    })
+    .await?;
     stored_principal_settings(principal_id_value, value)
 }
 
@@ -71,12 +75,13 @@ pub async fn mutate_principal_settings(
 ) -> Result<PrincipalSettings, ApiError> {
     use crate::schema::principals;
 
-    with_transaction(pool, |conn| -> Result<PrincipalSettings, ApiError> {
+    with_transaction(pool, async |conn| -> Result<PrincipalSettings, ApiError> {
         let (kind, name, stored_before) = principals::table
             .filter(principals::id.eq(principal_id_value))
             .select((principals::kind, principals::name, principals::settings))
             .for_update()
-            .first::<(String, String, serde_json::Value)>(conn)?;
+            .first::<(String, String, serde_json::Value)>(conn)
+            .await?;
         let before = stored_principal_settings(principal_id_value, stored_before)?;
         let after = match mutation {
             PrincipalSettingsMutation::Replace => input,
@@ -86,7 +91,8 @@ pub async fn mutate_principal_settings(
 
         diesel::update(principals::table.filter(principals::id.eq(principal_id_value)))
             .set(principals::settings.eq(after.as_value()))
-            .execute(conn)?;
+            .execute(conn)
+            .await?;
 
         let entity_type = match PrincipalKind::from_db(&kind)? {
             PrincipalKind::Human => EntityType::User,
@@ -103,10 +109,11 @@ pub async fn mutate_principal_settings(
         .with_entity_name(name)
         .with_before(json!({ "settings": before }))
         .with_after(json!({ "settings": after }));
-        emit_event(conn, &event)?;
+        emit_event(conn, &event).await?;
 
         Ok(after)
     })
+    .await
 }
 
 fn stored_principal_settings(
@@ -128,13 +135,15 @@ pub async fn load_principal_with_user(
 ) -> Result<(Principal, Option<User>), ApiError> {
     use crate::schema::{principals, users};
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         principals::table
             .left_join(users::table.on(users::id.eq(principals::id)))
             .filter(principals::id.eq(principal_id_value))
             .select((Principal::as_select(), Option::<User>::as_select()))
             .first::<(Principal, Option<User>)>(conn)
+            .await
     })
+    .await
 }
 
 pub struct PrincipalIdentityMetadata {
@@ -152,13 +161,15 @@ pub async fn principal_identity_scope_and_name(
 ) -> Result<(String, String), ApiError> {
     use crate::schema::{identity_scopes, principals};
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         principals::table
             .inner_join(identity_scopes::table)
             .filter(principals::id.eq(principal_id_value))
             .select((identity_scopes::name, principals::name))
             .first::<(String, String)>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn principal_identity_metadata(
@@ -174,7 +185,7 @@ pub async fn principal_identity_metadata(
         provider_managed,
         last_sync_attempted_at,
         last_sync_success_at,
-    ) = with_connection(pool, |conn| {
+    ) = with_connection(pool, async |conn| {
         principals::table
             .inner_join(identity_scopes::table)
             .filter(principals::id.eq(principal_id_value))
@@ -194,7 +205,9 @@ pub async fn principal_identity_metadata(
                 Option<chrono::NaiveDateTime>,
                 Option<chrono::NaiveDateTime>,
             )>(conn)
-    })?;
+            .await
+    })
+    .await?;
 
     Ok(PrincipalIdentityMetadata {
         identity_scope,

--- a/src/db/traits/relations.rs
+++ b/src/db/traits/relations.rs
@@ -1,5 +1,5 @@
+use crate::db::prelude::*;
 use crate::db::traits::ClassRelation;
-use diesel::prelude::*;
 
 pub use crate::config::max_transitive_depth as max_transitive_depth_from_config;
 
@@ -233,21 +233,24 @@ where
         &self,
         pool: &DbPool,
     ) -> Result<Vec<HubuumClassRelationTransitive>, ApiError> {
-        use diesel::prelude::*;
         use diesel::sql_query;
         use diesel::sql_types::Integer;
 
-        with_connection(pool, |conn| {
-            sql_query(
-                "SELECT ancestor_class_id, descendant_class_id, depth, path
-                 FROM get_bidirectionally_related_classes($1, ARRAY[]::INT[], $2)
-                 WHERE ancestor_class_id = $1 OR descendant_class_id = $1
-                 ORDER BY depth ASC, descendant_class_id ASC",
+        with_connection(pool, async |conn| {
+            diesel_async::RunQueryDsl::load::<HubuumClassRelationTransitive>(
+                sql_query(
+                    "SELECT ancestor_class_id, descendant_class_id, depth, path
+                     FROM get_bidirectionally_related_classes($1, ARRAY[]::INT[], $2)
+                     WHERE ancestor_class_id = $1 OR descendant_class_id = $1
+                     ORDER BY depth ASC, descendant_class_id ASC",
+                )
+                .bind::<Integer, _>(self.id())
+                .bind::<Integer, _>(max_transitive_depth_from_config()),
+                conn,
             )
-            .bind::<Integer, _>(self.id())
-            .bind::<Integer, _>(max_transitive_depth_from_config())
-            .load::<HubuumClassRelationTransitive>(conn)
+            .await
         })
+        .await
     }
 
     async fn relations_from_backend(
@@ -256,12 +259,14 @@ where
     ) -> Result<Vec<HubuumClassRelation>, ApiError> {
         use crate::schema::hubuumclass_relation::dsl::*;
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             hubuumclass_relation
                 .or_filter(from_hubuum_class_id.eq(self.id()))
                 .or_filter(to_hubuum_class_id.eq(self.id()))
                 .load::<HubuumClassRelation>(conn)
+                .await
         })
+        .await
     }
 
     async fn search_relations_from_backend(
@@ -304,12 +309,14 @@ where
 
         trace_query!(base_query, "Searching relations");
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             base_query
                 .select(hubuumclass_relation::all_columns())
                 .distinct()
                 .load::<HubuumClassRelation>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -384,18 +391,22 @@ where
     C1: SelfAccessors<HubuumClass> + Clone + Send + Sync,
     C2: SelfAccessors<HubuumClass> + Clone + Send + Sync,
 {
+    use crate::db::prelude::*;
     use crate::schema::hubuumclass_relation::dsl::*;
-    use diesel::prelude::*;
 
     let (from, to) = (from.id(), to.id());
     let (from, to) = if from > to { (to, from) } else { (from, to) };
 
-    with_connection(pool, |conn| {
-        hubuumclass_relation
-            .filter(from_hubuum_class_id.eq(from))
-            .filter(to_hubuum_class_id.eq(to))
-            .first::<HubuumClassRelation>(conn)
+    with_connection(pool, async |conn| {
+        diesel_async::RunQueryDsl::first::<HubuumClassRelation>(
+            hubuumclass_relation
+                .filter(from_hubuum_class_id.eq(from))
+                .filter(to_hubuum_class_id.eq(to)),
+            conn,
+        )
+        .await
     })
+    .await
 }
 
 #[allow(dead_code)]
@@ -408,26 +419,29 @@ where
     C1: SelfAccessors<HubuumClass> + Clone + Send + Sync,
     C2: SelfAccessors<HubuumClass> + Clone + Send + Sync,
 {
-    use diesel::prelude::*;
     use diesel::sql_query;
     use diesel::sql_types::Integer;
 
     let (from, to) = (from.id(), to.id());
     let (from, to) = if from > to { (to, from) } else { (from, to) };
 
-    with_connection(pool, |conn| {
-        sql_query(
-            "SELECT ancestor_class_id, descendant_class_id, depth, path
-             FROM get_bidirectionally_related_classes($1, ARRAY[]::INT[], $2)
-             WHERE ancestor_class_id = $3 AND descendant_class_id = $4
-             ORDER BY depth ASC, descendant_class_id ASC",
+    with_connection(pool, async |conn| {
+        diesel_async::RunQueryDsl::load::<HubuumClassRelationTransitive>(
+            sql_query(
+                "SELECT ancestor_class_id, descendant_class_id, depth, path
+                 FROM get_bidirectionally_related_classes($1, ARRAY[]::INT[], $2)
+                 WHERE ancestor_class_id = $3 AND descendant_class_id = $4
+                 ORDER BY depth ASC, descendant_class_id ASC",
+            )
+            .bind::<Integer, _>(from)
+            .bind::<Integer, _>(max_transitive_depth_from_config())
+            .bind::<Integer, _>(from)
+            .bind::<Integer, _>(to),
+            conn,
         )
-        .bind::<Integer, _>(from)
-        .bind::<Integer, _>(max_transitive_depth_from_config())
-        .bind::<Integer, _>(from)
-        .bind::<Integer, _>(to)
-        .load::<HubuumClassRelationTransitive>(conn)
+        .await
     })
+    .await
 }
 
 #[allow(dead_code)]
@@ -442,7 +456,6 @@ where
     C2: SelfAccessors<HubuumClass> + Clone + Send + Sync,
 {
     use crate::pagination::{cursor_filter_sql, normalized_sorts, order_sql_clause};
-    use diesel::prelude::*;
     use diesel::sql_query;
     use diesel::sql_types::Integer;
 
@@ -477,7 +490,7 @@ where
         raw_sql.push_str(&format!("\nLIMIT {limit}"));
     }
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         let query = bind_transitive_filter_params!(
             sql_query(raw_sql.clone())
                 .bind::<Integer, _>(from)
@@ -485,11 +498,13 @@ where
             filter
         );
 
-        query
-            .bind::<Integer, _>(from)
-            .bind::<Integer, _>(to)
-            .load::<HubuumClassRelationTransitive>(conn)
+        diesel_async::RunQueryDsl::load::<HubuumClassRelationTransitive>(
+            query.bind::<Integer, _>(from).bind::<Integer, _>(to),
+            conn,
+        )
+        .await
     })
+    .await
 }
 
 impl<U> ObjectRelationsFromUser for U
@@ -508,7 +523,6 @@ where
         C: SelfAccessors<HubuumClass> + Clone + Send + Sync,
     {
         use crate::models::Permissions;
-        use diesel::RunQueryDsl;
         use diesel::sql_query;
         use diesel::sql_types::{Array, Integer};
 
@@ -516,16 +530,20 @@ where
         // object endpoints go through the scope-aware `objects_related_to_page`),
         // so this runs with full principal authority.
         let collections = user_can_on_any(pool, self, Permissions::ReadObject, None).await?;
-        with_connection(pool, |conn| {
-            sql_query("SELECT * FROM get_transitively_linked_objects($1, $2, $3, $4)")
-                .bind::<Integer, _>(source_object.id())
-                .bind::<Integer, _>(target_class.id())
-                .bind::<Array<Integer>, _>(
-                    collections.into_iter().map(|n| n.id()).collect::<Vec<_>>(),
-                )
-                .bind::<Integer, _>(max_transitive_depth_from_config())
-                .load::<HubuumObjectTransitiveLink>(conn)
+        with_connection(pool, async |conn| {
+            diesel_async::RunQueryDsl::load::<HubuumObjectTransitiveLink>(
+                sql_query("SELECT * FROM get_transitively_linked_objects($1, $2, $3, $4)")
+                    .bind::<Integer, _>(source_object.id())
+                    .bind::<Integer, _>(target_class.id())
+                    .bind::<Array<Integer>, _>(
+                        collections.into_iter().map(|n| n.id()).collect::<Vec<_>>(),
+                    )
+                    .bind::<Integer, _>(max_transitive_depth_from_config()),
+                conn,
+            )
+            .await
         })
+        .await
     }
 }
 
@@ -568,7 +586,7 @@ where
         use crate::schema::hubuumclass_relation::dsl as class_rel;
         use crate::schema::hubuumobject_relation::dsl as obj_rel;
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             obj_rel::hubuumobject_relation
                 .inner_join(class_rel::hubuumclass_relation)
                 .filter(
@@ -579,8 +597,10 @@ where
                 .filter(class_rel::id.eq(class_relation.id))
                 .select(obj_rel::id)
                 .first::<i32>(conn)
+                .await
                 .optional()
         })
+        .await
         .map(|result| result.is_some())
     }
 
@@ -600,7 +620,7 @@ where
         let (from, to) = (self.id(), target_object.id());
         let (from, to) = if from > to { (to, from) } else { (from, to) };
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             obj_rel::hubuumobject_relation
                 .inner_join(class_rel::hubuumclass_relation)
                 .filter(
@@ -615,7 +635,9 @@ where
                 )
                 .select(obj_rel::hubuumobject_relation::all_columns())
                 .first::<HubuumObjectRelation>(conn)
+                .await
         })
+        .await
     }
 
     async fn related_objects_from_backend<C>(
@@ -659,7 +681,7 @@ where
             }
         }
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             base_query
                 .inner_join(
                     obj_rel::hubuumobject_relation.on(obj::id
@@ -685,7 +707,9 @@ where
                 .select(obj::hubuumobject::all_columns())
                 .distinct()
                 .load::<HubuumObject>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -703,11 +727,13 @@ impl LoadClassRelationRecord for HubuumClassRelationID {
     ) -> Result<HubuumClassRelation, ApiError> {
         use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             hubuumclass_relation
                 .filter(id.eq(self.id()))
                 .first::<HubuumClassRelation>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -734,9 +760,12 @@ impl DeleteClassRelationRecord for HubuumClassRelation {
     ) -> Result<(), ApiError> {
         use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
 
-        with_connection(pool, |conn| {
-            diesel::delete(hubuumclass_relation.filter(id.eq(self.id))).execute(conn)
-        })?;
+        with_connection(pool, async |conn| {
+            diesel::delete(hubuumclass_relation.filter(id.eq(self.id)))
+                .execute(conn)
+                .await
+        })
+        .await?;
         Ok(())
     }
 
@@ -752,15 +781,19 @@ impl DeleteClassRelationRecord for HubuumClassRelation {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id as class_id};
         use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
 
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let from_class = hubuumclass
                 .filter(class_id.eq(self.from_hubuum_class_id))
-                .first::<HubuumClass>(conn)?;
+                .first::<HubuumClass>(conn)
+                .await?;
             let to_class = hubuumclass
                 .filter(class_id.eq(self.to_hubuum_class_id))
-                .first::<HubuumClass>(conn)?;
+                .first::<HubuumClass>(conn)
+                .await?;
 
-            diesel::delete(hubuumclass_relation.filter(id.eq(self.id))).execute(conn)?;
+            diesel::delete(hubuumclass_relation.filter(id.eq(self.id)))
+                .execute(conn)
+                .await?;
             let event = NewEvent::new(
                 EntityType::ClassRelation,
                 Action::Deleted,
@@ -774,9 +807,10 @@ impl DeleteClassRelationRecord for HubuumClassRelation {
             .with_entity_id(self.id)
             .with_before(class_relation_snapshot(self))
             .with_metadata(class_relation_metadata(&from_class, &to_class));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(())
         })
+        .await
     }
 }
 
@@ -787,9 +821,12 @@ impl DeleteClassRelationRecord for HubuumClassRelationID {
     ) -> Result<(), ApiError> {
         use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
 
-        with_connection(pool, |conn| {
-            diesel::delete(hubuumclass_relation.filter(id.eq(self.id()))).execute(conn)
-        })?;
+        with_connection(pool, async |conn| {
+            diesel::delete(hubuumclass_relation.filter(id.eq(self.id())))
+                .execute(conn)
+                .await
+        })
+        .await?;
         Ok(())
     }
 
@@ -805,17 +842,22 @@ impl DeleteClassRelationRecord for HubuumClassRelationID {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id as class_id};
         use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
 
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let relation = hubuumclass_relation
                 .filter(id.eq(self.id()))
-                .first::<HubuumClassRelation>(conn)?;
+                .first::<HubuumClassRelation>(conn)
+                .await?;
             let from_class = hubuumclass
                 .filter(class_id.eq(relation.from_hubuum_class_id))
-                .first::<HubuumClass>(conn)?;
+                .first::<HubuumClass>(conn)
+                .await?;
             let to_class = hubuumclass
                 .filter(class_id.eq(relation.to_hubuum_class_id))
-                .first::<HubuumClass>(conn)?;
-            diesel::delete(hubuumclass_relation.filter(id.eq(self.id()))).execute(conn)?;
+                .first::<HubuumClass>(conn)
+                .await?;
+            diesel::delete(hubuumclass_relation.filter(id.eq(self.id())))
+                .execute(conn)
+                .await?;
 
             let event = NewEvent::new(
                 EntityType::ClassRelation,
@@ -830,9 +872,10 @@ impl DeleteClassRelationRecord for HubuumClassRelationID {
             .with_entity_id(relation.id)
             .with_before(class_relation_snapshot(&relation))
             .with_metadata(class_relation_metadata(&from_class, &to_class));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(())
         })
+        .await
     }
 }
 
@@ -882,11 +925,13 @@ impl SaveClassRelationRecord for NewHubuumClassRelation {
             );
         }
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             diesel::insert_into(hubuumclass_relation)
                 .values(&normalized)
                 .get_result(conn)
+                .await
         })
+        .await
     }
 
     async fn save_class_relation_record(
@@ -924,32 +969,39 @@ impl SaveClassRelationRecord for NewHubuumClassRelation {
             );
         }
 
-        with_transaction(pool, |conn| -> Result<HubuumClassRelation, ApiError> {
-            let relation = diesel::insert_into(hubuumclass_relation)
-                .values(&normalized)
-                .get_result::<HubuumClassRelation>(conn)?;
-            let from_class = hubuumclass
-                .filter(id.eq(relation.from_hubuum_class_id))
-                .first::<HubuumClass>(conn)?;
-            let to_class = hubuumclass
-                .filter(id.eq(relation.to_hubuum_class_id))
-                .first::<HubuumClass>(conn)?;
-            let event = NewEvent::new(
-                EntityType::ClassRelation,
-                Action::Created,
-                context.actor_kind(),
-                format!(
-                    "Class relation {} -> {} created",
-                    relation.from_hubuum_class_id, relation.to_hubuum_class_id
-                ),
-            )?
-            .with_context(context)
-            .with_entity_id(relation.id)
-            .with_after(class_relation_snapshot(&relation))
-            .with_metadata(class_relation_metadata(&from_class, &to_class));
-            emit_event(conn, &event)?;
-            Ok(relation)
-        })
+        with_transaction(
+            pool,
+            async |conn| -> Result<HubuumClassRelation, ApiError> {
+                let relation = diesel::insert_into(hubuumclass_relation)
+                    .values(&normalized)
+                    .get_result::<HubuumClassRelation>(conn)
+                    .await?;
+                let from_class = hubuumclass
+                    .filter(id.eq(relation.from_hubuum_class_id))
+                    .first::<HubuumClass>(conn)
+                    .await?;
+                let to_class = hubuumclass
+                    .filter(id.eq(relation.to_hubuum_class_id))
+                    .first::<HubuumClass>(conn)
+                    .await?;
+                let event = NewEvent::new(
+                    EntityType::ClassRelation,
+                    Action::Created,
+                    context.actor_kind(),
+                    format!(
+                        "Class relation {} -> {} created",
+                        relation.from_hubuum_class_id, relation.to_hubuum_class_id
+                    ),
+                )?
+                .with_context(context)
+                .with_entity_id(relation.id)
+                .with_after(class_relation_snapshot(&relation))
+                .with_metadata(class_relation_metadata(&from_class, &to_class));
+                emit_event(conn, &event).await?;
+                Ok(relation)
+            },
+        )
+        .await
     }
 }
 
@@ -971,11 +1023,13 @@ impl LoadObjectRelationRecord for HubuumObjectRelationID {
     ) -> Result<HubuumObjectRelation, ApiError> {
         use crate::schema::hubuumobject_relation::dsl::{hubuumobject_relation, id};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             hubuumobject_relation
                 .filter(id.eq(self.id()))
                 .first::<HubuumObjectRelation>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -1003,9 +1057,12 @@ impl DeleteObjectRelationRecord for HubuumObjectRelation {
     ) -> Result<(), ApiError> {
         use crate::schema::hubuumobject_relation::dsl::{hubuumobject_relation, id};
 
-        with_connection(pool, |conn| {
-            diesel::delete(hubuumobject_relation.filter(id.eq(self.id))).execute(conn)
-        })?;
+        with_connection(pool, async |conn| {
+            diesel::delete(hubuumobject_relation.filter(id.eq(self.id)))
+                .execute(conn)
+                .await
+        })
+        .await?;
         Ok(())
     }
 
@@ -1023,14 +1080,18 @@ impl DeleteObjectRelationRecord for HubuumObjectRelation {
         use crate::schema::hubuumobject::dsl::{hubuumobject, id as object_id};
         use crate::schema::hubuumobject_relation::dsl::{hubuumobject_relation, id};
 
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let from_object = hubuumobject
                 .filter(object_id.eq(self.from_hubuum_object_id))
-                .first::<HubuumObject>(conn)?;
+                .first::<HubuumObject>(conn)
+                .await?;
             let to_object = hubuumobject
                 .filter(object_id.eq(self.to_hubuum_object_id))
-                .first::<HubuumObject>(conn)?;
-            diesel::delete(hubuumobject_relation.filter(id.eq(self.id))).execute(conn)?;
+                .first::<HubuumObject>(conn)
+                .await?;
+            diesel::delete(hubuumobject_relation.filter(id.eq(self.id)))
+                .execute(conn)
+                .await?;
             let event = NewEvent::new(
                 EntityType::ObjectRelation,
                 Action::Deleted,
@@ -1044,9 +1105,10 @@ impl DeleteObjectRelationRecord for HubuumObjectRelation {
             .with_entity_id(self.id)
             .with_before(object_relation_snapshot(self))
             .with_metadata(object_relation_metadata(self, &from_object, &to_object));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(())
         })
+        .await
     }
 }
 
@@ -1057,9 +1119,12 @@ impl DeleteObjectRelationRecord for HubuumObjectRelationID {
     ) -> Result<(), ApiError> {
         use crate::schema::hubuumobject_relation::dsl::{hubuumobject_relation, id};
 
-        with_connection(pool, |conn| {
-            diesel::delete(hubuumobject_relation.filter(id.eq(self.id()))).execute(conn)
-        })?;
+        with_connection(pool, async |conn| {
+            diesel::delete(hubuumobject_relation.filter(id.eq(self.id())))
+                .execute(conn)
+                .await
+        })
+        .await?;
         Ok(())
     }
 
@@ -1077,17 +1142,22 @@ impl DeleteObjectRelationRecord for HubuumObjectRelationID {
         use crate::schema::hubuumobject::dsl::{hubuumobject, id as object_id};
         use crate::schema::hubuumobject_relation::dsl::{hubuumobject_relation, id};
 
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let relation = hubuumobject_relation
                 .filter(id.eq(self.id()))
-                .first::<HubuumObjectRelation>(conn)?;
+                .first::<HubuumObjectRelation>(conn)
+                .await?;
             let from_object = hubuumobject
                 .filter(object_id.eq(relation.from_hubuum_object_id))
-                .first::<HubuumObject>(conn)?;
+                .first::<HubuumObject>(conn)
+                .await?;
             let to_object = hubuumobject
                 .filter(object_id.eq(relation.to_hubuum_object_id))
-                .first::<HubuumObject>(conn)?;
-            diesel::delete(hubuumobject_relation.filter(id.eq(self.id()))).execute(conn)?;
+                .first::<HubuumObject>(conn)
+                .await?;
+            diesel::delete(hubuumobject_relation.filter(id.eq(self.id())))
+                .execute(conn)
+                .await?;
             let event = NewEvent::new(
                 EntityType::ObjectRelation,
                 Action::Deleted,
@@ -1105,9 +1175,10 @@ impl DeleteObjectRelationRecord for HubuumObjectRelationID {
                 &from_object,
                 &to_object,
             ));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(())
         })
+        .await
     }
 }
 
@@ -1171,11 +1242,13 @@ impl SaveObjectRelationRecord for NewHubuumObjectRelation {
             ));
         }
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             diesel::insert_into(hubuumobject_relation)
                 .values(self)
                 .get_result(conn)
+                .await
         })
+        .await
     }
 
     async fn save_object_relation_record(
@@ -1226,25 +1299,30 @@ impl SaveObjectRelationRecord for NewHubuumObjectRelation {
             ));
         }
 
-        with_transaction(pool, |conn| -> Result<HubuumObjectRelation, ApiError> {
-            let relation = diesel::insert_into(hubuumobject_relation)
-                .values(self)
-                .get_result::<HubuumObjectRelation>(conn)?;
-            let event = NewEvent::new(
-                EntityType::ObjectRelation,
-                Action::Created,
-                context.actor_kind(),
-                format!(
-                    "Object relation {} -> {} created",
-                    relation.from_hubuum_object_id, relation.to_hubuum_object_id
-                ),
-            )?
-            .with_context(context)
-            .with_entity_id(relation.id)
-            .with_after(object_relation_snapshot(&relation))
-            .with_metadata(object_relation_metadata(&relation, &obj1, &obj2));
-            emit_event(conn, &event)?;
-            Ok(relation)
-        })
+        with_transaction(
+            pool,
+            async |conn| -> Result<HubuumObjectRelation, ApiError> {
+                let relation = diesel::insert_into(hubuumobject_relation)
+                    .values(self)
+                    .get_result::<HubuumObjectRelation>(conn)
+                    .await?;
+                let event = NewEvent::new(
+                    EntityType::ObjectRelation,
+                    Action::Created,
+                    context.actor_kind(),
+                    format!(
+                        "Object relation {} -> {} created",
+                        relation.from_hubuum_object_id, relation.to_hubuum_object_id
+                    ),
+                )?
+                .with_context(context)
+                .with_entity_id(relation.id)
+                .with_after(object_relation_snapshot(&relation))
+                .with_metadata(object_relation_metadata(&relation, &obj1, &obj2));
+                emit_event(conn, &event).await?;
+                Ok(relation)
+            },
+        )
+        .await
     }
 }

--- a/src/db/traits/remote_target.rs
+++ b/src/db/traits/remote_target.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 
 use crate::apply_query_options;
 use crate::db::{DbPool, with_connection, with_transaction};
@@ -37,11 +37,13 @@ impl LoadRemoteTargetRecord for RemoteTargetID {
     async fn load_remote_target_record(&self, pool: &DbPool) -> Result<RemoteTargetRow, ApiError> {
         use crate::schema::remote_targets::dsl::{id, remote_targets};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             remote_targets
                 .filter(id.eq(self.id()))
                 .first::<RemoteTargetRow>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -68,11 +70,13 @@ impl SaveRemoteTargetRecord for NewRemoteTargetRow {
     ) -> Result<RemoteTargetRow, ApiError> {
         use crate::schema::remote_targets::dsl::remote_targets;
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             diesel::insert_into(remote_targets)
                 .values(self)
                 .get_result::<RemoteTargetRow>(conn)
+                .await
         })
+        .await
     }
 
     async fn save_remote_target_record(
@@ -86,10 +90,11 @@ impl SaveRemoteTargetRecord for NewRemoteTargetRow {
 
         use crate::schema::remote_targets::dsl::remote_targets;
 
-        with_transaction(pool, |conn| -> Result<RemoteTargetRow, ApiError> {
+        with_transaction(pool, async |conn| -> Result<RemoteTargetRow, ApiError> {
             let row = diesel::insert_into(remote_targets)
                 .values(self)
-                .get_result::<RemoteTargetRow>(conn)?;
+                .get_result::<RemoteTargetRow>(conn)
+                .await?;
             let event = remote_target_event(
                 &row,
                 Action::Created,
@@ -97,9 +102,10 @@ impl SaveRemoteTargetRecord for NewRemoteTargetRow {
                 format!("Remote target '{}' created", row.name),
             )?
             .with_after(row.audit_snapshot());
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(row)
         })
+        .await
     }
 }
 
@@ -130,15 +136,18 @@ impl UpdateRemoteTargetRecord for UpdateRemoteTargetRow {
     ) -> Result<RemoteTargetRow, ApiError> {
         use crate::schema::remote_targets::dsl::{id, remote_targets};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             crate::db::updated_or_current(
                 diesel::update(remote_targets.filter(id.eq(target_id)))
                     .set(self)
                     .get_result::<RemoteTargetRow>(conn)
+                    .await
                     .optional(),
-                || remote_targets.filter(id.eq(target_id)).first(conn),
+                async || remote_targets.filter(id.eq(target_id)).first(conn).await,
             )
+            .await
         })
+        .await
     }
 
     async fn update_remote_target_record(
@@ -155,13 +164,15 @@ impl UpdateRemoteTargetRecord for UpdateRemoteTargetRow {
 
         use crate::schema::remote_targets::dsl::{id, remote_targets};
 
-        with_transaction(pool, |conn| -> Result<RemoteTargetRow, ApiError> {
+        with_transaction(pool, async |conn| -> Result<RemoteTargetRow, ApiError> {
             let before = remote_targets
                 .filter(id.eq(target_id))
-                .first::<RemoteTargetRow>(conn)?;
+                .first::<RemoteTargetRow>(conn)
+                .await?;
             let after = diesel::update(remote_targets.filter(id.eq(target_id)))
                 .set(self)
-                .get_result::<RemoteTargetRow>(conn)?;
+                .get_result::<RemoteTargetRow>(conn)
+                .await?;
             let event = remote_target_event(
                 &after,
                 Action::Updated,
@@ -170,9 +181,10 @@ impl UpdateRemoteTargetRecord for UpdateRemoteTargetRow {
             )?
             .with_before(before.audit_snapshot())
             .with_after(after.audit_snapshot());
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(after)
         })
+        .await
     }
 }
 
@@ -199,9 +211,12 @@ impl DeleteRemoteTargetRecord for RemoteTargetID {
     ) -> Result<(), ApiError> {
         use crate::schema::remote_targets::dsl::{id, remote_targets};
 
-        with_connection(pool, |conn| {
-            diesel::delete(remote_targets.filter(id.eq(self.id()))).execute(conn)
-        })?;
+        with_connection(pool, async |conn| {
+            diesel::delete(remote_targets.filter(id.eq(self.id())))
+                .execute(conn)
+                .await
+        })
+        .await?;
         Ok(())
     }
 
@@ -216,11 +231,14 @@ impl DeleteRemoteTargetRecord for RemoteTargetID {
 
         use crate::schema::remote_targets::dsl::{id, remote_targets};
 
-        with_transaction(pool, |conn| -> Result<(), ApiError> {
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let before = remote_targets
                 .filter(id.eq(self.id()))
-                .first::<RemoteTargetRow>(conn)?;
-            diesel::delete(remote_targets.filter(id.eq(self.id()))).execute(conn)?;
+                .first::<RemoteTargetRow>(conn)
+                .await?;
+            diesel::delete(remote_targets.filter(id.eq(self.id())))
+                .execute(conn)
+                .await?;
             let event = remote_target_event(
                 &before,
                 Action::Deleted,
@@ -228,9 +246,10 @@ impl DeleteRemoteTargetRecord for RemoteTargetID {
                 format!("Remote target '{}' deleted", before.name),
             )?
             .with_before(before.audit_snapshot());
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(())
         })
+        .await
     }
 }
 
@@ -242,7 +261,7 @@ pub(crate) async fn emit_remote_target_invoked_event(
     subject_type: &str,
     subject_id: i32,
 ) -> Result<(), ApiError> {
-    with_connection(pool, |conn| -> Result<(), ApiError> {
+    with_connection(pool, async |conn| -> Result<(), ApiError> {
         let event = NewEvent::new(
             EntityType::RemoteTarget,
             Action::Invoked,
@@ -258,9 +277,10 @@ pub(crate) async fn emit_remote_target_invoked_event(
             "subject_type": subject_type,
             "subject_id": subject_id,
         }));
-        emit_event(conn, &event)?;
+        emit_event(conn, &event).await?;
         Ok(())
     })
+    .await
 }
 
 pub(crate) async fn list_rows_with_total_count(
@@ -269,13 +289,18 @@ pub(crate) async fn list_rows_with_total_count(
     query_options: &QueryOptions,
 ) -> Result<(Vec<RemoteTargetRow>, i64), ApiError> {
     let query = build_list_query(allowed_collection_ids, query_options)?;
-    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-        with_connection(pool, |conn| query.count().get_result::<i64>(conn))
-    })?;
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+        with_connection(pool, async |conn| {
+            query.count().get_result::<i64>(conn).await
+        })
+        .await
+    })
+    .await?;
 
     let mut query = build_list_query(allowed_collection_ids, query_options)?;
     apply_query_options!(query, query_options, RemoteTarget);
-    let rows = with_connection(pool, |conn| query.load::<RemoteTargetRow>(conn))?;
+    let rows =
+        with_connection(pool, async |conn| query.load::<RemoteTargetRow>(conn).await).await?;
 
     Ok((rows, total_count))
 }
@@ -324,7 +349,7 @@ pub async fn insert_remote_call_result(
 ) -> Result<RemoteCallResult, ApiError> {
     use crate::schema::remote_call_results::dsl::{remote_call_results, task_id};
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         diesel::insert_into(remote_call_results)
             .values(&entry)
             .on_conflict(task_id)
@@ -345,7 +370,9 @@ pub async fn insert_remote_call_result(
                 crate::schema::remote_call_results::error.eq(entry.error.clone()),
             ))
             .get_result::<RemoteCallResult>(conn)
+            .await
     })
+    .await
 }
 
 impl RemoteTargetID {

--- a/src/db/traits/service_account.rs
+++ b/src/db/traits/service_account.rs
@@ -1,10 +1,9 @@
-use diesel::PgConnection;
-use diesel::prelude::*;
 use serde_json::json;
 
+use crate::db::prelude::*;
 use crate::db::traits::identity::identity_scope_by_name;
 use crate::db::traits::principal::InsertPrincipalRecord;
-use crate::db::{DbPool, with_connection, with_transaction};
+use crate::db::{DbConnection, DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
 use crate::models::identity::LOCAL_IDENTITY_SCOPE;
@@ -91,13 +90,14 @@ where
 
     with_transaction(
         backend.db_pool(),
-        |conn| -> Result<ServiceAccount, ApiError> {
+        async |conn| -> Result<ServiceAccount, ApiError> {
             let principal = NewPrincipal {
                 identity_scope_id: local_scope.id,
                 kind: PrincipalKind::ServiceAccount.as_str(),
                 name: &name,
             }
-            .insert(conn)?;
+            .insert(conn)
+            .await?;
 
             let sa = diesel::insert_into(service_accounts::table)
                 .values((
@@ -106,7 +106,8 @@ where
                     service_accounts::owner_group_id.eq(owner_group_id),
                     service_accounts::created_by.eq(created_by),
                 ))
-                .get_result::<ServiceAccount>(conn)?;
+                .get_result::<ServiceAccount>(conn)
+                .await?;
             if let Some(event_context) = event_context {
                 let event = NewEvent::new(
                     EntityType::ServiceAccount,
@@ -129,12 +130,13 @@ where
                     "owner_group_id": sa.owner_group_id,
                     "created_by": created_by,
                 }));
-                emit_event(conn, &event)?;
+                emit_event(conn, &event).await?;
             }
 
             Ok(sa)
         },
     )
+    .await
 }
 
 impl UpdateAdapter for UpdateServiceAccount {
@@ -166,21 +168,23 @@ async fn update_service_account_record(
 ) -> Result<ServiceAccount, ApiError> {
     use crate::schema::service_accounts::dsl::{id, service_accounts as sa_table};
 
-    with_transaction(pool, |conn| -> Result<ServiceAccount, ApiError> {
+    with_transaction(pool, async |conn| -> Result<ServiceAccount, ApiError> {
         let before = if event_context.is_some() {
             Some(
                 sa_table
                     .filter(id.eq(service_account_id))
-                    .first::<ServiceAccount>(conn)?,
+                    .first::<ServiceAccount>(conn)
+                    .await?,
             )
         } else {
             None
         };
         let updated = diesel::update(sa_table.filter(id.eq(service_account_id)))
             .set(update)
-            .get_result::<ServiceAccount>(conn)?;
+            .get_result::<ServiceAccount>(conn)
+            .await?;
         if let Some(event_context) = event_context {
-            let name = load_principal_name_by_id(conn, updated.id)?;
+            let name = load_principal_name_by_id(conn, updated.id).await?;
             let before = before.ok_or_else(|| {
                 ApiError::InternalServerError("missing service account event snapshot".to_string())
             })?;
@@ -198,10 +202,11 @@ async fn update_service_account_record(
             .with_metadata(json!({
                 "owner_group_id": updated.owner_group_id,
             }));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
         }
         Ok(updated)
     })
+    .await
 }
 
 impl InstanceAdapter<ServiceAccount> for ServiceAccountID {
@@ -268,15 +273,17 @@ where
     let sa_id = account_id.id();
     with_transaction(
         backend.db_pool(),
-        |conn| -> Result<ServiceAccount, ApiError> {
+        async |conn| -> Result<ServiceAccount, ApiError> {
             let before = sa_table
                 .filter(id.eq(sa_id))
-                .first::<ServiceAccount>(conn)?;
+                .first::<ServiceAccount>(conn)
+                .await?;
             let disabled = diesel::update(sa_table.filter(id.eq(sa_id)))
                 .set(disabled_at.eq(diesel::dsl::now))
-                .get_result::<ServiceAccount>(conn)?;
+                .get_result::<ServiceAccount>(conn)
+                .await?;
             if let Some(event_context) = event_context {
-                let name = load_principal_name_by_id(conn, disabled.id)?;
+                let name = load_principal_name_by_id(conn, disabled.id).await?;
                 let event = NewEvent::new(
                     EntityType::ServiceAccount,
                     Action::Disabled,
@@ -291,11 +298,12 @@ where
                 .with_metadata(json!({
                     "owner_group_id": disabled.owner_group_id,
                 }));
-                emit_event(conn, &event)?;
+                emit_event(conn, &event).await?;
             }
             Ok(disabled)
         },
     )
+    .await
 }
 
 async fn delete_service_account(
@@ -305,10 +313,10 @@ async fn delete_service_account(
 ) -> Result<(), ApiError> {
     use crate::schema::principals::dsl::{id, principals as principals_table};
     let sa_id = account_id.id();
-    with_transaction(pool, |conn| -> Result<(), ApiError> {
-        let sa = load_service_account_by_id_conn(conn, sa_id)?;
+    with_transaction(pool, async |conn| -> Result<(), ApiError> {
+        let sa = load_service_account_by_id_conn(conn, sa_id).await?;
         if let Some(event_context) = event_context {
-            let name = load_principal_name_by_id(conn, sa_id)?;
+            let name = load_principal_name_by_id(conn, sa_id).await?;
             let event = NewEvent::new(
                 EntityType::ServiceAccount,
                 Action::Deleted,
@@ -322,15 +330,18 @@ async fn delete_service_account(
             .with_metadata(json!({
                 "owner_group_id": sa.owner_group_id,
             }));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
         }
-        diesel::delete(principals_table.filter(id.eq(sa_id))).execute(conn)?;
+        diesel::delete(principals_table.filter(id.eq(sa_id)))
+            .execute(conn)
+            .await?;
         Ok(())
     })
+    .await
 }
 
-fn load_principal_name_by_id(
-    conn: &mut PgConnection,
+async fn load_principal_name_by_id(
+    conn: &mut DbConnection,
     principal_id_value: i32,
 ) -> Result<String, ApiError> {
     use crate::schema::principals::dsl::{id, name, principals};
@@ -339,17 +350,19 @@ fn load_principal_name_by_id(
         .filter(id.eq(principal_id_value))
         .select(name)
         .first::<String>(conn)
+        .await
         .map_err(ApiError::from)
 }
 
-fn load_service_account_by_id_conn(
-    conn: &mut PgConnection,
+async fn load_service_account_by_id_conn(
+    conn: &mut DbConnection,
     service_account_id: i32,
 ) -> Result<ServiceAccount, ApiError> {
     use crate::schema::service_accounts::dsl::{id, service_accounts as sa_table};
     sa_table
         .filter(id.eq(service_account_id))
         .first::<ServiceAccount>(conn)
+        .await
         .map_err(ApiError::from)
 }
 
@@ -374,7 +387,7 @@ pub async fn is_human_owner_group_member(
     use crate::schema::principals;
     use diesel::dsl::{exists, select};
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         select(exists(
             group_memberships::table
                 .inner_join(
@@ -385,7 +398,9 @@ pub async fn is_human_owner_group_member(
                 .filter(principals::kind.eq(PrincipalKind::Human.as_str())),
         ))
         .get_result(conn)
+        .await
     })
+    .await
 }
 
 pub async fn principal_is_disabled(pool: &DbPool, principal: &Principal) -> Result<bool, ApiError> {
@@ -402,7 +417,7 @@ pub async fn revoke_all_tokens_for_principal(
     principal_id_value: i32,
 ) -> Result<usize, ApiError> {
     use crate::schema::tokens::dsl::{principal_id, revoked_at, tokens};
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         diesel::update(
             tokens
                 .filter(principal_id.eq(principal_id_value))
@@ -410,7 +425,9 @@ pub async fn revoke_all_tokens_for_principal(
         )
         .set(revoked_at.eq(diesel::dsl::now))
         .execute(conn)
+        .await
     })
+    .await
 }
 
 pub async fn cancel_pending_tasks_for_principal(
@@ -418,7 +435,7 @@ pub async fn cancel_pending_tasks_for_principal(
     principal_id_value: i32,
 ) -> Result<usize, ApiError> {
     use crate::schema::tasks::dsl::{status, submitted_by, tasks};
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         diesel::update(
             tasks
                 .filter(submitted_by.eq(principal_id_value))
@@ -426,7 +443,9 @@ pub async fn cancel_pending_tasks_for_principal(
         )
         .set(status.eq(TaskStatus::Cancelled.as_str()))
         .execute(conn)
+        .await
     })
+    .await
 }
 
 pub async fn service_accounts_owned_by_group(
@@ -435,13 +454,15 @@ pub async fn service_accounts_owned_by_group(
 ) -> Result<Vec<(i32, String)>, ApiError> {
     use crate::schema::principals;
     use crate::schema::service_accounts;
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         service_accounts::table
             .inner_join(principals::table.on(principals::id.eq(service_accounts::id)))
             .filter(service_accounts::owner_group_id.eq(owner_group))
             .select((service_accounts::id, principals::name))
             .load::<(i32, String)>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn load_service_account_by_id(
@@ -449,11 +470,13 @@ pub async fn load_service_account_by_id(
     service_account_id: i32,
 ) -> Result<ServiceAccount, ApiError> {
     use crate::schema::service_accounts::dsl::{id, service_accounts as sa_table};
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         sa_table
             .filter(id.eq(service_account_id))
             .first::<ServiceAccount>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn search_manageable_service_accounts<S>(
@@ -505,7 +528,7 @@ where
 
     apply_query_options!(base_query, query_options, ServiceAccountWithName);
 
-    let rows = with_connection(pool, |conn| {
+    let rows = with_connection(pool, async |conn| {
         base_query
             .select((
                 ServiceAccount::as_select(),
@@ -513,7 +536,9 @@ where
                 principals::name,
             ))
             .load::<(ServiceAccount, String, String)>(conn)
-    })?;
+            .await
+    })
+    .await?;
 
     Ok(rows
         .into_iter()
@@ -568,5 +593,8 @@ where
         }
     }
 
-    with_connection(pool, |conn| base_query.count().get_result::<i64>(conn))
+    with_connection(pool, async |conn| {
+        base_query.count().get_result::<i64>(conn).await
+    })
+    .await
 }

--- a/src/db/traits/task.rs
+++ b/src/db/traits/task.rs
@@ -1,6 +1,5 @@
+use crate::db::prelude::*;
 use chrono::Utc;
-use diesel::PgConnection;
-use diesel::prelude::*;
 use diesel::sql_types::{BigInt, Bool};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing::info;
@@ -118,9 +117,13 @@ pub trait TaskBackend: TaskIdentifier {
         use crate::schema::tasks::dsl::{id, tasks};
 
         let task_id_value = self.task_id();
-        with_connection(pool, |conn| {
-            tasks.filter(id.eq(task_id_value)).first::<TaskRecord>(conn)
+        with_connection(pool, async |conn| {
+            tasks
+                .filter(id.eq(task_id_value))
+                .first::<TaskRecord>(conn)
+                .await
         })
+        .await
     }
 
     async fn list_events_with_total_count(
@@ -136,22 +139,26 @@ pub trait TaskBackend: TaskIdentifier {
             .unwrap_or(page_limits_or_defaults().0.saturating_add(1));
         let descending = query_options
             .sort
+            .as_slice()
             .first()
             .map(|sort| sort.descending)
             .unwrap_or(false);
         let cursor_id = decode_task_event_cursor_id(query_options)?;
 
-        let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-            with_connection(pool, |conn| {
+        let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+            with_connection(pool, async |conn| {
                 events
                     .filter(entity_type.eq(EntityType::Task.as_str()))
                     .filter(entity_id.eq(Some(task_id_value)))
                     .count()
                     .get_result::<i64>(conn)
+                    .await
             })
-        })?;
+            .await
+        })
+        .await?;
 
-        let items = with_connection(pool, |conn| {
+        let items = with_connection(pool, async |conn| {
             let mut query = events
                 .filter(entity_type.eq(EntityType::Task.as_str()))
                 .filter(entity_id.eq(Some(task_id_value)))
@@ -169,13 +176,16 @@ pub trait TaskBackend: TaskIdentifier {
                     .order(id.desc())
                     .limit(limit as i64)
                     .load::<crate::events::Event>(conn)
+                    .await
             } else {
                 query
                     .order(id.asc())
                     .limit(limit as i64)
                     .load::<crate::events::Event>(conn)
+                    .await
             }
-        })?
+        })
+        .await?
         .into_iter()
         .map(TaskEventRecord::try_from)
         .collect::<Result<Vec<_>, _>>()?;
@@ -196,21 +206,25 @@ pub trait TaskBackend: TaskIdentifier {
             .unwrap_or(page_limits_or_defaults().0.saturating_add(1));
         let descending = query_options
             .sort
+            .as_slice()
             .first()
             .map(|sort| sort.descending)
             .unwrap_or(false);
         let cursor_id = decode_int_history_cursor_id(query_options)?;
 
-        let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-            with_connection(pool, |conn| {
+        let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+            with_connection(pool, async |conn| {
                 import_task_results
                     .filter(task_id.eq(task_id_value))
                     .count()
                     .get_result::<i64>(conn)
+                    .await
             })
-        })?;
+            .await
+        })
+        .await?;
 
-        let items = with_connection(pool, |conn| {
+        let items = with_connection(pool, async |conn| {
             let mut query = import_task_results
                 .filter(task_id.eq(task_id_value))
                 .into_boxed();
@@ -227,13 +241,16 @@ pub trait TaskBackend: TaskIdentifier {
                     .order(id.desc())
                     .limit(limit as i64)
                     .load::<ImportTaskResultRecord>(conn)
+                    .await
             } else {
                 query
                     .order(id.asc())
                     .limit(limit as i64)
                     .load::<ImportTaskResultRecord>(conn)
+                    .await
             }
-        })?;
+        })
+        .await?;
 
         Ok((items, total_count))
     }
@@ -248,12 +265,14 @@ pub trait TaskBackend: TaskIdentifier {
         let now = Utc::now().naive_utc();
         // Fetch without the expiry filter so an expired-but-present row is exported as `Expired`
         // (410) rather than silently looking like a row that never existed (404).
-        let record = with_connection(pool, |conn| {
+        let record = with_connection(pool, async |conn| {
             export_task_outputs
                 .filter(task_id.eq(task_id_value))
                 .first::<ExportTaskOutputRecord>(conn)
+                .await
                 .optional()
-        })?;
+        })
+        .await?;
 
         Ok(match record {
             Some(record) if record.output_expires_at > now => ExportOutputLookup::Available(record),
@@ -272,13 +291,15 @@ pub trait TaskBackend: TaskIdentifier {
 
         let task_id_value = self.task_id();
         let now = Utc::now().naive_utc();
-        let record = with_connection(pool, |conn| {
+        let record = with_connection(pool, async |conn| {
             export_task_outputs
                 .filter(task_id.eq(task_id_value))
                 .select(ExportTaskOutputSummaryRecord::as_select())
                 .first::<ExportTaskOutputSummaryRecord>(conn)
+                .await
                 .optional()
-        })?;
+        })
+        .await?;
 
         Ok(match record {
             Some(record) if record.output_expires_at > now => ExportOutputLookup::Available(record),
@@ -293,18 +314,21 @@ pub trait TaskBackend: TaskIdentifier {
         use crate::schema::import_task_results::dsl::{import_task_results, outcome, task_id};
 
         let task_id_value = self.task_id();
-        with_connection(pool, |conn| -> Result<TaskResultCounts, ApiError> {
+        with_connection(pool, async |conn| -> Result<TaskResultCounts, ApiError> {
             let processed = import_task_results
                 .filter(task_id.eq(task_id_value))
                 .count()
-                .get_result::<i64>(conn)?;
+                .get_result::<i64>(conn)
+                .await?;
             let failed = import_task_results
                 .filter(task_id.eq(task_id_value))
                 .filter(outcome.eq("failed"))
                 .count()
-                .get_result::<i64>(conn)?;
+                .get_result::<i64>(conn)
+                .await?;
             TaskResultCounts::new(processed, processed - failed, failed)
         })
+        .await
     }
 
     async fn update_state(
@@ -319,7 +343,7 @@ pub trait TaskBackend: TaskIdentifier {
 
         let task_id_value = self.task_id();
         let now = Utc::now().naive_utc();
-        let record = with_connection(pool, |conn| {
+        let record = with_connection(pool, async |conn| {
             diesel::update(tasks.filter(id.eq(task_id_value)))
                 .set((
                     status.eq(update.status.as_str()),
@@ -332,7 +356,9 @@ pub trait TaskBackend: TaskIdentifier {
                     updated_at.eq(now),
                 ))
                 .get_result::<TaskRecord>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         info!(
             message = "Task state updated",
@@ -359,9 +385,9 @@ pub trait TaskBackend: TaskIdentifier {
         };
 
         let task_id_value = self.task_id();
-        let record = with_transaction(pool, |conn| -> Result<TaskRecord, ApiError> {
+        let record = with_transaction(pool, async |conn| -> Result<TaskRecord, ApiError> {
             let event_record =
-                emit_task_lifecycle_event(conn, &event, ActorKind::Worker, None, None)?;
+                emit_task_lifecycle_event(conn, &event, ActorKind::Worker, None, None).await?;
 
             Ok(diesel::update(tasks.filter(id.eq(task_id_value)))
                 .set((
@@ -376,8 +402,10 @@ pub trait TaskBackend: TaskIdentifier {
                     request_redacted_at.eq(event_record.occurred_at),
                     updated_at.eq(event_record.occurred_at),
                 ))
-                .get_result::<TaskRecord>(conn)?)
-        })?;
+                .get_result::<TaskRecord>(conn)
+                .await?)
+        })
+        .await?;
 
         info!(
             message = "Task reached terminal state",
@@ -409,7 +437,7 @@ pub trait TaskBackend: TaskIdentifier {
         };
 
         let task_id_value = self.task_id();
-        let record = with_transaction(pool, |conn| -> Result<TaskRecord, ApiError> {
+        let record = with_transaction(pool, async |conn| -> Result<TaskRecord, ApiError> {
             // Idempotent so a future requeue / manual re-claim that re-finalizes the same task
             // cannot trip the `export_task_outputs.task_id` UNIQUE constraint and roll back the
             // transaction, which would otherwise leave the task stuck mid-flight.
@@ -417,10 +445,11 @@ pub trait TaskBackend: TaskIdentifier {
                 .values(output)
                 .on_conflict(export_output_task_id)
                 .do_nothing()
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
 
             let event_record =
-                emit_task_lifecycle_event(conn, &event, ActorKind::Worker, None, None)?;
+                emit_task_lifecycle_event(conn, &event, ActorKind::Worker, None, None).await?;
 
             Ok(diesel::update(tasks.filter(id.eq(task_id_value)))
                 .set((
@@ -435,8 +464,10 @@ pub trait TaskBackend: TaskIdentifier {
                     request_redacted_at.eq(event_record.occurred_at),
                     updated_at.eq(event_record.occurred_at),
                 ))
-                .get_result::<TaskRecord>(conn)?)
-        })?;
+                .get_result::<TaskRecord>(conn)
+                .await?)
+        })
+        .await?;
 
         info!(
             message = "Export task output stored and task finalized",
@@ -461,11 +492,13 @@ impl NewTaskRecord {
     pub async fn create(self, pool: &DbPool) -> Result<TaskRecord, ApiError> {
         use crate::schema::tasks::dsl::tasks;
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             diesel::insert_into(tasks)
                 .values(&self)
                 .get_result::<TaskRecord>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -478,13 +511,15 @@ impl TaskRecord {
     ) -> Result<Option<TaskRecord>, ApiError> {
         use crate::schema::tasks::dsl::{idempotency_key, submitted_by, tasks};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             tasks
                 .filter(submitted_by.eq(Some(submitter_id)))
                 .filter(idempotency_key.eq(key))
                 .first::<TaskRecord>(conn)
+                .await
                 .optional()
         })
+        .await
     }
 }
 
@@ -519,19 +554,23 @@ pub async fn list_tasks_with_total_count(
     status_filter: Option<&str>,
     query_options: &QueryOptions,
 ) -> Result<(Vec<TaskRecord>, i64), ApiError> {
-    let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-        with_connection(pool, |conn| {
+    let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+        with_connection(pool, async |conn| {
             build_task_query(submitted_by_filter, kind_filter, status_filter)
                 .count()
                 .get_result::<i64>(conn)
+                .await
         })
-    })?;
+        .await
+    })
+    .await?;
 
-    let items = with_connection(pool, |conn| -> Result<Vec<TaskRecord>, ApiError> {
+    let items = with_connection(pool, async |conn| -> Result<Vec<TaskRecord>, ApiError> {
         let mut query = build_task_query(submitted_by_filter, kind_filter, status_filter);
         apply_query_options!(query, query_options, TaskResponse);
-        Ok(query.load::<TaskRecord>(conn)?)
-    })?;
+        Ok(query.load::<TaskRecord>(conn).await?)
+    })
+    .await?;
 
     Ok((items, total_count))
 }
@@ -549,12 +588,14 @@ pub async fn list_export_task_output_summaries(
     // Return expired-but-present rows too; the caller classifies each against `now` so the
     // `output_expired` flag is consistent with the single-task lookups rather than silently
     // collapsing expired rows into "no output" on the task-list endpoint.
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         export_task_outputs
             .filter(task_id.eq_any(task_ids))
             .select(ExportTaskOutputSummaryRecord::as_select())
             .load(conn)
+            .await
     })
+    .await
 }
 
 pub async fn purge_expired_export_outputs(pool: &DbPool) -> Result<Vec<i32>, ApiError> {
@@ -563,11 +604,12 @@ pub async fn purge_expired_export_outputs(pool: &DbPool) -> Result<Vec<i32>, Api
     };
 
     let now = Utc::now().naive_utc();
-    let expired_task_ids = with_transaction(pool, |conn| {
+    let expired_task_ids = with_transaction(pool, async |conn| {
         let expired_task_ids =
             diesel::delete(export_task_outputs.filter(output_expires_at.le(now)))
                 .returning(task_id)
-                .get_results::<i32>(conn)?;
+                .get_results::<i32>(conn)
+                .await?;
 
         if !expired_task_ids.is_empty() {
             for expired_task_id in &expired_task_ids {
@@ -584,12 +626,14 @@ pub async fn purge_expired_export_outputs(pool: &DbPool) -> Result<Vec<i32>, Api
                     ActorKind::System,
                     None,
                     Some(TaskKind::Export.as_str()),
-                )?;
+                )
+                .await?;
             }
         }
 
         Ok::<_, ApiError>(expired_task_ids)
-    })?;
+    })
+    .await?;
 
     if !expired_task_ids.is_empty() {
         info!(
@@ -670,23 +714,28 @@ fn task_lifecycle_event(
     Ok(lifecycle_event)
 }
 
-fn emit_task_lifecycle_event(
-    conn: &mut PgConnection,
+async fn emit_task_lifecycle_event(
+    conn: &mut crate::db::DbConnection,
     event: &NewTaskEventRecord,
     actor_kind: ActorKind,
     actor_user_id: Option<i32>,
     task_kind: Option<&str>,
 ) -> Result<crate::events::Event, ApiError> {
     let lifecycle_event = task_lifecycle_event(event, actor_kind, actor_user_id, task_kind)?;
-    emit_event(conn, &lifecycle_event).map_err(ApiError::from)
+    emit_event(conn, &lifecycle_event)
+        .await
+        .map_err(ApiError::from)
 }
 
 impl NewTaskEventRecord {
     /// Append this event to its task's history and return the persisted event.
     pub async fn append(self, pool: &DbPool) -> Result<TaskEventRecord, ApiError> {
-        with_connection(pool, |conn| -> Result<TaskEventRecord, ApiError> {
-            emit_task_lifecycle_event(conn, &self, ActorKind::Worker, None, None)?.try_into()
+        with_connection(pool, async |conn| -> Result<TaskEventRecord, ApiError> {
+            emit_task_lifecycle_event(conn, &self, ActorKind::Worker, None, None)
+                .await?
+                .try_into()
         })
+        .await
     }
 }
 
@@ -700,11 +749,13 @@ pub async fn insert_import_results(
         return Ok(0);
     }
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         diesel::insert_into(import_task_results)
             .values(entries)
             .execute(conn)
+            .await
     })
+    .await
 }
 
 pub(crate) fn executable_task_kind_values() -> [&'static str; 3] {
@@ -725,7 +776,7 @@ fn task_kind_claim_order(start: usize) -> [&'static str; 3] {
 pub async fn claim_next_queued_task(pool: &DbPool) -> Result<Option<TaskRecord>, ApiError> {
     use crate::schema::tasks::dsl::{created_at, id, kind, started_at, status, tasks, updated_at};
 
-    let record = with_transaction(pool, |conn| -> Result<Option<TaskRecord>, ApiError> {
+    let record = with_transaction(pool, async |conn| -> Result<Option<TaskRecord>, ApiError> {
         let task_kinds = executable_task_kind_values();
         let first_kind = NEXT_TASK_KIND.fetch_add(1, Ordering::Relaxed) % task_kinds.len();
         let claim_order = task_kind_claim_order(first_kind);
@@ -739,6 +790,7 @@ pub async fn claim_next_queued_task(pool: &DbPool) -> Result<Option<TaskRecord>,
                 .skip_locked()
                 .select(id)
                 .first::<i32>(conn)
+                .await
                 .optional()?;
             if selected_task_id.is_some() {
                 break;
@@ -755,7 +807,8 @@ pub async fn claim_next_queued_task(pool: &DbPool) -> Result<Option<TaskRecord>,
                 started_at.eq(Some(now)),
                 updated_at.eq(now),
             ))
-            .get_result::<TaskRecord>(conn)?;
+            .get_result::<TaskRecord>(conn)
+            .await?;
 
         emit_task_lifecycle_event(
             conn,
@@ -768,10 +821,12 @@ pub async fn claim_next_queued_task(pool: &DbPool) -> Result<Option<TaskRecord>,
             ActorKind::Worker,
             None,
             Some(record.kind.as_str()),
-        )?;
+        )
+        .await?;
 
         Ok(Some(record))
-    })?;
+    })
+    .await?;
 
     if let Some(record) = &record {
         info!(
@@ -851,10 +906,10 @@ impl TaskCreateRequest {
 
         let max_active_tasks = i64::try_from(max_active_tasks).unwrap_or(i64::MAX);
         let submitter_id = self.submitted_by;
-        let task = with_transaction(pool, |conn| -> Result<TaskRecord, ApiError> {
-            acquire_task_capacity_lock(conn, submitter_id, limited_kind)?;
+        let task = with_transaction(pool, async |conn| -> Result<TaskRecord, ApiError> {
+            acquire_task_capacity_lock(conn, submitter_id, limited_kind).await?;
             let active_count =
-                count_active_tasks_for_user_in_transaction(conn, submitter_id, limited_kind)?;
+                count_active_tasks_for_user_in_transaction(conn, submitter_id, limited_kind).await?;
             if active_count >= max_active_tasks {
                 return Err(ApiError::TooManyRequests(format!(
                     "Too many active {} tasks for user ({active_count} >= {max_active_tasks}); wait for queued or running tasks to finish",
@@ -862,8 +917,8 @@ impl TaskCreateRequest {
                 )));
             }
 
-            insert_queued_task_with_event(conn, self)
-        })?;
+            insert_queued_task_with_event(conn, self).await
+        }).await?;
 
         log_task_queued(&task);
 
@@ -871,8 +926,8 @@ impl TaskCreateRequest {
     }
 }
 
-fn insert_queued_task_with_event(
-    conn: &mut PgConnection,
+async fn insert_queued_task_with_event(
+    conn: &mut crate::db::DbConnection,
     request: TaskCreateRequest,
 ) -> Result<TaskRecord, ApiError> {
     use crate::schema::tasks::dsl::tasks;
@@ -899,7 +954,8 @@ fn insert_queued_task_with_event(
             started_at: None,
             finished_at: None,
         })
-        .get_result::<TaskRecord>(conn)?;
+        .get_result::<TaskRecord>(conn)
+        .await?;
 
     emit_task_lifecycle_event(
         conn,
@@ -912,20 +968,22 @@ fn insert_queued_task_with_event(
         ActorKind::User,
         Some(submitted_by),
         Some(task_kind.as_str()),
-    )?;
+    )
+    .await?;
 
     Ok(task)
 }
 
-fn acquire_task_capacity_lock(
-    conn: &mut PgConnection,
+async fn acquire_task_capacity_lock(
+    conn: &mut crate::db::DbConnection,
     submitted_by: i32,
     kind: TaskKind,
 ) -> Result<(), ApiError> {
     let lock_key = task_capacity_lock_key(submitted_by, kind);
     let lock = diesel::sql_query("SELECT TRUE AS locked FROM pg_advisory_xact_lock($1)")
         .bind::<BigInt, _>(lock_key)
-        .get_result::<AdvisoryLockRow>(conn)?;
+        .get_result::<AdvisoryLockRow>(conn)
+        .await?;
     if !lock.locked {
         return Err(ApiError::InternalServerError(
             "Failed to acquire task capacity lock".to_string(),
@@ -947,8 +1005,8 @@ fn task_capacity_lock_key(submitted_by: i32, kind: TaskKind) -> i64 {
     BASE_KEY + (kind_slot * KIND_STRIDE) + i64::from(submitted_by)
 }
 
-fn count_active_tasks_for_user_in_transaction(
-    conn: &mut PgConnection,
+async fn count_active_tasks_for_user_in_transaction(
+    conn: &mut crate::db::DbConnection,
     submitted_by_value: i32,
     task_kind: TaskKind,
 ) -> Result<i64, ApiError> {
@@ -967,6 +1025,7 @@ fn count_active_tasks_for_user_in_transaction(
         .filter(deleted_at.is_null())
         .count()
         .get_result::<i64>(conn)
+        .await
         .map_err(ApiError::from)
 }
 
@@ -984,10 +1043,8 @@ fn log_task_queued(task: &TaskRecord) {
 
 #[cfg(test)]
 mod tests {
-    use diesel::prelude::*;
-    use futures::executor::block_on;
-    use std::sync::mpsc;
-    use std::thread;
+    use crate::db::prelude::*;
+    use tokio::sync::oneshot;
 
     use super::{
         TaskBackend, TaskCreateRequest, claim_next_queued_task, task_capacity_lock_key,
@@ -1025,8 +1082,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn task_claim_order_rotates_every_executable_kind_to_the_front() {
+    #[tokio::test]
+    async fn task_claim_order_rotates_every_executable_kind_to_the_front() {
         assert_eq!(
             task_kind_claim_order(0),
             [
@@ -1039,86 +1096,90 @@ mod tests {
         assert_eq!(task_kind_claim_order(2)[0], TaskKind::RemoteCall.as_str());
     }
 
-    #[test]
-    fn test_claim_next_queued_task_is_safe_under_concurrency() {
-        let context = block_on(TestContext::new());
+    #[tokio::test]
+    async fn test_claim_next_queued_task_is_safe_under_concurrency() {
+        let context = TestContext::new().await;
         let mut created_ids = Vec::new();
         let claim_prefix = context.scoped_name("claim");
 
         for index in 0..3 {
-            let task = block_on(
-                NewTaskRecord {
-                    kind: TaskKind::Import.as_str().to_string(),
-                    status: TaskStatus::Queued.as_str().to_string(),
-                    submitted_by: Some(context.admin_user.id),
-                    submitted_token_id: None,
-                    submitted_token_scoped: false,
-                    submitted_token_scopes: serde_json::json!([]),
-                    idempotency_key: Some(format!("{claim_prefix}-{index}")),
-                    request_hash: None,
-                    request_payload: None,
-                    summary: None,
-                    total_items: 0,
-                    processed_items: 0,
-                    success_items: 0,
-                    failed_items: 0,
-                    request_redacted_at: None,
-                    started_at: None,
-                    finished_at: None,
-                }
-                .create(&context.pool),
-            )
+            let task = NewTaskRecord {
+                kind: TaskKind::Import.as_str().to_string(),
+                status: TaskStatus::Queued.as_str().to_string(),
+                submitted_by: Some(context.admin_user.id),
+                submitted_token_id: None,
+                submitted_token_scoped: false,
+                submitted_token_scopes: serde_json::json!([]),
+                idempotency_key: Some(format!("{claim_prefix}-{index}")),
+                request_hash: None,
+                request_payload: None,
+                summary: None,
+                total_items: 0,
+                processed_items: 0,
+                success_items: 0,
+                failed_items: 0,
+                request_redacted_at: None,
+                started_at: None,
+                finished_at: None,
+            }
+            .create(&context.pool)
+            .await
             .unwrap();
             created_ids.push(task.id);
         }
 
-        let (locked_tx, locked_rx) = mpsc::channel();
-        let (release_tx, release_rx) = mpsc::channel();
+        let (locked_tx, locked_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
         let pool = context.pool.clone();
         let claim_prefix_for_locker = claim_prefix.clone();
-        let locker = thread::spawn(move || {
+        let locker = tokio::spawn(async move {
             use crate::schema::tasks::dsl::{created_at, id, idempotency_key, status, tasks};
 
-            with_transaction(&pool, |conn| -> Result<(), crate::errors::ApiError> {
-                let locked_id = tasks
-                    .filter(status.eq(TaskStatus::Queued.as_str()))
-                    .filter(idempotency_key.like(format!("{claim_prefix_for_locker}-%")))
-                    .order(created_at.asc())
-                    .for_update()
-                    .select(id)
-                    .first::<i32>(conn)?;
-                locked_tx.send(locked_id).unwrap();
-                release_rx.recv().unwrap();
-                Ok(())
-            })
+            with_transaction(
+                &pool,
+                async move |conn| -> Result<(), crate::errors::ApiError> {
+                    let locked_id = tasks
+                        .filter(status.eq(TaskStatus::Queued.as_str()))
+                        .filter(idempotency_key.like(format!("{claim_prefix_for_locker}-%")))
+                        .order(created_at.asc())
+                        .for_update()
+                        .select(id)
+                        .first::<i32>(conn)
+                        .await?;
+                    locked_tx.send(locked_id).unwrap();
+                    release_rx.await.unwrap();
+                    Ok(())
+                },
+            )
+            .await
             .unwrap();
         });
 
-        let locked_id = locked_rx.recv().unwrap();
-        let claimed = block_on(claim_next_queued_task(&context.pool))
+        let locked_id = locked_rx.await.unwrap();
+        let claimed = claim_next_queued_task(&context.pool)
+            .await
             .unwrap()
             .map(|task| task.id);
         release_tx.send(()).unwrap();
-        locker.join().unwrap();
+        locker.await.unwrap();
 
         assert!(claimed.is_some());
         assert_ne!(claimed.unwrap(), locked_id);
         assert!(created_ids.contains(&locked_id));
 
-        let (claimed_events, _) = block_on(
-            TaskID::new(claimed.unwrap())
-                .unwrap()
-                .list_events_with_total_count(
-                    &context.pool,
-                    &QueryOptions {
-                        filters: Vec::new(),
-                        sort: Vec::new(),
-                        limit: None,
-                        cursor: None,
-                        include_total: true,
-                    },
-                ),
-        )
+        let (claimed_events, _) = (TaskID::new(claimed.unwrap())
+            .unwrap()
+            .list_events_with_total_count(
+                &context.pool,
+                &QueryOptions {
+                    filters: Vec::new(),
+                    sort: Vec::new(),
+                    limit: None,
+                    cursor: None,
+                    include_total: true,
+                },
+            ))
+        .await
         .unwrap();
         assert_eq!(
             claimed_events
@@ -1129,75 +1190,74 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_task_history_survives_user_deletion() {
-        let context = block_on(TestContext::new());
-        let task_owner = block_on(create_test_user(&context.pool));
-        let task = block_on(
-            NewTaskRecord {
-                kind: TaskKind::Import.as_str().to_string(),
-                status: TaskStatus::Succeeded.as_str().to_string(),
-                submitted_by: Some(task_owner.id),
-                submitted_token_id: None,
-                submitted_token_scoped: false,
-                submitted_token_scopes: serde_json::json!([]),
-                idempotency_key: Some(context.scoped_name("deleted-owner-task")),
-                request_hash: None,
-                request_payload: None,
-                summary: Some("completed".to_string()),
-                total_items: 0,
-                processed_items: 0,
-                success_items: 0,
-                failed_items: 0,
-                request_redacted_at: None,
-                started_at: None,
-                finished_at: None,
-            }
-            .create(&context.pool),
-        )
+    #[tokio::test]
+    async fn test_task_history_survives_user_deletion() {
+        let context = (TestContext::new()).await;
+        let task_owner = (create_test_user(&context.pool)).await;
+        let task = (NewTaskRecord {
+            kind: TaskKind::Import.as_str().to_string(),
+            status: TaskStatus::Succeeded.as_str().to_string(),
+            submitted_by: Some(task_owner.id),
+            submitted_token_id: None,
+            submitted_token_scoped: false,
+            submitted_token_scopes: serde_json::json!([]),
+            idempotency_key: Some(context.scoped_name("deleted-owner-task")),
+            request_hash: None,
+            request_payload: None,
+            summary: Some("completed".to_string()),
+            total_items: 0,
+            processed_items: 0,
+            success_items: 0,
+            failed_items: 0,
+            request_redacted_at: None,
+            started_at: None,
+            finished_at: None,
+        }
+        .create(&context.pool))
+        .await
         .unwrap();
 
-        block_on(task_owner.delete_user_record_without_events(&context.pool)).unwrap();
+        (task_owner.delete_user_record_without_events(&context.pool))
+            .await
+            .unwrap();
 
-        let stored = block_on(task.find_record(&context.pool)).unwrap();
+        let stored = (task.find_record(&context.pool)).await.unwrap();
         assert_eq!(stored.submitted_by, None);
     }
 
-    #[test]
-    fn test_export_task_active_limit_blocks_new_work_for_same_user() {
-        let context = block_on(TestContext::new());
-        let first = block_on(
-            TaskCreateRequest {
-                kind: TaskKind::Export,
-                submitted_by: context.admin_user.id,
-                submitted_token_id: None,
-                submitted_token_scoped: false,
-                submitted_token_scopes: serde_json::json!([]),
-                idempotency_key: Some(context.scoped_name("export-cap-first")),
-                request_hash: Some(context.scoped_name("export-cap-first-hash")),
-                request_payload: serde_json::json!({"export": "first"}),
-                total_items: 1,
-            }
-            .create_idempotently_with_active_limit(&context.pool, 1),
-        )
+    #[tokio::test]
+    async fn test_export_task_active_limit_blocks_new_work_for_same_user() {
+        let context = (TestContext::new()).await;
+        let first = (TaskCreateRequest {
+            kind: TaskKind::Export,
+            submitted_by: context.admin_user.id,
+            submitted_token_id: None,
+            submitted_token_scoped: false,
+            submitted_token_scopes: serde_json::json!([]),
+            idempotency_key: Some(context.scoped_name("export-cap-first")),
+            request_hash: Some(context.scoped_name("export-cap-first-hash")),
+            request_payload: serde_json::json!({"export": "first"}),
+            total_items: 1,
+        }
+        .create_idempotently_with_active_limit(&context.pool, 1))
+        .await
         .unwrap();
 
         assert_eq!(first.status, TaskStatus::Queued.as_str());
 
-        let error = block_on(
-            TaskCreateRequest {
-                kind: TaskKind::Export,
-                submitted_by: context.admin_user.id,
-                submitted_token_id: None,
-                submitted_token_scoped: false,
-                submitted_token_scopes: serde_json::json!([]),
-                idempotency_key: Some(context.scoped_name("export-cap-second")),
-                request_hash: Some(context.scoped_name("export-cap-second-hash")),
-                request_payload: serde_json::json!({"export": "second"}),
-                total_items: 1,
-            }
-            .create_idempotently_with_active_limit(&context.pool, 1),
-        )
+        let error = (TaskCreateRequest {
+            kind: TaskKind::Export,
+            submitted_by: context.admin_user.id,
+            submitted_token_id: None,
+            submitted_token_scoped: false,
+            submitted_token_scopes: serde_json::json!([]),
+            idempotency_key: Some(context.scoped_name("export-cap-second")),
+            request_hash: Some(context.scoped_name("export-cap-second-hash")),
+            request_payload: serde_json::json!({"export": "second"}),
+            total_items: 1,
+        }
+        .create_idempotently_with_active_limit(&context.pool, 1))
+        .await
         .unwrap_err();
 
         match error {
@@ -1208,9 +1268,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_import_task_active_limit_blocks_new_work_for_same_user() {
-        let context = block_on(TestContext::new());
+    #[tokio::test]
+    async fn test_import_task_active_limit_blocks_new_work_for_same_user() {
+        let context = (TestContext::new()).await;
         let create_request = |suffix: &str| TaskCreateRequest {
             kind: TaskKind::Import,
             submitted_by: context.admin_user.id,
@@ -1223,15 +1283,15 @@ mod tests {
             total_items: 1,
         };
 
-        let first = block_on(
-            create_request("first").create_idempotently_with_active_limit(&context.pool, 1),
-        )
+        let first = (create_request("first")
+            .create_idempotently_with_active_limit(&context.pool, 1))
+        .await
         .unwrap();
         assert_eq!(first.status, TaskStatus::Queued.as_str());
 
-        let error = block_on(
-            create_request("second").create_idempotently_with_active_limit(&context.pool, 1),
-        )
+        let error = (create_request("second")
+            .create_idempotently_with_active_limit(&context.pool, 1))
+        .await
         .unwrap_err();
         match error {
             ApiError::TooManyRequests(message) => {
@@ -1241,9 +1301,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_remote_call_task_active_limit_blocks_new_work_for_same_user() {
-        let context = block_on(TestContext::new());
+    #[tokio::test]
+    async fn test_remote_call_task_active_limit_blocks_new_work_for_same_user() {
+        let context = (TestContext::new()).await;
         let payload = serde_json::to_value(StoredRemoteCallTaskPayload {
             target_id: RemoteTargetID::new(1).unwrap(),
             subject: RemoteInvocationSubject::Collection {
@@ -1254,38 +1314,36 @@ mod tests {
         })
         .unwrap();
 
-        let first = block_on(
-            TaskCreateRequest {
-                kind: TaskKind::RemoteCall,
-                submitted_by: context.admin_user.id,
-                submitted_token_id: None,
-                submitted_token_scoped: false,
-                submitted_token_scopes: serde_json::json!([]),
-                idempotency_key: Some(context.scoped_name("remote-cap-first")),
-                request_hash: Some(context.scoped_name("remote-cap-first-hash")),
-                request_payload: payload.clone(),
-                total_items: 1,
-            }
-            .create_idempotently_with_active_limit(&context.pool, 1),
-        )
+        let first = (TaskCreateRequest {
+            kind: TaskKind::RemoteCall,
+            submitted_by: context.admin_user.id,
+            submitted_token_id: None,
+            submitted_token_scoped: false,
+            submitted_token_scopes: serde_json::json!([]),
+            idempotency_key: Some(context.scoped_name("remote-cap-first")),
+            request_hash: Some(context.scoped_name("remote-cap-first-hash")),
+            request_payload: payload.clone(),
+            total_items: 1,
+        }
+        .create_idempotently_with_active_limit(&context.pool, 1))
+        .await
         .unwrap();
 
         assert_eq!(first.status, TaskStatus::Queued.as_str());
 
-        let error = block_on(
-            TaskCreateRequest {
-                kind: TaskKind::RemoteCall,
-                submitted_by: context.admin_user.id,
-                submitted_token_id: None,
-                submitted_token_scoped: false,
-                submitted_token_scopes: serde_json::json!([]),
-                idempotency_key: Some(context.scoped_name("remote-cap-second")),
-                request_hash: Some(context.scoped_name("remote-cap-second-hash")),
-                request_payload: payload,
-                total_items: 1,
-            }
-            .create_idempotently_with_active_limit(&context.pool, 1),
-        )
+        let error = (TaskCreateRequest {
+            kind: TaskKind::RemoteCall,
+            submitted_by: context.admin_user.id,
+            submitted_token_id: None,
+            submitted_token_scoped: false,
+            submitted_token_scopes: serde_json::json!([]),
+            idempotency_key: Some(context.scoped_name("remote-cap-second")),
+            request_hash: Some(context.scoped_name("remote-cap-second-hash")),
+            request_payload: payload,
+            total_items: 1,
+        }
+        .create_idempotently_with_active_limit(&context.pool, 1))
+        .await
         .unwrap_err();
 
         match error {

--- a/src/db/traits/task_import.rs
+++ b/src/db/traits/task_import.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 
 use crate::db::{DbPool, with_connection};
 use crate::errors::ApiError;
@@ -17,23 +17,28 @@ pub async fn lookup_collections_by_name(
 ) -> Result<Vec<Collection>, ApiError> {
     use crate::schema::collections::dsl::{collections, name};
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         collections
             .filter(name.eq(value))
             .order(crate::schema::collections::id.asc())
             .load::<Collection>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn lookup_root_collection(pool: &DbPool) -> Result<Collection, ApiError> {
-    with_connection(pool, lookup_root_collection_db)
+    with_connection(pool, lookup_root_collection_db).await
 }
 
 pub async fn lookup_collection_by_key(
     pool: &DbPool,
     key: &CollectionKey,
 ) -> Result<Option<Collection>, ApiError> {
-    with_connection(pool, |conn| lookup_collection_by_key_db(conn, key))
+    with_connection(pool, async |conn| {
+        lookup_collection_by_key_db(conn, key).await
+    })
+    .await
 }
 
 pub async fn lookup_collection_by_id(
@@ -42,12 +47,14 @@ pub async fn lookup_collection_by_id(
 ) -> Result<Option<Collection>, ApiError> {
     use crate::schema::collections::dsl::{collections, id};
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         collections
             .filter(id.eq(collection_id))
             .first::<Collection>(conn)
+            .await
             .optional()
     })
+    .await
 }
 
 pub async fn lookup_class_by_collection_and_name(
@@ -57,13 +64,15 @@ pub async fn lookup_class_by_collection_and_name(
 ) -> Result<Option<HubuumClass>, ApiError> {
     use crate::schema::hubuumclass::dsl::{collection_id, hubuumclass, name};
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         hubuumclass
             .filter(collection_id.eq(collection_id_value))
             .filter(name.eq(class_name))
             .first::<HubuumClass>(conn)
+            .await
             .optional()
     })
+    .await
 }
 
 pub async fn lookup_classes_by_collection_and_names(
@@ -77,12 +86,14 @@ pub async fn lookup_classes_by_collection_and_names(
         return Ok(Vec::new());
     }
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         hubuumclass
             .filter(collection_id.eq(collection_id_value))
             .filter(name.eq_any(class_names))
             .load::<HubuumClass>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn lookup_object_by_class_and_name(
@@ -92,13 +103,15 @@ pub async fn lookup_object_by_class_and_name(
 ) -> Result<Option<HubuumObject>, ApiError> {
     use crate::schema::hubuumobject::dsl::{hubuum_class_id, hubuumobject, name};
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         hubuumobject
             .filter(hubuum_class_id.eq(class_id_value))
             .filter(name.eq(object_name))
             .first::<HubuumObject>(conn)
+            .await
             .optional()
     })
+    .await
 }
 
 pub async fn lookup_objects_by_class_and_names(
@@ -112,12 +125,14 @@ pub async fn lookup_objects_by_class_and_names(
         return Ok(Vec::new());
     }
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         hubuumobject
             .filter(hubuum_class_id.eq(class_id_value))
             .filter(name.eq_any(object_names))
             .load::<HubuumObject>(conn)
+            .await
     })
+    .await
 }
 
 pub async fn lookup_direct_class_relation(
@@ -130,13 +145,15 @@ pub async fn lookup_direct_class_relation(
     };
     let pair = normalize_pair(left, right);
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         hubuumclass_relation
             .filter(from_hubuum_class_id.eq(pair.0))
             .filter(to_hubuum_class_id.eq(pair.1))
             .first::<HubuumClassRelation>(conn)
+            .await
             .optional()
     })
+    .await
 }
 
 pub async fn lookup_object_relation(
@@ -149,13 +166,15 @@ pub async fn lookup_object_relation(
     };
     let pair = normalize_pair(left, right);
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         hubuumobject_relation
             .filter(from_hubuum_object_id.eq(pair.0))
             .filter(to_hubuum_object_id.eq(pair.1))
             .first::<HubuumObjectRelation>(conn)
+            .await
             .optional()
     })
+    .await
 }
 
 pub async fn lookup_group_by_name(
@@ -165,22 +184,24 @@ pub async fn lookup_group_by_name(
 ) -> Result<Option<Group>, ApiError> {
     use crate::schema::{groups, identity_scopes};
 
-    with_connection(pool, |conn| {
+    with_connection(pool, async |conn| {
         groups::table
             .inner_join(identity_scopes::table)
             .filter(groups::groupname.eq(value))
             .filter(identity_scopes::name.eq(identity_scope))
             .select(groups::all_columns)
             .first::<Group>(conn)
+            .await
             .optional()
     })
+    .await
 }
 
-pub fn lookup_collection_by_name_db(
-    conn: &mut diesel::PgConnection,
+pub async fn lookup_collection_by_name_db(
+    conn: &mut crate::db::DbConnection,
     value: &str,
 ) -> Result<Option<Collection>, ApiError> {
-    let matches = lookup_collections_by_name_db(conn, value)?;
+    let matches = lookup_collections_by_name_db(conn, value).await?;
     match matches.as_slice() {
         [] => Ok(None),
         [collection] => Ok(Some(collection.clone())),
@@ -190,8 +211,8 @@ pub fn lookup_collection_by_name_db(
     }
 }
 
-pub fn lookup_collections_by_name_db(
-    conn: &mut diesel::PgConnection,
+pub async fn lookup_collections_by_name_db(
+    conn: &mut crate::db::DbConnection,
     value: &str,
 ) -> Result<Vec<Collection>, ApiError> {
     use crate::schema::collections::dsl::{collections, name};
@@ -200,20 +221,24 @@ pub fn lookup_collections_by_name_db(
         .filter(name.eq(value))
         .order(crate::schema::collections::id.asc())
         .load::<Collection>(conn)
+        .await
         .map_err(ApiError::from)
 }
 
-pub fn lookup_root_collection_db(conn: &mut diesel::PgConnection) -> Result<Collection, ApiError> {
+pub async fn lookup_root_collection_db(
+    conn: &mut crate::db::DbConnection,
+) -> Result<Collection, ApiError> {
     use crate::schema::collections::dsl::{collections, parent_collection_id};
 
     collections
         .filter(parent_collection_id.is_null())
         .first::<Collection>(conn)
+        .await
         .map_err(ApiError::from)
 }
 
-pub fn lookup_collection_child_by_name_db(
-    conn: &mut diesel::PgConnection,
+pub async fn lookup_collection_child_by_name_db(
+    conn: &mut crate::db::DbConnection,
     parent_id_value: i32,
     child_name: &str,
 ) -> Result<Option<Collection>, ApiError> {
@@ -223,6 +248,7 @@ pub fn lookup_collection_child_by_name_db(
         .filter(parent_collection_id.eq(parent_id_value))
         .filter(name.eq(child_name))
         .first::<Collection>(conn)
+        .await
         .optional()
         .map_err(ApiError::from)
 }
@@ -245,24 +271,24 @@ fn validate_collection_key_path(key: &CollectionKey) -> Result<(), ApiError> {
     }
 }
 
-pub fn lookup_collection_by_key_db(
-    conn: &mut diesel::PgConnection,
+pub async fn lookup_collection_by_key_db(
+    conn: &mut crate::db::DbConnection,
     key: &CollectionKey,
 ) -> Result<Option<Collection>, ApiError> {
     validate_collection_key_path(key)?;
 
     let Some(path) = &key.path else {
-        return lookup_collection_by_name_db(conn, &key.name);
+        return lookup_collection_by_name_db(conn, &key.name).await;
     };
 
     if path.is_empty() {
-        return lookup_root_collection_db(conn).map(Some);
+        return lookup_root_collection_db(conn).await.map(Some);
     }
 
-    let mut parent = lookup_root_collection_db(conn)?;
+    let mut parent = lookup_root_collection_db(conn).await?;
     let mut current = None;
     for segment in path {
-        let child = lookup_collection_child_by_name_db(conn, parent.id, segment)?;
+        let child = lookup_collection_child_by_name_db(conn, parent.id, segment).await?;
         let Some(child) = child else {
             return Ok(None);
         };
@@ -273,8 +299,8 @@ pub fn lookup_collection_by_key_db(
     Ok(current)
 }
 
-pub fn lookup_class_by_collection_and_name_db(
-    conn: &mut diesel::PgConnection,
+pub async fn lookup_class_by_collection_and_name_db(
+    conn: &mut crate::db::DbConnection,
     collection_id_value: i32,
     class_name: &str,
 ) -> Result<Option<HubuumClass>, ApiError> {
@@ -284,12 +310,13 @@ pub fn lookup_class_by_collection_and_name_db(
         .filter(collection_id.eq(collection_id_value))
         .filter(name.eq(class_name))
         .first::<HubuumClass>(conn)
+        .await
         .optional()
         .map_err(ApiError::from)
 }
 
-pub fn lookup_object_by_class_and_name_db(
-    conn: &mut diesel::PgConnection,
+pub async fn lookup_object_by_class_and_name_db(
+    conn: &mut crate::db::DbConnection,
     class_id_value: i32,
     object_name: &str,
 ) -> Result<Option<HubuumObject>, ApiError> {
@@ -299,12 +326,13 @@ pub fn lookup_object_by_class_and_name_db(
         .filter(hubuum_class_id.eq(class_id_value))
         .filter(name.eq(object_name))
         .first::<HubuumObject>(conn)
+        .await
         .optional()
         .map_err(ApiError::from)
 }
 
-pub fn lookup_group_by_name_db(
-    conn: &mut diesel::PgConnection,
+pub async fn lookup_group_by_name_db(
+    conn: &mut crate::db::DbConnection,
     identity_scope: &str,
     value: &str,
 ) -> Result<Option<Group>, ApiError> {
@@ -316,12 +344,13 @@ pub fn lookup_group_by_name_db(
         .filter(identity_scopes::name.eq(identity_scope))
         .select(groups::all_columns)
         .first::<Group>(conn)
+        .await
         .optional()
         .map_err(ApiError::from)
 }
 
-pub fn create_collection_db(
-    conn: &mut diesel::PgConnection,
+pub async fn create_collection_db(
+    conn: &mut crate::db::DbConnection,
     input: &ImportCollectionInput,
     parent_collection_id: Option<i32>,
 ) -> Result<Collection, ApiError> {
@@ -331,10 +360,11 @@ pub fn create_collection_db(
         &input.description,
         parent_collection_id,
     )
+    .await
 }
 
-pub fn update_collection_db(
-    conn: &mut diesel::PgConnection,
+pub async fn update_collection_db(
+    conn: &mut crate::db::DbConnection,
     collection_id_value: i32,
     input: &ImportCollectionInput,
 ) -> Result<Collection, ApiError> {
@@ -349,14 +379,21 @@ pub fn update_collection_db(
         diesel::update(collections.filter(id.eq(collection_id_value)))
             .set(&update)
             .get_result::<Collection>(conn)
+            .await
             .optional(),
-        || collections.filter(id.eq(collection_id_value)).first(conn),
+        async || {
+            collections
+                .filter(id.eq(collection_id_value))
+                .first(conn)
+                .await
+        },
     )
+    .await
     .map_err(ApiError::from)
 }
 
-pub fn create_class_db(
-    conn: &mut diesel::PgConnection,
+pub async fn create_class_db(
+    conn: &mut crate::db::DbConnection,
     input: &ImportClassInput,
     collection_id_value: i32,
 ) -> Result<HubuumClass, ApiError> {
@@ -373,11 +410,12 @@ pub fn create_class_db(
     diesel::insert_into(hubuumclass)
         .values(&new_class)
         .get_result::<HubuumClass>(conn)
+        .await
         .map_err(ApiError::from)
 }
 
-pub fn update_class_db(
-    conn: &mut diesel::PgConnection,
+pub async fn update_class_db(
+    conn: &mut crate::db::DbConnection,
     class_id_value: i32,
     input: &ImportClassInput,
 ) -> Result<HubuumClass, ApiError> {
@@ -395,14 +433,16 @@ pub fn update_class_db(
         diesel::update(hubuumclass.filter(id.eq(class_id_value)))
             .set(&update)
             .get_result::<HubuumClass>(conn)
+            .await
             .optional(),
-        || hubuumclass.filter(id.eq(class_id_value)).first(conn),
+        async || hubuumclass.filter(id.eq(class_id_value)).first(conn).await,
     )
+    .await
     .map_err(ApiError::from)
 }
 
-pub fn create_object_db(
-    conn: &mut diesel::PgConnection,
+pub async fn create_object_db(
+    conn: &mut crate::db::DbConnection,
     input: &ImportObjectInput,
     class: &HubuumClass,
 ) -> Result<HubuumObject, ApiError> {
@@ -419,11 +459,12 @@ pub fn create_object_db(
     diesel::insert_into(hubuumobject)
         .values(&new_object)
         .get_result::<HubuumObject>(conn)
+        .await
         .map_err(ApiError::from)
 }
 
-pub fn update_object_db(
-    conn: &mut diesel::PgConnection,
+pub async fn update_object_db(
+    conn: &mut crate::db::DbConnection,
     object_id_value: i32,
     input: &ImportObjectInput,
 ) -> Result<HubuumObject, ApiError> {
@@ -441,14 +482,21 @@ pub fn update_object_db(
         diesel::update(hubuumobject.filter(id.eq(object_id_value)))
             .set(&update)
             .get_result::<HubuumObject>(conn)
+            .await
             .optional(),
-        || hubuumobject.filter(id.eq(object_id_value)).first(conn),
+        async || {
+            hubuumobject
+                .filter(id.eq(object_id_value))
+                .first(conn)
+                .await
+        },
     )
+    .await
     .map_err(ApiError::from)
 }
 
-pub fn create_class_relation_db(
-    conn: &mut diesel::PgConnection,
+pub async fn create_class_relation_db(
+    conn: &mut crate::db::DbConnection,
     left: i32,
     right: i32,
     forward_template_alias: Option<String>,
@@ -478,6 +526,7 @@ pub fn create_class_relation_db(
     diesel::insert_into(hubuumclass_relation)
         .values(&new_relation)
         .get_result::<HubuumClassRelation>(conn)
+        .await
         .map_err(ApiError::from)
 }
 
@@ -485,8 +534,8 @@ fn normalize_template_alias_option(alias: Option<&str>) -> Result<Option<String>
     alias.map(normalize_template_alias).transpose()
 }
 
-pub fn create_object_relation_db(
-    conn: &mut diesel::PgConnection,
+pub async fn create_object_relation_db(
+    conn: &mut crate::db::DbConnection,
     from_object: &HubuumObject,
     to_object: &HubuumObject,
 ) -> Result<HubuumObjectRelation, ApiError> {
@@ -498,7 +547,8 @@ pub fn create_object_relation_db(
     let relation = hubuumclass_relation
         .filter(from_hubuum_class_id.eq(class_pair.0))
         .filter(to_hubuum_class_id.eq(class_pair.1))
-        .first::<HubuumClassRelation>(conn)?;
+        .first::<HubuumClassRelation>(conn)
+        .await?;
 
     let object_pair = normalize_pair(from_object.id, to_object.id);
     let new_relation = NewHubuumObjectRelation {
@@ -510,11 +560,12 @@ pub fn create_object_relation_db(
     diesel::insert_into(hubuumobject_relation)
         .values(&new_relation)
         .get_result::<HubuumObjectRelation>(conn)
+        .await
         .map_err(ApiError::from)
 }
 
-pub fn apply_permissions_db(
-    conn: &mut diesel::PgConnection,
+pub async fn apply_permissions_db(
+    conn: &mut crate::db::DbConnection,
     collection_id_value: i32,
     group_id_value: i32,
     permissions: &[Permissions],
@@ -528,6 +579,7 @@ pub fn apply_permissions_db(
         .filter(collection_id.eq(collection_id_value))
         .filter(group_id.eq(group_id_value))
         .first::<Permission>(conn)
+        .await
         .optional()?;
 
     let permission_list = PermissionsList::new(permissions.to_vec());
@@ -579,6 +631,7 @@ pub fn apply_permissions_db(
             )
             .set(&update)
             .get_result::<Permission>(conn)
+            .await
             .map_err(ApiError::from)
         }
         None => {
@@ -633,6 +686,7 @@ pub fn apply_permissions_db(
             diesel::insert_into(permissions_table)
                 .values(&new_entry)
                 .get_result::<Permission>(conn)
+                .await
                 .map_err(ApiError::from)
         }
     }
@@ -711,7 +765,7 @@ mod tests {
             ensure_identity_scope(&scope.pool, &external_scope_name, LDAP_PROVIDER_KIND)
                 .await
                 .unwrap();
-        let external_group = with_connection(&scope.pool, |conn| {
+        let external_group = with_connection(&scope.pool, async |conn| {
             use crate::schema::groups;
 
             diesel::insert_into(groups::table)
@@ -723,7 +777,9 @@ mod tests {
                     groups::external_key.eq(scope.scoped_name("external_group_key")),
                 ))
                 .get_result::<Group>(conn)
+                .await
         })
+        .await
         .unwrap();
 
         let external_key = GroupKey {
@@ -742,9 +798,11 @@ mod tests {
             identity_scope: None,
             groupname,
         };
-        let loaded_local = with_connection(&scope.pool, |conn| {
+        let loaded_local = with_connection(&scope.pool, async |conn| {
             lookup_group_by_name_db(conn, local_key.identity_scope_name(), &local_key.groupname)
+                .await
         })
+        .await
         .unwrap()
         .unwrap();
 

--- a/src/db/traits/user/auth.rs
+++ b/src/db/traits/user/auth.rs
@@ -3,6 +3,7 @@ use crate::db::traits::identity::identity_scope_by_name;
 use crate::db::traits::principal::InsertPrincipalRecord;
 use crate::models::identity::LOCAL_IDENTITY_SCOPE;
 use crate::models::principal::{NewPrincipal, PrincipalKind};
+use diesel_async::RunQueryDsl;
 
 /// Sentinel password value set during anonymization. It is not a valid Argon2
 /// PHC hash, so verification can never succeed.
@@ -34,8 +35,8 @@ fn user_event(
     )
 }
 
-fn load_user_with_name(
-    conn: &mut diesel::PgConnection,
+async fn load_user_with_name(
+    conn: &mut crate::db::DbConnection,
     user_id_value: i32,
 ) -> Result<(User, String), diesel::result::Error> {
     use crate::schema::{principals, users};
@@ -45,10 +46,11 @@ fn load_user_with_name(
         .filter(users::id.eq(user_id_value))
         .select((users::all_columns, principals::name))
         .first::<(User, String)>(conn)
+        .await
 }
 
-fn ensure_user_allows_local_write_conn(
-    conn: &mut diesel::PgConnection,
+async fn ensure_user_allows_local_write_conn(
+    conn: &mut crate::db::DbConnection,
     principal_id_value: i32,
 ) -> Result<(), ApiError> {
     use crate::schema::principals;
@@ -56,7 +58,8 @@ fn ensure_user_allows_local_write_conn(
     let provider_managed = principals::table
         .filter(principals::id.eq(principal_id_value))
         .select(principals::provider_managed)
-        .first::<bool>(conn)?;
+        .first::<bool>(conn)
+        .await?;
     if provider_managed {
         return Err(ApiError::Forbidden(
             "Provider-managed users are read-only in Hubuum".to_string(),
@@ -84,7 +87,7 @@ impl User {
         let pool = pool.clone();
         let name = name_arg.to_string();
         let scope = scope_arg.to_string();
-        crate::db::with_connection_async(pool, move |conn| {
+        crate::db::with_connection_async(pool, async move |conn| {
             users::table
                 .inner_join(principals::table.on(users::id.eq(principals::id)))
                 .inner_join(
@@ -95,6 +98,7 @@ impl User {
                 .filter(identity_scopes::name.eq(scope))
                 .select(users::all_columns)
                 .first::<User>(conn)
+                .await
         })
         .await
     }
@@ -109,20 +113,25 @@ impl User {
         let new_password = hash_password(new_password)
             .map_err(|e| ApiError::HashError(format!("Failed to hash password: {e}")))?;
 
-        with_connection(pool, |conn| -> Result<usize, ApiError> {
-            ensure_user_allows_local_write_conn(conn, self.id)?;
+        with_connection(pool, async |conn| -> Result<usize, ApiError> {
+            ensure_user_allows_local_write_conn(conn, self.id).await?;
             Ok(diesel::update(users.filter(id.eq(self.id)))
                 .set(password.eq(Some(new_password)))
-                .execute(conn)?)
-        })?;
+                .execute(conn)
+                .await?)
+        })
+        .await?;
 
         Ok(())
     }
 }
 
-pub fn count_user_records(pool: &DbPool) -> Result<i64, ApiError> {
+pub async fn count_user_records(pool: &DbPool) -> Result<i64, ApiError> {
     use crate::schema::users::dsl::users;
-    with_connection(pool, |conn| users.count().get_result::<i64>(conn))
+    with_connection(pool, async |conn| {
+        users.count().get_result::<i64>(conn).await
+    })
+    .await
 }
 
 pub trait StoreUserTokenRecord {
@@ -142,11 +151,13 @@ impl StoreUserTokenRecord for User {
         use crate::schema::tokens::dsl::{principal_id, token};
         let token_hash = token_value.storage_hash();
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             diesel::insert_into(crate::schema::tokens::table)
                 .values((principal_id.eq(self.id), token.eq(token_hash)))
                 .execute(conn)
-        })?;
+                .await
+        })
+        .await?;
         Ok(())
     }
 }
@@ -176,12 +187,14 @@ impl OwnedUserTokenRecord for User {
         use crate::schema::tokens::dsl::{principal_id, token, tokens};
         let token_hash = token_value.storage_hash();
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             tokens
                 .filter(principal_id.eq(self.id))
                 .filter(token.eq(token_hash))
                 .first::<PrincipalToken>(conn)
+                .await
         })
+        .await
     }
 
     async fn delete_owned_user_token_record(
@@ -193,7 +206,7 @@ impl OwnedUserTokenRecord for User {
         let token_hash = token_value.storage_hash();
 
         // Soft-revoke: revoked rows are retained for auditability.
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             diesel::update(
                 tokens
                     .filter(principal_id.eq(self.id))
@@ -202,13 +215,15 @@ impl OwnedUserTokenRecord for User {
             )
             .set(revoked_at.eq(diesel::dsl::now))
             .execute(conn)
+            .await
         })
+        .await
     }
 
     async fn delete_all_user_tokens_record(&self, pool: &DbPool) -> Result<usize, ApiError> {
         use crate::schema::tokens::dsl::{principal_id, revoked_at, tokens};
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             diesel::update(
                 tokens
                     .filter(principal_id.eq(self.id))
@@ -216,7 +231,9 @@ impl OwnedUserTokenRecord for User {
             )
             .set(revoked_at.eq(diesel::dsl::now))
             .execute(conn)
+            .await
         })
+        .await
     }
 }
 
@@ -236,32 +253,37 @@ pub trait DeleteUserRecord {
 /// Delete a user by removing its principal row, which cascades to the `users`
 /// row, group memberships, and tokens. (The FK cascades principal → subtype, so
 /// deleting the `users` row alone would orphan the principal.)
-fn delete_principal_without_events(
+async fn delete_principal_without_events(
     pool: &DbPool,
     principal_id_value: i32,
 ) -> Result<usize, ApiError> {
     use crate::schema::principals::dsl::{id, principals};
-    with_connection(pool, |conn| -> Result<usize, ApiError> {
-        ensure_user_allows_local_write_conn(conn, principal_id_value)?;
-        Ok(diesel::delete(principals.filter(id.eq(principal_id_value))).execute(conn)?)
+    with_connection(pool, async |conn| -> Result<usize, ApiError> {
+        ensure_user_allows_local_write_conn(conn, principal_id_value).await?;
+        Ok(diesel::delete(principals.filter(id.eq(principal_id_value)))
+            .execute(conn)
+            .await?)
     })
+    .await
 }
 
-fn delete_principal(
+async fn delete_principal(
     pool: &DbPool,
     principal_id_value: i32,
     context: Option<&EventContext>,
 ) -> Result<usize, ApiError> {
     let Some(context) = context else {
-        return delete_principal_without_events(pool, principal_id_value);
+        return delete_principal_without_events(pool, principal_id_value).await;
     };
 
     use crate::schema::principals::dsl::{id, principals};
 
-    with_transaction(pool, |conn| -> Result<usize, ApiError> {
-        let (user, name) = load_user_with_name(conn, principal_id_value)?;
-        ensure_user_allows_local_write_conn(conn, principal_id_value)?;
-        let deleted = diesel::delete(principals.filter(id.eq(principal_id_value))).execute(conn)?;
+    with_transaction(pool, async |conn| -> Result<usize, ApiError> {
+        let (user, name) = load_user_with_name(conn, principal_id_value).await?;
+        ensure_user_allows_local_write_conn(conn, principal_id_value).await?;
+        let deleted = diesel::delete(principals.filter(id.eq(principal_id_value)))
+            .execute(conn)
+            .await?;
         let event = user_event(
             &user,
             &name,
@@ -270,14 +292,15 @@ fn delete_principal(
             format!("User '{name}' deleted"),
         )?
         .with_before(user_snapshot(&user, &name));
-        emit_event(conn, &event)?;
+        emit_event(conn, &event).await?;
         Ok(deleted)
     })
+    .await
 }
 
 impl DeleteUserRecord for User {
     async fn delete_user_record_without_events(&self, pool: &DbPool) -> Result<usize, ApiError> {
-        delete_principal_without_events(pool, self.id)
+        delete_principal_without_events(pool, self.id).await
     }
 
     async fn delete_user_record(
@@ -285,13 +308,13 @@ impl DeleteUserRecord for User {
         pool: &DbPool,
         context: Option<&EventContext>,
     ) -> Result<usize, ApiError> {
-        delete_principal(pool, self.id, context)
+        delete_principal(pool, self.id, context).await
     }
 }
 
 impl DeleteUserRecord for UserID {
     async fn delete_user_record_without_events(&self, pool: &DbPool) -> Result<usize, ApiError> {
-        delete_principal_without_events(pool, self.id())
+        delete_principal_without_events(pool, self.id()).await
     }
 
     async fn delete_user_record(
@@ -299,7 +322,7 @@ impl DeleteUserRecord for UserID {
         pool: &DbPool,
         context: Option<&EventContext>,
     ) -> Result<usize, ApiError> {
-        delete_principal(pool, self.id(), context)
+        delete_principal(pool, self.id(), context).await
     }
 }
 
@@ -339,13 +362,14 @@ impl CreateUserRecord for NewUser {
         }
         let scope = identity_scope_by_name(pool, &scope_name).await?;
 
-        with_transaction(pool, |conn| -> Result<User, ApiError> {
+        with_transaction(pool, async |conn| -> Result<User, ApiError> {
             let principal = NewPrincipal {
                 identity_scope_id: scope.id,
                 kind: PrincipalKind::Human.as_str(),
                 name: &name,
             }
-            .insert(conn)?;
+            .insert(conn)
+            .await?;
 
             let user = diesel::insert_into(users::table)
                 .values((
@@ -354,10 +378,12 @@ impl CreateUserRecord for NewUser {
                     users::proper_name.eq(&proper_name),
                     users::email.eq(&email),
                 ))
-                .get_result::<User>(conn)?;
+                .get_result::<User>(conn)
+                .await?;
 
             Ok(user)
         })
+        .await
     }
 
     async fn create_user_record(
@@ -388,13 +414,14 @@ impl CreateUserRecord for NewUser {
         }
         let scope = identity_scope_by_name(pool, &scope_name).await?;
 
-        with_transaction(pool, |conn| -> Result<User, ApiError> {
+        with_transaction(pool, async |conn| -> Result<User, ApiError> {
             let principal = NewPrincipal {
                 identity_scope_id: scope.id,
                 kind: PrincipalKind::Human.as_str(),
                 name: &name,
             }
-            .insert(conn)?;
+            .insert(conn)
+            .await?;
 
             let user = diesel::insert_into(users::table)
                 .values((
@@ -403,7 +430,8 @@ impl CreateUserRecord for NewUser {
                     users::proper_name.eq(&proper_name),
                     users::email.eq(&email),
                 ))
-                .get_result::<User>(conn)?;
+                .get_result::<User>(conn)
+                .await?;
 
             let event = user_event(
                 &user,
@@ -413,9 +441,10 @@ impl CreateUserRecord for NewUser {
                 format!("User '{name}' created"),
             )?
             .with_after(user_snapshot(&user, &name));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(user)
         })
+        .await
     }
 }
 
@@ -445,12 +474,14 @@ impl UpdateUserRecord for UpdateUser {
     ) -> Result<User, ApiError> {
         use crate::schema::users::dsl::{id, users};
 
-        with_connection(pool, |conn| -> Result<User, ApiError> {
-            ensure_user_allows_local_write_conn(conn, user_id)?;
+        with_connection(pool, async |conn| -> Result<User, ApiError> {
+            ensure_user_allows_local_write_conn(conn, user_id).await?;
             Ok(diesel::update(users.filter(id.eq(user_id)))
                 .set(self)
-                .get_result::<User>(conn)?)
+                .get_result::<User>(conn)
+                .await?)
         })
+        .await
     }
 
     async fn update_user_record(
@@ -465,12 +496,13 @@ impl UpdateUserRecord for UpdateUser {
 
         use crate::schema::users::dsl::{id, users};
 
-        with_transaction(pool, |conn| -> Result<User, ApiError> {
-            let (before, name) = load_user_with_name(conn, user_id)?;
-            ensure_user_allows_local_write_conn(conn, user_id)?;
+        with_transaction(pool, async |conn| -> Result<User, ApiError> {
+            let (before, name) = load_user_with_name(conn, user_id).await?;
+            ensure_user_allows_local_write_conn(conn, user_id).await?;
             let after = diesel::update(users.filter(id.eq(user_id)))
                 .set(self)
-                .get_result::<User>(conn)?;
+                .get_result::<User>(conn)
+                .await?;
             let event = user_event(
                 &after,
                 &name,
@@ -483,9 +515,10 @@ impl UpdateUserRecord for UpdateUser {
             .with_metadata(serde_json::json!({
                 "password_changed": self.password.is_some(),
             }));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(after)
         })
+        .await
     }
 }
 
@@ -495,23 +528,23 @@ pub trait AnonymizeUserRecord {
 
 impl AnonymizeUserRecord for UserID {
     async fn anonymize_user_record(&self, pool: &DbPool) -> Result<(), ApiError> {
-        anonymize_user_record(pool, self.id())
+        anonymize_user_record(pool, self.id()).await
     }
 }
 
 impl AnonymizeUserRecord for User {
     async fn anonymize_user_record(&self, pool: &DbPool) -> Result<(), ApiError> {
-        anonymize_user_record(pool, self.id)
+        anonymize_user_record(pool, self.id).await
     }
 }
 
-fn anonymize_user_record(pool: &DbPool, target_id: i32) -> Result<(), ApiError> {
+async fn anonymize_user_record(pool: &DbPool, target_id: i32) -> Result<(), ApiError> {
     use crate::schema::principals::dsl as p;
     use crate::schema::tokens::dsl as t;
     use crate::schema::users::dsl as u;
 
-    with_transaction(pool, |conn| -> Result<(), ApiError> {
-        ensure_user_allows_local_write_conn(conn, target_id)?;
+    with_transaction(pool, async |conn| -> Result<(), ApiError> {
+        ensure_user_allows_local_write_conn(conn, target_id).await?;
         let updated = diesel::update(u::users.filter(u::id.eq(target_id)))
             .set((
                 u::proper_name.eq::<Option<String>>(None),
@@ -519,23 +552,27 @@ fn anonymize_user_record(pool: &DbPool, target_id: i32) -> Result<(), ApiError> 
                 u::password.eq(Some(ANONYMIZED_PASSWORD)),
                 u::anonymized_at.eq(diesel::dsl::now),
             ))
-            .execute(conn)?;
+            .execute(conn)
+            .await?;
         if updated == 0 {
             return Err(ApiError::NotFound(format!("User {target_id} not found")));
         }
 
         diesel::update(p::principals.filter(p::id.eq(target_id)))
             .set(p::name.eq(format!("anonymized-{target_id}")))
-            .execute(conn)?;
+            .execute(conn)
+            .await?;
         diesel::update(
             t::tokens
                 .filter(t::principal_id.eq(target_id))
                 .filter(t::revoked_at.is_null()),
         )
         .set(t::revoked_at.eq(diesel::dsl::now))
-        .execute(conn)?;
+        .execute(conn)
+        .await?;
         Ok(())
     })
+    .await
 }
 
 pub trait DeleteTokenRecord {
@@ -548,7 +585,7 @@ impl DeleteTokenRecord for Token {
         let token_hash = self.storage_hash();
 
         // Soft-revoke rather than hard-delete.
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             diesel::update(
                 tokens
                     .filter(token.eq(token_hash))
@@ -556,7 +593,9 @@ impl DeleteTokenRecord for Token {
             )
             .set(revoked_at.eq(diesel::dsl::now))
             .execute(conn)
-        })?;
+            .await
+        })
+        .await?;
         Ok(())
     }
 }
@@ -575,8 +614,9 @@ impl LoadUserRecord for UserID {
     async fn load_user_record(&self, pool: &DbPool) -> Result<User, ApiError> {
         use crate::schema::users::dsl::{id, users};
 
-        with_connection(pool, |conn| {
-            users.filter(id.eq(self.id())).first::<User>(conn)
+        with_connection(pool, async |conn| {
+            users.filter(id.eq(self.id())).first::<User>(conn).await
         })
+        .await
     }
 }

--- a/src/db/traits/user/membership.rs
+++ b/src/db/traits/user/membership.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::db::traits::authz::{AuthzSubject, scope_allows};
+use diesel_async::RunQueryDsl;
 
 pub trait LoadUserGroups: AuthzSubject {
     async fn load_user_groups(&self, pool: &DbPool) -> Result<Vec<Group>, ApiError>;
@@ -13,13 +14,16 @@ where
         use crate::schema::group_memberships::dsl::{group_id, group_memberships, principal_id};
         use crate::schema::groups::dsl::*;
 
-        with_connection(pool, |conn| {
+        let principal_id_value = self.principal_id();
+        with_connection(pool, async |conn| {
             group_memberships
                 .inner_join(groups.on(id.eq(group_id)))
-                .filter(principal_id.eq(self.principal_id()))
+                .filter(principal_id.eq(principal_id_value))
                 .select(groups::all_columns())
                 .load::<Group>(conn)
+                .await
         })
+        .await
     }
 }
 
@@ -80,13 +84,18 @@ where
         };
 
         let base_query = build_query()?;
-        let total_count = crate::pagination::exact_count_or_skipped(query_options, || {
-            with_connection(pool, |conn| base_query.count().get_result::<i64>(conn))
-        })?;
+        let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
+            with_connection(pool, async |conn| {
+                base_query.count().get_result::<i64>(conn).await
+            })
+            .await
+        })
+        .await?;
 
         let mut base_query = build_query()?.select(groups::all_columns());
         crate::apply_query_options!(base_query, query_options, Group);
-        let items = with_connection(pool, |conn| base_query.load::<Group>(conn))?;
+        let items =
+            with_connection(pool, async |conn| base_query.load::<Group>(conn).await).await?;
 
         Ok((items, total_count))
     }
@@ -164,11 +173,13 @@ where
         // Unscoped admins see everything; scoped admins fall through to the
         // permission query so their token scope still bounds the listing.
         if is_admin && scopes.is_none() {
-            return with_connection(pool, |conn| {
+            return with_connection(pool, async |conn| {
                 collections
                     .select(collections::all_columns())
                     .load::<Collection>(conn)
-            });
+                    .await
+            })
+            .await;
         }
 
         let groups_id_subquery = self.group_ids_subquery();
@@ -181,7 +192,7 @@ where
             base_query = perm.create_boxed_filter(base_query, true);
         }
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             base_query
                 .inner_join(
                     collection_closure.on(permission_collection_id.eq(ancestor_collection_id)),
@@ -190,6 +201,8 @@ where
                 .select(collections::all_columns())
                 .distinct()
                 .load::<Collection>(conn)
+                .await
         })
+        .await
     }
 }

--- a/src/db/traits/user/mod.rs
+++ b/src/db/traits/user/mod.rs
@@ -1,4 +1,4 @@
-use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl, RunQueryDsl, Table};
+use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl, Table};
 use std::iter::IntoIterator;
 
 use tracing::debug;

--- a/src/db/traits/user/permissions.rs
+++ b/src/db/traits/user/permissions.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::db::traits::authz::{AuthzSubject, scope_allows};
+use diesel_async::RunQueryDsl;
 pub trait UserPermissions: AuthzSubject {
     /// ## Check if a subject has a set of permissions in a set of collections
     ///
@@ -78,11 +79,13 @@ pub trait UserPermissions: AuthzSubject {
         }
 
         // Count the number of distinct collections that match all criteria
-        let matching_collections_count = with_connection(pool, |conn| {
+        let matching_collections_count = with_connection(pool, async |conn| {
             base_query
                 .select(count(descendant_collection_id).aggregate_distinct())
                 .first::<i64>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         // Check if the count of matching collections equals the number of input collections
         if matching_collections_count as usize == collection_ids.len() {

--- a/src/db/traits/user/search.rs
+++ b/src/db/traits/user/search.rs
@@ -6,6 +6,7 @@ use crate::models::search::SQLValue;
 use crate::traits::PrincipalIdAccessor;
 use crate::traits::{CursorPaginated, CursorSqlMapping};
 use crate::utilities::extensions::CustomStringExtensions;
+use diesel_async::RunQueryDsl;
 
 #[derive(diesel::QueryableByName)]
 struct CountRow {
@@ -177,11 +178,13 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
         crate::apply_query_options!(base_query, query_options, Collection);
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             base_query
                 .select(collections::all_columns())
                 .load::<Collection>(conn)
+                .await
         })
+        .await
     }
 
     async fn count_collections_from_backend_with_admin_status(
@@ -273,7 +276,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             }
         }
 
-        with_connection(pool, |conn| base_query.count().get_result::<i64>(conn))
+        with_connection(pool, async |conn| {
+            base_query.count().get_result::<i64>(conn).await
+        })
+        .await
     }
 
     async fn search_classes_from_backend(
@@ -394,12 +400,14 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
         trace_query!(base_query, "Searching classes");
 
-        let result = with_connection(pool, |conn| {
+        let result = with_connection(pool, async |conn| {
             base_query
                 .select(hubuumclass::all_columns())
                 .distinct()
                 .load::<HubuumClass>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         let collection_map: std::collections::HashMap<i32, Collection> =
             collections.into_iter().map(|n| (n.id, n)).collect();
@@ -478,13 +486,15 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             }
         }
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             base_query
                 .select(class_id)
                 .distinct()
                 .count()
                 .get_result::<i64>(conn)
+                .await
         })
+        .await
     }
 
     async fn search_objects_from_backend(
@@ -610,12 +620,14 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
         trace_query!(base_query, "Searching objects");
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             base_query
                 .select(hubuumobject::all_columns())
                 .distinct()
                 .load::<HubuumObject>(conn)
+                .await
         })
+        .await
     }
 
     async fn count_objects_from_backend_with_admin_status(
@@ -694,13 +706,15 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             }
         }
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             base_query
                 .select(object_id)
                 .distinct()
                 .count()
                 .get_result::<i64>(conn)
+                .await
         })
+        .await
     }
 
     async fn search_class_relations_from_backend(
@@ -915,27 +929,32 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         };
 
         let base_query = build_query()?;
-        let total_count = crate::pagination::exact_count_or_skipped(&query_options, || {
-            with_connection(pool, |conn| {
+        let total_count = crate::pagination::exact_count_or_skipped(&query_options, async || {
+            with_connection(pool, async |conn| {
                 base_query
                     .select(class_relation_id)
                     .distinct()
                     .count()
                     .get_result::<i64>(conn)
+                    .await
             })
-        })?;
+            .await
+        })
+        .await?;
 
         let mut base_query = build_query()?;
         crate::apply_query_options!(base_query, query_options, HubuumClassRelation);
 
         trace_query!(base_query, "Searching class relations");
 
-        let items = with_connection(pool, |conn| {
+        let items = with_connection(pool, async |conn| {
             base_query
                 .select(hubuumclass_relation::all_columns())
                 .distinct()
                 .load::<HubuumClassRelation>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         Ok((items, total_count))
     }
@@ -1051,15 +1070,18 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         };
 
         let base_query = build_query()?;
-        let total_count = crate::pagination::exact_count_or_skipped(&query_options, || {
-            with_connection(pool, |conn| {
+        let total_count = crate::pagination::exact_count_or_skipped(&query_options, async || {
+            with_connection(pool, async |conn| {
                 base_query
                     .select(relation_id)
                     .distinct()
                     .count()
                     .get_result::<i64>(conn)
+                    .await
             })
-        })?;
+            .await
+        })
+        .await?;
 
         let mut base_query = build_query()?;
         crate::apply_query_options!(base_query, query_options, HubuumClassRelation);
@@ -1069,12 +1091,14 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             "Searching direct class relations touching class"
         );
 
-        let items = with_connection(pool, |conn| {
+        let items = with_connection(pool, async |conn| {
             base_query
                 .select(hubuumclass_relation::all_columns())
                 .distinct()
                 .load::<HubuumClassRelation>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         Ok((items, total_count))
     }
@@ -1144,7 +1168,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
         trace_query!(base_query, "Searching class relations among class IDs");
 
-        with_connection(pool, |conn| base_query.load::<HubuumClassRelation>(conn))
+        with_connection(pool, async |conn| {
+            base_query.load::<HubuumClassRelation>(conn).await
+        })
+        .await
     }
 
     async fn search_classes_related_to_from_backend<K>(
@@ -1222,7 +1249,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         );
         trace_query!(query, "Searching related classes");
 
-        with_connection(pool, |conn| query.get_results::<ClassGraphRow>(conn))
+        with_connection(pool, async |conn| {
+            query.get_results::<ClassGraphRow>(conn).await
+        })
+        .await
     }
 
     async fn classes_related_to_page_from_backend_with_admin_status<K>(
@@ -1254,13 +1284,16 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         let total_count_spec = base_spec.clone().into_count_query("related_classes_count");
         let spec = apply_raw_sql_pagination::<ClassGraphRow>(base_spec, &query_options)?;
 
-        let total_count = crate::pagination::exact_count_or_skipped(&query_options, || {
-            with_connection(pool, |conn| {
+        let total_count = crate::pagination::exact_count_or_skipped(&query_options, async || {
+            with_connection(pool, async |conn| {
                 bind_raw_sql_query!(total_count_spec)
                     .get_result::<CountRow>(conn)
+                    .await
                     .map(|row| row.count)
             })
-        })?;
+            .await
+        })
+        .await?;
 
         let query = bind_raw_sql_query!(spec.clone());
         debug!(
@@ -1269,7 +1302,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             bind_variables = ?spec.bind_variables
         );
         trace_query!(query, "Searching related classes");
-        let items = with_connection(pool, |conn| query.get_results::<ClassGraphRow>(conn))?;
+        let items = with_connection(pool, async |conn| {
+            query.get_results::<ClassGraphRow>(conn).await
+        })
+        .await?;
 
         Ok((items, total_count))
     }
@@ -1422,27 +1458,32 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         };
 
         let base_query = build_query()?;
-        let total_count = crate::pagination::exact_count_or_skipped(&query_options, || {
-            with_connection(pool, |conn| {
+        let total_count = crate::pagination::exact_count_or_skipped(&query_options, async || {
+            with_connection(pool, async |conn| {
                 base_query
                     .select(relation_id)
                     .distinct()
                     .count()
                     .get_result::<i64>(conn)
+                    .await
             })
-        })?;
+            .await
+        })
+        .await?;
 
         let mut base_query = build_query()?;
         crate::apply_query_options!(base_query, query_options, HubuumObjectRelation);
 
         trace_query!(base_query, "Searching object relations");
 
-        let items = with_connection(pool, |conn| {
+        let items = with_connection(pool, async |conn| {
             base_query
                 .select(hubuumobject_relation::all_columns())
                 .distinct()
                 .load::<HubuumObjectRelation>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         Ok((items, total_count))
     }
@@ -1578,15 +1619,18 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         };
 
         let base_query = build_query()?;
-        let total_count = crate::pagination::exact_count_or_skipped(&query_options, || {
-            with_connection(pool, |conn| {
+        let total_count = crate::pagination::exact_count_or_skipped(&query_options, async || {
+            with_connection(pool, async |conn| {
                 base_query
                     .select(relation_id)
                     .distinct()
                     .count()
                     .get_result::<i64>(conn)
+                    .await
             })
-        })?;
+            .await
+        })
+        .await?;
 
         let mut base_query = build_query()?;
         crate::apply_query_options!(base_query, query_options, HubuumObjectRelation);
@@ -1596,12 +1640,14 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             "Searching direct object relations touching object"
         );
 
-        let items = with_connection(pool, |conn| {
+        let items = with_connection(pool, async |conn| {
             base_query
                 .select(hubuumobject_relation::all_columns())
                 .distinct()
                 .load::<HubuumObjectRelation>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         Ok((items, total_count))
     }
@@ -1678,7 +1724,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
         trace_query!(base_query, "Searching object relations among object IDs");
 
-        with_connection(pool, |conn| base_query.load::<HubuumObjectRelation>(conn))
+        with_connection(pool, async |conn| {
+            base_query.load::<HubuumObjectRelation>(conn).await
+        })
+        .await
     }
 
     async fn search_objects_related_to_from_backend<O>(
@@ -1756,9 +1805,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         );
         trace_query!(query, "Searching source-relative related objects");
 
-        with_connection(pool, |conn| {
-            query.get_results::<RelatedObjectGraphRow>(conn)
+        with_connection(pool, async |conn| {
+            query.get_results::<RelatedObjectGraphRow>(conn).await
         })
+        .await
     }
 
     async fn objects_related_to_page_from_backend_with_admin_status<O>(
@@ -1790,13 +1840,16 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         let total_count_spec = base_spec.clone().into_count_query("related_objects_count");
         let spec = apply_raw_sql_pagination::<RelatedObjectGraphRow>(base_spec, &query_options)?;
 
-        let total_count = crate::pagination::exact_count_or_skipped(&query_options, || {
-            with_connection(pool, |conn| {
+        let total_count = crate::pagination::exact_count_or_skipped(&query_options, async || {
+            with_connection(pool, async |conn| {
                 bind_raw_sql_query!(total_count_spec)
                     .get_result::<CountRow>(conn)
+                    .await
                     .map(|row| row.count)
             })
-        })?;
+            .await
+        })
+        .await?;
 
         let query = bind_raw_sql_query!(spec.clone());
         debug!(
@@ -1805,9 +1858,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             bind_variables = ?spec.bind_variables
         );
         trace_query!(query, "Searching source-relative related objects");
-        let items = with_connection(pool, |conn| {
-            query.get_results::<RelatedObjectGraphRow>(conn)
-        })?;
+        let items = with_connection(pool, async |conn| {
+            query.get_results::<RelatedObjectGraphRow>(conn).await
+        })
+        .await?;
 
         Ok((items, total_count))
     }
@@ -1891,9 +1945,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         );
         trace_query!(query, "Searching batched related objects");
 
-        with_connection(pool, |conn| {
-            query.get_results::<RelatedObjectIncludeRow>(conn)
+        with_connection(pool, async |conn| {
+            query.get_results::<RelatedObjectIncludeRow>(conn).await
         })
+        .await
     }
 
     async fn bidirectionally_related_objects_for_roots_from_backend(
@@ -1968,9 +2023,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         );
         trace_query!(query, "Searching batched bidirectionally related objects");
 
-        with_connection(pool, |conn| {
-            query.get_results::<RelatedObjectForRootRow>(conn)
+        with_connection(pool, async |conn| {
+            query.get_results::<RelatedObjectForRootRow>(conn).await
         })
+        .await
     }
 }
 
@@ -3188,7 +3244,7 @@ impl User {
 
         trace_query!(base_query, "Searching users");
 
-        let rows = with_connection(pool, |conn| {
+        let rows = with_connection(pool, async |conn| {
             base_query
                 .select((
                     crate::schema::users::all_columns,
@@ -3209,7 +3265,9 @@ impl User {
                     Option<chrono::NaiveDateTime>,
                     Option<chrono::NaiveDateTime>,
                 )>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         Ok(rows
             .into_iter()
@@ -3259,13 +3317,15 @@ impl User {
             }
         }
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             base_query
                 .select(id)
                 .distinct()
                 .count()
                 .get_result::<i64>(conn)
+                .await
         })
+        .await
     }
 
     pub async fn search_groups(
@@ -3316,12 +3376,14 @@ impl User {
 
         trace_query!(base_query, "Searching groups");
 
-        let result = with_connection(pool, |conn| {
+        let result = with_connection(pool, async |conn| {
             base_query
                 .select(groups::all_columns())
                 .distinct()
                 .load::<Group>(conn)
-        })?;
+                .await
+        })
+        .await?;
 
         Ok(result)
     }
@@ -3362,12 +3424,14 @@ impl User {
             }
         }
 
-        with_connection(pool, |conn| {
+        with_connection(pool, async |conn| {
             base_query
                 .select(id)
                 .distinct()
                 .count()
                 .get_result::<i64>(conn)
+                .await
         })
+        .await
     }
 }

--- a/src/db/traits/user/unified_search.rs
+++ b/src/db/traits/user/unified_search.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use diesel::sql_query;
 use diesel::sql_types::{BigInt, Bool, Integer, Text};
 
@@ -140,7 +140,7 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
             cursor_values(params.collection_cursor.as_ref());
         let limit = bounded_limit(params.limit_per_kind);
 
-        with_connection_async(pool.clone(), move |conn| {
+        with_connection_async(pool.clone(), async move |conn| {
             sql_query(COLLECTION_SEARCH_SQL)
                 .bind::<Text, _>(query)
                 .bind::<Bool, _>(is_unscoped_admin)
@@ -151,6 +151,7 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
                 .bind::<Integer, _>(cursor_id)
                 .bind::<BigInt, _>(limit)
                 .load::<Collection>(conn)
+                .await
         })
         .await
     }
@@ -176,7 +177,7 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
             cursor_values(params.class_cursor.as_ref());
         let limit = bounded_limit(params.limit_per_kind);
 
-        let classes = with_connection_async(pool.clone(), move |conn| {
+        let classes = with_connection_async(pool.clone(), async move |conn| {
             sql_query(CLASS_SEARCH_SQL)
                 .bind::<Text, _>(query)
                 .bind::<Bool, _>(search_schema)
@@ -188,6 +189,7 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
                 .bind::<Integer, _>(cursor_id)
                 .bind::<BigInt, _>(limit)
                 .load::<HubuumClass>(conn)
+                .await
         })
         .await?;
 
@@ -199,11 +201,12 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
             .iter()
             .map(|class| class.collection_id)
             .collect::<Vec<_>>();
-        let collections = with_connection_async(pool.clone(), move |conn| {
+        let collections = with_connection_async(pool.clone(), async move |conn| {
             use crate::schema::collections::dsl::{collections, id};
             collections
                 .filter(id.eq_any(collection_ids))
                 .load::<Collection>(conn)
+                .await
         })
         .await?;
         let collection_map = collections
@@ -235,7 +238,7 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
             cursor_values(params.object_cursor.as_ref());
         let limit = bounded_limit(params.limit_per_kind);
 
-        with_connection_async(pool.clone(), move |conn| {
+        with_connection_async(pool.clone(), async move |conn| {
             sql_query(OBJECT_SEARCH_SQL)
                 .bind::<Text, _>(query)
                 .bind::<Bool, _>(search_data)
@@ -247,6 +250,7 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
                 .bind::<Integer, _>(cursor_id)
                 .bind::<BigInt, _>(limit)
                 .load::<HubuumObject>(conn)
+                .await
         })
         .await
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,8 @@
 use actix_web::{
     HttpRequest, HttpResponse, ResponseError, error::JsonPayloadError, http::StatusCode,
 };
-use diesel::r2d2::PoolError;
 use diesel::result::{DatabaseErrorKind, Error as DieselError};
+use diesel_async::pooled_connection::bb8::RunError as PoolError;
 use serde::Serialize;
 use serde_json::json;
 use std::fmt;
@@ -349,27 +349,14 @@ mod tests {
         // We don't actually call it (would exit), just verify it compiles
     }
 
-    #[test]
-    fn test_api_error_from_pool_error() {
-        // Test that PoolError converts to DbConnectionError
-        use diesel::PgConnection;
-        use diesel::r2d2::ConnectionManager;
-
-        let manager = ConnectionManager::<PgConnection>::new("postgres://invalid:5432/nonexistent");
-        let pool_result = diesel::r2d2::Pool::builder()
-            .max_size(1)
-            .connection_timeout(std::time::Duration::from_millis(1))
-            .build(manager);
-
-        if let Ok(pool) = pool_result {
-            let result = crate::db::with_connection(&pool, |_conn| Ok::<(), ApiError>(()));
-            match result {
-                Err(ApiError::DbConnectionError(_)) => {
-                    // Expected
-                }
-                Err(other) => panic!("Expected DbConnectionError from PoolError, got: {other:?}"),
-                Ok(_) => panic!("Expected pool connection to fail"),
-            }
+    #[tokio::test]
+    async fn test_api_error_from_pool_error() {
+        let pool = crate::db::init_pool("postgres://invalid:5432/nonexistent", 1);
+        let result = crate::db::with_connection(&pool, async |_conn| Ok::<(), ApiError>(())).await;
+        match result {
+            Err(ApiError::DbConnectionError(_)) => {}
+            Err(other) => panic!("Expected DbConnectionError from pool error, got: {other:?}"),
+            Ok(_) => panic!("Expected pool connection to fail"),
         }
     }
 

--- a/src/events/db.rs
+++ b/src/events/db.rs
@@ -1,7 +1,7 @@
 //! Transaction-aware event writer (#71).
 //!
 //! [`emit_event`] is the narrow producer API: it accepts the caller's
-//! `&mut PgConnection` (the same connection used inside `with_transaction`)
+//! `&mut crate::db::DbConnection` (the same connection used inside `with_transaction`)
 //! and appends exactly one row to `events`. It deliberately exposes nothing
 //! about fan-out or delivery — mutation code depends only on this writer and
 //! the [`NewEvent`](super::NewEvent) builder.
@@ -10,7 +10,7 @@
 //! commits or rolls back together with the domain mutation, giving the
 //! "recorded iff committed" guarantee.
 
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use diesel::result::Error as DieselError;
 
 use crate::schema::events::dsl::events;
@@ -21,10 +21,14 @@ use super::{Event, NewEvent};
 ///
 /// Call this inside a `with_transaction(pool, |conn| { ...; emit_event(conn,
 /// &event) })` block so the event and the mutation commit atomically.
-pub fn emit_event(conn: &mut PgConnection, new_event: &NewEvent) -> Result<Event, DieselError> {
+pub async fn emit_event(
+    conn: &mut crate::db::DbConnection,
+    new_event: &NewEvent,
+) -> Result<Event, DieselError> {
     let event = diesel::insert_into(events)
         .values(new_event)
-        .get_result::<Event>(conn)?;
-    super::notify_event_fanout(conn)?;
+        .get_result::<Event>(conn)
+        .await?;
+    super::notify_event_fanout(conn).await?;
     Ok(event)
 }

--- a/src/events/model.rs
+++ b/src/events/model.rs
@@ -7,8 +7,8 @@
 //! catalog enums at the Diesel boundary while exposing typed builders; the
 //! [`Event`] read model converts back to the typed enums on demand.
 
+use crate::db::prelude::*;
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;

--- a/src/events/pg_notify.rs
+++ b/src/events/pg_notify.rs
@@ -1,7 +1,8 @@
 use std::thread;
 use std::time::Duration;
 
-use diesel::prelude::*;
+use crate::db::prelude::*;
+use futures_util::StreamExt;
 use tracing::{debug, error, info};
 
 use crate::db::DbPool;
@@ -9,16 +10,18 @@ use crate::db::DbPool;
 pub const EVENT_FANOUT_CHANNEL: &str = "hubuum_event_fanout";
 pub const EVENT_DELIVERY_CHANNEL: &str = "hubuum_event_delivery";
 
-pub fn notify_event_fanout(conn: &mut PgConnection) -> QueryResult<usize> {
-    notify_channel(conn, EVENT_FANOUT_CHANNEL)
+pub async fn notify_event_fanout(conn: &mut crate::db::DbConnection) -> QueryResult<usize> {
+    notify_channel(conn, EVENT_FANOUT_CHANNEL).await
 }
 
-pub fn notify_event_delivery(conn: &mut PgConnection) -> QueryResult<usize> {
-    notify_channel(conn, EVENT_DELIVERY_CHANNEL)
+pub async fn notify_event_delivery(conn: &mut crate::db::DbConnection) -> QueryResult<usize> {
+    notify_channel(conn, EVENT_DELIVERY_CHANNEL).await
 }
 
-fn notify_channel(conn: &mut PgConnection, channel: &str) -> QueryResult<usize> {
-    diesel::sql_query(format!("NOTIFY {channel}")).execute(conn)
+async fn notify_channel(conn: &mut crate::db::DbConnection, channel: &str) -> QueryResult<usize> {
+    diesel::sql_query(format!("NOTIFY {channel}"))
+        .execute(conn)
+        .await
 }
 
 pub fn spawn_postgres_notification_listener(
@@ -29,23 +32,27 @@ pub fn spawn_postgres_notification_listener(
 ) {
     thread::Builder::new()
         .name(thread_name.to_string())
-        .spawn(move || listen_loop(pool, channel, on_notification))
+        .spawn(move || {
+            let system = actix_rt::System::new();
+            system.block_on(listen_loop(pool, channel, on_notification));
+        })
         .expect("failed to spawn Postgres notification listener thread");
 }
 
-fn listen_loop(pool: DbPool, channel: &'static str, on_notification: fn()) {
+async fn listen_loop(pool: DbPool, channel: &'static str, on_notification: fn()) {
     loop {
-        match pool.get() {
+        match pool.get().await {
             Ok(mut conn) => {
-                if let Err(error) =
-                    diesel::sql_query(format!("LISTEN {channel}")).execute(&mut conn)
+                if let Err(error) = diesel::sql_query(format!("LISTEN {channel}"))
+                    .execute(&mut conn)
+                    .await
                 {
                     error!(
                         message = "Failed to register Postgres notification listener",
                         channel = channel,
                         error = %error
                     );
-                    thread::sleep(Duration::from_secs(1));
+                    actix_rt::time::sleep(Duration::from_secs(1)).await;
                     continue;
                 }
 
@@ -53,7 +60,7 @@ fn listen_loop(pool: DbPool, channel: &'static str, on_notification: fn()) {
                     message = "Listening for Postgres event worker notifications",
                     channel = channel
                 );
-                poll_notifications(&mut conn, channel, on_notification);
+                poll_notifications(&mut conn, channel, on_notification).await;
             }
             Err(error) => {
                 error!(
@@ -61,40 +68,38 @@ fn listen_loop(pool: DbPool, channel: &'static str, on_notification: fn()) {
                     channel = channel,
                     error = %error
                 );
-                thread::sleep(Duration::from_secs(1));
+                actix_rt::time::sleep(Duration::from_secs(1)).await;
             }
         }
     }
 }
 
-fn poll_notifications(conn: &mut PgConnection, channel: &'static str, on_notification: fn()) {
-    loop {
-        let mut should_reconnect = false;
-        for notification in conn.notifications_iter() {
-            match notification {
-                Ok(notification) if notification.channel == channel => {
-                    debug!(
-                        message = "Received Postgres event worker notification",
-                        channel = channel,
-                        process_id = notification.process_id
-                    );
-                    on_notification();
-                }
-                Ok(_) => {}
-                Err(error) => {
-                    error!(
-                        message = "Postgres notification listener failed",
-                        channel = channel,
-                        error = %error
-                    );
-                    should_reconnect = true;
-                    break;
-                }
+async fn poll_notifications(
+    conn: &mut crate::db::DbConnection,
+    channel: &'static str,
+    on_notification: fn(),
+) {
+    let notifications = conn.notifications_stream();
+    futures_util::pin_mut!(notifications);
+    while let Some(notification) = notifications.next().await {
+        match notification {
+            Ok(notification) if notification.channel == channel => {
+                debug!(
+                    message = "Received Postgres event worker notification",
+                    channel = channel,
+                    process_id = notification.process_id
+                );
+                on_notification();
+            }
+            Ok(_) => {}
+            Err(error) => {
+                error!(
+                    message = "Postgres notification listener failed",
+                    channel = channel,
+                    error = %error
+                );
+                return;
             }
         }
-        if should_reconnect {
-            return;
-        }
-        thread::sleep(Duration::from_millis(250));
     }
 }

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -7,7 +7,7 @@
 
 #![cfg(test)]
 
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use rstest::rstest;
 use uuid::Uuid;
 
@@ -55,19 +55,21 @@ static EVENT_DELIVERY_TEST_LOCK: TestMutex = test_mutex();
 static EVENT_RETENTION_TEST_LOCK: TestMutex = test_mutex();
 
 /// Count event rows for a given `event_id` (0 or 1, since `event_id` is UNIQUE).
-fn count_events_for(conn: &mut PgConnection, target: Uuid) -> i64 {
+async fn count_events_for(conn: &mut crate::db::DbConnection, target: Uuid) -> i64 {
     use crate::schema::events::dsl::event_id;
     events
         .filter(event_id.eq(target))
         .count()
         .get_result(conn)
+        .await
         .expect("count query")
 }
 
 #[rstest]
+#[tokio::test]
 #[case::commit_persists(false)]
 #[case::rollback_discards(true)]
-fn emit_event_respects_transaction_outcome(#[case] rollback: bool) {
+async fn emit_event_respects_transaction_outcome(#[case] rollback: bool) {
     let scope = test_scope();
     let pool = scope.pool.clone();
 
@@ -86,16 +88,17 @@ fn emit_event_respects_transaction_outcome(#[case] rollback: bool) {
     .with_metadata(serde_json::json!({"k": "v"}));
     let event_uuid = new_event.event_id();
 
-    let result: Result<Event, ApiError> = with_transaction(&pool, |conn| {
-        let event = emit_event(conn, &new_event)?;
+    let result: Result<Event, ApiError> = with_transaction(&pool, async |conn| {
+        let event = emit_event(conn, &new_event).await?;
         // The row is visible inside the same transaction.
-        assert_eq!(count_events_for(conn, event_uuid), 1);
+        assert_eq!(count_events_for(conn, event_uuid).await, 1);
         if rollback {
             // Simulate a later mutation step failing, aborting the whole tx.
             return Err(ApiError::InternalServerError("simulated failure".into()));
         }
         Ok(event)
-    });
+    })
+    .await;
 
     if rollback {
         assert!(result.is_err(), "expected rollback error");
@@ -104,9 +107,10 @@ fn emit_event_respects_transaction_outcome(#[case] rollback: bool) {
     }
 
     // After the transaction settles, the row persists iff it committed.
-    let persisted = with_connection(&pool, |conn| {
-        Ok::<_, diesel::result::Error>(count_events_for(conn, event_uuid))
+    let persisted = with_connection(&pool, async |conn| {
+        Ok::<_, diesel::result::Error>(count_events_for(conn, event_uuid).await)
     })
+    .await
     .unwrap();
     if rollback {
         assert_eq!(
@@ -172,11 +176,11 @@ fn new_event_applies_event_context() {
     assert_eq!(ev.correlation_id(), Some("client-correlation"));
 }
 
-#[test]
-fn fanout_backlog_index_exists() {
+#[tokio::test]
+async fn fanout_backlog_index_exists() {
     // The partial fan-out backlog index must be present before #76 (#71 done-when).
     let scope = test_scope();
-    with_connection(&scope.pool, |conn| {
+    with_connection(&scope.pool, async |conn| {
         let exists: bool = diesel::sql_query(
             "SELECT EXISTS (
                 SELECT 1 FROM pg_indexes
@@ -187,10 +191,12 @@ fn fanout_backlog_index_exists() {
             )",
         )
         .get_result::<IndexExistsRow>(conn)
+        .await
         .map(|r| r.exists)?;
         assert!(exists, "events_fanout_backlog_idx partial index is missing");
         Ok::<_, diesel::result::Error>(())
     })
+    .await
     .unwrap();
 }
 
@@ -248,7 +254,7 @@ async fn create_collection_event_subscription_with_filter(
     .id
 }
 
-fn emit_collection_created_event(scope: &TestScope, collection_id: i32) -> Event {
+async fn emit_collection_created_event(scope: &TestScope, collection_id: i32) -> Event {
     let event = NewEvent::new(
         EntityType::Collection,
         Action::Created,
@@ -260,10 +266,12 @@ fn emit_collection_created_event(scope: &TestScope, collection_id: i32) -> Event
     .with_entity_id(collection_id)
     .with_entity_name(scope.scoped_name("fanout_collection"));
 
-    with_connection(&scope.pool, |conn| emit_event(conn, &event)).unwrap()
+    with_connection(&scope.pool, async |conn| emit_event(conn, &event).await)
+        .await
+        .unwrap()
 }
 
-fn insert_collection_created_event_at(
+async fn insert_collection_created_event_at(
     scope: &TestScope,
     collection_id: i32,
     occurred_at_value: chrono::NaiveDateTime,
@@ -273,7 +281,7 @@ fn insert_collection_created_event_at(
         entity_type, event_id, events, metadata, occurred_at, summary,
     };
 
-    with_connection(&scope.pool, |conn| {
+    with_connection(&scope.pool, async |conn| {
         diesel::insert_into(events)
             .values((
                 event_id.eq(Uuid::new_v4()),
@@ -288,42 +296,50 @@ fn insert_collection_created_event_at(
                 metadata.eq(serde_json::json!({})),
             ))
             .get_result::<Event>(conn)
+            .await
     })
+    .await
     .unwrap()
 }
 
-fn mark_event_dispatched(scope: &TestScope, event_id_value: i64) {
+async fn mark_event_dispatched(scope: &TestScope, event_id_value: i64) {
     use crate::schema::events::dsl::{dispatched_at, events, id};
 
-    with_connection(&scope.pool, |conn| {
+    with_connection(&scope.pool, async |conn| {
         diesel::update(events.filter(id.eq(event_id_value)))
             .set(dispatched_at.eq(Some(chrono::Utc::now().naive_utc())))
             .execute(conn)
+            .await
     })
+    .await
     .unwrap();
 }
 
-fn delivery_for_event(scope: &TestScope, event_id_value: i64) -> EventDelivery {
+async fn delivery_for_event(scope: &TestScope, event_id_value: i64) -> EventDelivery {
     use crate::schema::event_deliveries::dsl::{event_deliveries, event_id};
 
-    with_connection(&scope.pool, |conn| {
+    with_connection(&scope.pool, async |conn| {
         event_deliveries
             .filter(event_id.eq(event_id_value))
             .first::<EventDelivery>(conn)
+            .await
     })
+    .await
     .unwrap()
 }
 
-fn expire_delivery_claim(scope: &TestScope, delivery_id: i64) {
+async fn expire_delivery_claim(scope: &TestScope, delivery_id: i64) {
     use crate::schema::event_deliveries::dsl::{event_deliveries, id, locked_until};
 
-    with_connection(&scope.pool, |conn| {
+    with_connection(&scope.pool, async |conn| {
         diesel::update(event_deliveries.filter(id.eq(delivery_id)))
             .set(locked_until.eq(Some(
                 chrono::Utc::now().naive_utc() - chrono::Duration::seconds(1),
             )))
             .execute(conn)
+            .await
     })
+    .await
     .unwrap();
 }
 
@@ -401,7 +417,7 @@ async fn event_fanout_creates_delivery_for_each_matching_subscription_once() {
     let fixture = scope.with_collection().await;
     create_collection_event_subscription(&scope, fixture.collection.id, "fanout_one", true).await;
     create_collection_event_subscription(&scope, fixture.collection.id, "fanout_two", true).await;
-    let event = emit_collection_created_event(&scope, fixture.collection.id);
+    let event = emit_collection_created_event(&scope, fixture.collection.id).await;
 
     let inserted = fanout_event(&scope.pool, event.id).await.unwrap();
     assert_eq!(inserted, 2);
@@ -428,7 +444,7 @@ async fn event_fanout_skips_disabled_subscriptions() {
     let fixture = scope.with_collection().await;
     create_collection_event_subscription(&scope, fixture.collection.id, "fanout_disabled", false)
         .await;
-    let event = emit_collection_created_event(&scope, fixture.collection.id);
+    let event = emit_collection_created_event(&scope, fixture.collection.id).await;
 
     let inserted = fanout_event(&scope.pool, event.id).await.unwrap();
 
@@ -467,7 +483,7 @@ async fn event_fanout_applies_subscription_filter_before_creating_delivery() {
         },
     )
     .await;
-    let event = emit_collection_created_event(&scope, fixture.collection.id);
+    let event = emit_collection_created_event(&scope, fixture.collection.id).await;
 
     let inserted = fanout_event(&scope.pool, event.id).await.unwrap();
 
@@ -484,7 +500,7 @@ async fn event_fanout_applies_subscription_filter_before_creating_delivery() {
 async fn event_fanout_reclaims_expired_claims() {
     let scope = test_scope();
     let fixture = scope.with_collection().await;
-    let event = emit_collection_created_event(&scope, fixture.collection.id);
+    let event = emit_collection_created_event(&scope, fixture.collection.id).await;
     let settings = EventFanoutSettings {
         batch_size: 100_000,
         lock_timeout_ms: 30_000,
@@ -500,7 +516,7 @@ async fn event_fanout_reclaims_expired_claims() {
         .unwrap();
     assert!(!blocked.iter().any(|claimed| claimed.id == event.id));
 
-    with_connection(&scope.pool, |conn| {
+    with_connection(&scope.pool, async |conn| {
         use crate::schema::events::dsl::{events, fanout_locked_until, id};
 
         diesel::update(events.filter(id.eq(event.id)))
@@ -508,7 +524,9 @@ async fn event_fanout_reclaims_expired_claims() {
                 chrono::Utc::now().naive_utc() - chrono::Duration::seconds(1),
             )))
             .execute(conn)
+            .await
     })
+    .await
     .unwrap();
 
     let reclaimed = claim_events_for_fanout(&scope.pool, settings)
@@ -520,11 +538,14 @@ async fn event_fanout_reclaims_expired_claims() {
 #[actix_web::test]
 async fn ordinary_event_delete_is_rejected_by_append_only_trigger() {
     let scope = test_scope();
-    let event = emit_collection_created_event(&scope, 1);
+    let event = emit_collection_created_event(&scope, 1).await;
 
-    let error = with_connection(&scope.pool, |conn| {
-        diesel::delete(events.filter(crate::schema::events::dsl::id.eq(event.id))).execute(conn)
+    let error = with_connection(&scope.pool, async |conn| {
+        diesel::delete(events.filter(crate::schema::events::dsl::id.eq(event.id)))
+            .execute(conn)
+            .await
     })
+    .await
     .unwrap_err();
 
     assert!(
@@ -543,19 +564,22 @@ async fn event_retention_purge_deletes_old_events_through_guarded_path() {
         &scope,
         1,
         chrono::Utc::now().naive_utc() - chrono::Duration::days(400),
-    );
-    mark_event_dispatched(&scope, old_event.id);
+    )
+    .await;
+    mark_event_dispatched(&scope, old_event.id).await;
 
     purge_event_retention_without_archive(&scope.pool, make_retention_settings())
         .await
         .unwrap();
 
-    let remaining = with_connection(&scope.pool, |conn| {
+    let remaining = with_connection(&scope.pool, async |conn| {
         events
             .filter(crate::schema::events::dsl::id.eq(old_event.id))
             .count()
             .get_result::<i64>(conn)
+            .await
     })
+    .await
     .unwrap();
     assert_eq!(remaining, 0);
 }
@@ -568,18 +592,21 @@ async fn event_retention_purge_keeps_events_pending_fanout() {
         &scope,
         1,
         chrono::Utc::now().naive_utc() - chrono::Duration::days(400),
-    );
+    )
+    .await;
 
     purge_event_retention_without_archive(&scope.pool, make_retention_settings())
         .await
         .unwrap();
 
-    let remaining = with_connection(&scope.pool, |conn| {
+    let remaining = with_connection(&scope.pool, async |conn| {
         events
             .filter(crate::schema::events::dsl::id.eq(old_event.id))
             .count()
             .get_result::<i64>(conn)
+            .await
     })
+    .await
     .unwrap();
     assert_eq!(remaining, 1);
 }
@@ -595,19 +622,22 @@ async fn event_retention_purge_keeps_events_with_active_deliveries() {
         &scope,
         fixture.collection.id,
         chrono::Utc::now().naive_utc() - chrono::Duration::days(400),
-    );
+    )
+    .await;
     fanout_event(&scope.pool, old_event.id).await.unwrap();
 
     purge_event_retention_without_archive(&scope.pool, make_retention_settings())
         .await
         .unwrap();
 
-    let remaining = with_connection(&scope.pool, |conn| {
+    let remaining = with_connection(&scope.pool, async |conn| {
         events
             .filter(crate::schema::events::dsl::id.eq(old_event.id))
             .count()
             .get_result::<i64>(conn)
+            .await
     })
+    .await
     .unwrap();
     assert_eq!(remaining, 1);
 }
@@ -624,13 +654,13 @@ async fn event_retention_purge_deletes_old_terminal_deliveries_without_deleting_
         true,
     )
     .await;
-    let event = emit_collection_created_event(&scope, fixture.collection.id);
+    let event = emit_collection_created_event(&scope, fixture.collection.id).await;
     let old_timestamp = chrono::Utc::now().naive_utc() - chrono::Duration::days(40);
     use crate::schema::event_deliveries::dsl::{
         created_at, event_deliveries, event_id, status,
         subscription_id as delivery_subscription_id, updated_at,
     };
-    with_connection(&scope.pool, |conn| {
+    with_connection(&scope.pool, async |conn| {
         diesel::insert_into(event_deliveries)
             .values((
                 event_id.eq(event.id),
@@ -640,7 +670,9 @@ async fn event_retention_purge_deletes_old_terminal_deliveries_without_deleting_
                 updated_at.eq(old_timestamp),
             ))
             .execute(conn)
+            .await
     })
+    .await
     .unwrap();
 
     let summary = purge_event_retention_without_archive(&scope.pool, make_retention_settings())
@@ -655,12 +687,14 @@ async fn event_retention_purge_deletes_old_terminal_deliveries_without_deleting_
             .unwrap(),
         0
     );
-    let remaining_events = with_connection(&scope.pool, |conn| {
+    let remaining_events = with_connection(&scope.pool, async |conn| {
         events
             .filter(crate::schema::events::dsl::id.eq(event.id))
             .count()
             .get_result::<i64>(conn)
+            .await
     })
+    .await
     .unwrap();
     assert_eq!(remaining_events, 1);
 }
@@ -672,12 +706,12 @@ async fn event_delivery_worker_marks_successful_delivery_succeeded() {
     let fixture = scope.with_collection().await;
     create_collection_event_subscription(&scope, fixture.collection.id, "delivery_success", true)
         .await;
-    let event = emit_collection_created_event(&scope, fixture.collection.id);
+    let event = emit_collection_created_event(&scope, fixture.collection.id).await;
     fanout_event(&scope.pool, event.id).await.unwrap();
     let sink = SuccessfulSink;
     let resolver = StaticSinkResolver { sink: &sink };
 
-    let delivery = delivery_for_event(&scope, event.id);
+    let delivery = delivery_for_event(&scope, event.id).await;
     let settings = make_delivery_settings(3);
     let claimed = claim_event_delivery_by_id(&scope.pool, delivery.id, settings)
         .await
@@ -686,7 +720,7 @@ async fn event_delivery_worker_marks_successful_delivery_succeeded() {
         .await
         .unwrap();
 
-    let delivery = delivery_for_event(&scope, event.id);
+    let delivery = delivery_for_event(&scope, event.id).await;
     assert_eq!(delivery.status, EventDeliveryStatus::Succeeded.as_str());
     assert_eq!(delivery.attempts, 0);
     assert!(delivery.claim_token.is_none());
@@ -701,32 +735,34 @@ async fn event_delivery_worker_retries_with_backoff_then_marks_dead() {
     let fixture = scope.with_collection().await;
     create_collection_event_subscription(&scope, fixture.collection.id, "delivery_retry", true)
         .await;
-    let event = emit_collection_created_event(&scope, fixture.collection.id);
+    let event = emit_collection_created_event(&scope, fixture.collection.id).await;
     fanout_event(&scope.pool, event.id).await.unwrap();
     let sink = FailingSink;
     let resolver = StaticSinkResolver { sink: &sink };
     let settings = make_delivery_settings(2);
 
-    let delivery = delivery_for_event(&scope, event.id);
+    let delivery = delivery_for_event(&scope, event.id).await;
     let claimed = claim_event_delivery_by_id(&scope.pool, delivery.id, settings)
         .await
         .unwrap();
     process_claimed_event_delivery(&scope.pool, settings, &resolver, claimed)
         .await
         .unwrap();
-    let first_failure = delivery_for_event(&scope, event.id);
+    let first_failure = delivery_for_event(&scope, event.id).await;
     assert_eq!(first_failure.status, EventDeliveryStatus::Failed.as_str());
     assert_eq!(first_failure.attempts, 1);
     assert_eq!(first_failure.last_error.as_deref(), Some("delivery failed"));
     assert!(first_failure.next_attempt_at > chrono::Utc::now().naive_utc());
 
-    with_connection(&scope.pool, |conn| {
+    with_connection(&scope.pool, async |conn| {
         use crate::schema::event_deliveries::dsl::{event_deliveries, id, next_attempt_at};
 
         diesel::update(event_deliveries.filter(id.eq(first_failure.id)))
             .set(next_attempt_at.eq(chrono::Utc::now().naive_utc() - chrono::Duration::seconds(1)))
             .execute(conn)
+            .await
     })
+    .await
     .unwrap();
 
     let claimed = claim_event_delivery_by_id(&scope.pool, first_failure.id, settings)
@@ -735,7 +771,7 @@ async fn event_delivery_worker_retries_with_backoff_then_marks_dead() {
     process_claimed_event_delivery(&scope.pool, settings, &resolver, claimed)
         .await
         .unwrap();
-    let dead = delivery_for_event(&scope, event.id);
+    let dead = delivery_for_event(&scope, event.id).await;
     assert_eq!(dead.status, EventDeliveryStatus::Dead.as_str());
     assert_eq!(dead.attempts, 2);
     assert!(dead.claim_token.is_none());
@@ -749,7 +785,7 @@ async fn event_delivery_claims_expired_in_flight_rows_again() {
     let fixture = scope.with_collection().await;
     create_collection_event_subscription(&scope, fixture.collection.id, "delivery_reclaim", true)
         .await;
-    let event = emit_collection_created_event(&scope, fixture.collection.id);
+    let event = emit_collection_created_event(&scope, fixture.collection.id).await;
     fanout_event(&scope.pool, event.id).await.unwrap();
     let settings = make_delivery_settings(3);
 
@@ -767,7 +803,7 @@ async fn event_delivery_claims_expired_in_flight_rows_again() {
             .any(|claimed| claimed.delivery.id == delivery_id)
     );
 
-    expire_delivery_claim(&scope, delivery_id);
+    expire_delivery_claim(&scope, delivery_id).await;
 
     let reclaimed = claim_event_deliveries(&scope.pool, settings).await.unwrap();
     assert!(
@@ -789,7 +825,7 @@ async fn event_delivery_failed_mark_respects_claim_token() {
         true,
     )
     .await;
-    let event = emit_collection_created_event(&scope, fixture.collection.id);
+    let event = emit_collection_created_event(&scope, fixture.collection.id).await;
     fanout_event(&scope.pool, event.id).await.unwrap();
     let settings = make_delivery_settings(3);
     let mut claimed = claim_event_deliveries(&scope.pool, settings).await.unwrap();
@@ -831,7 +867,7 @@ async fn collection_writes_emit_lifecycle_events_in_transaction() {
 
     updated.delete(&scope.pool, &context).await.unwrap();
 
-    let rows = events_for(&scope, "collection", collection.id);
+    let rows = events_for(&scope, "collection", collection.id).await;
     assert_eq!(rows.len(), 3);
 
     assert_eq!(rows[0].action, "created");
@@ -890,7 +926,7 @@ async fn class_writes_emit_lifecycle_events_in_transaction() {
 
     updated.delete(&scope.pool, &context).await.unwrap();
 
-    let rows = events_for(&scope, "class", class.id);
+    let rows = events_for(&scope, "class", class.id).await;
     assert_eq!(rows.len(), 3);
 
     assert_eq!(rows[0].action, "created");
@@ -956,7 +992,7 @@ async fn object_writes_emit_lifecycle_events_in_transaction() {
 
     updated.delete(&scope.pool, &context).await.unwrap();
 
-    let rows = events_for(&scope, "object", object.id);
+    let rows = events_for(&scope, "object", object.id).await;
     assert_eq!(rows.len(), 3);
 
     assert_eq!(rows[0].action, "created");
@@ -1029,7 +1065,7 @@ async fn class_relation_writes_emit_lifecycle_events_in_transaction() {
         .await
         .unwrap();
 
-    let rows = events_for(&scope, "class_relation", relation.id);
+    let rows = events_for(&scope, "class_relation", relation.id).await;
     assert_eq!(rows.len(), 2);
 
     assert_eq!(rows[0].action, "created");
@@ -1143,7 +1179,7 @@ async fn object_relation_writes_emit_lifecycle_events_in_transaction() {
 
     relation.delete(&scope.pool, &context).await.unwrap();
 
-    let rows = events_for(&scope, "object_relation", relation.id);
+    let rows = events_for(&scope, "object_relation", relation.id).await;
     assert_eq!(rows.len(), 2);
 
     assert_eq!(rows[0].action, "created");
@@ -1214,7 +1250,7 @@ async fn group_writes_emit_lifecycle_events_in_transaction() {
         .await
         .unwrap();
 
-    let rows = events_for(&scope, "group", group.id);
+    let rows = events_for(&scope, "group", group.id).await;
     assert_eq!(rows.len(), 3);
 
     assert_eq!(rows[0].action, "created");
@@ -1284,6 +1320,7 @@ async fn group_membership_writes_emit_added_removed_events_when_changed() {
         .unwrap();
 
     let rows = events_for_type(&scope, "user_group")
+        .await
         .into_iter()
         .filter(|row| {
             row.metadata["principal_id"] == serde_json::json!(user.id)
@@ -1337,7 +1374,7 @@ async fn user_writes_emit_lifecycle_events_without_password_material() {
 
     updated.delete(&scope.pool, Some(&context)).await.unwrap();
 
-    let rows = events_for(&scope, "user", user.id);
+    let rows = events_for(&scope, "user", user.id).await;
     assert_eq!(rows.len(), 3);
 
     assert_eq!(rows[0].action, "created");
@@ -1402,14 +1439,14 @@ async fn token_writes_emit_created_revoked_events_without_token_material() {
     )
     .await
     .unwrap();
-    let token = token_by_raw_value(&scope, &raw);
+    let token = token_by_raw_value(&scope, &raw).await;
 
     let revoked = revoke_token_by_id_for_principal(&scope.pool, token.id, user.id, Some(&context))
         .await
         .unwrap();
     assert_eq!(revoked, 1);
 
-    let rows = events_for(&scope, "token", token.id);
+    let rows = events_for(&scope, "token", token.id).await;
     assert_eq!(rows.len(), 2);
 
     assert_eq!(rows[0].action, "created");
@@ -1475,7 +1512,7 @@ async fn permission_writes_emit_granted_revoked_events() {
         .await
         .unwrap();
 
-    let rows = events_for(&scope, "permission", permission.id);
+    let rows = events_for(&scope, "permission", permission.id).await;
     assert_eq!(rows.len(), 3);
 
     assert_eq!(rows[0].action, "granted");
@@ -1576,7 +1613,7 @@ async fn export_template_writes_emit_lifecycle_events() {
         .await
         .unwrap();
 
-    let rows = events_for(&scope, "export_template", template.id);
+    let rows = events_for(&scope, "export_template", template.id).await;
     assert_eq!(rows.len(), 3);
 
     assert_eq!(rows[0].action, "created");
@@ -1668,7 +1705,7 @@ async fn remote_target_writes_emit_lifecycle_and_invoked_events_with_redacted_au
         .await
         .unwrap();
 
-    let rows = events_for(&scope, "remote_target", row.id);
+    let rows = events_for(&scope, "remote_target", row.id).await;
     assert_eq!(rows.len(), 4);
 
     assert_eq!(rows[0].action, "created");
@@ -1712,39 +1749,49 @@ async fn remote_target_writes_emit_lifecycle_and_invoked_events_with_redacted_au
     fixture.cleanup().await.unwrap();
 }
 
-fn events_for(scope: &TestScope, event_entity_type: &str, event_entity_id: i32) -> Vec<Event> {
+async fn events_for(
+    scope: &TestScope,
+    event_entity_type: &str,
+    event_entity_id: i32,
+) -> Vec<Event> {
     use crate::schema::events::dsl::{entity_id, entity_type, id};
 
-    with_connection(&scope.pool, |conn| {
+    with_connection(&scope.pool, async |conn| {
         events
             .filter(entity_type.eq(event_entity_type))
             .filter(entity_id.eq(event_entity_id))
             .order(id.asc())
             .load::<Event>(conn)
+            .await
     })
+    .await
     .unwrap()
 }
 
-fn token_by_raw_value(scope: &TestScope, raw: &Token) -> PrincipalToken {
+async fn token_by_raw_value(scope: &TestScope, raw: &Token) -> PrincipalToken {
     use crate::schema::tokens::dsl::{token, tokens};
 
-    with_connection(&scope.pool, |conn| {
+    with_connection(&scope.pool, async |conn| {
         tokens
             .filter(token.eq(raw.storage_hash()))
             .first::<PrincipalToken>(conn)
+            .await
     })
+    .await
     .unwrap()
 }
 
-fn events_for_type(scope: &TestScope, event_entity_type: &str) -> Vec<Event> {
+async fn events_for_type(scope: &TestScope, event_entity_type: &str) -> Vec<Event> {
     use crate::schema::events::dsl::{entity_type, id};
 
-    with_connection(&scope.pool, |conn| {
+    with_connection(&scope.pool, async |conn| {
         events
             .filter(entity_type.eq(event_entity_type))
             .order(id.asc())
             .load::<Event>(conn)
+            .await
     })
+    .await
     .unwrap()
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -102,7 +102,7 @@ macro_rules! can {
 /// `permissions` table.
 macro_rules! apply_permission_filter {
     ($base_query:ident, $permission:expr, $target:expr) => {{
-        use diesel::prelude::*;
+        use $crate::db::prelude::*;
         use $crate::models::Permissions;
         use $crate::schema::permissions;
 
@@ -317,7 +317,7 @@ macro_rules! numeric_search {
 macro_rules! date_search {
     ($base_query:expr, $parsed_query_param:expr, $operator:expr, $diesel_field:expr) => {{
         use diesel::dsl::not;
-        use diesel::prelude::*;
+        use $crate::db::prelude::*;
         use $crate::errors::ApiError;
         use $crate::models::search::{DataType, Operator};
 
@@ -418,7 +418,7 @@ macro_rules! date_search {
 macro_rules! array_search {
     ($base_query:expr, $param:expr, $operator:expr, $diesel_field:expr) => {{
         use diesel::dsl::not;
-        use diesel::prelude::*;
+        use $crate::db::prelude::*;
         use $crate::errors::ApiError;
         use $crate::models::search::{DataType, Operator};
 
@@ -474,7 +474,7 @@ macro_rules! array_search {
 macro_rules! string_search {
     ($base_query:expr, $param:expr, $operator:expr, $diesel_field:expr) => {{
         use diesel::dsl::not;
-        use diesel::prelude::*;
+        use $crate::db::prelude::*;
         use $crate::errors::ApiError;
         use $crate::models::search::{DataType, Operator};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
+#![allow(async_fn_in_trait)]
+
 mod api;
 mod auth;
 mod config;
-mod db;
+pub mod db;
 mod errors;
 pub mod events;
 mod extractors;

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -707,19 +707,23 @@ mod tests {
         let parent = scope.collection_fixture("protect_root").await;
         let root_id = parent.collection.parent_collection_id.unwrap();
 
-        let delete_result = crate::db::with_connection(&pool, |conn| {
+        let delete_result = crate::db::with_connection(&pool, async |conn| {
             sql_query("DELETE FROM collections WHERE id = $1")
                 .bind::<diesel::sql_types::Integer, _>(root_id)
                 .execute(conn)
-        });
+                .await
+        })
+        .await;
         assert!(delete_result.is_err());
 
-        let reparent_result = crate::db::with_connection(&pool, |conn| {
+        let reparent_result = crate::db::with_connection(&pool, async |conn| {
             sql_query("UPDATE collections SET parent_collection_id = $1 WHERE id = $2")
                 .bind::<diesel::sql_types::Integer, _>(parent.collection.id)
                 .bind::<diesel::sql_types::Integer, _>(root_id)
                 .execute(conn)
-        });
+                .await
+        })
+        .await;
         assert!(reparent_result.is_err());
 
         parent.cleanup().await.unwrap();
@@ -1262,7 +1266,7 @@ mod tests {
         assert!(!non_delegate_before.has_update_template);
         assert!(!non_delegate_before.has_delete_template);
 
-        let mut conn = pool.get().unwrap();
+        let mut conn = pool.get().await.unwrap();
         sql_query(
             "UPDATE permissions
              SET
@@ -1273,6 +1277,7 @@ mod tests {
              WHERE has_delegate_collection = TRUE",
         )
         .execute(&mut conn)
+        .await
         .unwrap();
 
         let delegate_after = group_on(&pool, collection.collection.id, delegate_group.id)

--- a/src/models/event_delivery.rs
+++ b/src/models/event_delivery.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
+use crate::db::prelude::*;
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;

--- a/src/models/event_subscription.rs
+++ b/src/models/event_subscription.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
+use crate::db::prelude::*;
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
 use hubuum_events_core::EventSubscriptionFilter;
 use serde::{Deserialize, Serialize, Serializer};
 use utoipa::ToSchema;

--- a/src/models/export_template.rs
+++ b/src/models/export_template.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 

--- a/src/models/group.rs
+++ b/src/models/group.rs
@@ -11,8 +11,8 @@ use crate::models::principal_group::NewPrincipalGroup;
 use crate::models::search::{FilterField, QueryOptions, SortParam};
 use crate::schema::groups;
 
+use crate::db::prelude::*;
 use crate::traits::PrincipalIdAccessor;
-use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 

--- a/src/models/object.rs
+++ b/src/models/object.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use diesel::sql_types::{BigInt, Integer, Jsonb, Text, Timestamp};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -186,11 +186,13 @@ pub mod tests {
     pub async fn verify_no_such_object(pool: &DbPool, object_id: i32) {
         use crate::schema::hubuumobject::dsl::*;
 
-        let result = with_connection(pool, |conn| {
+        let result = with_connection(pool, async |conn| {
             hubuumobject
                 .filter(id.eq(object_id))
                 .first::<HubuumObject>(conn)
-        });
+                .await
+        })
+        .await;
 
         match result {
             Ok(_) => panic!("Object {object_id} should not exist"),

--- a/src/models/permissions.rs
+++ b/src/models/permissions.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use std::{fmt, fmt::Display, slice};
 
 use serde::{Deserialize, Serialize};
@@ -466,7 +466,7 @@ pub struct UpdatePermission {
 
 #[cfg(test)]
 mod tests {
-    use diesel::prelude::*;
+    use crate::db::prelude::*;
 
     use super::{PermissionFilter, Permissions};
     use crate::schema::permissions::dsl::permissions;

--- a/src/models/principal.rs
+++ b/src/models/principal.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 

--- a/src/models/principal_group.rs
+++ b/src/models/principal_group.rs
@@ -11,8 +11,8 @@ use crate::traits::BackendContext;
 
 use crate::db::DbPool;
 
+use crate::db::prelude::*;
 use crate::traits::crud::SaveAdapter;
-use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 
 /// A principal's membership in a group. Both human users and service accounts

--- a/src/models/relation.rs
+++ b/src/models/relation.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use diesel::sql_types::{Array, Bool, Integer, Jsonb, Nullable, Text, Timestamp};
 
 use serde::{Deserialize, Serialize};

--- a/src/models/remote_target.rs
+++ b/src/models/remote_target.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
+use crate::db::prelude::*;
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
 use hubuum_templates::prepare_template;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;

--- a/src/models/service_account.rs
+++ b/src/models/service_account.rs
@@ -1,4 +1,4 @@
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -1,5 +1,5 @@
+use crate::db::prelude::*;
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDateTime;
 
-use diesel::prelude::*;
+use crate::db::prelude::*;
 use hmac::{Hmac, KeyInit, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -154,7 +154,7 @@ where
 {
     use crate::db::with_connection;
     use crate::schema::tokens::dsl::{id, principal_id, revoked_at, tokens};
-    with_connection(backend.db_pool(), |conn| {
+    with_connection(backend.db_pool(), async |conn| {
         diesel::update(
             tokens
                 .filter(id.eq(token_id))
@@ -163,7 +163,9 @@ where
         )
         .set(revoked_at.eq(diesel::dsl::now))
         .execute(conn)
+        .await
     })
+    .await
 }
 
 pub async fn revoke_token_by_id_for_principal<C>(
@@ -182,12 +184,13 @@ where
     use crate::db::with_transaction;
     use crate::schema::tokens::dsl::{id, principal_id, revoked_at, tokens};
 
-    with_transaction(backend.db_pool(), |conn| -> Result<usize, ApiError> {
+    with_transaction(backend.db_pool(), async |conn| -> Result<usize, ApiError> {
         let before = tokens
             .filter(id.eq(token_id))
             .filter(principal_id.eq(principal))
             .filter(revoked_at.is_null())
             .first::<PrincipalToken>(conn)
+            .await
             .optional()?;
 
         let updated = diesel::update(
@@ -198,6 +201,7 @@ where
         )
         .set(revoked_at.eq(diesel::dsl::now))
         .get_result::<PrincipalToken>(conn)
+        .await
         .optional()?;
 
         if let (Some(before), Some(after)) = (before, updated) {
@@ -212,12 +216,13 @@ where
             )?
             .with_before(token_snapshot(&before))
             .with_after(token_snapshot(&after));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
             Ok(1)
         } else {
             Ok(0)
         }
     })
+    .await
 }
 
 /// Create a named/expiring/optionally-scoped token for a principal and return
@@ -273,11 +278,12 @@ where
     let name = name.map(|s| s.to_string());
     let description = description.map(|s| s.to_string());
 
-    with_transaction(backend.db_pool(), |conn| -> Result<(), ApiError> {
+    with_transaction(backend.db_pool(), async |conn| -> Result<(), ApiError> {
         let principal_kind = principals::table
             .filter(principals::id.eq(principal))
             .select(principals::kind)
-            .first::<String>(conn)?;
+            .first::<String>(conn)
+            .await?;
 
         // Lock the SA row in the same transaction as insert so disable-vs-mint
         // races fail closed.
@@ -286,7 +292,8 @@ where
                 .filter(service_accounts::id.eq(principal))
                 .for_update()
                 .select(service_accounts::disabled_at)
-                .first::<Option<chrono::NaiveDateTime>>(conn)?;
+                .first::<Option<chrono::NaiveDateTime>>(conn)
+                .await?;
 
             if disabled_at.is_some() {
                 return Err(ApiError::Conflict(
@@ -304,7 +311,8 @@ where
                 tokens::expires_at.eq(expires_at),
                 tokens::scoped.eq(scoped),
             ))
-            .get_result::<PrincipalToken>(conn)?;
+            .get_result::<PrincipalToken>(conn)
+            .await?;
 
         for permission in &scope_strings {
             diesel::insert_into(crate::schema::token_scopes::table)
@@ -312,7 +320,8 @@ where
                     crate::schema::token_scopes::token_id.eq(token.id),
                     crate::schema::token_scopes::permission.eq(permission),
                 ))
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
         }
         if let Some(context) = context {
             let event = token_event(
@@ -325,10 +334,11 @@ where
                 ),
             )?
             .with_after(token_snapshot(&token));
-            emit_event(conn, &event)?;
+            emit_event(conn, &event).await?;
         }
         Ok(())
-    })?;
+    })
+    .await?;
 
     Ok(raw)
 }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -1,3 +1,4 @@
+use crate::db::prelude::*;
 use crate::db::traits::user::{
     AnonymizeUserRecord, CreateUserRecord, DeleteUserRecord, OwnedUserTokenRecord,
     StoreUserTokenRecord, UpdateUserRecord,
@@ -7,7 +8,6 @@ use crate::models::identity::LOCAL_IDENTITY_SCOPE;
 use crate::models::principal::load_principal_by_id;
 use crate::models::token::{PrincipalToken, Token};
 use crate::schema::users;
-use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 

--- a/src/pagination/mod.rs
+++ b/src/pagination/mod.rs
@@ -14,12 +14,12 @@ pub const NEXT_CURSOR_HEADER: &str = "X-Next-Cursor";
 pub const TOTAL_COUNT_HEADER: &str = "X-Total-Count";
 pub const SKIPPED_TOTAL_COUNT: i64 = -1;
 
-pub fn exact_count_or_skipped(
+pub async fn exact_count_or_skipped(
     query_options: &QueryOptions,
-    count: impl FnOnce() -> Result<i64, ApiError>,
+    count: impl AsyncFnOnce() -> Result<i64, ApiError>,
 ) -> Result<i64, ApiError> {
     if query_options.include_total {
-        count()
+        count().await
     } else {
         Ok(SKIPPED_TOTAL_COUNT)
     }
@@ -661,8 +661,8 @@ mod tests {
         assert_eq!(prepared.sort[1].field, FilterField::Id);
     }
 
-    #[test]
-    fn exact_total_count_can_be_skipped() {
+    #[tokio::test]
+    async fn exact_total_count_can_be_skipped() {
         let options = QueryOptions {
             filters: vec![],
             sort: vec![],
@@ -670,9 +670,10 @@ mod tests {
             cursor: None,
             include_total: false,
         };
-        let count = exact_count_or_skipped(&options, || {
+        let count = exact_count_or_skipped(&options, async || {
             panic!("count query must not execute when include_total is false")
         })
+        .await
         .unwrap();
         assert_eq!(count, SKIPPED_TOTAL_COUNT);
 

--- a/src/tasks/execution.rs
+++ b/src/tasks/execution.rs
@@ -292,31 +292,35 @@ pub(super) async fn execute_import_strict(
     planned_items: &[PlannedItem],
     accumulator: &mut ExecutionAccumulator,
 ) -> Result<(), ApiError> {
-    let execution = with_transaction(pool, |conn| -> Result<Vec<PlannedTaskResult>, ApiError> {
-        let mut runtime = RuntimeState::default();
-        let mut completed = Vec::with_capacity(planned_items.len());
+    let execution = with_transaction(
+        pool,
+        async |conn| -> Result<Vec<PlannedTaskResult>, ApiError> {
+            let mut runtime = RuntimeState::default();
+            let mut completed = Vec::with_capacity(planned_items.len());
 
-        for item in planned_items {
-            if let Some(execution) = &item.execution {
-                let identifier = item
-                    .result
-                    .identifier
-                    .clone()
-                    .unwrap_or_else(|| item.result.entity_kind.clone());
-                if let Err(err) = execute_planned_item(conn, &mut runtime, execution) {
-                    error!(
-                        message = "Import execution failed during strict transaction",
-                        identifier = %identifier,
-                        error = %err
-                    );
-                    return Err(err);
+            for item in planned_items {
+                if let Some(execution) = &item.execution {
+                    let identifier = item
+                        .result
+                        .identifier
+                        .clone()
+                        .unwrap_or_else(|| item.result.entity_kind.clone());
+                    if let Err(err) = execute_planned_item(conn, &mut runtime, execution).await {
+                        error!(
+                            message = "Import execution failed during strict transaction",
+                            identifier = %identifier,
+                            error = %err
+                        );
+                        return Err(err);
+                    }
                 }
+                completed.push(item.result.clone());
             }
-            completed.push(item.result.clone());
-        }
 
-        Ok(completed)
-    });
+            Ok(completed)
+        },
+    )
+    .await;
 
     match execution {
         Ok(completed) => {
@@ -341,9 +345,10 @@ pub(super) async fn execute_import_best_effort(
 
     for item in planned_items {
         let result = if let Some(execution) = &item.execution {
-            with_transaction(pool, |conn| {
-                execute_planned_item(conn, &mut runtime, execution)
+            with_transaction(pool, async |conn| {
+                execute_planned_item(conn, &mut runtime, execution).await
             })
+            .await
             .map(|_| ())
         } else {
             Ok(())
@@ -376,15 +381,15 @@ pub(super) async fn execute_import_best_effort(
     Ok(())
 }
 
-pub(super) fn execute_planned_item(
-    conn: &mut diesel::PgConnection,
+pub(super) async fn execute_planned_item(
+    conn: &mut crate::db::DbConnection,
     runtime: &mut RuntimeState,
     execution: &PlannedExecution,
 ) -> Result<(), ApiError> {
     match execution {
         PlannedExecution::CreateCollection(input) => {
-            let parent = resolve_collection_parent_runtime(conn, runtime, input)?;
-            let created = create_collection_db(conn, input, Some(parent.id))?;
+            let parent = resolve_collection_parent_runtime(conn, runtime, input).await?;
+            let created = create_collection_db(conn, input, Some(parent.id)).await?;
             if let Some(reference) = &input.ref_ {
                 runtime
                     .collections_by_ref
@@ -395,7 +400,7 @@ pub(super) fn execute_planned_item(
             collection_id,
             input,
         } => {
-            let updated = update_collection_db(conn, *collection_id, input)?;
+            let updated = update_collection_db(conn, *collection_id, input).await?;
             if let Some(reference) = &input.ref_ {
                 runtime
                     .collections_by_ref
@@ -408,14 +413,15 @@ pub(super) fn execute_planned_item(
                 runtime,
                 input.collection_ref.as_deref(),
                 input.collection_key.as_ref(),
-            )?;
-            let created = create_class_db(conn, input, collection.id)?;
+            )
+            .await?;
+            let created = create_class_db(conn, input, collection.id).await?;
             if let Some(reference) = &input.ref_ {
                 runtime.classes_by_ref.insert(reference.clone(), created);
             }
         }
         PlannedExecution::UpdateClass { class_id, input } => {
-            let updated = update_class_db(conn, *class_id, input)?;
+            let updated = update_class_db(conn, *class_id, input).await?;
             if let Some(reference) = &input.ref_ {
                 runtime.classes_by_ref.insert(reference.clone(), updated);
             }
@@ -426,14 +432,15 @@ pub(super) fn execute_planned_item(
                 runtime,
                 input.class_ref.as_deref(),
                 input.class_key.as_ref(),
-            )?;
-            let created = create_object_db(conn, input, &class)?;
+            )
+            .await?;
+            let created = create_object_db(conn, input, &class).await?;
             if let Some(reference) = &input.ref_ {
                 runtime.objects_by_ref.insert(reference.clone(), created);
             }
         }
         PlannedExecution::UpdateObject { object_id, input } => {
-            let updated = update_object_db(conn, *object_id, input)?;
+            let updated = update_object_db(conn, *object_id, input).await?;
             if let Some(reference) = &input.ref_ {
                 runtime.objects_by_ref.insert(reference.clone(), updated);
             }
@@ -444,20 +451,23 @@ pub(super) fn execute_planned_item(
                 runtime,
                 input.from_class_ref.as_deref(),
                 input.from_class_key.as_ref(),
-            )?;
+            )
+            .await?;
             let to_class = resolve_class_runtime(
                 conn,
                 runtime,
                 input.to_class_ref.as_deref(),
                 input.to_class_key.as_ref(),
-            )?;
+            )
+            .await?;
             create_class_relation_db(
                 conn,
                 from_class.id,
                 to_class.id,
                 input.forward_template_alias.clone(),
                 input.reverse_template_alias.clone(),
-            )?;
+            )
+            .await?;
         }
         PlannedExecution::CreateObjectRelation(input) => {
             let from_object = resolve_object_runtime(
@@ -465,14 +475,16 @@ pub(super) fn execute_planned_item(
                 runtime,
                 input.from_object_ref.as_deref(),
                 input.from_object_key.as_ref(),
-            )?;
+            )
+            .await?;
             let to_object = resolve_object_runtime(
                 conn,
                 runtime,
                 input.to_object_ref.as_deref(),
                 input.to_object_key.as_ref(),
-            )?;
-            create_object_relation_db(conn, &from_object, &to_object)?;
+            )
+            .await?;
+            create_object_relation_db(conn, &from_object, &to_object).await?;
         }
         PlannedExecution::ApplyCollectionPermissions(input) => {
             let collection = resolve_collection_runtime(
@@ -480,9 +492,11 @@ pub(super) fn execute_planned_item(
                 runtime,
                 input.collection_ref.as_deref(),
                 input.collection_key.as_ref(),
-            )?;
+            )
+            .await?;
             let identity_scope = input.group_key.identity_scope_name();
-            let group = lookup_group_by_name_db(conn, identity_scope, &input.group_key.groupname)?
+            let group = lookup_group_by_name_db(conn, identity_scope, &input.group_key.groupname)
+                .await?
                 .ok_or_else(|| {
                     ApiError::NotFound(format!(
                         "Group '{}/{}' not found",
@@ -495,7 +509,8 @@ pub(super) fn execute_planned_item(
                 group.id,
                 &input.permissions,
                 input.replace_existing.unwrap_or(false),
-            )?;
+            )
+            .await?;
         }
     }
 

--- a/src/tasks/planning.rs
+++ b/src/tasks/planning.rs
@@ -644,9 +644,10 @@ pub(super) async fn plan_collection(
                 parent_collection_id: collection.parent_collection_id,
             })
         } else {
-            with_connection(pool, |conn| {
-                lookup_existing_collection_for_import_db(conn, parent.id, &input.name)
+            with_connection(pool, async |conn| {
+                lookup_existing_collection_for_import_db(conn, parent.id, &input.name).await
             })
+            .await
             .map_err(|message| PlanningFailure {
                 kind: FailureKind::Runtime,
                 item: planned_result(

--- a/src/tasks/resolution.rs
+++ b/src/tasks/resolution.rs
@@ -273,8 +273,8 @@ pub(super) async fn resolve_object_planning(
     }
 }
 
-pub(super) fn resolve_collection_runtime(
-    conn: &mut diesel::PgConnection,
+pub(super) async fn resolve_collection_runtime(
+    conn: &mut crate::db::DbConnection,
     runtime: &RuntimeState,
     reference: Option<&str>,
     key: Option<&CollectionKey>,
@@ -285,20 +285,22 @@ pub(super) fn resolve_collection_runtime(
             .get(reference)
             .cloned()
             .ok_or_else(|| ApiError::BadRequest(format!("Unknown collection ref '{reference}'"))),
-        (None, Some(key)) => lookup_collection_by_key_db(conn, key)?.ok_or_else(|| {
-            ApiError::NotFound(format!(
-                "Collection '{}' not found during execution",
-                collection_key_label(key)
-            ))
-        }),
+        (None, Some(key)) => lookup_collection_by_key_db(conn, key)
+            .await?
+            .ok_or_else(|| {
+                ApiError::NotFound(format!(
+                    "Collection '{}' not found during execution",
+                    collection_key_label(key)
+                ))
+            }),
         _ => Err(ApiError::BadRequest(
             "Exactly one of collection_ref or collection_key must be provided".to_string(),
         )),
     }
 }
 
-pub(super) fn resolve_collection_parent_runtime(
-    conn: &mut diesel::PgConnection,
+pub(super) async fn resolve_collection_parent_runtime(
+    conn: &mut crate::db::DbConnection,
     runtime: &RuntimeState,
     input: &ImportCollectionInput,
 ) -> Result<Collection, ApiError> {
@@ -306,18 +308,20 @@ pub(super) fn resolve_collection_parent_runtime(
         input.parent_collection_ref.as_deref(),
         input.parent_collection_key.as_ref(),
     ) {
-        (None, None) => lookup_root_collection_db(conn),
+        (None, None) => lookup_root_collection_db(conn).await,
         (Some(reference), None) => runtime
             .collections_by_ref
             .get(reference)
             .cloned()
             .ok_or_else(|| ApiError::BadRequest(format!("Unknown collection ref '{reference}'"))),
-        (None, Some(key)) => lookup_collection_by_key_db(conn, key)?.ok_or_else(|| {
-            ApiError::NotFound(format!(
-                "Collection '{}' not found during execution",
-                collection_key_label(key)
-            ))
-        }),
+        (None, Some(key)) => lookup_collection_by_key_db(conn, key)
+            .await?
+            .ok_or_else(|| {
+                ApiError::NotFound(format!(
+                    "Collection '{}' not found during execution",
+                    collection_key_label(key)
+                ))
+            }),
         (Some(_), Some(_)) => Err(ApiError::BadRequest(
             "At most one of parent_collection_ref or parent_collection_key may be provided"
                 .to_string(),
@@ -325,16 +329,16 @@ pub(super) fn resolve_collection_parent_runtime(
     }
 }
 
-pub(super) fn lookup_existing_collection_for_import_db(
-    conn: &mut diesel::PgConnection,
+pub(super) async fn lookup_existing_collection_for_import_db(
+    conn: &mut crate::db::DbConnection,
     parent_collection_id: i32,
     name: &str,
 ) -> Result<Option<Collection>, ApiError> {
-    lookup_collection_child_by_name_db(conn, parent_collection_id, name)
+    lookup_collection_child_by_name_db(conn, parent_collection_id, name).await
 }
 
-pub(super) fn resolve_class_runtime(
-    conn: &mut diesel::PgConnection,
+pub(super) async fn resolve_class_runtime(
+    conn: &mut crate::db::DbConnection,
     runtime: &RuntimeState,
     reference: Option<&str>,
     key: Option<&ClassKey>,
@@ -351,15 +355,16 @@ pub(super) fn resolve_class_runtime(
                 runtime,
                 key.collection_ref.as_deref(),
                 key.collection_key.as_ref(),
-            )?;
-            lookup_class_by_collection_and_name_db(conn, collection.id, &key.name)?.ok_or_else(
-                || {
+            )
+            .await?;
+            lookup_class_by_collection_and_name_db(conn, collection.id, &key.name)
+                .await?
+                .ok_or_else(|| {
                     ApiError::NotFound(format!(
                         "Class '{}' not found in collection '{}' during execution",
                         key.name, collection.name
                     ))
-                },
-            )
+                })
         }
         _ => Err(ApiError::BadRequest(
             "Exactly one of class_ref or class_key must be provided".to_string(),
@@ -367,8 +372,8 @@ pub(super) fn resolve_class_runtime(
     }
 }
 
-pub(super) fn resolve_object_runtime(
-    conn: &mut diesel::PgConnection,
+pub(super) async fn resolve_object_runtime(
+    conn: &mut crate::db::DbConnection,
     runtime: &RuntimeState,
     reference: Option<&str>,
     key: Option<&ObjectKey>,
@@ -385,13 +390,16 @@ pub(super) fn resolve_object_runtime(
                 runtime,
                 key.class_ref.as_deref(),
                 key.class_key.as_ref(),
-            )?;
-            lookup_object_by_class_and_name_db(conn, class.id, &key.name)?.ok_or_else(|| {
-                ApiError::NotFound(format!(
-                    "Object '{}' not found in class '{}' during execution",
-                    key.name, class.name
-                ))
-            })
+            )
+            .await?;
+            lookup_object_by_class_and_name_db(conn, class.id, &key.name)
+                .await?
+                .ok_or_else(|| {
+                    ApiError::NotFound(format!(
+                        "Object '{}' not found in class '{}' during execution",
+                        key.name, class.name
+                    ))
+                })
         }
         _ => Err(ApiError::BadRequest(
             "Exactly one of object_ref or object_key must be provided".to_string(),

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDate;
-use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
-use futures::executor::block_on;
+use diesel::{ExpressionMethods, QueryDsl};
+use diesel_async::RunQueryDsl;
 
 use super::execution::{execute_import_best_effort, execute_import_strict, execute_planned_item};
 use super::helpers::{
@@ -34,9 +34,9 @@ use crate::schema::tasks::dsl::{created_at, id as task_id, tasks};
 use crate::tests::TestContext;
 use crate::traits::CanSave;
 
-#[test]
-fn test_execute_import_strict_rolls_back_on_runtime_failure() {
-    let context = block_on(TestContext::new());
+#[tokio::test]
+async fn test_execute_import_strict_rolls_back_on_runtime_failure() {
+    let context = (TestContext::new()).await;
     let collection = context.scoped_name("strict_rollback_collection");
     let class = context.scoped_name("strict_rollback_class");
     let planned_items = vec![
@@ -75,27 +75,26 @@ fn test_execute_import_strict_rolls_back_on_runtime_failure() {
     ];
 
     let mut accumulator = ExecutionAccumulator::default();
-    let result = block_on(execute_import_strict(
-        &context.pool,
-        1,
-        &planned_items,
-        &mut accumulator,
-    ));
+    let result = (execute_import_strict(&context.pool, 1, &planned_items, &mut accumulator)).await;
     assert!(result.is_err());
 
-    let collection_exists = with_connection(&context.pool, |conn| {
+    let collection_exists = with_connection(&context.pool, async |conn| {
         collections
             .filter(collection_name.eq(&collection))
             .count()
             .get_result::<i64>(conn)
+            .await
     })
+    .await
     .unwrap();
-    let class_exists = with_connection(&context.pool, |conn| {
+    let class_exists = with_connection(&context.pool, async |conn| {
         hubuumclass
             .filter(class_name.eq(&class))
             .count()
             .get_result::<i64>(conn)
+            .await
     })
+    .await
     .unwrap();
 
     assert_eq!(collection_exists, 0);
@@ -103,9 +102,9 @@ fn test_execute_import_strict_rolls_back_on_runtime_failure() {
     assert_eq!(accumulator.processed, 0);
 }
 
-#[test]
-fn test_execute_import_best_effort_keeps_successful_items() {
-    let context = block_on(TestContext::new());
+#[tokio::test]
+async fn test_execute_import_best_effort_keeps_successful_items() {
+    let context = (TestContext::new()).await;
     let collection_one = context.scoped_name("best_effort_collection_one");
     let collection_two = context.scoped_name("best_effort_collection_two");
     let class_bad = context.scoped_name("best_effort_class_bad");
@@ -160,7 +159,7 @@ fn test_execute_import_best_effort_keeps_successful_items() {
     ];
 
     let mut accumulator = ExecutionAccumulator::default();
-    block_on(execute_import_best_effort(
+    (execute_import_best_effort(
         &context.pool,
         1,
         &planned_items,
@@ -171,14 +170,17 @@ fn test_execute_import_best_effort_keeps_successful_items() {
         },
         &mut accumulator,
     ))
+    .await
     .unwrap();
 
-    let collection_count = with_connection(&context.pool, |conn| {
+    let collection_count = with_connection(&context.pool, async |conn| {
         collections
             .filter(collection_name.eq_any([collection_one.clone(), collection_two.clone()]))
             .count()
             .get_result::<i64>(conn)
+            .await
     })
+    .await
     .unwrap();
 
     assert_eq!(collection_count, 2);
@@ -187,9 +189,9 @@ fn test_execute_import_best_effort_keeps_successful_items() {
     assert_eq!(accumulator.failed, 1);
 }
 
-#[test]
-fn test_execute_import_best_effort_continues_after_non_policy_runtime_error() {
-    let context = block_on(TestContext::new());
+#[tokio::test]
+async fn test_execute_import_best_effort_continues_after_non_policy_runtime_error() {
+    let context = (TestContext::new()).await;
     let collection_one = context.scoped_name("best_effort_runtime_collection_one");
     let collection_two = context.scoped_name("best_effort_runtime_collection_two");
     let planned_items = vec![
@@ -243,7 +245,7 @@ fn test_execute_import_best_effort_continues_after_non_policy_runtime_error() {
     ];
 
     let mut accumulator = ExecutionAccumulator::default();
-    block_on(execute_import_best_effort(
+    (execute_import_best_effort(
         &context.pool,
         1,
         &planned_items,
@@ -254,14 +256,17 @@ fn test_execute_import_best_effort_continues_after_non_policy_runtime_error() {
         },
         &mut accumulator,
     ))
+    .await
     .unwrap();
 
-    let collection_count = with_connection(&context.pool, |conn| {
+    let collection_count = with_connection(&context.pool, async |conn| {
         collections
             .filter(collection_name.eq_any([collection_one.clone(), collection_two.clone()]))
             .count()
             .get_result::<i64>(conn)
+            .await
     })
+    .await
     .unwrap();
 
     assert_eq!(collection_count, 2);
@@ -270,9 +275,9 @@ fn test_execute_import_best_effort_continues_after_non_policy_runtime_error() {
     assert_eq!(accumulator.failed, 1);
 }
 
-#[test]
-fn test_execute_import_strict_preserves_underlying_error_variant() {
-    let context = block_on(TestContext::new());
+#[tokio::test]
+async fn test_execute_import_strict_preserves_underlying_error_variant() {
+    let context = (TestContext::new()).await;
     let planned_items = vec![PlannedItem {
         result: planned_result(
             "collection",
@@ -293,63 +298,59 @@ fn test_execute_import_strict_preserves_underlying_error_variant() {
     }];
 
     let mut accumulator = ExecutionAccumulator::default();
-    let result = block_on(execute_import_strict(
-        &context.pool,
-        1,
-        &planned_items,
-        &mut accumulator,
-    ));
+    let result = (execute_import_strict(&context.pool, 1, &planned_items, &mut accumulator)).await;
 
     assert!(matches!(result, Err(ApiError::NotFound(_))));
 }
 
-#[test]
-fn test_process_one_task_marks_claimed_task_failed_when_execution_setup_errors() {
-    let context = block_on(TestContext::new());
-    let task = block_on(
-        NewTaskRecord {
-            kind: TaskKind::Import.as_str().to_string(),
-            status: TaskStatus::Queued.as_str().to_string(),
-            submitted_by: Some(context.admin_user.id),
-            submitted_token_id: None,
-            submitted_token_scoped: false,
-            submitted_token_scopes: serde_json::json!([]),
-            idempotency_key: Some(context.scoped_name("missing-payload-task")),
-            request_hash: None,
-            request_payload: None,
-            summary: None,
-            total_items: 1,
-            processed_items: 0,
-            success_items: 0,
-            failed_items: 0,
-            request_redacted_at: None,
-            started_at: None,
-            finished_at: None,
-        }
-        .create(&context.pool),
-    )
+#[tokio::test]
+async fn test_process_one_task_marks_claimed_task_failed_when_execution_setup_errors() {
+    let context = (TestContext::new()).await;
+    let task = (NewTaskRecord {
+        kind: TaskKind::Import.as_str().to_string(),
+        status: TaskStatus::Queued.as_str().to_string(),
+        submitted_by: Some(context.admin_user.id),
+        submitted_token_id: None,
+        submitted_token_scoped: false,
+        submitted_token_scopes: serde_json::json!([]),
+        idempotency_key: Some(context.scoped_name("missing-payload-task")),
+        request_hash: None,
+        request_payload: None,
+        summary: None,
+        total_items: 1,
+        processed_items: 0,
+        success_items: 0,
+        failed_items: 0,
+        request_redacted_at: None,
+        started_at: None,
+        finished_at: None,
+    }
+    .create(&context.pool))
+    .await
     .unwrap();
 
     let earliest = NaiveDate::from_ymd_opt(2000, 1, 1)
         .expect("valid date")
         .and_hms_opt(0, 0, 0)
         .expect("valid timestamp");
-    with_connection(&context.pool, |conn| {
+    with_connection(&context.pool, async |conn| {
         diesel::update(tasks.filter(task_id.eq(task.id)))
             .set(created_at.eq(earliest))
             .execute(conn)
+            .await
     })
+    .await
     .unwrap();
 
     for _ in 0..20 {
-        let _ = block_on(process_one_task(&context.pool)).unwrap();
+        let _ = (process_one_task(&context.pool)).await.unwrap();
 
-        let stored = block_on(task.find_record(&context.pool)).unwrap();
+        let stored = (task.find_record(&context.pool)).await.unwrap();
         if stored.status == TaskStatus::Failed.as_str() {
             assert!(stored.finished_at.is_some());
             assert!(stored.request_redacted_at.is_some());
 
-            let (events, _) = block_on(task.list_events_with_total_count(
+            let (events, _) = (task.list_events_with_total_count(
                 &context.pool,
                 &crate::models::search::QueryOptions {
                     filters: Vec::new(),
@@ -359,6 +360,7 @@ fn test_process_one_task_marks_claimed_task_failed_when_execution_setup_errors()
                     include_total: true,
                 },
             ))
+            .await
             .unwrap();
             let event_types = events
                 .iter()
@@ -370,7 +372,7 @@ fn test_process_one_task_marks_claimed_task_failed_when_execution_setup_errors()
         }
     }
 
-    let stored = block_on(task.find_record(&context.pool)).unwrap();
+    let stored = (task.find_record(&context.pool)).await.unwrap();
     panic!(
         "Task {} did not reach failed state after repeated processing attempts; current status: {}",
         task.id, stored.status
@@ -409,9 +411,9 @@ fn test_remember_collection_populates_collection_id_index() {
     );
 }
 
-#[test]
-fn test_plan_collection_rejects_duplicate_name_within_request() {
-    let context = block_on(TestContext::new());
+#[tokio::test]
+async fn test_plan_collection_rejects_duplicate_name_within_request() {
+    let context = (TestContext::new()).await;
     let mut state = PlanningState::new();
     let mode = ImportMode {
         atomicity: Some(ImportAtomicity::BestEffort),
@@ -426,37 +428,39 @@ fn test_plan_collection_rejects_duplicate_name_within_request() {
         parent_collection_key: None,
     };
 
-    block_on(plan_collection(
+    (plan_collection(
         &context.pool,
         &context.admin_user,
         &mode,
         &mut state,
         &input,
     ))
+    .await
     .unwrap();
 
     let duplicate = ImportCollectionInput {
         ref_: Some("collection:two".to_string()),
         ..input
     };
-    let err = block_on(plan_collection(
+    let err = (plan_collection(
         &context.pool,
         &context.admin_user,
         &mode,
         &mut state,
         &duplicate,
     ))
+    .await
     .unwrap_err();
 
     assert!(matches!(err.kind, FailureKind::Validation));
     assert!(err.message.contains("Duplicate collection name"));
 }
 
-#[test]
-fn test_plan_collection_allows_duplicate_names_under_different_parents() {
-    let context = block_on(TestContext::new());
-    let parent_one = block_on(context.collection_fixture("duplicate_import_parent_one"));
-    let parent_two = block_on(context.collection_fixture("duplicate_import_parent_two"));
+#[tokio::test]
+async fn test_plan_collection_allows_duplicate_names_under_different_parents() {
+    let context = (TestContext::new()).await;
+    let parent_one = (context.collection_fixture("duplicate_import_parent_one")).await;
+    let parent_two = (context.collection_fixture("duplicate_import_parent_two")).await;
     let mut state = PlanningState::new();
     let mode = ImportMode {
         atomicity: Some(ImportAtomicity::BestEffort),
@@ -485,28 +489,30 @@ fn test_plan_collection_allows_duplicate_names_under_different_parents() {
         }),
     };
 
-    block_on(plan_collection(
+    (plan_collection(
         &context.pool,
         &context.admin_user,
         &mode,
         &mut state,
         &input_one,
     ))
+    .await
     .unwrap();
-    block_on(plan_collection(
+    (plan_collection(
         &context.pool,
         &context.admin_user,
         &mode,
         &mut state,
         &input_two,
     ))
+    .await
     .unwrap();
 }
 
-#[test]
-fn test_plan_class_rejects_duplicate_name_against_virtual_planned_class() {
-    let context = block_on(TestContext::new());
-    let fixture = block_on(context.collection_fixture("duplicate_virtual_class"));
+#[tokio::test]
+async fn test_plan_class_rejects_duplicate_name_against_virtual_planned_class() {
+    let context = (TestContext::new()).await;
+    let fixture = (context.collection_fixture("duplicate_virtual_class")).await;
     let mut state = PlanningState::new();
     remember_collection(
         &mut state,
@@ -535,37 +541,39 @@ fn test_plan_class_rejects_duplicate_name_against_virtual_planned_class() {
         collection_key: None,
     };
 
-    block_on(plan_class(
+    (plan_class(
         &context.pool,
         &context.admin_user,
         &mode,
         &mut state,
         &input,
     ))
+    .await
     .unwrap();
 
     let duplicate = ImportClassInput {
         ref_: Some("class:two".to_string()),
         ..input
     };
-    let err = block_on(plan_class(
+    let err = (plan_class(
         &context.pool,
         &context.admin_user,
         &mode,
         &mut state,
         &duplicate,
     ))
+    .await
     .unwrap_err();
 
     assert!(matches!(err.kind, FailureKind::Validation));
     assert!(err.message.contains("Duplicate class name"));
 }
 
-#[test]
-fn test_plan_object_rejects_duplicate_name_against_virtual_planned_object() {
-    let context = block_on(TestContext::new());
-    let fixture = block_on(context.collection_fixture("duplicate_virtual_object"));
-    let class = with_connection(&context.pool, |conn| {
+#[tokio::test]
+async fn test_plan_object_rejects_duplicate_name_against_virtual_planned_object() {
+    let context = (TestContext::new()).await;
+    let fixture = (context.collection_fixture("duplicate_virtual_object")).await;
+    let class = with_connection(&context.pool, async |conn| {
         create_class_db(
             conn,
             &ImportClassInput {
@@ -582,7 +590,9 @@ fn test_plan_object_rejects_duplicate_name_against_virtual_planned_object() {
             },
             fixture.collection.id,
         )
+        .await
     })
+    .await
     .unwrap();
     let mut state = PlanningState::new();
     remember_class(
@@ -605,37 +615,39 @@ fn test_plan_object_rejects_duplicate_name_against_virtual_planned_object() {
         class_key: None,
     };
 
-    block_on(plan_object(
+    (plan_object(
         &context.pool,
         &context.admin_user,
         &mode,
         &mut state,
         &input,
     ))
+    .await
     .unwrap();
 
     let duplicate = ImportObjectInput {
         ref_: Some("object:two".to_string()),
         ..input
     };
-    let err = block_on(plan_object(
+    let err = (plan_object(
         &context.pool,
         &context.admin_user,
         &mode,
         &mut state,
         &duplicate,
     ))
+    .await
     .unwrap_err();
 
     assert!(matches!(err.kind, FailureKind::Validation));
     assert!(err.message.contains("Duplicate object name"));
 }
 
-#[test]
-fn test_plan_class_rejects_duplicate_ref_against_virtual_planned_class() {
-    let context = block_on(TestContext::new());
-    let fixture_one = block_on(context.collection_fixture("duplicate_class_ref_one"));
-    let fixture_two = block_on(context.collection_fixture("duplicate_class_ref_two"));
+#[tokio::test]
+async fn test_plan_class_rejects_duplicate_ref_against_virtual_planned_class() {
+    let context = (TestContext::new()).await;
+    let fixture_one = (context.collection_fixture("duplicate_class_ref_one")).await;
+    let fixture_two = (context.collection_fixture("duplicate_class_ref_two")).await;
     let mut state = PlanningState::new();
     remember_collection(
         &mut state,
@@ -675,13 +687,14 @@ fn test_plan_class_rejects_duplicate_ref_against_virtual_planned_class() {
         collection_key: None,
     };
 
-    block_on(plan_class(
+    (plan_class(
         &context.pool,
         &context.admin_user,
         &mode,
         &mut state,
         &input,
     ))
+    .await
     .unwrap();
 
     let duplicate = ImportClassInput {
@@ -689,24 +702,25 @@ fn test_plan_class_rejects_duplicate_ref_against_virtual_planned_class() {
         collection_ref: Some("collection:two".to_string()),
         ..input
     };
-    let err = block_on(plan_class(
+    let err = (plan_class(
         &context.pool,
         &context.admin_user,
         &mode,
         &mut state,
         &duplicate,
     ))
+    .await
     .unwrap_err();
 
     assert!(matches!(err.kind, FailureKind::Validation));
     assert!(err.message.contains("Duplicate class ref"));
 }
 
-#[test]
-fn test_plan_object_rejects_duplicate_ref_against_virtual_planned_object() {
-    let context = block_on(TestContext::new());
-    let fixture = block_on(context.collection_fixture("duplicate_object_ref"));
-    let class_one = with_connection(&context.pool, |conn| {
+#[tokio::test]
+async fn test_plan_object_rejects_duplicate_ref_against_virtual_planned_object() {
+    let context = (TestContext::new()).await;
+    let fixture = (context.collection_fixture("duplicate_object_ref")).await;
+    let class_one = with_connection(&context.pool, async |conn| {
         create_class_db(
             conn,
             &ImportClassInput {
@@ -723,9 +737,11 @@ fn test_plan_object_rejects_duplicate_ref_against_virtual_planned_object() {
             },
             fixture.collection.id,
         )
+        .await
     })
+    .await
     .unwrap();
-    let class_two = with_connection(&context.pool, |conn| {
+    let class_two = with_connection(&context.pool, async |conn| {
         create_class_db(
             conn,
             &ImportClassInput {
@@ -742,7 +758,9 @@ fn test_plan_object_rejects_duplicate_ref_against_virtual_planned_object() {
             },
             fixture.collection.id,
         )
+        .await
     })
+    .await
     .unwrap();
     let mut state = PlanningState::new();
     remember_class(
@@ -770,13 +788,14 @@ fn test_plan_object_rejects_duplicate_ref_against_virtual_planned_object() {
         class_key: None,
     };
 
-    block_on(plan_object(
+    (plan_object(
         &context.pool,
         &context.admin_user,
         &mode,
         &mut state,
         &input,
     ))
+    .await
     .unwrap();
 
     let duplicate = ImportObjectInput {
@@ -784,26 +803,27 @@ fn test_plan_object_rejects_duplicate_ref_against_virtual_planned_object() {
         class_ref: Some("class:two".to_string()),
         ..input
     };
-    let err = block_on(plan_object(
+    let err = (plan_object(
         &context.pool,
         &context.admin_user,
         &mode,
         &mut state,
         &duplicate,
     ))
+    .await
     .unwrap_err();
 
     assert!(matches!(err.kind, FailureKind::Validation));
     assert!(err.message.contains("Duplicate object ref"));
 }
 
-#[test]
-fn test_resolve_collection_planning_backfills_caches_after_db_lookup() {
-    let context = block_on(TestContext::new());
-    let fixture = block_on(context.collection_fixture("planning_collection_cache"));
+#[tokio::test]
+async fn test_resolve_collection_planning_backfills_caches_after_db_lookup() {
+    let context = (TestContext::new()).await;
+    let fixture = (context.collection_fixture("planning_collection_cache")).await;
     let mut state = PlanningState::new();
 
-    let resolved = block_on(resolve_collection_planning(
+    let resolved = (resolve_collection_planning(
         &context.pool,
         &mut state,
         None,
@@ -812,6 +832,7 @@ fn test_resolve_collection_planning_backfills_caches_after_db_lookup() {
             path: None,
         }),
     ))
+    .await
     .unwrap();
 
     assert_eq!(resolved.id, fixture.collection.id);
@@ -835,36 +856,34 @@ fn test_resolve_collection_planning_backfills_caches_after_db_lookup() {
     );
 }
 
-#[test]
-fn test_resolve_collection_planning_rejects_ambiguous_bare_name() {
-    let context = block_on(TestContext::new());
-    let parent_one = block_on(context.collection_fixture("ambiguous_parent_one"));
-    let parent_two = block_on(context.collection_fixture("ambiguous_parent_two"));
+#[tokio::test]
+async fn test_resolve_collection_planning_rejects_ambiguous_bare_name() {
+    let context = (TestContext::new()).await;
+    let parent_one = (context.collection_fixture("ambiguous_parent_one")).await;
+    let parent_two = (context.collection_fixture("ambiguous_parent_two")).await;
     let child_name = context.scoped_name("ambiguous_child");
 
-    block_on(
-        (NewCollectionWithAssignee {
-            name: child_name.clone(),
-            description: "first ambiguous child".to_string(),
-            group_id: parent_one.owner_group.id,
-            parent_collection_id: Some(CollectionID::new(parent_one.collection.id).unwrap()),
-        })
-        .save_without_events(&context.pool),
-    )
+    ((NewCollectionWithAssignee {
+        name: child_name.clone(),
+        description: "first ambiguous child".to_string(),
+        group_id: parent_one.owner_group.id,
+        parent_collection_id: Some(CollectionID::new(parent_one.collection.id).unwrap()),
+    })
+    .save_without_events(&context.pool))
+    .await
     .unwrap();
-    block_on(
-        (NewCollectionWithAssignee {
-            name: child_name.clone(),
-            description: "second ambiguous child".to_string(),
-            group_id: parent_two.owner_group.id,
-            parent_collection_id: Some(CollectionID::new(parent_two.collection.id).unwrap()),
-        })
-        .save_without_events(&context.pool),
-    )
+    ((NewCollectionWithAssignee {
+        name: child_name.clone(),
+        description: "second ambiguous child".to_string(),
+        group_id: parent_two.owner_group.id,
+        parent_collection_id: Some(CollectionID::new(parent_two.collection.id).unwrap()),
+    })
+    .save_without_events(&context.pool))
+    .await
     .unwrap();
 
     let mut state = PlanningState::new();
-    let err = block_on(resolve_collection_planning(
+    let err = (resolve_collection_planning(
         &context.pool,
         &mut state,
         None,
@@ -873,42 +892,41 @@ fn test_resolve_collection_planning_rejects_ambiguous_bare_name() {
             path: None,
         }),
     ))
+    .await
     .unwrap_err();
 
     assert!(err.contains("ambiguous"));
     assert!(err.contains("collection_key.path"));
 }
 
-#[test]
-fn test_resolve_collection_planning_uses_path_to_disambiguate_name() {
-    let context = block_on(TestContext::new());
-    let parent_one = block_on(context.collection_fixture("path_parent_one"));
-    let parent_two = block_on(context.collection_fixture("path_parent_two"));
+#[tokio::test]
+async fn test_resolve_collection_planning_uses_path_to_disambiguate_name() {
+    let context = (TestContext::new()).await;
+    let parent_one = (context.collection_fixture("path_parent_one")).await;
+    let parent_two = (context.collection_fixture("path_parent_two")).await;
     let child_name = context.scoped_name("path_child");
 
-    block_on(
-        (NewCollectionWithAssignee {
-            name: child_name.clone(),
-            description: "first path child".to_string(),
-            group_id: parent_one.owner_group.id,
-            parent_collection_id: Some(CollectionID::new(parent_one.collection.id).unwrap()),
-        })
-        .save_without_events(&context.pool),
-    )
+    ((NewCollectionWithAssignee {
+        name: child_name.clone(),
+        description: "first path child".to_string(),
+        group_id: parent_one.owner_group.id,
+        parent_collection_id: Some(CollectionID::new(parent_one.collection.id).unwrap()),
+    })
+    .save_without_events(&context.pool))
+    .await
     .unwrap();
-    let target_child = block_on(
-        (NewCollectionWithAssignee {
-            name: child_name.clone(),
-            description: "second path child".to_string(),
-            group_id: parent_two.owner_group.id,
-            parent_collection_id: Some(CollectionID::new(parent_two.collection.id).unwrap()),
-        })
-        .save_without_events(&context.pool),
-    )
+    let target_child = ((NewCollectionWithAssignee {
+        name: child_name.clone(),
+        description: "second path child".to_string(),
+        group_id: parent_two.owner_group.id,
+        parent_collection_id: Some(CollectionID::new(parent_two.collection.id).unwrap()),
+    })
+    .save_without_events(&context.pool))
+    .await
     .unwrap();
 
     let mut state = PlanningState::new();
-    let resolved = block_on(resolve_collection_planning(
+    let resolved = (resolve_collection_planning(
         &context.pool,
         &mut state,
         None,
@@ -917,23 +935,22 @@ fn test_resolve_collection_planning_uses_path_to_disambiguate_name() {
             path: Some(vec![parent_two.collection.name.clone(), child_name]),
         }),
     ))
+    .await
     .unwrap();
 
     assert_eq!(resolved.id, target_child.id);
 }
 
-#[test]
-fn test_resolve_collection_by_id_planning_backfills_caches_after_db_lookup() {
-    let context = block_on(TestContext::new());
-    let fixture = block_on(context.collection_fixture("planning_collection_id_cache"));
+#[tokio::test]
+async fn test_resolve_collection_by_id_planning_backfills_caches_after_db_lookup() {
+    let context = (TestContext::new()).await;
+    let fixture = (context.collection_fixture("planning_collection_id_cache")).await;
     let mut state = PlanningState::new();
 
-    let resolved = block_on(resolve_collection_by_id_planning(
-        &context.pool,
-        &mut state,
-        fixture.collection.id,
-    ))
-    .unwrap();
+    let resolved =
+        (resolve_collection_by_id_planning(&context.pool, &mut state, fixture.collection.id))
+            .await
+            .unwrap();
 
     assert_eq!(resolved.name, fixture.collection.name);
     assert_eq!(
@@ -956,12 +973,12 @@ fn test_resolve_collection_by_id_planning_backfills_caches_after_db_lookup() {
     );
 }
 
-#[test]
-fn test_resolve_class_planning_backfills_cache_after_db_lookup() {
-    let context = block_on(TestContext::new());
-    let fixture = block_on(context.collection_fixture("planning_class_cache"));
+#[tokio::test]
+async fn test_resolve_class_planning_backfills_cache_after_db_lookup() {
+    let context = (TestContext::new()).await;
+    let fixture = (context.collection_fixture("planning_class_cache")).await;
     let class_name_value = context.scoped_name("planning_class_cache_value");
-    let class = with_connection(&context.pool, |conn| {
+    let class = with_connection(&context.pool, async |conn| {
         create_class_db(
             conn,
             &ImportClassInput {
@@ -978,11 +995,13 @@ fn test_resolve_class_planning_backfills_cache_after_db_lookup() {
             },
             fixture.collection.id,
         )
+        .await
     })
+    .await
     .unwrap();
     let mut state = PlanningState::new();
 
-    let resolved = block_on(resolve_class_planning(
+    let resolved = (resolve_class_planning(
         &context.pool,
         &mut state,
         None,
@@ -995,6 +1014,7 @@ fn test_resolve_class_planning_backfills_cache_after_db_lookup() {
             }),
         }),
     ))
+    .await
     .unwrap();
 
     assert_eq!(resolved.id, class.id);
@@ -1008,12 +1028,12 @@ fn test_resolve_class_planning_backfills_cache_after_db_lookup() {
     );
 }
 
-#[test]
-fn test_resolve_object_planning_backfills_cache_after_db_lookup() {
-    let context = block_on(TestContext::new());
-    let fixture = block_on(context.collection_fixture("planning_object_cache"));
+#[tokio::test]
+async fn test_resolve_object_planning_backfills_cache_after_db_lookup() {
+    let context = (TestContext::new()).await;
+    let fixture = (context.collection_fixture("planning_object_cache")).await;
     let class_name_value = context.scoped_name("planning_object_cache_class");
-    let class = with_connection(&context.pool, |conn| {
+    let class = with_connection(&context.pool, async |conn| {
         create_class_db(
             conn,
             &ImportClassInput {
@@ -1030,10 +1050,12 @@ fn test_resolve_object_planning_backfills_cache_after_db_lookup() {
             },
             fixture.collection.id,
         )
+        .await
     })
+    .await
     .unwrap();
     let object_name_value = context.scoped_name("planning_object_cache_value");
-    let object = with_connection(&context.pool, |conn| {
+    let object = with_connection(&context.pool, async |conn| {
         create_object_db(
             conn,
             &ImportObjectInput {
@@ -1053,11 +1075,13 @@ fn test_resolve_object_planning_backfills_cache_after_db_lookup() {
             },
             &class,
         )
+        .await
     })
+    .await
     .unwrap();
     let mut state = PlanningState::new();
 
-    let resolved = block_on(resolve_object_planning(
+    let resolved = (resolve_object_planning(
         &context.pool,
         &mut state,
         None,
@@ -1074,6 +1098,7 @@ fn test_resolve_object_planning_backfills_cache_after_db_lookup() {
             }),
         }),
     ))
+    .await
     .unwrap();
 
     assert_eq!(resolved.id, object.id);
@@ -1087,10 +1112,10 @@ fn test_resolve_object_planning_backfills_cache_after_db_lookup() {
     );
 }
 
-#[test]
-fn test_update_collection_refreshes_runtime_ref_for_following_items() {
-    let context = block_on(TestContext::new());
-    let fixture = block_on(context.collection_fixture("update_collection_ref"));
+#[tokio::test]
+async fn test_update_collection_refreshes_runtime_ref_for_following_items() {
+    let context = (TestContext::new()).await;
+    let fixture = (context.collection_fixture("update_collection_ref")).await;
     let updated_description = context.scoped_name("updated_collection_description");
     let execution = PlannedExecution::UpdateCollection {
         collection_id: fixture.collection.id,
@@ -1113,14 +1138,15 @@ fn test_update_collection_refreshes_runtime_ref_for_following_items() {
         collection_key: None,
     };
 
-    let result = with_connection(&context.pool, |conn| {
+    let result = with_connection(&context.pool, async |conn| {
         let mut runtime = RuntimeState::default();
-        execute_planned_item(conn, &mut runtime, &execution)?;
+        execute_planned_item(conn, &mut runtime, &execution).await?;
         execute_planned_item(
             conn,
             &mut runtime,
             &PlannedExecution::CreateClass(class_input.clone()),
-        )?;
+        )
+        .await?;
         Ok::<_, ApiError>(
             runtime
                 .collections_by_ref
@@ -1128,6 +1154,7 @@ fn test_update_collection_refreshes_runtime_ref_for_following_items() {
                 .cloned(),
         )
     })
+    .await
     .unwrap();
 
     let collection = result.expect("collection ref should be available after update");
@@ -1135,12 +1162,12 @@ fn test_update_collection_refreshes_runtime_ref_for_following_items() {
     assert_eq!(collection.description, updated_description);
 }
 
-#[test]
-fn test_update_class_refreshes_runtime_ref_for_following_items() {
-    let context = block_on(TestContext::new());
-    let fixture = block_on(context.collection_fixture("update_class_ref"));
+#[tokio::test]
+async fn test_update_class_refreshes_runtime_ref_for_following_items() {
+    let context = (TestContext::new()).await;
+    let fixture = (context.collection_fixture("update_class_ref")).await;
     let class_name_value = context.scoped_name("existing_class_for_update");
-    let class = with_connection(&context.pool, |conn| {
+    let class = with_connection(&context.pool, async |conn| {
         create_class_db(
             conn,
             &ImportClassInput {
@@ -1157,7 +1184,9 @@ fn test_update_class_refreshes_runtime_ref_for_following_items() {
             },
             fixture.collection.id,
         )
+        .await
     })
+    .await
     .unwrap();
 
     let execution = PlannedExecution::UpdateClass {
@@ -1185,16 +1214,18 @@ fn test_update_class_refreshes_runtime_ref_for_following_items() {
         class_key: None,
     };
 
-    let result = with_connection(&context.pool, |conn| {
+    let result = with_connection(&context.pool, async |conn| {
         let mut runtime = RuntimeState::default();
-        execute_planned_item(conn, &mut runtime, &execution)?;
+        execute_planned_item(conn, &mut runtime, &execution).await?;
         execute_planned_item(
             conn,
             &mut runtime,
             &PlannedExecution::CreateObject(object_input.clone()),
-        )?;
+        )
+        .await?;
         Ok::<_, ApiError>(runtime.classes_by_ref.get("class:existing").cloned())
     })
+    .await
     .unwrap();
 
     let updated = result.expect("class ref should be available after update");
@@ -1202,10 +1233,10 @@ fn test_update_class_refreshes_runtime_ref_for_following_items() {
     assert_eq!(updated.name, class.name);
 }
 
-#[test]
-fn test_plan_class_update_preserves_existing_schema_for_following_objects() {
-    let context = block_on(TestContext::new());
-    let fixture = block_on(context.collection_fixture("update_class_schema_ref"));
+#[tokio::test]
+async fn test_plan_class_update_preserves_existing_schema_for_following_objects() {
+    let context = (TestContext::new()).await;
+    let fixture = (context.collection_fixture("update_class_schema_ref")).await;
     let schema = serde_json::json!({
         "type": "object",
         "required": ["hostname"],
@@ -1214,7 +1245,7 @@ fn test_plan_class_update_preserves_existing_schema_for_following_objects() {
         }
     });
     let class_name_value = context.scoped_name("existing_class_with_schema");
-    let class = with_connection(&context.pool, |conn| {
+    let class = with_connection(&context.pool, async |conn| {
         create_class_db(
             conn,
             &ImportClassInput {
@@ -1231,7 +1262,9 @@ fn test_plan_class_update_preserves_existing_schema_for_following_objects() {
             },
             fixture.collection.id,
         )
+        .await
     })
+    .await
     .unwrap();
 
     let mut state = PlanningState::new();
@@ -1253,7 +1286,7 @@ fn test_plan_class_update_preserves_existing_schema_for_following_objects() {
         permission_policy: Some(ImportPermissionPolicy::Continue),
     };
 
-    block_on(plan_class(
+    (plan_class(
         &context.pool,
         &context.admin_user,
         &mode,
@@ -1268,9 +1301,10 @@ fn test_plan_class_update_preserves_existing_schema_for_following_objects() {
             collection_key: None,
         },
     ))
+    .await
     .unwrap();
 
-    let err = block_on(plan_object(
+    let err = (plan_object(
         &context.pool,
         &context.admin_user,
         &mode,
@@ -1284,17 +1318,18 @@ fn test_plan_class_update_preserves_existing_schema_for_following_objects() {
             class_key: None,
         },
     ))
+    .await
     .unwrap_err();
 
     assert!(matches!(err.kind, FailureKind::Validation));
 }
 
-#[test]
-fn test_update_object_refreshes_runtime_ref_for_following_items() {
-    let context = block_on(TestContext::new());
-    let fixture = block_on(context.collection_fixture("update_object_ref"));
+#[tokio::test]
+async fn test_update_object_refreshes_runtime_ref_for_following_items() {
+    let context = (TestContext::new()).await;
+    let fixture = (context.collection_fixture("update_object_ref")).await;
     let class_name_value = context.scoped_name("existing_class_for_object_update");
-    let class = with_connection(&context.pool, |conn| {
+    let class = with_connection(&context.pool, async |conn| {
         create_class_db(
             conn,
             &ImportClassInput {
@@ -1311,11 +1346,13 @@ fn test_update_object_refreshes_runtime_ref_for_following_items() {
             },
             fixture.collection.id,
         )
+        .await
     })
+    .await
     .unwrap();
 
     let object_name_value = context.scoped_name("existing_object_for_update");
-    let object = with_connection(&context.pool, |conn| {
+    let object = with_connection(&context.pool, async |conn| {
         create_object_db(
             conn,
             &ImportObjectInput {
@@ -1335,7 +1372,9 @@ fn test_update_object_refreshes_runtime_ref_for_following_items() {
             },
             &class,
         )
+        .await
     })
+    .await
     .unwrap();
 
     let execution = PlannedExecution::UpdateObject {
@@ -1357,11 +1396,12 @@ fn test_update_object_refreshes_runtime_ref_for_following_items() {
         },
     };
 
-    let resolved = with_connection(&context.pool, |conn| {
+    let resolved = with_connection(&context.pool, async |conn| {
         let mut runtime = RuntimeState::default();
-        execute_planned_item(conn, &mut runtime, &execution)?;
-        resolve_object_runtime(conn, &runtime, Some("object:existing"), None::<&ObjectKey>)
+        execute_planned_item(conn, &mut runtime, &execution).await?;
+        resolve_object_runtime(conn, &runtime, Some("object:existing"), None::<&ObjectKey>).await
     })
+    .await
     .unwrap();
 
     assert_eq!(resolved.id, object.id);
@@ -1456,47 +1496,48 @@ fn test_best_effort_execution_only_aborts_for_matching_policy_failures() {
     ));
 }
 
-#[test]
-fn test_process_one_task_export_failure_marks_single_failed_item() {
-    let context = block_on(TestContext::new());
-    let task = block_on(
-        NewTaskRecord {
-            kind: TaskKind::Export.as_str().to_string(),
-            status: TaskStatus::Queued.as_str().to_string(),
-            submitted_by: Some(context.admin_user.id),
-            submitted_token_id: None,
-            submitted_token_scoped: false,
-            submitted_token_scopes: serde_json::json!([]),
-            idempotency_key: Some(context.scoped_name("unimplemented-export-task")),
-            request_hash: None,
-            request_payload: Some(serde_json::json!({"export": "demo"})),
-            summary: None,
-            total_items: 0,
-            processed_items: 0,
-            success_items: 0,
-            failed_items: 0,
-            request_redacted_at: None,
-            started_at: None,
-            finished_at: None,
-        }
-        .create(&context.pool),
-    )
+#[tokio::test]
+async fn test_process_one_task_export_failure_marks_single_failed_item() {
+    let context = (TestContext::new()).await;
+    let task = (NewTaskRecord {
+        kind: TaskKind::Export.as_str().to_string(),
+        status: TaskStatus::Queued.as_str().to_string(),
+        submitted_by: Some(context.admin_user.id),
+        submitted_token_id: None,
+        submitted_token_scoped: false,
+        submitted_token_scopes: serde_json::json!([]),
+        idempotency_key: Some(context.scoped_name("unimplemented-export-task")),
+        request_hash: None,
+        request_payload: Some(serde_json::json!({"export": "demo"})),
+        summary: None,
+        total_items: 0,
+        processed_items: 0,
+        success_items: 0,
+        failed_items: 0,
+        request_redacted_at: None,
+        started_at: None,
+        finished_at: None,
+    }
+    .create(&context.pool))
+    .await
     .unwrap();
 
     let earliest = NaiveDate::from_ymd_opt(2000, 1, 1)
         .expect("valid date")
         .and_hms_opt(0, 0, 0)
         .expect("valid timestamp");
-    with_connection(&context.pool, |conn| {
+    with_connection(&context.pool, async |conn| {
         diesel::update(tasks.filter(task_id.eq(task.id)))
             .set(created_at.eq(earliest))
             .execute(conn)
+            .await
     })
+    .await
     .unwrap();
 
     for _ in 0..20 {
-        let _ = block_on(process_one_task(&context.pool)).unwrap();
-        let stored = block_on(task.find_record(&context.pool)).unwrap();
+        let _ = (process_one_task(&context.pool)).await.unwrap();
+        let stored = (task.find_record(&context.pool)).await.unwrap();
         if stored.status == TaskStatus::Failed.as_str() {
             assert_eq!(stored.total_items, 0);
             assert_eq!(stored.processed_items, 1);
@@ -1505,41 +1546,40 @@ fn test_process_one_task_export_failure_marks_single_failed_item() {
         }
     }
 
-    let stored = block_on(task.find_record(&context.pool)).unwrap();
+    let stored = (task.find_record(&context.pool)).await.unwrap();
     panic!(
         "Task {} did not reach failed state after repeated processing attempts; current status: {}",
         task.id, stored.status
     );
 }
 
-#[test]
-fn test_mark_claimed_task_failed_uses_recorded_result_counts() {
-    let context = block_on(TestContext::new());
-    let task = block_on(
-        NewTaskRecord {
-            kind: TaskKind::Import.as_str().to_string(),
-            status: TaskStatus::Queued.as_str().to_string(),
-            submitted_by: Some(context.admin_user.id),
-            submitted_token_id: None,
-            submitted_token_scoped: false,
-            submitted_token_scopes: serde_json::json!([]),
-            idempotency_key: Some(context.scoped_name("fallback-count-task")),
-            request_hash: None,
-            request_payload: Some(serde_json::json!({"version": 1})),
-            summary: None,
-            total_items: 3,
-            processed_items: 0,
-            success_items: 0,
-            failed_items: 0,
-            request_redacted_at: None,
-            started_at: None,
-            finished_at: None,
-        }
-        .create(&context.pool),
-    )
+#[tokio::test]
+async fn test_mark_claimed_task_failed_uses_recorded_result_counts() {
+    let context = (TestContext::new()).await;
+    let task = (NewTaskRecord {
+        kind: TaskKind::Import.as_str().to_string(),
+        status: TaskStatus::Queued.as_str().to_string(),
+        submitted_by: Some(context.admin_user.id),
+        submitted_token_id: None,
+        submitted_token_scoped: false,
+        submitted_token_scopes: serde_json::json!([]),
+        idempotency_key: Some(context.scoped_name("fallback-count-task")),
+        request_hash: None,
+        request_payload: Some(serde_json::json!({"version": 1})),
+        summary: None,
+        total_items: 3,
+        processed_items: 0,
+        success_items: 0,
+        failed_items: 0,
+        request_redacted_at: None,
+        started_at: None,
+        finished_at: None,
+    }
+    .create(&context.pool))
+    .await
     .unwrap();
 
-    block_on(insert_import_results(
+    (insert_import_results(
         &context.pool,
         &[
             NewImportTaskResultRecord {
@@ -1564,49 +1604,50 @@ fn test_mark_claimed_task_failed_uses_recorded_result_counts() {
             },
         ],
     ))
+    .await
     .unwrap();
 
-    block_on(mark_claimed_task_failed(
+    (mark_claimed_task_failed(
         &context.pool,
         &task,
         &ApiError::InternalServerError("boom".to_string()),
     ))
+    .await
     .unwrap();
 
-    let stored = block_on(task.find_record(&context.pool)).unwrap();
+    let stored = (task.find_record(&context.pool)).await.unwrap();
     assert_eq!(stored.processed_items, 2);
     assert_eq!(stored.success_items, 1);
     assert_eq!(stored.failed_items, 1);
 }
 
-#[test]
-fn test_count_import_results_summary_counts_success_and_failure_rows() {
-    let context = block_on(TestContext::new());
-    let task = block_on(
-        NewTaskRecord {
-            kind: TaskKind::Import.as_str().to_string(),
-            status: TaskStatus::Queued.as_str().to_string(),
-            submitted_by: Some(context.admin_user.id),
-            submitted_token_id: None,
-            submitted_token_scoped: false,
-            submitted_token_scopes: serde_json::json!([]),
-            idempotency_key: Some(context.scoped_name("aggregate-count-task")),
-            request_hash: None,
-            request_payload: Some(serde_json::json!({"version": 1})),
-            summary: None,
-            total_items: 4,
-            processed_items: 0,
-            success_items: 0,
-            failed_items: 0,
-            request_redacted_at: None,
-            started_at: None,
-            finished_at: None,
-        }
-        .create(&context.pool),
-    )
+#[tokio::test]
+async fn test_count_import_results_summary_counts_success_and_failure_rows() {
+    let context = (TestContext::new()).await;
+    let task = (NewTaskRecord {
+        kind: TaskKind::Import.as_str().to_string(),
+        status: TaskStatus::Queued.as_str().to_string(),
+        submitted_by: Some(context.admin_user.id),
+        submitted_token_id: None,
+        submitted_token_scoped: false,
+        submitted_token_scopes: serde_json::json!([]),
+        idempotency_key: Some(context.scoped_name("aggregate-count-task")),
+        request_hash: None,
+        request_payload: Some(serde_json::json!({"version": 1})),
+        summary: None,
+        total_items: 4,
+        processed_items: 0,
+        success_items: 0,
+        failed_items: 0,
+        request_redacted_at: None,
+        started_at: None,
+        finished_at: None,
+    }
+    .create(&context.pool))
+    .await
     .unwrap();
 
-    block_on(insert_import_results(
+    (insert_import_results(
         &context.pool,
         &[
             NewImportTaskResultRecord {
@@ -1641,9 +1682,10 @@ fn test_count_import_results_summary_counts_success_and_failure_rows() {
             },
         ],
     ))
+    .await
     .unwrap();
 
-    let counts = block_on(task.count_import_results(&context.pool)).unwrap();
+    let counts = (task.count_import_results(&context.pool)).await.unwrap();
 
     assert_eq!(counts.processed, 3);
     assert_eq!(counts.success, 2);

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -81,9 +81,28 @@ fn spawn_task_worker_loop(pool: DbPool, poll_interval: Duration, worker_index: u
                 poll_interval = ?poll_interval
             );
             let system = actix_rt::System::new();
-            system.block_on(task_worker_loop(pool, poll_interval));
+            system.block_on(async move {
+                let pool = task_worker_pool(pool);
+                task_worker_loop(pool, poll_interval).await;
+            });
         })
         .expect("failed to spawn task worker thread");
+}
+
+#[cfg(not(test))]
+fn task_worker_pool(pool: DbPool) -> DbPool {
+    pool
+}
+
+/// Async Postgres connections are tied to the runtime that established them.
+/// Test cases each own a short-lived Actix runtime, while the background worker
+/// thread is process-global. Build the test worker's pool on its own long-lived
+/// runtime so it never inherits connections driven by a completed test runtime.
+#[cfg(test)]
+fn task_worker_pool(pool: DbPool) -> DbPool {
+    drop(pool);
+    let config = get_config().expect("test task worker requires database configuration");
+    crate::db::init_pool(&config.database_url, config.db_pool_size)
 }
 
 pub fn ensure_task_worker_running(pool: DbPool) {

--- a/src/tests/api/meta.rs
+++ b/src/tests/api/meta.rs
@@ -15,6 +15,42 @@ mod tests {
 
     const LOGIN_RATE_LIMIT_ENDPOINT: &str = "/api/v0/meta/login-rate-limit";
 
+    #[rstest]
+    #[actix_web::test]
+    async fn test_db_meta_endpoint_returns_consistent_pool_state(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let resp = get_request(&context.pool, &context.admin_token, "/api/v0/meta/db").await;
+        let resp = assert_response_status(resp, StatusCode::OK).await;
+        let body: Value = test::read_body_json(resp).await;
+
+        let max = body["max_connections"].as_u64().unwrap();
+        let total = body["total_connections"].as_u64().unwrap();
+        let idle = body["idle_connections"].as_u64().unwrap();
+        let in_use = body["in_use_connections"].as_u64().unwrap();
+        let available = body["available_connections"].as_u64().unwrap();
+        let started = body["acquisitions_started"].as_u64().unwrap();
+        let completed = body["acquisitions_direct"].as_u64().unwrap()
+            + body["acquisitions_waited"].as_u64().unwrap()
+            + body["acquisitions_timed_out"].as_u64().unwrap();
+
+        assert!(max >= total);
+        assert!(total >= idle);
+        assert_eq!(in_use, total - idle);
+        assert_eq!(available, max - in_use);
+        assert_eq!(
+            body["pending_acquisitions"].as_u64().unwrap(),
+            started - completed
+        );
+        assert!(body["acquisition_wait_time_ms"].is_number());
+        assert!(body["connections_created"].is_number());
+        assert!(body["connections_closed_broken"].is_number());
+        assert!(body["connections_closed_invalid"].is_number());
+        assert!(body["connections_closed_max_lifetime"].is_number());
+        assert!(body["connections_closed_idle_timeout"].is_number());
+    }
+
     /// Drive enough failures to lock the `(username, ip)` scope (default threshold is 5).
     async fn lock_user_ip(username: &str, ip: IpAddr) {
         for _ in 0..5 {

--- a/src/tests/api/probes.rs
+++ b/src/tests/api/probes.rs
@@ -1,8 +1,8 @@
-use actix_web::{App, http::StatusCode, test, web::Data};
+use actix_web::{App, http::StatusCode, test};
 use serde_json::Value;
 
 use crate::api as prod_api;
-use crate::tests::POOL;
+use crate::tests::get_test_pool;
 
 #[actix_web::test]
 async fn test_healthz_returns_ok_without_database_pool() {
@@ -21,7 +21,7 @@ async fn test_healthz_returns_ok_without_database_pool() {
 async fn test_readyz_checks_database_connectivity() {
     let app = test::init_service(
         App::new()
-            .app_data(Data::new(POOL.clone()))
+            .app_data(get_test_pool())
             .configure(prod_api::config),
     )
     .await;

--- a/src/tests/api/v1/auth.rs
+++ b/src/tests/api/v1/auth.rs
@@ -37,7 +37,10 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let body: crate::api::handlers::auth::AuthProvidersResponse =
             test::read_body_json(resp).await;
-        assert_eq!(body.providers.first().map(String::as_str), Some("local"));
+        assert_eq!(
+            body.providers.as_slice().first().map(String::as_str),
+            Some("local")
+        );
         let mut sorted_external = body.providers[1..].to_vec();
         sorted_external.sort_unstable();
         assert_eq!(&body.providers[1..], sorted_external);

--- a/src/tests/api/v1/auth.rs
+++ b/src/tests/api/v1/auth.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::config::get_config;
+    use crate::db::prelude::*;
     use crate::db::traits::ActiveTokens;
     use crate::db::{init_pool, with_connection};
     use crate::middlewares::rate_limit::{
@@ -11,7 +12,6 @@ mod tests {
     use crate::{api, assert_not_contains};
     use actix_web::http::header;
     use actix_web::{App, http::StatusCode, test, web, web::Data};
-    use diesel::prelude::*;
 
     const LOGIN_ENDPOINT: &str = "/api/v0/auth/login";
     const AUTH_PROVIDERS_ENDPOINT: &str = "/api/v0/auth/providers";
@@ -135,12 +135,14 @@ mod tests {
         use crate::models::token::{PrincipalToken, Token};
         use crate::schema::tokens::dsl::*;
         let token_hash = Token::storage_hash_from_raw(&token_value);
-        let token_exists = with_connection(&pool, |conn| {
+        let token_exists = with_connection(&pool, async |conn| {
             tokens
                 .filter(token.eq(&token_hash))
                 .filter(principal_id.eq(new_user.id))
                 .first::<PrincipalToken>(conn)
+                .await
         })
+        .await
         .is_ok();
 
         assert!(token_exists, "Token not found in database");

--- a/src/tests/api/v1/classes.rs
+++ b/src/tests/api/v1/classes.rs
@@ -710,8 +710,8 @@ pub mod tests {
     #[rstest]
     #[actix_web::test]
     async fn test_api_create_records_actor(#[future(awt)] test_context: TestContext) {
+        use crate::db::prelude::*;
         use crate::db::with_connection;
-        use diesel::prelude::*;
 
         let context = test_context;
         let collection_fixture = context.collection_fixture("actor_history").await;
@@ -736,23 +736,27 @@ pub mod tests {
 
         // The user behind admin_token, resolved straight from the tokens table.
         let token_hash = crate::models::token::Token::storage_hash_from_raw(&context.admin_token);
-        let expected_actor: i32 = with_connection(&context.pool, |conn| {
+        let expected_actor: i32 = with_connection(&context.pool, async |conn| {
             use crate::schema::tokens::dsl as t;
             t::tokens
                 .filter(t::token.eq(&token_hash))
                 .select(t::principal_id)
                 .first::<i32>(conn)
+                .await
         })
+        .await
         .unwrap();
 
-        let actor: Option<i32> = with_connection(&context.pool, |conn| {
+        let actor: Option<i32> = with_connection(&context.pool, async |conn| {
             use crate::schema::hubuumclass_history::dsl as h;
             h::hubuumclass_history
                 .filter(h::id.eq(created.id))
                 .order(h::history_id.desc())
                 .select(h::actor_id)
                 .first::<Option<i32>>(conn)
+                .await
         })
+        .await
         .unwrap();
 
         assert_eq!(

--- a/src/tests/api/v1/event_deliveries.rs
+++ b/src/tests/api/v1/event_deliveries.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
+    use crate::db::prelude::*;
     use actix_web::{http::StatusCode, test};
-    use diesel::prelude::*;
     use serde_json::json;
 
     use crate::db::traits::event_fanout::fanout_event;
@@ -73,16 +73,20 @@ mod tests {
         .with_collection_id(fixture.collection.id)
         .with_entity_id(fixture.collection.id)
         .with_entity_name(&fixture.collection.name);
-        let event = with_connection(&context.pool, |conn| emit_event(conn, &event)).unwrap();
+        let event = with_connection(&context.pool, async |conn| emit_event(conn, &event).await)
+            .await
+            .unwrap();
         fanout_event(&context.pool, event.id).await.unwrap();
 
-        let delivery = with_connection(&context.pool, |conn| {
+        let delivery = with_connection(&context.pool, async |conn| {
             use crate::schema::event_deliveries::dsl::{event_deliveries, event_id};
 
             event_deliveries
                 .filter(event_id.eq(event.id))
                 .first::<EventDelivery>(conn)
+                .await
         })
+        .await
         .unwrap();
 
         DeliveryFixture {
@@ -167,13 +171,15 @@ mod tests {
     async fn test_event_delivery_dead_letter_does_not_rewrite_succeeded_delivery() {
         let context = TestContext::new().await;
         let delivery = create_delivery(&context).await.delivery;
-        with_connection(&context.pool, |conn| {
+        with_connection(&context.pool, async |conn| {
             use crate::schema::event_deliveries::dsl::{event_deliveries, id, status};
 
             diesel::update(event_deliveries.filter(id.eq(delivery.id)))
                 .set(status.eq(EventDeliveryStatus::Succeeded.as_str()))
                 .execute(conn)
+                .await
         })
+        .await
         .unwrap();
 
         let resp = post_request(
@@ -190,13 +196,15 @@ mod tests {
     async fn test_event_delivery_list_applies_status_filter_to_rows_and_total() {
         let context = TestContext::new().await;
         let dead = create_delivery(&context).await.delivery;
-        with_connection(&context.pool, |conn| {
+        with_connection(&context.pool, async |conn| {
             use crate::schema::event_deliveries::dsl::{event_deliveries, id, status};
 
             diesel::update(event_deliveries.filter(id.eq(dead.id)))
                 .set(status.eq(EventDeliveryStatus::Dead.as_str()))
                 .execute(conn)
+                .await
         })
+        .await
         .unwrap();
 
         let resp = get_request(

--- a/src/tests/api/v1/event_subscriptions.rs
+++ b/src/tests/api/v1/event_subscriptions.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
+    use crate::db::prelude::*;
     use actix_web::{http::StatusCode, test};
-    use diesel::prelude::*;
     use serde_json::json;
 
     use crate::db::with_connection;
@@ -50,13 +50,13 @@ mod tests {
         test::read_body_json(resp).await
     }
 
-    fn audit_event_count(
+    async fn audit_event_count(
         context: &TestContext,
         entity_type_value: EntityType,
         action_value: Action,
         entity_id_value: i32,
     ) -> i64 {
-        with_connection(&context.pool, |conn| {
+        with_connection(&context.pool, async |conn| {
             use crate::schema::events::dsl::{action, entity_id, entity_type, events};
 
             events
@@ -65,7 +65,9 @@ mod tests {
                 .filter(entity_id.eq(entity_id_value))
                 .count()
                 .get_result::<i64>(conn)
+                .await
         })
+        .await
         .unwrap()
     }
 
@@ -94,7 +96,7 @@ mod tests {
         let created: EventSink = test::read_body_json(resp).await;
         assert_eq!(created.kind, EventSinkKind::Webhook);
         assert_eq!(
-            audit_event_count(&context, EntityType::EventSink, Action::Created, created.id),
+            audit_event_count(&context, EntityType::EventSink, Action::Created, created.id).await,
             1
         );
 
@@ -134,7 +136,7 @@ mod tests {
         .await;
         assert_response_status(resp, StatusCode::NO_CONTENT).await;
         assert_eq!(
-            audit_event_count(&context, EntityType::EventSink, Action::Deleted, created.id),
+            audit_event_count(&context, EntityType::EventSink, Action::Deleted, created.id).await,
             1
         );
     }
@@ -178,7 +180,8 @@ mod tests {
                 EntityType::EventSubscription,
                 Action::Created,
                 created.id
-            ),
+            )
+            .await,
             1
         );
 

--- a/src/tests/api/v1/events.rs
+++ b/src/tests/api/v1/events.rs
@@ -14,8 +14,9 @@ mod tests {
 
     const EVENTS_ENDPOINT: &str = "/api/v1/events";
 
-    fn emit_test_event(pool: &crate::db::DbPool, event: &NewEvent) -> EventResponse {
-        with_connection(pool, |conn| emit_event(conn, event))
+    async fn emit_test_event(pool: &crate::db::DbPool, event: &NewEvent) -> EventResponse {
+        with_connection(pool, async |conn| emit_event(conn, event).await)
+            .await
             .expect("failed to emit test event")
             .into()
     }
@@ -39,7 +40,8 @@ mod tests {
             .with_collection_id(collection.collection.id)
             .with_entity_id(collection.collection.id)
             .with_entity_name(&collection.collection.name),
-        );
+        )
+        .await;
 
         let resp = get_request(&context.pool, &context.normal_token, EVENTS_ENDPOINT).await;
         let resp = assert_response_status(resp, StatusCode::OK).await;
@@ -101,7 +103,8 @@ mod tests {
             .with_collection_id(collection.collection.id)
             .with_entity_id(collection.collection.id)
             .with_entity_name(&collection.collection.name),
-        );
+        )
+        .await;
         let collection_less_event = emit_test_event(
             &context.pool,
             &NewEvent::new(
@@ -111,7 +114,8 @@ mod tests {
                 "collection-less audit filter test",
             )
             .unwrap(),
-        );
+        )
+        .await;
 
         let endpoint = format!(
             "{EVENTS_ENDPOINT}?entity_type=collection&action=created&collection_id={}",
@@ -171,7 +175,8 @@ mod tests {
             .with_collection_id(collection.collection.id)
             .with_entity_id(collection.collection.id)
             .with_entity_name(&collection.collection.name),
-        );
+        )
+        .await;
         let other_event = emit_test_event(
             &context.pool,
             &NewEvent::new(
@@ -184,7 +189,8 @@ mod tests {
             .with_collection_id(collection.collection.id)
             .with_entity_id(collection.collection.id)
             .with_entity_name("not-the-collection"),
-        );
+        )
+        .await;
 
         let endpoint = format!("/api/v1/collections/{}/events", collection.collection.id);
         let resp = get_request(&context.pool, &context.normal_token, &endpoint).await;
@@ -240,7 +246,8 @@ mod tests {
             .with_metadata(json!({
                 "related_collection_ids": [related_collection.id],
             })),
-        );
+        )
+        .await;
 
         let resp = get_request(&context.pool, &user_token, EVENTS_ENDPOINT).await;
         let resp = assert_response_status(resp, StatusCode::OK).await;

--- a/src/tests/api/v1/exports.rs
+++ b/src/tests/api/v1/exports.rs
@@ -1463,7 +1463,7 @@ mod tests {
     async fn test_export_output_cleanup_removes_expired_artifacts(
         #[future(awt)] test_context: TestContext,
     ) {
-        use diesel::prelude::*;
+        use crate::db::prelude::*;
 
         let context = test_context;
         let classes = create_test_classes(&context, "export_cleanup").await;
@@ -1500,7 +1500,7 @@ mod tests {
         // test, which relies on its own expired row surviving.
         let _purge_guard = lock_test_mutex(&EXPIRED_OUTPUT_PURGE_LOCK).await;
 
-        crate::db::with_connection(&context.pool, |conn| {
+        crate::db::with_connection(&context.pool, async |conn| {
             use crate::schema::export_task_outputs::dsl::{
                 export_task_outputs, output_expires_at, task_id,
             };
@@ -1511,7 +1511,9 @@ mod tests {
                         .eq(chrono::Utc::now().naive_utc() - chrono::Duration::hours(1)),
                 )
                 .execute(conn)
+                .await
         })
+        .await
         .unwrap();
 
         // The purge is process-wide; assert it cleaned *our* task rather than asserting it cleaned
@@ -1572,7 +1574,7 @@ mod tests {
     async fn test_export_output_returns_gone_when_expired_before_purge(
         #[future(awt)] test_context: TestContext,
     ) {
-        use diesel::prelude::*;
+        use crate::db::prelude::*;
 
         let context = test_context;
         let classes = create_test_classes(&context, "export_expired").await;
@@ -1613,7 +1615,7 @@ mod tests {
             .unwrap()
             .and_hms_opt(0, 0, 0)
             .unwrap();
-        crate::db::with_connection(&context.pool, |conn| {
+        crate::db::with_connection(&context.pool, async |conn| {
             use crate::schema::export_task_outputs::dsl::{
                 export_task_outputs, output_expires_at, task_id,
             };
@@ -1621,7 +1623,9 @@ mod tests {
             diesel::update(export_task_outputs.filter(task_id.eq(task.id)))
                 .set(output_expires_at.eq(backdated_expiry))
                 .execute(conn)
+                .await
         })
+        .await
         .unwrap();
 
         // Deliberately do NOT purge: the row still exists but is past its retention window.
@@ -1684,7 +1688,7 @@ mod tests {
     async fn test_finalize_export_with_output_is_idempotent(
         #[future(awt)] test_context: TestContext,
     ) {
-        use diesel::prelude::*;
+        use crate::db::prelude::*;
 
         let context = test_context;
         let classes = create_test_classes(&context, "export_refinalize").await;
@@ -1757,7 +1761,7 @@ mod tests {
 
         // The output row is untouched: exactly one row, and the original body, not the duplicate.
         let (count, text): (i64, Option<String>) =
-            crate::db::with_connection(&context.pool, |conn| {
+            crate::db::with_connection(&context.pool, async |conn| {
                 use crate::schema::export_task_outputs::dsl::{
                     export_task_outputs, task_id, text_output,
                 };
@@ -1765,13 +1769,16 @@ mod tests {
                 let count = export_task_outputs
                     .filter(task_id.eq(task.id))
                     .count()
-                    .get_result::<i64>(conn)?;
+                    .get_result::<i64>(conn)
+                    .await?;
                 let text = export_task_outputs
                     .filter(task_id.eq(task.id))
                     .select(text_output)
-                    .first::<Option<String>>(conn)?;
+                    .first::<Option<String>>(conn)
+                    .await?;
                 Ok::<_, diesel::result::Error>((count, text))
             })
+            .await
             .unwrap();
         assert_eq!(count, 1);
         assert_ne!(text.as_deref(), Some("second finalize body"));

--- a/src/tests/api/v1/groups.rs
+++ b/src/tests/api/v1/groups.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
+    use crate::db::prelude::*;
     use actix_web::{http::StatusCode, test};
-    use diesel::prelude::*;
     use rstest::rstest;
 
     use crate::db::traits::identity::ensure_identity_scope;
@@ -140,7 +140,7 @@ mod tests {
         .await
         .unwrap();
         let groupname = context.scoped_name("external_group");
-        let group = with_connection(&context.pool, |conn| {
+        let group = with_connection(&context.pool, async |conn| {
             use crate::schema::groups;
 
             diesel::insert_into(groups::table)
@@ -152,7 +152,9 @@ mod tests {
                     groups::external_key.eq(context.scoped_name("external_group_key")),
                 ))
                 .get_result::<Group>(conn)
+                .await
         })
+        .await
         .unwrap();
         let group_url = format!("{GROUPS_ENDPOINT}/{}", group.id);
 
@@ -196,7 +198,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let external_group = with_connection(&context.pool, |conn| {
+        let external_group = with_connection(&context.pool, async |conn| {
             use crate::schema::groups;
 
             diesel::insert_into(groups::table)
@@ -208,7 +210,9 @@ mod tests {
                     groups::external_key.eq(context.scoped_name("batch_external_group_key")),
                 ))
                 .get_result::<Group>(conn)
+                .await
         })
+        .await
         .unwrap();
 
         let responses =
@@ -241,7 +245,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let external = with_connection(&context.pool, |conn| {
+        let external = with_connection(&context.pool, async |conn| {
             use crate::schema::principals;
 
             diesel::insert_into(principals::table)
@@ -253,7 +257,9 @@ mod tests {
                     principals::external_subject.eq(context.scoped_name("batch_subject")),
                 ))
                 .get_result::<Principal>(conn)
+                .await
         })
+        .await
         .unwrap();
 
         let responses =

--- a/src/tests/api/v1/imports.rs
+++ b/src/tests/api/v1/imports.rs
@@ -3,7 +3,8 @@ mod tests {
     use actix_rt::time::sleep;
     use actix_web::{http::StatusCode, test};
     use chrono::Utc;
-    use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+    use diesel::{ExpressionMethods, QueryDsl};
+    use diesel_async::RunQueryDsl;
     use futures::join;
     use rstest::rstest;
     use std::time::Duration;
@@ -221,12 +222,14 @@ mod tests {
             .expect("import should have results");
         assert!(finished_at >= last_result_at);
 
-        let stored_payload = with_connection(&context.pool, |conn| {
+        let stored_payload = with_connection(&context.pool, async |conn| {
             tasks
                 .filter(task_id_field.eq(task.id))
                 .select((request_payload, request_redacted_at))
                 .first::<(Option<serde_json::Value>, Option<chrono::NaiveDateTime>)>(conn)
+                .await
         })
+        .await
         .unwrap();
         assert!(stored_payload.0.is_none());
         assert!(stored_payload.1.is_some());
@@ -728,12 +731,14 @@ mod tests {
         let completed = wait_for_task(&context, task.id, &[TaskStatus::Failed]).await;
         assert_eq!(completed.status, TaskStatus::Failed);
 
-        let description = with_connection(&context.pool, |conn| {
+        let description = with_connection(&context.pool, async |conn| {
             collections
                 .filter(collection_id_field.eq(fixture.collection.id))
                 .select(collection_description)
                 .first::<String>(conn)
+                .await
         })
+        .await
         .unwrap();
         assert_eq!(description, fixture.collection.description);
     }
@@ -770,12 +775,14 @@ mod tests {
         let completed = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
         assert_eq!(completed.status, TaskStatus::Succeeded);
 
-        let description = with_connection(&context.pool, |conn| {
+        let description = with_connection(&context.pool, async |conn| {
             collections
                 .filter(collection_id_field.eq(fixture.collection.id))
                 .select(collection_description)
                 .first::<String>(conn)
+                .await
         })
+        .await
         .unwrap();
         assert_eq!(description, updated_description);
     }
@@ -858,21 +865,25 @@ mod tests {
         .await;
         assert_eq!(completed.status, TaskStatus::PartiallySucceeded);
 
-        let created = with_connection(&context.pool, |conn| {
+        let created = with_connection(&context.pool, async |conn| {
             hubuumclass
                 .filter(class_name_col.eq(&allowed_class))
                 .filter(collection_id.eq(allowed.collection.id))
                 .count()
                 .get_result::<i64>(conn)
+                .await
         })
+        .await
         .unwrap();
-        let blocked = with_connection(&context.pool, |conn| {
+        let blocked = with_connection(&context.pool, async |conn| {
             hubuumclass
                 .filter(class_name_col.eq(&forbidden_class))
                 .filter(collection_id.eq(forbidden.collection.id))
                 .count()
                 .get_result::<i64>(conn)
+                .await
         })
+        .await
         .unwrap();
         assert_eq!(created, 1);
         assert_eq!(blocked, 0);
@@ -978,12 +989,14 @@ mod tests {
         .await;
         assert_eq!(completed.status, TaskStatus::Failed);
 
-        let created = with_connection(&context.pool, |conn| {
+        let created = with_connection(&context.pool, async |conn| {
             hubuumclass
                 .filter(class_name_col.eq_any([allowed_class.clone(), forbidden_class.clone()]))
                 .count()
                 .get_result::<i64>(conn)
+                .await
         })
+        .await
         .unwrap();
         assert_eq!(created, 0);
     }

--- a/src/tests/api/v1/objects.rs
+++ b/src/tests/api/v1/objects.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use diesel::prelude::*;
+    use crate::db::prelude::*;
     use diesel::sql_types::Text;
     use rstest::rstest;
 
@@ -1061,12 +1061,14 @@ mod tests {
             .unwrap();
         }
 
-        let plan_rows = with_connection(&context.pool, |conn| {
-            conn.transaction::<_, diesel::result::Error, _>(|conn| {
+        let plan_rows = with_connection(&context.pool, async |conn| {
+            conn.transaction::<_, diesel::result::Error, _>(async |conn| {
                 diesel::sql_query("DROP INDEX IF EXISTS idx_hubuumobject_hubuum_class_id")
-                    .execute(conn)?;
+                    .execute(conn)
+                    .await?;
                 diesel::sql_query("DROP INDEX IF EXISTS idx_hubuumobject_collection_id")
-                    .execute(conn)?;
+                    .execute(conn)
+                    .await?;
                 let create_index_sql = format!(
                     "CREATE INDEX IF NOT EXISTS idx_test_json_ip_expression \
                  ON hubuumobject USING GIST ((try_inet(data #>> '{{network,address}}')) inet_ops) \
@@ -1075,9 +1077,13 @@ mod tests {
                  AND try_inet(data #>> '{{network,address}}') IS NOT NULL",
                     class.id, collection.collection.id
                 );
-                diesel::sql_query(create_index_sql).execute(conn)?;
-                diesel::sql_query("ANALYZE hubuumobject").execute(conn)?;
-                diesel::sql_query("SET LOCAL enable_seqscan = off").execute(conn)?;
+                diesel::sql_query(create_index_sql).execute(conn).await?;
+                diesel::sql_query("ANALYZE hubuumobject")
+                    .execute(conn)
+                    .await?;
+                diesel::sql_query("SET LOCAL enable_seqscan = off")
+                    .execute(conn)
+                    .await?;
 
                 let explain_sql = format!(
                     "EXPLAIN SELECT id FROM hubuumobject \
@@ -1087,21 +1093,27 @@ mod tests {
                  AND try_inet(data #>> '{{network,address}}') <<= '10.42.1.0/24'::inet",
                     class.id, collection.collection.id
                 );
-                let plan_rows = diesel::sql_query(explain_sql).load::<ExplainRow>(conn)?;
+                let plan_rows = diesel::sql_query(explain_sql)
+                    .load::<ExplainRow>(conn)
+                    .await?;
 
                 diesel::sql_query(
                     "CREATE INDEX IF NOT EXISTS idx_hubuumobject_hubuum_class_id \
                  ON hubuumobject (hubuum_class_id)",
                 )
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
                 diesel::sql_query(
                     "CREATE INDEX IF NOT EXISTS idx_hubuumobject_collection_id \
                  ON hubuumobject (collection_id)",
                 )
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
                 Ok(plan_rows)
             })
+            .await
         })
+        .await
         .unwrap();
         let plan_text = plan_rows
             .iter()

--- a/src/tests/api/v1/principal_settings.rs
+++ b/src/tests/api/v1/principal_settings.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
+    use crate::db::prelude::*;
     use actix_web::{http::StatusCode, test};
-    use diesel::prelude::*;
     use rstest::rstest;
 
     use crate::db::with_connection;
@@ -65,14 +65,16 @@ mod tests {
     async fn database_rejects_non_object_settings() {
         let context = TestContext::new().await;
 
-        let result = with_connection(&context.pool, |conn| {
+        let result = with_connection(&context.pool, async |conn| {
             diesel::update(
                 crate::schema::principals::table
                     .filter(crate::schema::principals::id.eq(context.normal_user.id)),
             )
             .set(crate::schema::principals::settings.eq(serde_json::json!(["invalid"])))
             .execute(conn)
-        });
+            .await
+        })
+        .await;
 
         assert!(matches!(
             result,
@@ -282,14 +284,16 @@ mod tests {
                 (account.id, token)
             }
             SelfCaller::ProviderManagedHuman => {
-                with_connection(&context.pool, |conn| {
+                with_connection(&context.pool, async |conn| {
                     diesel::update(
                         crate::schema::principals::table
                             .filter(crate::schema::principals::id.eq(context.normal_user.id)),
                     )
                     .set(crate::schema::principals::provider_managed.eq(true))
                     .execute(conn)
+                    .await
                 })
+                .await
                 .unwrap();
                 (context.normal_user.id, context.normal_token.clone())
             }
@@ -436,14 +440,16 @@ mod tests {
         };
         assert_eq!(response.status(), expected_status);
 
-        let event = with_connection(&context.pool, |conn| {
+        let event = with_connection(&context.pool, async |conn| {
             crate::schema::events::table
                 .filter(crate::schema::events::entity_type.eq(entity_type.as_str()))
                 .filter(crate::schema::events::entity_id.eq(target_id))
                 .filter(crate::schema::events::action.eq(Action::Updated.as_str()))
                 .order(crate::schema::events::id.desc())
                 .first::<Event>(conn)
+                .await
         })
+        .await
         .unwrap();
 
         assert_eq!(

--- a/src/tests/api/v1/querying.rs
+++ b/src/tests/api/v1/querying.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
+    use crate::db::prelude::*;
     use actix_web::{http::StatusCode, test as actix_test};
     use chrono::{NaiveDate, NaiveDateTime};
-    use diesel::prelude::*;
     use rstest::rstest;
 
     use crate::db::with_connection;
@@ -121,19 +121,21 @@ mod tests {
         (collection, class, objects)
     }
 
-    fn set_object_created_at(
+    async fn set_object_created_at(
         context: &TestContext,
         object: &HubuumObject,
         created_at: NaiveDateTime,
     ) {
-        with_connection(&context.pool, |conn| {
+        with_connection(&context.pool, async |conn| {
             diesel::update(hubuumobject.filter(hubuumobject_id.eq(object.id)))
                 .set((
                     object_created_at.eq(created_at),
                     object_updated_at.eq(created_at),
                 ))
                 .execute(conn)
+                .await
         })
+        .await
         .unwrap();
     }
 
@@ -488,7 +490,7 @@ mod tests {
                 .unwrap()
                 .and_hms_opt(0, 0, 0)
                 .unwrap();
-            set_object_created_at(&context, object, created_at);
+            set_object_created_at(&context, object, created_at).await;
         }
 
         let resp = get_request(

--- a/src/tests/api/v1/remote_targets.rs
+++ b/src/tests/api/v1/remote_targets.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 mod tests {
+    use crate::db::prelude::*;
     use actix_rt::time::sleep;
     use actix_web::{
         http::{StatusCode, header},
         test,
     };
     use base64::Engine;
-    use diesel::prelude::*;
     use futures::join;
     use std::sync::Arc;
     use std::time::Duration;
@@ -344,14 +344,16 @@ mod tests {
         (port, request_rx)
     }
 
-    fn remote_call_result(context: &TestContext, task_id_value: i32) -> RemoteCallResult {
+    async fn remote_call_result(context: &TestContext, task_id_value: i32) -> RemoteCallResult {
         use crate::schema::remote_call_results::dsl::{remote_call_results, task_id};
 
-        with_connection(&context.pool, |conn| {
+        with_connection(&context.pool, async |conn| {
             remote_call_results
                 .filter(task_id.eq(task_id_value))
                 .first::<RemoteCallResult>(conn)
+                .await
         })
+        .await
         .unwrap()
     }
 
@@ -897,7 +899,7 @@ mod tests {
         assert!(request.contains("\"trace\": \"trace-123\""));
         assert!(request.contains("\"force\":true"));
 
-        let result = remote_call_result(&context, task.id);
+        let result = remote_call_result(&context, task.id).await;
         assert!(result.success);
         assert_eq!(result.target_id, Some(target.id));
         assert_eq!(result.subject_type, "object");
@@ -946,7 +948,7 @@ mod tests {
         assert_eq!(finished.status, TaskStatus::Succeeded);
 
         let _request = request_rx.await.unwrap();
-        let result = remote_call_result(&context, task.id);
+        let result = remote_call_result(&context, task.id).await;
         assert!(result.success);
         assert_eq!(
             result.response_body_preview.as_deref(),

--- a/src/tests/api/v1/service_accounts.rs
+++ b/src/tests/api/v1/service_accounts.rs
@@ -12,8 +12,8 @@
 
 #[cfg(test)]
 mod tests {
+    use crate::db::prelude::*;
     use actix_web::{App, http::StatusCode, test, web};
-    use diesel::prelude::*;
     use rstest::rstest;
 
     use crate::api;
@@ -148,7 +148,7 @@ mod tests {
         let user = create_test_user(pool).await;
         let group = create_test_group(pool).await;
 
-        let result = with_connection(pool, |conn| {
+        let result = with_connection(pool, async |conn| {
             diesel::insert_into(crate::schema::service_accounts::table)
                 .values((
                     crate::schema::service_accounts::id.eq(user.id),
@@ -156,7 +156,9 @@ mod tests {
                     crate::schema::service_accounts::owner_group_id.eq(group.id),
                 ))
                 .execute(conn)
-        });
+                .await
+        })
+        .await;
 
         assert!(result.is_err());
     }
@@ -170,14 +172,16 @@ mod tests {
         let group = create_test_group(pool).await;
         let sa: ServiceAccount = create_test_service_account(pool, &group, None).await;
 
-        let result = with_connection(pool, |conn| {
+        let result = with_connection(pool, async |conn| {
             diesel::insert_into(crate::schema::users::table)
                 .values((
                     crate::schema::users::id.eq(sa.id),
                     crate::schema::users::password.eq(Some("x")),
                 ))
                 .execute(conn)
-        });
+                .await
+        })
+        .await;
 
         assert!(result.is_err());
     }
@@ -213,33 +217,41 @@ mod tests {
             .expect("user delete should succeed");
 
         let remaining: i64 = match facet {
-            CascadeFacet::Principal => with_connection(pool, |conn| {
+            CascadeFacet::Principal => with_connection(pool, async |conn| {
                 crate::schema::principals::table
                     .filter(crate::schema::principals::id.eq(pid))
                     .count()
                     .get_result(conn)
+                    .await
             })
+            .await
             .unwrap(),
-            CascadeFacet::UsersRow => with_connection(pool, |conn| {
+            CascadeFacet::UsersRow => with_connection(pool, async |conn| {
                 crate::schema::users::table
                     .filter(crate::schema::users::id.eq(pid))
                     .count()
                     .get_result(conn)
+                    .await
             })
+            .await
             .unwrap(),
-            CascadeFacet::Tokens => with_connection(pool, |conn| {
+            CascadeFacet::Tokens => with_connection(pool, async |conn| {
                 crate::schema::tokens::table
                     .filter(crate::schema::tokens::principal_id.eq(pid))
                     .count()
                     .get_result(conn)
+                    .await
             })
+            .await
             .unwrap(),
-            CascadeFacet::Memberships => with_connection(pool, |conn| {
+            CascadeFacet::Memberships => with_connection(pool, async |conn| {
                 crate::schema::group_memberships::table
                     .filter(crate::schema::group_memberships::principal_id.eq(pid))
                     .count()
                     .get_result(conn)
+                    .await
             })
+            .await
             .unwrap(),
         };
 
@@ -303,12 +315,14 @@ mod tests {
         let hash = raw.storage_hash();
         raw.delete(pool).await.unwrap();
 
-        let revoked_at_value: Option<chrono::NaiveDateTime> = with_connection(pool, |conn| {
+        let revoked_at_value: Option<chrono::NaiveDateTime> = with_connection(pool, async |conn| {
             tokens
                 .filter(token_col.eq(&hash))
                 .select(revoked_at)
                 .first::<Option<chrono::NaiveDateTime>>(conn)
+                .await
         })
+        .await
         .expect("token row should still exist after soft-revoke");
 
         assert!(revoked_at_value.is_some());
@@ -346,12 +360,14 @@ mod tests {
         let returned = raw.is_valid(pool).await.unwrap().last_used_at;
 
         let hash = raw.storage_hash();
-        let persisted: Option<chrono::NaiveDateTime> = with_connection(pool, |conn| {
+        let persisted: Option<chrono::NaiveDateTime> = with_connection(pool, async |conn| {
             tokens
                 .filter(token_col.eq(&hash))
                 .select(last_used_at)
                 .first::<Option<chrono::NaiveDateTime>>(conn)
+                .await
         })
+        .await
         .expect("token row should exist after validation");
 
         assert_eq!(returned, persisted);
@@ -468,12 +484,14 @@ mod tests {
             "precondition: token mint succeeds"
         );
 
-        let scoped_flags: Vec<bool> = with_connection(pool, |conn| {
+        let scoped_flags: Vec<bool> = with_connection(pool, async |conn| {
             tokens
                 .filter(principal_id.eq(sa.id))
                 .select(scoped)
                 .load::<bool>(conn)
+                .await
         })
+        .await
         .unwrap();
 
         assert_eq!(scoped_flags, vec![false]);
@@ -706,14 +724,16 @@ mod tests {
         let other = create_test_service_account(pool, &group, None).await;
 
         service_account_token(pool, &owner, None, None).await;
-        let token_id: i32 = with_connection(pool, |conn| {
+        let token_id: i32 = with_connection(pool, async |conn| {
             use crate::schema::tokens::dsl::{id, principal_id, tokens};
             tokens
                 .filter(principal_id.eq(owner.id))
                 .select(id)
                 .order(id.desc())
                 .first::<i32>(conn)
+                .await
         })
+        .await
         .unwrap();
 
         let path_principal = if use_owning_principal {
@@ -1188,13 +1208,15 @@ mod tests {
             .await
             .unwrap();
 
-        let status: String = with_connection(pool, |conn| {
+        let status: String = with_connection(pool, async |conn| {
             use crate::schema::tasks::dsl::{id, status, tasks};
             tasks
                 .filter(id.eq(task.id))
                 .select(status)
                 .first::<String>(conn)
+                .await
         })
+        .await
         .unwrap();
         assert_eq!(status, TaskStatus::Cancelled.as_str());
     }
@@ -1355,12 +1377,12 @@ mod tests {
 
     const SERVICE_ACCOUNTS_ENDPOINT: &str = "/api/v1/iam/service-accounts";
 
-    fn service_account_audit_event_count(
+    async fn service_account_audit_event_count(
         context: &TestContext,
         action_value: Action,
         service_account_id: i32,
     ) -> i64 {
-        with_connection(&context.pool, |conn| {
+        with_connection(&context.pool, async |conn| {
             use crate::schema::events::dsl::{action, entity_id, entity_type, events};
 
             events
@@ -1369,7 +1391,9 @@ mod tests {
                 .filter(entity_id.eq(service_account_id))
                 .count()
                 .get_result::<i64>(conn)
+                .await
         })
+        .await
         .unwrap()
     }
 
@@ -1393,7 +1417,7 @@ mod tests {
         let resp = assert_response_status(resp, StatusCode::CREATED).await;
         let created: ServiceAccountResponse = test::read_body_json(resp).await;
         assert_eq!(
-            service_account_audit_event_count(&context, Action::Created, created.id),
+            service_account_audit_event_count(&context, Action::Created, created.id).await,
             1
         );
 
@@ -1406,7 +1430,7 @@ mod tests {
         .await;
         assert_response_status(resp, StatusCode::OK).await;
         assert_eq!(
-            service_account_audit_event_count(&context, Action::Disabled, created.id),
+            service_account_audit_event_count(&context, Action::Disabled, created.id).await,
             1
         );
 
@@ -1418,7 +1442,7 @@ mod tests {
         .await;
         assert_response_status(resp, StatusCode::NO_CONTENT).await;
         assert_eq!(
-            service_account_audit_event_count(&context, Action::Deleted, created.id),
+            service_account_audit_event_count(&context, Action::Deleted, created.id).await,
             1
         );
     }
@@ -1500,13 +1524,15 @@ mod tests {
             .await
             .unwrap();
 
-        let status: String = with_connection(pool, |conn| {
+        let status: String = with_connection(pool, async |conn| {
             use crate::schema::tasks::dsl::{id, status, tasks};
             tasks
                 .filter(id.eq(task.id))
                 .select(status)
                 .first::<String>(conn)
+                .await
         })
+        .await
         .unwrap();
         assert_eq!(status, TaskStatus::Running.as_str());
     }

--- a/src/tests/api/v1/users.rs
+++ b/src/tests/api/v1/users.rs
@@ -778,8 +778,8 @@ mod tests {
     #[rstest]
     #[actix_web::test]
     async fn test_api_anonymize_user(#[future(awt)] test_context: TestContext) {
+        use crate::db::prelude::*;
         use crate::db::with_connection;
-        use diesel::prelude::*;
 
         let context = test_context;
 
@@ -805,13 +805,15 @@ mod tests {
         .await;
         assert_response_status(resp, StatusCode::NO_CONTENT).await;
 
-        let principal_name: String = with_connection(&context.pool, |conn| {
+        let principal_name: String = with_connection(&context.pool, async |conn| {
             use crate::schema::principals::dsl as p;
             p::principals
                 .filter(p::id.eq(new_user.id))
                 .select(p::name)
                 .first(conn)
+                .await
         })
+        .await
         .unwrap();
         assert_eq!(principal_name, format!("anonymized-{}", new_user.id));
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -15,8 +15,8 @@ pub mod search;
 pub mod temporal;
 pub mod validation;
 
+use crate::db::prelude::*;
 use actix_web::web;
-use diesel::prelude::*;
 #[cfg(test)]
 use rstest::fixture;
 
@@ -37,10 +37,10 @@ use crate::traits::{CanDelete, CanSave};
 use std::sync::LazyLock;
 use tokio::sync::{Mutex, MutexGuard};
 
-static POOL: LazyLock<DbPool> = LazyLock::new(|| {
+fn new_test_pool() -> DbPool {
     let config = get_config().unwrap();
     init_pool(&config.database_url, 20)
-});
+}
 
 pub type TestMutex = LazyLock<Mutex<()>>;
 pub type TestMutexGuard = MutexGuard<'static, ()>;
@@ -601,11 +601,13 @@ pub async fn ensure_admin_group(pool: &DbPool) -> Group {
         .map(|config| config.admin_groupname.clone())
         .unwrap_or_else(|_| "admin".to_string());
 
-    let result = with_connection(pool, |conn| {
+    let result = with_connection(pool, async |conn| {
         groups
             .filter(groupname.eq(&admin_groupname))
             .first::<Group>(conn)
-    });
+            .await
+    })
+    .await;
 
     if let Ok(group) = result {
         return group;
@@ -622,11 +624,13 @@ pub async fn ensure_admin_group(pool: &DbPool) -> Group {
     if let Err(e) = result {
         match e {
             ApiError::Conflict(_) => {
-                return with_connection(pool, |conn| {
+                return with_connection(pool, async |conn| {
                     groups
                         .filter(groupname.eq(&admin_groupname))
                         .first::<Group>(conn)
+                        .await
                 })
+                .await
                 .expect("Failed to fetch user after conflict");
             }
             _ => panic!("Failed to create admin group: {e:?}"),
@@ -638,13 +642,13 @@ pub async fn ensure_admin_group(pool: &DbPool) -> Group {
 
 pub async fn get_pool_and_config() -> (DbPool, AppConfig) {
     let config = get_config().unwrap();
-    let pool = POOL.clone();
+    let pool = new_test_pool();
 
     (pool, config.clone())
 }
 
 pub async fn setup_pool_and_tokens() -> (DbPool, String, String) {
-    let pool = POOL.clone();
+    let pool = new_test_pool();
     let admin_user = ensure_admin_user(&pool).await;
     let admin_token = admin_user.create_token(&pool).await.unwrap().get_token();
     let normal_user = ensure_normal_user(&pool).await;
@@ -654,7 +658,7 @@ pub async fn setup_pool_and_tokens() -> (DbPool, String, String) {
 }
 
 pub fn get_test_pool() -> web::Data<DbPool> {
-    web::Data::new(POOL.clone())
+    web::Data::new(new_test_pool())
 }
 
 #[cfg(test)]

--- a/src/tests/temporal/mod.rs
+++ b/src/tests/temporal/mod.rs
@@ -1,9 +1,9 @@
+use crate::db::prelude::*;
 use crate::db::with_connection;
 use crate::models::{NewHubuumClass, UpdateHubuumClass};
 use crate::tests::TestScope;
 use crate::traits::{CanSave, CanUpdate};
 use chrono::{DateTime, Utc};
-use diesel::prelude::*;
 use diesel::sql_types::{Integer, Text, Timestamp, Timestamptz};
 
 /// Driving INSERT/UPDATE/DELETE on a base table through raw SQL (with the
@@ -17,39 +17,46 @@ async fn trigger_records_ops_and_actor() {
     let cname = format!("trigger_actor_class_{}", scope.scope_id);
 
     // All three DML statements in one transaction with the actor GUC set.
-    with_connection(&pool, |conn| {
-        conn.transaction::<(), diesel::result::Error, _>(|conn| {
+    with_connection(&pool, async |conn| {
+        conn.transaction::<(), diesel::result::Error, _>(async |conn| {
             diesel::sql_query("SELECT set_config('hubuum.actor_id', '4242', true)")
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
             diesel::sql_query(
                 "INSERT INTO hubuumclass (name, collection_id, validate_schema, description)
                  VALUES ($1, $2, false, 'd')",
             )
             .bind::<Text, _>(&cname)
             .bind::<Integer, _>(collection_id)
-            .execute(conn)?;
+            .execute(conn)
+            .await?;
 
             let cid: i32 = {
                 use crate::schema::hubuumclass::dsl as c;
                 c::hubuumclass
                     .filter(c::name.eq(&cname))
                     .select(c::id)
-                    .first(conn)?
+                    .first(conn)
+                    .await?
             };
             diesel::sql_query("UPDATE hubuumclass SET description='d2' WHERE id=$1")
                 .bind::<Integer, _>(cid)
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
             diesel::sql_query("DELETE FROM hubuumclass WHERE id=$1")
                 .bind::<Integer, _>(cid)
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
             Ok(())
         })
+        .await
     })
+    .await
     .unwrap();
 
     // Read back the history for that class, oldest first.
     type HistRow = (String, DateTime<Utc>, Option<DateTime<Utc>>, Option<i32>);
-    let rows: Vec<HistRow> = with_connection(&pool, |conn| {
+    let rows: Vec<HistRow> = with_connection(&pool, async |conn| {
         use crate::schema::hubuumclass_history::dsl as h;
         // The class itself is deleted; find history by the name snapshot instead.
         h::hubuumclass_history
@@ -57,7 +64,9 @@ async fn trigger_records_ops_and_actor() {
             .order(h::history_id.asc())
             .select((h::op, h::valid_from, h::valid_to, h::actor_id))
             .load(conn)
+            .await
     })
+    .await
     .unwrap();
 
     let ops: Vec<&str> = rows.iter().map(|(op, _, _, _)| op.as_str()).collect();
@@ -91,8 +100,8 @@ async fn trigger_inserts_history_by_column_name() {
     let scope = TestScope::new();
     let pool = scope.pool.clone();
 
-    let row: ColumnOrderHistoryRow = with_connection(&pool, |conn| {
-        conn.transaction::<_, diesel::result::Error, _>(|conn| {
+    let row: ColumnOrderHistoryRow = with_connection(&pool, async |conn| {
+        conn.transaction::<_, diesel::result::Error, _>(async |conn| {
             diesel::sql_query(
                 "CREATE TEMP TABLE temporal_column_order (
                     id int PRIMARY KEY,
@@ -100,7 +109,8 @@ async fn trigger_inserts_history_by_column_name() {
                     a int NOT NULL
                  )",
             )
-            .execute(conn)?;
+            .execute(conn)
+            .await?;
             diesel::sql_query(
                 "CREATE TEMP TABLE temporal_column_order_history (
                     a int NOT NULL,
@@ -113,25 +123,32 @@ async fn trigger_inserts_history_by_column_name() {
                     history_id bigint NOT NULL
                  )",
             )
-            .execute(conn)?;
+            .execute(conn)
+            .await?;
             diesel::sql_query("CREATE TEMP SEQUENCE temporal_column_order_history_seq")
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
             diesel::sql_query(
                 "CREATE TRIGGER temporal_column_order_history_trg
                  AFTER INSERT OR UPDATE OR DELETE ON temporal_column_order
                  FOR EACH ROW EXECUTE FUNCTION hubuum_record_history()",
             )
-            .execute(conn)?;
+            .execute(conn)
+            .await?;
             diesel::sql_query("INSERT INTO temporal_column_order (id, b, a) VALUES (7, 'bee', 42)")
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
             diesel::sql_query(
                 "SELECT id AS hist_id, a AS hist_a, b AS hist_b
                  FROM temporal_column_order_history
                  WHERE history_id = 1",
             )
             .get_result(conn)
+            .await
         })
+        .await
     })
+    .await
     .unwrap();
 
     assert_eq!(
@@ -149,33 +166,41 @@ async fn trigger_timestamp_is_execution_time_not_transaction_start() {
     let collection_fixture = scope.collection_fixture("clock_timestamp").await;
     let cname = format!("clock_timestamp_class_{}", scope.scope_id);
 
-    let (tx_start, valid_from): (DateTime<Utc>, DateTime<Utc>) = with_connection(&pool, |conn| {
-        conn.transaction::<_, diesel::result::Error, _>(|conn| {
-            let tx_start = diesel::sql_query("SELECT transaction_timestamp() AS value")
-                .get_result::<SingleTimestamp>(conn)?
-                .value;
-            diesel::sql_query("SELECT pg_sleep(0.02)").execute(conn)?;
-            diesel::sql_query(
-                "INSERT INTO hubuumclass (name, collection_id, validate_schema, description)
+    let (tx_start, valid_from): (DateTime<Utc>, DateTime<Utc>) =
+        with_connection(&pool, async |conn| {
+            conn.transaction::<_, diesel::result::Error, _>(async |conn| {
+                let tx_start = diesel::sql_query("SELECT transaction_timestamp() AS value")
+                    .get_result::<SingleTimestamp>(conn)
+                    .await?
+                    .value;
+                diesel::sql_query("SELECT pg_sleep(0.02)")
+                    .execute(conn)
+                    .await?;
+                diesel::sql_query(
+                    "INSERT INTO hubuumclass (name, collection_id, validate_schema, description)
                      VALUES ($1, $2, false, 'd')",
-            )
-            .bind::<Text, _>(&cname)
-            .bind::<Integer, _>(collection_fixture.collection.id)
-            .execute(conn)?;
-            let valid_from = diesel::sql_query(
-                "SELECT valid_from AS value
+                )
+                .bind::<Text, _>(&cname)
+                .bind::<Integer, _>(collection_fixture.collection.id)
+                .execute(conn)
+                .await?;
+                let valid_from = diesel::sql_query(
+                    "SELECT valid_from AS value
                      FROM hubuumclass_history
                      WHERE name = $1
                      ORDER BY history_id DESC
                      LIMIT 1",
-            )
-            .bind::<Text, _>(&cname)
-            .get_result::<SingleTimestamp>(conn)?
-            .value;
-            Ok((tx_start, valid_from))
+                )
+                .bind::<Text, _>(&cname)
+                .get_result::<SingleTimestamp>(conn)
+                .await?
+                .value;
+                Ok((tx_start, valid_from))
+            })
+            .await
         })
-    })
-    .unwrap();
+        .await
+        .unwrap();
 
     assert!(
         valid_from > tx_start,
@@ -207,9 +232,12 @@ async fn unchanged_domain_update_is_noop() {
     .unwrap();
     let before_updated_at = class.updated_at;
 
-    with_connection(&pool, |conn| {
-        diesel::sql_query("SELECT pg_sleep(0.02)").execute(conn)
+    with_connection(&pool, async |conn| {
+        diesel::sql_query("SELECT pg_sleep(0.02)")
+            .execute(conn)
+            .await
     })
+    .await
     .unwrap();
 
     let returned = UpdateHubuumClass {
@@ -224,21 +252,24 @@ async fn unchanged_domain_update_is_noop() {
     .unwrap();
 
     let (after_updated_at, history_count): (chrono::NaiveDateTime, i64) =
-        with_connection(&pool, |conn| {
+        with_connection(&pool, async |conn| {
             let after_updated_at =
                 diesel::sql_query("SELECT updated_at AS value FROM hubuumclass WHERE id = $1")
                     .bind::<Integer, _>(class.id)
-                    .get_result::<SingleNaiveTimestamp>(conn)?
+                    .get_result::<SingleNaiveTimestamp>(conn)
+                    .await?
                     .value;
             let history_count = {
                 use crate::schema::hubuumclass_history::dsl as h;
                 h::hubuumclass_history
                     .filter(h::id.eq(class.id))
                     .count()
-                    .get_result::<i64>(conn)?
+                    .get_result::<i64>(conn)
+                    .await?
             };
             Ok::<_, diesel::result::Error>((after_updated_at, history_count))
         })
+        .await
         .unwrap();
 
     assert_eq!(returned.updated_at, before_updated_at);
@@ -296,14 +327,16 @@ async fn cascade_delete_records_history() {
 
     collection_fixture.cleanup().await.unwrap(); // cascade-deletes the class
 
-    let ops: Vec<String> = with_connection(&pool, |conn| {
+    let ops: Vec<String> = with_connection(&pool, async |conn| {
         use crate::schema::hubuumclass_history::dsl as h;
         h::hubuumclass_history
             .filter(h::id.eq(class.id))
             .order(h::history_id.asc())
             .select(h::op)
             .load(conn)
+            .await
     })
+    .await
     .unwrap();
 
     assert_eq!(
@@ -356,30 +389,32 @@ async fn actor_scope_sets_actor_and_default_is_null() {
     .await
     .unwrap();
 
-    let read_actor = |id: i32| {
-        with_connection(&pool, move |conn| {
+    let read_actor = async |id: i32| {
+        with_connection(&pool, async move |conn| {
             use crate::schema::hubuumclass_history::dsl as h;
             h::hubuumclass_history
                 .filter(h::id.eq(id))
                 .order(h::history_id.desc())
                 .select(h::actor_id)
                 .first::<Option<i32>>(conn)
+                .await
         })
+        .await
         .unwrap()
     };
 
-    assert_eq!(read_actor(in_class.id), Some(4242));
-    assert_eq!(read_actor(out_class.id), None);
+    assert_eq!(read_actor(in_class.id).await, Some(4242));
+    assert_eq!(read_actor(out_class.id).await, None);
 
     collection_fixture.cleanup().await.unwrap();
 }
 
 #[actix_rt::test]
 async fn anonymize_scrubs_pii_but_keeps_history_actor() {
+    use crate::db::prelude::*;
     use crate::db::{with_actor_scope, with_connection};
     use crate::models::{NewHubuumClass, NewUser, UserID};
     use crate::traits::CanSave;
-    use diesel::prelude::*;
 
     let scope = TestScope::new();
     let pool = scope.pool.clone();
@@ -428,25 +463,29 @@ async fn anonymize_scrubs_pii_but_keeps_history_actor() {
         Option<String>,
         Option<String>,
         Option<chrono::NaiveDateTime>,
-    ) = with_connection(&pool, |conn| {
+    ) = with_connection(&pool, async |conn| {
         use crate::schema::users::dsl as u;
         u::users
             .filter(u::id.eq(user.id))
             .select((u::proper_name, u::email, u::password, u::anonymized_at))
             .first(conn)
+            .await
     })
+    .await
     .unwrap();
     assert_eq!(proper_name, None);
     assert_eq!(email, None);
     assert!(anonymized_at.is_some());
 
-    let principal_name: String = with_connection(&pool, |conn| {
+    let principal_name: String = with_connection(&pool, async |conn| {
         use crate::schema::principals::dsl as p;
         p::principals
             .filter(p::id.eq(user.id))
             .select(p::name)
             .first(conn)
+            .await
     })
+    .await
     .unwrap();
     assert_eq!(principal_name, format!("anonymized-{}", user.id));
 
@@ -462,26 +501,30 @@ async fn anonymize_scrubs_pii_but_keeps_history_actor() {
     );
 
     // Tokens revoked.
-    let token_count: i64 = with_connection(&pool, |conn| {
+    let token_count: i64 = with_connection(&pool, async |conn| {
         use crate::schema::tokens::dsl as t;
         t::tokens
             .filter(t::principal_id.eq(user.id))
             .filter(t::revoked_at.is_null())
             .count()
             .get_result(conn)
+            .await
     })
+    .await
     .unwrap();
     assert_eq!(token_count, 0);
 
     // History still attributes the change to the (now pseudonymous) id.
-    let actor: Option<i32> = with_connection(&pool, |conn| {
+    let actor: Option<i32> = with_connection(&pool, async |conn| {
         use crate::schema::hubuumclass_history::dsl as h;
         h::hubuumclass_history
             .filter(h::id.eq(class.id))
             .order(h::history_id.desc())
             .select(h::actor_id)
             .first::<Option<i32>>(conn)
+            .await
     })
+    .await
     .unwrap();
     assert_eq!(actor, Some(user.id));
 

--- a/src/utilities/init.rs
+++ b/src/utilities/init.rs
@@ -29,7 +29,7 @@ pub async fn init(pool: DbPool) -> InitResult {
         return Err(err_msg);
     }
 
-    let users_count = match count_user_records(&pool) {
+    let users_count = match count_user_records(&pool).await {
         Ok(count) => count,
         Err(e) => {
             let err_msg = format!("Failed to count users during initialization: {}", e);
@@ -38,7 +38,7 @@ pub async fn init(pool: DbPool) -> InitResult {
         }
     };
 
-    let groups_count = match count_group_records(&pool) {
+    let groups_count = match count_group_records(&pool).await {
         Ok(count) => count,
         Err(e) => {
             let err_msg = format!("Failed to count groups during initialization: {}", e);


### PR DESCRIPTION
## Summary

- replace Diesel's synchronous r2d2/Postgres connection layer with `diesel-async`, `AsyncPgConnection`, and bb8
- convert connection helpers, transactions, backend traits, handlers, task execution, admin commands, tests, and LISTEN/NOTIFY to native async database I/O
- preserve server-side statement timeouts and transaction-local actor context
- retain PostgreSQL TLS support with platform verification and `PGSSLROOTCERT` custom-CA support
- make test fixtures and the background task worker respect the runtime-bound lifecycle of tokio-postgres connections
- expose bb8 capacity, contention, timeout, wait-time, creation, and recycling statistics through the admin DB-state endpoint
- prove cancelled transactions are discarded and rolled back, and document pool sizing with a repeatable k6 load scenario

## Stack

This PR is based on and targets #115 (`hardening-and-cleanup`). It should be reviewed and merged after that PR, or rebased onto `main` once #115 lands.

## Why

The existing request paths wrapped synchronous Diesel work in `spawn_blocking`. That prevented direct blocking of Actix workers, but every database wait still occupied a blocking-pool thread and added a scheduler handoff. This change makes connection acquisition, query execution, transactions, and notifications non-blocking end to end.

## Benefits

- database latency and pool contention no longer consume Tokio blocking threads
- removes the per-operation `spawn_blocking` handoff and makes async composition explicit
- bb8 queues connection waiters asynchronously and the admin endpoint now exposes its pool statistics
- preserves bounded pool acquisition and Postgres-enforced statement timeouts
- keeps notification listeners on asynchronous streams instead of polling a blocking connection

These are architectural benefits; this PR does not claim a measured throughput improvement. `docs/performance.md` and `load-tests/pool.js` now provide a production-shaped pool-size and arrival-rate test procedure for quantifying latency and capacity changes.

## Tradeoffs and risks

- this is necessarily a large, mostly mechanical diff across 90 files, which increases review and regression surface
- diesel-async transaction futures are cancellation-sensitive; bb8 now demonstrably discards a cancelled transaction's connection and PostgreSQL rolls back its work, at the cost of connection churn
- a tokio-postgres connection driver belongs to the runtime that established it; clients can cross runtimes while that driver runtime remains alive, and the pool detects and replaces closed drivers
- async I/O does not reduce database execution time or remove connection-count limits; it can expose Postgres to more concurrent work, so pool sizing and backpressure remain important
- the dependency and compile-time footprint increases through bb8, tokio-postgres, and the Rustls connector
- pool construction remains synchronous and lazy via `build_unchecked` to preserve the current API; startup initialization immediately checks out a connection and verifies database connectivity
- TLS certificate and hostname verification is stricter than libpq's historical `sslmode=require` behavior; custom CAs are supported through `PGSSLROOTCERT`

Graceful shutdown and joining of the process-long background worker/listener threads remains a focused follow-up in #117.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `k6 inspect load-tests/pool.js`
- `source .env && ./run_tests.sh --quiet`
  - 865 passed, 0 failed, 2 ignored
  - admin CLI tests passed
  - doctests passed
- regenerated `docs/openapi.json`
- `git diff --check`
