### PR TITLE
Gracefully shut down background workers

### DIFF
--- a/docs/background_workers.md
+++ b/docs/background_workers.md
@@ -1,0 +1,44 @@
+# Background Worker Lifecycle
+
+Hubuum owns its task, event fan-out, event delivery, retention, and PostgreSQL
+notification workers as one process lifecycle. Workers start only after database
+initialization and HTTP binding succeed. Every worker thread is named, retained,
+and given the same cancellation signal.
+
+## Graceful Shutdown
+
+Actix handles the operating-system shutdown signal and first stops accepting
+HTTP traffic. When the HTTP server finishes, Hubuum shuts down background work
+in this order:
+
+1. Request cancellation for every worker and notification listener.
+2. Wake polling sleeps and stop starting new database iterations.
+3. Cancel active event iterations. Claimed rows remain protected by their
+   existing claim timeout and can be reclaimed normally.
+4. Cancel an active task execution and mark its task failed with a sanitized
+   service-unavailable result instead of leaving it in an active state.
+5. Run `UNLISTEN` on PostgreSQL notification connections that remain open and
+   release them. An already-closed session has already released its listener.
+6. Join all named worker threads, bounded by 30 seconds.
+7. Drop the process database pool only after worker shutdown completes.
+
+The ordering ensures a worker cannot start new database work after pool
+shutdown begins. A worker that does not stop within the bound is logged by name;
+its pool clone remains alive, so the underlying pool cannot be dropped while
+that worker could still use it.
+
+Shutdown logs contain worker names, counts, elapsed time, and timeout status.
+They do not contain database URLs, credentials, event payloads, or task input.
+
+## PostgreSQL Notifications
+
+Event fan-out and delivery listeners select between the notification stream and
+the shared shutdown signal. This wakes an otherwise idle `LISTEN` connection
+immediately. The listener executes `UNLISTEN` before returning an open
+connection, and the process pool closes its sessions after all workers have
+joined.
+
+## Startup Failures
+
+Workers are not started if database initialization or HTTP binding fails. This
+prevents detached workers from surviving a failed server startup path.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -86,6 +86,10 @@ budgeting, pool observability, and a repeatable k6 scenario.
 | `HUBUUM_TASK_POLL_INTERVAL_MS` | `200` | Idle polling interval for background task workers |
 | `HUBUUM_IMPORT_MAX_ACTIVE_TASKS_PER_USER` | `100` | Maximum queued, validating, or running import tasks one user may have at once |
 
+Background workers and PostgreSQL notification listeners participate in
+bounded graceful shutdown. See [Background Worker Lifecycle](background_workers.md)
+for startup ownership, cancellation, task interruption, and pool-drop ordering.
+
 ### Event And Audit Configuration
 
 | Variable | Default | Description |

--- a/src/events/delivery.rs
+++ b/src/events/delivery.rs
@@ -1,6 +1,5 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Once, OnceLock};
-use std::thread;
 use std::time::Duration;
 
 use actix_rt::time::sleep;
@@ -21,6 +20,7 @@ use crate::db::traits::event_delivery::{
 };
 use crate::errors::ApiError;
 use crate::events::sink::{DefaultSinkResolver, EventEnvelope, SinkResolver};
+use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::{EventSink, EventSubscription, EventWorkerWakeupStats};
 
 static EVENT_DELIVERY_WORKER: Once = Once::new();
@@ -160,13 +160,20 @@ fn delivery_worker_should_continue(result: &Result<usize, ApiError>) -> bool {
     }
 }
 
