### PR TITLE
Prepare v0.0.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - name: Check Docker workspace manifest parity
         run: cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked
+      - name: Test deployment script refresh
+        run: bash scripts/test-install-script-refresh.sh
       - name: Markdown lint
         uses: DavidAnson/markdownlint-cli2-action@v24
         with:
@@ -539,7 +541,8 @@ jobs:
           mkdir -p dist
           archive_name="hubuum-${{ matrix.platform.os_name }}-all-features-${GITHUB_REF_NAME}.tar.gz"
           tar czvf "dist/${archive_name}" -C "target/${{ matrix.platform.target }}/release" hubuum-server hubuum-admin
-          shasum -a 256 "dist/${archive_name}" > "dist/${archive_name}.sha256"
+          cd dist
+          shasum -a 256 "${archive_name}" > "${archive_name}.sha256"
       
       - name: Package release archive (Windows)
         if: contains(matrix.platform.os, 'windows')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,46 +7,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
-### Security
-
-- Fix login rate-limiter bypass (GHSA-63j4-jh8h-chch). Login throttling is now layered
-  across per-`(username, IP)`, per-IP, and per-subnet scopes with exponential backoff, so
-  password spraying across many usernames and distributed attempts from one network are
-  throttled. The client IP is now resolved from the right of the
-  `[X-Forwarded-For..., peer]` hop chain using a configurable trusted-proxy allowlist
-  (`HUBUUM_TRUSTED_PROXIES`) or hop count (`HUBUUM_TRUSTED_PROXY_HOPS`), so spoofed
-  `X-Forwarded-For` values can no longer mint fresh rate-limit buckets or bypass the
-  client allowlist.
-
-### Added
-
-- New login rate-limit configuration: `HUBUUM_LOGIN_RATE_LIMIT_ENABLED`,
-  `HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS_PER_IP`,
-  `HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS_PER_SUBNET`,
-  `HUBUUM_LOGIN_RATE_LIMIT_BACKOFF_BASE_SECONDS`,
-  `HUBUUM_LOGIN_RATE_LIMIT_BACKOFF_MAX_SECONDS`,
-  `HUBUUM_LOGIN_RATE_LIMIT_SUBNET_PREFIX_V4`, `HUBUUM_LOGIN_RATE_LIMIT_SUBNET_PREFIX_V6`,
-  and proxy-trust configuration `HUBUUM_TRUSTED_PROXIES` / `HUBUUM_TRUSTED_PROXY_HOPS`.
-- Principal-centric identity model with two principal kinds: `human` and
-  `service_account`.
-- Service-account IAM endpoints under `/api/v1/iam/service-accounts`.
-- Principal management endpoints under `/api/v1/iam/principals/{principal_id}`
-  for token, group, and effective-permission management.
-- Token scopes for least-privilege automation, including fail-closed scope
-  enforcement and persisted task scope snapshots.
-
-### Changed
-
-- Group membership is principal-centric (`group_memberships`) and applies to both
-  human users and service accounts.
-- Tokens are principal-centric and now support lifecycle metadata (`name`,
-  `description`, `expires_at`, `last_used_at`, `revoked_at`, `scoped`).
-- Service-account disable flow now immediately soft-revokes its tokens and
-  cancels queued tasks.
-- Human/IAM extractors are explicitly privilege-separated: service accounts and
-  scoped tokens are rejected from human/management endpoints.
-
-## [0.0.1] - 2026-03-12
+## [0.0.1] - 2026-07-11
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,37 @@
 # Hubuum - A flexible asset management system
 
