### PR TITLE
Harden container runtime and Compose defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Local Docker Compose only. Generate a unique value with:
+# openssl rand -hex 32
+POSTGRES_PASSWORD=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,33 @@
 # syntax=docker/dockerfile:1
-FROM rust:slim-trixie AS builder
+FROM docker.io/library/rust:1.96.0-slim-trixie@sha256:c37af730be4fd8104cbf9aedbd6ab259e51ca2d5437817a0f8680edf66ac6c28 AS builder
 
 ARG CARGO_BUILD_FLAGS="--locked --release"
+ARG CARGO_BINSTALL_VERSION="1.20.1"
+ARG CARGO_BINSTALL_SHA256_AMD64="f12954bc382e1d0b2df3fbfb217a05d92c25570e4517841e0613499a24f4594e"
+ARG CARGO_BINSTALL_SHA256_ARM64="23679581c4cfa1782953264a6e36965198aed995b3a5287550dd78a113ce2288"
+ARG DIESEL_CLI_VERSION="2.3.11"
+ARG TARGETARCH
 
 WORKDIR /usr/src/hubuum
 
-# Install system dependencies and cargo-binstall in one layer
+# Install build dependencies and a checksum-verified cargo-binstall release.
 RUN apt-get update && \
-    apt-get install -y pkg-config libpq-dev libpq5 libssl3 libssl-dev curl && \
+    apt-get install -y --no-install-recommends pkg-config libpq-dev libpq5 libssl3 libssl-dev curl ca-certificates && \
     rm -rf /var/lib/apt/lists/* && \
-    curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+    case "${TARGETARCH}" in \
+        amd64) binstall_target="x86_64-unknown-linux-musl"; binstall_sha256="${CARGO_BINSTALL_SHA256_AMD64}" ;; \
+        arm64) binstall_target="aarch64-unknown-linux-musl"; binstall_sha256="${CARGO_BINSTALL_SHA256_ARM64}" ;; \
+        *) echo "Unsupported build architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    curl -L --proto '=https' --tlsv1.2 -sSf \
+        "https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-${binstall_target}.tgz" \
+        -o /tmp/cargo-binstall.tgz && \
+    echo "${binstall_sha256}  /tmp/cargo-binstall.tgz" | sha256sum --check --strict && \
+    tar -xzf /tmp/cargo-binstall.tgz -C /usr/local/cargo/bin cargo-binstall && \
+    rm /tmp/cargo-binstall.tgz
 
-# Install diesel CLI using binstall (much faster)
-RUN cargo binstall --no-confirm diesel_cli
+# Install an explicit Diesel CLI release using binstall.
+RUN cargo binstall --no-confirm --disable-telemetry "diesel_cli@${DIESEL_CLI_VERSION}"
 
 # Copy manifests first for better layer caching. Workspace member manifests are
 # required for Cargo to load the workspace during the dependency-only build.
@@ -83,9 +98,17 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp target/release/hubuum-server /tmp/ && \
     cp target/release/hubuum-admin /tmp/
 
-FROM debian:trixie-slim
+FROM docker.io/library/debian:trixie-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
 
-RUN apt-get update && apt-get install -y libpq5 libssl3 postgresql-client && rm -rf /var/lib/apt/lists/*
+ARG HUBUUM_UID="10001"
+ARG HUBUUM_GID="10001"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl libpq5 libssl3 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --gid "${HUBUUM_GID}" hubuum && \
+    useradd --uid "${HUBUUM_UID}" --gid hubuum --no-create-home \
+        --home-dir /nonexistent --shell /usr/sbin/nologin hubuum
 
 COPY --from=builder /tmp/hubuum-server /usr/local/bin/hubuum-server
 COPY --from=builder /tmp/hubuum-admin /usr/local/bin/hubuum-admin
@@ -97,5 +120,10 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 EXPOSE 8080
+
+USER hubuum:hubuum
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD curl --fail --silent --show-error "http://127.0.0.1:${HUBUUM_BIND_PORT:-8080}/healthz" || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,28 +4,37 @@ services:
     ports:
       - "127.0.0.1:9999:8080"
     environment:
-      - HUBUUM_BIND_IP=0.0.0.0
-      - HUBUUM_DATABASE_URL=postgres://hubuum:hubuum_password@db/hubuum
-      - HUBUUM_LOG_LEVEL=debug
-      - DATABASE_URL=postgres://hubuum:hubuum_password@db/hubuum
+      HUBUUM_BIND_IP: 0.0.0.0
+      HUBUUM_CLIENT_ALLOWLIST: "*"
+      HUBUUM_DATABASE_URL: postgres://hubuum:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db/hubuum
+      HUBUUM_LOG_LEVEL: debug
+      DATABASE_URL: postgres://hubuum:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db/hubuum
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
 
   db:
     build:
       context: .
       dockerfile: docker/postgres/Dockerfile
     ports:
-      - "9998:5432"
+      - "127.0.0.1:9998:5432"
     environment:
-      - POSTGRES_USER=hubuum
-      - POSTGRES_PASSWORD=hubuum_password
-      - POSTGRES_DB=hubuum
-      - PGUSER=hubuum
+      POSTGRES_USER: hubuum
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: hubuum
+      PGUSER: hubuum
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U hubuum" ]
+      test: [ "CMD-SHELL", "pg_isready -U hubuum -d hubuum" ]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,6 +1,1 @@
-FROM postgres:17
-
-ENV POSTGRES_USER=hubuum \
-    POSTGRES_PASSWORD=hubuum_password \
-    POSTGRES_DB=hubuum \
-    PGUSER=hubuum
+FROM docker.io/library/postgres:17@sha256:0af65001d05296a2ead57ac4a6412433d8913d1bb5d0c88435a7d1e1ee5cb04b

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -15,6 +15,28 @@ Hubuum exposes unauthenticated probe endpoints for container schedulers and load
 
 Probe paths bypass the client IP allowlist so platform health checks are not rejected before reaching the handler.
 
+### Local Docker Compose
+
+The development Compose stack requires a local, untracked `.env` file instead
+of using a password committed to the repository:
+
+```bash
+cp .env.example .env
+printf 'POSTGRES_PASSWORD=%s\n' "$(openssl rand -hex 32)" > .env
+docker compose up --build
+```
+
+The API is published on `127.0.0.1:9999` and PostgreSQL on
+`127.0.0.1:9998`; neither service listens on all host interfaces by default.
+The Hubuum container runs as the unprivileged `hubuum` user with a read-only
+root filesystem, all Linux capabilities dropped, and only a small temporary
+filesystem at `/tmp`.
+
+The production image includes a `/healthz` health check and retains the pinned
+Diesel CLI solely for the existing startup migration workflow. PostgreSQL
+client administration tools are not installed in the runtime image. Set
+`HUBUUM_SKIP_MIGRATIONS=true` only when migrations are coordinated externally.
+
 ### Server Configuration
 
 | Variable | Default | Description |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ should_skip_migrations() {
 wait_for_db() {
     echo "Waiting for database to be ready..."
     if should_skip_migrations; then
-        while ! psql "$HUBUUM_DATABASE_URL" -c 'SELECT 1' >/dev/null 2>&1; do
+        while ! diesel migration list --migration-dir /migrations --database-url "$HUBUUM_DATABASE_URL" >/dev/null 2>&1; do
             echo "Database is unavailable - sleeping"
             sleep 1
         done
@@ -34,9 +34,6 @@ wait_for_db
 
 if should_skip_migrations; then
     echo "HUBUUM_SKIP_MIGRATIONS is set; skipping database migrations."
-else
-    echo "Running database migrations... (shouldn't be needed)"
-    diesel migration run --migration-dir /migrations --database-url "$HUBUUM_DATABASE_URL"
 fi
 
 # Start the application

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -646,6 +646,13 @@ fi
 cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
     container_name: hubuum-api
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     environment:
       HUBUUM_BIND_IP: ${HUBUUM_BIND_IP}
       HUBUUM_BIND_PORT: ${HUBUUM_BIND_PORT}

--- a/src/tests/container_build.rs
+++ b/src/tests/container_build.rs
@@ -61,3 +61,48 @@ fn dockerfile_copies_every_workspace_manifest() {
         "Dockerfile dependency-cache manifest COPY entries must exactly match Cargo workspace members"
     );
 }
+
+#[test]
+fn production_container_runs_as_non_root_with_a_healthcheck() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let dockerfile = fs::read_to_string(repository.join("Dockerfile"))
+        .expect("repository Dockerfile should be readable");
+
+    assert!(
+        dockerfile
+            .lines()
+            .any(|line| line.trim() == "USER hubuum:hubuum"),
+        "production Dockerfile must select the dedicated hubuum user"
+    );
+    assert!(
+        dockerfile.contains("HEALTHCHECK") && dockerfile.contains("/healthz"),
+        "production Dockerfile must probe the unauthenticated liveness endpoint"
+    );
+}
+
+#[test]
+fn container_build_tool_downloads_are_pinned_and_verified() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let dockerfile = fs::read_to_string(repository.join("Dockerfile"))
+        .expect("repository Dockerfile should be readable");
+
+    assert!(dockerfile.contains("CARGO_BINSTALL_VERSION=\"1.20.1\""));
+    assert!(dockerfile.contains("sha256sum --check --strict"));
+    assert!(dockerfile.contains("DIESEL_CLI_VERSION=\"2.3.11\""));
+    assert!(dockerfile.contains("diesel_cli@${DIESEL_CLI_VERSION}"));
+    assert!(
+        !dockerfile.contains("cargo-bins/cargo-binstall/main/install-from-binstall-release.sh"),
+        "Docker builds must not execute the mutable cargo-binstall bootstrap script"
+    );
+}
+
+#[test]
+fn development_compose_requires_a_local_password_and_loopback_database_port() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let compose = fs::read_to_string(repository.join("docker-compose.yml"))
+        .expect("repository docker-compose.yml should be readable");
+
+    assert!(compose.contains("${POSTGRES_PASSWORD:?"));
+    assert!(compose.contains("127.0.0.1:9998:5432"));
+    assert!(!compose.contains("hubuum_password"));
+}


### PR DESCRIPTION
## Summary

- run the production image as a dedicated `hubuum` user (UID/GID 10001)
- pin the Rust, Debian, and PostgreSQL images by version/digest
- install cargo-binstall 1.20.1 from architecture-specific release archives after SHA-256 verification
- pin diesel_cli 2.3.11 and remove the mutable remote-script bootstrap
- remove PostgreSQL client administration tools from the runtime image while preserving startup migrations through Diesel
- add a secret-free `/healthz` image health check
- require an untracked local Compose password and bind both API and PostgreSQL ports to loopback
- apply a read-only root filesystem, dropped capabilities, `no-new-privileges`, and a bounded `/tmp` tmpfs to development and single-host API containers
- add regression tests and local Compose setup documentation

## Runtime verification

The full production-feature image was built and inspected:

- configured user: `hubuum:hubuum`
- runtime identity: UID/GID 10001
- image health check: `/healthz`
- diesel CLI: 2.3.11
- `psql`: absent
- image size on arm64: 64,327,388 bytes

An isolated Compose stack then ran migrations and started successfully with the read-only filesystem and dropped capabilities. PostgreSQL and Hubuum became healthy, and `GET http://127.0.0.1:9999/healthz` returned `{"status":"ok"}`. The disposable containers, network, and volume were removed afterward.

## Verification

- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- container hardening regression tests
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `source .env && ./run_tests.sh` (`984 passed`, `2 ignored`; integration tests and doctests passed)
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `scripts/test-install-script-refresh.sh`
- `POSTGRES_PASSWORD=test-only docker compose config --quiet`
- production-feature `docker build`
- live Compose smoke test

## Sequencing

This branch is based on current `main`. PR #105 also changes the Dockerfile, so this PR will need a mechanical rebase after #105 lands; no #105 workspace changes are duplicated here.

Closes #114
