### PR TITLE
Treat unchanged audited mutations as no-ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-- Principal settings mutations that leave the document unchanged are now
-  treated as no-ops, avoiding misleading `updated` audit events and
-  `updated_at` changes.
+- Audited mutations that leave domain state unchanged are now treated as
+  no-ops, avoiding misleading lifecycle events and `updated_at` changes. This
+  includes entity updates, principal settings, collection moves, permission
+  grants and revocations, service-account disable, and group membership
+  transitions.
 
 ### Security
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -8,6 +8,13 @@ The event stream is append-only during normal application operation. Domain
 changes emit events in the same database transaction as the state change, so an
 event exists only if the change commits.
 
+Audited mutation paths compare the requested state with the stored state before
+writing. Requests that would leave domain state unchanged are no-ops: they do
+not advance `updated_at` or append lifecycle events. This includes identical
+entity updates, moves to the current parent, repeated permission grants or
+revocations, repeated service-account disable requests, and membership changes
+that do not change effective membership.
+
 ## Audit Log
 
 Audit readers query the canonical stream with `GET /api/v1/events`. The

--- a/src/db/traits/class.rs
+++ b/src/db/traits/class.rs
@@ -287,8 +287,12 @@ impl UpdateClassRecord for UpdateHubuumClass {
         with_transaction(pool, async |conn| -> Result<HubuumClass, ApiError> {
             let before = hubuumclass
                 .filter(id.eq(class_id))
+                .for_update()
                 .first::<HubuumClass>(conn)
                 .await?;
+            if !self.has_changes(&before) {
+                return Ok(before);
+            }
             let updated = diesel::update(hubuumclass.filter(id.eq(class_id)))
                 .set(self)
                 .get_result::<HubuumClass>(conn)
@@ -346,16 +350,21 @@ impl DeleteClassRecord for HubuumClass {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id};
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
+            let before = hubuumclass
+                .filter(id.eq(self.id))
+                .for_update()
+                .first::<HubuumClass>(conn)
+                .await?;
             diesel::delete(hubuumclass.filter(id.eq(self.id)))
                 .execute(conn)
                 .await?;
             let event = class_event(
-                self,
+                &before,
                 Action::Deleted,
                 context,
-                format!("Class '{}' deleted", self.name),
+                format!("Class '{}' deleted", before.name),
             )?
-            .with_before(class_snapshot(self));
+            .with_before(class_snapshot(&before));
             emit_event(conn, &event).await?;
             Ok(())
         })

--- a/src/db/traits/collection/records.rs
+++ b/src/db/traits/collection/records.rs
@@ -253,17 +253,22 @@ impl DeleteCollectionRecord for Collection {
         use crate::schema::collections::dsl::{collections, id};
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            validate_collection_can_be_deleted(conn, self.id).await?;
+            let before = collections
+                .filter(id.eq(self.id))
+                .for_update()
+                .first::<Collection>(conn)
+                .await?;
+            validate_collection_can_be_deleted(conn, before.id).await?;
             diesel::delete(collections.filter(id.eq(self.id)))
                 .execute(conn)
                 .await?;
             let event = collection_event(
-                self,
+                &before,
                 Action::Deleted,
                 context,
-                format!("Collection '{}' deleted", self.name),
+                format!("Collection '{}' deleted", before.name),
             )?
-            .with_before(collection_snapshot(self));
+            .with_before(collection_snapshot(&before));
             emit_event(conn, &event).await?;
             Ok(())
         })
