### PR TITLE
Optimize active task capacity query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- Active task admission now uses a partial per-submitter and per-kind index so
+  capacity checks remain bounded by queued, validating, and running work rather
+  than scanning a submitter's completed task history.
 - **Breaking:** Import and export submission now requires an unscoped runtime
   administrator. Non-admin and scoped tokens now receive `403 Forbidden`.
   Automation should use dedicated service accounts in the configured admin

--- a/migrations/2026-07-15-000001_task_active_capacity_index/down.sql
+++ b/migrations/2026-07-15-000001_task_active_capacity_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY idx_tasks_active_capacity;

--- a/migrations/2026-07-15-000001_task_active_capacity_index/metadata.toml
+++ b/migrations/2026-07-15-000001_task_active_capacity_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-07-15-000001_task_active_capacity_index/up.sql
+++ b/migrations/2026-07-15-000001_task_active_capacity_index/up.sql
@@ -1,0 +1,5 @@
+CREATE INDEX CONCURRENTLY idx_tasks_active_capacity
+    ON tasks (submitted_by, kind)
+    WHERE submitted_by IS NOT NULL
+      AND deleted_at IS NULL
+      AND status IN ('queued', 'validating', 'running');

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -52,7 +52,7 @@ pub type DbPool = Pool<DbConnection>;
 /// Latest migration required by this binary. The test below keeps this value
 /// synchronized with the migration directory so readiness cannot silently lag
 /// behind a newly added schema change.
-pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260714000001";
+pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260715000001";
 
 #[derive(diesel::QueryableByName)]
 struct DatabaseSchemaReadiness {

--- a/src/db/traits/task.rs
+++ b/src/db/traits/task.rs
@@ -1530,6 +1530,14 @@ mod tests {
     };
     use crate::tests::{TestContext, create_test_user};
 
+    #[derive(QueryableByName)]
+    struct TaskCapacityIndex {
+        #[diesel(sql_type = diesel::sql_types::Bool)]
+        valid: bool,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        definition: String,
+    }
+
     #[tokio::test]
     async fn database_time_is_naive_utc_under_non_utc_session_timezone() {
         let context = TestContext::new().await;
@@ -1623,6 +1631,51 @@ mod tests {
             fallback_key,
             task_capacity_lock_key(user_id, TaskKind::Reindex)
         );
+    }
+
+    #[tokio::test]
+    async fn active_task_capacity_index_matches_the_admission_query() {
+        let context = TestContext::new().await;
+        let index = with_connection(&context.pool, async |conn| {
+            diesel::sql_query(
+                "SELECT pg_index.indisvalid AS valid,
+                        pg_get_indexdef(pg_index.indexrelid) AS definition
+                 FROM pg_index
+                 JOIN pg_class AS index_class
+                   ON index_class.oid = pg_index.indexrelid
+                 JOIN pg_class AS table_class
+                   ON table_class.oid = pg_index.indrelid
+                 JOIN pg_namespace
+                   ON pg_namespace.oid = table_class.relnamespace
+                 WHERE pg_namespace.nspname = 'public'
+                   AND table_class.relname = 'tasks'
+                   AND index_class.relname = 'idx_tasks_active_capacity'",
+            )
+            .get_result::<TaskCapacityIndex>(conn)
+            .await
+        })
+        .await
+        .unwrap();
+
+        assert!(index.valid, "task capacity index must be valid");
+        assert!(
+            index.definition.contains("(submitted_by, kind)"),
+            "task capacity index has unexpected columns: {}",
+            index.definition
+        );
+        for predicate in [
+            "submitted_by IS NOT NULL",
+            "deleted_at IS NULL",
+            "queued",
+            "validating",
+            "running",
+        ] {
+            assert!(
+                index.definition.contains(predicate),
+                "task capacity index is missing predicate `{predicate}`: {}",
+                index.definition
+            );
+        }
     }
 
     #[tokio::test]
@@ -2189,5 +2242,45 @@ mod tests {
             }
             other => panic!("expected TooManyRequests, got {other:?}"),
         }