+[![CI](https://github.com/hubuum/hubuum/actions/workflows/ci.yml/badge.svg)](https://github.com/hubuum/hubuum/actions/workflows/ci.yml)
+[![GitHub release](https://img.shields.io/github/v/release/hubuum/hubuum)](https://github.com/hubuum/hubuum/releases)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 *Hubuum (𒄷𒁍𒌝) in Sumerian translates as “axle” or “wheel assembly”*[^1].
 
 Hubuum is a REST service that provides a shared interface for your resources.
+
+Hubuum `0.0.1` is the first public release. It is suitable for evaluation and early
+deployments, but its API and configuration may change before `1.0.0`. Pin deployments to
+an explicit version instead of using the moving `main` image tag.
+
+## Getting Started
+
+Hubuum requires PostgreSQL. The release is available as pre-built archives for Linux,
+macOS, and Windows, and as a Linux container image for AMD64 and ARM64.
+
+```sh
+docker pull ghcr.io/hubuum/hubuum-server:v0.0.1
+```
+
+- Follow the [quick start guide](docs/quick_start.md) for configuration and first-time
+  administrator setup.
+- Follow the [deployment guide](docs/deployment.md) for Docker or Podman Compose
+  installation.
+- Download native binaries and checksums from
+  [GitHub Releases](https://github.com/hubuum/hubuum/releases).
+- Check a running instance at `/healthz` and `/readyz`.
+
+The default container image includes the `rustls` and OpenSSL TLS backends. A smaller
+`v0.0.1-rustls-only` image is also published. See the
+[release guide](docs/releasing.md#container-images) for the complete tag scheme.
 
 ## Concept
 
@@ -144,6 +173,36 @@ inspecting and releasing throttled scopes), see [docs/login_rate_limiting.md](do
 - All-in-one installs expose both frontend and backend API hostnames; browser frontend flows can still use the frontend BFF routes.
 - Published container images are used by default; local repository cloning/building is opt-in for source builds.
 - Curl-style install, update, stop, and uninstall flows are supported; systemd service installation is opt-in.
+
+## Development
+
+Build the workspace with Cargo:
+
+```sh
+cargo build --all-features --locked
+```
+
+The local test environment is configured through `.env`:
+
+```sh
+source .env && ./run_tests.sh
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+See [docs/development.md](docs/development.md) for database setup, Git hooks, and the full
+development workflow.
+
+## Releases
+
+Release notes are maintained in [CHANGELOG.md](CHANGELOG.md). Pushing an annotated
+`vX.Y.Z` tag for a commit that has passed CI on `main` publishes a GitHub Release with
+native archives, SHA-256 checksums, and versioned multi-architecture container images.
+Maintainer instructions are in [docs/releasing.md](docs/releasing.md).
+
+## License
+
+Hubuum is available under the [MIT License](LICENSE).
 
 [^1]: Hubuum is probably a loanword from Akkadian.
 [^2]: [JSON schema](https://json-schema.org) is a powerful tool for validating the structure of JSON data. It allows you to define the expected format of your data, including required fields, data types, and constraints on values.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -230,7 +230,9 @@ Use `--service-name NAME` to install the unit under a different name. Without `-
 
 ## Updates
 
-The installer copies `update-single-host.sh` into the install directory:
+The installer copies `install-single-host.sh`, `update-single-host.sh`,
+`stop-single-host.sh`, and `uninstall-single-host.sh` into the install directory. A curl-based
+installer rerun refreshes all four management scripts before updating the deployment:
 
 ```bash
 cd /opt/hubuum

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -12,6 +12,21 @@ This repository uses the CI workflow in
 
 ## Scripted release flow
 
+### First release (`v0.0.1`)
+
+The repository is already prepared at version `0.0.1`. Once the release changes are on
+`main` and that commit has a successful CI run:
+
+1. Check out the release commit on a clean local `main` branch.
+2. Run `./scripts/check-release-readiness.sh v0.0.1`.
+3. Run `./scripts/release.sh tag`.
+4. Push the tag with `git push origin v0.0.1`.
+
+Do not tag a different commit while CI is still running: the tag workflow requires the
+exact tagged commit to have a successful `main` CI run.
+
+### Later releases
+
 Use the helper script in [`scripts/release.sh`](../scripts/release.sh):
 
 1. Start from a clean local `main`.
@@ -32,8 +47,11 @@ The helper script:
 Once the tag is pushed, the CI workflow will:
 
 - verify the tagged commit already passed CI on `main`
-- publish GitHub release archives for Linux x86_64 and aarch64
-- publish multi-arch GHCR images for the release tag
+- verify that the tag, `Cargo.toml`, changelog, and OpenAPI versions match
+- publish GitHub release archives and SHA-256 checksums for Linux x86_64, Linux ARM64,
+  Windows x86_64, and macOS ARM64
+- use the matching changelog section as the GitHub Release notes
+- publish AMD64 and ARM64 GHCR images for the release tag
 
 ## Container images
 

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -367,20 +367,27 @@ install_management_script() {
   local script_name="$1"
   local local_path="$SCRIPT_DIR/$script_name"
   local dest_path="$INSTALL_DIR/$script_name"
+  local temp_path
 
   if [[ -f "$local_path" && "$local_path" != "$dest_path" ]]; then
     install -m 0755 "$local_path" "$dest_path"
     return 0
-  elif [[ -f "$dest_path" ]]; then
-    chmod 0755 "$dest_path"
-    return 0
   fi
 
   if command -v curl >/dev/null 2>&1; then
-    if curl -fsSL "${SCRIPT_BASE_URL}/${script_name}" -o "$dest_path"; then
-      chmod 0755 "$dest_path"
+    temp_path="$(mktemp "$INSTALL_DIR/.${script_name}.XXXXXX")"
+    if curl -fsSL "${SCRIPT_BASE_URL}/${script_name}" -o "$temp_path"; then
+      install -m 0755 "$temp_path" "$dest_path"
+      rm -f "$temp_path"
       return 0
     fi
+    rm -f "$temp_path"
+  fi
+
+  if [[ -f "$dest_path" ]]; then
+    chmod 0755 "$dest_path"
+    echo "WARNING: could not refresh $script_name; keeping the installed copy" >&2
+    return 0
   fi
 
   echo "WARNING: could not install $script_name; curl is unavailable and no local script was found" >&2

--- a/scripts/test-install-script-refresh.sh
+++ b/scripts/test-install-script-refresh.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPOSITORY_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+SCRIPT_DIR="$TEST_ROOT/installed"
+INSTALL_DIR="$SCRIPT_DIR"
+REMOTE_DIR="$TEST_ROOT/remote"
+SCRIPT_BASE_URL="https://example.invalid/scripts"
+mkdir -p "$INSTALL_DIR" "$REMOTE_DIR"
+
+curl() {
+  local output_path=""
+  local url=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o)
+        output_path="$2"
+        shift 2
+        ;;
+      -*)
+        shift
+        ;;
+      *)
+        url="$1"
+        shift
+        ;;
+    esac
+  done
+
+  [[ -n "$output_path" && -n "$url" ]]
+  cp "$REMOTE_DIR/${url##*/}" "$output_path"
+}
+
+function_source="$(
+  sed -n '/^install_management_script() {$/,/^}$/p' \
+    "$REPOSITORY_ROOT/scripts/install-single-host.sh"
+)"
+[[ -n "$function_source" ]]
+eval "$function_source"
+
+management_scripts=(
+  install-single-host.sh
+  update-single-host.sh
+  stop-single-host.sh
+  uninstall-single-host.sh
+)
+
+for script_name in "${management_scripts[@]}"; do
+  printf '#!/usr/bin/env bash\nprintf old\n' > "$INSTALL_DIR/$script_name"
+  printf '#!/usr/bin/env bash\nprintf refreshed\n' > "$REMOTE_DIR/$script_name"
+done
+
+for script_name in "${management_scripts[@]}"; do
+  install_management_script "$script_name"
+  cmp "$REMOTE_DIR/$script_name" "$INSTALL_DIR/$script_name"
+  [[ -x "$INSTALL_DIR/$script_name" ]]
+done
+
+echo "Management script refresh test passed"


### PR DESCRIPTION
## Summary

- prepare the changelog and README for the first public release
- document the initial and subsequent release process
- verify and harden the existing tag-driven GitHub Release and GHCR publishing jobs
- refresh every installed management script when the curl installer is rerun
- fix downloaded Unix release checksum paths

## Verification

- `source .env && ./run_tests.sh` (910 passed, 2 ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Markdown lint
- `actionlint .github/workflows/ci.yml`
- `bash scripts/test-install-script-refresh.sh`
- `bash -n scripts/*.sh`
- `./scripts/check-release-readiness.sh v0.0.1`