### PR TITLE
Build self-contained and hardened images and release artifacts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Local Docker Compose only. Generate a unique value with:
+# openssl rand -hex 32
+POSTGRES_PASSWORD=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,19 @@ jobs:
     name: Container build (production features)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_DB: hubuum_container_test
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d hubuum_container_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -400,12 +413,74 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          load: true
           push: false
+          tags: hubuum-server:ci
           build-args: |
             CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release
             HUBUUM_BUILD_GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Export static release binaries
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          target: release-artifacts
+          outputs: type=local,dest=dist/release-smoke
+          build-args: |
+            CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release
+            HUBUUM_BUILD_GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+      - name: Verify exported release binaries
+        run: |
+          for binary in dist/release-smoke/hubuum-server dist/release-smoke/hubuum-admin; do
+            if readelf --dynamic "$binary" | grep --quiet '(NEEDED)'; then
+              echo "$binary unexpectedly has dynamic runtime dependencies" >&2
+              readelf --dynamic "$binary" >&2
+              exit 1
+            fi
+            "$binary" --version
+          done
+      - name: Test embedded database migrations and readiness
+        env:
+          IMAGE: hubuum-server:ci
+          DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/hubuum_container_test?sslmode=disable
+        run: |
+          docker run --rm --entrypoint hubuum-admin "$IMAGE" --help \
+            | grep --quiet -- "--migrate"
+          docker run --rm --network host \
+            --entrypoint hubuum-admin \
+            --env HUBUUM_DATABASE_URL="$DATABASE_URL" \
+            "$IMAGE" --migrate
+          docker run --rm --network host \
+            --entrypoint hubuum-admin \
+            --env HUBUUM_DATABASE_URL="$DATABASE_URL" \
+            "$IMAGE" --database-ready
+          test "$(docker run --rm --network host \
+            --env PGPASSWORD=postgres \
+            postgres:18 psql \
+            --host 127.0.0.1 \
+            --username postgres \
+            --dbname hubuum_container_test \
+            --tuples-only \
+            --no-align \
+            --command "SELECT to_regclass('public.users') IS NOT NULL")" = "t"
+          container_id="$(docker run --rm --detach --network host \
+            --env HUBUUM_DATABASE_URL="$DATABASE_URL" \
+            --env HUBUUM_BIND_IP=127.0.0.1 \
+            "$IMAGE")"
+          trap 'docker stop "$container_id"' EXIT
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:8080/readyz; then
+              break
+            fi
+            if [[ "$attempt" == 30 ]]; then
+              docker logs "$container_id"
+              exit 1
+            fi
+            sleep 1
+          done
 
   verify-tag-main-ci-success:
     name: Verify tagged commit already passed CI on main
@@ -462,31 +537,80 @@ jobs:
       - name: Check release metadata
         run: ./scripts/check-release-readiness.sh "${GITHUB_REF_NAME}"
 
-  build-tag-artifacts:
-    name: Build release artifacts (${{ matrix.platform.name }})
+  build-tag-linux-artifacts:
+    name: Build static release artifacts (${{ matrix.platform.name }})
     if: startsWith(github.ref, 'refs/tags/v')
     needs: validate-tag-release
-    runs-on: ${{ matrix.platform.os }}
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
       matrix:
         platform:
           - name: Linux-x86_64
-            target: x86_64-unknown-linux-gnu
+            arch: amd64
             os_name: linux-x86_64
-            os: ubuntu-24.04
+            runner: ubuntu-24.04
           - name: Linux-aarch64
-            target: aarch64-unknown-linux-gnu
+            arch: arm64
             os_name: linux-aarch64
