### PR TITLE
Add LDAP group filters and robust identity reconciliation

### DIFF
--- a/crates/hubuum-auth-ldap/src/lib.rs
+++ b/crates/hubuum-auth-ldap/src/lib.rs
@@ -35,6 +35,8 @@ pub struct LdapScopeConfig {
     #[serde(default)]
     pub group_attributes: Vec<String>,
     #[serde(default)]
+    pub group_filters: Vec<String>,
+    #[serde(default)]
     pub group_rules: Vec<GroupMappingRuleConfig>,
 }
 
@@ -58,6 +60,7 @@ impl fmt::Debug for LdapScopeConfig {
             .field("display_name_attribute", &self.display_name_attribute)
             .field("email_attribute", &self.email_attribute)
             .field("group_attributes", &self.group_attributes)
+            .field("group_filters", &self.group_filters)
             .field("group_rules", &self.group_rules)
             .finish()
     }
@@ -100,6 +103,7 @@ struct GroupMappingRule {
 pub struct LdapIdentityProvider {
     scope_name: IdentityScopeName,
     config: LdapScopeConfig,
+    group_filters: Vec<Regex>,
     rules: Vec<GroupMappingRule>,
     starttls: bool,
 }
@@ -148,6 +152,15 @@ impl LdapIdentityProvider {
                 "ldap bind_dn and bind_password must be configured together".to_string(),
             ));
         }
+        let group_filters = config
+            .group_filters
+            .iter()
+            .map(|filter| {
+                Regex::new(filter).map_err(|e| {
+                    AuthProviderError::Config(format!("invalid ldap group filter '{filter}': {e}"))
+                })
+            })
+            .collect::<Result<Vec<_>, AuthProviderError>>()?;
         let rules = config
             .group_rules
             .iter()
