### PR TITLE
Add typed runtime configuration boundaries

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -697,6 +697,53 @@
         ]
       }
     },
+    "/api/v1/admin/config": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Get Api V1 Admin Config",
+        "description": "Auto-generated documentation for GET /api/v1/admin/config.",
+        "operationId": "getApiV1AdminConfig",
+        "responses": {
+          "200": {
+            "description": "Effective redacted process configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunningConfig"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/v1/classes": {
       "get": {
         "tags": [
@@ -12883,6 +12930,40 @@
           }
         }
       },
+      "AuthenticationConfig": {
+        "type": "object",
+        "required": [
+          "token_lifetime_hours",
+          "stable_token_hash_key_configured",
+          "admin_groupname",
+          "provider_config_path",
+          "login_rate_limit"
+        ],
+        "properties": {
+          "admin_groupname": {
+            "type": "string"
+          },
+          "admin_identity_scope": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "login_rate_limit": {
+            "$ref": "#/components/schemas/LoginRateLimitConfig"
+          },
+          "provider_config_path": {
+            "$ref": "#/components/schemas/SecretStatus"
+          },
+          "stable_token_hash_key_configured": {
+            "type": "boolean"
+          },
+          "token_lifetime_hours": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
       "ClassKey": {
         "type": "object",
         "required": [
@@ -12917,6 +12998,22 @@
         ],
         "properties": {
           "cleared": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
+      "ClientAllowlistStatus": {
+        "type": "object",
+        "required": [
+          "allows_any",
+          "network_count"
+        ],
+        "properties": {
+          "allows_any": {
+            "type": "boolean"
+          },
+          "network_count": {
             "type": "integer",
             "minimum": 0
           }
@@ -13145,6 +13242,35 @@
           }
         }
       },
+      "DatabaseConfig": {
+        "type": "object",
+        "required": [
+          "url",
+          "pool_size",
+          "pool_acquire_timeout_ms",
+          "statement_timeout_ms"
+        ],
+        "properties": {
+          "pool_acquire_timeout_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "pool_size": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "statement_timeout_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "url": {
+            "$ref": "#/components/schemas/SecretStatus"
+          }
+        }
+      },
       "DbStateResponse": {
         "type": "object",
         "required": [
@@ -13312,6 +13438,113 @@
           },
           "target_collection": {
             "$ref": "#/components/schemas/Collection"
+          }
+        }
+      },
+      "EventConfig": {
+        "type": "object",
+        "required": [
+          "fanout_workers",
+          "fanout_batch_size",
+          "fanout_poll_interval_ms",
+          "fanout_lock_timeout_ms",
+          "delivery_workers",
+          "delivery_batch_size",
+          "delivery_poll_interval_ms",
+          "delivery_lock_timeout_ms",
+          "delivery_transport_timeout_ms",
+          "delivery_retry_backoff_base_ms",
+          "delivery_retry_backoff_max_ms",
+          "delivery_max_attempts",
+          "retention_purge_enabled",
+          "retention_days",
+          "delivery_retention_days",
+          "retention_purge_interval_seconds",
+          "retention_purge_batch_size",
+          "retention_file_archive_enabled",
+          "retention_archive_path_configured"
+        ],
+        "properties": {
+          "delivery_batch_size": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "delivery_lock_timeout_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "delivery_max_attempts": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "delivery_poll_interval_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "delivery_retention_days": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "delivery_retry_backoff_base_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "delivery_retry_backoff_max_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "delivery_transport_timeout_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "delivery_workers": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "fanout_batch_size": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "fanout_lock_timeout_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "fanout_poll_interval_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "fanout_workers": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "retention_archive_path_configured": {
+            "type": "boolean"
+          },
+          "retention_days": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "retention_file_archive_enabled": {
+            "type": "boolean"
+          },
+          "retention_purge_batch_size": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "retention_purge_enabled": {
+            "type": "boolean"
+          },
+          "retention_purge_interval_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
           }
         }
       },
@@ -13955,6 +14188,57 @@
           "poll_wakeups": {
             "type": "integer",
             "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
+      "ExportConfig": {
+        "type": "object",
+        "required": [
+          "output_retention_hours",
+          "output_cleanup_interval_seconds",
+          "template_recursion_limit",
+          "template_fuel",
+          "template_max_objects",
+          "max_output_bytes",
+          "stage_timeout_ms",
+          "database_statement_timeout_ms"
+        ],
+        "properties": {
+          "database_statement_timeout_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "max_output_bytes": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "output_cleanup_interval_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "output_retention_hours": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "stage_timeout_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "template_fuel": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "template_max_objects": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "template_recursion_limit": {
+            "type": "integer",
             "minimum": 0
           }
         }
@@ -16239,6 +16523,62 @@
           }
         }
       },
+      "LoginRateLimitConfig": {
+        "type": "object",
+        "required": [
+          "enabled",
+          "max_attempts",
+          "max_attempts_per_ip",
+          "max_attempts_per_subnet",
+          "window_seconds",
+          "backoff_base_seconds",
+          "backoff_max_seconds",
+          "subnet_prefix_v4",
+          "subnet_prefix_v6"
+        ],
+        "properties": {
+          "backoff_base_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "backoff_max_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "max_attempts": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "max_attempts_per_ip": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "max_attempts_per_subnet": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "subnet_prefix_v4": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "subnet_prefix_v6": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "window_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
       "LoginRateLimitConfigResponse": {
         "type": "object",
         "description": "Effective login rate-limit configuration, echoed back in the admin state endpoint.",
@@ -16462,6 +16802,31 @@
         },
         "example": {
           "message": "Token is valid."
+        }
+      },
+      "NetworkConfig": {
+        "type": "object",
+        "required": [
+          "trust_ip_headers",
+          "trusted_proxy_hops",
+          "trusted_proxy_networks",
+          "client_allowlist"
+        ],
+        "properties": {
+          "client_allowlist": {
+            "$ref": "#/components/schemas/ClientAllowlistStatus"
+          },
+          "trust_ip_headers": {
+            "type": "boolean"
+          },
+          "trusted_proxy_hops": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "trusted_proxy_networks": {
+            "type": "integer",
+            "minimum": 0
+          }
         }
       },
       "NewCollectionWithAssignee": {
@@ -17084,6 +17449,28 @@
           }
         }
       },