-            os: ubuntu-24.04-arm
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Export stripped static binaries
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          target: release-artifacts
+          platforms: linux/${{ matrix.platform.arch }}
+          outputs: type=local,dest=dist/bin
+          build-args: |
+            CARGO_BUILD_FLAGS=--all-features --locked --release
+            HUBUUM_BUILD_GIT_SHA=${{ github.sha }}
+          cache-from: type=gha,scope=static-${{ matrix.platform.os_name }}-all-features
+          cache-to: type=gha,mode=max,scope=static-${{ matrix.platform.os_name }}-all-features
+      - name: Verify static linkage and package release archive
+        shell: bash
+        run: |
+          for binary in dist/bin/hubuum-server dist/bin/hubuum-admin; do
+            if readelf --dynamic "$binary" | grep --quiet '(NEEDED)'; then
+              echo "$binary unexpectedly has dynamic runtime dependencies" >&2
+              readelf --dynamic "$binary" >&2
+              exit 1
+            fi
+            "$binary" --version
+          done
+          archive_name="hubuum-${{ matrix.platform.os_name }}-all-features-${GITHUB_REF_NAME}.tar.gz"
+          tar czvf "dist/${archive_name}" -C dist/bin hubuum-server hubuum-admin
+          shasum -a 256 "dist/${archive_name}" > "dist/${archive_name}.sha256"
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-${{ matrix.platform.os_name }}
+          path: |
+            dist/*.tar.gz
+            dist/*.sha256
+
+  build-tag-native-artifacts:
+    name: Build native release artifacts (${{ matrix.platform.name }})
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: validate-tag-release
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
           - name: Windows-x86_64
             target: x86_64-pc-windows-msvc
             os_name: windows-x86_64
-            os: windows-latest
+            runner: windows-latest
           - name: macOS-ARM64
             target: aarch64-apple-darwin
             os_name: macos-aarch64
-            os: macos-latest
+            runner: macos-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -502,41 +626,41 @@ jobs:
         with:
           shared-key: ${{ matrix.platform.target }}-stable-release
       
-      - name: Install Linux dependencies
-        if: contains(matrix.platform.os, 'ubuntu')
-        run: |
-          sudo apt-get update --yes
-          sudo apt-get install --yes libsqlite3-dev libmysqlclient-dev libpq-dev libssl-dev
-      
-      - name: Install macOS dependencies
-        if: contains(matrix.platform.os, 'macos')
-        run: |
-          brew install postgresql@17 mysql-client
-          # Configure library paths for linking
-          echo "LIBRARY_PATH=$(brew --prefix postgresql@17)/lib:${LIBRARY_PATH:-}" >> "$GITHUB_ENV"
-          echo "PKG_CONFIG_PATH=$(brew --prefix postgresql@17)/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
-
-      - name: Install Windows PostgreSQL libraries
-        if: contains(matrix.platform.os, 'windows')
-        shell: pwsh
-        run: |
-          choco install postgresql --params '"/Password:postgres"' --no-progress -y
-          $pgRoot = Get-ChildItem 'C:\Program Files\PostgreSQL' -Directory | Sort-Object Name -Descending | Select-Object -First 1
-          if (-not $pgRoot) { throw 'PostgreSQL installation directory not found' }
-          $libPath = Join-Path $pgRoot.FullName 'lib'
-          if (-not (Test-Path (Join-Path $libPath 'libpq.lib'))) { throw "libpq.lib not found in $libPath" }
-          "LIB=$libPath;$env:LIB" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-      
-      - name: Build release binaries (native, all features)
-        if: "!contains(matrix.platform.os, 'windows')"
+      - name: Build release binaries (macOS, all features)
+        if: contains(matrix.platform.os_name, 'macos')
+        env:
+          HUBUUM_BUILD_GIT_SHA: ${{ github.sha }}
         run: cargo build --all-features --locked --release --target ${{ matrix.platform.target }}
 
-      - name: Build release binaries (Windows, full release feature set)
-        if: contains(matrix.platform.os, 'windows')
-        run: cargo build -F tls-rustls,amqp,email,valkey --locked --release --target ${{ matrix.platform.target }}
+      - name: Build release binaries (Windows, self-contained feature set)
+        if: contains(matrix.platform.os_name, 'windows')
+        env:
+          HUBUUM_BUILD_GIT_SHA: ${{ github.sha }}
+        run: cargo build -F tls-rustls,amqp,email,valkey,embedded-migrations,vendored-openssl --locked --release --target ${{ matrix.platform.target }}
+
+      - name: Verify macOS runtime dependencies
+        if: contains(matrix.platform.os_name, 'macos')
+        shell: bash
+        run: |
+          for binary in hubuum-server hubuum-admin; do
+            binary_path="target/${{ matrix.platform.target }}/release/${binary}"
+            "$binary_path" --version
+            if xcrun otool -L "$binary_path" | grep --extended-regexp --quiet '(/opt/homebrew|/usr/local/opt|libpq|libssl|libcrypto)'; then
+              echo "$binary unexpectedly depends on a package-manager library" >&2
+              xcrun otool -L "$binary_path" >&2
+              exit 1
+            fi
+          done
+
+      - name: Verify Windows binaries start without third-party DLLs
+        if: contains(matrix.platform.os_name, 'windows')
+        shell: pwsh
+        run: |
+          & "target/${{ matrix.platform.target }}/release/hubuum-server.exe" --version
+          & "target/${{ matrix.platform.target }}/release/hubuum-admin.exe" --version
       
       - name: Package release archive (Unix)
-        if: "!contains(matrix.platform.os, 'windows')"
+        if: contains(matrix.platform.os_name, 'macos')
         shell: bash
         run: |
           mkdir -p dist
@@ -546,7 +670,7 @@ jobs:
           shasum -a 256 "${archive_name}" > "${archive_name}.sha256"
       
       - name: Package release archive (Windows)
-        if: contains(matrix.platform.os, 'windows')
+        if: contains(matrix.platform.os_name, 'windows')
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path dist
@@ -564,7 +688,9 @@ jobs:
   publish-github-release:
     name: Publish GitHub release
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: build-tag-artifacts
+    needs:
+      - build-tag-linux-artifacts
+      - build-tag-native-artifacts
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -595,8 +721,8 @@ jobs:
           body_path: /tmp/release-notes.md
           files: dist/*
 
-  build-main-artifacts:
-    name: Build main artifacts (${{ matrix.platform.os_name }}, ${{ matrix.feature.ext }})
+  build-main-linux-artifacts:
+    name: Build static main artifacts (${{ matrix.platform.os_name }}, ${{ matrix.feature.ext }})
     if: github.ref == 'refs/heads/main'
     needs:
       - lint
@@ -610,21 +736,81 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - target: x86_64-unknown-linux-gnu
+          - arch: amd64
             os_name: linux-x86_64
-            os: ubuntu-24.04
             runner: ubuntu-24.04
-          - target: aarch64-unknown-linux-gnu
+          - arch: arm64
             os_name: linux-aarch64
-            os: ubuntu-24.04-arm
             runner: ubuntu-24.04-arm
+        feature:
+          - extra_args: "--all-features"
+            ext: all-features
+          - extra_args: "--no-default-features"
+            ext: no-tls
+          - extra_args: "-F tls-openssl"
+            ext: tls-openssl
+          - extra_args: "-F tls-rustls"
+            ext: tls-rustls
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Export stripped static binaries
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          target: release-artifacts
+          platforms: linux/${{ matrix.platform.arch }}
+          outputs: type=local,dest=dist/bin
+          build-args: |
+            CARGO_BUILD_FLAGS=${{ matrix.feature.extra_args }} --locked --release
+            HUBUUM_BUILD_GIT_SHA=${{ github.sha }}
+          cache-from: type=gha,scope=static-${{ matrix.platform.os_name }}-${{ matrix.feature.ext }}
+          cache-to: type=gha,mode=max,scope=static-${{ matrix.platform.os_name }}-${{ matrix.feature.ext }}
+      - name: Verify static linkage and package main archive
+        shell: bash
+        run: |
+          for binary in dist/bin/hubuum-server dist/bin/hubuum-admin; do
+            if readelf --dynamic "$binary" | grep --quiet '(NEEDED)'; then
+              echo "$binary unexpectedly has dynamic runtime dependencies" >&2
+              readelf --dynamic "$binary" >&2
+              exit 1
+            fi
+            "$binary" --version
+          done
+          archive_name="hubuum-${{ matrix.platform.os_name }}-${{ matrix.feature.ext }}-main.tar.gz"
+          tar czvf "dist/${archive_name}" -C dist/bin hubuum-server hubuum-admin
+          shasum -a 256 "dist/${archive_name}" > "dist/${archive_name}.sha256"
+      - name: Upload main artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: main-${{ matrix.platform.os_name }}-${{ matrix.feature.ext }}
+          path: |
+            dist/*.tar.gz
+            dist/*.sha256
+
+  build-main-native-artifacts:
+    name: Build native main artifacts (${{ matrix.platform.os_name }}, ${{ matrix.feature.ext }})
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - lint
+      - release-metadata
+      - openapi-contract
+      - feature-permutations
+      - test
+      - all-features-release-build
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
           - target: x86_64-pc-windows-msvc
             os_name: windows-x86_64
-            os: windows-latest
             runner: windows-latest
           - target: aarch64-apple-darwin
             os_name: macos-aarch64
-            os: macos-latest
             runner: macos-latest
         feature:
           - extra_args: "--all-features"
@@ -636,7 +822,6 @@ jobs:
           - extra_args: "-F tls-rustls"
             ext: tls-rustls
         exclude:
-          # tls-openssl requires libssl which is not straightforward on Windows
           - platform: { os_name: windows-x86_64 }
             feature: { ext: tls-openssl }
           - platform: { os_name: windows-x86_64 }
@@ -652,32 +837,31 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.platform.target }}-stable-release
-      - name: Install Linux dependencies
-        if: contains(matrix.platform.os, 'ubuntu')
+      - name: Build self-contained main binaries
+        env:
+          HUBUUM_BUILD_GIT_SHA: ${{ github.sha }}
+        run: cargo build ${{ matrix.feature.extra_args }} -F embedded-migrations,vendored-openssl --locked --release --target ${{ matrix.platform.target }}
+      - name: Verify macOS runtime dependencies
+        if: contains(matrix.platform.os_name, 'macos')
+        shell: bash
         run: |
-          sudo apt-get update --yes
-          sudo apt-get install --yes libsqlite3-dev libmysqlclient-dev libpq-dev libssl-dev
-      - name: Install macOS dependencies
-        if: contains(matrix.platform.os, 'macos')
-        run: |
-          brew install postgresql@17 openssl@3
-          # Configure library paths for linking
-          echo "LIBRARY_PATH=$(brew --prefix postgresql@17)/lib:$(brew --prefix openssl@3)/lib:${LIBRARY_PATH:-}" >> "$GITHUB_ENV"
-          echo "PKG_CONFIG_PATH=$(brew --prefix postgresql@17)/lib/pkgconfig:$(brew --prefix openssl@3)/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
-      - name: Install Windows PostgreSQL libraries
-        if: contains(matrix.platform.os, 'windows')
+          for binary in hubuum-server hubuum-admin; do
+            binary_path="target/${{ matrix.platform.target }}/release/${binary}"
+            "$binary_path" --version
+            if xcrun otool -L "$binary_path" | grep --extended-regexp --quiet '(/opt/homebrew|/usr/local/opt|libpq|libssl|libcrypto)'; then
+              echo "$binary unexpectedly depends on a package-manager library" >&2
+              xcrun otool -L "$binary_path" >&2
+              exit 1
+            fi
+          done
+      - name: Verify Windows binaries start without third-party DLLs
+        if: contains(matrix.platform.os_name, 'windows')
         shell: pwsh
         run: |
-          choco install postgresql --params '"/Password:postgres"' --no-progress -y
-          $pgRoot = Get-ChildItem 'C:\Program Files\PostgreSQL' -Directory | Sort-Object Name -Descending | Select-Object -First 1
-          if (-not $pgRoot) { throw 'PostgreSQL installation directory not found' }
-          $libPath = Join-Path $pgRoot.FullName 'lib'
-          if (-not (Test-Path (Join-Path $libPath 'libpq.lib'))) { throw "libpq.lib not found in $libPath" }
-          "LIB=$libPath;$env:LIB" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-      - name: Build main binaries
-        run: cargo build ${{ matrix.feature.extra_args }} --locked --release --target ${{ matrix.platform.target }}
-      - name: Package main archive (Unix)
-        if: "!contains(matrix.platform.os, 'windows')"
+          & "target/${{ matrix.platform.target }}/release/hubuum-server.exe" --version
+          & "target/${{ matrix.platform.target }}/release/hubuum-admin.exe" --version
+      - name: Package main archive (macOS)
+        if: contains(matrix.platform.os_name, 'macos')
         shell: bash
         run: |
           mkdir -p dist
@@ -685,7 +869,7 @@ jobs:
           tar czvf "dist/${archive_name}" -C "target/${{ matrix.platform.target }}/release" hubuum-server hubuum-admin
           shasum -a 256 "dist/${archive_name}" > "dist/${archive_name}.sha256"
       - name: Package main archive (Windows)
-        if: contains(matrix.platform.os, 'windows')
+        if: contains(matrix.platform.os_name, 'windows')
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path dist
@@ -702,7 +886,9 @@ jobs:
   publish-main-release:
     name: Publish main-latest artifacts
     if: github.ref == 'refs/heads/main'
-    needs: build-main-artifacts
+    needs:
+      - build-main-linux-artifacts
+      - build-main-native-artifacts
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -724,7 +910,7 @@ jobs:
           files: dist/*
 
   publish-main-container-images:
-    name: Build main container (${{ matrix.variant.name }}, ${{ matrix.platform.arch }})
+    name: Build main container (${{ matrix.platform.arch }})
     if: github.ref == 'refs/heads/main'
     needs:
       - lint
@@ -739,11 +925,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant:
-          - name: full
-            build_args: "-F tls-rustls -F tls-openssl"
-          - name: rustls-only
-            build_args: "-F tls-rustls"
         platform:
           - arch: amd64
             runner: ubuntu-24.04
@@ -767,31 +948,25 @@ jobs:
           file: Dockerfile
           platforms: linux/${{ matrix.platform.arch }}
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/hubuum-server:main-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+          tags: ghcr.io/${{ github.repository_owner }}/hubuum-server:main-full-${{ matrix.platform.arch }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ github.ref_name }}
           build-args: |
-            CARGO_BUILD_FLAGS=${{ matrix.variant.build_args }} --locked --release
+            CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release
             HUBUUM_BUILD_GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   publish-main-container-manifests:
-    name: Create main multi-arch manifest (${{ matrix.variant.name }})
+    name: Create main multi-arch manifest
     if: github.ref == 'refs/heads/main'
     needs: publish-main-container-images
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        variant:
-          - name: full
-          - name: rustls-only
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -804,24 +979,17 @@ jobs:
         run: |
           owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           image="ghcr.io/${owner}/hubuum-server"
-          variant="${{ matrix.variant.name }}"
-          
-          # Determine final tags
-          if [[ "$variant" == "full" ]]; then
-            final_tags=("${image}:main" "${image}:main-full")
-          else
-            final_tags=("${image}:main-${variant}")
-          fi
+          final_tags=("${image}:main" "${image}:main-full")
           
           # Create and push manifest for each tag
           for tag in "${final_tags[@]}"; do
             docker buildx imagetools create -t "$tag" \
-              "${image}:main-${variant}-amd64" \
-              "${image}:main-${variant}-arm64"
+              "${image}:main-full-amd64" \
+              "${image}:main-full-arm64"
           done
 
   publish-tag-container-images:
-    name: Build release container (${{ matrix.variant.name }}, ${{ matrix.platform.arch }})
+    name: Build release container (${{ matrix.platform.arch }})
     if: startsWith(github.ref, 'refs/tags/v')
     needs: validate-tag-release
     runs-on: ${{ matrix.platform.runner }}
@@ -831,11 +999,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant:
-          - name: full
-            build_args: "-F tls-rustls -F tls-openssl"
-          - name: rustls-only
-            build_args: "-F tls-rustls"
         platform:
           - arch: amd64
             runner: ubuntu-24.04
@@ -863,31 +1026,25 @@ jobs:
           file: Dockerfile
           platforms: linux/${{ matrix.platform.arch }}
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/hubuum-server:${{ github.ref_name }}-${{ matrix.variant.name }}-${{ matrix.platform.arch }}
+          tags: ghcr.io/${{ github.repository_owner }}/hubuum-server:${{ github.ref_name }}-full-${{ matrix.platform.arch }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ github.ref_name }}
           build-args: |
-            CARGO_BUILD_FLAGS=${{ matrix.variant.build_args }} --locked --release
+            CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release
             HUBUUM_BUILD_GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   publish-tag-container-manifests:
-    name: Create release multi-arch manifest (${{ matrix.variant.name }})
+    name: Create release multi-arch manifest
     if: startsWith(github.ref, 'refs/tags/v')
     needs: publish-tag-container-images
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        variant:
-          - name: full
-          - name: rustls-only
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -902,26 +1059,16 @@ jobs:
           image="ghcr.io/${owner}/hubuum-server"
           version_tag="${GITHUB_REF_NAME}"
           version="${version_tag#v}"
-          variant="${{ matrix.variant.name }}"
-          
-          # Determine final tags
-          if [[ "$variant" == "full" ]]; then
-            final_tags=(
-              "${image}:${version_tag}"
-              "${image}:${version}"
-              "${image}:${version_tag}-full"
-              "${image}:${version}-full"
-            )
-          else
-            final_tags=(
-              "${image}:${version_tag}-${variant}"
-              "${image}:${version}-${variant}"
-            )
-          fi
+          final_tags=(
+            "${image}:${version_tag}"
+            "${image}:${version}"
+            "${image}:${version_tag}-full"
+            "${image}:${version}-full"
+          )
           
           # Create and push manifest for each tag
           for tag in "${final_tags[@]}"; do
             docker buildx imagetools create -t "$tag" \
-              "${image}:${version_tag}-${variant}-amd64" \
-              "${image}:${version_tag}-${variant}-arm64"
+              "${image}:${version_tag}-full-amd64" \
+              "${image}:${version_tag}-full-arm64"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,7 @@ jobs:
     runs-on: ubuntu-24.04
     services:
       postgres:
-        image: postgres:18
+        image: postgres:18.4@sha256:22c89fe0d0f507606260237fd55e51f6137f58b2d5bcf6152242b96d9fe8f9a4
         env:
           POSTGRES_DB: hubuum_container_test
           POSTGRES_PASSWORD: postgres
@@ -459,7 +459,7 @@ jobs:
             "$IMAGE" --database-ready
           test "$(docker run --rm --network host \
             --env PGPASSWORD=postgres \
-            postgres:18 psql \
+            postgres:18.4@sha256:22c89fe0d0f507606260237fd55e51f6137f58b2d5bcf6152242b96d9fe8f9a4 psql \
             --host 127.0.0.1 \
             --username postgres \
             --dbname hubuum_container_test \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,6 +1330,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel_migrations"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d0f4a98124ba6d4ca75da535f65984badec16a003b6e2f94a01e31a79490b8"
+dependencies = [
+ "diesel",
+ "migrations_internals",
+ "migrations_macros",
+]
+
+[[package]]
 name = "diesel_table_macro_syntax"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2033,7 @@ dependencies = [
  "criterion",
  "diesel",
  "diesel-async",
+ "diesel_migrations",
  "futures",
  "futures-util",
  "hmac 0.13.0",
@@ -2046,6 +2058,7 @@ dependencies = [
  "opentelemetry-prometheus",
  "opentelemetry_sdk",
  "percent-encoding",
+ "pq-sys",
  "prometheus",
  "rand 0.10.1",
  "regex",
@@ -2812,6 +2825,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
+name = "migrations_internals"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c791ecdf977c99f45f23280405d7723727470f6689a5e6dbf513ac547ae10d"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36fc5ac76be324cfd2d3f2cf0fdf5d5d3c4f14ed8aaebadb09e304ba42282703"
+dependencies = [
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,6 +3116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3089,6 +3132,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3404,6 +3448,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pq-src"
+version = "0.3.11+libpq-18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb5bfbe0c3445d371dd8acf7d6c912ece8baf2f61f7c571af85a1d7687c2d0f"
+dependencies = [
+ "cc",
+ "openssl-sys",
+]
+
+[[package]]
 name = "pq-sys"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3411,6 +3465,7 @@ checksum = "574ddd6a267294433f140b02a726b0640c43cf7c6f717084684aaa3b285aba61"
 dependencies = [
  "libc",
  "pkg-config",
+ "pq-src",
  "vcpkg",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ diesel = { version = "2", features = [
     "uuid",
 ] }
 diesel-async = { version = "0.9.2", features = ["postgres", "bb8"] }
+diesel_migrations = { version = "2.3.2", optional = true }
+pq-sys = { version = "0.7.5", optional = true }
 ipnet = "2.12"
 futures = "0.3"
 futures-util = "0.3"
@@ -111,6 +113,8 @@ swagger-ui = ["dep:utoipa-swagger-ui"]
 tls-rustls = ["actix-web/rustls-0_23"]
 tls-openssl = ["dep:openssl", "actix-web/openssl"]
 valkey = ["dep:hubuum-event-sink-valkey"]
+embedded-migrations = ["dep:diesel_migrations", "pq-sys/bundled"]
+vendored-openssl = ["openssl/vendored"]
 
 [profile.release]
 codegen-units = 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/src/hubuum/target \
     HUBUUM_BUILD_GIT_SHA="${HUBUUM_BUILD_GIT_SHA}" \
-    find . -path '*/src/*' -type f -exec touch {} + && \
+    find ./src ./crates -path '*/src/*' -type f -exec touch {} + && \
     cargo build ${CARGO_BUILD_FLAGS} --features embedded-migrations \
         --bin hubuum-server --bin hubuum-admin && \
     cp target/release/hubuum-server /tmp/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,17 @@
 # syntax=docker/dockerfile:1
-FROM rust:slim-trixie AS builder
+FROM rust:alpine AS builder
 
-ARG CARGO_BUILD_FLAGS="--locked --release"
+ARG CARGO_BUILD_FLAGS="-F tls-rustls -F tls-openssl --locked --release"
 
 WORKDIR /usr/src/hubuum
 
-# Install system dependencies and cargo-binstall in one layer
-RUN apt-get update && \
-    apt-get install -y pkg-config libpq-dev libpq5 libssl3 libssl-dev curl && \
-    rm -rf /var/lib/apt/lists/* && \
-    curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+# Rust's Alpine target produces static executables. pq-sys builds its bundled
+# libpq source, and the static OpenSSL archives retain TLS support for both the
+# server and embedded migration runner.
+RUN apk add --no-cache build-base openssl-dev openssl-libs-static perl pkgconf
 
-# Install diesel CLI using binstall (much faster)
-RUN cargo binstall --no-confirm diesel_cli
-
-# Copy manifests first for better layer caching. Workspace member manifests are
-# required for Cargo to load the workspace during the dependency-only build.
-#
-# NOTE: workspace members are listed explicitly (not auto-detected) so that only
-# crate manifests, not their sources, enter the dependency-cache layer. This
-# keeps that layer valid across crate source edits. When you add a crate under
-# crates/, add a COPY for its Cargo.toml here; the dependency-only build below
-# creates and cleans up dummy source files for every copied crate manifest.
+# Copy manifests first for dependency-layer caching. Keep this list in exact
+# parity with the workspace members in Cargo.toml.
 COPY Cargo.toml Cargo.lock ./
 COPY crates/hubuum-auth-core/Cargo.toml ./crates/hubuum-auth-core/Cargo.toml
 COPY crates/hubuum-auth-ldap/Cargo.toml ./crates/hubuum-auth-ldap/Cargo.toml
@@ -34,13 +24,13 @@ COPY crates/hubuum-events-core/Cargo.toml ./crates/hubuum-events-core/Cargo.toml
 COPY crates/hubuum-outbound-http/Cargo.toml ./crates/hubuum-outbound-http/Cargo.toml
 COPY crates/hubuum-query/Cargo.toml ./crates/hubuum-query/Cargo.toml
 COPY crates/hubuum-templates/Cargo.toml ./crates/hubuum-templates/Cargo.toml
-COPY migrations ./migrations
 
-# The production image only builds binaries. Strip benchmark targets from every
-# copied manifest so Cargo does not require benchmark files in the Docker build
-# context. Keep [dev-dependencies] intact so Cargo.lock stays in sync and
-# --locked succeeds.
-RUN find . -name Cargo.toml -exec sh -c ' \
+# Build dependencies against dummy targets. Benchmark targets are removed from
+# the copied manifests because benchmark sources are not present in this layer.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/src/hubuum/target \
+    find . -name Cargo.toml -exec sh -c ' \
     for manifest do \
         awk '\'' \
             /^\[\[bench\]\]$/ { skip = 1; next } \
@@ -49,12 +39,7 @@ RUN find . -name Cargo.toml -exec sh -c ' \
             !skip { print } \
         '\'' "$manifest" > "$manifest.docker" && mv "$manifest.docker" "$manifest"; \
     done \
-    ' sh {} +
-
-# Build dependencies only (creates dummy project)
-# Use cache mounts to persist cargo registry/git between builds
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
+    ' sh {} + && \
     mkdir -p src/bin && \
     find crates -mindepth 2 -maxdepth 2 -name Cargo.toml \
         -exec sh -c 'mkdir -p "$(dirname "$1")/src" && echo "pub fn dummy() { }" > "$(dirname "$1")/src/lib.rs"' sh {} \; && \
@@ -62,16 +47,13 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     echo "pub fn dummy() {}" > src/lib.rs && \
     echo "fn main() {}" > src/bin/admin.rs && \
     echo "fn main() {}" > src/bin/openapi.rs && \
-    cargo build ${CARGO_BUILD_FLAGS} --bin hubuum-server --bin hubuum-admin && \
+    cargo build ${CARGO_BUILD_FLAGS} --features embedded-migrations \
+        --bin hubuum-server --bin hubuum-admin && \
     rm -rf src && \
     find crates -mindepth 2 -maxdepth 2 -type d -name src -exec rm -rf {} +
 
-# Copy the actual source code
 COPY . .
 
-# COPY restores the repository manifests; prune benchmark targets again before
-# the real production build so benchmark-only targets stay out of the image
-# build, while keeping [dev-dependencies] so --locked stays satisfied.
 RUN find . -name Cargo.toml -exec sh -c ' \
     for manifest do \
         awk '\'' \
@@ -83,26 +65,30 @@ RUN find . -name Cargo.toml -exec sh -c ' \
     done \
     ' sh {} +
 
-# Build the real application (dependencies are cached)
 ARG HUBUUM_BUILD_GIT_SHA="unknown"
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/src/hubuum/target \
     HUBUUM_BUILD_GIT_SHA="${HUBUUM_BUILD_GIT_SHA}" \
-    cargo build ${CARGO_BUILD_FLAGS} --bin hubuum-server --bin hubuum-admin && \
+    find . -path '*/src/*' -type f -exec touch {} + && \
+    cargo build ${CARGO_BUILD_FLAGS} --features embedded-migrations \
+        --bin hubuum-server --bin hubuum-admin && \
     cp target/release/hubuum-server /tmp/ && \
     cp target/release/hubuum-admin /tmp/
 
-FROM debian:trixie-slim
+RUN strip /tmp/hubuum-server /tmp/hubuum-admin
 
-RUN apt-get update && apt-get install -y libpq5 libssl3 postgresql-client && rm -rf /var/lib/apt/lists/*
+FROM scratch AS release-artifacts
+
+COPY --from=builder /tmp/hubuum-server /hubuum-server
+COPY --from=builder /tmp/hubuum-admin /hubuum-admin
+
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /tmp/hubuum-server /usr/local/bin/hubuum-server
 COPY --from=builder /tmp/hubuum-admin /usr/local/bin/hubuum-admin
-COPY --from=builder /usr/local/cargo/bin/diesel /usr/local/bin/diesel
-COPY --from=builder /usr/src/hubuum/migrations /migrations
-
-# Copy a start script
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM rust:alpine AS builder
+FROM docker.io/library/rust:1.97.0-alpine3.24@sha256:ec9c91e77119ce498cd1e87d96d77e0f75b2cee21655a29bc2bf75a51a2b20a4 AS builder
 
 ARG CARGO_BUILD_FLAGS="-F tls-rustls -F tls-openssl --locked --release"
 
@@ -83,9 +83,14 @@ FROM scratch AS release-artifacts
 COPY --from=builder /tmp/hubuum-server /hubuum-server
 COPY --from=builder /tmp/hubuum-admin /hubuum-admin
 
-FROM alpine:latest
+FROM docker.io/library/alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
-RUN apk add --no-cache ca-certificates
+ARG HUBUUM_UID="10001"
+ARG HUBUUM_GID="10001"
+
+RUN apk add --no-cache ca-certificates && \
+    addgroup -S -g "${HUBUUM_GID}" hubuum && \
+    adduser -S -D -H -u "${HUBUUM_UID}" -G hubuum hubuum
 
 COPY --from=builder /tmp/hubuum-server /usr/local/bin/hubuum-server
 COPY --from=builder /tmp/hubuum-admin /usr/local/bin/hubuum-admin
@@ -93,5 +98,13 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 EXPOSE 8080
+
+USER hubuum:hubuum
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD scheme=http; \
+        if [ -n "${HUBUUM_TLS_CERT_PATH:-}" ] && [ -n "${HUBUUM_TLS_KEY_PATH:-}" ]; then scheme=https; fi; \
+        wget --quiet --no-check-certificate --output-document=/dev/null \
+            "${scheme}://127.0.0.1:${HUBUUM_BIND_PORT:-8080}/healthz" || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ an explicit version instead of using the moving `main` image tag.
 Hubuum requires PostgreSQL. The release is available as pre-built archives for Linux,
 macOS, and Windows, and as a Linux container image for AMD64 and ARM64.
 
+Linux archives contain stripped, statically linked executables and do not require a compatible
+system glibc, libpq, or OpenSSL installation. macOS and Windows archives bundle libpq and OpenSSL
+while retaining only their normal operating-system runtime dependencies.
+
 ```sh
 docker pull ghcr.io/hubuum/hubuum-server:v0.0.1
 ```
@@ -29,8 +33,7 @@ docker pull ghcr.io/hubuum/hubuum-server:v0.0.1
   [GitHub Releases](https://github.com/hubuum/hubuum/releases).
 - Check a running instance at `/healthz` and `/readyz`.
 
-The default container image includes the `rustls` and OpenSSL TLS backends. A smaller
-`v0.0.1-rustls-only` image is also published. See the
+The Alpine-based container image includes both the `rustls` and OpenSSL TLS backends. See the
 [release guide](docs/releasing.md#container-images) for the complete tag scheme.
 
 ## Concept
@@ -162,11 +165,10 @@ inspecting and releasing throttled scopes), see [docs/login_rate_limiting.md](do
 - If unset, Hubuum generates an ephemeral in-memory key at startup and logs a warning.
 - With an ephemeral key, all existing bearer tokens become invalid after each restart.
 
-### Container Image Variants
+### Container Image
 
 - The default container tags include both TLS backends and allow runtime selection with `HUBUUM_TLS_BACKEND`.
 - The default image can also run without TLS if no certificate and key are configured.
-- Slim container tags ending in `-rustls-only` include only the `rustls` backend.
 
 ### Configuration Reference
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,28 +4,37 @@ services:
     ports:
       - "127.0.0.1:9999:8080"
     environment:
-      - HUBUUM_BIND_IP=0.0.0.0
-      - HUBUUM_DATABASE_URL=postgres://hubuum:hubuum_password@db/hubuum
-      - HUBUUM_LOG_LEVEL=debug
-      - DATABASE_URL=postgres://hubuum:hubuum_password@db/hubuum
+      HUBUUM_BIND_IP: 0.0.0.0
+      HUBUUM_CLIENT_ALLOWLIST: "*"
+      HUBUUM_DATABASE_URL: postgres://hubuum:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db/hubuum
+      HUBUUM_LOG_LEVEL: debug
+      DATABASE_URL: postgres://hubuum:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db/hubuum
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
 
   db:
     build:
       context: .
       dockerfile: docker/postgres/Dockerfile
     ports:
-      - "9998:5432"
+      - "127.0.0.1:9998:5432"
     environment:
-      - POSTGRES_USER=hubuum
-      - POSTGRES_PASSWORD=hubuum_password
-      - POSTGRES_DB=hubuum
-      - PGUSER=hubuum
+      POSTGRES_USER: hubuum
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: hubuum
+      PGUSER: hubuum
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U hubuum" ]
+      test: [ "CMD-SHELL", "pg_isready -U hubuum -d hubuum" ]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,6 +1,1 @@
-FROM postgres:17
-
-ENV POSTGRES_USER=hubuum \
-    POSTGRES_PASSWORD=hubuum_password \
-    POSTGRES_DB=hubuum \
-    PGUSER=hubuum
+FROM docker.io/library/postgres:18.4@sha256:22c89fe0d0f507606260237fd55e51f6137f58b2d5bcf6152242b96d9fe8f9a4

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -15,6 +15,27 @@ Hubuum exposes unauthenticated probe endpoints for container schedulers and load
 
 Probe paths bypass the client IP allowlist so platform health checks are not rejected before reaching the handler.
 
+### Local Docker Compose
+
+The development Compose stack requires a local, untracked `.env` file instead
+of using a password committed to the repository:
+
+```bash
+printf 'POSTGRES_PASSWORD=%s\n' "$(openssl rand -hex 32)" > .env
+docker compose up --build
+```
+
+The API is published on `127.0.0.1:9999` and PostgreSQL on
+`127.0.0.1:9998`; neither service listens on all host interfaces by default.
+The Hubuum container runs as the unprivileged `hubuum` user with a read-only
+root filesystem, all Linux capabilities dropped, and only a small temporary
+filesystem at `/tmp`.
+
+The production image includes a `/healthz` health check and runs pending
+embedded migrations during startup. PostgreSQL client administration tools and
+the standalone Diesel CLI are not installed. Set
+`HUBUUM_SKIP_MIGRATIONS=true` only when migrations are coordinated externally.
+
 ### Server Configuration
 
 | Variable | Default | Description |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -53,15 +53,33 @@ Once the tag is pushed, the CI workflow will:
 - use the matching changelog section as the GitHub Release notes
 - publish AMD64 and ARM64 GHCR images for the release tag
 
+## Native archives
+
+Linux AMD64 and ARM64 archives are exported from the same Alpine builder used by the production
+container. Both executables are stripped, statically linked musl binaries. CI rejects the archive
+if either binary declares a dynamic runtime dependency, so users do not need system copies of
+glibc, libpq, or OpenSSL.
+
+macOS and Windows use their native Rust targets. Their builds enable embedded migrations, bundled
+libpq, and vendored OpenSSL, so users do not need Homebrew, PostgreSQL client libraries, or OpenSSL
+packages. They retain the standard operating-system libraries expected by native executables.
+
+Both tagged releases and `main-latest` use these platform contracts. Every archive includes
+`hubuum-server`, `hubuum-admin`, and the embedded migration runner exposed through
+`hubuum-admin --migrate`.
+
 ## Container images
 
-The CI workflow publishes two container image variants:
+The CI workflow publishes one Alpine-based container image with both the `rustls` and OpenSSL TLS
+backends:
 
 - Default tags like `ghcr.io/hubuum/hubuum-server:v0.0.1` and `:main` are the full image.
-  This image includes both `rustls` and `openssl`, and it can also run plain HTTP when no TLS
-  certificate and key are configured.
-- Tags ending in `-rustls-only` are the slimmer image that only includes the `rustls` backend.
+  It can also run plain HTTP when no TLS certificate and key are configured.
 
 The full image also gets explicit aliases ending in `-full`.
+
+The image runs pending embedded Diesel migrations during startup unless
+`HUBUUM_SKIP_MIGRATIONS` is enabled. The image does not need the standalone Diesel CLI or `psql`;
+operators can run migrations explicitly with `hubuum-admin --migrate`.
 
 Publishing from `main` happens in the same workflow run and depends directly on the CI jobs passing.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,31 +12,22 @@ should_skip_migrations() {
     esac
 }
 
-# Function to wait for the database to be ready
-wait_for_db() {
-    echo "Waiting for database to be ready..."
+echo "Waiting for database to be ready..."
+until {
     if should_skip_migrations; then
-        while ! psql "$HUBUUM_DATABASE_URL" -c 'SELECT 1' >/dev/null 2>&1; do
-            echo "Database is unavailable - sleeping"
-            sleep 1
-        done
+        hubuum-admin --database-ready
     else
-        while ! diesel database setup --migration-dir /migrations --database-url "$HUBUUM_DATABASE_URL"; do
-            echo "Database is unavailable - sleeping"
-            sleep 1
-        done
+        hubuum-admin --migrate
     fi
-    echo "Database is up - executing command"
-}
-
-# Wait for the database to be ready
-wait_for_db
+}; do
+    echo "Database is unavailable - sleeping"
+    sleep 1
+done
 
 if should_skip_migrations; then
-    echo "HUBUUM_SKIP_MIGRATIONS is set; skipping database migrations."
+    echo "Database is ready; migrations were skipped."
 else
-    echo "Running database migrations... (shouldn't be needed)"
-    diesel migration run --migration-dir /migrations --database-url "$HUBUUM_DATABASE_URL"
+    echo "Database is ready; all pending migrations were applied."
 fi
 
 # Start the application

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -15,7 +15,7 @@ BACKEND_REPO="https://github.com/hubuum/hubuum.git"
 FRONTEND_REPO="https://github.com/hubuum/hubuum-frontend.git"
 BACKEND_IMAGE="ghcr.io/hubuum/hubuum-server:main"
 FRONTEND_IMAGE="ghcr.io/hubuum/hubuum-frontend:main"
-POSTGRES_IMAGE="docker.io/library/postgres:18-alpine"
+POSTGRES_IMAGE="docker.io/library/postgres:18.4-alpine3.24@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15"
 VALKEY_IMAGE="docker.io/valkey/valkey:9-alpine"
 CADDY_IMAGE="docker.io/library/caddy:2-alpine"
 EXTERNAL_DATABASE_URL=""
@@ -64,7 +64,7 @@ Options:
   --database-url URL      Existing Postgres URL. If set, no Postgres container is created
   --auth-config PATH      Host auth-provider TOML file to mount read-only in the API container
   --engine ENGINE         Container engine: auto, docker, or podman. Default: auto
-  --postgres-image IMAGE  Postgres image. Default: docker.io/library/postgres:18-alpine
+  --postgres-image IMAGE  Postgres image. Default: PostgreSQL 18.4 on Alpine 3.24 (digest-pinned)
   --valkey-image IMAGE    Valkey image. Default: docker.io/valkey/valkey:9-alpine
   --caddy-image IMAGE     Caddy image. Default: docker.io/library/caddy:2-alpine
   --network-subnet CIDR   Container bridge subnet. Default: 172.30.42.0/24
@@ -646,6 +646,13 @@ fi
 cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
     container_name: hubuum-api
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     environment:
       HUBUUM_BIND_IP: ${HUBUUM_BIND_IP}
       HUBUUM_BIND_PORT: ${HUBUUM_BIND_PORT}

--- a/src/bin/admin.rs
+++ b/src/bin/admin.rs
@@ -1,4 +1,11 @@
 use clap::Parser;
+use diesel::dsl::sql;
+use diesel::select;
+use diesel::sql_types::Integer;
+#[cfg(feature = "embedded-migrations")]
+use diesel::{Connection, PgConnection};
+#[cfg(feature = "embedded-migrations")]
+use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use std::collections::BTreeMap;
 
 use hubuum::config::{
@@ -7,6 +14,8 @@ use hubuum::config::{
 };
 use hubuum::db::prelude::*;
 use hubuum::db::{DbPool, init_pool_with_statement_timeout, with_connection};
+#[cfg(feature = "embedded-migrations")]
+use hubuum::errors::EXIT_CODE_DATABASE_ERROR;
 use hubuum::errors::{ApiError, EXIT_CODE_CONFIG_ERROR, fatal_error};
 use hubuum::logger;
 use hubuum::models::{ExportTaskOutputRecord, ExportTemplate, User};
@@ -14,6 +23,9 @@ use hubuum::schema::export_task_outputs::dsl::export_task_outputs;
 use hubuum::utilities::auth::generate_random_password;
 use hubuum::utilities::exporting::validate_template_with_limits;
 use hubuum::utilities::is_valid_log_level;
+
+#[cfg(feature = "embedded-migrations")]
+const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 
 #[derive(Parser)]
 #[command(
@@ -34,6 +46,15 @@ struct AdminCli {
     /// Summarize stored export output health by template name
     #[arg(long, default_value_t = false)]
     export_template_health: bool,
+
+    /// Check that the database accepts connections
+    #[arg(long, default_value_t = false)]
+    database_ready: bool,
+
+    /// Run all pending embedded database migrations
+    #[cfg(feature = "embedded-migrations")]
+    #[arg(long, default_value_t = false)]
+    migrate: bool,
 
     /// Database URL
     #[arg(long, env = "HUBUUM_DATABASE_URL")]
@@ -83,6 +104,12 @@ async fn main() -> Result<(), ApiError> {
         })
     });
 
+    #[cfg(feature = "embedded-migrations")]
+    if admin_cli.migrate {
+        run_migrations(&database_url);
+        return Ok(());
+    }
+
     // Initialize database connection
     let pool =
         init_pool_with_statement_timeout(&database_url, 1, admin_cli.db_statement_timeout_ms);
@@ -98,10 +125,43 @@ async fn main() -> Result<(), ApiError> {
         .await?;
     } else if admin_cli.export_template_health {
         export_template_health(pool).await?;
+    } else if admin_cli.database_ready {
+        database_ready(pool).await?;
     } else {
         println!("No command specified. Use --help for usage information.");
     }
 
+    Ok(())
+}
+
+#[cfg(feature = "embedded-migrations")]
+fn run_migrations(database_url: &str) {
+    let mut connection = PgConnection::establish(database_url).unwrap_or_else(|error| {
+        fatal_error(
+            &format!("Failed to connect to the database for migrations: {error}"),
+            EXIT_CODE_DATABASE_ERROR,
+        )
+    });
+    let applied = connection
+        .run_pending_migrations(MIGRATIONS)
+        .unwrap_or_else(|error| {
+            fatal_error(
+                &format!("Failed to run database migrations: {error}"),
+                EXIT_CODE_DATABASE_ERROR,
+            )
+        });
+
+    println!("Applied {} database migration(s).", applied.len());
+}
+
+async fn database_ready(pool: DbPool) -> Result<(), ApiError> {
+    with_connection(&pool, async |connection| {
+        select(sql::<Integer>("1"))
+            .get_result::<i32>(connection)
+            .await
+    })
+    .await?;
+    println!("Database is ready.");
     Ok(())
 }
 

--- a/src/tests/container_build.rs
+++ b/src/tests/container_build.rs
@@ -61,3 +61,95 @@ fn dockerfile_copies_every_workspace_manifest() {
         "Dockerfile dependency-cache manifest COPY entries must exactly match Cargo workspace members"
     );
 }
+
+#[test]
+fn production_container_runs_as_non_root() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let dockerfile = fs::read_to_string(repository.join("Dockerfile"))
+        .expect("repository Dockerfile should be readable");
+
+    assert!(
+        dockerfile
+            .lines()
+            .any(|line| line.trim() == "USER hubuum:hubuum"),
+        "production Dockerfile must select the dedicated hubuum user"
+    );
+}
+
+#[test]
+fn production_container_has_a_healthcheck() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let dockerfile = fs::read_to_string(repository.join("Dockerfile"))
+        .expect("repository Dockerfile should be readable");
+
+    assert!(
+        dockerfile.contains("HEALTHCHECK") && dockerfile.contains("/healthz"),
+        "production Dockerfile must probe the unauthenticated liveness endpoint"
+    );
+}
+
+#[test]
+fn production_container_base_images_are_pinned() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let dockerfile = fs::read_to_string(repository.join("Dockerfile"))
+        .expect("repository Dockerfile should be readable");
+    let postgres_dockerfile = fs::read_to_string(repository.join("docker/postgres/Dockerfile"))
+        .expect("PostgreSQL Dockerfile should be readable");
+
+    for line in dockerfile
+        .lines()
+        .chain(postgres_dockerfile.lines())
+        .map(str::trim)
+        .filter(|line| line.starts_with("FROM ") && !line.starts_with("FROM scratch"))
+    {
+        assert!(
+            line.contains("@sha256:"),
+            "container base image must be pinned by digest: {line}"
+        );
+    }
+}
+
+#[test]
+fn container_dependency_images_are_pinned() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workflow = fs::read_to_string(repository.join(".github/workflows/ci.yml"))
+        .expect("CI workflow should be readable");
+    let installer = fs::read_to_string(repository.join("scripts/install-single-host.sh"))
+        .expect("single-host installer should be readable");
+
+    assert!(workflow.contains("postgres:18.4@sha256:"));
+    assert!(installer.contains("postgres:18.4-alpine3.24@sha256:"));
+}
+
+#[test]
+fn development_compose_requires_a_local_password() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let compose = fs::read_to_string(repository.join("docker-compose.yml"))
+        .expect("repository docker-compose.yml should be readable");
+
+    assert!(compose.contains("${POSTGRES_PASSWORD:?"));
+    assert!(!compose.contains("hubuum_password"));
+}
+
+#[test]
+fn development_compose_limits_container_privileges() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let compose = fs::read_to_string(repository.join("docker-compose.yml"))
+        .expect("repository docker-compose.yml should be readable");
+
+    assert!(compose.contains("127.0.0.1:9998:5432"));
+    assert!(compose.contains("read_only: true"));
+    assert!(compose.contains("cap_drop:"));
+    assert!(compose.contains("no-new-privileges:true"));
+}
+
+#[test]
+fn single_host_installer_limits_api_container_privileges() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let installer = fs::read_to_string(repository.join("scripts/install-single-host.sh"))
+        .expect("single-host installer should be readable");
+
+    assert!(installer.contains("read_only: true"));
+    assert!(installer.contains("cap_drop:"));
+    assert!(installer.contains("no-new-privileges:true"));
+}


### PR DESCRIPTION
## Summary

- replace the Debian production image with one Alpine image containing both TLS backends
- bundle libpq through `pq-sys`, embed Diesel migrations in `hubuum-admin`, and remove the Diesel CLI and `psql` from the runtime image
- export stripped static musl Linux release binaries from the same Docker builder
- make macOS and Windows artifacts self-contained with bundled libpq and vendored OpenSSL
- run the production container as a dedicated UID/GID 10001 user with a built-in `/healthz` check
- pin the current stable Rust 1.97.0, Alpine 3.24.1, and PostgreSQL 18.4 images by explicit version and multi-architecture digest
- harden development and single-host Compose services with a read-only root, bounded `/tmp`, dropped capabilities, and `no-new-privileges`
- require an untracked local Compose password and bind both development ports to loopback
- update tagged and `main-latest` release workflows to verify linkage and binary startup
- document the container, Compose, and native archive contracts

## Why

The production image previously carried a Debian runtime, PostgreSQL client tooling, the Diesel CLI, libpq, and OpenSSL runtime packages. The server only needs the application binaries and CA certificates when migrations and readiness checks are handled by `hubuum-admin`.

The previous development Compose defaults also committed a database password, exposed PostgreSQL on all host interfaces, and did not apply the restrictions used by the single-host deployment.

This reduces the published image and dependency surface while preserving migrations, PostgreSQL TLS, both inbound TLS backends, native release artifacts, and the existing release feature variants.

## User impact

The default image is now the single full Alpine-based image. Existing `-full` tags remain aliases, while the redundant `-rustls-only` variant is removed.

Container startup continues to wait for PostgreSQL and runs pending migrations by default. Operators can invoke migrations directly with `hubuum-admin --migrate` or perform a readiness probe with `hubuum-admin --database-ready`.

The image runs as the unprivileged `hubuum` account and includes a health check that supports HTTP and configured HTTPS. Alpine's built-in `wget` performs the probe, so no additional runtime package is required.

Linux archives no longer require glibc, libpq, or OpenSSL on the host. Native macOS and Windows archives bundle libpq and OpenSSL while retaining their normal operating-system dependencies.

Local Docker Compose users must generate a password in an untracked `.env` file before starting the stack.

Closes #24
Closes #114

## Verification

- `source .env && ./run_tests.sh` — 1000 passed, 2 ignored, plus 6 admin CLI tests, 3 binary smoke tests, and 2 doctests
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Markdown lint
- Dockerfile workspace-manifest parity and container-hardening regression tests
- production Alpine image build with both TLS backends
- static Linux artifact linkage checks
- native macOS all-feature build and runtime dependency inspection
- live PostgreSQL 18.4 migration, readiness, and Docker health checks
- live non-root container with read-only root, bounded `/tmp`, dropped capabilities, and `no-new-privileges`
- single-host installer refresh test
- Compose configuration and GitHub Actions workflow lint