-async fn wait_for_event_delivery_wakeup(poll_interval: Duration) {
+async fn wait_for_event_delivery_wakeup(
+    poll_interval: Duration,
+    shutdown: &ShutdownSignal,
+) -> bool {
     tokio::select! {
+        biased;
+        _ = shutdown.requested() => false,
         _ = sleep(poll_interval) => {
             EVENT_DELIVERY_POLL_WAKEUPS.fetch_add(1, Ordering::Relaxed);
+            true
         }
         _ = get_event_delivery_notify().notified() => {
             EVENT_DELIVERY_NOTIFICATION_WAKEUPS.fetch_add(1, Ordering::Relaxed);
+            true
         }
     }
 }
@@ -176,13 +183,20 @@ async fn event_delivery_worker_loop(
     settings: EventDeliverySettings,
     poll_interval: Duration,
     resolver: &'static dyn SinkResolver,
+    shutdown: ShutdownSignal,
 ) {
     loop {
-        let result = process_event_delivery_batch(&pool, settings, resolver).await;
+        let result = tokio::select! {
+            biased;
+            _ = shutdown.requested() => break,
+            result = process_event_delivery_batch(&pool, settings, resolver) => result,
+        };
         if delivery_worker_should_continue(&result) {
             continue;
         }
-        wait_for_event_delivery_wakeup(poll_interval).await;
+        if !wait_for_event_delivery_wakeup(poll_interval, &shutdown).await {
+            break;
+        }
     }
 }
 
@@ -193,9 +207,9 @@ fn spawn_event_delivery_worker_loop(
     worker_index: usize,
     resolver: &'static dyn SinkResolver,
 ) {
-    thread::Builder::new()
-        .name(format!("event-delivery-worker-{worker_index}"))
-        .spawn(move || {
+    spawn_background_worker(
+        format!("event-delivery-worker-{worker_index}"),
+        move |shutdown| {
             info!(
                 message = "Starting event delivery worker loop",
                 worker_index = worker_index,
@@ -212,9 +226,10 @@ fn spawn_event_delivery_worker_loop(
                 settings,
                 poll_interval,
                 resolver,
+                shutdown,
             ));
-        })
-        .expect("failed to spawn event delivery worker thread");
+        },
+    );
 }
 
 pub fn ensure_event_delivery_worker_running(pool: DbPool) {

--- a/src/events/fanout.rs
+++ b/src/events/fanout.rs
@@ -1,6 +1,5 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Once, OnceLock};
-use std::thread;
 use std::time::Duration;
 
 use actix_rt::time::sleep;
@@ -14,6 +13,7 @@ use crate::config::{
 use crate::db::DbPool;
 use crate::db::traits::event_fanout::{EventFanoutSettings, process_event_fanout_batch};
 use crate::errors::ApiError;
+use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::EventWorkerWakeupStats;
 
 static EVENT_FANOUT_WORKER: Once = Once::new();
@@ -66,13 +66,17 @@ pub(super) fn fanout_worker_should_continue(result: &Result<usize, ApiError>) ->
     }
 }
 