+      "PaginationConfig": {
+        "type": "object",
+        "required": [
+          "default_page_limit",
+          "max_page_limit",
+          "max_transitive_depth"
+        ],
+        "properties": {
+          "default_page_limit": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "max_page_limit": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "max_transitive_depth": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
       "Permission": {
         "type": "object",
         "required": [
@@ -17607,6 +17994,28 @@
           }
         ]
       },
+      "RemoteCallConfig": {
+        "type": "object",
+        "required": [
+          "timeout_ms",
+          "max_response_bytes",
+          "allow_private_targets"
+        ],
+        "properties": {
+          "allow_private_targets": {
+            "type": "boolean"
+          },
+          "max_response_bytes": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "timeout_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
       "RemoteCallResult": {
         "type": "object",
         "required": [
@@ -18000,6 +18409,99 @@
           "object_relation"
         ]
       },
+      "RunningConfig": {
+        "type": "object",
+        "required": [
+          "server",
+          "database",
+          "tasks",
+          "events",
+          "exports",
+          "remote_calls",
+          "authentication",
+          "pagination",
+          "network"
+        ],
+        "properties": {
+          "authentication": {
+            "$ref": "#/components/schemas/AuthenticationConfig"
+          },
+          "database": {
+            "$ref": "#/components/schemas/DatabaseConfig"
+          },
+          "events": {
+            "$ref": "#/components/schemas/EventConfig"
+          },
+          "exports": {
+            "$ref": "#/components/schemas/ExportConfig"
+          },
+          "network": {
+            "$ref": "#/components/schemas/NetworkConfig"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationConfig"
+          },
+          "remote_calls": {
+            "$ref": "#/components/schemas/RemoteCallConfig"
+          },
+          "server": {
+            "$ref": "#/components/schemas/ServerConfig"
+          },
+          "tasks": {
+            "$ref": "#/components/schemas/TaskConfig"
+          }
+        }
+      },
+      "SecretStatus": {
+        "type": "object",
+        "required": [
+          "configured"
+        ],
+        "properties": {
+          "configured": {
+            "type": "boolean",
+            "description": "Whether a value is configured. The value itself is never returned."
+          }
+        }
+      },
+      "ServerConfig": {
+        "type": "object",
+        "required": [
+          "bind_ip",
+          "bind_port",
+          "log_level",
+          "actix_workers",
+          "metrics_enabled",
+          "metrics_path",
+          "tls"
+        ],
+        "properties": {
+          "actix_workers": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "bind_ip": {
+            "type": "string"
+          },
+          "bind_port": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "log_level": {
+            "type": "string"
+          },
+          "metrics_enabled": {
+            "type": "boolean"
+          },
+          "metrics_path": {
+            "type": "string"
+          },
+          "tls": {
+            "$ref": "#/components/schemas/TlsConfig"
+          }
+        }
+      },
       "ServiceAccountResponse": {
         "type": "object",
         "description": "Public response shape, combining the service-account row with its principal\nname (the name lives on `principals`).",
@@ -18051,6 +18553,39 @@
           "updated_at": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "TaskConfig": {
+        "type": "object",
+        "required": [
+          "workers",
+          "poll_interval_ms",
+          "import_max_active_per_user",
+          "export_max_active_per_user",
+          "remote_call_max_active_per_user"
+        ],
+        "properties": {
+          "export_max_active_per_user": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "import_max_active_per_user": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "poll_interval_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "remote_call_max_active_per_user": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "workers": {
+            "type": "integer",
+            "minimum": 0
           }
         }
       },
@@ -18378,6 +18913,35 @@
           "partially_succeeded",
           "cancelled"
         ]
+      },
+      "TlsConfig": {
+        "type": "object",
+        "required": [
+          "enabled",
+          "certificate_path_configured",
+          "private_key_path",
+          "private_key_passphrase"
+        ],
+        "properties": {
+          "backend": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "certificate_path_configured": {
+            "type": "boolean"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "private_key_passphrase": {
+            "$ref": "#/components/schemas/SecretStatus"
+          },
+          "private_key_path": {
+            "$ref": "#/components/schemas/SecretStatus"
+          }
+        }
       },
       "UnifiedSearchBatchResponse": {
         "type": "object",
@@ -19074,6 +19638,10 @@
     }
   },
   "tags": [
+    {
+      "name": "admin",
+      "description": "Administrative process inspection endpoints"
+    },
     {
       "name": "meta",
       "description": "Meta and database state endpoints"

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -2,8 +2,13 @@ use crate::api::handlers::{auth, meta, probes};
 use crate::api::v1::handlers::history::HistoryResponse;
 use crate::api::v1::handlers::{
     classes, collections, event_deliveries, event_sinks, event_subscriptions, events,
-    export_templates, exports, groups, imports, me, principals, relations, remote_targets, search,
-    service_accounts, tasks, users,
+    export_templates, exports, groups, imports, me, principals, relations, remote_targets,
+    runtime_config, search, service_accounts, tasks, users,
+};
+use crate::config::running::{
+    AuthenticationConfig, ClientAllowlistStatus, DatabaseConfig, EventConfig, ExportConfig,
+    LoginRateLimitConfig as RunningLoginRateLimitConfig, NetworkConfig, PaginationConfig,
+    RemoteCallConfig, RunningConfig, SecretStatus, ServerConfig, TaskConfig, TlsConfig,
 };
 use crate::events::EventResponse;
 use crate::models::{
@@ -57,6 +62,7 @@ use utoipa::{Modify, OpenApi, ToSchema};
     paths(
         probes::healthz,
         probes::readyz,
+        runtime_config::get_running_config,
         meta::get_db_state,
         meta::get_object_and_class_count,
         meta::get_task_queue_state,
@@ -228,6 +234,20 @@ use utoipa::{Modify, OpenApi, ToSchema};
             meta::LoginRateLimitStateResponse,
             meta::ReleaseRateLimitResponse,
             meta::ClearRateLimitResponse,
+            RunningConfig,
+            SecretStatus,
+            ServerConfig,
+            TlsConfig,
+            DatabaseConfig,
+            TaskConfig,
+            EventConfig,
+            ExportConfig,
+            RemoteCallConfig,
+            AuthenticationConfig,
+            RunningLoginRateLimitConfig,
+            PaginationConfig,
+            NetworkConfig,
+            ClientAllowlistStatus,
             ObjectsByClass,
             UserResponse,
             NewUser,
@@ -366,6 +386,7 @@ use utoipa::{Modify, OpenApi, ToSchema};
     ),
     modifiers(&SecurityAddon, &OperationDefaults),
     tags(
+        (name = "admin", description = "Administrative process inspection endpoints"),
         (name = "meta", description = "Meta and database state endpoints"),
         (name = "auth", description = "Authentication and token lifecycle"),
         (name = "users", description = "User management endpoints"),
@@ -844,6 +865,7 @@ mod tests {
             "/api/v0/meta/tasks",
             "/api/v0/meta/login-rate-limit",
             "/api/v0/meta/login-rate-limit/{id}",
+            "/api/v1/admin/config",
             "/api/v1/iam/users",
             "/api/v1/iam/users/{user_id}",
             "/api/v1/iam/users/{user_id}/events",

--- a/src/api/v1/handlers/mod.rs
+++ b/src/api/v1/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod me;
 pub mod principals;
 pub mod relations;
 pub mod remote_targets;
+pub mod runtime_config;
 pub mod search;
 pub mod service_accounts;
 pub mod tasks;

--- a/src/api/v1/handlers/runtime_config.rs
+++ b/src/api/v1/handlers/runtime_config.rs
@@ -1,0 +1,30 @@
+use actix_web::{Responder, get, http::StatusCode, web};
+
+use crate::api::openapi::ApiErrorResponse;
+use crate::api::response::ApiResponse;
+use crate::config::running::RunningConfig;
+use crate::errors::ApiError;
+use crate::extractors::AdminAccess;
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/admin/config",
+    tag = "admin",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Effective redacted process configuration", body = RunningConfig),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Forbidden", body = ApiErrorResponse)
+    )
+)]
+#[get("/config")]
+pub async fn get_running_config(
+    config: web::Data<RunningConfig>,
+    _admin: AdminAccess,
+) -> Result<impl Responder, ApiError> {
+    Ok(ApiResponse::new(config.get_ref().clone(), StatusCode::OK))
+}
+
+pub fn config(cfg: &mut web::ServiceConfig) {
+    cfg.service(get_running_config);
+}

--- a/src/api/v1/routes/mod.rs
+++ b/src/api/v1/routes/mod.rs
@@ -37,6 +37,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         .service(web::scope("/event-sinks").configure(event_sinks::config))
         .service(web::scope("/tasks").configure(tasks::config))
         .service(web::scope("/events").configure(events::config))
+        .service(web::scope("/admin").configure(crate::api::v1::handlers::runtime_config::config))
         .service(web::scope("/export-templates").configure(export_templates::config))
         .service(web::scope("/remote-targets").configure(remote_targets::config))
         .service(web::scope("/relations").configure(relations::config));

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,11 @@
+pub mod environment;
+pub mod running;
+
 use std::sync::LazyLock;
 #[cfg(test)]
 use std::sync::Mutex;
 #[cfg(not(test))]
-use std::sync::{RwLock, RwLockReadGuard};
+use std::sync::OnceLock;
 
 use clap::{Parser, ValueEnum};
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
@@ -187,7 +190,7 @@ impl TlsBackend {
     }
 }
 
-#[derive(Parser, Debug, Deserialize, Serialize, Clone)]
+#[derive(Parser, Deserialize, Clone)]
 #[command(version = env!("CARGO_PKG_VERSION"), about = "Hubuum server", long_about = None)]
 pub struct AppConfig {
     /// IP address to bind to
@@ -740,6 +743,15 @@ pub struct AppConfig {
     pub client_allowlist: ClientAllowlist,
 }
 
+impl std::fmt::Debug for AppConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_tuple("AppConfig")
+            .field(&running::RunningConfig::from(self))
+            .finish()
+    }
+}
+
 fn parse_client_allowlist(s: &str) -> Result<ClientAllowlist, String> {
     ClientAllowlist::from_str(s).map_err(|e| e.to_string())
 }
@@ -1152,14 +1164,15 @@ pub fn login_rate_limit_config() -> LoginRateLimitConfig {
 
     #[cfg(not(test))]
     let config = get_config()
-        .map(|config| LoginRateLimitConfig::from(&*config))
+        .map(LoginRateLimitConfig::from)
         .unwrap_or_default();
 
     config
 }
 
 #[cfg(not(test))]