@@ -299,6 +304,7 @@ impl DeleteCollectionRecord for CollectionID {
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let collection = collections
                 .filter(id.eq(self.id()))
+                .for_update()
                 .first::<Collection>(conn)
                 .await?;
             validate_collection_can_be_deleted(conn, collection.id).await?;
@@ -378,8 +384,12 @@ impl UpdateCollectionRecord for UpdateCollection {
         with_transaction(pool, async |conn| -> Result<Collection, ApiError> {
             let before = collections
                 .filter(id.eq(collection_id))
+                .for_update()
                 .first::<Collection>(conn)
                 .await?;
+            if !self.has_changes(&before) {
+                return Ok(before);
+            }
             let updated = diesel::update(collections.filter(id.eq(collection_id)))
                 .set(self)
                 .get_result::<Collection>(conn)
@@ -565,6 +575,7 @@ pub async fn move_collection_record_from_backend(
     with_transaction(pool, async |conn| -> Result<Collection, ApiError> {
         let before = collections
             .filter(id.eq(target_collection_id))
+            .for_update()
             .first::<Collection>(conn)
             .await?;
 
@@ -572,6 +583,10 @@ pub async fn move_collection_record_from_backend(
             return Err(ApiError::Conflict(
                 "The root collection cannot be moved".to_string(),
             ));
+        }
+
+        if before.parent_collection_id == Some(new_parent_collection_id) {
+            return Ok(before);
         }
 
         if target_collection_id == new_parent_collection_id {

--- a/src/db/traits/event_subscription.rs
+++ b/src/db/traits/event_subscription.rs
@@ -111,8 +111,12 @@ async fn update_event_sink_record_impl(
     with_transaction(pool, async |conn| -> Result<EventSinkRow, ApiError> {
         let before = event_sinks
             .filter(id.eq(sink_id))
+            .for_update()
             .first::<EventSinkRow>(conn)
             .await?;
+        if !row.has_changes(&before) {
+            return Ok(before);
+        }
         let updated = diesel::update(event_sinks.filter(id.eq(sink_id)))
             .set(row)
             .get_result::<EventSinkRow>(conn)
@@ -158,6 +162,7 @@ async fn delete_event_sink_record_impl(
     with_transaction(pool, async |conn| -> Result<(), ApiError> {
         let before = event_sinks
             .filter(id.eq(sink_id.id()))
+            .for_update()
             .first::<EventSinkRow>(conn)
             .await?;
         emit_event_sink_audit(conn, Action::Deleted, event_context, Some(&before), &before).await?;
@@ -283,8 +288,12 @@ async fn update_event_subscription_record_impl(
         async |conn| -> Result<EventSubscriptionRow, ApiError> {
             let before = event_subscriptions
                 .filter(id.eq(subscription_id))
+                .for_update()
                 .first::<EventSubscriptionRow>(conn)
                 .await?;
+            if !row.has_changes(&before) {
+                return Ok(before);
+            }
             let updated = diesel::update(event_subscriptions.filter(id.eq(subscription_id)))
                 .set(row)
                 .get_result::<EventSubscriptionRow>(conn)
@@ -331,6 +340,7 @@ async fn delete_event_subscription_record_impl(
     with_transaction(pool, async |conn| -> Result<(), ApiError> {
         let before = event_subscriptions
             .filter(id.eq(subscription_id.id()))
+            .for_update()
             .first::<EventSubscriptionRow>(conn)
             .await?;
         emit_event_subscription_audit(conn, Action::Deleted, event_context, Some(&before), &before)

--- a/src/db/traits/export_template.rs
+++ b/src/db/traits/export_template.rs
@@ -190,8 +190,12 @@ impl UpdateExportTemplateRecord for UpdateExportTemplateRow {
         with_transaction(pool, async |conn| -> Result<ExportTemplateRow, ApiError> {
             let before = export_templates
                 .filter(id.eq(template_id))
+                .for_update()
                 .first::<ExportTemplateRow>(conn)
                 .await?;
+            if !self.has_changes(&before) {
+                return Ok(before);
+            }
             let after = diesel::update(export_templates.filter(id.eq(template_id)))
                 .set(self)
                 .get_result::<ExportTemplateRow>(conn)
@@ -262,6 +266,7 @@ impl DeleteExportTemplateRecord for ExportTemplateID {
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let before = export_templates
                 .filter(id.eq(self.id()))
+                .for_update()
                 .first::<ExportTemplateRow>(conn)
                 .await?;
             diesel::delete(export_templates.filter(id.eq(self.id())))

--- a/src/db/traits/group.rs
+++ b/src/db/traits/group.rs
@@ -51,7 +51,7 @@ async fn insert_effective_membership(
     conn: &mut DbConnection,
     principal: i32,
     group: i32,
-) -> Result<PrincipalGroup, diesel::result::Error> {
+) -> Result<(PrincipalGroup, bool), diesel::result::Error> {
     use crate::schema::group_memberships::dsl::group_memberships;
 
     let inserted = diesel::insert_into(group_memberships)
@@ -64,8 +64,8 @@ async fn insert_effective_membership(
         .await
         .optional()?;
     match inserted {
-        Some(membership) => Ok(membership),
-        None => load_principal_group(conn, principal, group).await,
+        Some(membership) => Ok((membership, true)),
+        None => Ok((load_principal_group(conn, principal, group).await?, false)),
     }
 }
 
@@ -96,7 +96,7 @@ async fn remove_manual_membership_source(
     conn: &mut DbConnection,
     principal: i32,
     group: i32,
-) -> Result<(), ApiError> {
+) -> Result<bool, ApiError> {
     use crate::schema::{group_membership_sources, group_memberships};
 
     ensure_group_allows_local_write(conn, group).await?;
@@ -119,15 +119,16 @@ async fn remove_manual_membership_source(
         .get_result::<i64>(conn)
         .await?;
     if remaining == 0 {
-        diesel::delete(
+        let deleted = diesel::delete(
             group_memberships::table
                 .filter(group_memberships::principal_id.eq(principal))
                 .filter(group_memberships::group_id.eq(group)),
         )
         .execute(conn)
         .await?;
+        return Ok(deleted > 0);
     }
-    Ok(())
+    Ok(false)
 }
 
 async fn ensure_group_allows_local_write(
@@ -226,7 +227,11 @@ impl DeleteGroupRecord for GroupID {
         use crate::schema::groups::dsl::{groups, id};
 
         with_transaction(pool, async |conn| -> Result<usize, ApiError> {
-            let group = groups.filter(id.eq(self.id())).first::<Group>(conn).await?;
+            let group = groups
+                .filter(id.eq(self.id()))
+                .for_update()
+                .first::<Group>(conn)
+                .await?;
             ensure_group_allows_local_write(conn, group.id).await?;
             let deleted = diesel::delete(groups.filter(id.eq(self.id())))
                 .execute(conn)
@@ -270,7 +275,11 @@ impl DeleteGroupRecord for Group {
         use crate::schema::groups::dsl::{groups, id};
 
         with_transaction(pool, async |conn| -> Result<usize, ApiError> {
-            let before = groups.filter(id.eq(self.id)).first::<Group>(conn).await?;
+            let before = groups
+                .filter(id.eq(self.id))
+                .for_update()
+                .first::<Group>(conn)
+                .await?;
             ensure_group_allows_local_write(conn, before.id).await?;
             let deleted = diesel::delete(groups.filter(id.eq(self.id)))
                 .execute(conn)
@@ -432,8 +441,15 @@ impl UpdateGroupRecord for UpdateGroup {
         use crate::schema::groups::dsl::{groups, id};
 
         with_transaction(pool, async |conn| -> Result<Group, ApiError> {
-            let before = groups.filter(id.eq(group_id)).first::<Group>(conn).await?;
+            let before = groups
+                .filter(id.eq(group_id))
+                .for_update()
+                .first::<Group>(conn)
+                .await?;
             ensure_group_allows_local_write(conn, before.id).await?;
+            if !self.has_changes(&before) {
+                return Ok(before);
+            }
             let after = diesel::update(groups.filter(id.eq(group_id)))
                 .set(self)
                 .get_result::<Group>(conn)
@@ -585,7 +601,7 @@ impl GroupMembersBackend for Group {
         pool: &DbPool,
     ) -> Result<(), ApiError> {
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            remove_manual_membership_source(conn, member_principal_id, self.id).await?;
+            let _ = remove_manual_membership_source(conn, member_principal_id, self.id).await?;
             Ok(())
         })
         .await?;
@@ -608,9 +624,10 @@ impl GroupMembersBackend for Group {
             let membership = load_principal_group(conn, member_principal_id, self.id)
                 .await
                 .optional()?;
-            remove_manual_membership_source(conn, member_principal_id, self.id).await?;
+            let removed_effective =
+                remove_manual_membership_source(conn, member_principal_id, self.id).await?;
 
-            if let Some(membership) = membership {
+            if let Some(membership) = membership.filter(|_| removed_effective) {
                 let event = NewEvent::new(
                     EntityType::UserGroup,
                     Action::Removed,
@@ -656,7 +673,7 @@ impl SavePrincipalGroupRecord for NewPrincipalGroup {
         pool: &DbPool,
     ) -> Result<PrincipalGroup, ApiError> {
         with_transaction(pool, async |conn| -> Result<PrincipalGroup, ApiError> {
-            let membership =
+            let (membership, _) =
                 insert_effective_membership(conn, self.principal_id, self.group_id).await?;
             insert_manual_membership_source(conn, self.principal_id, self.group_id).await?;
             Ok(membership)
@@ -674,33 +691,27 @@ impl SavePrincipalGroupRecord for NewPrincipalGroup {
         };
 
         with_transaction(pool, async |conn| -> Result<PrincipalGroup, ApiError> {
-            let already_present = load_principal_group(conn, self.principal_id, self.group_id)
-                .await
-                .optional()?;
-            let membership =
+            let (membership, inserted) =
                 insert_effective_membership(conn, self.principal_id, self.group_id).await?;
             insert_manual_membership_source(conn, self.principal_id, self.group_id).await?;
-            match already_present {
-                None => {
-                    let event = NewEvent::new(
-                        EntityType::UserGroup,
-                        Action::Added,
-                        context.actor_kind(),
-                        format!(
-                            "Principal {} added to group {}",
-                            membership.principal_id, membership.group_id
-                        ),
-                    )?
-                    .with_context(context)
-                    .with_metadata(user_group_metadata(
-                        membership.principal_id,
-                        membership.group_id,
-                    ));
-                    emit_event(conn, &event).await?;
-                    Ok(membership)
-                }
-                Some(_) => Ok(membership),
+            if inserted {
+                let event = NewEvent::new(
+                    EntityType::UserGroup,
+                    Action::Added,
+                    context.actor_kind(),
+                    format!(
+                        "Principal {} added to group {}",
+                        membership.principal_id, membership.group_id
+                    ),
+                )?
+                .with_context(context)
+                .with_metadata(user_group_metadata(
+                    membership.principal_id,
+                    membership.group_id,
+                ));
+                emit_event(conn, &event).await?;
             }
+            Ok(membership)
         })
         .await
     }
@@ -712,7 +723,7 @@ impl SavePrincipalGroupRecord for PrincipalGroup {
         pool: &DbPool,
     ) -> Result<PrincipalGroup, ApiError> {
         with_transaction(pool, async |conn| -> Result<PrincipalGroup, ApiError> {
-            let membership =
+            let (membership, _) =
                 insert_effective_membership(conn, self.principal_id, self.group_id).await?;
             insert_manual_membership_source(conn, self.principal_id, self.group_id).await?;
             Ok(membership)
@@ -730,24 +741,26 @@ impl SavePrincipalGroupRecord for PrincipalGroup {
         };
 
         with_transaction(pool, async |conn| -> Result<PrincipalGroup, ApiError> {
-            let membership =
+            let (membership, inserted) =
                 insert_effective_membership(conn, self.principal_id, self.group_id).await?;
             insert_manual_membership_source(conn, self.principal_id, self.group_id).await?;
-            let event = NewEvent::new(
-                EntityType::UserGroup,
-                Action::Added,
-                context.actor_kind(),
-                format!(
-                    "Principal {} added to group {}",
-                    membership.principal_id, membership.group_id
-                ),
-            )?
-            .with_context(context)
-            .with_metadata(user_group_metadata(
-                membership.principal_id,
-                membership.group_id,
-            ));
-            emit_event(conn, &event).await?;
+            if inserted {
+                let event = NewEvent::new(
+                    EntityType::UserGroup,
+                    Action::Added,
+                    context.actor_kind(),
+                    format!(
+                        "Principal {} added to group {}",
+                        membership.principal_id, membership.group_id
+                    ),
+                )?
+                .with_context(context)
+                .with_metadata(user_group_metadata(
+                    membership.principal_id,
+                    membership.group_id,
+                ));
+                emit_event(conn, &event).await?;
+            }
             Ok(membership)
         })
         .await
@@ -774,7 +787,8 @@ pub trait DeletePrincipalGroupRecord {
 impl DeletePrincipalGroupRecord for PrincipalGroup {
     async fn delete_principal_group_record(&self, pool: &DbPool) -> Result<(), ApiError> {
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            remove_manual_membership_source(conn, self.principal_id, self.group_id).await
+            let _ = remove_manual_membership_source(conn, self.principal_id, self.group_id).await?;
+            Ok(())
         })
         .await?;
         Ok(())

--- a/src/db/traits/object.rs
+++ b/src/db/traits/object.rs
@@ -449,8 +449,12 @@ impl UpdateObjectRecord for UpdateHubuumObject {
         with_transaction(pool, async |conn| -> Result<HubuumObject, ApiError> {
             let before = hubuumobject
                 .filter(id.eq(object_id))
+                .for_update()
                 .first::<HubuumObject>(conn)
                 .await?;
+            if !self.has_changes(&before) {
+                return Ok(before);
+            }
             let updated = diesel::update(hubuumobject.filter(id.eq(object_id)))
                 .set(self)
                 .get_result::<HubuumObject>(conn)
@@ -508,16 +512,21 @@ impl DeleteObjectRecord for HubuumObject {
         use crate::schema::hubuumobject::dsl::{hubuumobject, id};
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
+            let before = hubuumobject
+                .filter(id.eq(self.id))
+                .for_update()
+                .first::<HubuumObject>(conn)
+                .await?;
             diesel::delete(hubuumobject.filter(id.eq(self.id)))
                 .execute(conn)
                 .await?;
             let event = object_event(
-                self,
+                &before,
                 Action::Deleted,
                 context,
-                format!("Object '{}' deleted", self.name),
+                format!("Object '{}' deleted", before.name),
             )?
-            .with_before(object_snapshot(self));
+            .with_before(object_snapshot(&before));
             emit_event(conn, &event).await?;
             Ok(())
         })

--- a/src/db/traits/permissions.rs
+++ b/src/db/traits/permissions.rs
@@ -168,6 +168,33 @@ fn update_permission_for_grant(
     update_perm
 }
 
+fn grant_changes_permission(
+    current: &Permission,
+    requested: &PermissionsList<Permissions>,
+    replace_existing: bool,
+) -> bool {
+    let granted = current.granted();
+    if replace_existing {
+        Permissions::ALL
+            .iter()
+            .any(|permission| granted.contains(permission) != requested.contains(permission))
+    } else {
+        requested
+            .iter()
+            .any(|permission| !granted.contains(permission))
+    }
+}
+
+fn revoke_changes_permission(
+    current: &Permission,
+    requested: &PermissionsList<Permissions>,
+) -> bool {
+    let granted = current.granted();
+    requested
+        .iter()
+        .any(|permission| granted.contains(permission))
+}
+
 fn update_permission_for_revoke(
     permission_list: &PermissionsList<Permissions>,
 ) -> UpdatePermission {
@@ -324,12 +351,16 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
             let existing_entry = permissions
                 .filter(collection_id.eq(target_collection_id))
                 .filter(group_id.eq(group_id_for_grant))
+                .for_update()
                 .first::<Permission>(conn)
                 .await
                 .optional()?;
 
             match existing_entry {
-                Some(_) => {
+                Some(existing) => {
+                    if !grant_changes_permission(&existing, &permission_list, replace_existing) {
+                        return Ok(existing);
+                    }
                     let mut update_perm = if replace_existing {
                         UpdatePermission {
                             has_read_collection: Some(false),
@@ -565,9 +596,16 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
             let before = permissions
                 .filter(collection_id.eq(target_collection_id))
                 .filter(group_id.eq(group_id_for_grant))
+                .for_update()
                 .first::<Permission>(conn)
                 .await
                 .optional()?;
+
+            if let Some(current) = before
+                && !grant_changes_permission(&current, &permission_list, replace_existing)
+            {
+                return Ok(current);
+            }
 
             let after = match before {
                 Some(_) => {
@@ -628,11 +666,16 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
         let target_collection_id = self.collection_id(pool).await?.id();
 
         with_transaction(pool, async |conn| -> Result<Permission, ApiError> {
-            permissions
+            let before = permissions
                 .filter(collection_id.eq(target_collection_id))
                 .filter(group_id.eq(group_id_for_revoke))
+                .for_update()
                 .first::<Permission>(conn)
                 .await?;
+
+            if !revoke_changes_permission(&before, &permission_list) {
+                return Ok(before);
+            }
 
             let mut update_perm = UpdatePermission::default();
             for permission in permission_list.into_iter() {
@@ -769,8 +812,13 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
             let before = permissions
                 .filter(collection_id.eq(target_collection_id))
                 .filter(group_id.eq(group_id_for_revoke))
+                .for_update()
                 .first::<Permission>(conn)
                 .await?;
+
+            if !revoke_changes_permission(&before, &permission_list) {
+                return Ok(before);
+            }
 
             let update_perm = update_permission_for_revoke(&permission_list);
             let after = diesel::update(permissions)
@@ -838,6 +886,7 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
             let before = permissions
                 .filter(collection_id.eq(collection_id_for_revoke))
                 .filter(group_id.eq(group_id_for_revoke))
+                .for_update()
                 .first::<Permission>(conn)
                 .await
                 .optional()?;

--- a/src/db/traits/relations.rs
+++ b/src/db/traits/relations.rs
@@ -782,12 +782,17 @@ impl DeleteClassRelationRecord for HubuumClassRelation {
         use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
+            let relation = hubuumclass_relation
+                .filter(id.eq(self.id))
+                .for_update()
+                .first::<HubuumClassRelation>(conn)
+                .await?;
             let from_class = hubuumclass
-                .filter(class_id.eq(self.from_hubuum_class_id))
+                .filter(class_id.eq(relation.from_hubuum_class_id))
                 .first::<HubuumClass>(conn)
                 .await?;
             let to_class = hubuumclass
-                .filter(class_id.eq(self.to_hubuum_class_id))
+                .filter(class_id.eq(relation.to_hubuum_class_id))
                 .first::<HubuumClass>(conn)
                 .await?;
 
@@ -800,12 +805,12 @@ impl DeleteClassRelationRecord for HubuumClassRelation {
                 context.actor_kind(),
                 format!(
                     "Class relation {} -> {} deleted",
-                    self.from_hubuum_class_id, self.to_hubuum_class_id
+                    relation.from_hubuum_class_id, relation.to_hubuum_class_id
                 ),
             )?
             .with_context(context)
-            .with_entity_id(self.id)
-            .with_before(class_relation_snapshot(self))
+            .with_entity_id(relation.id)
+            .with_before(class_relation_snapshot(&relation))
             .with_metadata(class_relation_metadata(&from_class, &to_class));
             emit_event(conn, &event).await?;
             Ok(())
@@ -845,6 +850,7 @@ impl DeleteClassRelationRecord for HubuumClassRelationID {
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let relation = hubuumclass_relation
                 .filter(id.eq(self.id()))
+                .for_update()
                 .first::<HubuumClassRelation>(conn)
                 .await?;
             let from_class = hubuumclass
@@ -1081,12 +1087,17 @@ impl DeleteObjectRelationRecord for HubuumObjectRelation {
         use crate::schema::hubuumobject_relation::dsl::{hubuumobject_relation, id};
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
+            let relation = hubuumobject_relation
+                .filter(id.eq(self.id))
+                .for_update()
+                .first::<HubuumObjectRelation>(conn)
+                .await?;
             let from_object = hubuumobject
-                .filter(object_id.eq(self.from_hubuum_object_id))
+                .filter(object_id.eq(relation.from_hubuum_object_id))
                 .first::<HubuumObject>(conn)
                 .await?;
             let to_object = hubuumobject
-                .filter(object_id.eq(self.to_hubuum_object_id))
+                .filter(object_id.eq(relation.to_hubuum_object_id))
                 .first::<HubuumObject>(conn)
                 .await?;
             diesel::delete(hubuumobject_relation.filter(id.eq(self.id)))
@@ -1098,13 +1109,17 @@ impl DeleteObjectRelationRecord for HubuumObjectRelation {
                 context.actor_kind(),
                 format!(
                     "Object relation {} -> {} deleted",
-                    self.from_hubuum_object_id, self.to_hubuum_object_id
+                    relation.from_hubuum_object_id, relation.to_hubuum_object_id
                 ),
             )?
             .with_context(context)
-            .with_entity_id(self.id)
-            .with_before(object_relation_snapshot(self))
-            .with_metadata(object_relation_metadata(self, &from_object, &to_object));
+            .with_entity_id(relation.id)
+            .with_before(object_relation_snapshot(&relation))
+            .with_metadata(object_relation_metadata(
+                &relation,
+                &from_object,
+                &to_object,
+            ));
             emit_event(conn, &event).await?;
             Ok(())
         })
@@ -1145,6 +1160,7 @@ impl DeleteObjectRelationRecord for HubuumObjectRelationID {
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let relation = hubuumobject_relation
                 .filter(id.eq(self.id()))
+                .for_update()
                 .first::<HubuumObjectRelation>(conn)
                 .await?;
             let from_object = hubuumobject

--- a/src/db/traits/remote_target.rs
+++ b/src/db/traits/remote_target.rs
@@ -167,8 +167,12 @@ impl UpdateRemoteTargetRecord for UpdateRemoteTargetRow {
         with_transaction(pool, async |conn| -> Result<RemoteTargetRow, ApiError> {
             let before = remote_targets
                 .filter(id.eq(target_id))
+                .for_update()
                 .first::<RemoteTargetRow>(conn)
                 .await?;
+            if !self.has_changes(&before) {
+                return Ok(before);
+            }
             let after = diesel::update(remote_targets.filter(id.eq(target_id)))
                 .set(self)
                 .get_result::<RemoteTargetRow>(conn)
@@ -234,6 +238,7 @@ impl DeleteRemoteTargetRecord for RemoteTargetID {
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let before = remote_targets
                 .filter(id.eq(self.id()))
+                .for_update()
                 .first::<RemoteTargetRow>(conn)
                 .await?;
             diesel::delete(remote_targets.filter(id.eq(self.id())))

--- a/src/db/traits/service_account.rs
+++ b/src/db/traits/service_account.rs
@@ -169,25 +169,20 @@ async fn update_service_account_record(
     use crate::schema::service_accounts::dsl::{id, service_accounts as sa_table};
 
     with_transaction(pool, async |conn| -> Result<ServiceAccount, ApiError> {
-        let before = if event_context.is_some() {
-            Some(
-                sa_table
-                    .filter(id.eq(service_account_id))
-                    .first::<ServiceAccount>(conn)
-                    .await?,
-            )
-        } else {
-            None
-        };
+        let before = sa_table
+            .filter(id.eq(service_account_id))
+            .for_update()
+            .first::<ServiceAccount>(conn)
+            .await?;
+        if !update.has_changes(&before) {
+            return Ok(before);
+        }
         let updated = diesel::update(sa_table.filter(id.eq(service_account_id)))
             .set(update)
             .get_result::<ServiceAccount>(conn)
             .await?;
         if let Some(event_context) = event_context {
             let name = load_principal_name_by_id(conn, updated.id).await?;
-            let before = before.ok_or_else(|| {
-                ApiError::InternalServerError("missing service account event snapshot".to_string())
-            })?;
             let event = NewEvent::new(
                 EntityType::ServiceAccount,
                 Action::Updated,
@@ -276,8 +271,12 @@ where
         async |conn| -> Result<ServiceAccount, ApiError> {
             let before = sa_table
                 .filter(id.eq(sa_id))
+                .for_update()
                 .first::<ServiceAccount>(conn)
                 .await?;
+            if before.disabled_at.is_some() {
+                return Ok(before);
+            }
             let disabled = diesel::update(sa_table.filter(id.eq(sa_id)))
                 .set(disabled_at.eq(diesel::dsl::now))
                 .get_result::<ServiceAccount>(conn)
@@ -314,6 +313,12 @@ async fn delete_service_account(
     use crate::schema::principals::dsl::{id, principals as principals_table};
     let sa_id = account_id.id();
     with_transaction(pool, async |conn| -> Result<(), ApiError> {
+        principals_table
+            .filter(id.eq(sa_id))
+            .for_update()
+            .select(id)
+            .first::<i32>(conn)
+            .await?;
         let sa = load_service_account_by_id_conn(conn, sa_id).await?;
         if let Some(event_context) = event_context {
             let name = load_principal_name_by_id(conn, sa_id).await?;

--- a/src/db/traits/user/auth.rs
+++ b/src/db/traits/user/auth.rs
@@ -279,6 +279,12 @@ async fn delete_principal(
     use crate::schema::principals::dsl::{id, principals};
 
     with_transaction(pool, async |conn| -> Result<usize, ApiError> {
+        principals
+            .filter(id.eq(principal_id_value))
+            .for_update()
+            .select(id)
+            .first::<i32>(conn)
+            .await?;
         let (user, name) = load_user_with_name(conn, principal_id_value).await?;
         ensure_user_allows_local_write_conn(conn, principal_id_value).await?;
         let deleted = diesel::delete(principals.filter(id.eq(principal_id_value)))
@@ -497,8 +503,22 @@ impl UpdateUserRecord for UpdateUser {
         use crate::schema::users::dsl::{id, users};
 
         with_transaction(pool, async |conn| -> Result<User, ApiError> {
-            let (before, name) = load_user_with_name(conn, user_id).await?;
+            use crate::schema::principals;
+
+            let before = users
+                .filter(id.eq(user_id))
+                .for_update()
+                .first::<User>(conn)
+                .await?;
+            let name = principals::table
+                .filter(principals::id.eq(user_id))
+                .select(principals::name)
+                .first::<String>(conn)
+                .await?;
             ensure_user_allows_local_write_conn(conn, user_id).await?;
+            if !self.has_changes(&before) {
+                return Ok(before);
+            }
             let after = diesel::update(users.filter(id.eq(user_id)))
                 .set(self)
                 .get_result::<User>(conn)

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -33,7 +33,7 @@ use crate::events::{
     Action, ActorKind, EntityType, Event, EventContext, NewEvent, RequestProvenance, emit_event,
 };
 use crate::models::class::{NewHubuumClass, UpdateHubuumClass};
-use crate::models::collection::{NewCollectionWithAssignee, UpdateCollection};
+use crate::models::collection::{NewCollectionWithAssignee, UpdateCollection, move_collection};
 use crate::models::group::{NewGroup, UpdateGroup};
 use crate::models::object::{NewHubuumObject, UpdateHubuumObject};
 use crate::models::token::{create_principal_token, revoke_token_by_id_for_principal};
@@ -865,7 +865,16 @@ async fn collection_writes_emit_lifecycle_events_in_transaction() {
     .await
     .unwrap();
 
-    updated.delete(&scope.pool, &context).await.unwrap();
+    let unchanged = UpdateCollection {
+        name: Some(collection_name.clone()),
+        description: Some("after".to_string()),
+    }
+    .update(&scope.pool, collection.id, &context)
+    .await
+    .unwrap();
+    assert_eq!(unchanged.updated_at, updated.updated_at);
+
+    unchanged.delete(&scope.pool, &context).await.unwrap();
 
     let rows = events_for(&scope, "collection", collection.id).await;
     assert_eq!(rows.len(), 3);
@@ -892,6 +901,27 @@ async fn collection_writes_emit_lifecycle_events_in_transaction() {
     assert_eq!(rows[2].before.as_ref().unwrap()["description"], "after");
     assert!(rows[2].after.is_none());
 
+    fixture.cleanup().await.unwrap();
+}
+
+#[actix_web::test]
+async fn moving_a_collection_to_its_current_parent_is_a_noop() {
+    let scope = test_scope();
+    let fixture = scope.with_collection().await;
+    let context = EventContext::user(8, Some(Uuid::new_v4()), None);
+    let collection = fixture.collection.clone();
+    let parent_id = collection.parent_collection_id.unwrap();
+    let event_count = events_for(&scope, "collection", collection.id).await.len();
+
+    let unchanged = move_collection(&scope.pool, collection.id, parent_id, Some(&context))
+        .await
+        .unwrap();
+
+    assert_eq!(unchanged.updated_at, collection.updated_at);
+    assert_eq!(
+        events_for(&scope, "collection", collection.id).await.len(),
+        event_count
+    );
     fixture.cleanup().await.unwrap();
 }
 
@@ -924,7 +954,22 @@ async fn class_writes_emit_lifecycle_events_in_transaction() {
     .await
     .unwrap();
 
-    updated.delete(&scope.pool, &context).await.unwrap();
+    let unchanged = UpdateHubuumClass {
+        name: Some(class_name.clone()),
+        collection_id: Some(fixture.collection.id),
+        json_schema: Some(serde_json::json!({
+            "type": "object",
+            "additionalProperties": true
+        })),
+        validate_schema: Some(false),
+        description: Some("after".to_string()),
+    }
+    .update(&scope.pool, class.id, &context)
+    .await
+    .unwrap();
+    assert_eq!(unchanged.updated_at, updated.updated_at);
+
+    unchanged.delete(&scope.pool, &context).await.unwrap();
 
     let rows = events_for(&scope, "class", class.id).await;
     assert_eq!(rows.len(), 3);
@@ -990,7 +1035,19 @@ async fn object_writes_emit_lifecycle_events_in_transaction() {
     .await
     .unwrap();
 
-    updated.delete(&scope.pool, &context).await.unwrap();
+    let unchanged = UpdateHubuumObject {
+        name: Some(object_name.clone()),
+        collection_id: Some(fixture.collection.id),
+        hubuum_class_id: Some(class.id),
+        data: Some(serde_json::json!({"state": "after"})),
+        description: Some("after".to_string()),
+    }
+    .update(&scope.pool, object.id, &context)
+    .await
+    .unwrap();
+    assert_eq!(unchanged.updated_at, updated.updated_at);
+
+    unchanged.delete(&scope.pool, &context).await.unwrap();
 
     let rows = events_for(&scope, "object", object.id).await;
     assert_eq!(rows.len(), 3);
@@ -1244,7 +1301,15 @@ async fn group_writes_emit_lifecycle_events_in_transaction() {
     .await
     .unwrap();
 
-    GroupID::new(updated.id)
+    let unchanged = UpdateGroup {
+        groupname: Some(updated.groupname.clone()),
+    }
+    .save(group.id, &scope.pool, Some(&context))
+    .await
+    .unwrap();
+    assert_eq!(unchanged.updated_at, updated.updated_at);
+
+    GroupID::new(unchanged.id)
         .unwrap()
         .delete(&scope.pool, Some(&context))
         .await
@@ -1372,7 +1437,17 @@ async fn user_writes_emit_lifecycle_events_without_password_material() {
     .await
     .unwrap();
 
-    updated.delete(&scope.pool, Some(&context)).await.unwrap();
+    let unchanged = UpdateUser {
+        password: None,
+        proper_name: Some("After User".to_string()),
+        email: Some("after@example.invalid".to_string()),
+    }
+    .save(user.id, &scope.pool, Some(&context))
+    .await
+    .unwrap();
+    assert_eq!(unchanged.updated_at, updated.updated_at);
+
+    unchanged.delete(&scope.pool, Some(&context)).await.unwrap();
 
     let rows = events_for(&scope, "user", user.id).await;
     assert_eq!(rows.len(), 3);
@@ -1497,6 +1572,29 @@ async fn permission_writes_emit_granted_revoked_events() {
 
     fixture
         .collection
+        .grant(
+            &scope.pool,
+            group.id,
+            PermissionsList::new([Permissions::ReadCollection, Permissions::CreateClass]),
+            Some(&context),
+        )
+        .await
+        .unwrap();
+
+    fixture
+        .collection
+        .apply_permissions(
+            &scope.pool,
+            group.id,
+            PermissionsList::new([Permissions::ReadCollection, Permissions::CreateClass]),
+            true,
+            Some(&context),
+        )
+        .await
+        .unwrap();
+
+    fixture
+        .collection
         .revoke(
             &scope.pool,
             group.id,
@@ -1506,6 +1604,22 @@ async fn permission_writes_emit_granted_revoked_events() {
         .await
         .unwrap();
 
+    fixture
+        .collection
+        .revoke(
+            &scope.pool,
+            group.id,
+            PermissionsList::new([Permissions::CreateClass]),
+            Some(&context),
+        )
+        .await
+        .unwrap();
+
+    fixture
+        .collection
+        .revoke_all(&scope.pool, group.id, Some(&context))
+        .await
+        .unwrap();
     fixture
         .collection
         .revoke_all(&scope.pool, group.id, Some(&context))
@@ -1607,6 +1721,24 @@ async fn export_template_writes_emit_lifecycle_events() {
     .await
     .unwrap();
 
+    UpdateExportTemplate {
+        collection_id: Some(fixture.collection.id),
+        name: Some(updated.name.clone()),
+        description: Some("after".to_string()),
+        template: Some("Goodbye {{ name }}".to_string()),
+        kind: Some(ExportTemplateKind::Fragment),
+        scope_kind: None,
+        class_id: None,
+        default_query: None,
+        include: None,
+        relation_context: None,
+        default_missing_data_policy: None,
+        default_limits: None,
+    }
+    .update(&scope.pool, template.id, &context)
+    .await
+    .unwrap();
+
     ExportTemplateID::new(updated.id)
         .unwrap()
         .delete(&scope.pool, &context)
@@ -1686,6 +1818,24 @@ async fn remote_target_writes_emit_lifecycle_and_invoked_events_with_redacted_au
     .update_remote_target_record(&scope.pool, row.id, Some(&context))
     .await
     .unwrap();
+    let unchanged = UpdateRemoteTargetRow {
+        collection_id: Some(updated.collection_id),
+        class_id: Some(updated.class_id),
+        name: Some(updated.name.clone()),
+        description: Some(updated.description.clone()),
+        method: Some(updated.method.clone()),
+        url_template: Some(updated.url_template.clone()),
+        headers_template: Some(updated.headers_template.clone()),
+        body_template: Some(updated.body_template.clone()),
+        auth_config: Some(updated.auth_config.clone()),
+        allowed_subject_types: Some(updated.allowed_subject_types.clone()),
+        timeout_ms: Some(updated.timeout_ms),
+        enabled: Some(updated.enabled),
+    }
+    .update_remote_target_record(&scope.pool, row.id, Some(&context))
+    .await
+    .unwrap();
+    assert_eq!(unchanged.updated_at, updated.updated_at);
     let target = updated.clone().try_into().unwrap();
 
     emit_remote_target_invoked_event(

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -42,6 +42,28 @@ pub struct UpdateHubuumClass {
     pub description: Option<String>,
 }
 
+impl UpdateHubuumClass {
+    pub(crate) fn has_changes(&self, current: &HubuumClass) -> bool {
+        self.name
+            .as_ref()
+            .is_some_and(|value| value != &current.name)
+            || self
+                .collection_id
+                .is_some_and(|value| value != current.collection_id)
+            || self
+                .json_schema
+                .as_ref()
+                .is_some_and(|value| Some(value) != current.json_schema.as_ref())
+            || self
+                .validate_schema
+                .is_some_and(|value| value != current.validate_schema)
+            || self
+                .description
+                .as_ref()
+                .is_some_and(|value| value != &current.description)
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
 pub struct HubuumClassWithPath {
     pub id: i32,

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -52,6 +52,18 @@ pub struct UpdateCollection {
     pub description: Option<String>,
 }
 
+impl UpdateCollection {
+    pub(crate) fn has_changes(&self, current: &Collection) -> bool {
+        self.name
+            .as_ref()
+            .is_some_and(|value| value != &current.name)
+            || self
+                .description
+                .as_ref()
+                .is_some_and(|value| value != &current.description)
+    }
+}
+
 /// A new collection, with an assignee. Used for creating new collection entries
 /// into the database and assign all permissions to the group given as group_id.
 ///

--- a/src/models/event_subscription.rs
+++ b/src/models/event_subscription.rs
@@ -147,6 +147,27 @@ pub(crate) struct UpdateEventSinkRow {
     pub enabled: Option<bool>,
 }
 
+impl UpdateEventSinkRow {
+    pub(crate) fn has_changes(&self, current: &EventSinkRow) -> bool {
+        self.name
+            .as_ref()
+            .is_some_and(|value| value != &current.name)
+            || self
+                .kind
+                .as_ref()
+                .is_some_and(|value| value != &current.kind)
+            || self
+                .config
+                .as_ref()
+                .is_some_and(|value| value != &current.config)
+            || self
+                .secret_ref
+                .as_ref()
+                .is_some_and(|value| value != &current.secret_ref)
+            || self.enabled.is_some_and(|value| value != current.enabled)
+    }
+}
+
 #[derive(Debug, Clone, Queryable, Selectable)]
 #[diesel(table_name = event_subscriptions)]
 pub(crate) struct EventSubscriptionRow {
@@ -234,6 +255,37 @@ pub(crate) struct UpdateEventSubscriptionRow {
     pub filter: Option<serde_json::Value>,
     pub routing: Option<serde_json::Value>,
     pub enabled: Option<bool>,
+}
+
+impl UpdateEventSubscriptionRow {
+    pub(crate) fn has_changes(&self, current: &EventSubscriptionRow) -> bool {
+        self.sink_id.is_some_and(|value| value != current.sink_id)
+            || self
+                .name
+                .as_ref()
+                .is_some_and(|value| value != &current.name)
+            || self
+                .description
+                .as_ref()
+                .is_some_and(|value| value != &current.description)
+            || self
+                .entity_types
+                .as_ref()
+                .is_some_and(|value| value != &current.entity_types)
+            || self
+                .actions
+                .as_ref()
+                .is_some_and(|value| value != &current.actions)
+            || self
+                .filter
+                .as_ref()
+                .is_some_and(|value| value != &current.filter)
+            || self
+                .routing
+                .as_ref()
+                .is_some_and(|value| value != &current.routing)
+            || self.enabled.is_some_and(|value| value != current.enabled)
+    }
 }
 
 impl TryFrom<EventSinkRow> for EventSink {

--- a/src/models/export_template.rs
+++ b/src/models/export_template.rs
@@ -258,6 +258,57 @@ pub(crate) struct UpdateExportTemplateRow {
     default_limits: Option<Option<serde_json::Value>>,
 }
 
+impl UpdateExportTemplateRow {
+    pub(crate) fn has_changes(&self, current: &ExportTemplateRow) -> bool {
+        self.collection_id
+            .is_some_and(|value| value != current.collection_id)
+            || self
+                .name
+                .as_ref()
+                .is_some_and(|value| value != &current.name)
+            || self
+                .description
+                .as_ref()
+                .is_some_and(|value| value != &current.description)
+            || self
+                .template
+                .as_ref()
+                .is_some_and(|value| value != &current.template)
+            || self
+                .kind
+                .as_ref()
+                .is_some_and(|value| value != &current.kind)
+            || self
+                .scope_kind
+                .as_ref()
+                .is_some_and(|value| value != &current.scope_kind)
+            || self
+                .class_id
+                .as_ref()
+                .is_some_and(|value| value != &current.class_id)
+            || self
+                .default_query
+                .as_ref()
+                .is_some_and(|value| value != &current.default_query)
+            || self
+                .include
+                .as_ref()
+                .is_some_and(|value| value != &current.include)
+            || self
+                .relation_context
+                .as_ref()
+                .is_some_and(|value| value != &current.relation_context)
+            || self
+                .default_missing_data_policy
+                .as_ref()
+                .is_some_and(|value| value != &current.default_missing_data_policy)
+            || self
+                .default_limits
+                .as_ref()
+                .is_some_and(|value| value != &current.default_limits)
+    }
+}
+
 impl TryFrom<ExportTemplateRow> for ExportTemplate {
     type Error = ApiError;
 

--- a/src/models/group.rs
+++ b/src/models/group.rs
@@ -389,6 +389,14 @@ pub struct UpdateGroup {
 }
 
 impl UpdateGroup {
+    pub(crate) fn has_changes(&self, current: &Group) -> bool {
+        self.groupname
+            .as_ref()
+            .is_some_and(|value| value != &current.groupname)
+    }
+}
+
+impl UpdateGroup {
     /// Persist changes without emitting domain events.
     ///
     /// Intended only for internal infrastructure paths such as bootstrap/setup,

--- a/src/models/object.rs
+++ b/src/models/object.rs
@@ -55,6 +55,28 @@ pub struct UpdateHubuumObject {
     pub description: Option<String>,
 }
 
+impl UpdateHubuumObject {
+    pub(crate) fn has_changes(&self, current: &HubuumObject) -> bool {
+        self.name
+            .as_ref()
+            .is_some_and(|value| value != &current.name)
+            || self
+                .collection_id
+                .is_some_and(|value| value != current.collection_id)
+            || self
+                .hubuum_class_id
+                .is_some_and(|value| value != current.hubuum_class_id)
+            || self
+                .data
+                .as_ref()
+                .is_some_and(|value| value != &current.data)
+            || self
+                .description
+                .as_ref()
+                .is_some_and(|value| value != &current.description)
+    }
+}
+
 crate::int_id_newtype! {
     /// Identifier wrapper for a [`HubuumObject`].
     pub struct HubuumObjectID;

--- a/src/models/remote_target.rs
+++ b/src/models/remote_target.rs
@@ -265,6 +265,53 @@ pub(crate) struct UpdateRemoteTargetRow {
     pub enabled: Option<bool>,
 }
 
+impl UpdateRemoteTargetRow {
+    pub(crate) fn has_changes(&self, current: &RemoteTargetRow) -> bool {
+        self.collection_id
+            .is_some_and(|value| value != current.collection_id)
+            || self
+                .class_id
+                .as_ref()
+                .is_some_and(|value| value != &current.class_id)
+            || self
+                .name
+                .as_ref()
+                .is_some_and(|value| value != &current.name)
+            || self
+                .description
+                .as_ref()
+                .is_some_and(|value| value != &current.description)
+            || self
+                .method
+                .as_ref()
+                .is_some_and(|value| value != &current.method)
+            || self
+                .url_template
+                .as_ref()
+                .is_some_and(|value| value != &current.url_template)
+            || self
+                .headers_template
+                .as_ref()
+                .is_some_and(|value| value != &current.headers_template)
+            || self
+                .body_template
+                .as_ref()
+                .is_some_and(|value| value != &current.body_template)
+            || self
+                .auth_config
+                .as_ref()
+                .is_some_and(|value| value != &current.auth_config)
+            || self
+                .allowed_subject_types
+                .as_ref()
+                .is_some_and(|value| value != &current.allowed_subject_types)
+            || self
+                .timeout_ms
+                .is_some_and(|value| value != current.timeout_ms)
+            || self.enabled.is_some_and(|value| value != current.enabled)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct RemoteTargetInvokeRequest {
     pub subject: RemoteInvocationSubject,

--- a/src/models/service_account.rs
+++ b/src/models/service_account.rs
@@ -201,6 +201,17 @@ pub struct UpdateServiceAccount {
     pub owner_group_id: Option<i32>,
 }
 
+impl UpdateServiceAccount {
+    pub(crate) fn has_changes(&self, current: &ServiceAccount) -> bool {
+        self.description
+            .as_ref()
+            .is_some_and(|value| value != &current.description)
+            || self
+                .owner_group_id
+                .is_some_and(|value| value != current.owner_group_id)
+    }
+}
+
 crate::int_id_newtype! {
     /// Identifier wrapper for a [`ServiceAccount`].
     pub struct ServiceAccountID;

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -385,6 +385,18 @@ pub struct UpdateUser {
 }
 
 impl UpdateUser {
+    pub(crate) fn has_changes(&self, current: &User) -> bool {
+        self.password.is_some()
+            || self
+                .proper_name
+                .as_ref()
+                .is_some_and(|value| Some(value) != current.proper_name.as_ref())
+            || self
+                .email
+                .as_ref()
+                .is_some_and(|value| Some(value) != current.email.as_ref())
+    }
+
     pub fn hash_password(self) -> Result<Self, ApiError> {
         if let Some(ref pass) = self.password {
             match crate::utilities::auth::hash_password(pass) {

--- a/src/tests/api/v1/event_subscriptions.rs
+++ b/src/tests/api/v1/event_subscriptions.rs
@@ -10,7 +10,7 @@ mod tests {
         EventSink, EventSinkKind, EventSubscription, NewEventSink, NewEventSubscription,
     };
     use crate::tests::TestContext;
-    use crate::tests::api_operations::{delete_request, get_request, post_request};
+    use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
     use crate::tests::asserts::assert_response_status;
 
     const SINKS_ENDPOINT: &str = "/api/v1/event-sinks";
@@ -110,6 +110,19 @@ mod tests {
         let fetched: EventSink = test::read_body_json(resp).await;
         assert_eq!(fetched.id, created.id);
 
+        let resp = patch_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("{SINKS_ENDPOINT}/{}", created.id),
+            json!({ "enabled": true }),
+        )
+        .await;
+        assert_response_status(resp, StatusCode::OK).await;
+        assert_eq!(
+            audit_event_count(&context, EntityType::EventSink, Action::Updated, created.id).await,
+            0
+        );
+
         if let Some(kind) = disabled_sink_kind_for_feature_set() {
             let disabled_kind = NewEventSink {
                 name: context.scoped_name("sink_disabled"),
@@ -183,6 +196,25 @@ mod tests {
             )
             .await,
             1
+        );
+
+        let resp = patch_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("{endpoint}/{}", created.id),
+            json!({ "enabled": true }),
+        )
+        .await;
+        assert_response_status(resp, StatusCode::OK).await;
+        assert_eq!(
+            audit_event_count(
+                &context,
+                EntityType::EventSubscription,
+                Action::Updated,
+                created.id
+            )
+            .await,
+            0
         );
 
         let invalid_pair = NewEventSubscription {

--- a/src/tests/api/v1/service_accounts.rs
+++ b/src/tests/api/v1/service_accounts.rs
@@ -1421,14 +1421,32 @@ mod tests {
             1
         );
 
-        let resp = post_request(
+        let resp = patch_request(
             &context.pool,
             &context.admin_token,
-            &format!("{SERVICE_ACCOUNTS_ENDPOINT}/{}/disable", created.id),
-            serde_json::json!({}),
+            &format!("{SERVICE_ACCOUNTS_ENDPOINT}/{}", created.id),
+            serde_json::json!({
+                "description": "audited",
+                "owner_group_id": group.id
+            }),
         )
         .await;
         assert_response_status(resp, StatusCode::OK).await;
+        assert_eq!(
+            service_account_audit_event_count(&context, Action::Updated, created.id).await,
+            0
+        );
+
+        for _ in 0..2 {
+            let resp = post_request(
+                &context.pool,
+                &context.admin_token,
+                &format!("{SERVICE_ACCOUNTS_ENDPOINT}/{}/disable", created.id),
+                serde_json::json!({}),
+            )
+            .await;
+            assert_response_status(resp, StatusCode::OK).await;
+        }
         assert_eq!(
             service_account_audit_event_count(&context, Action::Disabled, created.id).await,
             1


### PR DESCRIPTION
## Summary

- Treat audited updates as no-ops when the requested values already match the
  persisted domain state.
- Suppress duplicate lifecycle events for same-parent collection moves,
  repeated permission grants or revocations, repeated service-account disable
  requests, and membership changes that do not change effective membership.
- Serialize event decisions with the affected rows so concurrent update,
  delete, membership, and revoke-all requests cannot append duplicate state
  transitions.
- Document the no-op event contract and broaden the Unreleased changelog entry.

## Root cause

Most event-aware update paths executed their Diesel changeset and emitted an
`updated` event without first comparing the requested values with the stored
row. Ordinary tables still advanced `updated_at`, while temporal tables can
cancel unchanged writes in a trigger, so an identical request could either
produce a misleading event or surface as a missing updated row. Other
idempotent mutations similarly emitted events from the request rather than from
an actual effective-state transition.

## Behavior notes

Identical audited updates now return the current row without advancing
`updated_at` or appending an event. The same rule applies to idempotent moves,
permission changes, service-account disable requests, and effective group
membership transitions. Activity events such as task lifecycle, external
identity synchronization, and remote-target invocation remain unchanged
because they record an operation rather than a domain-state transition.

There are no API shape, database schema, migration, or breaking changes.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `git diff --check`
