### PR TITLE
Backfill changelog and require PR updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@
 
 ## Pull Requests And Merges
 
+- Treat the changelog review as required for every pull request. Before merge, add relevant user-facing additions, changes, fixes, and security notes to the `[Unreleased]` section of `CHANGELOG.md`. If a pull request has no changelog-worthy impact, state that explicitly in its description; do not add empty or internal-only changelog entries.
+- Call out every breaking change explicitly in both the pull request description and its `[Unreleased]` changelog entry, including the upgrade or migration action users must take.
 - When squash-merging a pull request, use its detailed PR description as the squash commit body. Preserve the substantive summary, rationale, behavior notes, and issue references, but remove verification-only sections such as test commands, checklists, and `## Verification` before merging.
 
 ## Change Discipline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Added a Prometheus-compatible runtime metrics endpoint, enabled by default at
+  `/metrics`, with low-cardinality metrics for HTTP traffic, database activity,
+  background tasks, imports, exports, remote calls, authentication, event
+  processing, and inventory.
+- Added the admin-only `GET /api/v1/admin/config` endpoint for inspecting a
+  deny-by-default, redacted view of the effective runtime configuration.
+- Added `include_total=false` to cursor-paginated API requests so
+  latency-sensitive clients can skip the exact count query and omit the
+  `X-Total-Count` response header.
+
+### Changed
+
+- **Breaking:** Operational logs from the server and admin CLI are now
+  newline-delimited JSON only. Update log collectors and parsers that expect the
+  previous text format. Records now include request and correlation IDs,
+  status-aware request completion, authenticated principal context, committed
+  mutations, authorization decisions, and structured startup information.
+- PostgreSQL access now uses an asynchronous connection pool with bounded
+  acquisition waits. The admin database metadata endpoint exposes pool capacity,
+  wait, timeout, and connection-lifecycle statistics.
+- **Breaking:** The default global PostgreSQL statement timeout is now 30
+  seconds. Set `HUBUUM_DB_STATEMENT_TIMEOUT_MS=0` to retain an unlimited timeout,
+  or configure a deployment-appropriate bound.
+- **Breaking:** Active imports are limited to 100 per user by default and unified
+  search queries are limited to 256 characters. Adjust
+  `HUBUUM_IMPORT_MAX_ACTIVE_TASKS_PER_USER` where needed and keep client search
+  input within the new bound.
+- **Breaking:** Published containers now use one unprivileged Alpine-based image
+  with both TLS backends, embedded migrations, and a built-in health check. Move
+  deployments using a `-rustls-only` tag to the default or `-full` tag.
+- Linux, macOS, and Windows release archives are now self-contained with bundled
+  PostgreSQL and TLS dependencies. The admin CLI can run embedded migrations and
+  database readiness checks without external PostgreSQL or Diesel tools.
+- **Breaking:** Local Docker Compose services now require an untracked `.env`
+  file containing `POSTGRES_PASSWORD`; create it before starting the stack.
+  Published ports now bind to loopback, root filesystems are read-only, Linux
+  capabilities are dropped, and `no-new-privileges` is enabled.
+- Server shutdown now cancels and joins task, event, retention, and PostgreSQL
+  notification workers before dropping the database pool. Interrupted active
+  tasks are marked failed instead of remaining active.
+
+### Security
+
+- Hardened login handling against username enumeration and concurrent
+  rate-limit bypasses, and stopped exposing internal database, hashing, and
+  service details in public error responses.
+- **Breaking:** Remote HTTP calls now enforce their configured timeout and do
+  not follow redirects, preventing redirects from bypassing target validation.
+  Configure the final validated destination URL directly instead of relying on
+  redirects.
+
 ## [0.0.1] - 2026-07-11
 
 ### Added


### PR DESCRIPTION
## Summary

- require changelog review for every pull request before merge
- require breaking changes to be called out in both the PR description and the `[Unreleased]` changelog entry, with upgrade or migration guidance
- backfill user-facing additions, changes, and security notes merged since `v0.0.1`

## Why

The changelog had not been updated after the initial `v0.0.1` release entry, leaving API, observability, deployment, security, and lifecycle changes undocumented. Making changelog review an explicit merge requirement keeps future release notes current without adding noise for internal-only work.

## User and developer impact

Users and operators get a consolidated description of the currently unreleased behavior. Contributors must now either update `CHANGELOG.md` for user-facing changes or state explicitly that a PR has no changelog-worthy impact.

## Breaking changes

This documentation-only PR introduces no new runtime breaking behavior. It explicitly documents these breaking changes already present on `main` and their required actions:

- update log collectors and parsers for newline-delimited JSON-only logs
- configure `HUBUUM_DB_STATEMENT_TIMEOUT_MS` if the new 30-second default is unsuitable; use `0` to retain an unlimited timeout
- keep unified search input within 256 characters and adjust `HUBUUM_IMPORT_MAX_ACTIVE_TASKS_PER_USER` where the default active-import limit is unsuitable
- move deployments from removed `-rustls-only` image tags to the default or `-full` tag
- create an untracked Compose `.env` containing `POSTGRES_PASSWORD`
- configure final remote-target URLs directly because remote HTTP calls no longer follow redirects

## Verification

- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `git diff --check`