-async fn wait_for_event_fanout_wakeup(poll_interval: Duration) {
+async fn wait_for_event_fanout_wakeup(poll_interval: Duration, shutdown: &ShutdownSignal) -> bool {
     tokio::select! {
+        biased;
+        _ = shutdown.requested() => false,
         _ = sleep(poll_interval) => {
             EVENT_FANOUT_POLL_WAKEUPS.fetch_add(1, Ordering::Relaxed);
+            true
         }
         _ = get_event_fanout_notify().notified() => {
             EVENT_FANOUT_NOTIFICATION_WAKEUPS.fetch_add(1, Ordering::Relaxed);
+            true
         }
     }
 }
@@ -81,13 +85,20 @@ async fn event_fanout_worker_loop(
     pool: DbPool,
     settings: EventFanoutSettings,
     poll_interval: Duration,
+    shutdown: ShutdownSignal,
 ) {
     loop {
-        let result = process_event_fanout_batch(&pool, settings).await;
+        let result = tokio::select! {
+            biased;
+            _ = shutdown.requested() => break,
+            result = process_event_fanout_batch(&pool, settings) => result,
+        };
         if fanout_worker_should_continue(&result) {
             continue;
         }
-        wait_for_event_fanout_wakeup(poll_interval).await;
+        if !wait_for_event_fanout_wakeup(poll_interval, &shutdown).await {
+            break;
+        }
     }
 }
 
@@ -97,9 +108,9 @@ fn spawn_event_fanout_worker_loop(
     poll_interval: Duration,
     worker_index: usize,
 ) {
-    thread::Builder::new()
-        .name(format!("event-fanout-worker-{worker_index}"))
-        .spawn(move || {
+    spawn_background_worker(
+        format!("event-fanout-worker-{worker_index}"),
+        move |shutdown| {
             info!(
                 message = "Starting event fan-out worker loop",
                 worker_index = worker_index,
@@ -108,9 +119,14 @@ fn spawn_event_fanout_worker_loop(
                 poll_interval = ?poll_interval
             );
             let system = actix_rt::System::new();
-            system.block_on(event_fanout_worker_loop(pool, settings, poll_interval));
-        })
-        .expect("failed to spawn event fan-out worker thread");
+            system.block_on(event_fanout_worker_loop(
+                pool,
+                settings,
+                poll_interval,
+                shutdown,
+            ));
+        },
+    );
 }
 
 pub fn ensure_event_fanout_worker_running(pool: DbPool) {

--- a/src/events/pg_notify.rs
+++ b/src/events/pg_notify.rs
@@ -1,4 +1,3 @@
-use std::thread;
 use std::time::Duration;
 
 use crate::db::prelude::*;
@@ -6,6 +5,7 @@ use futures_util::StreamExt;
 use tracing::{debug, error, info};
 
 use crate::db::DbPool;
+use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 
 pub const EVENT_FANOUT_CHANNEL: &str = "hubuum_event_fanout";
 pub const EVENT_DELIVERY_CHANNEL: &str = "hubuum_event_delivery";
@@ -30,29 +30,42 @@ pub fn spawn_postgres_notification_listener(
     thread_name: &'static str,
     on_notification: fn(),
 ) {
-    thread::Builder::new()
-        .name(thread_name.to_string())
-        .spawn(move || {
-            let system = actix_rt::System::new();
-            system.block_on(listen_loop(pool, channel, on_notification));
-        })
-        .expect("failed to spawn Postgres notification listener thread");
+    spawn_background_worker(thread_name, move |shutdown| {
+        let system = actix_rt::System::new();
+        system.block_on(listen_loop(pool, channel, on_notification, || {}, shutdown));
+    });
 }
 
-async fn listen_loop(pool: DbPool, channel: &'static str, on_notification: fn()) {
+async fn listen_loop(
+    pool: DbPool,
+    channel: &'static str,
+    on_notification: fn(),
+    on_listening: fn(),
+    shutdown: ShutdownSignal,
+) {
     loop {
-        match pool.get().await {
+        let connection = tokio::select! {
+            biased;
+            _ = shutdown.requested() => break,
+            connection = pool.get() => connection,
+        };
+        match connection {
             Ok(mut conn) => {
-                if let Err(error) = diesel::sql_query(format!("LISTEN {channel}"))
-                    .execute(&mut conn)
-                    .await
-                {
+                let listen_result = tokio::select! {
+                    biased;
+                    _ = shutdown.requested() => break,
+                    result = diesel::sql_query(format!("LISTEN {channel}"))
+                        .execute(&mut conn) => result,
+                };
+                if let Err(error) = listen_result {
                     error!(
                         message = "Failed to register Postgres notification listener",
                         channel = channel,
                         error = %error
                     );
-                    actix_rt::time::sleep(Duration::from_secs(1)).await;
+                    if !wait_for_retry_or_shutdown(&shutdown).await {
+                        break;
+                    }
                     continue;
                 }
 
@@ -60,7 +73,20 @@ async fn listen_loop(pool: DbPool, channel: &'static str, on_notification: fn())
                     message = "Listening for Postgres event worker notifications",
                     channel = channel
                 );
-                poll_notifications(&mut conn, channel, on_notification).await;
+                on_listening();
+                if poll_notifications(&mut conn, channel, on_notification, &shutdown).await {
+                    if let Err(error) = diesel::sql_query(format!("UNLISTEN {channel}"))
+                        .execute(&mut conn)
+                        .await
+                    {
+                        info!(
+                            message = "Postgres notification connection closed during shutdown",
+                            channel = channel,
+                            error = %error
+                        );
+                    }
+                    break;
+                }
             }
             Err(error) => {
                 error!(
@@ -68,9 +94,19 @@ async fn listen_loop(pool: DbPool, channel: &'static str, on_notification: fn())
                     channel = channel,
                     error = %error
                 );
-                actix_rt::time::sleep(Duration::from_secs(1)).await;
+                if !wait_for_retry_or_shutdown(&shutdown).await {
+                    break;
+                }
             }
         }
+    }
+}
+
+async fn wait_for_retry_or_shutdown(shutdown: &ShutdownSignal) -> bool {
+    tokio::select! {
+        biased;
+        _ = shutdown.requested() => false,
+        _ = actix_rt::time::sleep(Duration::from_secs(1)) => true,
     }
 }
 
@@ -78,10 +114,19 @@ async fn poll_notifications(
     conn: &mut crate::db::DbConnection,
     channel: &'static str,
     on_notification: fn(),
-) {
+    shutdown: &ShutdownSignal,
+) -> bool {
     let notifications = conn.notifications_stream();
     futures_util::pin_mut!(notifications);
-    while let Some(notification) = notifications.next().await {
+    loop {
+        let notification = tokio::select! {
+            biased;
+            _ = shutdown.requested() => return true,
+            notification = notifications.next() => notification,
+        };
+        let Some(notification) = notification else {
+            return false;
+        };
         match notification {
             Ok(notification) if notification.channel == channel => {
                 debug!(
@@ -98,8 +143,82 @@ async fn poll_notifications(
                     channel = channel,
                     error = %error
                 );
-                return;
+                return false;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use diesel::sql_types::Text;
+
+    use crate::config::get_config;
+    use crate::db::init_pool;
+
+    use super::*;
+
+    const TEST_CHANNEL: &str = "hubuum_shutdown_listener_test";
+    static LISTENER_READY: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(QueryableByName)]
+    struct ListeningChannel {
+        #[diesel(sql_type = Text)]
+        channel: String,
+    }
+
+    fn mark_listener_ready() {
+        LISTENER_READY.fetch_add(1, Ordering::Release);
+    }
+
+    #[actix_rt::test]
+    async fn shutdown_releases_postgres_notification_listener() {
+        LISTENER_READY.store(0, Ordering::Relaxed);
+        let config = get_config().expect("test requires database configuration");
+        let listener_pool = init_pool(&config.database_url, 1);
+        let shutdown = ShutdownSignal::new();
+        let listener = actix_rt::spawn(listen_loop(
+            listener_pool.clone(),
+            TEST_CHANNEL,
+            || {},
+            mark_listener_ready,
+            shutdown.clone(),
+        ));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if AtomicUsize::load(&LISTENER_READY, Ordering::Acquire) > 0 {
+                    break;
+                }
+                actix_rt::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("listener should register promptly");
+
+        shutdown.request();
+        tokio::time::timeout(Duration::from_secs(1), listener)
+            .await
+            .expect("listener should stop promptly")
+            .expect("listener task should not panic");
+
+        let mut listener_connection = listener_pool
+            .get()
+            .await
+            .expect("listener connection should return to its pool");
+        let channels = diesel::sql_query("SELECT pg_listening_channels()::text AS channel")
+            .load::<ListeningChannel>(&mut listener_connection)
+            .await
+            .expect("listening channels should be queryable");
+        assert!(
+            channels.is_empty(),
+            "listener connection should UNLISTEN before returning to the pool: {:?}",
+            channels
+                .into_iter()
+                .map(|row| row.channel)
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/src/events/retention.rs
+++ b/src/events/retention.rs
@@ -3,7 +3,6 @@ use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
-use std::thread;
 use std::time::Duration;
 
 use actix_rt::time::sleep;
@@ -23,6 +22,7 @@ use crate::db::traits::event_retention::{
 };
 use crate::errors::ApiError;
 use crate::events::Event;
+use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 
 static EVENT_RETENTION_WORKER: std::sync::Once = std::sync::Once::new();
 
@@ -93,34 +93,43 @@ fn retention_worker_should_continue(result: &Result<EventRetentionPurgeSummary, 
     }
 }
 
-async fn event_retention_worker_loop(pool: DbPool, config: EventRetentionWorkerConfig) {
+async fn event_retention_worker_loop(
+    pool: DbPool,
+    config: EventRetentionWorkerConfig,
+    shutdown: ShutdownSignal,
+) {
     loop {
         let archive_path = config.file_archive_path().map(Path::new);
-        let result = process_event_retention_batch(&pool, config.settings, archive_path).await;
+        let result = tokio::select! {
+            biased;
+            _ = shutdown.requested() => break,
+            result = process_event_retention_batch(&pool, config.settings, archive_path) => result,
+        };
         if retention_worker_should_continue(&result) {
             continue;
         }
-        sleep(config.interval).await;
+        tokio::select! {
+            biased;
+            _ = shutdown.requested() => break,
+            _ = sleep(config.interval) => {}
+        }
     }
 }
 
 fn spawn_event_retention_worker_loop(pool: DbPool, config: EventRetentionWorkerConfig) {
-    thread::Builder::new()
-        .name("event-retention-worker".to_string())
-        .spawn(move || {
-            info!(
-                message = "Starting event retention worker loop",
-                event_retention_days = config.settings.event_retention_days,
-                delivery_retention_days = config.settings.delivery_retention_days,
-                batch_size = config.settings.batch_size,
-                interval = ?config.interval,
-                file_archive_enabled = config.file_archive_enabled,
-                archive_path_configured = config.archive_path.is_some()
-            );
-            let system = actix_rt::System::new();
-            system.block_on(event_retention_worker_loop(pool, config));
-        })
-        .expect("failed to spawn event retention worker thread");
+    spawn_background_worker("event-retention-worker", move |shutdown| {
+        info!(
+            message = "Starting event retention worker loop",
+            event_retention_days = config.settings.event_retention_days,
+            delivery_retention_days = config.settings.delivery_retention_days,
+            batch_size = config.settings.batch_size,
+            interval = ?config.interval,
+            file_archive_enabled = config.file_archive_enabled,
+            archive_path_configured = config.archive_path.is_some()
+        );
+        let system = actix_rt::System::new();
+        system.block_on(event_retention_worker_loop(pool, config, shutdown));
+    });
 }
 
 pub fn ensure_event_retention_worker_running(pool: DbPool) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub mod errors;
 pub mod events;
 pub mod exports;
 pub mod extractors;
+#[doc(hidden)]
+pub mod lifecycle;
 pub mod logger;
 pub mod macros;
 pub mod middlewares;

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -1,0 +1,243 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, LazyLock, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use tokio::sync::Notify;
+use tracing::{error, info, warn};
+
+const JOIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[derive(Clone, Debug)]
+pub struct ShutdownSignal {
+    state: Arc<ShutdownState>,
+}
+
+#[derive(Debug)]
+struct ShutdownState {
+    requested: AtomicBool,
+    notify: Notify,
+}
+
+impl ShutdownSignal {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Arc::new(ShutdownState {
+                requested: AtomicBool::new(false),
+                notify: Notify::new(),
+            }),
+        }
+    }
+
+    pub(crate) fn is_requested(&self) -> bool {
+        self.state.requested.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn request(&self) {
+        if !self.state.requested.swap(true, Ordering::AcqRel) {
+            self.state.notify.notify_waiters();
+        }
+    }
+
+    pub(crate) async fn requested(&self) {
+        loop {
+            let notified = self.state.notify.notified();
+            if self.is_requested() {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+struct NamedWorkerHandle {
+    name: String,
+    handle: JoinHandle<()>,
+}
+
+struct BackgroundWorkers {
+    shutdown: ShutdownSignal,
+    handles: Mutex<Vec<NamedWorkerHandle>>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ShutdownReport {
+    pub joined: usize,
+    pub panicked: Vec<String>,
+    pub timed_out: Vec<String>,
+}
+
+impl BackgroundWorkers {
+    fn new() -> Self {
+        Self {
+            shutdown: ShutdownSignal::new(),
+            handles: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn spawn<F>(&self, name: impl Into<String>, run: F)
+    where
+        F: FnOnce(ShutdownSignal) + Send + 'static,
+    {
+        let name = name.into();
+        let thread_name = name.clone();
+        let shutdown = self.shutdown.clone();
+        let handle = thread::Builder::new()
+            .name(thread_name.clone())
+            .spawn(move || {
+                run(shutdown);
+                info!(message = "Background worker stopped", worker = thread_name);
+            })
+            .unwrap_or_else(|error| panic!("failed to spawn {name}: {error}"));
+
+        self.handles
+            .lock()
+            .expect("background worker handle lock poisoned")
+            .push(NamedWorkerHandle { name, handle });
+    }
+
+    async fn shutdown(&self, timeout: Duration) -> ShutdownReport {
+        let started_at = Instant::now();
+        self.shutdown.request();
+        let mut handles = {
+            let mut handles = self
+                .handles
+                .lock()
+                .expect("background worker handle lock poisoned");
+            std::mem::take(&mut *handles)
+        };
+        let worker_count = handles.len();
+        info!(
+            message = "Background worker shutdown started",
+            worker_count,
+            timeout_ms = timeout.as_millis()
+        );
+
+        while handles.iter().any(|worker| !worker.handle.is_finished())
+            && started_at.elapsed() < timeout
+        {
+            tokio::time::sleep(
+                JOIN_POLL_INTERVAL.min(timeout.saturating_sub(started_at.elapsed())),
+            )
+            .await;
+        }
+
+        let mut report = ShutdownReport::default();
+        for worker in handles.drain(..) {
+            if !worker.handle.is_finished() {
+                report.timed_out.push(worker.name);
+                continue;
+            }
+            match worker.handle.join() {
+                Ok(()) => report.joined += 1,
+                Err(_) => report.panicked.push(worker.name),
+            }
+        }
+
+        if report.panicked.is_empty() && report.timed_out.is_empty() {
+            info!(
+                message = "Background worker shutdown completed",
+                joined = report.joined,
+                elapsed_ms = started_at.elapsed().as_millis()
+            );
+        } else {
+            if !report.panicked.is_empty() {
+                error!(
+                    message = "Background workers panicked during shutdown",
+                    workers = ?report.panicked
+                );
+            }
+            if !report.timed_out.is_empty() {
+                warn!(
+                    message = "Background worker shutdown timed out",
+                    workers = ?report.timed_out,
+                    timeout_ms = timeout.as_millis()
+                );
+            }
+        }
+
+        report
+    }
+}
+
+static BACKGROUND_WORKERS: LazyLock<BackgroundWorkers> = LazyLock::new(BackgroundWorkers::new);
+
+pub fn spawn_background_worker<F>(name: impl Into<String>, run: F)
+where
+    F: FnOnce(ShutdownSignal) + Send + 'static,
+{
+    BACKGROUND_WORKERS.spawn(name, run);
+}
+
+pub async fn shutdown_background_workers(timeout: Duration) -> ShutdownReport {
+    BACKGROUND_WORKERS.shutdown(timeout).await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::*;
+
+    #[actix_rt::test]
+    async fn shutdown_joins_an_idle_worker() {
+        let workers = BackgroundWorkers::new();
+        workers.spawn("idle-worker", |shutdown| {
+            actix_rt::System::new().block_on(shutdown.requested());
+        });
+
+        let report = workers.shutdown(Duration::from_secs(1)).await;
+
+        assert_eq!(report.joined, 1);
+        assert!(report.panicked.is_empty());
+        assert!(report.timed_out.is_empty());
+    }
+
+    #[actix_rt::test]
+    async fn shutdown_interrupts_a_worker_in_polling_sleep() {
+        let workers = BackgroundWorkers::new();
+        workers.spawn("sleeping-worker", |shutdown| {
+            actix_rt::System::new().block_on(async move {
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_secs(60)) => {}
+                    _ = shutdown.requested() => {}
+                }
+            });
+        });
+
+        let report = workers.shutdown(Duration::from_secs(1)).await;
+
+        assert_eq!(report.joined, 1);
+        assert!(report.timed_out.is_empty());
+    }
+
+    #[actix_rt::test]
+    async fn shutdown_cancels_an_in_progress_iteration() {
+        let workers = BackgroundWorkers::new();
+        let iteration_dropped = Arc::new(AtomicBool::new(false));
+        let dropped = iteration_dropped.clone();
+        workers.spawn("busy-worker", move |shutdown| {
+            struct DropMarker(Arc<AtomicBool>);
+            impl Drop for DropMarker {
+                fn drop(&mut self) {
+                    self.0.store(true, Ordering::Release);
+                }
+            }
+
+            actix_rt::System::new().block_on(async move {
+                let marker = DropMarker(dropped);
+                tokio::select! {
+                    _ = std::future::pending::<()>() => {}
+                    _ = shutdown.requested() => {}
+                }
+                drop(marker);
+            });
+        });
+
+        let report = workers.shutdown(Duration::from_secs(1)).await;
+
+        assert_eq!(report.joined, 1);
+        assert!(iteration_dropped.load(Ordering::Acquire));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod errors;
 pub mod events;
 mod exports;
 mod extractors;
+mod lifecycle;
 mod logger;
 mod macros;
 mod middlewares;
@@ -29,6 +30,7 @@ use utoipa::OpenApi;
 #[cfg(feature = "swagger-ui")]
 use utoipa_swagger_ui::SwaggerUi;
 
+use std::time::Duration;
 use tracing::{info, warn};
 
 use crate::api::openapi::openapi_json as openapi_json_handler;
@@ -46,6 +48,7 @@ use crate::events::{
     ensure_event_delivery_worker_running, ensure_event_fanout_worker_running,
     ensure_event_retention_worker_running,
 };
+use crate::lifecycle::shutdown_background_workers;
 use crate::tasks::ensure_task_worker_running;
 use crate::utilities::is_valid_log_level;
 
@@ -127,11 +130,6 @@ async fn main() -> std::io::Result<()> {
             }
         };
 
-    ensure_task_worker_running(pool.clone());
-    ensure_event_fanout_worker_running(pool.clone());
-    ensure_event_delivery_worker_running(pool.clone());
-    ensure_event_retention_worker_running(pool.clone());
-
     let client_allowlist = config.client_allowlist.clone();
     let proxy_trust = middlewares::ProxyTrust::new(
         config.trust_ip_headers,
@@ -141,6 +139,7 @@ async fn main() -> std::io::Result<()> {
     let running_config = RunningConfig::from(&config);
     let metrics_enabled = config.metrics_enabled;
     let metrics_path = config.metrics_path.clone();
+    let app_pool = pool.clone();
 
     let server = HttpServer::new(move || {
         let app = App::new()
@@ -156,7 +155,7 @@ async fn main() -> std::io::Result<()> {
             ))
             .app_data(Data::new(proxy_trust.clone()))
             .app_data(Data::new(running_config.clone()))
-            .app_data(Data::new(pool.clone()))
+            .app_data(Data::new(app_pool.clone()))
             .app_data(JsonConfig::default().error_handler(json_error_handler))
             .route("/api-doc/openapi.json", web::get().to(openapi_json_handler));
 
@@ -206,6 +205,11 @@ async fn main() -> std::io::Result<()> {
         _ => server.bind(&bind_address)?,
     };
 
+    ensure_task_worker_running(pool.clone());
+    ensure_event_fanout_worker_running(pool.clone());
+    ensure_event_delivery_worker_running(pool.clone());
+    ensure_event_retention_worker_running(pool.clone());
+
     info!(
         message = "server startup",
         version = env!("CARGO_PKG_VERSION"),
@@ -223,5 +227,8 @@ async fn main() -> std::io::Result<()> {
         active_event_sinks,
     );
 
-    server.workers(config.actix_workers).run().await
+    let result = server.workers(config.actix_workers).run().await;
+    shutdown_background_workers(Duration::from_secs(30)).await;
+    drop(pool);
+    result
 }

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -343,7 +343,7 @@ async fn test_process_one_task_marks_claimed_task_failed_when_execution_setup_er
     .unwrap();
 
     for _ in 0..20 {
-        let _ = (process_one_task(&context.pool)).await.unwrap();
+        let _ = (process_one_task(&context.pool, None)).await.unwrap();
 
         let stored = (task.find_record(&context.pool)).await.unwrap();
         if stored.status == TaskStatus::Failed.as_str() {
@@ -1536,7 +1536,7 @@ async fn test_process_one_task_export_failure_marks_single_failed_item() {
     .unwrap();
 
     for _ in 0..20 {
-        let _ = (process_one_task(&context.pool)).await.unwrap();
+        let _ = (process_one_task(&context.pool, None)).await.unwrap();
         let stored = (task.find_record(&context.pool)).await.unwrap();
         if stored.status == TaskStatus::Failed.as_str() {
             assert_eq!(stored.total_items, 0);

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -1,5 +1,4 @@
 use std::sync::{Mutex, Once, OnceLock};
-use std::thread;
 use std::time::{Duration, Instant};
 
 use actix_rt::time::sleep;
@@ -14,6 +13,7 @@ use crate::db::traits::task::{
 };
 use crate::errors::ApiError;
 use crate::exports::execute_export_task;
+use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::{NewTaskEventRecord, TaskKind, TaskRecord, TaskResultCounts, TaskStatus};
 use crate::observability::metrics;
 
@@ -56,39 +56,48 @@ pub(super) fn background_worker_action(result: &Result<bool, ApiError>) -> Worke
     }
 }
 
-async fn wait_for_task_worker_wakeup(poll_interval: Duration) {
+async fn wait_for_task_worker_wakeup(poll_interval: Duration, shutdown: &ShutdownSignal) -> bool {
     tokio::select! {
-        _ = sleep(poll_interval) => {}
-        _ = get_task_worker_notify().notified() => {}
+        biased;
+        _ = shutdown.requested() => false,
+        _ = sleep(poll_interval) => true,
+        _ = get_task_worker_notify().notified() => true,
     }
 }
 
-async fn task_worker_loop(pool: DbPool, poll_interval: Duration) {
+async fn task_worker_loop(pool: DbPool, poll_interval: Duration, shutdown: ShutdownSignal) {
     loop {
-        let result = process_one_task(&pool).await;
+        if shutdown.is_requested() {
+            break;
+        }
+        let result = process_one_task(&pool, Some(&shutdown)).await;
+        if shutdown.is_requested() {
+            break;
+        }
         match background_worker_action(&result) {
             WorkerLoopAction::Continue => continue,
-            WorkerLoopAction::Sleep => wait_for_task_worker_wakeup(poll_interval).await,
+            WorkerLoopAction::Sleep => {
+                if !wait_for_task_worker_wakeup(poll_interval, &shutdown).await {
+                    break;
+                }
+            }
         }
     }
 }
 
 fn spawn_task_worker_loop(pool: DbPool, poll_interval: Duration, worker_index: usize) {
-    thread::Builder::new()
-        .name(format!("task-worker-{worker_index}"))
-        .spawn(move || {
-            info!(
-                message = "Starting task worker loop",
-                worker_index = worker_index,
-                poll_interval = ?poll_interval
-            );
-            let system = actix_rt::System::new();
-            system.block_on(async move {
-                let pool = task_worker_pool(pool);
-                task_worker_loop(pool, poll_interval).await;
-            });
-        })
-        .expect("failed to spawn task worker thread");
+    spawn_background_worker(format!("task-worker-{worker_index}"), move |shutdown| {
+        info!(
+            message = "Starting task worker loop",
+            worker_index = worker_index,
+            poll_interval = ?poll_interval
+        );
+        let system = actix_rt::System::new();
+        system.block_on(async move {
+            let pool = task_worker_pool(pool);
+            task_worker_loop(pool, poll_interval, shutdown).await;
+        });
+    });
 }
 
 #[cfg(not(test))]
@@ -128,7 +137,10 @@ pub fn kick_task_worker(pool: DbPool) {
     get_task_worker_notify().notify_one();
 }
 
-pub(super) async fn process_one_task(pool: &DbPool) -> Result<bool, ApiError> {
+pub(super) async fn process_one_task(
+    pool: &DbPool,
+    shutdown: Option<&ShutdownSignal>,
+) -> Result<bool, ApiError> {
     if let Err(error) = maybe_cleanup_expired_export_outputs(pool).await {
         metrics::task_worker_iteration("error");
         return Err(error);
@@ -157,7 +169,19 @@ pub(super) async fn process_one_task(pool: &DbPool) -> Result<bool, ApiError> {
         worker = std::thread::current().name().unwrap_or("task-worker")
     );
 
-    if let Err(err) = process_claimed_task(pool, &task).await {
+    let result = match shutdown {
+        Some(shutdown) => {
+            tokio::select! {
+                biased;
+                _ = shutdown.requested() => Err(ApiError::ServiceUnavailable(
+                    "Task interrupted by graceful server shutdown".to_string(),
+                )),
+                result = process_claimed_task(pool, &task) => result,
+            }
+        }
+        None => process_claimed_task(pool, &task).await,
+    };
+    if let Err(err) = result {
         mark_claimed_task_failed(pool, &task, &err).await?;
     }
 


### PR DESCRIPTION
## Summary

- own task, fan-out, delivery, retention, and PostgreSQL notification threads through a shared lifecycle registry
- propagate a race-safe cancellation signal through polling sleeps and active worker iterations, then join named workers with a 30-second bound before dropping the database pool
- mark a claimed task failed when graceful shutdown interrupts its execution, and release PostgreSQL `LISTEN` registrations during listener shutdown
- start background workers only after the HTTP listener binds successfully
- document worker startup, cancellation, timeout, and pool-drop ordering

## Behavior

Actix stops the HTTP server first. Hubuum then requests cancellation for every registered background worker, wakes idle pollers and listeners, waits for named worker threads to finish, logs any panic or timeout by worker name, and drops the process pool only after that shutdown phase. A timed-out worker retains its pool clone, preventing physical pool destruction while it may still be using a connection.

The PostgreSQL regression test observes successful `LISTEN` registration, requests cancellation, verifies prompt listener completion, reacquires the same one-connection pool, and confirms no listening channels remain.

## Integration

#124 has merged. This PR is rebased onto `main` and retains the typed runtime configuration changes at the server composition root.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `source .env && ./run_tests.sh` (1004 passed, 2 ignored; 6 admin CLI tests, 3 binary smoke tests, and 2 doctests passed)
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `git diff --check origin/main...HEAD`

Closes #117
