### PR TITLE
Fix auth provider discovery and Rustls initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ utoipa-swagger-ui = { version = "9", features = [
 urlparse = "0.7"
 uuid = { version = "1", features = ["v4", "serde"] }
 percent-encoding = "2"
-rustls = { version = "0.23", features = ["aws-lc-rs", "ring"], optional = true }
+rustls = { version = "0.23", features = ["aws-lc-rs", "ring"] }
 openssl = { version = "0.10.80", optional = true }
 lru = "0.18.0"
 toml = "0.9"
@@ -100,7 +100,7 @@ default = ["swagger-ui"]
 amqp = ["dep:hubuum-event-sink-amqp"]
 email = ["dep:hubuum-event-sink-email"]
 swagger-ui = ["dep:utoipa-swagger-ui"]
-tls-rustls = ["dep:rustls", "actix-web/rustls-0_23"]
+tls-rustls = ["actix-web/rustls-0_23"]
 tls-openssl = ["dep:openssl", "actix-web/openssl"]
 valkey = ["dep:hubuum-event-sink-valkey"]
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -288,6 +288,38 @@
         ]
       }
     },
+    "/api/v0/auth/providers": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Get Api V0 Auth Providers",
+        "description": "Auto-generated documentation for GET /api/v0/auth/providers.",
+        "operationId": "getApiV0AuthProviders",
+        "responses": {
+          "200": {
+            "description": "Configured authentication provider names",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthProvidersResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v0/auth/validate": {
       "get": {
         "tags": [
@@ -12573,6 +12605,20 @@
         "example": {
           "error": "Unauthorized",
           "message": "Authentication failure"
+        }
+      },
+      "AuthProvidersResponse": {
+        "type": "object",
+        "required": [
+          "providers"
+        ],
+        "properties": {
+          "providers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       },
       "ClassKey": {

--- a/src/api/handlers/auth.rs
+++ b/src/api/handlers/auth.rs
@@ -17,9 +17,30 @@ pub struct LogoutTokenRequest {
     pub token: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AuthProvidersResponse {
+    pub providers: Vec<String>,
+}
+
 // During auth, no matter what the error is, we return a 401 Unauthorized
 // with a generic message. This is to prevent leaking information about
 // the existence of internal data.
+
+#[utoipa::path(
+    get,
+    path = "/api/v0/auth/providers",
+    tag = "auth",
+    responses(
+        (status = 200, description = "Configured authentication provider names", body = AuthProvidersResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse)
+    )
+)]
+#[get("/providers")]
+pub async fn get_auth_providers() -> Result<impl Responder, ApiError> {
+    Ok(ApiResponse::ok(AuthProvidersResponse {
+        providers: crate::auth::auth_provider_names()?,
+    }))
+}
 
 #[utoipa::path(
     post,

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -63,6 +63,7 @@ use utoipa::{Modify, OpenApi, ToSchema};
         meta::get_login_rate_limit_state,
         meta::release_login_rate_limit_entry,
         meta::clear_login_rate_limit,
+        auth::get_auth_providers,
         auth::login,
         auth::logout,
         auth::logout_all,
@@ -232,6 +233,7 @@ use utoipa::{Modify, OpenApi, ToSchema};
             NewUser,
             UpdateUser,
             LoginUser,
+            auth::AuthProvidersResponse,
             auth::LogoutTokenRequest,
             PrincipalToken,
             PrincipalTokenMetadata,
@@ -825,6 +827,7 @@ mod tests {
             "/healthz",
             "/readyz",
             "/api/v0/auth/login",
+            "/api/v0/auth/providers",
             "/api/v0/auth/logout",
             "/api/v0/auth/logout_all",
             "/api/v0/auth/logout/token",
@@ -1075,7 +1078,8 @@ mod tests {
                 let is_public_probe =
                     matches!(path.as_str(), "/healthz" | "/readyz") && method == "get";
                 let is_login = path == "/api/v0/auth/login" && method == "post";
-                if !is_login && !is_public_probe {
+                let is_provider_discovery = path == "/api/v0/auth/providers" && method == "get";
+                if !is_login && !is_provider_discovery && !is_public_probe {
                     let security = operation
                         .get("security")
                         .and_then(Value::as_array)

--- a/src/api/routes/auth.rs
+++ b/src/api/routes/auth.rs
@@ -2,7 +2,8 @@ use actix_web::web;
 
 use crate::api::handlers::auth as auth_handlers;
 pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.service(auth_handlers::login)
+    cfg.service(auth_handlers::get_auth_providers)
+        .service(auth_handlers::login)
         .service(auth_handlers::logout)
         .service(auth_handlers::logout_all)
         .service(auth_handlers::logout_other)

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,9 +1,13 @@
 use chrono::NaiveDateTime;
-use hubuum_auth_core::{AuthProviderError, AuthenticatedExternalUser, ExternalIdentityProvider};
+#[cfg(test)]
+use hubuum_auth_core::AuthenticatedExternalUser;
+use hubuum_auth_core::{AuthProviderError, ExternalIdentityProvider};
 use hubuum_auth_ldap::{LdapIdentityProvider, LdapScopeConfig};
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::{Arc, LazyLock, OnceLock};
 use tokio::sync::Mutex;
 
@@ -80,48 +84,144 @@ impl ConfiguredLdapScope {
 }
 
 struct AuthProviderRegistry {
-    ldap: HashMap<String, ConfiguredLdapProvider>,
+    providers: HashMap<String, RegisteredAuthProvider>,
 }
 
-struct ConfiguredLdapProvider {
-    scope: String,
+type AuthProviderFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, ApiError>> + Send + 'a>>;
+type AuthProviderRefreshFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<(), AuthProviderRefreshError>> + Send + 'a>>;
+
+enum AuthProviderRefreshError {
+    Provider(ApiError),
+    Internal(ApiError),
+}
+
+trait AuthProviderBackend: Send + Sync {
+    fn authenticate<'a>(
+        &'a self,
+        pool: &'a DbPool,
+        login: LoginUser,
+    ) -> AuthProviderFuture<'a, User>;
+
+    fn refresh<'a>(
+        &'a self,
+        pool: &'a DbPool,
+        state: &'a ExternalUserState,
+    ) -> AuthProviderRefreshFuture<'a>;
+}
+
+struct RegisteredAuthProvider {
+    name: String,
+    kind: String,
+    display_order: u16,
+    refresh_policy: Option<RefreshPolicy>,
+    backend: Box<dyn AuthProviderBackend>,
+}
+
+#[derive(Clone, Copy)]
+struct RefreshPolicy {
     refresh_ttl_seconds: i64,
     max_stale_seconds: i64,
+}
+
+struct LocalAuthProvider;
+
+struct LdapAuthProvider {
+    scope: String,
     provider: LdapIdentityProvider,
 }
 
 impl AuthProviderRegistry {
     fn from_config(config: AuthProvidersConfig) -> Result<Self, ApiError> {
-        let mut ldap = HashMap::new();
+        let mut registry = Self {
+            providers: HashMap::new(),
+        };
+        LocalAuthProvider::register(&mut registry)?;
         for configured in config.ldap {
-            let provider = ConfiguredLdapProvider::new(configured)?;
-            if provider.scope == LOCAL_IDENTITY_SCOPE {
-                return Err(ApiError::BadRequest(
-                    "external auth provider scope must not be 'local'".to_string(),
-                ));
-            }
-            if ldap.insert(provider.scope.clone(), provider).is_some() {
-                return Err(ApiError::BadRequest(
-                    "duplicate external auth provider scope".to_string(),
-                ));
-            }
+            LdapAuthProvider::register(configured, &mut registry)?;
         }
-        Ok(Self { ldap })
+        Ok(registry)
     }
 
-    fn ldap_scope(&self, scope: &str) -> Result<&ConfiguredLdapProvider, ApiError> {
-        self.ldap
-            .get(scope)
+    fn register(&mut self, provider: RegisteredAuthProvider) -> Result<(), ApiError> {
+        let name = provider.name.clone();
+        if self.providers.insert(name.clone(), provider).is_some() {
+            return Err(ApiError::BadRequest(format!(
+                "duplicate auth provider name '{name}'"
+            )));
+        }
+        Ok(())
+    }
+
+    fn provider_names(&self) -> Vec<String> {
+        let mut providers = self.providers.values().collect::<Vec<_>>();
+        providers.sort_unstable_by(|left, right| {
+            left.display_order
+                .cmp(&right.display_order)
+                .then_with(|| left.name.cmp(&right.name))
+        });
+        providers
+            .into_iter()
+            .map(|provider| provider.name.clone())
+            .collect()
+    }
+
+    fn provider(&self, name: &str) -> Result<&RegisteredAuthProvider, ApiError> {
+        self.providers
+            .get(name)
             .ok_or_else(|| ApiError::Unauthorized("Authentication failure".to_string()))
     }
 
-    fn scopes(&self) -> impl Iterator<Item = &ConfiguredLdapProvider> {
-        self.ldap.values()
+    fn providers(&self) -> impl Iterator<Item = &RegisteredAuthProvider> {
+        self.providers.values()
     }
 }
 
-impl ConfiguredLdapProvider {
-    fn new(configured: ConfiguredLdapScope) -> Result<Self, ApiError> {
+pub fn auth_provider_names() -> Result<Vec<String>, ApiError> {
+    Ok(auth_provider_registry()?.provider_names())
+}
+
+impl LocalAuthProvider {
+    fn register(registry: &mut AuthProviderRegistry) -> Result<(), ApiError> {
+        registry.register(RegisteredAuthProvider {
+            name: LOCAL_IDENTITY_SCOPE.to_string(),
+            kind: LOCAL_PROVIDER_KIND.to_string(),
+            display_order: 0,
+            refresh_policy: None,
+            backend: Box::new(Self),
+        })
+    }
+}
+
+impl AuthProviderBackend for LocalAuthProvider {
+    fn authenticate<'a>(
+        &'a self,
+        pool: &'a DbPool,
+        login: LoginUser,
+    ) -> AuthProviderFuture<'a, User> {
+        Box::pin(async move { login.login(pool).await })
+    }
+
+    fn refresh<'a>(
+        &'a self,
+        _pool: &'a DbPool,
+        _state: &'a ExternalUserState,
+    ) -> AuthProviderRefreshFuture<'a> {
+        Box::pin(async {
+            Err(AuthProviderRefreshError::Internal(
+                ApiError::InternalServerError(
+                    "Local authentication provider does not support external refresh".to_string(),
+                ),
+            ))
+        })
+    }
+}
+
+impl LdapAuthProvider {
+    fn register(
+        configured: ConfiguredLdapScope,
+        registry: &mut AuthProviderRegistry,
+    ) -> Result<(), ApiError> {
         let refresh_ttl_seconds = configured.refresh_ttl_seconds();
         let max_stale_seconds = configured.max_stale_seconds();
         if refresh_ttl_seconds <= 0 {
@@ -136,11 +236,51 @@ impl ConfiguredLdapProvider {
         }
         let scope = configured.ldap.scope.clone();
         let provider = LdapIdentityProvider::new(configured.ldap).map_err(provider_config_error)?;
-        Ok(Self {
-            scope,
-            refresh_ttl_seconds,
-            max_stale_seconds,
-            provider,
+        registry.register(RegisteredAuthProvider {
+            name: scope.clone(),
+            kind: LDAP_PROVIDER_KIND.to_string(),
+            display_order: 100,
+            refresh_policy: Some(RefreshPolicy {
+                refresh_ttl_seconds,
+                max_stale_seconds,
+            }),
+            backend: Box::new(Self { scope, provider }),
+        })
+    }
+}
+
+impl AuthProviderBackend for LdapAuthProvider {
+    fn authenticate<'a>(
+        &'a self,
+        pool: &'a DbPool,
+        login: LoginUser,
+    ) -> AuthProviderFuture<'a, User> {
+        Box::pin(async move {
+            let authenticated = self
+                .provider
+                .authenticate(&login.name, &login.password)
+                .await
+                .map_err(login_provider_error)?;
+            sync_external_user_from_backend(pool, &self.scope, LDAP_PROVIDER_KIND, authenticated)
+                .await
+        })
+    }
+
+    fn refresh<'a>(
+        &'a self,
+        pool: &'a DbPool,
+        state: &'a ExternalUserState,
+    ) -> AuthProviderRefreshFuture<'a> {
+        Box::pin(async move {
+            let refreshed = self
+                .provider
+                .refresh_user(&state.external_subject)
+                .await
+                .map_err(|error| AuthProviderRefreshError::Provider(provider_error(error)))?;
+            sync_external_user_from_backend(pool, &self.scope, LDAP_PROVIDER_KIND, refreshed)
+                .await
+                .map(|_| ())
+                .map_err(AuthProviderRefreshError::Internal)
         })
     }
 }
@@ -151,17 +291,11 @@ pub async fn login(pool: &DbPool, login: LoginUser) -> Result<User, ApiError> {
         .as_deref()
         .unwrap_or(LOCAL_IDENTITY_SCOPE)
         .to_string();
-    if scope == LOCAL_IDENTITY_SCOPE {
-        return login.login(pool).await;
-    }
-
-    let configured = auth_provider_registry()?.ldap_scope(&scope)?;
-    let authenticated = configured
-        .provider
-        .authenticate(&login.name, &login.password)
+    auth_provider_registry()?
+        .provider(&scope)?
+        .backend
+        .authenticate(pool, login)
         .await
-        .map_err(login_provider_error)?;
-    sync_external_user_from_configured_provider(pool, configured, authenticated).await
 }
 
 pub async fn refresh_principal_if_needed(pool: &DbPool, principal_id: i32) -> Result<(), ApiError> {
@@ -192,38 +326,33 @@ pub async fn refresh_principal_if_needed(pool: &DbPool, principal_id: i32) -> Re
                 RefreshStatus::Fresh => Ok(()),
                 RefreshStatus::Backoff => cached_external_state_result(&state),
                 RefreshStatus::Due => match auth_provider_registry()
-                    .and_then(|registry| registry.ldap_scope(&state.identity_scope))
+                    .and_then(|registry| registry.provider(&state.identity_scope))
                 {
                     Err(err) => Err(err),
-                    Ok(configured) => match configured
-                        .provider
-                        .refresh_user(&state.external_subject)
-                        .await
-                    {
-                        Ok(refreshed) => {
-                            sync_external_user_from_configured_provider(pool, configured, refreshed)
-                                .await
-                                .map(|_| ())
-                        }
-                        Err(err) => match mark_external_sync_attempted(pool, principal_id) {
-                            Err(mark_err) => Err(mark_err),
-                            Ok(()) => {
-                                if within_max_stale(
-                                    state.last_sync_success_at,
-                                    state.max_stale_seconds,
-                                ) {
-                                    tracing::warn!(
-                                        principal_id,
-                                        identity_scope = state.identity_scope,
-                                        error = %err,
-                                        "External identity refresh failed; using cached memberships inside max-stale window"
-                                    );
-                                    Ok(())
-                                } else {
-                                    stale_external_state_error()
+                    Ok(configured) => match configured.backend.refresh(pool, &state).await {
+                        Ok(()) => Ok(()),
+                        Err(AuthProviderRefreshError::Internal(err)) => Err(err),
+                        Err(AuthProviderRefreshError::Provider(err)) => {
+                            match mark_external_sync_attempted(pool, principal_id) {
+                                Err(mark_err) => Err(mark_err),
+                                Ok(()) => {
+                                    if within_max_stale(
+                                        state.last_sync_success_at,
+                                        state.max_stale_seconds,
+                                    ) {
+                                        tracing::warn!(
+                                            principal_id,
+                                            identity_scope = state.identity_scope,
+                                            error = %err,
+                                            "External identity refresh failed; using cached memberships inside max-stale window"
+                                        );
+                                        Ok(())
+                                    } else {
+                                        stale_external_state_error()
+                                    }
                                 }
                             }
-                        },
+                        }
                     },
                 },
             },
@@ -241,9 +370,8 @@ pub async fn refresh_principal_if_needed(pool: &DbPool, principal_id: i32) -> Re
 }
 
 pub async fn ensure_configured_identity_scopes(pool: &DbPool) -> Result<(), ApiError> {
-    ensure_identity_scope(pool, LOCAL_IDENTITY_SCOPE, LOCAL_PROVIDER_KIND).await?;
-    for scope in auth_provider_registry()?.scopes() {
-        ensure_identity_scope(pool, &scope.scope, LDAP_PROVIDER_KIND).await?;
+    for provider in auth_provider_registry()?.providers() {
+        ensure_identity_scope(pool, &provider.name, &provider.kind).await?;
     }
     Ok(())
 }
@@ -396,24 +524,21 @@ async fn external_user_state(
     let Some(state) = external_principal_state(pool, principal_id_value).await? else {
         return Ok(None);
     };
-    let configured = auth_provider_registry()?.ldap_scope(&state.identity_scope)?;
+    let configured = auth_provider_registry()?.provider(&state.identity_scope)?;
+    let refresh_policy = configured.refresh_policy.ok_or_else(|| {
+        ApiError::InternalServerError(format!(
+            "Authentication provider '{}' does not support external refresh",
+            configured.name
+        ))
+    })?;
     Ok(Some(ExternalUserState {
         identity_scope: state.identity_scope,
         external_subject: state.external_subject,
         last_sync_attempted_at: state.last_sync_attempted_at,
         last_sync_success_at: state.last_sync_success_at,
-        refresh_ttl_seconds: configured.refresh_ttl_seconds,
-        max_stale_seconds: configured.max_stale_seconds,
+        refresh_ttl_seconds: refresh_policy.refresh_ttl_seconds,
+        max_stale_seconds: refresh_policy.max_stale_seconds,
     }))
-}
-
-async fn sync_external_user_from_configured_provider(
-    pool: &DbPool,
-    configured: &ConfiguredLdapProvider,
-    authenticated: AuthenticatedExternalUser,
-) -> Result<User, ApiError> {
-    sync_external_user_from_backend(pool, &configured.scope, LDAP_PROVIDER_KIND, authenticated)
-        .await
 }
 
 #[cfg(test)]
@@ -434,12 +559,47 @@ pub(crate) async fn sync_external_user(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hubuum_auth_ldap::{LdapScopeConfig, LdapSearchScope};
+
+    fn ldap_scope(scope: &str) -> ConfiguredLdapScope {
+        ConfiguredLdapScope {
+            ldap: LdapScopeConfig {
+                scope: scope.to_string(),
+                url: "ldap://ldap.example.org".to_string(),
+                bind_dn: None,
+                bind_password: None,
+                connect_timeout_seconds: 5,
+                operation_timeout_seconds: 10,
+                user_base_dn: "ou=people,dc=example,dc=org".to_string(),
+                user_filter: "(uid={username})".to_string(),
+                user_scope: LdapSearchScope::Subtree,
+                username_attribute: "uid".to_string(),
+                subject_attribute: "dn".to_string(),
+                display_name_attribute: Some("cn".to_string()),
+                email_attribute: Some("mail".to_string()),
+                group_attributes: Vec::new(),
+                group_rules: Vec::new(),
+            },
+            refresh_ttl_seconds: Some(300),
+            max_stale_seconds: Some(3600),
+        }
+    }
 
     fn timestamp() -> NaiveDateTime {
         chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
             .unwrap()
             .and_hms_opt(12, 0, 0)
             .unwrap()
+    }
+
+    #[test]
+    fn provider_names_include_local_and_sorted_external_scopes() {
+        let registry = AuthProviderRegistry::from_config(AuthProvidersConfig {
+            ldap: vec![ldap_scope("zeta"), ldap_scope("alpha")],
+        })
+        .unwrap();
+
+        assert_eq!(registry.provider_names(), vec!["local", "alpha", "zeta"]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,13 @@ use crate::utilities::is_valid_log_level;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    if let Err(e) = tls::install_default_crypto_provider() {
+        fatal_error(
+            &format!("Failed to initialize TLS cryptography: {e}"),
+            EXIT_CODE_INIT_ERROR,
+        );
+    }
+
     // Clone the config to prevent the mutex from being locked
     // See https://rust-lang.github.io/rust-clippy/master/index.html#await_holding_lock
     let config = match get_config() {

--- a/src/tests/acl.rs
+++ b/src/tests/acl.rs
@@ -42,6 +42,12 @@ async fn test_endpoint_access() {
     let admin_user_endpoint = &format!("/api/v1/iam/users/{}", admin_user.id);
 
     let endpoints = vec![
+        (
+            "/api/v0/auth/providers",
+            Method::GET,
+            AccessLevel::Open,
+            None,
+        ),
         ("/api/v0/auth/logout", Method::POST, AccessLevel::User, None),
         (
             "/api/v0/auth/logout_all",

--- a/src/tests/api/v1/auth.rs
+++ b/src/tests/api/v1/auth.rs
@@ -14,6 +14,7 @@ mod tests {
     use diesel::prelude::*;
 
     const LOGIN_ENDPOINT: &str = "/api/v0/auth/login";
+    const AUTH_PROVIDERS_ENDPOINT: &str = "/api/v0/auth/providers";
     const LOGOUT_ENDPOINT: &str = "/api/v0/auth/logout";
     const LOGOUT_ALL_ENDPOINT: &str = "/api/v0/auth/logout_all";
     const LOGOUT_ALL_FOR_OTHER_USER_ENDPOINT: &str = "/api/v0/auth/logout/uid/";
@@ -22,6 +23,24 @@ mod tests {
 
     async fn lock_auth_test_state() -> TestMutexGuard {
         lock_test_mutex(&LOGIN_RATE_LIMIT_TEST_LOCK).await
+    }
+
+    #[actix_web::test]
+    async fn test_auth_providers_are_publicly_discoverable() {
+        let app = test::init_service(App::new().configure(api::config)).await;
+
+        let resp = test::TestRequest::get()
+            .uri(AUTH_PROVIDERS_ENDPOINT)
+            .send_request(&app)
+            .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: crate::api::handlers::auth::AuthProvidersResponse =
+            test::read_body_json(resp).await;
+        assert_eq!(body.providers.first().map(String::as_str), Some("local"));
+        let mut sorted_external = body.providers[1..].to_vec();
+        sorted_external.sort_unstable();
+        assert_eq!(&body.providers[1..], sorted_external);
     }
 
     #[actix_web::test]

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -6,6 +6,20 @@ use crate::config::TlsBackend;
 
 type ServerResult<F, I, S, B> = std::io::Result<HttpServer<F, I, S, B>>;
 
+pub fn install_default_crypto_provider() -> std::io::Result<()> {
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    }
+
+    if rustls::crypto::CryptoProvider::get_default().is_some() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(
+            "Failed to install the process-wide rustls crypto provider",
+        ))
+    }
+}
+
 #[cfg(not(any(feature = "tls-rustls", feature = "tls-openssl")))]
 fn no_tls_backend_error(requested_backend: Option<TlsBackend>) -> std::io::Error {
     let message = match requested_backend {
@@ -134,12 +148,6 @@ mod tls_rustls {
             ));
         }
 
-        rustls::crypto::aws_lc_rs::default_provider()
-            .install_default()
-            .map_err(|e| {
-                std::io::Error::other(format!("Failed to install crypto provider: {e:?}"))
-            })?;
-
         let cert_chain = CertificateDer::pem_file_iter(cert)
             .map_err(|e| {
                 std::io::Error::new(
@@ -246,8 +254,14 @@ mod tls_openssl {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_backend;
+    use super::{install_default_crypto_provider, resolve_backend};
     use crate::config::TlsBackend;
+
+    #[test]
+    fn installs_a_process_wide_crypto_provider() {
+        install_default_crypto_provider().unwrap();
+        assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+    }
 
     #[cfg(all(feature = "tls-rustls", feature = "tls-openssl"))]
     #[test]


### PR DESCRIPTION
## Summary

- install the process-wide Rustls AWS-LC crypto provider during server startup, including plain-HTTP deployments behind a TLS-terminating proxy
- replace LDAP-specific authentication lookups with a central provider registry used by login, refresh, identity-scope initialization, and discovery
- add public GET /api/v0/auth/providers, returning local first and remaining provider names alphabetically
- regenerate the committed OpenAPI document

## Cause

LDAP enables the Rustls ring provider while jsonschema enables AWS-LC. With both features present, Rustls cannot infer a process-level provider. Hubuum previously installed AWS-LC only while configuring its own Rustls HTTPS listener, so plain-HTTP deployments first encountered the ambiguity when LDAP opened a TLS connection.

## Verification

- source .env && ./run_tests.sh: 909 tests and doctests passed; 2 known tests ignored
- cargo clippy --all-targets -- -D warnings
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- OpenAPI contract tests and regenerated docs/openapi.json
- rustls-only production Docker build