@@ -164,6 +177,7 @@ impl LdapIdentityProvider {
         Ok(Self {
             scope_name,
             config,
+            group_filters,
             rules,
             starttls,
         })
@@ -293,6 +307,14 @@ impl LdapIdentityProvider {
                 continue;
             };
             for value in values {
+                if !self.group_filters.is_empty()
+                    && !self
+                        .group_filters
+                        .iter()
+                        .any(|filter| filter.is_match(value))
+                {
+                    continue;
+                }
                 for rule in &self.rules {
                     if let Some(captures) = rule.pattern.captures(value) {
                         let name = expand_template(&rule.name, &captures);
@@ -474,6 +496,7 @@ mod tests {
             display_name_attribute: None,
             email_attribute: None,
             group_attributes: Vec::new(),
+            group_filters: Vec::new(),
             group_rules: Vec::new(),
         }
     }
@@ -598,5 +621,56 @@ mod tests {
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].key, "example:admin");
         assert_eq!(groups[0].name, "admin");
+    }
+
+    #[test]
+    fn group_filters_include_values_matching_any_configured_regex() {
+        let provider = LdapIdentityProvider::new(LdapScopeConfig {
+            group_attributes: vec!["memberOf".into()],
+            group_filters: vec!["^cn=hubuum-".into(), "^cn=admin,".into()],
+            group_rules: vec![GroupMappingRuleConfig {
+                pattern: "^cn=([^,]+),ou=groups,dc=example,dc=org$".into(),
+                name: "$1".into(),
+                key: None,
+                description: None,
+            }],
+            ..ldap_config("ldap://localhost")
+        })
+        .unwrap();
+        let entry = SearchEntry {
+            dn: "uid=alice,ou=people,dc=example,dc=org".into(),
+            attrs: HashMap::from([(
+                "memberOf".into(),
+                vec![
+                    "cn=admin,ou=groups,dc=example,dc=org".into(),
+                    "cn=hubuum-editors,ou=groups,dc=example,dc=org".into(),
+                    "cn=irrelevant,ou=groups,dc=example,dc=org".into(),
+                ],
+            )]),
+            bin_attrs: HashMap::new(),
+        };
+
+        let groups = provider.groups_from_entry(&entry);
+
+        assert_eq!(
+            groups
+                .iter()
+                .map(|group| group.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["admin", "hubuum-editors"]
+        );
+    }
+
+    #[test]
+    fn invalid_group_filter_is_rejected_during_construction() {
+        let error = LdapIdentityProvider::new(LdapScopeConfig {
+            group_filters: vec!["[".into()],
+            ..ldap_config("ldaps://localhost")
+        })
+        .err()
+        .unwrap();
+
+        assert!(matches!(&error, AuthProviderError::Config(_)));
+        assert!(error.to_string().contains("invalid ldap group filter '['"));
     }
 }

--- a/docs/external_auth.md
+++ b/docs/external_auth.md
@@ -29,6 +29,7 @@ subject_attribute = "entryUUID"
 display_name_attribute = "cn"
 email_attribute = "mail"
 group_attributes = ["memberOf"]
+group_filters = ["^cn=hubuum-", "^cn=admin,"]
 refresh_ttl_seconds = 300
 max_stale_seconds = 3600
 
@@ -48,7 +49,11 @@ startup.
 
 All group extraction is configuration-driven. Use `group_attributes` and
 `group_rules` to map provider attributes to Hubuum groups; do not hard-code
-directory-specific group formats in code.
+directory-specific group formats in code. The optional `group_filters` list
+filters the raw values read from `group_attributes` before mapping. When the
+list is non-empty, a value must match at least one regular expression to be
+included. Omitting the list or setting it to an empty list preserves all values
+that match a group rule.
 
 ### Multiple LDAP scopes
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -578,6 +578,7 @@ mod tests {
                 display_name_attribute: Some("cn".to_string()),
                 email_attribute: Some("mail".to_string()),
                 group_attributes: Vec::new(),
+                group_filters: Vec::new(),
                 group_rules: Vec::new(),
             },
             refresh_ttl_seconds: Some(300),

--- a/src/db/traits/external_identity.rs
+++ b/src/db/traits/external_identity.rs
@@ -149,8 +149,7 @@ pub async fn sync_external_user(
                         .filter(principals::identity_scope_id.eq(scope.id))
                         .filter(principals::name.eq(&profile.name))
                         .first::<Principal>(conn)?;
-                    if principal.provider_managed
-                        && principal.external_subject.as_deref() == Some(profile.subject.as_str())
+                    if principal.provider_managed && principal.kind == PrincipalKind::Human.as_str()
                     {
                         principal
                     } else {
@@ -376,6 +375,45 @@ mod tests {
         })
         .unwrap();
         assert_eq!(principal_count, 1);
+    }
+
+    #[actix_rt::test]
+    async fn sync_external_user_preserves_principal_when_source_subject_changes() {
+        let scope = TestScope::new();
+        let identity_scope = scope.scoped_name("directory");
+        let username = scope.scoped_name("external_alice");
+        let initial_subject = format!("uid={username},ou=people,dc=example,dc=org");
+        let reformatted_subject = format!("UID={username},OU=people,DC=example,DC=org");
+
+        let user = sync_external_user(
+            &scope.pool,
+            &identity_scope,
+            LDAP_PROVIDER_KIND,
+            external_user(&initial_subject, &username, Vec::new()),
+        )
+        .await
+        .unwrap();
+        let synced_after_subject_change = sync_external_user(
+            &scope.pool,
+            &identity_scope,
+            LDAP_PROVIDER_KIND,
+            external_user(&reformatted_subject, &username, Vec::new()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(synced_after_subject_change.id, user.id);
+        let external_subject = with_connection(scope.pool.get_ref(), |conn| {
+            principals::table
+                .find(user.id)
+                .select(principals::external_subject)
+                .first::<Option<String>>(conn)
+        })
+        .unwrap();
+        assert_eq!(
+            external_subject.as_deref(),
+            Some(reformatted_subject.as_str())
+        );
     }
 
     #[actix_rt::test]

--- a/src/tests/api/v1/users.rs
+++ b/src/tests/api/v1/users.rs
@@ -37,6 +37,7 @@ mod tests {
                 display_name_attribute: Some("cn".to_string()),
                 email_attribute: Some("mail".to_string()),
                 group_attributes: Vec::new(),
+                group_filters: Vec::new(),
                 group_rules: Vec::new(),
             },
             refresh_ttl_seconds: Some(300),


### PR DESCRIPTION
## Summary

- add optional LDAP `group_filters` with any-match regex semantics
- reject invalid group filter regexes during provider construction
- reconcile an existing provider-managed human by scope and username when the external subject representation changes
- document the new LDAP configuration and add regression coverage

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `cargo test -p hubuum-auth-ldap`