+    }
+
+    #[rstest]
+    #[case(TaskKind::Import)]
+    #[case(TaskKind::Export)]
+    #[case(TaskKind::Backup)]
+    #[case(TaskKind::RemoteCall)]
+    #[tokio::test]
+    async fn concurrent_active_task_admission_preserves_the_per_kind_limit(#[case] kind: TaskKind) {
+        let context = TestContext::new().await;
+        let request = |suffix: &str| TaskCreateRequest {
+            kind,
+            submitted_by: context.admin_user.id,
+            submitted_token_id: None,
+            submitted_token_scoped: false,
+            submitted_token_scopes: serde_json::json!([]),
+            idempotency_key: Some(
+                context.scoped_name(&format!("{}-concurrent-cap-{suffix}", kind.as_str())),
+            ),
+            request_hash: Some(
+                context.scoped_name(&format!("{}-concurrent-cap-{suffix}-hash", kind.as_str())),
+            ),
+            request_payload: serde_json::json!({"kind": kind.as_str(), "case": suffix}),
+            total_items: 1,
+        };
+
+        let first = request("first").create_idempotently_with_active_limit(&context.pool, 1);
+        let second = request("second").create_idempotently_with_active_limit(&context.pool, 1);
+        let (first, second) = tokio::join!(first, second);
+        let results = [first, second];
+
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        let error = results
+            .into_iter()
+            .find_map(Result::err)
+            .expect("one concurrent task submission must exceed the active limit");
+        assert!(
+            matches!(error, ApiError::TooManyRequests(_)),
+            "expected TooManyRequests, got {error:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add a concurrent partial PostgreSQL index for active task admission by submitter and task kind
- make the new migration the schema version required by server startup and readiness
- verify the migrated index definition and concurrent per-kind capacity enforcement
- document the task-admission scaling improvement in the changelog

## Why

Active-task creation is already correctness-safe: a transaction-scoped advisory lock serializes one submitter and task kind before Hubuum counts active tasks and inserts new work. The count filters by `submitted_by`, exact `kind`, active status, and `deleted_at IS NULL`.

The existing indexes cover the submitter and active status/deletion dimensions separately. A submitter with substantial completed task history therefore makes PostgreSQL scan or combine broader indexes before filtering to the small active set.

## Query-plan evidence

A rolled-back temporary-table benchmark used 1,000,000 terminal tasks plus 100,000 active tasks across 1,000 submitters. For a hot submitter with 100,100 historical/active rows, an export capacity count matched 34 active rows:

| Plan | Execution time | Relevant index work |
| --- | ---: | --- |
| Existing indexes | 4.601 ms | Scanned 100,100 submitter entries and 100,000 active-status entries |
| Partial `(submitted_by, kind)` index | 0.069 ms | Scanned 34 matching active entries |

The targeted index removes the demonstrated bottleneck without introducing a maintained counter or changing task-capacity semantics.

## Behavior and operational impact

- Import, export, backup, and remote-call limits keep their current advisory-lock and row-count behavior.
- Existing broader task indexes remain in place for listings and other filters.
- The established Import/Reindex fallback lock slot is unchanged; Reindex does not use capacity admission.
- The migration builds and drops `idx_tasks_active_capacity` concurrently, so ordinary task writes remain available.
- API and worker readiness require migration `20260715000001`, consistent with the repository's latest-migration contract.
- A failed concurrent index build remains retry-visible rather than being hidden by `IF NOT EXISTS`; operators should remove an invalid same-named index before retrying the one-shot migration.
- The logical backup format is unchanged. Backups do not serialize indexes or active tasks, and restore preserves the migrated index while replacing table data, so existing version 2 backups remain compatible.
- Restore targets must apply the latest migration before running a destructive restore. Operators should not intentionally overlap the one-shot migration with restore because their PostgreSQL locks may make either operation wait.
- There are no API, configuration, OpenAPI, or backup-document schema changes.

## Changelog and compatibility

- The `[Unreleased]` changelog records the task-admission scaling improvement.
- Breaking changes: none.
- Closes #67.
- Scale-readiness follow-up to #92.