### PR TITLE
Treat unchanged principal settings as no-ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   notification workers before dropping the database pool. Interrupted active
   tasks are marked failed instead of remaining active.
 
+### Fixed
+
+- Principal settings mutations that leave the document unchanged are now
+  treated as no-ops, avoiding misleading `updated` audit events and
+  `updated_at` changes.
+
 ### Security
 
 - Hardened login handling against username enumeration and concurrent

--- a/docs/auth_model.md
+++ b/docs/auth_model.md
@@ -323,9 +323,9 @@ For example:
 ```
 
 Settings mutations are serialized with a principal row lock, so concurrent patches
-preserve unrelated changes. Each successful mutation records a complete before and
-after settings snapshot in an `updated` audit event for the target user or service
-account.
+preserve unrelated changes. Each mutation that changes the settings records a
+complete before and after snapshot in an `updated` audit event for the target user
+or service account. Unchanged mutations are no-ops and do not emit an event.
 
 ---
 

--- a/src/db/traits/principal.rs
+++ b/src/db/traits/principal.rs
@@ -89,6 +89,10 @@ pub async fn mutate_principal_settings(
             PrincipalSettingsMutation::Reset => PrincipalSettings::default(),
         };
 
+        if before == after {
+            return Ok(after);
+        }
+
         diesel::update(principals::table.filter(principals::id.eq(principal_id_value)))
             .set(principals::settings.eq(after.as_value()))
             .execute(conn)

--- a/src/tests/api/v1/principal_settings.rs
+++ b/src/tests/api/v1/principal_settings.rs
@@ -2,9 +2,11 @@
 mod tests {
     use crate::db::prelude::*;
     use actix_web::{http::StatusCode, test};
+    use chrono::NaiveDateTime;
     use rstest::rstest;
 
-    use crate::db::with_connection;
+    use crate::db::{DbPool, with_connection};
+    use crate::errors::ApiError;
     use crate::events::{Action, EntityType, Event};
     use crate::models::{Permissions, PrincipalID};
     use crate::tests::api_operations::{delete_request, get_request, patch_request, put_request};
@@ -27,6 +29,28 @@ mod tests {
             RouteFamily::Me => ME_SETTINGS.to_string(),
             RouteFamily::Principal => format!("{PRINCIPALS}/{principal_id}/settings"),
         }
+    }
+
+    async fn principal_mutation_state(pool: &DbPool, principal_id: i32) -> (NaiveDateTime, i64) {
+        use crate::schema::{events, principals};
+
+        with_connection(pool, async |conn| -> Result<_, ApiError> {
+            let updated_at = principals::table
+                .filter(principals::id.eq(principal_id))
+                .select(principals::updated_at)
+                .first::<NaiveDateTime>(conn)
+                .await?;
+            let event_count = events::table
+                .filter(events::entity_type.eq(EntityType::User.as_str()))
+                .filter(events::entity_id.eq(principal_id))
+                .filter(events::action.eq(Action::Updated.as_str()))
+                .count()
+                .get_result::<i64>(conn)
+                .await?;
+            Ok((updated_at, event_count))
+        })
+        .await
+        .unwrap()
     }
 
     #[rstest]
@@ -457,6 +481,55 @@ mod tests {
             Some(serde_json::json!({ "settings": before }))
         );
         assert_eq!(event.after, Some(serde_json::json!({ "settings": after })));
+    }
+
+    #[rstest]
+    #[case::put(Mutation::Put)]
+    #[case::patch(Mutation::Patch)]
+    #[case::delete(Mutation::Delete)]
+    #[actix_web::test]
+    async fn unchanged_settings_mutations_do_not_update_the_principal_or_emit_events(
+        #[case] mutation: Mutation,
+    ) {
+        let context = TestContext::new().await;
+        let principal_id = context.normal_user.id;
+        let initial = serde_json::json!({
+            "theme": "dark",
+            "layout": { "density": "comfortable" }
+        });
+
+        if matches!(mutation, Mutation::Put | Mutation::Patch) {
+            let setup =
+                put_request(&context.pool, &context.normal_token, ME_SETTINGS, &initial).await;
+            assert_eq!(setup.status(), StatusCode::OK);
+        }
+        let before = principal_mutation_state(&context.pool, principal_id).await;
+
+        let response = match mutation {
+            Mutation::Put => {
+                put_request(&context.pool, &context.normal_token, ME_SETTINGS, &initial).await
+            }
+            Mutation::Patch => {
+                patch_request(
+                    &context.pool,
+                    &context.normal_token,
+                    ME_SETTINGS,
+                    serde_json::json!({ "layout": { "density": "comfortable" } }),
+                )
+                .await
+            }
+            Mutation::Delete => {
+                delete_request(&context.pool, &context.normal_token, ME_SETTINGS).await
+            }
+        };
+        let expected_status = match mutation {
+            Mutation::Put | Mutation::Patch => StatusCode::OK,
+            Mutation::Delete => StatusCode::NO_CONTENT,
+        };
+        assert_eq!(response.status(), expected_status);
+
+        let after = principal_mutation_state(&context.pool, principal_id).await;
+        assert_eq!(after, before);
     }
 
     #[actix_web::test]


### PR DESCRIPTION
## Summary

- treat principal-settings PUT, PATCH, and DELETE requests as no-ops when the resulting JSON document is unchanged
- avoid bumping `principals.updated_at` or emitting a misleading `updated` audit event for unchanged settings
- add regression coverage for repeated PUT, ineffective PATCH, and DELETE on empty settings
- update the changelog and principal-settings documentation

## Root cause

`mutate_principal_settings` computed complete before and after documents under a principal row lock, but then unconditionally executed the SQL update and emitted an `Action::Updated` event. This produced audit entries with identical before and after snapshots and also advanced the principal's `updated_at` timestamp.

The mutation now returns the computed document immediately when it equals the locked stored document. Changed mutations retain the existing transactional update and event behavior.

## Impact

API status codes and response bodies are unchanged. Clients can continue safely retrying settings mutations, while the audit stream and principal timestamp now reflect actual state changes.

## Verification

- `source .env && ./run_tests.sh` (1,018 passed, 2 existing ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`

OpenAPI was not regenerated because endpoint and schema shapes did not change.