-fn load_config() -> Result<AppConfig, ApiError> {
+pub fn load_config() -> Result<AppConfig, ApiError> {
+    environment::validate_registry().map_err(ApiError::BadRequest)?;
     match AppConfig::try_parse() {
         Ok(config) => config.validate(),
         Err(error) => match error.kind() {
@@ -1174,16 +1187,29 @@ fn load_config() -> Result<AppConfig, ApiError> {
 }
 
 #[cfg(not(test))]
-pub static CONFIG: LazyLock<RwLock<AppConfig>> = LazyLock::new(|| {
-    let config = load_config().unwrap_or_else(|e| panic!("Invalid application configuration: {e}"));
-    RwLock::new(config)
-});
+static CONFIG: OnceLock<AppConfig> = OnceLock::new();
+
+/// Resolve and install the process configuration before starting async work.
+///
+/// Calling this more than once returns the first installed value. This makes
+/// startup composition explicit while retaining a small compatibility accessor
+/// for code that has not yet received consumer-owned settings.
+#[cfg(not(test))]
+pub fn initialize_config() -> Result<&'static AppConfig, ApiError> {
+    if let Some(config) = CONFIG.get() {
+        return Ok(config);
+    }
+
+    let config = load_config()?;
+    let _ = CONFIG.set(config);
+    CONFIG.get().ok_or_else(|| {
+        ApiError::InternalServerError("Failed to initialize application config".to_string())
+    })
+}
 
 #[cfg(not(test))]
-pub fn get_config() -> Result<RwLockReadGuard<'static, AppConfig>, ApiError> {
-    CONFIG
-        .read()
-        .map_err(|e| ApiError::InternalServerError(format!("Failed to read config: {e}")))
+pub fn get_config() -> Result<&'static AppConfig, ApiError> {
+    initialize_config()
 }
 
 #[cfg(test)]
@@ -1192,6 +1218,8 @@ static TEST_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 #[cfg(test)]
 fn get_config_from_env() -> Result<AppConfig, ApiError> {
     use std::env;
+
+    environment::validate_registry().map_err(ApiError::BadRequest)?;
 
     // Helper function to read an environment variable or return a default value
     fn env_or_default(key: &str, default: &str) -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1171,7 +1171,7 @@ pub fn login_rate_limit_config() -> LoginRateLimitConfig {
 }
 
 #[cfg(not(test))]
-pub fn load_config() -> Result<AppConfig, ApiError> {
+fn load_config() -> Result<AppConfig, ApiError> {
     environment::validate_registry().map_err(ApiError::BadRequest)?;
     match AppConfig::try_parse() {
         Ok(config) => config.validate(),
@@ -1201,10 +1201,7 @@ pub fn initialize_config() -> Result<&'static AppConfig, ApiError> {
     }
 
     let config = load_config()?;
-    let _ = CONFIG.set(config);
-    CONFIG.get().ok_or_else(|| {
-        ApiError::InternalServerError("Failed to initialize application config".to_string())
-    })
+    Ok(CONFIG.get_or_init(|| config))
 }
 
 #[cfg(not(test))]

--- a/src/config/environment.rs
+++ b/src/config/environment.rs
@@ -1,0 +1,369 @@
+//! Registry for environment variables owned by Hubuum.
+//!
+//! Configuration consumers receive typed values. Only startup/configuration
+//! adapters should map these names to those values. Adding a variable requires
+//! declaring its owner and sensitivity here, which prevents a consumer from
+//! quietly introducing an ambiguous name such as `HUBUUM_TIMEOUT`.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EnvironmentOwner {
+    Server,
+    Database,
+    Tasks,
+    Events,
+    Exports,
+    RemoteCalls,
+    Authentication,
+    Pagination,
+    Relations,
+    Network,
+    Operations,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Exposure {
+    Public,
+    Sensitive,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EnvironmentVariable {
+    pub name: &'static str,
+    pub owner: EnvironmentOwner,
+    pub exposure: Exposure,
+}
+
+macro_rules! option {
+    ($name:literal, $owner:ident) => {
+        EnvironmentVariable {
+            name: $name,
+            owner: EnvironmentOwner::$owner,
+            exposure: Exposure::Public,
+        }
+    };
+    ($name:literal, $owner:ident, sensitive) => {
+        EnvironmentVariable {
+            name: $name,
+            owner: EnvironmentOwner::$owner,
+            exposure: Exposure::Sensitive,
+        }
+    };
+}
+
+/// Variables consumed by `AppConfig` through clap.
+pub const APP_CONFIG_ENVIRONMENT: &[EnvironmentVariable] = &[
+    option!("HUBUUM_BIND_IP", Server),
+    option!("HUBUUM_BIND_PORT", Server),
+    option!("HUBUUM_LOG_LEVEL", Server),
+    option!("HUBUUM_ACTIX_WORKERS", Server),
+    option!("HUBUUM_DATABASE_URL", Database, sensitive),
+    option!("HUBUUM_DB_POOL_SIZE", Database),
+    option!("HUBUUM_DB_POOL_ACQUIRE_TIMEOUT_MS", Database),
+    option!("HUBUUM_DB_STATEMENT_TIMEOUT_MS", Database),
+    option!("HUBUUM_TASK_WORKERS", Tasks),
+    option!("HUBUUM_TASK_POLL_INTERVAL_MS", Tasks),
+    option!("HUBUUM_IMPORT_MAX_ACTIVE_TASKS_PER_USER", Tasks),
+    option!("HUBUUM_EVENT_FANOUT_WORKERS", Events),
+    option!("HUBUUM_EVENT_FANOUT_BATCH_SIZE", Events),
+    option!("HUBUUM_EVENT_FANOUT_POLL_INTERVAL_MS", Events),
+    option!("HUBUUM_EVENT_FANOUT_LOCK_TIMEOUT_MS", Events),
+    option!("HUBUUM_EVENT_DELIVERY_WORKERS", Events),
+    option!("HUBUUM_EVENT_DELIVERY_BATCH_SIZE", Events),
+    option!("HUBUUM_EVENT_DELIVERY_POLL_INTERVAL_MS", Events),
+    option!("HUBUUM_EVENT_DELIVERY_LOCK_TIMEOUT_MS", Events),
+    option!("HUBUUM_EVENT_DELIVERY_TRANSPORT_TIMEOUT_MS", Events),
+    option!("HUBUUM_EVENT_DELIVERY_RETRY_BACKOFF_BASE_MS", Events),
+    option!("HUBUUM_EVENT_DELIVERY_RETRY_BACKOFF_MAX_MS", Events),
+    option!("HUBUUM_EVENT_DELIVERY_MAX_ATTEMPTS", Events),
+    option!("HUBUUM_EVENT_DELIVERY_RETENTION_DAYS", Events),
+    option!("HUBUUM_EVENT_RETENTION_PURGE_ENABLED", Events),
+    option!("HUBUUM_EVENT_RETENTION_DAYS", Events),
+    option!("HUBUUM_EVENT_RETENTION_PURGE_INTERVAL_SECONDS", Events),
+    option!("HUBUUM_EVENT_RETENTION_PURGE_BATCH_SIZE", Events),
+    option!("HUBUUM_EVENT_RETENTION_FILE_ARCHIVE_ENABLED", Events),
+    option!("HUBUUM_EVENT_RETENTION_ARCHIVE_PATH", Events),
+    option!("HUBUUM_EXPORT_OUTPUT_RETENTION_HOURS", Exports),
+    option!("HUBUUM_EXPORT_OUTPUT_CLEANUP_INTERVAL_SECONDS", Exports),
+    option!("HUBUUM_EXPORT_MAX_ACTIVE_TASKS_PER_USER", Exports),
+    option!("HUBUUM_EXPORT_TEMPLATE_RECURSION_LIMIT", Exports),
+    option!("HUBUUM_EXPORT_TEMPLATE_FUEL", Exports),
+    option!("HUBUUM_EXPORT_TEMPLATE_MAX_OBJECTS", Exports),
+    option!("HUBUUM_EXPORT_MAX_OUTPUT_BYTES", Exports),
+    option!("HUBUUM_EXPORT_STAGE_TIMEOUT_MS", Exports),
+    option!("HUBUUM_EXPORT_DB_STATEMENT_TIMEOUT_MS", Exports),
+    option!("HUBUUM_REMOTE_CALL_TIMEOUT_MS", RemoteCalls),
+    option!("HUBUUM_REMOTE_CALL_MAX_RESPONSE_BYTES", RemoteCalls),
+    option!("HUBUUM_REMOTE_CALL_ALLOW_PRIVATE_TARGETS", RemoteCalls),
+    option!("HUBUUM_REMOTE_CALL_MAX_ACTIVE_TASKS_PER_USER", RemoteCalls),
+    option!("HUBUUM_TOKEN_LIFETIME_HOURS", Authentication),
+    option!("HUBUUM_LOGIN_RATE_LIMIT_ENABLED", Authentication),
+    option!("HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS", Authentication),
+    option!(
+        "HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS_PER_IP",
+        Authentication
+    ),
+    option!(
+        "HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS_PER_SUBNET",
+        Authentication
+    ),
+    option!("HUBUUM_LOGIN_RATE_LIMIT_WINDOW_SECONDS", Authentication),
+    option!(
+        "HUBUUM_LOGIN_RATE_LIMIT_BACKOFF_BASE_SECONDS",
+        Authentication
+    ),
+    option!(
+        "HUBUUM_LOGIN_RATE_LIMIT_BACKOFF_MAX_SECONDS",
+        Authentication
+    ),
+    option!("HUBUUM_LOGIN_RATE_LIMIT_SUBNET_PREFIX_V4", Authentication),
+    option!("HUBUUM_LOGIN_RATE_LIMIT_SUBNET_PREFIX_V6", Authentication),
+    option!("HUBUUM_ADMIN_GROUPNAME", Authentication),
+    option!("HUBUUM_ADMIN_IDENTITY_SCOPE", Authentication),
+    option!("HUBUUM_AUTH_CONFIG_PATH", Authentication, sensitive),
+    option!("HUBUUM_DEFAULT_PAGE_LIMIT", Pagination),
+    option!("HUBUUM_MAX_PAGE_LIMIT", Pagination),
+    option!("HUBUUM_MAX_TRANSITIVE_DEPTH", Relations),
+    option!("HUBUUM_TLS_CERT_PATH", Server),
+    option!("HUBUUM_TLS_KEY_PATH", Server, sensitive),
+    option!("HUBUUM_TLS_KEY_PASSPHRASE", Server, sensitive),
+    option!("HUBUUM_TLS_BACKEND", Server),
+    option!("HUBUUM_METRICS_ENABLED", Server),
+    option!("HUBUUM_METRICS_PATH", Server),
+    option!("HUBUUM_TRUST_IP_HEADERS", Network),
+    option!("HUBUUM_TRUSTED_PROXIES", Network),
+    option!("HUBUUM_TRUSTED_PROXY_HOPS", Network),
+    option!("HUBUUM_CLIENT_ALLOWLIST", Network),
+];
+
+/// Exact Hubuum variables resolved outside clap's `AppConfig` adapter.
+pub const PROCESS_ENVIRONMENT: &[EnvironmentVariable] = &[
+    option!("HUBUUM_TOKEN_HASH_KEY", Authentication, sensitive),
+    option!("HUBUUM_BUILD_GIT_SHA", Operations),
+    option!("HUBUUM_SKIP_MIGRATIONS", Operations),
+    option!("HUBUUM_AUTH_CONFIG_HOST_PATH", Operations, sensitive),
+];
+
+/// Registered dynamic secret namespaces. The suffix is a consumer-supplied
+/// reference validated by the corresponding secret resolver.
+pub const DYNAMIC_SECRET_PREFIXES: &[(&str, EnvironmentOwner)] = &[
+    ("HUBUUM_REMOTE_SECRET_", EnvironmentOwner::RemoteCalls),
+    ("HUBUUM_EVENT_SINK_SECRET_", EnvironmentOwner::Events),
+];
+
+/// Files allowed to translate Hubuum-owned environment values. This list is
+/// intentionally small and reviewable. Dynamic secret resolvers remain here
+/// until they can receive an injected secret-provider trait.
+pub const ENVIRONMENT_ADAPTER_PATHS: &[&str] = &[
+    "src/config.rs",
+    "src/bin/admin.rs",
+    "src/logger.rs",
+    "src/tasks/remote_call.rs",
+    "crates/hubuum-events-core/src/lib.rs",
+];
+
+pub fn declared(name: &str) -> bool {
+    APP_CONFIG_ENVIRONMENT
+        .iter()
+        .chain(PROCESS_ENVIRONMENT)
+        .any(|variable| variable.name == name)
+        || DYNAMIC_SECRET_PREFIXES
+            .iter()
+            .any(|(prefix, _)| name.starts_with(prefix) && name.len() > prefix.len())
+}
+
+/// Check registry invariants before configuration parsing. These are also
+/// covered by tests, but keeping the registry executable avoids it becoming a
+/// test-only manifest that can silently drift in unusual build targets.
+pub fn validate_registry() -> Result<(), String> {
+    let mut names = std::collections::BTreeSet::new();
+    for variable in APP_CONFIG_ENVIRONMENT.iter().chain(PROCESS_ENVIRONMENT) {
+        if !variable.name.starts_with("HUBUUM_") {
+            return Err(format!(
+                "environment variable is outside the HUBUUM namespace: {}",
+                variable.name
+            ));
+        }
+        if !names.insert(variable.name) {
+            return Err(format!(
+                "environment variable is declared more than once: {}",
+                variable.name
+            ));
+        }
+        if !declared(variable.name) {
+            return Err(format!(
+                "registry entry cannot be resolved as declared: {}",
+                variable.name
+            ));
+        }
+        let duration_name = ["_TIMEOUT", "_INTERVAL", "_WINDOW", "_BACKOFF", "_LIFETIME"]
+            .iter()
+            .any(|marker| variable.name.contains(marker));
+        let explicit_unit = ["_MS", "_SECONDS", "_MINUTES", "_HOURS", "_DAYS"]
+            .iter()
+            .any(|unit| variable.name.ends_with(unit));
+        if duration_name && !explicit_unit {
+            return Err(format!(
+                "duration environment variable must declare its unit: {}",
+                variable.name
+            ));
+        }
+
+        // Reading both classifications here is intentional: every entry must
+        // carry ownership and exposure metadata even when parsing needs only
+        // the variable name.
+        let _classification = (variable.owner, variable.exposure);
+    }
+
+    for (prefix, owner) in DYNAMIC_SECRET_PREFIXES {
+        if !prefix.starts_with("HUBUUM_") || !prefix.ends_with('_') {
+            return Err(format!("invalid dynamic secret prefix: {prefix}"));
+        }
+        let _owner = owner;
+    }
+    if ENVIRONMENT_ADAPTER_PATHS.is_empty() {
+        return Err("at least one environment adapter must be declared".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn declared_reference(name: &str) -> bool {
+    declared(name)
+        || DYNAMIC_SECRET_PREFIXES
+            .iter()
+            .any(|(prefix, _)| name == *prefix)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    use clap::CommandFactory;
+    use regex::Regex;
+
+    use super::*;
+    use crate::config::AppConfig;
+
+    #[test]
+    fn clap_environment_is_exactly_the_declared_app_config_set() {
+        let clap_names = AppConfig::command()
+            .get_arguments()
+            .filter_map(|argument| argument.get_env())
+            .map(|name| name.to_string_lossy().into_owned())
+            .collect::<BTreeSet<_>>();
+        let declared_names = APP_CONFIG_ENVIRONMENT
+            .iter()
+            .map(|variable| variable.name.to_string())
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(clap_names, declared_names);
+    }
+
+    #[test]
+    fn every_declared_variable_has_one_owner_and_unique_name() {
+        let all = APP_CONFIG_ENVIRONMENT.iter().chain(PROCESS_ENVIRONMENT);
+        let names = all
+            .clone()
+            .map(|variable| variable.name)
+            .collect::<Vec<_>>();
+        let unique = names.iter().copied().collect::<BTreeSet<_>>();
+
+        assert_eq!(names.len(), unique.len());
+        assert!(names.iter().all(|name| name.starts_with("HUBUUM_")));
+    }
+
+    #[test]
+    fn undeclared_or_ambiguous_names_are_rejected() {
+        assert!(!declared("HUBUUM_TIMEOUT"));
+        assert!(!declared("HUBUUM_REMOTE_SECRET_"));
+        assert!(declared("HUBUUM_REMOTE_SECRET_EXAMPLE"));
+    }
+
+    fn rust_sources(directory: &Path) -> Vec<PathBuf> {
+        let mut sources = Vec::new();
+        let mut pending = vec![directory.to_path_buf()];
+        while let Some(path) = pending.pop() {
+            for entry in fs::read_dir(path).unwrap() {
+                let entry = entry.unwrap();
+                let path = entry.path();
+                if path.is_dir() {
+                    pending.push(path);
+                } else if path.extension().is_some_and(|extension| extension == "rs") {
+                    sources.push(path);
+                }
+            }
+        }
+        sources
+    }
+
+    fn workspace_sources() -> Vec<PathBuf> {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        [root.join("src"), root.join("crates")]
+            .iter()
+            .flat_map(|directory| rust_sources(directory))
+            .collect()
+    }
+
+    #[test]
+    fn every_hubuum_environment_reference_in_every_crate_is_declared() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let registry = root.join("src/config/environment.rs");
+        let variable = Regex::new(r"HUBUUM_[A-Z][A-Z0-9_]*").unwrap();
+        let mut unknown = Vec::new();
+
+        for path in workspace_sources()
+            .into_iter()
+            .filter(|path| path != &registry)
+        {
+            let source = fs::read_to_string(&path).unwrap();
+            for name in variable.find_iter(&source).map(|matched| matched.as_str()) {
+                if !declared_reference(name) {
+                    unknown.push(format!(
+                        "{}: {name}",
+                        path.strip_prefix(root).unwrap().display()
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            unknown.is_empty(),
+            "undeclared Hubuum environment variables:\n{}",
+            unknown.join("\n")
+        );
+    }
+
+    #[test]
+    fn only_declared_adapters_read_hubuum_environment_variables() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let registry = Path::new("src/config/environment.rs");
+        let adapters = ENVIRONMENT_ADAPTER_PATHS
+            .iter()
+            .map(Path::new)
+            .collect::<BTreeSet<_>>();
+        let mut unexpected = Vec::new();
+
+        for path in workspace_sources() {
+            let relative = path.strip_prefix(root).unwrap();
+            if relative == registry {
+                continue;
+            }
+            let source = fs::read_to_string(&path).unwrap();
+            let reads_environment = source.contains("env::var(")
+                || source.contains("std::env::var(")
+                || source.contains("env::var_os(")
+                || source.contains("std::env::var_os(");
+            if source.contains("HUBUUM_") && reads_environment && !adapters.contains(relative) {
+                unexpected.push(relative.display().to_string());
+            }
+        }
+
+        assert!(
+            unexpected.is_empty(),
+            "Hubuum environment access outside declared adapters:\n{}",
+            unexpected.join("\n")
+        );
+    }
+}

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -1,0 +1,301 @@
+//! Explicit, safe projection of the effective process configuration.
+//!
+//! This is deliberately not implemented by serializing `AppConfig`: newly
+//! added options are hidden until they are consciously classified here.
+
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use super::{AppConfig, ClientAllowlist, token_hash_key_is_ephemeral};
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct RunningConfig {
+    pub server: ServerConfig,
+    pub database: DatabaseConfig,
+    pub tasks: TaskConfig,
+    pub events: EventConfig,
+    pub exports: ExportConfig,
+    pub remote_calls: RemoteCallConfig,
+    pub authentication: AuthenticationConfig,
+    pub pagination: PaginationConfig,
+    pub network: NetworkConfig,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct SecretStatus {
+    /// Whether a value is configured. The value itself is never returned.
+    pub configured: bool,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct ServerConfig {
+    pub bind_ip: String,
+    pub bind_port: u16,
+    pub log_level: String,
+    pub actix_workers: usize,
+    pub metrics_enabled: bool,
+    pub metrics_path: String,
+    pub tls: TlsConfig,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct TlsConfig {
+    pub enabled: bool,
+    pub backend: Option<String>,
+    pub certificate_path_configured: bool,
+    pub private_key_path: SecretStatus,
+    pub private_key_passphrase: SecretStatus,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct DatabaseConfig {
+    pub url: SecretStatus,
+    pub pool_size: u32,
+    pub pool_acquire_timeout_ms: u64,
+    pub statement_timeout_ms: u64,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct TaskConfig {
+    pub workers: usize,
+    pub poll_interval_ms: u64,
+    pub import_max_active_per_user: usize,
+    pub export_max_active_per_user: usize,
+    pub remote_call_max_active_per_user: usize,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct EventConfig {
+    pub fanout_workers: usize,
+    pub fanout_batch_size: usize,
+    pub fanout_poll_interval_ms: u64,
+    pub fanout_lock_timeout_ms: u64,
+    pub delivery_workers: usize,
+    pub delivery_batch_size: usize,
+    pub delivery_poll_interval_ms: u64,
+    pub delivery_lock_timeout_ms: u64,
+    pub delivery_transport_timeout_ms: u64,
+    pub delivery_retry_backoff_base_ms: u64,
+    pub delivery_retry_backoff_max_ms: u64,
+    pub delivery_max_attempts: i32,
+    pub retention_purge_enabled: bool,
+    pub retention_days: i64,
+    pub delivery_retention_days: i64,
+    pub retention_purge_interval_seconds: u64,
+    pub retention_purge_batch_size: usize,
+    pub retention_file_archive_enabled: bool,
+    pub retention_archive_path_configured: bool,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct ExportConfig {
+    pub output_retention_hours: i64,
+    pub output_cleanup_interval_seconds: u64,
+    pub template_recursion_limit: usize,
+    pub template_fuel: u64,
+    pub template_max_objects: usize,
+    pub max_output_bytes: usize,
+    pub stage_timeout_ms: u64,
+    pub database_statement_timeout_ms: u64,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct RemoteCallConfig {
+    pub timeout_ms: u64,
+    pub max_response_bytes: usize,
+    pub allow_private_targets: bool,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct AuthenticationConfig {
+    pub token_lifetime_hours: i64,
+    pub stable_token_hash_key_configured: bool,
+    pub admin_groupname: String,
+    pub admin_identity_scope: Option<String>,
+    pub provider_config_path: SecretStatus,
+    pub login_rate_limit: LoginRateLimitConfig,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct LoginRateLimitConfig {
+    pub enabled: bool,
+    pub max_attempts: usize,
+    pub max_attempts_per_ip: usize,
+    pub max_attempts_per_subnet: usize,
+    pub window_seconds: u64,
+    pub backoff_base_seconds: u64,
+    pub backoff_max_seconds: u64,
+    pub subnet_prefix_v4: u8,
+    pub subnet_prefix_v6: u8,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct PaginationConfig {
+    pub default_page_limit: usize,
+    pub max_page_limit: usize,
+    pub max_transitive_depth: i32,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct NetworkConfig {
+    pub trust_ip_headers: bool,
+    pub trusted_proxy_hops: usize,
+    pub trusted_proxy_networks: usize,
+    pub client_allowlist: ClientAllowlistStatus,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct ClientAllowlistStatus {
+    pub allows_any: bool,
+    pub network_count: usize,
+}
+
+impl From<&AppConfig> for RunningConfig {
+    fn from(config: &AppConfig) -> Self {
+        let client_allowlist = match &config.client_allowlist {
+            ClientAllowlist::Any => ClientAllowlistStatus {
+                allows_any: true,
+                network_count: 0,
+            },
+            ClientAllowlist::Nets(networks) => ClientAllowlistStatus {
+                allows_any: false,
+                network_count: networks.len(),
+            },
+        };
+
+        Self {
+            server: ServerConfig {
+                bind_ip: config.bind_ip.clone(),
+                bind_port: config.port,
+                log_level: config.log_level.clone(),
+                actix_workers: config.actix_workers,
+                metrics_enabled: config.metrics_enabled,
+                metrics_path: config.metrics_path.as_str().to_string(),
+                tls: TlsConfig {
+                    enabled: config.tls_cert_path.is_some() && config.tls_key_path.is_some(),
+                    backend: config.tls_backend.map(|backend| match backend {
+                        super::TlsBackend::Rustls => "rustls".to_string(),
+                        super::TlsBackend::Openssl => "openssl".to_string(),
+                    }),
+                    certificate_path_configured: config.tls_cert_path.is_some(),
+                    private_key_path: SecretStatus {
+                        configured: config.tls_key_path.is_some(),
+                    },
+                    private_key_passphrase: SecretStatus {
+                        configured: config.tls_key_passphrase.is_some(),
+                    },
+                },
+            },
+            database: DatabaseConfig {
+                url: SecretStatus {
+                    configured: !config.database_url.trim().is_empty(),
+                },
+                pool_size: config.db_pool_size,
+                pool_acquire_timeout_ms: config.db_pool_acquire_timeout_ms,
+                statement_timeout_ms: config.db_statement_timeout_ms,
+            },
+            tasks: TaskConfig {
+                workers: config.task_workers,
+                poll_interval_ms: config.task_poll_interval_ms,
+                import_max_active_per_user: config.import_max_active_tasks_per_user,
+                export_max_active_per_user: config.export_max_active_tasks_per_user,
+                remote_call_max_active_per_user: config.remote_call_max_active_tasks_per_user,
+            },
+            events: EventConfig {
+                fanout_workers: config.event_fanout_workers,
+                fanout_batch_size: config.event_fanout_batch_size,
+                fanout_poll_interval_ms: config.event_fanout_poll_interval_ms,
+                fanout_lock_timeout_ms: config.event_fanout_lock_timeout_ms,
+                delivery_workers: config.event_delivery_workers,
+                delivery_batch_size: config.event_delivery_batch_size,
+                delivery_poll_interval_ms: config.event_delivery_poll_interval_ms,
+                delivery_lock_timeout_ms: config.event_delivery_lock_timeout_ms,
+                delivery_transport_timeout_ms: config.event_delivery_transport_timeout_ms,
+                delivery_retry_backoff_base_ms: config.event_delivery_retry_backoff_base_ms,
+                delivery_retry_backoff_max_ms: config.event_delivery_retry_backoff_max_ms,
+                delivery_max_attempts: config.event_delivery_max_attempts,
+                retention_purge_enabled: config.event_retention_purge_enabled,
+                retention_days: config.event_retention_days,
+                delivery_retention_days: config.event_delivery_retention_days,
+                retention_purge_interval_seconds: config.event_retention_purge_interval_seconds,
+                retention_purge_batch_size: config.event_retention_purge_batch_size,
+                retention_file_archive_enabled: config.event_retention_file_archive_enabled,
+                retention_archive_path_configured: config.event_retention_archive_path.is_some(),
+            },
+            exports: ExportConfig {
+                output_retention_hours: config.export_output_retention_hours,
+                output_cleanup_interval_seconds: config.export_output_cleanup_interval_seconds,
+                template_recursion_limit: config.export_template_recursion_limit,
+                template_fuel: config.export_template_fuel,
+                template_max_objects: config.export_template_max_objects,
+                max_output_bytes: config.export_max_output_bytes,
+                stage_timeout_ms: config.export_stage_timeout_ms,
+                database_statement_timeout_ms: config.export_db_statement_timeout_ms,
+            },
+            remote_calls: RemoteCallConfig {
+                timeout_ms: config.remote_call_timeout_ms,
+                max_response_bytes: config.remote_call_max_response_bytes,
+                allow_private_targets: config.remote_call_allow_private_targets,
+            },
+            authentication: AuthenticationConfig {
+                token_lifetime_hours: config.token_lifetime_hours,
+                stable_token_hash_key_configured: !token_hash_key_is_ephemeral(),
+                admin_groupname: config.admin_groupname.clone(),
+                admin_identity_scope: config.admin_identity_scope.clone(),
+                provider_config_path: SecretStatus {
+                    configured: config.auth_config_path.is_some(),
+                },
+                login_rate_limit: LoginRateLimitConfig {
+                    enabled: config.login_rate_limit_enabled,
+                    max_attempts: config.login_rate_limit_max_attempts,
+                    max_attempts_per_ip: config.login_rate_limit_max_attempts_per_ip,
+                    max_attempts_per_subnet: config.login_rate_limit_max_attempts_per_subnet,
+                    window_seconds: config.login_rate_limit_window_seconds,
+                    backoff_base_seconds: config.login_rate_limit_backoff_base_seconds,
+                    backoff_max_seconds: config.login_rate_limit_backoff_max_seconds,
+                    subnet_prefix_v4: config.login_rate_limit_subnet_prefix_v4,
+                    subnet_prefix_v6: config.login_rate_limit_subnet_prefix_v6,
+                },
+            },
+            pagination: PaginationConfig {
+                default_page_limit: config.default_page_limit,
+                max_page_limit: config.max_page_limit,
+                max_transitive_depth: config.max_transitive_depth,
+            },
+            network: NetworkConfig {
+                trust_ip_headers: config.trust_ip_headers,
+                trusted_proxy_hops: config.trusted_proxy_hops,
+                trusted_proxy_networks: config.trusted_proxies.nets().len(),
+                client_allowlist,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[test]
+    fn running_config_is_an_explicit_redacted_projection() {
+        let mut config = AppConfig::parse_from(["hubuum"]);
+        config.database_url = "postgres://secret-user:secret-password@example/db".to_string();
+        config.tls_key_path = Some("/secret/private-key.pem".to_string());
+        config.tls_key_passphrase = Some("correct horse battery staple".to_string());
+        config.auth_config_path = Some("/secret/providers.toml".to_string());
+
+        let json = serde_json::to_string(&RunningConfig::from(&config)).unwrap();
+        let debug = format!("{config:?}");
+
+        assert!(!json.contains("secret-user"));
+        assert!(!json.contains("secret-password"));
+        assert!(!json.contains("private-key.pem"));
+        assert!(!json.contains("correct horse battery staple"));
+        assert!(!json.contains("providers.toml"));
+        assert!(json.contains("\"configured\":true"));
+        assert!(!debug.contains("secret-password"));
+        assert!(!debug.contains("correct horse battery staple"));
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -49,6 +49,78 @@ use crate::utilities::db::DatabaseUrlComponents;
 pub type DbConnection = AsyncPgConnection;
 pub type DbPool = Pool<DbConnection>;
 
+/// Consumer-owned settings needed to construct the process database pool.
+///
+/// Keeping this type in the database adapter means startup can translate from
+/// env/CLI configuration once, without giving the adapter the whole AppConfig.
+pub struct DatabasePoolSettings {
+    database_url: String,
+    max_size: u32,
+    statement_timeout_ms: u64,
+    acquire_timeout_ms: u64,
+}
+
+impl DatabasePoolSettings {
+    pub fn builder(database_url: impl Into<String>) -> DatabasePoolSettingsBuilder {
+        DatabasePoolSettingsBuilder {
+            database_url: database_url.into(),
+            max_size: None,
+            statement_timeout_ms: 0,
+            acquire_timeout_ms: None,
+        }
+    }
+}
+
+pub struct DatabasePoolSettingsBuilder {
+    database_url: String,
+    max_size: Option<u32>,
+    statement_timeout_ms: u64,
+    acquire_timeout_ms: Option<u64>,
+}
+
+impl DatabasePoolSettingsBuilder {
+    pub fn max_size(mut self, max_size: u32) -> Self {
+        self.max_size = Some(max_size);
+        self
+    }
+
+    pub fn statement_timeout_ms(mut self, statement_timeout_ms: u64) -> Self {
+        self.statement_timeout_ms = statement_timeout_ms;
+        self
+    }
+
+    pub fn acquire_timeout_ms(mut self, acquire_timeout_ms: u64) -> Self {
+        self.acquire_timeout_ms = Some(acquire_timeout_ms);
+        self
+    }
+
+    pub fn build(self) -> Result<DatabasePoolSettings, String> {
+        let max_size = self
+            .max_size
+            .ok_or_else(|| "database pool size is required".to_string())?;
+        let acquire_timeout_ms = self
+            .acquire_timeout_ms
+            .ok_or_else(|| "database pool acquire timeout is required".to_string())?;
+        let database_url = self.database_url;
+        if database_url.trim().is_empty() {
+            return Err("database URL must not be empty".to_string());
+        }
+        if max_size == 0 {
+            return Err("database pool size must be greater than zero".to_string());
+        }
+        if acquire_timeout_ms == 0 {
+            return Err("database pool acquire timeout must be greater than zero".to_string());
+        }
+
+        Ok(DatabasePoolSettings {
+            database_url,
+            max_size,
+            statement_timeout_ms: self.statement_timeout_ms,
+            acquire_timeout_ms,
+        })
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DatabaseTlsMode {
     Disable,
@@ -481,6 +553,15 @@ pub fn init_pool(database_url: &str, max_size: u32) -> DbPool {
     )
 }
 
+pub fn init_pool_with_settings(settings: &DatabasePoolSettings) -> DbPool {
+    init_pool_with_timeouts(
+        &settings.database_url,
+        settings.max_size,
+        settings.statement_timeout_ms,
+        settings.acquire_timeout_ms,
+    )
+}
+
 /// Build a pool with an explicit Postgres `statement_timeout` (in milliseconds)
 /// applied to every connection on acquisition. A value of 0 disables the
 /// timeout. Exposed so tests can exercise the customizer without mutating the
@@ -593,6 +674,34 @@ mod tests {
             .as_nanos();
         let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
         format!("{prefix}_{now}_{counter}")
+    }
+
+    #[rstest]
+    #[case::empty_url("", 1, 100, "database URL must not be empty")]
+    #[case::zero_pool_size(
+        "postgres://localhost/db",
+        0,
+        100,
+        "database pool size must be greater than zero"
+    )]
+    #[case::zero_acquire_timeout(
+        "postgres://localhost/db",
+        1,
+        0,
+        "database pool acquire timeout must be greater than zero"
+    )]
+    fn database_pool_settings_reject_invalid_values(
+        #[case] database_url: &str,
+        #[case] max_size: u32,
+        #[case] acquire_timeout_ms: u64,
+        #[case] expected: &str,
+    ) {
+        let result = DatabasePoolSettings::builder(database_url)
+            .max_size(max_size)
+            .acquire_timeout_ms(acquire_timeout_ms)
+            .build();
+
+        assert_eq!(result.err().as_deref(), Some(expected));
     }
 
     #[rstest]

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ mod traits;
 mod utilities;
 
 use actix_web::{App, HttpServer, middleware::from_fn, web, web::Data, web::JsonConfig};
-use db::init_pool;
+use db::{DatabasePoolSettings, init_pool_with_settings};
 #[cfg(feature = "swagger-ui")]
 use utoipa::OpenApi;
 #[cfg(feature = "swagger-ui")]
@@ -31,7 +31,12 @@ use utoipa_swagger_ui::SwaggerUi;
 use tracing::{info, warn};
 
 use crate::api::openapi::openapi_json as openapi_json_handler;
-use crate::config::{get_config, token_hash_key_is_ephemeral};
+#[cfg(test)]
+use crate::config::get_config;
+#[cfg(not(test))]
+use crate::config::initialize_config;
+use crate::config::running::RunningConfig;
+use crate::config::token_hash_key_is_ephemeral;
 use crate::errors::{
     EXIT_CODE_CONFIG_ERROR, EXIT_CODE_INIT_ERROR, EXIT_CODE_TLS_ERROR, fatal_error,
     json_error_handler,
@@ -52,8 +57,15 @@ async fn main() -> std::io::Result<()> {
         );
     }
 
-    // Clone the config to prevent the mutex from being locked
-    // See https://rust-lang.github.io/rust-clippy/master/index.html#await_holding_lock
+    #[cfg(not(test))]
+    let config = match initialize_config() {
+        Ok(cfg) => cfg.clone(),
+        Err(e) => fatal_error(
+            &format!("Failed to load configuration: {}", e),
+            EXIT_CODE_CONFIG_ERROR,
+        ),
+    };
+    #[cfg(test)]
     let config = match get_config() {
         Ok(cfg) => cfg.clone(),
         Err(e) => fatal_error(
@@ -87,7 +99,13 @@ async fn main() -> std::io::Result<()> {
         );
     }
     utilities::auth::initialize_dummy_password_hash();
-    let pool = init_pool(&config.database_url, config.db_pool_size);
+    let database_settings = DatabasePoolSettings::builder(config.database_url.clone())
+        .max_size(config.db_pool_size)
+        .statement_timeout_ms(config.db_statement_timeout_ms)
+        .acquire_timeout_ms(config.db_pool_acquire_timeout_ms)
+        .build()
+        .unwrap_or_else(|error| fatal_error(&error, EXIT_CODE_CONFIG_ERROR));
+    let pool = init_pool_with_settings(&database_settings);
 
     if let Err(e) = utilities::init::init(pool.clone()).await {
         fatal_error(
@@ -114,8 +132,12 @@ async fn main() -> std::io::Result<()> {
     ensure_event_retention_worker_running(pool.clone());
 
     let client_allowlist = config.client_allowlist.clone();
-    let proxy_trust = middlewares::ProxyTrust::from_config(&config);
-    let app_config = config.clone();
+    let proxy_trust = middlewares::ProxyTrust::new(
+        config.trust_ip_headers,
+        config.trusted_proxies.nets().to_vec(),
+        config.trusted_proxy_hops,
+    );
+    let running_config = RunningConfig::from(&config);
     let metrics_enabled = config.metrics_enabled;
     let metrics_path = config.metrics_path.clone();
 
@@ -131,7 +153,8 @@ async fn main() -> std::io::Result<()> {
             .wrap(middlewares::TracingMiddleware::new_with_trust(
                 proxy_trust.clone(),
             ))
-            .app_data(Data::new(app_config.clone()))
+            .app_data(Data::new(proxy_trust.clone()))
+            .app_data(Data::new(running_config.clone()))
             .app_data(Data::new(pool.clone()))
             .app_data(JsonConfig::default().error_handler(json_error_handler))
             .route("/api-doc/openapi.json", web::get().to(openapi_json_handler));

--- a/src/middlewares/client_allowlist.rs
+++ b/src/middlewares/client_allowlist.rs
@@ -10,7 +10,7 @@ use std::sync::Once;
 use std::task::{Context, Poll};
 use tracing::warn;
 
-use crate::config::{AppConfig, ClientAllowlist};
+use crate::config::ClientAllowlist;
 
 /// Policy for resolving the real client IP from a request that may have traversed
 /// reverse proxies.
@@ -22,9 +22,9 @@ use crate::config::{AppConfig, ClientAllowlist};
 /// connection peer inward, which is the part an attacker cannot forge.
 #[derive(Clone, Debug, Default)]
 pub struct ProxyTrust {
-    pub trust_headers: bool,
-    pub trusted_proxies: Vec<IpNet>,
-    pub hops: usize,
+    trust_headers: bool,
+    trusted_proxies: Vec<IpNet>,
+    hops: usize,
 }
 
 impl ProxyTrust {
@@ -33,12 +33,11 @@ impl ProxyTrust {
         Self::default()
     }
 
-    /// Build the policy from application configuration.
-    pub fn from_config(config: &AppConfig) -> Self {
+    pub fn new(trust_headers: bool, trusted_proxies: Vec<IpNet>, hops: usize) -> Self {
         Self {
-            trust_headers: config.trust_ip_headers,
-            trusted_proxies: config.trusted_proxies.nets().to_vec(),
-            hops: config.trusted_proxy_hops,
+            trust_headers,
+            trusted_proxies,
+            hops,
         }
     }
 }

--- a/src/middlewares/rate_limit.rs
+++ b/src/middlewares/rate_limit.rs
@@ -351,12 +351,10 @@ pub(crate) async fn finish_login_attempt(permit: LoginAttemptPermit, outcome: Lo
 /// Resolve the trustworthy client IP for a login request, honoring the configured proxy
 /// trust policy. Returns `None` when no address can be determined.
 pub(crate) fn client_ip_for_request(req: &HttpRequest) -> Option<IpAddr> {
-    let policy = req
-        .app_data::<web::Data<ProxyTrust>>()
-        .map(|policy| policy.get_ref().clone())
-        .unwrap_or_default();
-
-    extract_client_ip_from_http_request(req, &policy)
+    match req.app_data::<web::Data<ProxyTrust>>() {
+        Some(policy) => extract_client_ip_from_http_request(req, policy.get_ref()),
+        None => extract_client_ip_from_http_request(req, &ProxyTrust::default()),
+    }
 }
 
 /// Record a failed login attempt across all applicable scopes, applying lockouts with

--- a/src/middlewares/rate_limit.rs
+++ b/src/middlewares/rate_limit.rs
@@ -1,7 +1,7 @@
 use actix_web::{HttpRequest, web};
 use ipnet::{Ipv4Net, Ipv6Net};
 
-use crate::config::{AppConfig, LoginRateLimitConfig, login_rate_limit_config};
+use crate::config::{LoginRateLimitConfig, login_rate_limit_config};
 use crate::middlewares::client_allowlist::{ProxyTrust, extract_client_ip_from_http_request};
 
 #[cfg(test)]
@@ -352,8 +352,8 @@ pub(crate) async fn finish_login_attempt(permit: LoginAttemptPermit, outcome: Lo
 /// trust policy. Returns `None` when no address can be determined.
 pub(crate) fn client_ip_for_request(req: &HttpRequest) -> Option<IpAddr> {
     let policy = req
-        .app_data::<web::Data<AppConfig>>()
-        .map(|config| ProxyTrust::from_config(config))
+        .app_data::<web::Data<ProxyTrust>>()
+        .map(|policy| policy.get_ref().clone())
         .unwrap_or_default();
 
     extract_client_ip_from_http_request(req, &policy)

--- a/src/tests/api/v1/auth.rs
+++ b/src/tests/api/v1/auth.rs
@@ -4,6 +4,7 @@ mod tests {
     use crate::db::prelude::*;
     use crate::db::traits::ActiveTokens;
     use crate::db::{init_pool, with_connection};
+    use crate::middlewares::ProxyTrust;
     use crate::middlewares::rate_limit::{
         LOGIN_RATE_LIMIT_TEST_LOCK, reset_login_rate_limit_for_tests,
     };
@@ -512,6 +513,11 @@ mod tests {
         // Trust forwarded headers, but only behind the known proxy at 203.0.113.1.
         config.trust_ip_headers = true;
         config.trusted_proxies = "203.0.113.1/32".parse().unwrap();
+        let proxy_trust = ProxyTrust::new(
+            config.trust_ip_headers,
+            config.trusted_proxies.nets().to_vec(),
+            config.trusted_proxy_hops,
+        );
         let max_attempts = config.login_rate_limit_max_attempts;
         let pool = init_pool(&config.database_url, config.db_pool_size);
         let app = test::init_service(
@@ -519,7 +525,7 @@ mod tests {
                 .wrap(actix_web::middleware::from_fn(
                     crate::middlewares::actor_context,
                 ))
-                .app_data(Data::new(config.clone()))
+                .app_data(Data::new(proxy_trust))
                 .app_data(Data::new(pool.clone()))
                 .configure(api::config),
         )
@@ -572,6 +578,11 @@ mod tests {
         let mut config = get_config().unwrap();
         config.trust_ip_headers = true;
         config.trusted_proxies = "203.0.113.1/32".parse().unwrap();
+        let proxy_trust = ProxyTrust::new(
+            config.trust_ip_headers,
+            config.trusted_proxies.nets().to_vec(),
+            config.trusted_proxy_hops,
+        );
         let max_attempts = config.login_rate_limit_max_attempts;
         let pool = init_pool(&config.database_url, config.db_pool_size);
         let app = test::init_service(
@@ -579,7 +590,7 @@ mod tests {
                 .wrap(actix_web::middleware::from_fn(
                     crate::middlewares::actor_context,
                 ))
-                .app_data(Data::new(config.clone()))
+                .app_data(Data::new(proxy_trust))
                 .app_data(Data::new(pool.clone()))
                 .configure(api::config),
         )
@@ -630,6 +641,11 @@ mod tests {
         let mut config = get_config().unwrap();
         config.trust_ip_headers = true;
         config.trusted_proxies = "203.0.113.1/32".parse().unwrap();
+        let proxy_trust = ProxyTrust::new(
+            config.trust_ip_headers,
+            config.trusted_proxies.nets().to_vec(),
+            config.trusted_proxy_hops,
+        );
         let per_ip = config.login_rate_limit_max_attempts_per_ip;
         let pool = init_pool(&config.database_url, config.db_pool_size);
         let app = test::init_service(
@@ -637,7 +653,7 @@ mod tests {
                 .wrap(actix_web::middleware::from_fn(
                     crate::middlewares::actor_context,
                 ))
-                .app_data(Data::new(config.clone()))
+                .app_data(Data::new(proxy_trust))
                 .app_data(Data::new(pool.clone()))
                 .configure(api::config),
         )

--- a/src/tests/api/v1/event_deliveries.rs
+++ b/src/tests/api/v1/event_deliveries.rs
@@ -210,7 +210,7 @@ mod tests {
         let resp = get_request(
             &context.pool,
             &context.admin_token,
-            &format!("{DELIVERIES_ENDPOINT}?status=dead"),
+            &format!("{DELIVERIES_ENDPOINT}?id={}&status=dead", dead.id),
         )
         .await;
         let resp = assert_response_status(resp, StatusCode::OK).await;

--- a/src/tests/api/v1/mod.rs
+++ b/src/tests/api/v1/mod.rs
@@ -14,6 +14,7 @@ pub mod querying;
 pub mod relations;
 pub mod remote_targets;
 pub mod request_and_correlation;
+pub mod runtime_config;
 pub mod search;
 pub mod service_accounts;
 pub mod tasks;

--- a/src/tests/api/v1/runtime_config.rs
+++ b/src/tests/api/v1/runtime_config.rs
@@ -1,0 +1,49 @@
+#[cfg(test)]
+mod tests {
+    use actix_web::{App, http::StatusCode, test, web::Data};
+    use rstest::rstest;
+    use serde_json::Value;
+
+    use crate::api;
+    use crate::config::{get_config, running::RunningConfig};
+    use crate::tests::{TestContext, test_context};
+
+    async fn request(context: &TestContext, token: &str) -> actix_web::dev::ServiceResponse {
+        let config = get_config().unwrap();
+        let app = test::init_service(
+            App::new()
+                .app_data(context.pool.clone())
+                .app_data(Data::new(RunningConfig::from(&config)))
+                .configure(api::config),
+        )
+        .await;
+
+        test::TestRequest::get()
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .uri("/api/v1/admin/config")
+            .send_request(&app)
+            .await
+            .map_into_boxed_body()
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn admin_can_inspect_redacted_running_config(#[future(awt)] test_context: TestContext) {
+        let response = request(&test_context, &test_context.admin_token).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(response).await;
+        let serialized = serde_json::to_string(&body).unwrap();
+
+        assert_eq!(body["database"]["url"]["configured"], true);
+        assert!(body["database"]["pool_size"].is_number());
+        assert!(!serialized.contains("postgres://"));
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn non_admin_cannot_inspect_running_config(#[future(awt)] test_context: TestContext) {
+        let response = request(&test_context, &test_context.normal_token).await;
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/src/tests/client_allowlist.rs
+++ b/src/tests/client_allowlist.rs
@@ -13,11 +13,7 @@ mod tests {
 
     /// Trust forwarded headers behind a single trusted reverse proxy at `203.0.113.1`.
     fn trusts_proxy() -> ProxyTrust {
-        ProxyTrust {
-            trust_headers: true,
-            trusted_proxies: vec![IpNet::from_str("203.0.113.1/32").unwrap()],
-            hops: 0,
-        }
+        ProxyTrust::new(true, vec![IpNet::from_str("203.0.113.1/32").unwrap()], 0)
     }
 
     #[actix_web::test]


### PR DESCRIPTION
## Summary

- Resolve server configuration explicitly at startup and store the immutable result in OnceLock instead of a process-wide RwLock.
- Introduce consumer-owned database pool settings and inject ProxyTrust plus a redacted RunningConfig into Actix instead of the complete AppConfig.
- Add a declared environment registry with an owner and sensitivity classification for every Hubuum variable, explicit dynamic-secret namespaces, duration-unit validation, and a short allowlist of environment adapters.
- Enforce the registry across the root package and every workspace crate: clap mappings must match exactly, unknown HUBUUM_ references fail tests, and direct environment reads outside declared adapters fail tests.
- Add the admin-only GET /api/v1/admin/config endpoint and committed OpenAPI schema. Its response is an explicit deny-by-default projection: credentials, secret values, file paths, proxy networks, and allowlist contents are never returned.
- Remove AppConfig serialization and make its Debug implementation use the same redacted projection.
- Isolate the event-delivery status filter test to its own fixture after the faster main-branch fixtures exposed a parallel count/page race.

## Architecture

This is an incremental composition-root approach rather than a new global hubuum-config service locator. Environment and CLI mapping remain centralized, while consumers can progressively define narrow settings types with private fields. DatabasePoolSettings and ProxyTrust are the first migrated boundaries. The existing get_config compatibility accessor remains for consumers that need separate follow-up migrations.

The running-config API receives only the safe projection, not AppConfig, so adding a new configuration field cannot expose it accidentally.

## Related issues

- #88: advances explicit internal boundaries and provides the pattern for further consumer-owned settings; does not close the broader crate-boundary audit.
- #92: centralizes environment ownership and secret classification needed for consistent distributed deployment configuration; does not implement deployment roles or shared state.
- #117: explicit startup initialization is groundwork for lifecycle ownership, but graceful worker and pool shutdown remain out of scope.
- #53: the typed settings approach can carry a future login-rate-limit backend selection without distributing environment parsing; no backend behavior changes here.

## Verification

- source .env && ./run_tests.sh
  - 992 passed, 2 existing ignored; admin CLI, binary smoke, and doctests passed
- cargo clippy --all-targets -- -D warnings
- cargo fmt -- --check
- cargo run --quiet --bin hubuum-openapi > docs/openapi.json
- git diff --check