### PR TITLE
Harden distributed runtime safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,30 @@ jobs:
       - name: Test (${{ matrix.feature.name }})
         run: cargo test ${{ matrix.feature.args }} --locked --release
 
+  valkey-rate-limit-contract:
+    name: Valkey login limiter contract
+    if: "!startsWith(github.ref, 'refs/tags/')"
+    runs-on: ubuntu-24.04
+    services:
+      valkey:
+        image: valkey/valkey:9-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Cache cargo & target directories
+        uses: Swatinem/rust-cache@v2
+      - name: Run the shared limiter contract
+        run: >-
+          cargo test --locked --lib
+          'middlewares::rate_limit::tests::' -- --ignored
+
   test:
     name: ${{ matrix.platform.os_name }}, rust ${{ matrix.toolchain }}
     if: "!startsWith(github.ref, 'refs/tags/')"
@@ -487,6 +511,13 @@ jobs:
         run: |
           docker run --rm --entrypoint hubuum-admin "$IMAGE" --help \
             | grep --quiet -- "--migrate"
+          if docker run --rm --network host \
+            --entrypoint hubuum-admin \
+            --env HUBUUM_DATABASE_URL="$DATABASE_URL" \
+            "$IMAGE" --database-ready; then
+            echo "database readiness unexpectedly accepted an unmigrated schema" >&2
+            exit 1
+          fi
           docker run --rm --network host \
             --entrypoint hubuum-admin \
             --env HUBUUM_DATABASE_URL="$DATABASE_URL" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Background task workers now use the configured permission backend for
+  execution-time authorization, including worker-only replicas, rather than
+  falling back to local SQL permissions when Treetop is authoritative.
+- In-memory login limiting now rejects new high-cardinality scopes at its key
+  cap instead of evicting active failures or lockouts, preserving both the
+  default limiter and the local Valkey-outage safety state. CI now executes the
+  Valkey limiter contract against a real service.
+- Distributed API and worker startup, the admin database-readiness command, and
+  `/readyz` now require the latest application migration instead of checking
+  database connectivity alone.
 - Task workers now renew leases through a dedicated database pool and runtime
   thread, stop side-effecting work when renewal failures outlive the confirmed
   lease, keep renewing through failure finalization, and reconstruct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Breaking:** Import and export submission now requires an unscoped runtime
+  administrator. Non-admin and scoped tokens now receive `403 Forbidden`.
+  Automation should use dedicated service accounts in the configured admin
+  group with unscoped tokens; service accounts remain excluded from human/IAM
+  administration. Workers recheck runtime-admin authority before execution, so
+  queued tasks fail closed if that authority is revoked.
 - **Breaking:** Operational logs from the server and admin CLI are now
   newline-delimited JSON only. Update log collectors and parsers that expect the
   previous text format. Records now include request and correlation IDs,

--- a/docs/auth_model.md
+++ b/docs/auth_model.md
@@ -189,13 +189,16 @@ Unknown strings are rejected (fail-closed) wherever scopes are parsed.
 
 ### Scopes and async tasks
 
-Asynchronous work (import / export / remote-call tasks) must not later run with more
-authority than the request that enqueued it. At enqueue time the task records a
-**scope snapshot**: the submitting token id, its `scoped` flag, and a JSON array of
-its effective scope strings. The worker reconstructs the scopes from this snapshot
-(parsing every string fail-closed — an unknown value is a terminal task failure) and
-enforces them during execution. Revoking or changing the token after enqueue does
-not widen or narrow the accepted task; the snapshot is the execution boundary.
+Asynchronous work must not later run with more authority than the request that
+enqueued it. Remote-call tasks record a **scope snapshot** at enqueue time: the
+submitting token id, its `scoped` flag, and a JSON array of its effective scope
+strings. The worker reconstructs those scopes fail-closed and enforces them during
+execution.
+
+Import and export tasks accept only unscoped runtime administrators, so they store
+an unscoped marker instead of resource scopes. The worker rechecks the principal's
+current runtime-admin authority before execution. Revoking that authority or
+disabling the service account while the task is queued makes the task fail closed.
 
 ---
 
@@ -336,10 +339,11 @@ Each handler declares the authority it requires. There are two families.
 **Scope-aware (the only family that accepts scoped tokens and service accounts):**
 
 - `Authenticated` — resolves the principal and, if the token is scoped, its scope
-  set. Every downstream authority decision threads the scopes into the fail-closed
-  pre-filter. All resource and task-creating endpoints (collections, classes,
-  objects, relations, export_templates, search, exports, imports, remote-target invocation)
-  use this.
+  set. Every downstream authority decision threads the scopes into the
+  fail-closed pre-filter. Resource endpoints and task submission use this
+  extractor. Imports and exports add an unscoped runtime-admin gate after
+  authentication; the gate accepts service accounts but rejects scoped tokens.
+  Remote-target invocation retains ordinary scope-aware authorization.
 
 **Human/IAM (privilege-separated):**
 

--- a/docs/distributed_deployment.md
+++ b/docs/distributed_deployment.md
@@ -81,6 +81,11 @@ replicas. For the task-lease migration, use this upgrade order:
 The drain prevents a new worker from treating a task owned by an old,
 lease-unaware worker as abandoned.
 
+The `api` and `worker` entrypoints wait until the database records the latest
+migration required by the binary. API `/readyz` performs the same schema check.
+This prevents a missed or incomplete migration job from making a replica appear
+ready, while keeping migration ownership in the one-shot job.
+
 ## Shared Configuration And Secrets
 
 All replicas must use the same values for settings that define cluster-wide

--- a/docs/export_api.md
+++ b/docs/export_api.md
@@ -1,6 +1,7 @@
 # Export API
 
-The export API executes an authorized Hubuum query server-side through the generic task system.
+The export API executes a runtime-administrator Hubuum query server-side through
+the generic task system.
 
 Endpoints:
 
@@ -11,7 +12,11 @@ Endpoints:
 
 Authentication:
 
-- Bearer token required
+- An unscoped bearer token for a runtime administrator is required.
+- Runtime administrators may be humans or service accounts in the configured
+  admin group. Service accounts do not gain access to human/IAM administration.
+- The worker rechecks admin authority before execution. Dedicated backup
+  service accounts are recommended for automated exports.
 
 ## Submission model
 

--- a/docs/import_api.md
+++ b/docs/import_api.md
@@ -22,7 +22,11 @@ Import results are intentionally not exposed through a generic shared task-resul
 
 Authentication:
 
-- Bearer token required
+- An unscoped bearer token for a runtime administrator is required.
+- Runtime administrators may be humans or service accounts in the configured
+  admin group. Service accounts do not gain access to human/IAM administration.
+- The worker rechecks admin authority before execution. Use a dedicated backup
+  or restore service account for automation.
 
 ## Request model
 
@@ -401,11 +405,9 @@ Allowed permission values:
 
 ### `mode.permission_policy`
 
-- default: `abort`
-- `abort`
-  - permission failures stop strict imports and stop best-effort imports once encountered
-- `continue`
-  - best-effort imports record permission failures and continue
+This field remains accepted for payload compatibility. API imports require
+runtime-admin authority and do not perform per-item authorization, so `abort`
+and `continue` currently have no effect on API-submitted tasks.
 
 ## Submit example
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7624,6 +7624,16 @@
               }
             }
           },
+          "403": {
+            "description": "Runtime administrator required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
           "409": {
             "description": "Conflict",
             "content": {
@@ -10826,6 +10836,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Runtime administrator required",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -129,15 +129,15 @@ Export templates are used to format export output and are scoped to collections.
 
 | Permission | Description |
 | --- | --- |
-| `ReadTemplate` | Allows reading export templates and using them in export generation. Required to view template definitions or to reference a template when running an export. |
+| `ReadTemplate` | Allows reading export template definitions. |
 | `CreateTemplate` | Allows creating new export templates within the collection. Also required when moving a template to a different collection (as the target collection permission). |
 | `UpdateTemplate` | Allows modifying existing export templates (name, description, template content, collection). Required when moving a template to a different collection (as the source collection permission). |
 | `DeleteTemplate` | Allows deleting export_templates from the collection. |
 
 **Important notes about template permissions:**
 
-- Templates are collection-scoped, meaning all template operations require the appropriate permission on the template's collection.
-- Using a template in an export requires `read_template` permission on the collection containing the template.
+- Template management is collection-scoped, meaning CRUD operations require the appropriate permission on the template's collection.
+- Running any export, including one backed by a stored template, requires an unscoped runtime administrator. `read_template` alone does not grant export authority.
 - Moving a template between collections requires both `update_template` on the source collection and `create_template` on the target collection.
 - Templates with the same name cannot exist within the same collection (enforced by a unique constraint).
 - Valid template content types are: `text/plain`, `text/html`, and `text/csv`. The `application/json` content type is reserved for the default JSON export output and cannot be used for stored export templates.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -11,7 +11,7 @@ Hubuum exposes unauthenticated probe endpoints for container schedulers and load
 | Endpoint | Purpose |
 | -------- | ------- |
 | `/healthz` | Liveness probe. Returns `200 OK` when the process can serve HTTP. Does not touch the database. |
-| `/readyz` | Readiness probe. Returns `200 OK` only after a simple database query succeeds. Returns `503 Service Unavailable` when the service should not receive traffic. |
+| `/readyz` | Readiness probe. Returns `200 OK` only after the database is reachable and the migration required by this binary is applied. Returns `503 Service Unavailable` when the service should not receive traffic. |
 
 Probe paths bypass the client IP allowlist so platform health checks are not rejected before reaching the handler.
 

--- a/docs/task_system.md
+++ b/docs/task_system.md
@@ -11,7 +11,7 @@ It is intentionally implementation-focused. For public API behavior, see:
 
 The task system provides a generic framework for long-running server-side work.
 
-Current task kind:
+Current task kinds:
 
 - `import`
 - `export`
@@ -19,7 +19,6 @@ Current task kind:
 
 Reserved task kinds already modeled in the schema:
 
-- `export`
 - `reindex`
 
 The goal is to keep task lifecycle, queueing, polling, and audit history generic, while letting each task kind supply its own execution logic and its own typed result storage.
@@ -248,13 +247,17 @@ After a task is claimed, `process_one_task` dispatches by `task.kind`.
 Current dispatch:
 
 - `import` -> import executor
-- anything else -> unimplemented error
+- `export` -> export executor
+- `remote_call` -> remote HTTP invocation executor
+- reserved task kinds -> unimplemented error
 
 This logic is in:
 
 - [process_one_task](../src/tasks/worker.rs)
 
-The task framework is generic even though only imports execute today.
+Task workers carry the same permission-backend context as API handlers. Execution
+therefore rechecks the submitting principal through the configured local or
+Treetop backend while preserving the submitted token's scope snapshot.
 
 ## Import execution pipeline
 

--- a/docs/task_system.md
+++ b/docs/task_system.md
@@ -257,7 +257,9 @@ This logic is in:
 
 Task workers carry the same permission-backend context as API handlers. Execution
 therefore rechecks the submitting principal through the configured local or
-Treetop backend while preserving the submitted token's scope snapshot.
+Treetop backend. Import and export workers require unscoped runtime-admin
+authority; remote-call workers preserve and enforce the submitted token's scope
+snapshot.
 
 ## Import execution pipeline
 
@@ -405,8 +407,9 @@ Planning and execution behavior is shaped by:
 Current behavior:
 
 - `strict` always aborts on the first planning failure
-- `best_effort + permission_policy=continue` records permission failures and continues with remaining plannable work
-- `best_effort + permission_policy=abort` stops once a permission failure requires abort
+- `mode.permission_policy` remains accepted for payload compatibility, but
+  API-submitted imports run with runtime-admin authority and therefore do not
+  produce per-item authorization failures
 - `collision_policy=abort` records or aborts on collisions depending on atomicity
 - `collision_policy=overwrite` turns matching collection/class/object collisions into update operations
 
@@ -431,9 +434,17 @@ Import-specific endpoints:
 - `GET /api/v1/imports/{id}`
 - `GET /api/v1/imports/{id}/results`
 
-Import execution itself runs under the submitting user’s effective permissions, not as a privileged system bypass.
+Import and export submission requires an unscoped runtime administrator. The
+principal may be either a human or a service account; unlike human/IAM admin
+extractors, this gate intentionally accepts service accounts in the configured
+admin group. A dedicated service account is recommended for backup and restore
+automation.
 
-That means planning checks and execution permission checks are based on the task submitter.
+The worker repeats the configured-backend admin check after claiming the task.
+Revoking admin membership or disabling the submitting service account while a
+task is queued therefore prevents execution. Once execution starts, the single
+admin decision authorizes the complete operation instead of applying
+resource-by-resource permission filtering.
 
 ## Queue introspection
 

--- a/src/api/handlers/probes.rs
+++ b/src/api/handlers/probes.rs
@@ -1,11 +1,10 @@
 use actix_web::{Responder, get, http::StatusCode, web};
-use diesel_async::RunQueryDsl;
 use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::db::{DbPool, with_connection_async};
+use crate::db::{DbPool, ensure_database_schema_ready};
 use crate::errors::ApiError;
 
 #[derive(Serialize, ToSchema)]
@@ -45,13 +44,9 @@ pub async fn healthz() -> impl Responder {
 )]
 #[get("/readyz")]
 pub async fn readyz(pool: web::Data<DbPool>) -> Result<impl Responder, ApiError> {
-    with_connection_async(pool.get_ref().clone(), async |conn| {
-        diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>("1"))
-            .get_result::<i32>(conn)
-            .await
-    })
-    .await
-    .map_err(|_| ApiError::ServiceUnavailable("Database is not ready".to_string()))?;
+    ensure_database_schema_ready(pool.get_ref())
+        .await
+        .map_err(|_| ApiError::ServiceUnavailable("Database schema is not ready".to_string()))?;
 
     Ok(ApiResponse::new(ProbeResponse::ok("ready"), StatusCode::OK))
 }

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -41,7 +41,7 @@ use crate::models::{
     NewHubuumObjectRelation, Permissions, RelatedClassGraph, RelatedObjectGraph,
     RelatedObjectGraphRow, UpdateHubuumClass, UpdateHubuumObject,
 };
-use crate::traits::{CanDelete, CanSave, CanUpdate, CollectionAccessors, Search, SelfAccessors};
+use crate::traits::{CanDelete, CanSave, CanUpdate, Search, SelfAccessors};
 use crate::utilities::extensions::CustomStringExtensions;
 
 use crate::models::search::{

--- a/src/api/v1/handlers/collections.rs
+++ b/src/api/v1/handlers/collections.rs
@@ -24,9 +24,7 @@ use actix_web::{
 };
 use tracing::{debug, info};
 
-use crate::traits::{
-    CanDelete, CanSave, CanUpdate, CollectionAccessors, PermissionController, Search, SelfAccessors,
-};
+use crate::traits::{CanDelete, CanSave, CanUpdate, PermissionController, Search, SelfAccessors};
 
 #[utoipa::path(
     get,

--- a/src/api/v1/handlers/event_subscriptions.rs
+++ b/src/api/v1/handlers/event_subscriptions.rs
@@ -16,7 +16,6 @@ use crate::models::{
 };
 use crate::pagination::prepare_db_pagination;
 use crate::permissions::AppContext;
-use crate::traits::CollectionAccessors;
 
 #[utoipa::path(
     post,

--- a/src/api/v1/handlers/export_templates.rs
+++ b/src/api/v1/handlers/export_templates.rs
@@ -24,6 +24,7 @@ use crate::pagination::{count_query_options, prepare_db_pagination};
 use crate::permissions::visibility::authorize_cursor_page;
 use crate::permissions::{
     AppContext, PrincipalRef, ResourceAttrs, ResourceKind, ResourceRef, authorize_resources,
+    require_unscoped_runtime_admin,
 };
 use crate::tasks::{idempotency_key_from_headers, kick_task_worker};
 use crate::traits::{CanDelete, CanSave, CanUpdate, SelfAccessors};
@@ -235,6 +236,8 @@ pub async fn run_template_export(
     template_id: web::Path<ExportTemplateID>,
     run: web::Json<ExportTemplateRunRequest>,
 ) -> Result<impl Responder, ApiError> {
+    require_unscoped_runtime_admin(&pool, &requestor.principal, requestor.token_meta.scoped)
+        .await?;
     let user = &requestor.principal;
     let template_id = template_id.into_inner();
     let run = run.into_inner();
@@ -247,20 +250,11 @@ pub async fn run_template_export(
 
     let template = template_id.instance(&pool).await?;
 
-    can!(
-        &pool,
-        user.clone(),
-        requestor.scopes(),
-        [Permissions::ReadTemplate],
-        &template
-    );
-
     let export = template.build_export_request(run)?;
     let idempotency_key = idempotency_key_from_headers(req.headers())?;
     let task = submit_export_task(
         &pool,
         user,
-        requestor.scopes(),
         Some(requestor.token_meta.id),
         idempotency_key,
         export,

--- a/src/api/v1/handlers/export_templates.rs
+++ b/src/api/v1/handlers/export_templates.rs
@@ -25,8 +25,8 @@ use crate::permissions::visibility::authorize_cursor_page;
 use crate::permissions::{
     AppContext, PrincipalRef, ResourceAttrs, ResourceKind, ResourceRef, authorize_resources,
 };
-use crate::tasks::idempotency_key_from_headers;
-use crate::traits::{CanDelete, CanSave, CanUpdate, CollectionAccessors, SelfAccessors};
+use crate::tasks::{idempotency_key_from_headers, kick_task_worker};
+use crate::traits::{CanDelete, CanSave, CanUpdate, SelfAccessors};
 
 #[utoipa::path(
     post,
@@ -267,6 +267,7 @@ pub async fn run_template_export(
         Some(template),
     )
     .await?;
+    kick_task_worker(pool.clone());
     let response = task.to_response()?;
 
     Ok(ApiResponse::accepted_at(

--- a/src/api/v1/handlers/exports.rs
+++ b/src/api/v1/handlers/exports.rs
@@ -3,7 +3,6 @@ use actix_web::{HttpRequest, HttpResponse, Responder, get, http::StatusCode, pos
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::db::DbPool;
 use crate::db::traits::task::TaskBackend;
 use crate::errors::ApiError;
 use crate::exports::submit_export_task;
@@ -12,6 +11,7 @@ use crate::models::{
     ExportContentType, ExportJsonResponse, ExportMeta, ExportOutputLookup, ExportRequest,
     ExportTaskOutputRecord, ExportWarning, TaskID, TaskResponse,
 };
+use crate::permissions::AppContext;
 use crate::tasks::{ensure_task_worker_running, idempotency_key_from_headers, kick_task_worker};
 
 const EXPORT_WARNINGS_HEADER: &str = "X-Hubuum-Export-Warnings";
@@ -60,7 +60,7 @@ fn render_export_task_output(output: ExportTaskOutputRecord) -> Result<HttpRespo
 )]
 #[post("")]
 pub async fn run_export(
-    pool: web::Data<DbPool>,
+    pool: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     export: web::Json<ExportRequest>,
@@ -78,7 +78,7 @@ pub async fn run_export(
     .await?;
 
     let response = task.to_response()?;
-    kick_task_worker(pool.get_ref().clone());
+    kick_task_worker(pool.clone());
 
     Ok(ApiResponse::accepted_at(
         response,
@@ -102,11 +102,11 @@ pub async fn run_export(
 )]
 #[get("/{task_id}")]
 pub async fn get_export(
-    pool: web::Data<DbPool>,
+    pool: AppContext,
     requestor: Authenticated,
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.get_ref().clone());
+    ensure_task_worker_running(pool.clone());
     let task = task_id
         .into_inner()
         .load_authorized_export(&pool, &requestor.principal)
@@ -144,11 +144,11 @@ pub async fn get_export(
 )]
 #[get("/{task_id}/output")]
 pub async fn get_export_output(
-    pool: web::Data<DbPool>,
+    pool: AppContext,
     requestor: Authenticated,
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.get_ref().clone());
+    ensure_task_worker_running(pool.clone());
     let task_id = task_id.into_inner();
     task_id
         .load_authorized_export(&pool, &requestor.principal)

--- a/src/api/v1/handlers/exports.rs
+++ b/src/api/v1/handlers/exports.rs
@@ -11,7 +11,7 @@ use crate::models::{
     ExportContentType, ExportJsonResponse, ExportMeta, ExportOutputLookup, ExportRequest,
     ExportTaskOutputRecord, ExportWarning, TaskID, TaskResponse,
 };
-use crate::permissions::AppContext;
+use crate::permissions::{AppContext, require_unscoped_runtime_admin};
 use crate::tasks::{ensure_task_worker_running, idempotency_key_from_headers, kick_task_worker};
 
 const EXPORT_WARNINGS_HEADER: &str = "X-Hubuum-Export-Warnings";
@@ -54,6 +54,7 @@ fn render_export_task_output(output: ExportTaskOutputRecord) -> Result<HttpRespo
         (status = 202, description = "Export task accepted", body = TaskResponse),
         (status = 400, description = "Bad request", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Runtime administrator required", body = ApiErrorResponse),
         (status = 409, description = "Conflict", body = ApiErrorResponse),
         (status = 429, description = "Too many active export tasks", body = ApiErrorResponse)
     )
@@ -65,11 +66,12 @@ pub async fn run_export(
     req: HttpRequest,
     export: web::Json<ExportRequest>,
 ) -> Result<impl Responder, ApiError> {
+    require_unscoped_runtime_admin(&pool, &requestor.principal, requestor.token_meta.scoped)
+        .await?;
     let export = export.into_inner();
     let task = submit_export_task(
         &pool,
         &requestor.principal,
-        requestor.scopes(),
         Some(requestor.token_meta.id),
         idempotency_key_from_headers(req.headers())?,
         export,

--- a/src/api/v1/handlers/imports.rs
+++ b/src/api/v1/handlers/imports.rs
@@ -14,7 +14,7 @@ use crate::models::{
     TaskResponse,
 };
 use crate::pagination::prepare_db_pagination;
-use crate::permissions::AppContext;
+use crate::permissions::{AppContext, require_unscoped_runtime_admin};
 use crate::tasks::{
     ensure_task_worker_running, idempotency_key_from_headers, kick_task_worker, request_hash,
 };
@@ -54,7 +54,8 @@ async fn find_or_create_import_task(
         (status = 400, description = "Bad request", body = ApiErrorResponse),
         (status = 409, description = "Conflict", body = ApiErrorResponse),
         (status = 429, description = "Too many active import tasks", body = ApiErrorResponse),
-        (status = 401, description = "Unauthorized", body = ApiErrorResponse)
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Runtime administrator required", body = ApiErrorResponse)
     )
 )]
 #[post("")]
@@ -64,6 +65,8 @@ pub async fn create_import(
     req: HttpRequest,
     import_request: web::Json<ImportRequest>,
 ) -> Result<impl Responder, ApiError> {
+    require_unscoped_runtime_admin(&pool, &requestor.principal, requestor.token_meta.scoped)
+        .await?;
     ensure_task_worker_running(pool.clone());
 
     let import_request = import_request.into_inner();
@@ -76,8 +79,7 @@ pub async fn create_import(
     let payload = serde_json::to_value(&import_request)?;
     let hash = request_hash(&payload)?;
     let idempotency_key = idempotency_key_from_headers(req.headers())?;
-    let snapshot =
-        TaskScopeSnapshot::from_request(Some(requestor.token_meta.id), requestor.scopes());
+    let snapshot = TaskScopeSnapshot::from_request(Some(requestor.token_meta.id), None);
 
     let task = find_or_create_import_task(
         &pool,

--- a/src/api/v1/handlers/imports.rs
+++ b/src/api/v1/handlers/imports.rs
@@ -14,6 +14,7 @@ use crate::models::{
     TaskResponse,
 };
 use crate::pagination::prepare_db_pagination;
+use crate::permissions::AppContext;
 use crate::tasks::{
     ensure_task_worker_running, idempotency_key_from_headers, kick_task_worker, request_hash,
 };
@@ -58,12 +59,12 @@ async fn find_or_create_import_task(
 )]
 #[post("")]
 pub async fn create_import(
-    pool: web::Data<DbPool>,
+    pool: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     import_request: web::Json<ImportRequest>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.get_ref().clone());
+    ensure_task_worker_running(pool.clone());
 
     let import_request = import_request.into_inner();
     if import_request.version != CURRENT_IMPORT_VERSION {
@@ -90,7 +91,7 @@ pub async fn create_import(
     .await?;
 
     let response = task.to_response()?;
-    kick_task_worker(pool.get_ref().clone());
+    kick_task_worker(pool.clone());
 
     Ok(ApiResponse::accepted_at(
         response,
@@ -121,11 +122,11 @@ fn max_active_import_tasks_per_user() -> usize {
 )]
 #[get("/{task_id}")]
 pub async fn get_import(
-    pool: web::Data<DbPool>,
+    pool: AppContext,
     requestor: Authenticated,
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.get_ref().clone());
+    ensure_task_worker_running(pool.clone());
     let task = task_id
         .into_inner()
         .load_authorized_import(&pool, &requestor.principal)
@@ -150,12 +151,12 @@ pub async fn get_import(
 )]
 #[get("/{task_id}/results")]
 pub async fn get_import_results(
-    pool: web::Data<DbPool>,
+    pool: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.get_ref().clone());
+    ensure_task_worker_running(pool.clone());
     let task_id = task_id.into_inner();
     task_id
         .load_authorized_import(&pool, &requestor.principal)

--- a/src/api/v1/handlers/remote_targets.rs
+++ b/src/api/v1/handlers/remote_targets.rs
@@ -32,7 +32,7 @@ use crate::permissions::{AppContext, PrincipalRef};
 use crate::tasks::{
     ensure_task_worker_running, idempotency_key_from_headers, kick_task_worker, request_hash,
 };
-use crate::traits::{ClassAccessors, CollectionAccessors};
+use crate::traits::ClassAccessors;
 
 #[utoipa::path(
     post,
@@ -312,7 +312,7 @@ pub async fn invoke_remote_target(
     target_id: web::Path<RemoteTargetID>,
     body: web::Json<RemoteTargetInvokeRequest>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.db_pool.clone());
+    ensure_task_worker_running(pool.clone());
     let user = &requestor.principal;
     let target_id = target_id.into_inner();
     let invoke = body.into_inner();
@@ -347,7 +347,7 @@ pub async fn invoke_remote_target(
         resolved.subject_id,
     )
     .await?;
-    kick_task_worker(pool.db_pool.clone());
+    kick_task_worker(pool.clone());
 
     debug!(
         message = "Remote target invocation queued",

--- a/src/api/v1/handlers/tasks.rs
+++ b/src/api/v1/handlers/tasks.rs
@@ -102,7 +102,7 @@ pub async fn get_tasks(
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.db_pool.clone());
+    ensure_task_worker_running(pool.clone());
     let (params, filters) = parse_task_list_query(req.query_string())?;
     let search_params = prepare_db_pagination::<TaskResponse>(&params)?;
     let backend = pool.permission_backend();
@@ -205,7 +205,7 @@ pub async fn get_task(
     requestor: Authenticated,
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.db_pool.clone());
+    ensure_task_worker_running(pool.clone());
     let task_id = task_id.into_inner();
     let task = if pool.permission_backend().uses_sql_permission_store() {
         task_id.load_authorized(&pool, &requestor.principal).await?
@@ -256,7 +256,7 @@ pub async fn get_task_events(
     req: HttpRequest,
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.db_pool.clone());
+    ensure_task_worker_running(pool.clone());
     let task_id = task_id.into_inner();
     if pool.permission_backend().uses_sql_permission_store() {
         task_id.load_authorized(&pool, &requestor.principal).await?;

--- a/src/bin/admin.rs
+++ b/src/bin/admin.rs
@@ -1,7 +1,4 @@
 use clap::Parser;
-use diesel::dsl::sql;
-use diesel::select;
-use diesel::sql_types::Integer;
 #[cfg(feature = "embedded-migrations")]
 use diesel::{Connection, PgConnection};
 #[cfg(feature = "embedded-migrations")]
@@ -13,7 +10,9 @@ use hubuum::config::{
     DEFAULT_EXPORT_TEMPLATE_RECURSION_LIMIT,
 };
 use hubuum::db::prelude::*;
-use hubuum::db::{DbPool, init_pool_with_statement_timeout, with_connection};
+use hubuum::db::{
+    DbPool, ensure_database_schema_ready, init_pool_with_statement_timeout, with_connection,
+};
 #[cfg(feature = "embedded-migrations")]
 use hubuum::errors::EXIT_CODE_DATABASE_ERROR;
 use hubuum::errors::{ApiError, EXIT_CODE_CONFIG_ERROR, fatal_error};
@@ -155,13 +154,8 @@ fn run_migrations(database_url: &str) {
 }
 
 async fn database_ready(pool: DbPool) -> Result<(), ApiError> {
-    with_connection(&pool, async |connection| {
-        select(sql::<Integer>("1"))
-            .get_result::<i32>(connection)
-            .await
-    })
-    .await?;
-    println!("Database is ready.");
+    ensure_database_schema_ready(&pool).await?;
+    println!("Database is ready and all required migrations are applied.");
     Ok(())
 }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -49,6 +49,48 @@ use crate::utilities::db::DatabaseUrlComponents;
 pub type DbConnection = AsyncPgConnection;
 pub type DbPool = Pool<DbConnection>;
 
+/// Latest migration required by this binary. The test below keeps this value
+/// synchronized with the migration directory so readiness cannot silently lag
+/// behind a newly added schema change.
+pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260713000001";
+
+#[derive(diesel::QueryableByName)]
+struct DatabaseSchemaReadiness {
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    ready: bool,
+}
+
+async fn database_schema_is_ready(
+    connection: &mut DbConnection,
+) -> Result<bool, diesel::result::Error> {
+    Ok(diesel::sql_query(
+        "SELECT EXISTS (\
+            SELECT 1 FROM __diesel_schema_migrations WHERE version = $1\
+        ) AS ready",
+    )
+    .bind::<diesel::sql_types::Text, _>(REQUIRED_DATABASE_MIGRATION_VERSION)
+    .get_result::<DatabaseSchemaReadiness>(connection)
+    .await?
+    .ready)
+}
+
+/// Verify both database connectivity and the schema version required by this
+/// binary. Distributed API and worker replicas use this without taking
+/// migration ownership from the one-shot migration job.
+pub async fn ensure_database_schema_ready(pool: &DbPool) -> Result<(), ApiError> {
+    let ready = with_connection(pool, async |connection| {
+        database_schema_is_ready(connection).await
+    })
+    .await?;
+    if ready {
+        Ok(())
+    } else {
+        Err(ApiError::ServiceUnavailable(format!(
+            "Database migration {REQUIRED_DATABASE_MIGRATION_VERSION} has not been applied"
+        )))
+    }
+}
+
 /// Consumer-owned settings needed to construct the process database pool.
 ///
 /// Keeping this type in the database adapter means startup can translate from
@@ -674,6 +716,32 @@ mod tests {
             .as_nanos();
         let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
         format!("{prefix}_{now}_{counter}")
+    }
+
+    #[test]
+    fn required_database_migration_matches_latest_migration_directory() {
+        let migrations = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+        let latest = std::fs::read_dir(migrations)
+            .expect("migration directory")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().join("up.sql").is_file())
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .filter_map(|name| name.split('_').next().map(str::to_string))
+            .map(|version| version.replace('-', ""))
+            .max()
+            .expect("at least one migration");
+
+        assert_eq!(REQUIRED_DATABASE_MIGRATION_VERSION, latest);
+    }
+
+    #[tokio::test]
+    async fn database_schema_readiness_accepts_the_migrated_test_database() {
+        let config = get_config().expect("Failed to load config for test");
+        let pool = init_pool(&config.database_url, 1);
+
+        ensure_database_schema_ready(&pool)
+            .await
+            .expect("test database should have the latest migration");
     }
 
     #[rstest]

--- a/src/db/traits/relations.rs
+++ b/src/db/traits/relations.rs
@@ -84,18 +84,40 @@ pub async fn class_relation_authorization_resources(
         .collect()
 }
 
-/// Build Cedar authorization resources for object relations with one bulk
-/// object lookup, rather than issuing endpoint lookups for every row.
-pub async fn object_relation_authorization_resources(
+/// Build Cedar authorization resources for object IDs with one bulk lookup.
+pub async fn object_authorization_resources(
     pool: &DbPool,
-    relations: &[HubuumObjectRelation],
+    object_ids: &[i32],
 ) -> Result<Vec<ResourceRef>, ApiError> {
+    let by_id = load_objects_by_id(pool, object_ids).await?;
+    object_ids
+        .iter()
+        .map(|object_id| {
+            let object = by_id.get(object_id).ok_or_else(|| {
+                ApiError::InternalServerError(format!(
+                    "authorization candidate references missing object {object_id}"
+                ))
+            })?;
+            Ok(ResourceRef {
+                kind: ResourceKind::Object,
+                id: object.id,
+                attrs: ResourceAttrs {
+                    collection_id: Some(object.collection_id),
+                    class_id: Some(object.hubuum_class_id),
+                    name: Some(object.name.clone()),
+                    ..Default::default()
+                },
+            })
+        })
+        .collect()
+}
+
+async fn load_objects_by_id(
+    pool: &DbPool,
+    object_ids: &[i32],
+) -> Result<HashMap<i32, HubuumObject>, ApiError> {
     use crate::schema::hubuumobject::dsl::{hubuumobject, id};
 
-    let object_ids = relations
-        .iter()
-        .flat_map(|relation| [relation.from_hubuum_object_id, relation.to_hubuum_object_id])
-        .collect::<Vec<_>>();
     let objects = with_connection(pool, async |conn| {
         hubuumobject
             .filter(id.eq_any(object_ids))
@@ -103,10 +125,23 @@ pub async fn object_relation_authorization_resources(
             .await
     })
     .await?;
-    let by_id = objects
+    Ok(objects
         .into_iter()
         .map(|object| (object.id, object))
-        .collect::<HashMap<_, _>>();
+        .collect())
+}
+
+/// Build Cedar authorization resources for object relations with one bulk
+/// object lookup, rather than issuing endpoint lookups for every row.
+pub async fn object_relation_authorization_resources(
+    pool: &DbPool,
+    relations: &[HubuumObjectRelation],
+) -> Result<Vec<ResourceRef>, ApiError> {
+    let object_ids = relations
+        .iter()
+        .flat_map(|relation| [relation.from_hubuum_object_id, relation.to_hubuum_object_id])
+        .collect::<Vec<_>>();
+    let by_id = load_objects_by_id(pool, &object_ids).await?;
 
     relations
         .iter()

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -1,29 +1,22 @@
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::time::Instant;
 
 use hubuum_templates::SizeLimitedWriter;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::can;
 use crate::config::{
     DEFAULT_EXPORT_DB_STATEMENT_TIMEOUT_MS, DEFAULT_EXPORT_MAX_ACTIVE_TASKS_PER_USER,
     DEFAULT_EXPORT_MAX_OUTPUT_BYTES, DEFAULT_EXPORT_OUTPUT_RETENTION_HOURS,
     DEFAULT_EXPORT_STAGE_TIMEOUT_MS, DEFAULT_EXPORT_TEMPLATE_MAX_OBJECTS, get_config,
-};
-use crate::db::traits::UserPermissions;
-use crate::db::traits::authz::scope_allows;
-use crate::db::traits::relations::{
-    class_relation_authorization_resources, object_authorization_resources,
-    object_relation_authorization_resources,
 };
 use crate::db::traits::task::{TaskBackend, TaskCreateRequest, TaskScopeSnapshot, TaskStateUpdate};
 use crate::db::traits::user::UserSearchBackend;
 use crate::db::{DbPool, with_statement_timeout_scope};
 use crate::errors::ApiError;
 use crate::models::search::{
-    FilterField, ParsedQueryParam, QueryOptions, QueryParamsExt, SearchOperator,
-    StatementTimeoutMs, parse_query_parameter,
+    FilterField, ParsedQueryParam, QueryOptions, SearchOperator, StatementTimeoutMs,
+    parse_query_parameter,
 };
 use crate::models::{
     ClassIdSet, Collection, CollectionExportTemplates, CollectionID, ExportContentType,
@@ -31,19 +24,14 @@ use crate::models::{
     ExportJsonResponse, ExportMeta, ExportMissingDataPolicy, ExportRequest, ExportScope,
     ExportScopeKind, ExportTemplate, ExportTemplateID, ExportWarning, HubuumClassExpanded,
     HubuumClassID, HubuumClassRelation, HubuumObject, HubuumObjectID, HubuumObjectRelation,
-    HubuumObjectWithPath, NewExportTaskOutputRecord, NewTaskEventRecord, Permissions,
+    HubuumObjectWithPath, NewExportTaskOutputRecord, NewTaskEventRecord,
     RELATED_INCLUDE_DEFAULT_LIMIT, RELATED_INCLUDE_DEFAULT_MAX_DEPTH, RelatedObjectForRootRow,
     RelatedObjectGraphRow, RelatedObjectIncludeRow, TaskKind, TaskRecord,
 };
 use crate::observability::metrics;
-use crate::pagination::{page_limits_or_defaults, paginate_in_memory};
-use crate::permissions::visibility::authorize_cursor_page;
-use crate::permissions::{
-    AppContext, PermissionBackend, PrincipalRef, ResourceAttrs, ResourceKind, ResourceRef,
-};
-use crate::permissions::{PermissionDecision, PermissionRequest};
+use crate::pagination::page_limits_or_defaults;
 use crate::tasks::request_hash;
-use crate::traits::{AuthzSubject, BackendContext, CursorPaginated, SelfAccessors};
+use crate::traits::{AuthzSubject, SelfAccessors};
 use crate::utilities::exporting::render_template;
 
 use crate::models::traits::check_if_object_in_class;
@@ -193,19 +181,138 @@ struct ReachableTemplateTarget {
     remaining_depth: i32,
 }
 
+/// Query capability used only after the worker has authorized the complete
+/// export as a runtime-admin operation. Keeping the explicit SQL admin bypass
+/// here prevents individual export stages from accidentally reintroducing
+/// resource-by-resource authorization.
+struct RuntimeAdminExport<'a, S: ?Sized> {
+    subject: &'a S,
+}
+
+impl<'a, S> RuntimeAdminExport<'a, S>
+where
+    S: crate::traits::Search + ?Sized,
+{
+    fn new(subject: &'a S) -> Self {
+        Self { subject }
+    }
+
+    async fn collections(
+        &self,
+        pool: &DbPool,
+        query: QueryOptions,
+    ) -> Result<Vec<Collection>, ApiError> {
+        self.subject
+            .search_collections_from_backend_with_admin_status(pool, query, true, None)
+            .await
+    }
+
+    async fn classes(
+        &self,
+        pool: &DbPool,
+        query: QueryOptions,
+    ) -> Result<Vec<HubuumClassExpanded>, ApiError> {
+        self.subject
+            .search_classes_from_backend_with_admin_status(pool, query, true, None)
+            .await
+    }
+
+    async fn objects(
+        &self,
+        pool: &DbPool,
+        query: QueryOptions,
+    ) -> Result<Vec<HubuumObject>, ApiError> {
+        self.subject
+            .search_objects_from_backend_with_admin_status(pool, query, true, None)
+            .await
+    }
+
+    async fn class_relations(
+        &self,
+        pool: &DbPool,
+        query: QueryOptions,
+    ) -> Result<Vec<HubuumClassRelation>, ApiError> {
+        self.subject
+            .search_class_relations_from_backend_with_admin_status(pool, query, true, None)
+            .await
+    }
+
+    async fn object_relations(
+        &self,
+        pool: &DbPool,
+        query: QueryOptions,
+    ) -> Result<Vec<HubuumObjectRelation>, ApiError> {
+        self.subject
+            .search_object_relations_from_backend_with_admin_status(pool, query, true, None)
+            .await
+    }
+
+    async fn related_objects(
+        &self,
+        pool: &DbPool,
+        object: HubuumObjectID,
+        query: QueryOptions,
+    ) -> Result<Vec<RelatedObjectGraphRow>, ApiError> {
+        self.subject
+            .search_objects_related_to_from_backend_with_admin_status(
+                pool, object, query, true, None,
+            )
+            .await
+    }
+
+    async fn related_objects_for_roots(
+        &self,
+        pool: &DbPool,
+        root_ids: &[i32],
+        include: ExportIncludeRelatedQuery,
+    ) -> Result<Vec<RelatedObjectIncludeRow>, ApiError> {
+        self.subject
+            .related_objects_for_roots_from_backend_with_admin_status(
+                pool, root_ids, include, true, None,
+            )
+            .await
+    }
+
+    async fn bidirectionally_related_objects_for_roots(
+        &self,
+        pool: &DbPool,
+        root_ids: &[i32],
+        max_depth: i32,
+        per_root_cap: i32,
+    ) -> Result<Vec<RelatedObjectForRootRow>, ApiError> {
+        self.subject
+            .bidirectionally_related_objects_for_roots_from_backend_with_admin_status(
+                pool,
+                root_ids,
+                max_depth,
+                per_root_cap,
+                true,
+                None,
+            )
+            .await
+    }
+
+    async fn object_relations_between_ids(
+        &self,
+        pool: &DbPool,
+        object_ids: &[i32],
+    ) -> Result<Vec<HubuumObjectRelation>, ApiError> {
+        self.subject
+            .search_object_relations_between_ids_from_backend_with_admin_status(
+                pool, object_ids, true, None,
+            )
+            .await
+    }
+}
+
 pub(crate) async fn submit_export_task<S: AuthzSubject>(
-    context: &AppContext,
+    pool: &DbPool,
     subject: &S,
-    // Scope boundary of the submitting token, persisted as the task scope
-    // snapshot so async execution cannot exceed it.
-    scopes: Option<&[Permissions]>,
     submitted_token_id: Option<i32>,
     idempotency_key: Option<String>,
     export: ExportRequest,
     template: Option<ExportTemplate>,
 ) -> Result<TaskRecord, ApiError> {
-    let pool = &context.db_pool;
-
     let task_payload = StoredExportTaskPayload {
         export,
         template_id: template.as_ref().map(|template| template.id),
@@ -217,7 +324,7 @@ pub(crate) async fn submit_export_task<S: AuthzSubject>(
     validate_export_submission(&runtime)?;
     let task_payload = runtime_to_task_payload(&runtime)?;
 
-    let snapshot = TaskScopeSnapshot::from_request(submitted_token_id, scopes);
+    let snapshot = TaskScopeSnapshot::from_request(submitted_token_id, None);
 
     find_or_create_export_task(
         pool,
@@ -262,30 +369,18 @@ async fn prepare_export_runtime(
     })
 }
 
-async fn resolve_template<C>(
-    backend: &C,
-    subject: &impl crate::traits::Search,
-    scopes: Option<&[Permissions]>,
+async fn resolve_template(
+    pool: &DbPool,
     template_id: Option<i32>,
-) -> Result<Option<ExportTemplate>, ApiError>
-where
-    C: BackendContext + ?Sized,
-{
-    let pool = backend.db_pool();
+) -> Result<Option<ExportTemplate>, ApiError> {
     let Some(template_id) = template_id else {
         return Ok(None);
     };
 
-    let template = ExportTemplateID::new(template_id)?.instance(pool).await?;
-    can!(
-        backend,
-        subject,
-        scopes,
-        [Permissions::ReadTemplate],
-        CollectionID::new(template.collection_id)?
-    );
-
-    Ok(Some(template))
+    ExportTemplateID::new(template_id)?
+        .instance(pool)
+        .await
+        .map(Some)
 }
 
 fn validate_export_submission(runtime: &ExportRuntime) -> Result<(), ApiError> {
@@ -338,22 +433,17 @@ async fn find_or_create_export_task(
     .await
 }
 
-pub(crate) async fn execute_export_task<C>(
-    backend: &C,
+pub(crate) async fn execute_export_task(
+    pool: &DbPool,
     task: &TaskRecord,
     subject: &impl crate::traits::Search,
-    scopes: Option<&[Permissions]>,
-) -> Result<(), ApiError>
-where
-    C: BackendContext + ?Sized,
-{
-    let pool = backend.db_pool();
+) -> Result<(), ApiError> {
     let payload = task
         .request_payload
         .clone()
         .ok_or_else(|| ApiError::BadRequest("Export task payload is missing".to_string()))?;
     let payload: StoredExportTaskPayload = serde_json::from_value(payload)?;
-    let template = resolve_template(backend, subject, scopes, payload.template_id).await?;
+    let template = resolve_template(pool, payload.template_id).await?;
     let runtime = prepare_export_runtime(pool, payload.export, template).await?;
     validate_export_submission(&runtime)?;
     let total_start = Instant::now();
@@ -403,19 +493,13 @@ where
     let query_start = Instant::now();
     let (items, mut warnings, truncated) = with_statement_timeout_scope(
         statement_timeout,
-        execute_scope(
-            backend,
-            subject,
-            scopes,
-            &runtime.export.scope,
-            query_options,
-        ),
+        execute_scope(pool, subject, &runtime.export.scope, query_options),
     )
     .await?;
     let mut items = items;
     with_statement_timeout_scope(
         statement_timeout,
-        apply_export_includes(backend, subject, scopes, &runtime.export, &mut items),
+        apply_export_includes(pool, subject, &runtime.export, &mut items),
     )
     .await?;
     let query_elapsed = query_start.elapsed();
@@ -445,14 +529,7 @@ where
     let hydration_start = Instant::now();
     let (template_items, source) = with_statement_timeout_scope(
         statement_timeout,
-        build_template_items(
-            backend,
-            subject,
-            scopes,
-            &runtime,
-            &items,
-            relation_hydration,
-        ),
+        build_template_items(pool, subject, &runtime, &items, relation_hydration),
     )
     .await?;
     let hydration_elapsed = hydration_start.elapsed();
@@ -905,18 +982,13 @@ fn validate_relation_depth(depth: i32) -> Result<i32, ApiError> {
     Ok(depth)
 }
 
-async fn build_template_items<C>(
-    backend: &C,
+async fn build_template_items(
+    pool: &DbPool,
     user: &impl crate::traits::Search,
-    scopes: Option<&[Permissions]>,
     runtime: &ExportRuntime,
     items: &[serde_json::Value],
     relation_hydration: Option<RelationHydrationPlan>,
-) -> Result<(Vec<serde_json::Value>, Option<serde_json::Value>), ApiError>
-where
-    C: BackendContext + ?Sized,
-{
-    let pool = backend.db_pool();
+) -> Result<(Vec<serde_json::Value>, Option<serde_json::Value>), ApiError> {
     if runtime.template.is_none() {
         return Ok((items.to_vec(), None));
     }
@@ -933,6 +1005,7 @@ where
 
     match runtime.export.scope.kind {
         ExportScopeKind::ObjectsInClass => {
+            let admin = RuntimeAdminExport::new(user);
             let roots = items
                 .iter()
                 .cloned()
@@ -944,43 +1017,14 @@ where
 
             let root_ids = roots.iter().map(|root| root.id).collect::<Vec<_>>();
             let per_root_cap = i32::try_from(max_hydrated_template_objects()).unwrap_or(i32::MAX);
-            let related_rows =
-                if let Some(permission_backend) = external_visibility_backend(backend) {
-                    let candidates = user
-                        .bidirectionally_related_objects_for_roots_from_backend_with_admin_status(
-                            pool,
-                            &root_ids,
-                            relation_hydration.depth_limit,
-                            i32::MAX,
-                            true,
-                            None,
-                        )
-                        .await?;
-                    let authorized =
-                        authorize_related_paths(permission_backend, pool, user, scopes, candidates)
-                            .await?;
-                    let mut per_root_counts = HashMap::<i32, i32>::new();
-                    authorized
-                        .into_iter()
-                        .filter(|row| {
-                            let count = per_root_counts.entry(row.root_object_id).or_default();
-                            if *count >= per_root_cap {
-                                return false;
-                            }
-                            *count += 1;
-                            true
-                        })
-                        .collect()
-                } else {
-                    user.bidirectionally_related_objects_for_roots(
-                        backend,
-                        &root_ids,
-                        relation_hydration.depth_limit,
-                        per_root_cap,
-                        scopes,
-                    )
-                    .await?
-                };
+            let related_rows = admin
+                .bidirectionally_related_objects_for_roots(
+                    pool,
+                    &root_ids,
+                    relation_hydration.depth_limit,
+                    per_root_cap,
+                )
+                .await?;
 
             // Descendants grouped per root, preserving the query's per-root ordering.
             let mut related_by_root: BTreeMap<i32, Vec<HubuumObjectWithPath>> =
@@ -998,8 +1042,9 @@ where
             }
             all_object_ids.sort_unstable();
             all_object_ids.dedup();
-            let all_relations =
-                search_object_relations_for_export(backend, user, scopes, &all_object_ids).await?;
+            let all_relations = admin
+                .object_relations_between_ids(pool, &all_object_ids)
+                .await?;
 
             // One class-metadata fetch over every object in the export.
             let mut all_objects = BTreeMap::<i32, HubuumObjectWithPath>::new();
@@ -1062,9 +1107,8 @@ where
                 .map(serde_json::from_value::<HubuumObjectWithPath>)
                 .collect::<Result<Vec<_>, _>>()?;
             let hydrated = hydrate_related_root(
-                backend,
+                pool,
                 user,
-                scopes,
                 source,
                 related_objects,
                 relation_hydration.depth_limit,
@@ -1078,19 +1122,14 @@ where
     }
 }
 
-async fn hydrate_related_root<C>(
-    backend: &C,
+async fn hydrate_related_root(
+    pool: &DbPool,
     user: &impl crate::traits::Search,
-    scopes: Option<&[Permissions]>,
     source: HubuumObjectWithPath,
     related_objects: Vec<HubuumObjectWithPath>,
     depth_limit: i32,
     hydration_budget: &mut HydrationBudget,
-) -> Result<HydratedTemplateObject, ApiError>
-where
-    C: BackendContext + ?Sized,
-{
-    let pool = backend.db_pool();
+) -> Result<HydratedTemplateObject, ApiError> {
     let max_related_objects = hydration_budget.remaining_related_capacity()?;
     if related_objects.len() > max_related_objects {
         return Err(ApiError::BadRequest(format!(
@@ -1103,7 +1142,9 @@ where
     let object_ids = std::iter::once(source.id)
         .chain(related_objects.iter().map(|object| object.id))
         .collect::<Vec<_>>();
-    let relations = search_object_relations_for_export(backend, user, scopes, &object_ids).await?;
+    let relations = RuntimeAdminExport::new(user)
+        .object_relations_between_ids(pool, &object_ids)
+        .await?;
 
     let mut all_objects = BTreeMap::<i32, HubuumObjectWithPath>::new();
     all_objects.insert(source.id, source.clone());
@@ -1870,538 +1911,41 @@ fn object_with_root_path(object: &HubuumObject) -> HubuumObjectWithPath {
     }
 }
 
-fn external_visibility_backend<C>(backend: &C) -> Option<&dyn PermissionBackend>
-where
-    C: BackendContext + ?Sized,
-{
-    backend
-        .permission_backend()
-        .filter(|permission_backend| !permission_backend.supports_sql_visibility_pushdown())
-}
-
-fn export_candidate_options(query_options: &QueryOptions) -> QueryOptions {
-    let mut candidates = query_options.clone();
-    candidates.cursor = None;
-    candidates.limit = None;
-    candidates.include_total = false;
-    candidates
-}
-
-struct ExportAuthorizer<'a, S: ?Sized> {
-    permission_backend: &'a dyn PermissionBackend,
-    pool: &'a DbPool,
-    subject: &'a S,
-    scopes: Option<&'a [Permissions]>,
-}
-
-impl<'a, S> ExportAuthorizer<'a, S>
-where
-    S: AuthzSubject + ?Sized,
-{
-    fn new(
-        permission_backend: &'a dyn PermissionBackend,
-        pool: &'a DbPool,
-        subject: &'a S,
-        scopes: Option<&'a [Permissions]>,
-    ) -> Self {
-        Self {
-            permission_backend,
-            pool,
-            subject,
-            scopes,
-        }
-    }
-
-    async fn page<T, F>(
-        &self,
-        candidates: Vec<T>,
-        permissions: Vec<Permissions>,
-        query_options: &QueryOptions,
-        to_resource: F,
-    ) -> Result<Vec<T>, ApiError>
-    where
-        T: CursorPaginated,
-        F: Fn(&T) -> ResourceRef,
-    {
-        if !scope_allows(self.scopes, &permissions) || candidates.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let principal = PrincipalRef::load(self.pool, self.subject).await?;
-        Ok(authorize_cursor_page(
-            self.permission_backend,
-            &principal,
-            candidates,
-            permissions,
-            query_options,
-            to_resource,
-        )
-        .await?
-        .rows)
-    }
-
-    async fn candidates<T>(
-        &self,
-        candidates: Vec<T>,
-        permissions: Vec<Permissions>,
-        resources: Vec<ResourceRef>,
-    ) -> Result<Vec<T>, ApiError> {
-        if !scope_allows(self.scopes, &permissions) || candidates.is_empty() {
-            return Ok(Vec::new());
-        }
-        if candidates.len() != resources.len() {
-            return Err(ApiError::InternalServerError(format!(
-                "built {} authorization resources for {} export candidates",
-                resources.len(),
-                candidates.len()
-            )));
-        }
-
-        let principal = PrincipalRef::load(self.pool, self.subject).await?;
-        let requests = resources
-            .into_iter()
-            .map(|resource| PermissionRequest {
-                resource,
-                permissions: permissions.clone(),
-            })
-            .collect();
-        let decisions = self
-            .permission_backend
-            .authorize_many(&principal, requests)
-            .await?;
-        if decisions.len() != candidates.len() {
-            return Err(ApiError::PermissionBackendUnavailable(format!(
-                "permission backend returned {} decisions for {} export candidates",
-                decisions.len(),
-                candidates.len()
-            )));
-        }
-
-        Ok(candidates
-            .into_iter()
-            .zip(decisions)
-            .filter_map(|(candidate, decision)| {
-                (decision == PermissionDecision::Allow).then_some(candidate)
-            })
-            .collect())
-    }
-}
-
-async fn search_object_relations_for_export<C, S>(
-    backend: &C,
-    subject: &S,
-    scopes: Option<&[Permissions]>,
-    object_ids: &[i32],
-) -> Result<Vec<HubuumObjectRelation>, ApiError>
-where
-    C: BackendContext + ?Sized,
-    S: crate::traits::Search + ?Sized,
-{
-    let pool = backend.db_pool();
-    let Some(permission_backend) = external_visibility_backend(backend) else {
-        return subject
-            .search_object_relations_between_ids(backend, object_ids, scopes)
-            .await;
-    };
-    let candidates = subject
-        .search_object_relations_between_ids_from_backend_with_admin_status(
-            pool, object_ids, true, None,
-        )
-        .await?;
-    let resources = object_relation_authorization_resources(pool, &candidates).await?;
-    ExportAuthorizer::new(permission_backend, pool, subject, scopes)
-        .candidates(candidates, vec![Permissions::ReadObjectRelation], resources)
-        .await
-}
-
-fn class_resource(class: &HubuumClassExpanded) -> ResourceRef {
-    ResourceRef {
-        kind: ResourceKind::Class,
-        id: class.id,
-        attrs: ResourceAttrs {
-            collection_id: Some(class.collection.id),
-            name: Some(class.name.clone()),
-            ..Default::default()
-        },
-    }
-}
-
-fn object_resource(object: &HubuumObject) -> ResourceRef {
-    ResourceRef {
-        kind: ResourceKind::Object,
-        id: object.id,
-        attrs: ResourceAttrs {
-            collection_id: Some(object.collection_id),
-            class_id: Some(object.hubuum_class_id),
-            name: Some(object.name.clone()),
-            ..Default::default()
-        },
-    }
-}
-
-fn required_relation_permissions(
-    query_options: &QueryOptions,
-    read_permission: Permissions,
-) -> Result<Vec<Permissions>, ApiError> {
-    let mut permissions = query_options.filters.permissions()?;
-    permissions.ensure_contains(&[read_permission]);
-    Ok(permissions.iter().copied().collect())
-}
-
-fn normalized_object_pair(left: i32, right: i32) -> (i32, i32) {
-    if left <= right {
-        (left, right)
-    } else {
-        (right, left)
-    }
-}
-
-fn related_path_is_authorized(
-    path: &[i32],
-    permitted_object_ids: &HashSet<i32>,
-    permitted_pairs: &HashSet<(i32, i32)>,
-) -> bool {
-    path.iter()
-        .all(|object_id| permitted_object_ids.contains(object_id))
-        && path
-            .windows(2)
-            .all(|pair| permitted_pairs.contains(&normalized_object_pair(pair[0], pair[1])))
-}
-
-trait RelatedPathCandidate {
-    fn path(&self) -> &[i32];
-}
-
-macro_rules! impl_related_path_candidate {
-    ($type:ty) => {
-        impl RelatedPathCandidate for $type {
-            fn path(&self) -> &[i32] {
-                &self.path
-            }
-        }
-    };
-}
-
-impl_related_path_candidate!(RelatedObjectGraphRow);
-impl_related_path_candidate!(RelatedObjectIncludeRow);
-impl_related_path_candidate!(RelatedObjectForRootRow);
-
-async fn authorize_related_paths<S, T>(
-    permission_backend: &dyn PermissionBackend,
+async fn execute_scope(
     pool: &DbPool,
-    subject: &S,
-    scopes: Option<&[Permissions]>,
-    candidates: Vec<T>,
-) -> Result<Vec<T>, ApiError>
-where
-    S: crate::traits::Search + ?Sized,
-    T: RelatedPathCandidate,
-{
-    let required = [Permissions::ReadObject, Permissions::ReadObjectRelation];
-    if !scope_allows(scopes, &required) || candidates.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let principal = PrincipalRef::load(pool, subject).await?;
-    let object_ids = candidates
-        .iter()
-        .flat_map(|row| row.path().iter().copied())
-        .collect::<HashSet<_>>()
-        .into_iter()
-        .collect::<Vec<_>>();
-    let object_resources = object_authorization_resources(pool, &object_ids).await?;
-    let object_requests = object_resources
-        .into_iter()
-        .map(|resource| PermissionRequest {
-            resource,
-            permissions: vec![Permissions::ReadObject],
-        })
-        .collect();
-    let object_decisions = permission_backend
-        .authorize_many(&principal, object_requests)
-        .await?;
-    if object_decisions.len() != object_ids.len() {
-        return Err(ApiError::PermissionBackendUnavailable(format!(
-            "permission backend returned {} object decisions for {} export path objects",
-            object_decisions.len(),
-            object_ids.len()
-        )));
-    }
-    let permitted_object_ids = object_ids
-        .iter()
-        .copied()
-        .zip(object_decisions)
-        .filter_map(|(object_id, decision)| {
-            (decision == PermissionDecision::Allow).then_some(object_id)
-        })
-        .collect::<HashSet<_>>();
-    let relations = subject
-        .search_object_relations_between_ids_from_backend_with_admin_status(
-            pool,
-            &object_ids,
-            true,
-            None,
-        )
-        .await?;
-    let relation_resources = object_relation_authorization_resources(pool, &relations).await?;
-    let relation_requests = relation_resources
-        .into_iter()
-        .map(|resource| PermissionRequest {
-            resource,
-            permissions: vec![Permissions::ReadObjectRelation],
-        })
-        .collect();
-    let relation_decisions = permission_backend
-        .authorize_many(&principal, relation_requests)
-        .await?;
-    if relation_decisions.len() != relations.len() {
-        return Err(ApiError::PermissionBackendUnavailable(format!(
-            "permission backend returned {} relation decisions for {} export candidates",
-            relation_decisions.len(),
-            relations.len()
-        )));
-    }
-    let permitted_pairs = relations
-        .iter()
-        .zip(relation_decisions)
-        .filter_map(|(relation, decision)| {
-            (decision == PermissionDecision::Allow).then_some(normalized_object_pair(
-                relation.from_hubuum_object_id,
-                relation.to_hubuum_object_id,
-            ))
-        })
-        .collect::<HashSet<_>>();
-
-    let authorized = candidates
-        .into_iter()
-        .filter(|candidate| {
-            related_path_is_authorized(candidate.path(), &permitted_object_ids, &permitted_pairs)
-        })
-        .collect();
-    Ok(authorized)
-}
-
-async fn authorize_related_export_page<S>(
-    permission_backend: &dyn PermissionBackend,
-    pool: &DbPool,
-    subject: &S,
-    scopes: Option<&[Permissions]>,
-    candidates: Vec<RelatedObjectGraphRow>,
-    query_options: &QueryOptions,
-) -> Result<Vec<RelatedObjectGraphRow>, ApiError>
-where
-    S: crate::traits::Search + ?Sized,
-{
-    let authorized =
-        authorize_related_paths(permission_backend, pool, subject, scopes, candidates).await?;
-    paginate_in_memory(authorized, query_options)
-}
-
-async fn execute_scope<C>(
-    backend: &C,
     subject: &impl crate::traits::Search,
-    scopes: Option<&[Permissions]>,
     scope: &ExportScope,
     mut query_options: QueryOptions,
-) -> Result<(Vec<serde_json::Value>, Vec<ExportWarning>, bool), ApiError>
-where
-    C: BackendContext + ?Sized,
-{
-    let pool = backend.db_pool();
+) -> Result<(Vec<serde_json::Value>, Vec<ExportWarning>, bool), ApiError> {
     let item_limit = query_options.limit.unwrap_or(1).saturating_sub(1).max(1);
-    let external_backend = external_visibility_backend(backend);
+    let admin = RuntimeAdminExport::new(subject);
 
     let data = match scope.kind {
         ExportScopeKind::Collections => {
-            let collections = if let Some(permission_backend) = external_backend {
-                let candidates = subject
-                    .search_collections_from_backend_with_admin_status(
-                        pool,
-                        export_candidate_options(&query_options),
-                        true,
-                        None,
-                    )
-                    .await?;
-                ExportAuthorizer::new(permission_backend, pool, subject, scopes)
-                    .page(
-                        candidates,
-                        vec![Permissions::ReadCollection],
-                        &query_options,
-                        |collection: &Collection| ResourceRef::collection(collection.id),
-                    )
-                    .await?
-            } else {
-                subject
-                    .search_collections(backend, query_options, scopes)
-                    .await?
-            };
-            to_json_items(collections)?
+            to_json_items(admin.collections(pool, query_options).await?)?
         }
-        ExportScopeKind::Classes => {
-            let classes = if let Some(permission_backend) = external_backend {
-                let candidates = subject
-                    .search_classes_from_backend_with_admin_status(
-                        pool,
-                        export_candidate_options(&query_options),
-                        true,
-                        None,
-                    )
-                    .await?;
-                ExportAuthorizer::new(permission_backend, pool, subject, scopes)
-                    .page(
-                        candidates,
-                        vec![Permissions::ReadClass],
-                        &query_options,
-                        class_resource,
-                    )
-                    .await?
-            } else {
-                subject
-                    .search_classes(backend, query_options, scopes)
-                    .await?
-            };
-            to_json_items(classes)?
-        }
+        ExportScopeKind::Classes => to_json_items(admin.classes(pool, query_options).await?)?,
         ExportScopeKind::ObjectsInClass => {
             push_exact_filter(
                 &mut query_options,
                 FilterField::ClassId,
                 scope.class_id_required()?,
             )?;
-            let objects = if let Some(permission_backend) = external_backend {
-                let candidates = subject
-                    .search_objects_from_backend_with_admin_status(
-                        pool,
-                        export_candidate_options(&query_options),
-                        true,
-                        None,
-                    )
-                    .await?;
-                ExportAuthorizer::new(permission_backend, pool, subject, scopes)
-                    .page(
-                        candidates,
-                        vec![Permissions::ReadObject],
-                        &query_options,
-                        object_resource,
-                    )
-                    .await?
-            } else {
-                subject
-                    .search_objects(backend, query_options, scopes)
-                    .await?
-            };
-            to_json_items(objects)?
+            to_json_items(admin.objects(pool, query_options).await?)?
         }
         ExportScopeKind::ClassRelations => {
-            let relations = if let Some(permission_backend) = external_backend {
-                let candidates = subject
-                    .search_class_relations_from_backend_with_admin_status(
-                        pool,
-                        export_candidate_options(&query_options),
-                        true,
-                        None,
-                    )
-                    .await?;
-                let resources = class_relation_authorization_resources(pool, &candidates)
-                    .await?
-                    .into_iter()
-                    .map(|resource| (resource.id, resource))
-                    .collect::<HashMap<_, _>>();
-                let permissions =
-                    required_relation_permissions(&query_options, Permissions::ReadClassRelation)?;
-                ExportAuthorizer::new(permission_backend, pool, subject, scopes)
-                    .page(
-                        candidates,
-                        permissions,
-                        &query_options,
-                        |relation: &HubuumClassRelation| {
-                            resources
-                                .get(&relation.id)
-                                .expect("every relation candidate has an authorization resource")
-                                .clone()
-                        },
-                    )
-                    .await?
-            } else {
-                subject
-                    .search_class_relations(backend, query_options, scopes)
-                    .await?
-            };
-            to_json_items(relations)?
+            to_json_items(admin.class_relations(pool, query_options).await?)?
         }
         ExportScopeKind::ObjectRelations => {
-            let relations = if let Some(permission_backend) = external_backend {
-                let candidates = subject
-                    .search_object_relations_from_backend_with_admin_status(
-                        pool,
-                        export_candidate_options(&query_options),
-                        true,
-                        None,
-                    )
-                    .await?;
-                let resources = object_relation_authorization_resources(pool, &candidates)
-                    .await?
-                    .into_iter()
-                    .map(|resource| (resource.id, resource))
-                    .collect::<HashMap<_, _>>();
-                let permissions =
-                    required_relation_permissions(&query_options, Permissions::ReadObjectRelation)?;
-                ExportAuthorizer::new(permission_backend, pool, subject, scopes)
-                    .page(
-                        candidates,
-                        permissions,
-                        &query_options,
-                        |relation: &HubuumObjectRelation| {
-                            resources
-                                .get(&relation.id)
-                                .expect("every relation candidate has an authorization resource")
-                                .clone()
-                        },
-                    )
-                    .await?
-            } else {
-                subject
-                    .search_object_relations(backend, query_options, scopes)
-                    .await?
-            };
-            to_json_items(relations)?
+            to_json_items(admin.object_relations(pool, query_options).await?)?
         }
         ExportScopeKind::RelatedObjects => {
             let class_id = HubuumClassID::new(scope.class_id_required()?)?;
             let object_id = HubuumObjectID::new(scope.object_id_required()?)?;
             check_if_object_in_class(pool, &class_id, &object_id).await?;
-            let source_object = object_id.instance(pool).await?;
-            can!(
-                backend,
-                subject,
-                scopes,
-                [Permissions::ReadObject],
-                source_object
-            );
-            let related = if let Some(permission_backend) = external_backend {
-                let candidates = subject
-                    .search_objects_related_to_from_backend_with_admin_status(
-                        pool,
-                        object_id,
-                        export_candidate_options(&query_options),
-                        true,
-                        None,
-                    )
-                    .await?;
-                authorize_related_export_page(
-                    permission_backend,
-                    pool,
-                    subject,
-                    scopes,
-                    candidates,
-                    &query_options,
-                )
-                .await?
-            } else {
-                subject
-                    .search_objects_related_to(backend, object_id, query_options, scopes)
-                    .await?
-            };
+            let related = admin
+                .related_objects(pool, object_id, query_options)
+                .await?;
             to_json_items(
                 related
                     .into_iter()
@@ -2415,16 +1959,12 @@ where
     Ok((items, Vec::new(), truncated))
 }
 
-async fn apply_export_includes<C>(
-    backend: &C,
+async fn apply_export_includes(
+    pool: &DbPool,
     user: &impl crate::traits::Search,
-    scopes: Option<&[Permissions]>,
     export: &ExportRequest,
     items: &mut [serde_json::Value],
-) -> Result<(), ApiError>
-where
-    C: BackendContext + ?Sized,
-{
+) -> Result<(), ApiError> {
     let Some(related_objects) = export
         .include
         .as_ref()
@@ -2447,6 +1987,7 @@ where
         .enumerate()
         .map(|(index, object_id)| (*object_id, index))
         .collect::<HashMap<i32, usize>>();
+    let admin = RuntimeAdminExport::new(user);
 
     for (alias, include) in related_objects {
         let max_depth = include
@@ -2465,43 +2006,9 @@ where
             max_depth,
             limit,
         };
-        let related = if let Some(permission_backend) = external_visibility_backend(backend) {
-            let candidates = user
-                .related_objects_for_roots_from_backend_with_admin_status(
-                    backend.db_pool(),
-                    &root_object_ids,
-                    ExportIncludeRelatedQuery {
-                        limit: i32::MAX,
-                        ..include_query
-                    },
-                    true,
-                    None,
-                )
-                .await?;
-            let authorized = authorize_related_paths(
-                permission_backend,
-                backend.db_pool(),
-                user,
-                scopes,
-                candidates,
-            )
+        let related = admin
+            .related_objects_for_roots(pool, &root_object_ids, include_query)
             .await?;
-            let mut per_root_counts = HashMap::<i32, i32>::new();
-            authorized
-                .into_iter()
-                .filter(|row| {
-                    let count = per_root_counts.entry(row.root_object_id).or_default();
-                    if *count >= limit {
-                        return false;
-                    }
-                    *count += 1;
-                    true
-                })
-                .collect()
-        } else {
-            user.related_objects_for_roots(backend, &root_object_ids, include_query, scopes)
-                .await?
-        };
 
         for row in related {
             let Some(item_index) = item_indexes.get(&row.root_object_id) else {
@@ -2655,23 +2162,18 @@ fn enforce_json_output_limit(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
-    use std::sync::Arc;
+    use std::collections::HashMap;
 
-    use crate::models::search::parse_query_parameter;
     use crate::models::{
         ExportContentType, ExportInclude, ExportIncludeRelatedObject, ExportLimits,
         ExportMissingDataPolicy, ExportRelationContext, ExportRequest, ExportScope,
-        ExportScopeKind, ExportTemplate, ExportTemplateKind, Permissions,
+        ExportScopeKind, ExportTemplate, ExportTemplateKind,
     };
-    use crate::permissions::test_support::{MockAllowRule, MockTreetopBackend};
-    use crate::permissions::{AppContext, ResourceAttrs, ResourceKind};
-    use crate::tests::TestContext;
 
     use super::{
-        ExportRuntime, HydrationBudget, execute_scope, inferred_relation_alias,
-        normalize_alias_segment, pluralize_alias, related_path_is_authorized,
-        take_related_within_budget, validate_export_limits, validate_export_submission,
+        ExportRuntime, HydrationBudget, inferred_relation_alias, normalize_alias_segment,
+        pluralize_alias, take_related_within_budget, validate_export_limits,
+        validate_export_submission,
     };
     use crate::errors::ApiError;
 
@@ -2693,54 +2195,6 @@ mod tests {
             updated_at: test_timestamp(),
             path: vec![id],
         }
-    }
-
-    #[tokio::test]
-    async fn export_scope_uses_external_permission_backend_visibility() {
-        let context = TestContext::new().await;
-        let fixture = context
-            .collection_fixture("external_export_visibility")
-            .await;
-        let permission_backend = Arc::new(MockTreetopBackend::new());
-        permission_backend.add_rule(MockAllowRule {
-            group_id: fixture.owner_group.id,
-            action: Permissions::ReadCollection,
-            resource_kind: ResourceKind::Collection,
-            resource_id: Some(fixture.collection.id),
-            attrs: ResourceAttrs::default(),
-        });
-        let backend = AppContext::new(context.pool.get_ref().clone(), permission_backend);
-        let scope = ExportScope {
-            kind: ExportScopeKind::Collections,
-            class_id: None,
-            object_id: None,
-        };
-        let mut query_options = parse_query_parameter("").unwrap();
-        query_options.limit = Some(101);
-
-        let (items, _, _) =
-            execute_scope(&backend, &context.admin_user, None, &scope, query_options)
-                .await
-                .unwrap();
-        let ids = items
-            .iter()
-            .filter_map(|item| item.get("id").and_then(serde_json::Value::as_i64))
-            .collect::<Vec<_>>();
-
-        assert_eq!(ids, vec![i64::from(fixture.collection.id)]);
-        fixture.cleanup().await.unwrap();
-    }
-
-    #[test]
-    fn related_path_rejects_hidden_intermediate_object() {
-        let permitted_object_ids = HashSet::from([1, 3]);
-        let permitted_pairs = HashSet::from([(1, 2), (2, 3)]);
-
-        assert!(!related_path_is_authorized(
-            &[1, 2, 3],
-            &permitted_object_ids,
-            &permitted_pairs,
-        ));
     }
 
     #[test]

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::time::Instant;
 
 use hubuum_templates::SizeLimitedWriter;
@@ -12,26 +12,38 @@ use crate::config::{
     DEFAULT_EXPORT_STAGE_TIMEOUT_MS, DEFAULT_EXPORT_TEMPLATE_MAX_OBJECTS, get_config,
 };
 use crate::db::traits::UserPermissions;
+use crate::db::traits::authz::scope_allows;
+use crate::db::traits::relations::{
+    class_relation_authorization_resources, object_authorization_resources,
+    object_relation_authorization_resources,
+};
 use crate::db::traits::task::{TaskBackend, TaskCreateRequest, TaskScopeSnapshot, TaskStateUpdate};
+use crate::db::traits::user::UserSearchBackend;
 use crate::db::{DbPool, with_statement_timeout_scope};
 use crate::errors::ApiError;
 use crate::models::search::{
-    FilterField, ParsedQueryParam, QueryOptions, SearchOperator, StatementTimeoutMs,
-    parse_query_parameter,
+    FilterField, ParsedQueryParam, QueryOptions, QueryParamsExt, SearchOperator,
+    StatementTimeoutMs, parse_query_parameter,
 };
 use crate::models::{
-    ClassIdSet, CollectionExportTemplates, CollectionID, ExportContentType,
+    ClassIdSet, Collection, CollectionExportTemplates, CollectionID, ExportContentType,
     ExportIncludeRelatedDirection, ExportIncludeRelatedQuery, ExportIncludeRelatedSort,
     ExportJsonResponse, ExportMeta, ExportMissingDataPolicy, ExportRequest, ExportScope,
-    ExportScopeKind, ExportTemplate, ExportTemplateID, ExportWarning, HubuumClassID,
-    HubuumClassRelation, HubuumObject, HubuumObjectID, HubuumObjectRelation, HubuumObjectWithPath,
-    NewExportTaskOutputRecord, NewTaskEventRecord, Permissions, RELATED_INCLUDE_DEFAULT_LIMIT,
-    RELATED_INCLUDE_DEFAULT_MAX_DEPTH, TaskKind, TaskRecord,
+    ExportScopeKind, ExportTemplate, ExportTemplateID, ExportWarning, HubuumClassExpanded,
+    HubuumClassID, HubuumClassRelation, HubuumObject, HubuumObjectID, HubuumObjectRelation,
+    HubuumObjectWithPath, NewExportTaskOutputRecord, NewTaskEventRecord, Permissions,
+    RELATED_INCLUDE_DEFAULT_LIMIT, RELATED_INCLUDE_DEFAULT_MAX_DEPTH, RelatedObjectForRootRow,
+    RelatedObjectGraphRow, RelatedObjectIncludeRow, TaskKind, TaskRecord,
 };
 use crate::observability::metrics;
-use crate::pagination::page_limits_or_defaults;
-use crate::tasks::{ensure_task_worker_running, request_hash};
-use crate::traits::{AuthzSubject, CollectionAccessors, SelfAccessors};
+use crate::pagination::{page_limits_or_defaults, paginate_in_memory};
+use crate::permissions::visibility::authorize_cursor_page;
+use crate::permissions::{
+    AppContext, PermissionBackend, PrincipalRef, ResourceAttrs, ResourceKind, ResourceRef,
+};
+use crate::permissions::{PermissionDecision, PermissionRequest};
+use crate::tasks::request_hash;
+use crate::traits::{AuthzSubject, BackendContext, CursorPaginated, SelfAccessors};
 use crate::utilities::exporting::render_template;
 
 use crate::models::traits::check_if_object_in_class;
@@ -182,7 +194,7 @@ struct ReachableTemplateTarget {
 }
 
 pub(crate) async fn submit_export_task<S: AuthzSubject>(
-    pool: &DbPool,
+    context: &AppContext,
     subject: &S,
     // Scope boundary of the submitting token, persisted as the task scope
     // snapshot so async execution cannot exceed it.
@@ -192,7 +204,7 @@ pub(crate) async fn submit_export_task<S: AuthzSubject>(
     export: ExportRequest,
     template: Option<ExportTemplate>,
 ) -> Result<TaskRecord, ApiError> {
-    ensure_task_worker_running(pool.clone());
+    let pool = &context.db_pool;
 
     let task_payload = StoredExportTaskPayload {
         export,
@@ -250,19 +262,23 @@ async fn prepare_export_runtime(
     })
 }
 
-async fn resolve_template(
-    pool: &DbPool,
+async fn resolve_template<C>(
+    backend: &C,
     subject: &impl crate::traits::Search,
     scopes: Option<&[Permissions]>,
     template_id: Option<i32>,
-) -> Result<Option<ExportTemplate>, ApiError> {
+) -> Result<Option<ExportTemplate>, ApiError>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     let Some(template_id) = template_id else {
         return Ok(None);
     };
 
     let template = ExportTemplateID::new(template_id)?.instance(pool).await?;
     can!(
-        pool,
+        backend,
         subject,
         scopes,
         [Permissions::ReadTemplate],
@@ -322,18 +338,22 @@ async fn find_or_create_export_task(
     .await
 }
 
-pub(crate) async fn execute_export_task(
-    pool: &DbPool,
+pub(crate) async fn execute_export_task<C>(
+    backend: &C,
     task: &TaskRecord,
     subject: &impl crate::traits::Search,
     scopes: Option<&[Permissions]>,
-) -> Result<(), ApiError> {
+) -> Result<(), ApiError>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     let payload = task
         .request_payload
         .clone()
         .ok_or_else(|| ApiError::BadRequest("Export task payload is missing".to_string()))?;
     let payload: StoredExportTaskPayload = serde_json::from_value(payload)?;
-    let template = resolve_template(pool, subject, scopes, payload.template_id).await?;
+    let template = resolve_template(backend, subject, scopes, payload.template_id).await?;
     let runtime = prepare_export_runtime(pool, payload.export, template).await?;
     validate_export_submission(&runtime)?;
     let total_start = Instant::now();
@@ -383,13 +403,19 @@ pub(crate) async fn execute_export_task(
     let query_start = Instant::now();
     let (items, mut warnings, truncated) = with_statement_timeout_scope(
         statement_timeout,
-        execute_scope(pool, subject, scopes, &runtime.export.scope, query_options),
+        execute_scope(
+            backend,
+            subject,
+            scopes,
+            &runtime.export.scope,
+            query_options,
+        ),
     )
     .await?;
     let mut items = items;
     with_statement_timeout_scope(
         statement_timeout,
-        apply_export_includes(pool, subject, scopes, &runtime.export, &mut items),
+        apply_export_includes(backend, subject, scopes, &runtime.export, &mut items),
     )
     .await?;
     let query_elapsed = query_start.elapsed();
@@ -419,7 +445,14 @@ pub(crate) async fn execute_export_task(
     let hydration_start = Instant::now();
     let (template_items, source) = with_statement_timeout_scope(
         statement_timeout,
-        build_template_items(pool, subject, scopes, &runtime, &items, relation_hydration),
+        build_template_items(
+            backend,
+            subject,
+            scopes,
+            &runtime,
+            &items,
+            relation_hydration,
+        ),
     )
     .await?;
     let hydration_elapsed = hydration_start.elapsed();
@@ -872,14 +905,18 @@ fn validate_relation_depth(depth: i32) -> Result<i32, ApiError> {
     Ok(depth)
 }
 
-async fn build_template_items(
-    pool: &DbPool,
+async fn build_template_items<C>(
+    backend: &C,
     user: &impl crate::traits::Search,
     scopes: Option<&[Permissions]>,
     runtime: &ExportRuntime,
     items: &[serde_json::Value],
     relation_hydration: Option<RelationHydrationPlan>,
-) -> Result<(Vec<serde_json::Value>, Option<serde_json::Value>), ApiError> {
+) -> Result<(Vec<serde_json::Value>, Option<serde_json::Value>), ApiError>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     if runtime.template.is_none() {
         return Ok((items.to_vec(), None));
     }
@@ -907,15 +944,43 @@ async fn build_template_items(
 
             let root_ids = roots.iter().map(|root| root.id).collect::<Vec<_>>();
             let per_root_cap = i32::try_from(max_hydrated_template_objects()).unwrap_or(i32::MAX);
-            let related_rows = user
-                .bidirectionally_related_objects_for_roots(
-                    pool,
-                    &root_ids,
-                    relation_hydration.depth_limit,
-                    per_root_cap,
-                    scopes,
-                )
-                .await?;
+            let related_rows =
+                if let Some(permission_backend) = external_visibility_backend(backend) {
+                    let candidates = user
+                        .bidirectionally_related_objects_for_roots_from_backend_with_admin_status(
+                            pool,
+                            &root_ids,
+                            relation_hydration.depth_limit,
+                            i32::MAX,
+                            true,
+                            None,
+                        )
+                        .await?;
+                    let authorized =
+                        authorize_related_paths(permission_backend, pool, user, scopes, candidates)
+                            .await?;
+                    let mut per_root_counts = HashMap::<i32, i32>::new();
+                    authorized
+                        .into_iter()
+                        .filter(|row| {
+                            let count = per_root_counts.entry(row.root_object_id).or_default();
+                            if *count >= per_root_cap {
+                                return false;
+                            }
+                            *count += 1;
+                            true
+                        })
+                        .collect()
+                } else {
+                    user.bidirectionally_related_objects_for_roots(
+                        backend,
+                        &root_ids,
+                        relation_hydration.depth_limit,
+                        per_root_cap,
+                        scopes,
+                    )
+                    .await?
+                };
 
             // Descendants grouped per root, preserving the query's per-root ordering.
             let mut related_by_root: BTreeMap<i32, Vec<HubuumObjectWithPath>> =
@@ -933,9 +998,8 @@ async fn build_template_items(
             }
             all_object_ids.sort_unstable();
             all_object_ids.dedup();
-            let all_relations = user
-                .search_object_relations_between_ids(pool, &all_object_ids, scopes)
-                .await?;
+            let all_relations =
+                search_object_relations_for_export(backend, user, scopes, &all_object_ids).await?;
 
             // One class-metadata fetch over every object in the export.
             let mut all_objects = BTreeMap::<i32, HubuumObjectWithPath>::new();
@@ -998,7 +1062,7 @@ async fn build_template_items(
                 .map(serde_json::from_value::<HubuumObjectWithPath>)
                 .collect::<Result<Vec<_>, _>>()?;
             let hydrated = hydrate_related_root(
-                pool,
+                backend,
                 user,
                 scopes,
                 source,
@@ -1014,15 +1078,19 @@ async fn build_template_items(
     }
 }
 
-async fn hydrate_related_root(
-    pool: &DbPool,
+async fn hydrate_related_root<C>(
+    backend: &C,
     user: &impl crate::traits::Search,
     scopes: Option<&[Permissions]>,
     source: HubuumObjectWithPath,
     related_objects: Vec<HubuumObjectWithPath>,
     depth_limit: i32,
     hydration_budget: &mut HydrationBudget,
-) -> Result<HydratedTemplateObject, ApiError> {
+) -> Result<HydratedTemplateObject, ApiError>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     let max_related_objects = hydration_budget.remaining_related_capacity()?;
     if related_objects.len() > max_related_objects {
         return Err(ApiError::BadRequest(format!(
@@ -1035,9 +1103,7 @@ async fn hydrate_related_root(
     let object_ids = std::iter::once(source.id)
         .chain(related_objects.iter().map(|object| object.id))
         .collect::<Vec<_>>();
-    let relations = user
-        .search_object_relations_between_ids(pool, &object_ids, scopes)
-        .await?;
+    let relations = search_object_relations_for_export(backend, user, scopes, &object_ids).await?;
 
     let mut all_objects = BTreeMap::<i32, HubuumObjectWithPath>::new();
     all_objects.insert(source.id, source.clone());
@@ -1804,23 +1870,397 @@ fn object_with_root_path(object: &HubuumObject) -> HubuumObjectWithPath {
     }
 }
 
-async fn execute_scope(
+fn external_visibility_backend<C>(backend: &C) -> Option<&dyn PermissionBackend>
+where
+    C: BackendContext + ?Sized,
+{
+    backend
+        .permission_backend()
+        .filter(|permission_backend| !permission_backend.supports_sql_visibility_pushdown())
+}
+
+fn export_candidate_options(query_options: &QueryOptions) -> QueryOptions {
+    let mut candidates = query_options.clone();
+    candidates.cursor = None;
+    candidates.limit = None;
+    candidates.include_total = false;
+    candidates
+}
+
+struct ExportAuthorizer<'a, S: ?Sized> {
+    permission_backend: &'a dyn PermissionBackend,
+    pool: &'a DbPool,
+    subject: &'a S,
+    scopes: Option<&'a [Permissions]>,
+}
+
+impl<'a, S> ExportAuthorizer<'a, S>
+where
+    S: AuthzSubject + ?Sized,
+{
+    fn new(
+        permission_backend: &'a dyn PermissionBackend,
+        pool: &'a DbPool,
+        subject: &'a S,
+        scopes: Option<&'a [Permissions]>,
+    ) -> Self {
+        Self {
+            permission_backend,
+            pool,
+            subject,
+            scopes,
+        }
+    }
+
+    async fn page<T, F>(
+        &self,
+        candidates: Vec<T>,
+        permissions: Vec<Permissions>,
+        query_options: &QueryOptions,
+        to_resource: F,
+    ) -> Result<Vec<T>, ApiError>
+    where
+        T: CursorPaginated,
+        F: Fn(&T) -> ResourceRef,
+    {
+        if !scope_allows(self.scopes, &permissions) || candidates.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let principal = PrincipalRef::load(self.pool, self.subject).await?;
+        Ok(authorize_cursor_page(
+            self.permission_backend,
+            &principal,
+            candidates,
+            permissions,
+            query_options,
+            to_resource,
+        )
+        .await?
+        .rows)
+    }
+
+    async fn candidates<T>(
+        &self,
+        candidates: Vec<T>,
+        permissions: Vec<Permissions>,
+        resources: Vec<ResourceRef>,
+    ) -> Result<Vec<T>, ApiError> {
+        if !scope_allows(self.scopes, &permissions) || candidates.is_empty() {
+            return Ok(Vec::new());
+        }
+        if candidates.len() != resources.len() {
+            return Err(ApiError::InternalServerError(format!(
+                "built {} authorization resources for {} export candidates",
+                resources.len(),
+                candidates.len()
+            )));
+        }
+
+        let principal = PrincipalRef::load(self.pool, self.subject).await?;
+        let requests = resources
+            .into_iter()
+            .map(|resource| PermissionRequest {
+                resource,
+                permissions: permissions.clone(),
+            })
+            .collect();
+        let decisions = self
+            .permission_backend
+            .authorize_many(&principal, requests)
+            .await?;
+        if decisions.len() != candidates.len() {
+            return Err(ApiError::PermissionBackendUnavailable(format!(
+                "permission backend returned {} decisions for {} export candidates",
+                decisions.len(),
+                candidates.len()
+            )));
+        }
+
+        Ok(candidates
+            .into_iter()
+            .zip(decisions)
+            .filter_map(|(candidate, decision)| {
+                (decision == PermissionDecision::Allow).then_some(candidate)
+            })
+            .collect())
+    }
+}
+
+async fn search_object_relations_for_export<C, S>(
+    backend: &C,
+    subject: &S,
+    scopes: Option<&[Permissions]>,
+    object_ids: &[i32],
+) -> Result<Vec<HubuumObjectRelation>, ApiError>
+where
+    C: BackendContext + ?Sized,
+    S: crate::traits::Search + ?Sized,
+{
+    let pool = backend.db_pool();
+    let Some(permission_backend) = external_visibility_backend(backend) else {
+        return subject
+            .search_object_relations_between_ids(backend, object_ids, scopes)
+            .await;
+    };
+    let candidates = subject
+        .search_object_relations_between_ids_from_backend_with_admin_status(
+            pool, object_ids, true, None,
+        )
+        .await?;
+    let resources = object_relation_authorization_resources(pool, &candidates).await?;
+    ExportAuthorizer::new(permission_backend, pool, subject, scopes)
+        .candidates(candidates, vec![Permissions::ReadObjectRelation], resources)
+        .await
+}
+
+fn class_resource(class: &HubuumClassExpanded) -> ResourceRef {
+    ResourceRef {
+        kind: ResourceKind::Class,
+        id: class.id,
+        attrs: ResourceAttrs {
+            collection_id: Some(class.collection.id),
+            name: Some(class.name.clone()),
+            ..Default::default()
+        },
+    }
+}
+
+fn object_resource(object: &HubuumObject) -> ResourceRef {
+    ResourceRef {
+        kind: ResourceKind::Object,
+        id: object.id,
+        attrs: ResourceAttrs {
+            collection_id: Some(object.collection_id),
+            class_id: Some(object.hubuum_class_id),
+            name: Some(object.name.clone()),
+            ..Default::default()
+        },
+    }
+}
+
+fn required_relation_permissions(
+    query_options: &QueryOptions,
+    read_permission: Permissions,
+) -> Result<Vec<Permissions>, ApiError> {
+    let mut permissions = query_options.filters.permissions()?;
+    permissions.ensure_contains(&[read_permission]);
+    Ok(permissions.iter().copied().collect())
+}
+
+fn normalized_object_pair(left: i32, right: i32) -> (i32, i32) {
+    if left <= right {
+        (left, right)
+    } else {
+        (right, left)
+    }
+}
+
+fn related_path_is_authorized(
+    path: &[i32],
+    permitted_object_ids: &HashSet<i32>,
+    permitted_pairs: &HashSet<(i32, i32)>,
+) -> bool {
+    path.iter()
+        .all(|object_id| permitted_object_ids.contains(object_id))
+        && path
+            .windows(2)
+            .all(|pair| permitted_pairs.contains(&normalized_object_pair(pair[0], pair[1])))
+}
+
+trait RelatedPathCandidate {
+    fn path(&self) -> &[i32];
+}
+
+macro_rules! impl_related_path_candidate {
+    ($type:ty) => {
+        impl RelatedPathCandidate for $type {
+            fn path(&self) -> &[i32] {
+                &self.path
+            }
+        }
+    };
+}
+
+impl_related_path_candidate!(RelatedObjectGraphRow);
+impl_related_path_candidate!(RelatedObjectIncludeRow);
+impl_related_path_candidate!(RelatedObjectForRootRow);
+
+async fn authorize_related_paths<S, T>(
+    permission_backend: &dyn PermissionBackend,
     pool: &DbPool,
+    subject: &S,
+    scopes: Option<&[Permissions]>,
+    candidates: Vec<T>,
+) -> Result<Vec<T>, ApiError>
+where
+    S: crate::traits::Search + ?Sized,
+    T: RelatedPathCandidate,
+{
+    let required = [Permissions::ReadObject, Permissions::ReadObjectRelation];
+    if !scope_allows(scopes, &required) || candidates.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let principal = PrincipalRef::load(pool, subject).await?;
+    let object_ids = candidates
+        .iter()
+        .flat_map(|row| row.path().iter().copied())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let object_resources = object_authorization_resources(pool, &object_ids).await?;
+    let object_requests = object_resources
+        .into_iter()
+        .map(|resource| PermissionRequest {
+            resource,
+            permissions: vec![Permissions::ReadObject],
+        })
+        .collect();
+    let object_decisions = permission_backend
+        .authorize_many(&principal, object_requests)
+        .await?;
+    if object_decisions.len() != object_ids.len() {
+        return Err(ApiError::PermissionBackendUnavailable(format!(
+            "permission backend returned {} object decisions for {} export path objects",
+            object_decisions.len(),
+            object_ids.len()
+        )));
+    }
+    let permitted_object_ids = object_ids
+        .iter()
+        .copied()
+        .zip(object_decisions)
+        .filter_map(|(object_id, decision)| {
+            (decision == PermissionDecision::Allow).then_some(object_id)
+        })
+        .collect::<HashSet<_>>();
+    let relations = subject
+        .search_object_relations_between_ids_from_backend_with_admin_status(
+            pool,
+            &object_ids,
+            true,
+            None,
+        )
+        .await?;
+    let relation_resources = object_relation_authorization_resources(pool, &relations).await?;
+    let relation_requests = relation_resources
+        .into_iter()
+        .map(|resource| PermissionRequest {
+            resource,
+            permissions: vec![Permissions::ReadObjectRelation],
+        })
+        .collect();
+    let relation_decisions = permission_backend
+        .authorize_many(&principal, relation_requests)
+        .await?;
+    if relation_decisions.len() != relations.len() {
+        return Err(ApiError::PermissionBackendUnavailable(format!(
+            "permission backend returned {} relation decisions for {} export candidates",
+            relation_decisions.len(),
+            relations.len()
+        )));
+    }
+    let permitted_pairs = relations
+        .iter()
+        .zip(relation_decisions)
+        .filter_map(|(relation, decision)| {
+            (decision == PermissionDecision::Allow).then_some(normalized_object_pair(
+                relation.from_hubuum_object_id,
+                relation.to_hubuum_object_id,
+            ))
+        })
+        .collect::<HashSet<_>>();
+
+    let authorized = candidates
+        .into_iter()
+        .filter(|candidate| {
+            related_path_is_authorized(candidate.path(), &permitted_object_ids, &permitted_pairs)
+        })
+        .collect();
+    Ok(authorized)
+}
+
+async fn authorize_related_export_page<S>(
+    permission_backend: &dyn PermissionBackend,
+    pool: &DbPool,
+    subject: &S,
+    scopes: Option<&[Permissions]>,
+    candidates: Vec<RelatedObjectGraphRow>,
+    query_options: &QueryOptions,
+) -> Result<Vec<RelatedObjectGraphRow>, ApiError>
+where
+    S: crate::traits::Search + ?Sized,
+{
+    let authorized =
+        authorize_related_paths(permission_backend, pool, subject, scopes, candidates).await?;
+    paginate_in_memory(authorized, query_options)
+}
+
+async fn execute_scope<C>(
+    backend: &C,
     subject: &impl crate::traits::Search,
     scopes: Option<&[Permissions]>,
     scope: &ExportScope,
     mut query_options: QueryOptions,
-) -> Result<(Vec<serde_json::Value>, Vec<ExportWarning>, bool), ApiError> {
+) -> Result<(Vec<serde_json::Value>, Vec<ExportWarning>, bool), ApiError>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     let item_limit = query_options.limit.unwrap_or(1).saturating_sub(1).max(1);
+    let external_backend = external_visibility_backend(backend);
 
     let data = match scope.kind {
-        ExportScopeKind::Collections => to_json_items(
-            subject
-                .search_collections(pool, query_options, scopes)
-                .await?,
-        )?,
+        ExportScopeKind::Collections => {
+            let collections = if let Some(permission_backend) = external_backend {
+                let candidates = subject
+                    .search_collections_from_backend_with_admin_status(
+                        pool,
+                        export_candidate_options(&query_options),
+                        true,
+                        None,
+                    )
+                    .await?;
+                ExportAuthorizer::new(permission_backend, pool, subject, scopes)
+                    .page(
+                        candidates,
+                        vec![Permissions::ReadCollection],
+                        &query_options,
+                        |collection: &Collection| ResourceRef::collection(collection.id),
+                    )
+                    .await?
+            } else {
+                subject
+                    .search_collections(backend, query_options, scopes)
+                    .await?
+            };
+            to_json_items(collections)?
+        }
         ExportScopeKind::Classes => {
-            to_json_items(subject.search_classes(pool, query_options, scopes).await?)?
+            let classes = if let Some(permission_backend) = external_backend {
+                let candidates = subject
+                    .search_classes_from_backend_with_admin_status(
+                        pool,
+                        export_candidate_options(&query_options),
+                        true,
+                        None,
+                    )
+                    .await?;
+                ExportAuthorizer::new(permission_backend, pool, subject, scopes)
+                    .page(
+                        candidates,
+                        vec![Permissions::ReadClass],
+                        &query_options,
+                        class_resource,
+                    )
+                    .await?
+            } else {
+                subject
+                    .search_classes(backend, query_options, scopes)
+                    .await?
+            };
+            to_json_items(classes)?
         }
         ExportScopeKind::ObjectsInClass => {
             push_exact_filter(
@@ -1828,33 +2268,140 @@ async fn execute_scope(
                 FilterField::ClassId,
                 scope.class_id_required()?,
             )?;
-            to_json_items(subject.search_objects(pool, query_options, scopes).await?)?
+            let objects = if let Some(permission_backend) = external_backend {
+                let candidates = subject
+                    .search_objects_from_backend_with_admin_status(
+                        pool,
+                        export_candidate_options(&query_options),
+                        true,
+                        None,
+                    )
+                    .await?;
+                ExportAuthorizer::new(permission_backend, pool, subject, scopes)
+                    .page(
+                        candidates,
+                        vec![Permissions::ReadObject],
+                        &query_options,
+                        object_resource,
+                    )
+                    .await?
+            } else {
+                subject
+                    .search_objects(backend, query_options, scopes)
+                    .await?
+            };
+            to_json_items(objects)?
         }
-        ExportScopeKind::ClassRelations => to_json_items(
-            subject
-                .search_class_relations(pool, query_options, scopes)
-                .await?,
-        )?,
-        ExportScopeKind::ObjectRelations => to_json_items(
-            subject
-                .search_object_relations(pool, query_options, scopes)
-                .await?,
-        )?,
+        ExportScopeKind::ClassRelations => {
+            let relations = if let Some(permission_backend) = external_backend {
+                let candidates = subject
+                    .search_class_relations_from_backend_with_admin_status(
+                        pool,
+                        export_candidate_options(&query_options),
+                        true,
+                        None,
+                    )
+                    .await?;
+                let resources = class_relation_authorization_resources(pool, &candidates)
+                    .await?
+                    .into_iter()
+                    .map(|resource| (resource.id, resource))
+                    .collect::<HashMap<_, _>>();
+                let permissions =
+                    required_relation_permissions(&query_options, Permissions::ReadClassRelation)?;
+                ExportAuthorizer::new(permission_backend, pool, subject, scopes)
+                    .page(
+                        candidates,
+                        permissions,
+                        &query_options,
+                        |relation: &HubuumClassRelation| {
+                            resources
+                                .get(&relation.id)
+                                .expect("every relation candidate has an authorization resource")
+                                .clone()
+                        },
+                    )
+                    .await?
+            } else {
+                subject
+                    .search_class_relations(backend, query_options, scopes)
+                    .await?
+            };
+            to_json_items(relations)?
+        }
+        ExportScopeKind::ObjectRelations => {
+            let relations = if let Some(permission_backend) = external_backend {
+                let candidates = subject
+                    .search_object_relations_from_backend_with_admin_status(
+                        pool,
+                        export_candidate_options(&query_options),
+                        true,
+                        None,
+                    )
+                    .await?;
+                let resources = object_relation_authorization_resources(pool, &candidates)
+                    .await?
+                    .into_iter()
+                    .map(|resource| (resource.id, resource))
+                    .collect::<HashMap<_, _>>();
+                let permissions =
+                    required_relation_permissions(&query_options, Permissions::ReadObjectRelation)?;
+                ExportAuthorizer::new(permission_backend, pool, subject, scopes)
+                    .page(
+                        candidates,
+                        permissions,
+                        &query_options,
+                        |relation: &HubuumObjectRelation| {
+                            resources
+                                .get(&relation.id)
+                                .expect("every relation candidate has an authorization resource")
+                                .clone()
+                        },
+                    )
+                    .await?
+            } else {
+                subject
+                    .search_object_relations(backend, query_options, scopes)
+                    .await?
+            };
+            to_json_items(relations)?
+        }
         ExportScopeKind::RelatedObjects => {
             let class_id = HubuumClassID::new(scope.class_id_required()?)?;
             let object_id = HubuumObjectID::new(scope.object_id_required()?)?;
             check_if_object_in_class(pool, &class_id, &object_id).await?;
             let source_object = object_id.instance(pool).await?;
             can!(
-                pool,
+                backend,
                 subject,
                 scopes,
                 [Permissions::ReadObject],
                 source_object
             );
-            let related = subject
-                .search_objects_related_to(pool, object_id, query_options, scopes)
-                .await?;
+            let related = if let Some(permission_backend) = external_backend {
+                let candidates = subject
+                    .search_objects_related_to_from_backend_with_admin_status(
+                        pool,
+                        object_id,
+                        export_candidate_options(&query_options),
+                        true,
+                        None,
+                    )
+                    .await?;
+                authorize_related_export_page(
+                    permission_backend,
+                    pool,
+                    subject,
+                    scopes,
+                    candidates,
+                    &query_options,
+                )
+                .await?
+            } else {
+                subject
+                    .search_objects_related_to(backend, object_id, query_options, scopes)
+                    .await?
+            };
             to_json_items(
                 related
                     .into_iter()
@@ -1868,13 +2415,16 @@ async fn execute_scope(
     Ok((items, Vec::new(), truncated))
 }
 
-async fn apply_export_includes(
-    pool: &DbPool,
+async fn apply_export_includes<C>(
+    backend: &C,
     user: &impl crate::traits::Search,
     scopes: Option<&[Permissions]>,
     export: &ExportRequest,
     items: &mut [serde_json::Value],
-) -> Result<(), ApiError> {
+) -> Result<(), ApiError>
+where
+    C: BackendContext + ?Sized,
+{
     let Some(related_objects) = export
         .include
         .as_ref()
@@ -1915,9 +2465,43 @@ async fn apply_export_includes(
             max_depth,
             limit,
         };
-        let related = user
-            .related_objects_for_roots(pool, &root_object_ids, include_query, scopes)
+        let related = if let Some(permission_backend) = external_visibility_backend(backend) {
+            let candidates = user
+                .related_objects_for_roots_from_backend_with_admin_status(
+                    backend.db_pool(),
+                    &root_object_ids,
+                    ExportIncludeRelatedQuery {
+                        limit: i32::MAX,
+                        ..include_query
+                    },
+                    true,
+                    None,
+                )
+                .await?;
+            let authorized = authorize_related_paths(
+                permission_backend,
+                backend.db_pool(),
+                user,
+                scopes,
+                candidates,
+            )
             .await?;
+            let mut per_root_counts = HashMap::<i32, i32>::new();
+            authorized
+                .into_iter()
+                .filter(|row| {
+                    let count = per_root_counts.entry(row.root_object_id).or_default();
+                    if *count >= limit {
+                        return false;
+                    }
+                    *count += 1;
+                    true
+                })
+                .collect()
+        } else {
+            user.related_objects_for_roots(backend, &root_object_ids, include_query, scopes)
+                .await?
+        };
 
         for row in related {
             let Some(item_index) = item_indexes.get(&row.root_object_id) else {
@@ -2071,18 +2655,23 @@ fn enforce_json_output_limit(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
+    use std::sync::Arc;
 
+    use crate::models::search::parse_query_parameter;
     use crate::models::{
         ExportContentType, ExportInclude, ExportIncludeRelatedObject, ExportLimits,
         ExportMissingDataPolicy, ExportRelationContext, ExportRequest, ExportScope,
-        ExportScopeKind, ExportTemplate, ExportTemplateKind,
+        ExportScopeKind, ExportTemplate, ExportTemplateKind, Permissions,
     };
+    use crate::permissions::test_support::{MockAllowRule, MockTreetopBackend};
+    use crate::permissions::{AppContext, ResourceAttrs, ResourceKind};
+    use crate::tests::TestContext;
 
     use super::{
-        ExportRuntime, HydrationBudget, inferred_relation_alias, normalize_alias_segment,
-        pluralize_alias, take_related_within_budget, validate_export_limits,
-        validate_export_submission,
+        ExportRuntime, HydrationBudget, execute_scope, inferred_relation_alias,
+        normalize_alias_segment, pluralize_alias, related_path_is_authorized,
+        take_related_within_budget, validate_export_limits, validate_export_submission,
     };
     use crate::errors::ApiError;
 
@@ -2104,6 +2693,54 @@ mod tests {
             updated_at: test_timestamp(),
             path: vec![id],
         }
+    }
+
+    #[tokio::test]
+    async fn export_scope_uses_external_permission_backend_visibility() {
+        let context = TestContext::new().await;
+        let fixture = context
+            .collection_fixture("external_export_visibility")
+            .await;
+        let permission_backend = Arc::new(MockTreetopBackend::new());
+        permission_backend.add_rule(MockAllowRule {
+            group_id: fixture.owner_group.id,
+            action: Permissions::ReadCollection,
+            resource_kind: ResourceKind::Collection,
+            resource_id: Some(fixture.collection.id),
+            attrs: ResourceAttrs::default(),
+        });
+        let backend = AppContext::new(context.pool.get_ref().clone(), permission_backend);
+        let scope = ExportScope {
+            kind: ExportScopeKind::Collections,
+            class_id: None,
+            object_id: None,
+        };
+        let mut query_options = parse_query_parameter("").unwrap();
+        query_options.limit = Some(101);
+
+        let (items, _, _) =
+            execute_scope(&backend, &context.admin_user, None, &scope, query_options)
+                .await
+                .unwrap();
+        let ids = items
+            .iter()
+            .filter_map(|item| item.get("id").and_then(serde_json::Value::as_i64))
+            .collect::<Vec<_>>();
+
+        assert_eq!(ids, vec![i64::from(fixture.collection.id)]);
+        fixture.cleanup().await.unwrap();
+    }
+
+    #[test]
+    fn related_path_rejects_hidden_intermediate_object() {
+        let permitted_object_ids = HashSet::from([1, 3]);
+        let permitted_pairs = HashSet::from([(1, 2), (2, 3)]);
+
+        assert!(!related_path_is_authorized(
+            &[1, 2, 3],
+            &permitted_object_ids,
+            &permitted_pairs,
+        ));
     }
 
     #[test]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -83,8 +83,12 @@ macro_rules! can {
     // scope bypass. Resource/task handlers pass `requestor.scopes()`; truly
     // unscoped internal callers pass `None` explicitly.
     ($pool:expr, $subject:expr, $scopes:expr, [$($perm:expr),+], $($collection:expr),+) => {{
+        #[allow(unused_imports)]
         use $crate::permissions::AuthzTarget as _;
+        #[allow(unused_imports)]
         use $crate::traits::BackendContext as _;
+        #[allow(unused_imports)]
+        use $crate::traits::CollectionAccessors as _;
 
         match $crate::traits::BackendContext::permission_backend($pool) {
             Some(permission_backend) if !permission_backend.uses_sql_permission_store() => {
@@ -102,10 +106,10 @@ macro_rules! can {
             }
             _ => {
                 $subject.can(
-                    $pool,
+                    $pool.db_pool(),
                     vec![$($perm),+],
                     vec![
-                        $($collection.collection_id($pool).await?),+
+                        $($collection.collection_id($pool.db_pool()).await?),+
                     ],
                     $scopes,
                 ).await?

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,8 @@ use crate::config::running::RunningConfig;
 use crate::config::token_hash_key_is_ephemeral;
 use crate::config::{AppConfig, LoginRateLimitBackendKind};
 use crate::errors::{
-    EXIT_CODE_CONFIG_ERROR, EXIT_CODE_INIT_ERROR, EXIT_CODE_PERMISSION_BACKEND_ERROR,
-    EXIT_CODE_TLS_ERROR, fatal_error, json_error_handler,
+    EXIT_CODE_CONFIG_ERROR, EXIT_CODE_DATABASE_ERROR, EXIT_CODE_INIT_ERROR,
+    EXIT_CODE_PERMISSION_BACKEND_ERROR, EXIT_CODE_TLS_ERROR, fatal_error, json_error_handler,
 };
 use crate::events::{
     ensure_event_delivery_worker_running, ensure_event_fanout_worker_running,
@@ -120,6 +120,14 @@ async fn main() -> std::io::Result<()> {
         .build()
         .unwrap_or_else(|error| fatal_error(&error, EXIT_CODE_CONFIG_ERROR));
     let pool = init_pool_with_settings(&database_settings);
+    db::ensure_database_schema_ready(&pool)
+        .await
+        .unwrap_or_else(|error| {
+            fatal_error(
+                &format!("Database schema is not ready: {error}"),
+                EXIT_CODE_DATABASE_ERROR,
+            )
+        });
 
     let task_worker_count = if config.runtime_role.runs_background_workers() {
         config.task_workers
@@ -148,6 +156,17 @@ async fn main() -> std::io::Result<()> {
         );
     }
 
+    let permission_backend = build_permission_backend(&config, pool.clone())
+        .await
+        .unwrap_or_else(|error| {
+            fatal_error(
+                &format!("Failed to initialize permission backend: {error}"),
+                EXIT_CODE_PERMISSION_BACKEND_ERROR,
+            )
+        });
+    let app_context = AppContext::new(pool.clone(), permission_backend);
+    let authorization_backend = app_context.permission_backend().kind();
+
     let active_event_sinks =
         match db::traits::event_subscription::enabled_event_sink_count(&pool).await {
             Ok(count) => Some(count),
@@ -161,7 +180,7 @@ async fn main() -> std::io::Result<()> {
         };
 
     if !config.runtime_role.serves_http() {
-        start_background_workers(&pool);
+        start_background_workers(&app_context);
         info!(
             message = "worker startup",
             version = env!("CARGO_PKG_VERSION"),
@@ -171,6 +190,7 @@ async fn main() -> std::io::Result<()> {
             event_fanout_workers = config.event_fanout_workers,
             event_delivery_workers = config.event_delivery_workers,
             db_backend = "postgresql",
+            authorization_backend,
             active_event_sinks,
         );
         let worker_exit = tokio::select! {
@@ -187,6 +207,7 @@ async fn main() -> std::io::Result<()> {
             );
         }
         shutdown_background_workers(Duration::from_secs(30)).await;
+        drop(app_context);
         drop(pool);
         if let Some(exit) = worker_exit {
             return Err(std::io::Error::other(format!(
@@ -207,16 +228,6 @@ async fn main() -> std::io::Result<()> {
             )
         });
 
-    let permission_backend = build_permission_backend(&config, pool.clone())
-        .await
-        .unwrap_or_else(|error| {
-            fatal_error(
-                &format!("Failed to initialize permission backend: {error}"),
-                EXIT_CODE_PERMISSION_BACKEND_ERROR,
-            )
-        });
-    let app_context = AppContext::new(pool.clone(), permission_backend);
-
     let client_allowlist = config.client_allowlist.clone();
     let proxy_trust = middlewares::ProxyTrust::new(
         config.trust_ip_headers,
@@ -227,6 +238,7 @@ async fn main() -> std::io::Result<()> {
     let metrics_enabled = config.metrics_enabled;
     let metrics_path = config.metrics_path.clone();
     let app_pool = pool.clone();
+    let server_app_context = app_context.clone();
 
     let server = HttpServer::new(move || {
         let app = App::new()
@@ -243,7 +255,7 @@ async fn main() -> std::io::Result<()> {
             .app_data(Data::new(proxy_trust.clone()))
             .app_data(Data::new(running_config.clone()))
             .app_data(Data::new(app_pool.clone()))
-            .app_data(Data::new(app_context.clone()))
+            .app_data(Data::new(server_app_context.clone()))
             .app_data(JsonConfig::default().error_handler(json_error_handler))
             .route("/api-doc/openapi.json", web::get().to(openapi_json_handler));
 
@@ -294,7 +306,7 @@ async fn main() -> std::io::Result<()> {
     };
 
     if config.runtime_role.runs_background_workers() {
-        start_background_workers(&pool);
+        start_background_workers(&app_context);
     }
 
     info!(
@@ -311,7 +323,7 @@ async fn main() -> std::io::Result<()> {
         event_fanout_workers = config.event_fanout_workers,
         event_delivery_workers = config.event_delivery_workers,
         db_backend = "postgresql",
-        authorization_backend = "database_permissions",
+        authorization_backend,
         login_rate_limit_backend = config.login_rate_limit_backend.as_str(),
         active_event_sinks,
     );
@@ -334,15 +346,16 @@ async fn main() -> std::io::Result<()> {
         server.await
     };
     shutdown_background_workers(Duration::from_secs(30)).await;
+    drop(app_context);
     drop(pool);
     result
 }
 
-fn start_background_workers(pool: &db::DbPool) {
-    ensure_task_worker_running(pool.clone());
-    ensure_event_fanout_worker_running(pool.clone());
-    ensure_event_delivery_worker_running(pool.clone());
-    ensure_event_retention_worker_running(pool.clone());
+fn start_background_workers(context: &AppContext) {
+    ensure_task_worker_running(context.clone());
+    ensure_event_fanout_worker_running(context.db_pool.clone());
+    ensure_event_delivery_worker_running(context.db_pool.clone());
+    ensure_event_retention_worker_running(context.db_pool.clone());
 }
 
 fn login_rate_limit_store_settings(

--- a/src/middlewares/rate_limit.rs
+++ b/src/middlewares/rate_limit.rs
@@ -30,7 +30,6 @@ struct ScopeState {
     locked_until: Option<Instant>,
     lockout_level: u32,
     in_flight: usize,
-    last_activity_at: Option<Instant>,
 }
 
 impl ScopeState {
@@ -87,7 +86,6 @@ impl ScopeState {
         self.prune(now, window);
         self.reset_escalation_if_cooled_off(now, window);
         self.attempts.push_back(now);
-        self.last_activity_at = Some(now);
         if self.attempts.len() >= threshold {
             self.trigger_lockout(now, cfg);
             true
@@ -108,20 +106,6 @@ impl ScopeState {
             Some(until) => now.duration_since(until) < window,
             None => false,
         }
-    }
-
-    /// Most recent point of activity, counting an active lockout's expiry. Used to pick
-    /// the stalest entry for eviction; locked entries sort as "freshest" (their expiry is
-    /// in the future) and are therefore protected from premature eviction.
-    fn last_activity(&self) -> Option<Instant> {
-        [
-            self.attempts.back().copied(),
-            self.locked_until,
-            self.last_activity_at,
-        ]
-        .into_iter()
-        .flatten()
-        .max()
     }
 }
 
@@ -498,26 +482,6 @@ fn prune_login_attempts_map(
     });
 }
 
-fn evict_stalest_login_attempt_key(attempts_by_key: &mut HashMap<String, ScopeState>) -> bool {
-    let stalest_key = attempts_by_key
-        .iter()
-        .filter(|(_, state)| state.in_flight == 0)
-        .filter_map(|(key, state)| state.last_activity().map(|last| (key.clone(), last)))
-        .min_by_key(|(_, last)| *last)
-        .map(|(key, _)| key);
-
-    if let Some(stalest_key) = stalest_key {
-        attempts_by_key.remove(&stalest_key);
-        warn!(
-            message = "Evicted stalest login limiter entry to enforce key cap",
-            max_tracked_keys = MAX_LOGIN_ATTEMPT_KEYS
-        );
-        true
-    } else {
-        false
-    }
-}
-
 /// Reservation for a login attempt. Applicable scope budgets are reserved before
 /// password verification starts so concurrent requests cannot all pass the limiter
 /// check before any of them records a failure.
@@ -582,11 +546,12 @@ pub(crate) async fn finish_login_attempt(
     Ok(())
 }
 
-impl LoginRateLimitStore for MemoryLoginRateLimitStore {
-    async fn begin(
+impl MemoryLoginRateLimitStore {
+    async fn begin_with_max_keys(
         &self,
         permit: &LoginAttemptPermit,
         config: &LoginRateLimitConfig,
+        max_keys: usize,
     ) -> Result<bool, ApiError> {
         let now = Instant::now();
         let window = Duration::from_secs(config.window_seconds);
@@ -608,18 +573,29 @@ impl LoginRateLimitStore for MemoryLoginRateLimitStore {
             .iter()
             .filter(|(key, _)| !guard.contains_key(key))
             .count();
-        while guard.len().saturating_add(missing_scopes) > MAX_LOGIN_ATTEMPT_KEYS {
-            if !evict_stalest_login_attempt_key(&mut guard) {
-                return Ok(false);
-            }
+        if guard.len().saturating_add(missing_scopes) > max_keys {
+            // Every inactive entry was removed by `prune_login_attempts_map`.
+            // Reject new high-cardinality scopes instead of discarding live
+            // failures, lockouts, cool-off state, or reservations.
+            return Ok(false);
         }
 
         for (key, _) in &permit.scopes {
             let state = guard.entry(key.clone()).or_default();
             state.in_flight = state.in_flight.saturating_add(1);
-            state.last_activity_at = Some(now);
         }
         Ok(true)
+    }
+}
+
+impl LoginRateLimitStore for MemoryLoginRateLimitStore {
+    async fn begin(
+        &self,
+        permit: &LoginAttemptPermit,
+        config: &LoginRateLimitConfig,
+    ) -> Result<bool, ApiError> {
+        self.begin_with_max_keys(permit, config, MAX_LOGIN_ATTEMPT_KEYS)
+            .await
     }
 
     async fn finish(
@@ -636,7 +612,6 @@ impl LoginRateLimitStore for MemoryLoginRateLimitStore {
         for (key, threshold) in &permit.scopes {
             if let Some(state) = guard.get_mut(key) {
                 state.in_flight = state.in_flight.saturating_sub(1);
-                state.last_activity_at = Some(now);
                 if matches!(outcome, LoginAttemptOutcome::Failed)
                     && state.register_failure(now, *threshold, config)
                 {
@@ -736,7 +711,7 @@ pub(crate) async fn record_login_failure(
         if !guard.contains_key(&key) && guard.len() >= MAX_LOGIN_ATTEMPT_KEYS {
             prune_login_attempts_map(&mut guard, now, window);
             if guard.len() >= MAX_LOGIN_ATTEMPT_KEYS {
-                let _ = evict_stalest_login_attempt_key(&mut guard);
+                continue;
             }
         }
 
@@ -1155,24 +1130,40 @@ mod tests {
         assert!(keys.contains(&"s:198.51.100.0/24"));
     }
 
-    #[test]
-    fn evict_stalest_protects_locked_entries() {
-        let now = Instant::now();
-        let config = cfg();
-        let mut map: HashMap<String, ScopeState> = HashMap::new();
+    #[tokio::test]
+    async fn memory_capacity_rejects_new_scope_without_evicting_active_lockout() {
+        let _guard = LOGIN_RATE_LIMIT_TEST_LOCK.lock().await;
+        reset_login_rate_limit_for_tests().await;
+        let mut config = cfg();
+        config.max_attempts = 1;
+        config.max_attempts_per_ip = 0;
+        config.max_attempts_per_subnet = 0;
+        let store = MemoryLoginRateLimitStore;
+        let protected = permit_for("protected-memory-lock", &config);
+        let newcomer = permit_for("newcomer-memory-lock", &config);
 
-        let mut stale = ScopeState::default();
-        stale.attempts.push_back(now - Duration::from_secs(120));
-        map.insert("stale".to_string(), stale);
+        assert!(
+            store
+                .begin_with_max_keys(&protected, &config, 1)
+                .await
+                .unwrap()
+        );
+        store
+            .finish(&protected, LoginAttemptOutcome::Failed, &config)
+            .await
+            .unwrap();
+        assert!(
+            !store
+                .begin_with_max_keys(&newcomer, &config, 1)
+                .await
+                .unwrap()
+        );
 
-        let mut locked = ScopeState::default();
-        locked.trigger_lockout(now, &config);
-        map.insert("locked".to_string(), locked);
-
-        assert!(evict_stalest_login_attempt_key(&mut map));
-
-        assert!(!map.contains_key("stale"));
-        assert!(map.contains_key("locked"));
+        let snapshots = store.snapshot(&config).await.unwrap();
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0].key, protected.user_ip_key);
+        assert!(snapshots[0].locked);
+        reset_login_rate_limit_for_tests().await;
     }
 
     #[test]

--- a/src/models/remote_target.rs
+++ b/src/models/remote_target.rs
@@ -725,22 +725,25 @@ impl RemoteTarget {
     }
 }
 
-pub async fn authorize_remote_invocation(
-    pool: &DbPool,
+pub async fn authorize_remote_invocation<C>(
+    backend: &C,
     actor: &impl crate::db::traits::authz::AuthzSubject,
     scopes: Option<&[Permissions]>,
     target: &RemoteTarget,
     subject: &RemoteInvocationSubject,
-) -> Result<ResolvedRemoteInvocationSubject, ApiError> {
+) -> Result<ResolvedRemoteInvocationSubject, ApiError>
+where
+    C: crate::traits::BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     let target_collection_id = CollectionID::new(target.collection_id)?;
-    actor
-        .can(
-            pool,
-            [Permissions::ExecuteRemoteTarget],
-            [target_collection_id],
-            scopes,
-        )
-        .await?;
+    crate::can!(
+        backend,
+        actor,
+        scopes,
+        [Permissions::ExecuteRemoteTarget],
+        target_collection_id
+    );
 
     if !target.enabled {
         return Err(ApiError::BadRequest(
@@ -771,14 +774,15 @@ pub async fn authorize_remote_invocation(
             "Remote target not found for invocation subject".to_string(),
         ));
     }
-    actor
-        .can(
-            pool,
-            [resolved.required_read_permission],
-            resolved.collections.clone(),
+    for collection in &resolved.collections {
+        crate::can!(
+            backend,
+            actor,
             scopes,
-        )
-        .await?;
+            [resolved.required_read_permission],
+            collection
+        );
+    }
 
     Ok(resolved)
 }

--- a/src/permissions/mod.rs
+++ b/src/permissions/mod.rs
@@ -31,7 +31,7 @@ use crate::db::DbPool;
 use crate::db::traits::authz::scope_allows;
 use crate::errors::ApiError;
 use crate::models::Permissions;
-use crate::traits::PrincipalIdAccessor;
+use crate::traits::{AuthzSubject, BackendContext, PrincipalIdAccessor};
 
 pub async fn authorize_resources<S>(
     backend: &dyn PermissionBackend,
@@ -65,6 +65,45 @@ where
         Ok(())
     } else {
         Err(ApiError::Forbidden("Permission denied".to_string()))
+    }
+}
+
+/// Require runtime-wide administrator authority for a queued data-transfer task.
+///
+/// Unlike [`crate::extractors::AdminAccess`], this accepts both human principals
+/// and service accounts. Tokens must still be unscoped: this capability grants
+/// access to the complete import/export data set and cannot be represented by a
+/// collection permission subset.
+pub async fn require_unscoped_runtime_admin<C, S>(
+    context: &C,
+    subject: &S,
+    token_scoped: bool,
+) -> Result<(), ApiError>
+where
+    C: BackendContext + ?Sized,
+    S: AuthzSubject + ?Sized,
+{
+    if token_scoped {
+        return Err(ApiError::Forbidden(
+            "Import and export require an unscoped runtime administrator".to_string(),
+        ));
+    }
+
+    let pool = context.db_pool();
+    let is_admin = match context.permission_backend() {
+        Some(backend) => {
+            let principal = PrincipalRef::load(pool, subject).await?;
+            backend.is_admin(&principal).await?
+        }
+        None => subject.is_admin(pool).await?,
+    };
+
+    if is_admin {
+        Ok(())
+    } else {
+        Err(ApiError::Forbidden(
+            "Import and export require an unscoped runtime administrator".to_string(),
+        ))
     }
 }
 

--- a/src/tasks/execution.rs
+++ b/src/tasks/execution.rs
@@ -15,7 +15,7 @@ use crate::traits::BackendContext;
 use super::helpers::{
     flush_import_result_batches, sanitize_error_for_storage, should_abort_best_effort_execution,
 };
-use super::planning::plan_import;
+use super::planning::plan_runtime_admin_import;
 use super::resolution::{
     resolve_class_runtime, resolve_collection_parent_runtime, resolve_collection_runtime,
     resolve_object_runtime,
@@ -34,7 +34,6 @@ pub(super) async fn execute_import_task<C>(
     backend: &C,
     task: &TaskRecord,
     user: &impl crate::db::traits::authz::AuthzSubject,
-    scopes: Option<&[crate::models::Permissions]>,
 ) -> Result<(), ApiError>
 where
     C: BackendContext + ?Sized,
@@ -68,7 +67,7 @@ where
     async {
         let total_start = Instant::now();
         let planning_start = Instant::now();
-        let planning = plan_import(backend, user, scopes, &request)
+        let planning = plan_runtime_admin_import(backend, user, &request)
             .instrument(info_span!("import_planning"))
             .await;
         let planning_time = planning_start.elapsed();

--- a/src/tasks/execution.rs
+++ b/src/tasks/execution.rs
@@ -10,6 +10,7 @@ use crate::models::{
     NewTaskEventRecord, TaskRecord, TaskStatus,
 };
 use crate::observability::metrics;
+use crate::traits::BackendContext;
 
 use super::helpers::{
     flush_import_result_batches, sanitize_error_for_storage, should_abort_best_effort_execution,
@@ -29,12 +30,16 @@ use crate::db::traits::task_import::{
     update_collection_db, update_object_db,
 };
 
-pub(super) async fn execute_import_task(
-    pool: &DbPool,
+pub(super) async fn execute_import_task<C>(
+    backend: &C,
     task: &TaskRecord,
     user: &impl crate::db::traits::authz::AuthzSubject,
     scopes: Option<&[crate::models::Permissions]>,
-) -> Result<(), ApiError> {
+) -> Result<(), ApiError>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     let payload = task
         .request_payload
         .clone()
@@ -63,7 +68,7 @@ pub(super) async fn execute_import_task(
     async {
         let total_start = Instant::now();
         let planning_start = Instant::now();
-        let planning = plan_import(pool, user, scopes, &request)
+        let planning = plan_import(backend, user, scopes, &request)
             .instrument(info_span!("import_planning"))
             .await;
         let planning_time = planning_start.elapsed();

--- a/src/tasks/planning.rs
+++ b/src/tasks/planning.rs
@@ -29,33 +29,53 @@ use crate::models::{
     ImportObjectInput, ImportObjectRelationInput, ImportPermissionPolicy, ImportRequest,
     Permissions,
 };
+use crate::permissions::PrincipalRef;
+use crate::traits::BackendContext;
 
-async fn is_import_admin(
-    pool: &DbPool,
+async fn is_import_admin<C>(
+    backend: &C,
     user: &impl crate::db::traits::authz::AuthzSubject,
     state: &mut PlanningState,
-) -> Result<bool, String> {
+) -> Result<bool, String>
+where
+    C: BackendContext + ?Sized,
+{
     if let Some(is_admin) = state.is_admin {
         return Ok(is_admin);
     }
 
-    let is_admin = user.is_admin(pool).await.map_err(|err| err.to_string())?;
+    let pool = backend.db_pool();
+    let is_admin = match backend.permission_backend() {
+        Some(permission_backend) if !permission_backend.uses_sql_permission_store() => {
+            let principal = PrincipalRef::load(pool, user)
+                .await
+                .map_err(|err| err.to_string())?;
+            permission_backend
+                .is_admin(&principal)
+                .await
+                .map_err(|err| err.to_string())?
+        }
+        _ => user.is_admin(pool).await.map_err(|err| err.to_string())?,
+    };
     state.is_admin = Some(is_admin);
     Ok(is_admin)
 }
 
-async fn ensure_collection_permission_cached(
-    pool: &DbPool,
+async fn ensure_collection_permission_cached<C>(
+    backend: &C,
     user: &impl crate::db::traits::authz::AuthzSubject,
     state: &mut PlanningState,
     collection_id: i32,
     collection_exists_in_db: bool,
     permission: Permissions,
-) -> Result<(), String> {
+) -> Result<(), String>
+where
+    C: BackendContext + ?Sized,
+{
     if !collection_exists_in_db {
         // Admin-bypass for newly-created collections applies only to unscoped
         // tokens; a scoped import can never operate on new collections.
-        if state.scopes.is_none() && is_import_admin(pool, user, state).await? {
+        if state.scopes.is_none() && is_import_admin(backend, user, state).await? {
             return Ok(());
         }
         return Err("Only admins may operate on newly created collections within an import".into());
@@ -68,10 +88,12 @@ async fn ensure_collection_permission_cached(
 
     let collection = CollectionID::new(collection_id).map_err(|err| err.to_string())?;
     let scopes = state.scopes.clone();
-    let result = user
-        .can(pool, vec![permission], vec![collection], scopes.as_deref())
-        .await
-        .map_err(|err| err.to_string());
+    let result: Result<(), crate::errors::ApiError> = async {
+        crate::can!(backend, user, scopes.as_deref(), [permission], collection);
+        Ok(())
+    }
+    .await;
+    let result = result.map_err(|err| err.to_string());
     state
         .collection_permission_cache
         .insert(key, result.clone());
@@ -122,12 +144,16 @@ async fn object_relation_exists_cached(
     Ok(exists)
 }
 
-pub(super) async fn plan_import(
-    pool: &DbPool,
+pub(super) async fn plan_import<C>(
+    backend: &C,
     user: &impl crate::db::traits::authz::AuthzSubject,
     scopes: Option<&[Permissions]>,
     request: &ImportRequest,
-) -> PlanningOutcome {
+) -> PlanningOutcome
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     let mode = request.mode();
     let mut state = PlanningState::new();
     state.scopes = scopes.map(|s| s.to_vec());
@@ -162,7 +188,9 @@ pub(super) async fn plan_import(
     let collection_start = Instant::now();
     async {
         for collection in &request.graph.collections {
-            push_or_stop!(plan_collection(pool, user, &mode, &mut state, collection));
+            push_or_stop!(plan_collection(
+                backend, user, &mode, &mut state, collection
+            ));
         }
     }
     .instrument(info_span!(
@@ -205,7 +233,7 @@ pub(super) async fn plan_import(
     let class_start = Instant::now();
     async {
         for class in &request.graph.classes {
-            push_or_stop!(plan_class(pool, user, &mode, &mut state, class));
+            push_or_stop!(plan_class(backend, user, &mode, &mut state, class));
         }
     }
     .instrument(info_span!(
@@ -248,7 +276,7 @@ pub(super) async fn plan_import(
     let object_start = Instant::now();
     async {
         for object in &request.graph.objects {
-            push_or_stop!(plan_object(pool, user, &mode, &mut state, object));
+            push_or_stop!(plan_object(backend, user, &mode, &mut state, object));
         }
     }
     .instrument(info_span!(
@@ -277,7 +305,9 @@ pub(super) async fn plan_import(
     let class_relation_start = Instant::now();
     async {
         for relation in &request.graph.class_relations {
-            push_or_stop!(plan_class_relation(pool, user, &mode, &mut state, relation));
+            push_or_stop!(plan_class_relation(
+                backend, user, &mode, &mut state, relation
+            ));
         }
     }
     .instrument(info_span!(
@@ -307,7 +337,7 @@ pub(super) async fn plan_import(
     async {
         for relation in &request.graph.object_relations {
             push_or_stop!(plan_object_relation(
-                pool, user, &mode, &mut state, relation
+                backend, user, &mode, &mut state, relation
             ));
         }
     }
@@ -338,7 +368,7 @@ pub(super) async fn plan_import(
     async {
         for acl in &request.graph.collection_permissions {
             push_or_stop!(plan_collection_permission(
-                pool, user, &mode, &mut state, acl
+                backend, user, &mode, &mut state, acl
             ));
         }
     }
@@ -365,13 +395,17 @@ pub(super) async fn plan_import(
     }
 }
 
-pub(super) async fn plan_collection(
-    pool: &DbPool,
+pub(super) async fn plan_collection<C>(
+    backend: &C,
     user: &impl crate::db::traits::authz::AuthzSubject,
     mode: &ImportMode,
     state: &mut PlanningState,
     input: &ImportCollectionInput,
-) -> Result<PlannedItem, PlanningFailure> {
+) -> Result<PlannedItem, PlanningFailure>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     if let Some(reference) = &input.ref_
         && state.collections_by_ref.contains_key(reference)
     {
@@ -454,7 +488,7 @@ pub(super) async fn plan_collection(
 
     if let Some(collection) = existing {
         ensure_collection_permission_cached(
-            pool,
+            backend,
             user,
             state,
             collection.id,
@@ -554,13 +588,17 @@ pub(super) async fn plan_collection(
     }
 }
 
-pub(super) async fn plan_class(
-    pool: &DbPool,
+pub(super) async fn plan_class<C>(
+    backend: &C,
     user: &impl crate::db::traits::authz::AuthzSubject,
     mode: &ImportMode,
     state: &mut PlanningState,
     input: &ImportClassInput,
-) -> Result<PlannedItem, PlanningFailure> {
+) -> Result<PlannedItem, PlanningFailure>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     if let Some(reference) = &input.ref_
         && state.classes_by_ref.contains_key(reference)
     {
@@ -640,7 +678,7 @@ pub(super) async fn plan_class(
 
     if let Some(class) = existing {
         ensure_collection_permission_cached(
-            pool,
+            backend,
             user,
             state,
             collection.id,
@@ -697,7 +735,7 @@ pub(super) async fn plan_class(
         })
     } else {
         ensure_collection_permission_cached(
-            pool,
+            backend,
             user,
             state,
             collection.id,
@@ -733,13 +771,17 @@ pub(super) async fn plan_class(
     }
 }
 
-pub(super) async fn plan_object(
-    pool: &DbPool,
+pub(super) async fn plan_object<C>(
+    backend: &C,
     user: &impl crate::db::traits::authz::AuthzSubject,
     mode: &ImportMode,
     state: &mut PlanningState,
     input: &ImportObjectInput,
-) -> Result<PlannedItem, PlanningFailure> {
+) -> Result<PlannedItem, PlanningFailure>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     if let Some(reference) = &input.ref_
         && state.objects_by_ref.contains_key(reference)
     {
@@ -846,7 +888,7 @@ pub(super) async fn plan_object(
 
     if let Some(object) = existing {
         ensure_collection_permission_cached(
-            pool,
+            backend,
             user,
             state,
             collection.id,
@@ -899,7 +941,7 @@ pub(super) async fn plan_object(
         })
     } else {
         ensure_collection_permission_cached(
-            pool,
+            backend,
             user,
             state,
             collection.id,
@@ -934,13 +976,17 @@ pub(super) async fn plan_object(
     }
 }
 
-pub(super) async fn plan_class_relation(
-    pool: &DbPool,
+pub(super) async fn plan_class_relation<C>(
+    backend: &C,
     user: &impl crate::db::traits::authz::AuthzSubject,
     mode: &ImportMode,
     state: &mut PlanningState,
     input: &ImportClassRelationInput,
-) -> Result<PlannedItem, PlanningFailure> {
+) -> Result<PlannedItem, PlanningFailure>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     let from_class = resolve_class_planning(
         pool,
         state,
@@ -994,7 +1040,7 @@ pub(super) async fn plan_class_relation(
         })?;
 
     ensure_collection_permission_cached(
-        pool,
+        backend,
         user,
         state,
         from_collection.id,
@@ -1013,7 +1059,7 @@ pub(super) async fn plan_class_relation(
         message,
     })?;
     ensure_collection_permission_cached(
-        pool,
+        backend,
         user,
         state,
         to_collection.id,
@@ -1072,13 +1118,17 @@ pub(super) async fn plan_class_relation(
     })
 }
 
-pub(super) async fn plan_object_relation(
-    pool: &DbPool,
+pub(super) async fn plan_object_relation<C>(
+    backend: &C,
     user: &impl crate::db::traits::authz::AuthzSubject,
     mode: &ImportMode,
     state: &mut PlanningState,
     input: &ImportObjectRelationInput,
-) -> Result<PlannedItem, PlanningFailure> {
+) -> Result<PlannedItem, PlanningFailure>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     let from_object = resolve_object_planning(
         pool,
         state,
@@ -1121,7 +1171,7 @@ pub(super) async fn plan_object_relation(
         })?;
 
     ensure_collection_permission_cached(
-        pool,
+        backend,
         user,
         state,
         from_collection.id,
@@ -1135,7 +1185,7 @@ pub(super) async fn plan_object_relation(
         message,
     })?;
     ensure_collection_permission_cached(
-        pool,
+        backend,
         user,
         state,
         to_collection.id,
@@ -1203,13 +1253,17 @@ pub(super) async fn plan_object_relation(
     })
 }
 
-pub(super) async fn plan_collection_permission(
-    pool: &DbPool,
+pub(super) async fn plan_collection_permission<C>(
+    backend: &C,
     user: &impl crate::db::traits::authz::AuthzSubject,
     _mode: &ImportMode,
     state: &mut PlanningState,
     input: &ImportCollectionPermissionInput,
-) -> Result<PlannedItem, PlanningFailure> {
+) -> Result<PlannedItem, PlanningFailure>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     let collection = resolve_collection_planning(
         pool,
         state,
@@ -1229,7 +1283,7 @@ pub(super) async fn plan_collection_permission(
     })?;
 
     ensure_collection_permission_cached(
-        pool,
+        backend,
         user,
         state,
         collection.id,

--- a/src/tasks/planning.rs
+++ b/src/tasks/planning.rs
@@ -72,12 +72,11 @@ async fn ensure_collection_permission_cached<C>(
 where
     C: BackendContext + ?Sized,
 {
+    if state.scopes.is_none() && is_import_admin(backend, user, state).await? {
+        return Ok(());
+    }
+
     if !collection_exists_in_db {
-        // Admin-bypass for newly-created collections applies only to unscoped
-        // tokens; a scoped import can never operate on new collections.
-        if state.scopes.is_none() && is_import_admin(backend, user, state).await? {
-            return Ok(());
-        }
         return Err("Only admins may operate on newly created collections within an import".into());
     }
 
@@ -144,6 +143,7 @@ async fn object_relation_exists_cached(
     Ok(exists)
 }
 
+#[cfg(test)]
 pub(super) async fn plan_import<C>(
     backend: &C,
     user: &impl crate::db::traits::authz::AuthzSubject,
@@ -153,10 +153,35 @@ pub(super) async fn plan_import<C>(
 where
     C: BackendContext + ?Sized,
 {
+    plan_import_with_admin_status(backend, user, scopes, request, None).await
+}
+
+pub(super) async fn plan_runtime_admin_import<C>(
+    backend: &C,
+    user: &impl crate::db::traits::authz::AuthzSubject,
+    request: &ImportRequest,
+) -> PlanningOutcome
+where
+    C: BackendContext + ?Sized,
+{
+    plan_import_with_admin_status(backend, user, None, request, Some(true)).await
+}
+
+async fn plan_import_with_admin_status<C>(
+    backend: &C,
+    user: &impl crate::db::traits::authz::AuthzSubject,
+    scopes: Option<&[Permissions]>,
+    request: &ImportRequest,
+    is_admin: Option<bool>,
+) -> PlanningOutcome
+where
+    C: BackendContext + ?Sized,
+{
     let pool = backend.db_pool();
     let mode = request.mode();
     let mut state = PlanningState::new();
     state.scopes = scopes.map(|s| s.to_vec());
+    state.is_admin = is_admin;
     let mut planned_items = Vec::with_capacity(request.total_items() as usize);
     let mut failures = Vec::new();
     let mut aborted = false;
@@ -542,7 +567,7 @@ where
             }),
         })
     } else {
-        if !is_import_admin(pool, user, state)
+        if !is_import_admin(backend, user, state)
             .await
             .map_err(|err| PlanningFailure {
                 kind: FailureKind::Permission,

--- a/src/tasks/remote_call.rs
+++ b/src/tasks/remote_call.rs
@@ -21,13 +21,18 @@ use crate::models::{
     StoredRemoteCallTaskPayload, TaskRecord, TaskStatus, authorize_remote_invocation,
 };
 use crate::observability::metrics;
+use crate::traits::BackendContext;
 
-pub(super) async fn execute_remote_call_task(
-    pool: &DbPool,
+pub(super) async fn execute_remote_call_task<C>(
+    backend: &C,
     task: &TaskRecord,
     user: &impl crate::db::traits::authz::AuthzSubject,
     scopes: Option<&[crate::models::Permissions]>,
-) -> Result<(), ApiError> {
+) -> Result<(), ApiError>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     let payload = task
         .request_payload
         .clone()
@@ -48,7 +53,7 @@ pub(super) async fn execute_remote_call_task(
     )
     .await?;
 
-    let result = execute_remote_call(pool, task.id, user, scopes, &request).await;
+    let result = execute_remote_call(backend, task.id, user, scopes, &request).await;
     match result {
         Ok(success) => finalize_remote_task(pool, task, success).await,
         Err(error) => {
@@ -102,16 +107,20 @@ struct RemoteFailureContext<'a> {
     method: &'a str,
 }
 
-async fn execute_remote_call(
-    pool: &DbPool,
+async fn execute_remote_call<C>(
+    backend: &C,
     task_id: i32,
     user: &impl crate::db::traits::authz::AuthzSubject,
     scopes: Option<&[crate::models::Permissions]>,
     request: &StoredRemoteCallTaskPayload,
-) -> Result<RemoteExecutionOutcome, ApiError> {
+) -> Result<RemoteExecutionOutcome, ApiError>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = backend.db_pool();
     let target = request.target_id.instance(pool).await?;
     let resolved =
-        authorize_remote_invocation(pool, user, scopes, &target, &request.subject).await?;
+        authorize_remote_invocation(backend, user, scopes, &target, &request.subject).await?;
 
     let context = invocation_context(
         resolved.context,

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -7,7 +7,7 @@ use super::helpers::{
     class_to_resolution, planned_result, sanitize_error_for_storage,
     should_abort_best_effort_execution,
 };
-use super::planning::{plan_class, plan_collection, plan_object};
+use super::planning::{plan_class, plan_collection, plan_import, plan_object};
 use super::request_hash;
 use super::resolution::{
     remember_class, remember_collection, resolve_class_planning, resolve_collection_by_id_planning,
@@ -23,16 +23,53 @@ use crate::db::traits::task_import::{create_class_db, create_object_db};
 use crate::db::with_connection;
 use crate::errors::ApiError;
 use crate::models::{
-    ClassKey, CollectionID, CollectionKey, ImportAtomicity, ImportClassInput,
-    ImportCollectionInput, ImportCollisionPolicy, ImportMode, ImportObjectInput,
-    ImportPermissionPolicy, NewCollectionWithAssignee, NewImportTaskResultRecord, NewTaskRecord,
-    ObjectKey, TaskKind, TaskStatus,
+    CURRENT_IMPORT_VERSION, ClassKey, CollectionID, CollectionKey, ImportAtomicity,
+    ImportClassInput, ImportCollectionInput, ImportCollisionPolicy, ImportGraph, ImportMode,
+    ImportObjectInput, ImportPermissionPolicy, ImportRequest, NewCollectionWithAssignee,
+    NewImportTaskResultRecord, NewTaskRecord, ObjectKey, TaskKind, TaskStatus,
 };
+use crate::permissions::test_support::MockTreetopBackend;
+use crate::permissions::{AppContext, PermissionBackend};
 use crate::schema::collections::dsl::{collections, name as collection_name};
 use crate::schema::hubuumclass::dsl::{hubuumclass, name as class_name};
 use crate::schema::tasks::dsl::{created_at, id as task_id, tasks};
 use crate::tests::TestContext;
 use crate::traits::CanSave;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn import_planning_uses_the_task_execution_permission_backend() {
+    let context = TestContext::new().await;
+    let fixture = context
+        .collection_fixture("external_task_authorization")
+        .await;
+    let permissions: Arc<dyn PermissionBackend> = Arc::new(MockTreetopBackend::new());
+    let backend = AppContext::new(context.pool.get_ref().clone(), permissions);
+    let request = ImportRequest {
+        version: CURRENT_IMPORT_VERSION,
+        dry_run: Some(true),
+        mode: Some(ImportMode {
+            collision_policy: Some(ImportCollisionPolicy::Overwrite),
+            ..ImportMode::default()
+        }),
+        graph: ImportGraph {
+            collections: vec![ImportCollectionInput {
+                ref_: Some("collection:existing".to_string()),
+                name: fixture.collection.name.clone(),
+                description: "updated by import".to_string(),
+                parent_collection_ref: None,
+                parent_collection_key: None,
+            }],
+            ..ImportGraph::default()
+        },
+    };
+
+    let planning = plan_import(&backend, &context.admin_user, None, &request).await;
+
+    assert!(planning.aborted);
+    assert_eq!(planning.failures.len(), 1);
+    assert!(matches!(planning.failures[0].kind, FailureKind::Permission));
+}
 
 #[tokio::test]
 async fn test_execute_import_strict_rolls_back_on_runtime_failure() {

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -23,6 +23,10 @@ use crate::exports::execute_export_task;
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::{NewTaskEventRecord, TaskKind, TaskRecord, TaskResultCounts, TaskStatus};
 use crate::observability::metrics;
+use crate::permissions::AppContext;
+#[cfg(test)]
+use crate::permissions::LocalPermissionBackend;
+use crate::traits::BackendContext;
 
 use super::execution::execute_import_task;
 use super::helpers::sanitize_error_for_storage;
@@ -180,12 +184,12 @@ async fn wait_for_task_worker_wakeup(poll_interval: Duration, shutdown: &Shutdow
     }
 }
 
-async fn task_worker_loop(pool: DbPool, poll_interval: Duration, shutdown: ShutdownSignal) {
+async fn task_worker_loop(context: AppContext, poll_interval: Duration, shutdown: ShutdownSignal) {
     loop {
         if shutdown.is_requested() {
             break;
         }
-        let result = process_one_task(&pool, Some(&shutdown)).await;
+        let result = process_one_task(&context, Some(&shutdown)).await;
         if shutdown.is_requested() {
             break;
         }
@@ -200,7 +204,7 @@ async fn task_worker_loop(pool: DbPool, poll_interval: Duration, shutdown: Shutd
     }
 }
 
-fn spawn_task_worker_loop(pool: DbPool, poll_interval: Duration, worker_index: usize) {
+fn spawn_task_worker_loop(context: AppContext, poll_interval: Duration, worker_index: usize) {
     spawn_background_worker(format!("task-worker-{worker_index}"), move |shutdown| {
         info!(
             message = "Starting task worker loop",
@@ -209,15 +213,15 @@ fn spawn_task_worker_loop(pool: DbPool, poll_interval: Duration, worker_index: u
         );
         let system = actix_rt::System::new();
         system.block_on(async move {
-            let pool = task_worker_pool(pool);
-            task_worker_loop(pool, poll_interval, shutdown).await;
+            let context = task_worker_context(context);
+            task_worker_loop(context, poll_interval, shutdown).await;
         });
     });
 }
 
 #[cfg(not(test))]
-fn task_worker_pool(pool: DbPool) -> DbPool {
-    pool
+fn task_worker_context(context: AppContext) -> AppContext {
+    context
 }
 
 /// Async Postgres connections are tied to the runtime that established them.
@@ -225,13 +229,18 @@ fn task_worker_pool(pool: DbPool) -> DbPool {
 /// thread is process-global. Build the test worker's pool on its own long-lived
 /// runtime so it never inherits connections driven by a completed test runtime.
 #[cfg(test)]
-fn task_worker_pool(pool: DbPool) -> DbPool {
-    drop(pool);
+fn task_worker_context(context: AppContext) -> AppContext {
+    drop(context);
     let config = get_config().expect("test task worker requires database configuration");
-    crate::db::init_pool(&config.database_url, config.db_pool_size)
+    let pool = crate::db::init_pool(&config.database_url, config.db_pool_size);
+    let permissions = std::sync::Arc::new(LocalPermissionBackend::new(
+        pool.clone(),
+        config.admin_groupname.clone(),
+    ));
+    AppContext::new(pool, permissions)
 }
 
-pub fn ensure_task_worker_running(pool: DbPool) {
+pub fn ensure_task_worker_running(context: AppContext) {
     let worker_count = configured_task_worker_count();
     if worker_count == 0 {
         return;
@@ -245,20 +254,24 @@ pub fn ensure_task_worker_running(pool: DbPool) {
         );
         metrics::task_worker_config(worker_count, poll_interval);
         for worker_index in 0..worker_count {
-            spawn_task_worker_loop(pool.clone(), poll_interval, worker_index);
+            spawn_task_worker_loop(context.clone(), poll_interval, worker_index);
         }
     });
 }
 
-pub fn kick_task_worker(pool: DbPool) {
-    ensure_task_worker_running(pool);
+pub fn kick_task_worker(context: AppContext) {
+    ensure_task_worker_running(context);
     get_task_worker_notify().notify_one();
 }
 
-pub(super) async fn process_one_task(
-    pool: &DbPool,
+pub(super) async fn process_one_task<C>(
+    context: &C,
     shutdown: Option<&ShutdownSignal>,
-) -> Result<bool, ApiError> {
+) -> Result<bool, ApiError>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = context.db_pool();
     maybe_recover_expired_task_leases(pool).await?;
 
     if let Err(error) = maybe_cleanup_expired_export_outputs(pool).await {
@@ -304,10 +317,10 @@ pub(super) async fn process_one_task(
                     _ = shutdown.requested() => Err(ApiError::ServiceUnavailable(
                         "Task interrupted by graceful server shutdown".to_string(),
                     )),
-                    result = process_claimed_task(pool, &task) => result,
+                    result = process_claimed_task(context, &task) => result,
                 }
             }
-            None => process_claimed_task(pool, &task).await,
+            None => process_claimed_task(context, &task).await,
         }
     };
     let mut ownership_lost = false;
@@ -590,7 +603,11 @@ fn duration_since(timestamp: chrono::NaiveDateTime) -> Option<Duration> {
     (elapsed >= 0).then(|| Duration::from_millis(elapsed as u64))
 }
 
-async fn process_claimed_task(pool: &DbPool, task: &TaskRecord) -> Result<(), ApiError> {
+async fn process_claimed_task<C>(context: &C, task: &TaskRecord) -> Result<(), ApiError>
+where
+    C: BackendContext + ?Sized,
+{
+    let pool = context.db_pool();
     let submitted_by = task.submitted_by.ok_or_else(|| {
         ApiError::BadRequest(
             "Submitting principal is no longer available for this task".to_string(),
@@ -637,9 +654,9 @@ async fn process_claimed_task(pool: &DbPool, task: &TaskRecord) -> Result<(), Ap
     );
 
     match TaskKind::from_db(&task.kind)? {
-        TaskKind::Import => execute_import_task(pool, task, &principal, scopes).await,
-        TaskKind::Export => execute_export_task(pool, task, &principal, scopes).await,
-        TaskKind::RemoteCall => execute_remote_call_task(pool, task, &principal, scopes).await,
+        TaskKind::Import => execute_import_task(context, task, &principal, scopes).await,
+        TaskKind::Export => execute_export_task(context, task, &principal, scopes).await,
+        TaskKind::RemoteCall => execute_remote_call_task(context, task, &principal, scopes).await,
         other => Err(ApiError::BadRequest(format!(
             "Task kind '{}' is not implemented",
             other.as_str()

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -23,9 +23,9 @@ use crate::exports::execute_export_task;
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::{NewTaskEventRecord, TaskKind, TaskRecord, TaskResultCounts, TaskStatus};
 use crate::observability::metrics;
-use crate::permissions::AppContext;
 #[cfg(test)]
 use crate::permissions::LocalPermissionBackend;
+use crate::permissions::{AppContext, require_unscoped_runtime_admin};
 use crate::traits::BackendContext;
 
 use super::execution::execute_import_task;
@@ -623,25 +623,32 @@ where
         ));
     }
 
+    let task_kind = TaskKind::from_db(&task.kind)?;
+    if matches!(task_kind, TaskKind::Import | TaskKind::Export) {
+        require_unscoped_runtime_admin(context, &principal, task.submitted_token_scoped).await?;
+    }
+
     // Reconstruct the submitting token's scope boundary from the snapshot,
-    // failing closed on any unknown permission string.
-    let snapshot_scopes: Option<Vec<crate::models::Permissions>> = if task.submitted_token_scoped {
-        let entries = task.submitted_token_scopes.as_array().ok_or_else(|| {
-            ApiError::InternalServerError("Task scope snapshot is not an array".to_string())
-        })?;
-        let mut parsed = Vec::with_capacity(entries.len());
-        for entry in entries {
-            let raw = entry.as_str().ok_or_else(|| {
-                ApiError::InternalServerError(
-                    "Task scope snapshot entry is not a string".to_string(),
-                )
+    // failing closed on any unknown permission string. Import and export are
+    // runtime-admin operations, so only remote calls consume scoped snapshots.
+    let snapshot_scopes: Option<Vec<crate::models::Permissions>> =
+        if task_kind == TaskKind::RemoteCall && task.submitted_token_scoped {
+            let entries = task.submitted_token_scopes.as_array().ok_or_else(|| {
+                ApiError::InternalServerError("Task scope snapshot is not an array".to_string())
             })?;
-            parsed.push(crate::models::Permissions::from_string(raw)?);
-        }
-        Some(parsed)
-    } else {
-        None
-    };
+            let mut parsed = Vec::with_capacity(entries.len());
+            for entry in entries {
+                let raw = entry.as_str().ok_or_else(|| {
+                    ApiError::InternalServerError(
+                        "Task scope snapshot entry is not a string".to_string(),
+                    )
+                })?;
+                parsed.push(crate::models::Permissions::from_string(raw)?);
+            }
+            Some(parsed)
+        } else {
+            None
+        };
     let scopes = snapshot_scopes.as_deref();
 
     info!(
@@ -653,9 +660,9 @@ where
         scoped = task.submitted_token_scoped
     );
 
-    match TaskKind::from_db(&task.kind)? {
-        TaskKind::Import => execute_import_task(context, task, &principal, scopes).await,
-        TaskKind::Export => execute_export_task(context, task, &principal, scopes).await,
+    match task_kind {
+        TaskKind::Import => execute_import_task(context, task, &principal).await,
+        TaskKind::Export => execute_export_task(pool, task, &principal).await,
         TaskKind::RemoteCall => execute_remote_call_task(context, task, &principal, scopes).await,
         other => Err(ApiError::BadRequest(format!(
             "Task kind '{}' is not implemented",

--- a/src/tests/api/v1/exports.rs
+++ b/src/tests/api/v1/exports.rs
@@ -14,14 +14,16 @@ mod tests {
         ExportScopeKind, ExportTemplateKind, HubuumClass, HubuumClassRelation,
         HubuumObjectRelation, NewExportTaskOutputRecord, NewExportTemplate, NewHubuumClass,
         NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, NewTaskEventRecord,
-        NewTaskRecord, TaskEventResponse, TaskID, TaskKind, TaskResponse, TaskStatus,
+        NewTaskRecord, Permissions, TaskEventResponse, TaskID, TaskKind, TaskResponse, TaskStatus,
         UpdateExportTemplate,
     };
     use crate::tests::api::v1::classes::tests::{cleanup, create_test_classes};
     use crate::tests::api_operations::{get_request, post_request_with_headers};
     use crate::tests::asserts::{assert_response_status, header_value};
     use crate::tests::{
-        TestContext, TestMutex, create_test_user, lock_test_mutex, test_context, test_mutex,
+        TestContext, TestMutex, create_test_group, create_test_service_account, create_test_user,
+        ensure_admin_group, lock_test_mutex, scoped_token, service_account_token, test_context,
+        test_mutex,
     };
     use crate::traits::{CanSave, CanUpdate};
     const EXPORTS_ENDPOINT: &str = "/api/v1/exports";
@@ -31,6 +33,82 @@ mod tests {
     /// row to survive until it has queried it. They cannot safely interleave; every other test in
     /// the suite remains free to run in parallel.
     static EXPIRED_OUTPUT_PURGE_LOCK: TestMutex = test_mutex();
+
+    #[derive(Clone, Copy)]
+    enum UnauthorizedExportCaller {
+        NonAdmin,
+        ScopedAdmin,
+    }
+
+    #[rstest]
+    #[case::non_admin(UnauthorizedExportCaller::NonAdmin)]
+    #[case::scoped_admin(UnauthorizedExportCaller::ScopedAdmin)]
+    #[actix_web::test]
+    async fn test_export_requires_unscoped_runtime_admin(
+        #[future(awt)] test_context: TestContext,
+        #[case] caller: UnauthorizedExportCaller,
+    ) {
+        let context = test_context;
+        let token = match caller {
+            UnauthorizedExportCaller::NonAdmin => context.normal_token.clone(),
+            UnauthorizedExportCaller::ScopedAdmin => {
+                scoped_token(
+                    &context.pool,
+                    context.admin_user.id,
+                    &[Permissions::ReadCollection],
+                )
+                .await
+            }
+        };
+        let body = collection_export_request();
+
+        let resp =
+            post_request_with_headers(&context.pool, &token, EXPORTS_ENDPOINT, &body, vec![]).await;
+
+        assert_response_status(resp, StatusCode::FORBIDDEN).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_export_accepts_unscoped_admin_service_account(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let owner_group = create_test_group(&context.pool).await;
+        let admin_group = ensure_admin_group(&context.pool).await;
+        let service_account =
+            create_test_service_account(&context.pool, &owner_group, Some(context.admin_user.id))
+                .await;
+        admin_group
+            .add_member_without_events(&context.pool, &service_account)
+            .await
+            .unwrap();
+        let token = service_account_token(&context.pool, &service_account, None, None).await;
+        let body = collection_export_request();
+
+        let resp =
+            post_request_with_headers(&context.pool, &token, EXPORTS_ENDPOINT, &body, vec![]).await;
+        let resp = assert_response_status(resp, StatusCode::ACCEPTED).await;
+        let task: TaskResponse = test::read_body_json(resp).await;
+        let completed = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+
+        assert_eq!(completed.status, TaskStatus::Succeeded);
+    }
+
+    fn collection_export_request() -> ExportRequest {
+        ExportRequest {
+            scope: ExportScope {
+                kind: ExportScopeKind::Collections,
+                class_id: None,
+                object_id: None,
+            },
+            query: None,
+            missing_data_policy: None,
+            limits: None,
+            include: None,
+            relation_context: None,
+        }
+    }
 
     async fn wait_for_task(
         context: &TestContext,
@@ -1079,7 +1157,7 @@ mod tests {
 
     #[rstest]
     #[actix_web::test]
-    async fn test_export_rejects_template_permission_failure_before_task_creation(
+    async fn test_template_export_requires_runtime_admin_before_task_creation(
         #[future(awt)] test_context: TestContext,
     ) {
         let context = test_context;

--- a/src/tests/api/v1/imports.rs
+++ b/src/tests/api/v1/imports.rs
@@ -11,7 +11,7 @@ mod tests {
 
     use crate::db::with_connection;
     use crate::models::{
-        CollectionKey, GroupKey, ImportAtomicity, ImportClassInput, ImportCollectionInput,
+        CURRENT_IMPORT_VERSION, GroupKey, ImportAtomicity, ImportClassInput, ImportCollectionInput,
         ImportCollectionPermissionInput, ImportCollisionPolicy, ImportGraph, ImportMode,
         ImportObjectInput, ImportPermissionPolicy, ImportRequest, ImportTaskResultResponse,
         NewTaskRecord, Permissions, TaskEventResponse, TaskKind, TaskResponse, TaskStatus,
@@ -20,13 +20,15 @@ mod tests {
     use crate::schema::collections::dsl::{
         collections, description as collection_description, id as collection_id_field,
     };
-    use crate::schema::hubuumclass::dsl::{collection_id, hubuumclass, name as class_name_col};
     use crate::schema::tasks::dsl::{
         id as task_id_field, request_payload, request_redacted_at, tasks,
     };
     use crate::tests::api_operations::{get_request, post_request_with_headers};
     use crate::tests::asserts::{assert_response_status, header_value};
-    use crate::tests::{TestContext, create_test_group, test_context};
+    use crate::tests::{
+        TestContext, create_test_group, create_test_service_account, ensure_admin_group,
+        scoped_token, service_account_token, test_context,
+    };
 
     const IMPORTS_ENDPOINT: &str = "/api/v1/imports";
 
@@ -787,218 +789,77 @@ mod tests {
         assert_eq!(description, updated_description);
     }
 
+    #[derive(Clone, Copy)]
+    enum UnauthorizedImportCaller {
+        NonAdmin,
+        ScopedAdmin,
+    }
+
     #[rstest]
+    #[case::non_admin(UnauthorizedImportCaller::NonAdmin)]
+    #[case::scoped_admin(UnauthorizedImportCaller::ScopedAdmin)]
     #[actix_web::test]
-    async fn test_import_permission_continue_allows_partial_success(
+    async fn test_import_requires_unscoped_runtime_admin(
         #[future(awt)] test_context: TestContext,
+        #[case] caller: UnauthorizedImportCaller,
     ) {
         let context = test_context;
-        let allowed = context
-            .collection_fixture("permission_continue_allowed")
-            .await;
-        let forbidden = context
-            .collection_fixture("permission_continue_forbidden")
-            .await;
-        allowed
-            .owner_group
-            .add_member_without_events(&context.pool, &context.normal_user)
-            .await
-            .unwrap();
-
-        let allowed_class = context.scoped_name("permission_continue_allowed_class");
-        let forbidden_class = context.scoped_name("permission_continue_forbidden_class");
+        let token = match caller {
+            UnauthorizedImportCaller::NonAdmin => context.normal_token.clone(),
+            UnauthorizedImportCaller::ScopedAdmin => {
+                scoped_token(
+                    &context.pool,
+                    context.admin_user.id,
+                    &[Permissions::ReadCollection],
+                )
+                .await
+            }
+        };
         let body = ImportRequest {
-            version: 1,
-            dry_run: Some(false),
-            mode: Some(ImportMode {
-                atomicity: Some(ImportAtomicity::BestEffort),
-                collision_policy: Some(ImportCollisionPolicy::Abort),
-                permission_policy: Some(ImportPermissionPolicy::Continue),
-            }),
-            graph: ImportGraph {
-                classes: vec![
-                    ImportClassInput {
-                        ref_: Some("class:allowed".to_string()),
-                        name: allowed_class.clone(),
-                        description: "allowed".to_string(),
-                        json_schema: None,
-                        validate_schema: Some(false),
-                        collection_ref: None,
-                        collection_key: Some(CollectionKey {
-                            name: allowed.collection.name.clone(),
-                            path: None,
-                        }),
-                    },
-                    ImportClassInput {
-                        ref_: Some("class:forbidden".to_string()),
-                        name: forbidden_class.clone(),
-                        description: "forbidden".to_string(),
-                        json_schema: None,
-                        validate_schema: Some(false),
-                        collection_ref: None,
-                        collection_key: Some(CollectionKey {
-                            name: forbidden.collection.name.clone(),
-                            path: None,
-                        }),
-                    },
-                ],
-                ..ImportGraph::default()
-            },
+            version: CURRENT_IMPORT_VERSION,
+            dry_run: Some(true),
+            mode: None,
+            graph: ImportGraph::default(),
         };
 
-        let resp = post_request_with_headers(
-            &context.pool,
-            &context.normal_token,
-            IMPORTS_ENDPOINT,
-            &body,
-            vec![],
-        )
-        .await;
-        let resp = assert_response_status(resp, StatusCode::ACCEPTED).await;
-        let task: TaskResponse = test::read_body_json(resp).await;
-        let completed = wait_for_task_with_token(
-            &context.pool,
-            &context.normal_token,
-            task.id,
-            &[TaskStatus::PartiallySucceeded],
-        )
-        .await;
-        assert_eq!(completed.status, TaskStatus::PartiallySucceeded);
+        let resp =
+            post_request_with_headers(&context.pool, &token, IMPORTS_ENDPOINT, &body, vec![]).await;
 
-        let created = with_connection(&context.pool, async |conn| {
-            hubuumclass
-                .filter(class_name_col.eq(&allowed_class))
-                .filter(collection_id.eq(allowed.collection.id))
-                .count()
-                .get_result::<i64>(conn)
-                .await
-        })
-        .await
-        .unwrap();
-        let blocked = with_connection(&context.pool, async |conn| {
-            hubuumclass
-                .filter(class_name_col.eq(&forbidden_class))
-                .filter(collection_id.eq(forbidden.collection.id))
-                .count()
-                .get_result::<i64>(conn)
-                .await
-        })
-        .await
-        .unwrap();
-        assert_eq!(created, 1);
-        assert_eq!(blocked, 0);
-
-        let resp = get_request(
-            &context.pool,
-            &context.normal_token,
-            &format!("/api/v1/imports/{}/results", task.id),
-        )
-        .await;
-        let resp = assert_response_status(resp, StatusCode::OK).await;
-        let results: Vec<ImportTaskResultResponse> = test::read_body_json(resp).await;
-        assert_eq!(results.len(), 2);
-        assert_eq!(
-            results
-                .iter()
-                .filter(|result| result.outcome == "succeeded")
-                .count(),
-            1
-        );
-        assert_eq!(
-            results
-                .iter()
-                .filter(|result| result.outcome == "failed")
-                .count(),
-            1
-        );
+        assert_response_status(resp, StatusCode::FORBIDDEN).await;
     }
 
     #[rstest]
     #[actix_web::test]
-    async fn test_import_permission_abort_prevents_any_mutation(
+    async fn test_import_accepts_unscoped_admin_service_account(
         #[future(awt)] test_context: TestContext,
     ) {
         let context = test_context;
-        let allowed = context.collection_fixture("permission_abort_allowed").await;
-        let forbidden = context
-            .collection_fixture("permission_abort_forbidden")
-            .await;
-        allowed
-            .owner_group
-            .add_member_without_events(&context.pool, &context.normal_user)
+        let owner_group = create_test_group(&context.pool).await;
+        let admin_group = ensure_admin_group(&context.pool).await;
+        let service_account =
+            create_test_service_account(&context.pool, &owner_group, Some(context.admin_user.id))
+                .await;
+        admin_group
+            .add_member_without_events(&context.pool, &service_account)
             .await
             .unwrap();
-
-        let allowed_class = context.scoped_name("permission_abort_allowed_class");
-        let forbidden_class = context.scoped_name("permission_abort_forbidden_class");
+        let token = service_account_token(&context.pool, &service_account, None, None).await;
         let body = ImportRequest {
-            version: 1,
-            dry_run: Some(false),
-            mode: Some(ImportMode {
-                atomicity: Some(ImportAtomicity::BestEffort),
-                collision_policy: Some(ImportCollisionPolicy::Abort),
-                permission_policy: Some(ImportPermissionPolicy::Abort),
-            }),
-            graph: ImportGraph {
-                classes: vec![
-                    ImportClassInput {
-                        ref_: Some("class:allowed".to_string()),
-                        name: allowed_class.clone(),
-                        description: "allowed".to_string(),
-                        json_schema: None,
-                        validate_schema: Some(false),
-                        collection_ref: None,
-                        collection_key: Some(CollectionKey {
-                            name: allowed.collection.name.clone(),
-                            path: None,
-                        }),
-                    },
-                    ImportClassInput {
-                        ref_: Some("class:forbidden".to_string()),
-                        name: forbidden_class.clone(),
-                        description: "forbidden".to_string(),
-                        json_schema: None,
-                        validate_schema: Some(false),
-                        collection_ref: None,
-                        collection_key: Some(CollectionKey {
-                            name: forbidden.collection.name.clone(),
-                            path: None,
-                        }),
-                    },
-                ],
-                ..ImportGraph::default()
-            },
+            version: CURRENT_IMPORT_VERSION,
+            dry_run: Some(true),
+            mode: None,
+            graph: ImportGraph::default(),
         };
 
-        let resp = post_request_with_headers(
-            &context.pool,
-            &context.normal_token,
-            IMPORTS_ENDPOINT,
-            &body,
-            vec![],
-        )
-        .await;
+        let resp =
+            post_request_with_headers(&context.pool, &token, IMPORTS_ENDPOINT, &body, vec![]).await;
         let resp = assert_response_status(resp, StatusCode::ACCEPTED).await;
         let task: TaskResponse = test::read_body_json(resp).await;
-        let completed = wait_for_task_with_token(
-            &context.pool,
-            &context.normal_token,
-            task.id,
-            &[TaskStatus::Failed],
-        )
-        .await;
-        assert_eq!(completed.status, TaskStatus::Failed);
+        let completed =
+            wait_for_task_with_token(&context.pool, &token, task.id, &[TaskStatus::Succeeded])
+                .await;
 
-        let created = with_connection(&context.pool, async |conn| {
-            hubuumclass
-                .filter(class_name_col.eq_any([allowed_class.clone(), forbidden_class.clone()]))
-                .count()
-                .get_result::<i64>(conn)
-                .await
-        })
-        .await
-        .unwrap();
-        assert_eq!(created, 0);
+        assert_eq!(completed.status, TaskStatus::Succeeded);
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

- Require an unscoped runtime administrator for every import and export, while allowing dedicated service accounts in the configured admin group and keeping human/IAM administration human-only.
- Recheck the submitting principal's runtime-admin authority in the worker before execution, then use a private trusted capability for the complete data transfer; remote-call tasks continue to enforce their persisted token scopes.
- Initialize the configured permission backend in worker-only replicas so execution-time decisions do not silently fall back to local SQL when Treetop is authoritative.
- Preserve active in-memory login limiter state at the key cap by rejecting new high-cardinality scopes, and exercise the Valkey limiter contract against a real service in CI.
- Require the latest application migration for server startup, `/readyz`, and `hubuum-admin --database-ready`, with updated distributed-deployment and task-system guidance.

## Why

Import and export are complete backup/restore-style operations. Treating them as collections of per-resource authorization checks made behavior depend on traversal details and could produce incomplete transfers. A single explicit runtime-admin gate provides a stable security boundary, supports dedicated automation identities, and lets administrators revoke queued work before it starts.

The distributed runtime also needed consistent configured-backend authorization in workers, protection against limiter-state eviction under high-cardinality traffic, and readiness checks that reject databases older than the running binary.

## Behavior and impact

- **Breaking:** Non-admin and scoped-token import/export submissions now return `403 Forbidden`. Automation must use an unscoped token belonging to a dedicated service account in the configured admin group, or an unscoped human runtime administrator.
- Service accounts authorized for import/export remain unable to access human/IAM administration surfaces.
- Workers fail queued import/export tasks closed if the submitting service account is disabled or the principal is no longer a runtime administrator before execution starts.
- Once authorized, import/export execute as complete runtime-admin operations without resource-by-resource filtering. The compatibility `permission_policy` import field remains accepted but has no effect for API-submitted imports.
- Remote-call task authorization remains bounded by the persisted submitting-token scope snapshot.
- At the in-memory limiter cap, existing protections remain intact and a new scope is denied until inactive state can be pruned.
- API and worker processes fail startup, and `/readyz` returns unavailable, until the migration required by the binary is recorded.
- Request and response schemas are unchanged; OpenAPI now documents the new `403` responses.

## Verification

- `source .env && ./run_tests.sh` (1,081 passed; 6 intentionally ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- OpenAPI generator output matches `docs/openapi.json`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`