### PR TITLE
Harden validation and audit infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Active task admission now uses a partial per-submitter and per-kind index so
   capacity checks remain bounded by queued, validating, and running work rather
   than scanning a submitter's completed task history.
+- **Breaking:** Class JSON Schemas are now validated as schema documents before
+  storage. Schemas used for object validation reject external HTTP, file,
+  dynamic, or recursive references; inline those definitions and reference them
+  with local `#...` fragments before enabling validation. Compiled local schemas
+  are cached for object validation.
+- Related-collection audit visibility now uses an indexed relational projection
+  instead of generating JSON predicates for every collection visible to the
+  caller.
 - **Breaking:** Import and export submission now requires an unscoped runtime
   administrator. Non-admin and scoped tokens now receive `403 Forbidden`.
   Automation should use dedicated service accounts in the configured admin
@@ -98,6 +106,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Password hashing and verification now run through a bounded blocking-work
+  pool instead of blocking asynchronous API and task-worker runtimes.
+- Object audit routes now reject class/object path mismatches, and all audit
+  route identifiers validate through their domain ID types.
+- Event fan-out now uses the transaction-aware PostgreSQL insert trigger as its
+  single wakeup source, eliminating the duplicate notification on a mismatched
+  channel.
 - Background task workers now use the configured permission backend for
   execution-time authorization, including worker-only replicas, rather than
   falling back to local SQL permissions when Treetop is authoritative.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
  "flate2",
  "foldhash 0.1.5",
  "futures-core",
- "h2 0.3.27",
+ "h2",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -1812,25 +1812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.4.2",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2253,7 +2234,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
  "http 1.4.2",
  "http-body",
  "httparse",
@@ -2634,8 +2614,6 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
- "reqwest 0.13.4",
- "rustls",
  "serde",
  "serde_json",
  "unicode-general-category",
@@ -3891,10 +3869,7 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
- "h2 0.4.15",
  "http 1.4.2",
  "http-body",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ pq-sys = { version = "0.7.5", optional = true }
 ipnet = "2.12"
 futures = "0.3"
 futures-util = "0.3"
-jsonschema = "0"
+jsonschema = { version = "0", default-features = false }
 rand = "0.10"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 redis = { version = "1.3.0", default-features = false, features = ["connection-manager", "tokio-rustls-comp"], optional = true }
@@ -131,7 +131,6 @@ opt-level = "z"
 [lib]
 name = "hubuum"
 path = "src/lib.rs"
-test = false
 
 
 [[bin]]

--- a/docs/events.md
+++ b/docs/events.md
@@ -73,6 +73,10 @@ GET /api/v1/export-templates/11/events
 GET /api/v1/remote-targets/22/events
 ```
 
+The object convenience route verifies that the object belongs to the class in
+the path. A mismatched class and object pair returns `404 Not Found` rather than
+querying the object through an unrelated class URL.
+
 Use the generic endpoint for relation, permission, token, sink, and
 subscription events where the useful identity is often in event metadata rather
 than a single resource path.

--- a/docs/import_api.md
+++ b/docs/import_api.md
@@ -275,6 +275,12 @@ name under different parents in one request.
 
 Exactly one of `collection_ref` or `collection_key` must be set.
 
+`json_schema`, when supplied, must itself be a valid JSON Schema. References
+in classes with `validate_schema: true` must be local fragments such as
+`#/$defs/address`; external HTTP, file, dynamic, and recursive references cannot
+be evaluated. This keeps object validation deterministic and prevents schema
+evaluation from accessing external resources.
+
 ### `objects`
 
 | Field | Type | Required | Notes |

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3519,6 +3519,16 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Object not found in the requested class",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/migrations/2026-07-15-000002_event_related_collections/down.sql
+++ b/migrations/2026-07-15-000002_event_related_collections/down.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER IF EXISTS events_related_collections ON events;
+DROP FUNCTION IF EXISTS record_event_related_collections();
+DROP TABLE IF EXISTS event_related_collections;

--- a/migrations/2026-07-15-000002_event_related_collections/up.sql
+++ b/migrations/2026-07-15-000002_event_related_collections/up.sql
@@ -1,0 +1,63 @@
+CREATE TABLE event_related_collections (
+    event_id BIGINT NOT NULL REFERENCES events (id) ON DELETE CASCADE,
+    collection_id INTEGER NOT NULL CHECK (collection_id > 0),
+    PRIMARY KEY (event_id, collection_id)
+);
+
+CREATE INDEX event_related_collections_collection_event_idx
+    ON event_related_collections (collection_id, event_id);
+
+CREATE FUNCTION record_event_related_collections()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO event_related_collections (event_id, collection_id)
+    SELECT NEW.id, normalized.collection_id
+    FROM (
+        SELECT CASE
+            WHEN value ~ '^[1-9][0-9]{0,9}$'
+            THEN CASE
+                WHEN value::numeric <= 2147483647 THEN value::integer
+                ELSE NULL
+            END
+            ELSE NULL
+        END AS collection_id
+        FROM jsonb_array_elements_text(
+            CASE
+                WHEN jsonb_typeof(NEW.metadata -> 'related_collection_ids') = 'array'
+                THEN NEW.metadata -> 'related_collection_ids'
+                ELSE '[]'::jsonb
+            END
+        ) AS related(value)
+    ) AS normalized
+    WHERE normalized.collection_id IS NOT NULL
+    ON CONFLICT DO NOTHING;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER events_related_collections
+AFTER INSERT ON events
+FOR EACH ROW EXECUTE FUNCTION record_event_related_collections();
+
+INSERT INTO event_related_collections (event_id, collection_id)
+SELECT event.id, normalized.collection_id
+FROM events AS event
+CROSS JOIN LATERAL (
+    SELECT CASE
+        WHEN value ~ '^[1-9][0-9]{0,9}$'
+        THEN CASE
+            WHEN value::numeric <= 2147483647 THEN value::integer
+            ELSE NULL
+        END
+        ELSE NULL
+    END AS collection_id
+    FROM jsonb_array_elements_text(
+        CASE
+            WHEN jsonb_typeof(event.metadata -> 'related_collection_ids') = 'array'
+            THEN event.metadata -> 'related_collection_ids'
+            ELSE '[]'::jsonb
+        END
+    ) AS related(value)
+) AS normalized
+WHERE normalized.collection_id IS NOT NULL
+ON CONFLICT DO NOTHING;

--- a/src/api/handlers/meta.rs
+++ b/src/api/handlers/meta.rs
@@ -1,7 +1,8 @@
 use crate::api::openapi::{ApiErrorResponse, CountsResponse};
 use crate::api::response::ApiResponse;
 use crate::config::{get_config, login_rate_limit_config};
-use crate::db::{DbPool, with_connection};
+use crate::db::DbPool;
+use crate::db::traits::meta::{load_database_state, load_task_queue_state};
 use crate::errors::ApiError;
 use crate::extractors::AdminAccess;
 use crate::middlewares::rate_limit;
@@ -11,10 +12,6 @@ use crate::models::object::{objects_per_class_count, total_object_count};
 use actix_web::{Responder, delete, get, http::StatusCode, web};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use diesel::QueryableByName;
-use diesel::sql_query;
-use diesel::sql_types::{BigInt, Nullable, Timestamp};
-use diesel_async::RunQueryDsl;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 use utoipa::ToSchema;
@@ -84,51 +81,6 @@ pub struct TaskQueueStateResponse {
     oldest_active_at: Option<String>,
 }
 
-#[derive(QueryableByName, Debug)]
-#[diesel(table_name = pg_stat_user_tables)]
-struct DbState {
-    #[diesel(sql_type = BigInt)]
-    active_connections: i64,
-    #[diesel(sql_type = BigInt)]
-    db_size: i64,
-    #[diesel(sql_type = Nullable<Timestamp>)]
-    last_vacuum_time: Option<chrono::NaiveDateTime>,
-}
-
-#[derive(QueryableByName, Debug)]
-struct TaskQueueState {
-    #[diesel(sql_type = BigInt)]
-    total_tasks: i64,
-    #[diesel(sql_type = BigInt)]
-    queued_tasks: i64,
-    #[diesel(sql_type = BigInt)]
-    validating_tasks: i64,
-    #[diesel(sql_type = BigInt)]
-    running_tasks: i64,
-    #[diesel(sql_type = BigInt)]
-    succeeded_tasks: i64,
-    #[diesel(sql_type = BigInt)]
-    failed_tasks: i64,
-    #[diesel(sql_type = BigInt)]
-    partially_succeeded_tasks: i64,
-    #[diesel(sql_type = BigInt)]
-    cancelled_tasks: i64,
-    #[diesel(sql_type = BigInt)]
-    import_tasks: i64,
-    #[diesel(sql_type = BigInt)]
-    export_tasks: i64,
-    #[diesel(sql_type = BigInt)]
-    reindex_tasks: i64,
-    #[diesel(sql_type = BigInt)]
-    total_task_events: i64,
-    #[diesel(sql_type = BigInt)]
-    total_import_result_rows: i64,
-    #[diesel(sql_type = Nullable<Timestamp>)]
-    oldest_queued_at: Option<chrono::NaiveDateTime>,
-    #[diesel(sql_type = Nullable<Timestamp>)]
-    oldest_active_at: Option<chrono::NaiveDateTime>,
-}
-
 #[utoipa::path(
     get,
     path = "/api/v0/meta/db",
@@ -145,67 +97,40 @@ pub async fn get_db_state(
     pool: web::Data<DbPool>,
     requestor: AdminAccess,
 ) -> Result<impl Responder, ApiError> {
-    let query = r#"
-        SELECT
-          (SELECT count(*) FROM pg_stat_activity WHERE state = 'active') AS active_connections,
-          pg_database_size(current_database()) AS db_size,
-          MAX(last_vacuum) AS last_vacuum_time
-        FROM 
-          pg_stat_user_tables;
-    "#;
+    let row = load_database_state(&pool).await?;
+    let state = pool.state();
+    let max_connections = pool.config().max_size;
+    let in_use_connections = state.connections.saturating_sub(state.idle_connections);
+    let available_connections = max_connections.saturating_sub(in_use_connections);
+    let acquisition_wait_time_ms =
+        u64::try_from(state.statistics.get_wait_time.as_millis()).unwrap_or(u64::MAX);
+    debug!(
+        message = "DB state requested",
+        requestor = requestor.user.id
+    );
 
-    let results = match with_connection(&pool, async |conn| {
-        sql_query(query).load::<DbState>(conn).await
-    })
-    .await
-    {
-        Ok(results) => results,
-        Err(e) => {
-            return Err(ApiError::InternalServerError(format!(
-                "Error getting state for the database: {e}"
-            )));
-        }
+    let response = DbStateResponse {
+        max_connections,
+        total_connections: state.connections,
+        available_connections,
+        idle_connections: state.idle_connections,
+        in_use_connections,
+        pending_acquisitions: state.statistics.pending_gets(),
+        acquisitions_started: state.statistics.get_started,
+        acquisitions_direct: state.statistics.get_direct,
+        acquisitions_waited: state.statistics.get_waited,
+        acquisitions_timed_out: state.statistics.get_timed_out,
+        acquisition_wait_time_ms,
+        connections_created: state.statistics.connections_created,
+        connections_closed_broken: state.statistics.connections_closed_broken,
+        connections_closed_invalid: state.statistics.connections_closed_invalid,
+        connections_closed_max_lifetime: state.statistics.connections_closed_max_lifetime,
+        connections_closed_idle_timeout: state.statistics.connections_closed_idle_timeout,
+        active_connections: row.active_connections,
+        db_size: row.db_size,
+        last_vacuum_time: row.last_vacuum_time.map(|dt| dt.to_string()),
     };
-
-    if let Some(row) = results.as_slice().first() {
-        let state = pool.state();
-        let max_connections = pool.config().max_size;
-        let in_use_connections = state.connections.saturating_sub(state.idle_connections);
-        let available_connections = max_connections.saturating_sub(in_use_connections);
-        let acquisition_wait_time_ms =
-            u64::try_from(state.statistics.get_wait_time.as_millis()).unwrap_or(u64::MAX);
-        debug!(
-            message = "DB state requested",
-            requestor = requestor.user.id
-        );
-
-        let response = DbStateResponse {
-            max_connections,
-            total_connections: state.connections,
-            available_connections,
-            idle_connections: state.idle_connections,
-            in_use_connections,
-            pending_acquisitions: state.statistics.pending_gets(),
-            acquisitions_started: state.statistics.get_started,
-            acquisitions_direct: state.statistics.get_direct,
-            acquisitions_waited: state.statistics.get_waited,
-            acquisitions_timed_out: state.statistics.get_timed_out,
-            acquisition_wait_time_ms,
-            connections_created: state.statistics.connections_created,
-            connections_closed_broken: state.statistics.connections_closed_broken,
-            connections_closed_invalid: state.statistics.connections_closed_invalid,
-            connections_closed_max_lifetime: state.statistics.connections_closed_max_lifetime,
-            connections_closed_idle_timeout: state.statistics.connections_closed_idle_timeout,
-            active_connections: row.active_connections,
-            db_size: row.db_size,
-            last_vacuum_time: row.last_vacuum_time.map(|dt| dt.to_string()),
-        };
-        Ok(ApiResponse::new(response, StatusCode::OK))
-    } else {
-        Err(ApiError::InternalServerError(
-            "Error getting state for the database".to_string(),
-        ))
-    }
+    Ok(ApiResponse::new(response, StatusCode::OK))
 }
 
 #[utoipa::path(
@@ -256,33 +181,7 @@ pub async fn get_task_queue_state(
     requestor: AdminAccess,
 ) -> Result<impl Responder, ApiError> {
     let config = get_config()?.clone();
-    let query = r#"
-        SELECT
-          COUNT(*)::bigint AS total_tasks,
-          COUNT(*) FILTER (WHERE status = 'queued')::bigint AS queued_tasks,
-          COUNT(*) FILTER (WHERE status = 'validating')::bigint AS validating_tasks,
-          COUNT(*) FILTER (WHERE status = 'running')::bigint AS running_tasks,
-          COUNT(*) FILTER (WHERE status = 'succeeded')::bigint AS succeeded_tasks,
-          COUNT(*) FILTER (WHERE status = 'failed')::bigint AS failed_tasks,
-          COUNT(*) FILTER (WHERE status = 'partially_succeeded')::bigint AS partially_succeeded_tasks,
-          COUNT(*) FILTER (WHERE status = 'cancelled')::bigint AS cancelled_tasks,
-          COUNT(*) FILTER (WHERE kind = 'import')::bigint AS import_tasks,
-          COUNT(*) FILTER (WHERE kind = 'export')::bigint AS export_tasks,
-          COUNT(*) FILTER (WHERE kind = 'reindex')::bigint AS reindex_tasks,
-          (SELECT COUNT(*) FROM events WHERE entity_type = 'task')::bigint AS total_task_events,
-          (SELECT COUNT(*) FROM import_task_results)::bigint AS total_import_result_rows,
-          MIN(created_at) FILTER (WHERE status = 'queued') AS oldest_queued_at,
-          MIN(started_at) FILTER (WHERE status IN ('validating', 'running')) AS oldest_active_at
-        FROM tasks;
-    "#;
-
-    let results = with_connection(&pool, async |conn| {
-        sql_query(query).load::<TaskQueueState>(conn).await
-    })
-    .await?;
-    let state = results.as_slice().first().ok_or_else(|| {
-        ApiError::InternalServerError("Error getting state for the task queue".to_string())
-    })?;
+    let state = load_task_queue_state(&pool).await?;
 
     debug!(
         message = "Task queue state requested",

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -495,7 +495,6 @@ pub struct CountsResponse {
     pub objects_per_class: Vec<ObjectsByClass>,
 }
 
-#[allow(dead_code)]
 fn api_error_response_example() -> ApiErrorResponse {
     ApiErrorResponse {
         error: "Unauthorized".to_string(),
@@ -503,17 +502,14 @@ fn api_error_response_example() -> ApiErrorResponse {
     }
 }
 
-#[allow(dead_code)]
 fn message_response_example() -> MessageResponse {
     MessageResponse::new("Token is valid.")
 }
 
-#[allow(dead_code)]
 fn login_response_example() -> LoginResponse {
     LoginResponse::new("eyJhbGciOi...example-token")
 }
 
-#[allow(dead_code)]
 fn counts_response_example() -> CountsResponse {
     CountsResponse {
         total_objects: 42,

--- a/src/api/v1/handlers/events.rs
+++ b/src/api/v1/handlers/events.rs
@@ -7,9 +7,13 @@ use crate::db::traits::events::{list_events_with_total_count, parse_event_filter
 use crate::errors::ApiError;
 use crate::events::{EntityType, EventResponse};
 use crate::extractors::Authenticated;
-use crate::models::Permissions;
 use crate::models::collection::user_can_on_any;
 use crate::models::search::parse_query_parameter_with_passthrough;
+use crate::models::traits::check_if_object_in_class;
+use crate::models::{
+    CollectionID, ExportTemplateID, GroupID, HubuumClassID, HubuumObjectID, Permissions,
+    RemoteTargetID, UserID,
+};
 use crate::pagination::prepare_db_pagination;
 use crate::permissions::{AppContext, PrincipalRef};
 use crate::traits::AuthzSubject;
@@ -148,13 +152,13 @@ pub async fn get_collection_events(
     pool: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
-    collection_id: web::Path<i32>,
+    collection_id: web::Path<CollectionID>,
 ) -> Result<impl Responder, ApiError> {
     list_visible_events(
         pool,
         requestor,
         req,
-        Some((EntityType::Collection, collection_id.into_inner())),
+        Some((EntityType::Collection, collection_id.into_inner().id())),
     )
     .await
 }
@@ -187,13 +191,13 @@ pub async fn get_class_events(
     pool: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
-    class_id: web::Path<i32>,
+    class_id: web::Path<HubuumClassID>,
 ) -> Result<impl Responder, ApiError> {
     list_visible_events(
         pool,
         requestor,
         req,
-        Some((EntityType::Class, class_id.into_inner())),
+        Some((EntityType::Class, class_id.into_inner().id())),
     )
     .await
 }
@@ -219,7 +223,8 @@ pub async fn get_class_events(
     responses(
         (status = 200, description = "Visible object audit events", body = [EventResponse]),
         (status = 400, description = "Bad request", body = ApiErrorResponse),
-        (status = 401, description = "Unauthorized", body = ApiErrorResponse)
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 404, description = "Object not found in the requested class", body = ApiErrorResponse)
     )
 )]
 #[get("/{class_id}/{object_id}/events")]
@@ -227,10 +232,17 @@ pub async fn get_object_events(
     pool: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
-    path: web::Path<(i32, i32)>,
+    path: web::Path<(HubuumClassID, HubuumObjectID)>,
 ) -> Result<impl Responder, ApiError> {
-    let (_, object_id) = path.into_inner();
-    list_visible_events(pool, requestor, req, Some((EntityType::Object, object_id))).await
+    let (class_id, object_id) = path.into_inner();
+    check_if_object_in_class(&pool, &class_id, &object_id).await?;
+    list_visible_events(
+        pool,
+        requestor,
+        req,
+        Some((EntityType::Object, object_id.id())),
+    )
+    .await
 }
 
 #[utoipa::path(
@@ -261,13 +273,13 @@ pub async fn get_user_events(
     pool: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
-    user_id: web::Path<i32>,
+    user_id: web::Path<UserID>,
 ) -> Result<impl Responder, ApiError> {
     list_visible_events(
         pool,
         requestor,
         req,
-        Some((EntityType::User, user_id.into_inner())),
+        Some((EntityType::User, user_id.into_inner().id())),
     )
     .await
 }
@@ -300,13 +312,13 @@ pub async fn get_group_events(
     pool: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
-    group_id: web::Path<i32>,
+    group_id: web::Path<GroupID>,
 ) -> Result<impl Responder, ApiError> {
     list_visible_events(
         pool,
         requestor,
         req,
-        Some((EntityType::Group, group_id.into_inner())),
+        Some((EntityType::Group, group_id.into_inner().id())),
     )
     .await
 }
@@ -339,13 +351,13 @@ pub async fn get_export_template_events(
     pool: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
-    template_id: web::Path<i32>,
+    template_id: web::Path<ExportTemplateID>,
 ) -> Result<impl Responder, ApiError> {
     list_visible_events(
         pool,
         requestor,
         req,
-        Some((EntityType::ExportTemplate, template_id.into_inner())),
+        Some((EntityType::ExportTemplate, template_id.into_inner().id())),
     )
     .await
 }
@@ -378,13 +390,13 @@ pub async fn get_remote_target_events(
     pool: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
-    target_id: web::Path<i32>,
+    target_id: web::Path<RemoteTargetID>,
 ) -> Result<impl Responder, ApiError> {
     list_visible_events(
         pool,
         requestor,
         req,
-        Some((EntityType::RemoteTarget, target_id.into_inner())),
+        Some((EntityType::RemoteTarget, target_id.into_inner().id())),
     )
     .await
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -52,7 +52,7 @@ pub type DbPool = Pool<DbConnection>;
 /// Latest migration required by this binary. The test below keeps this value
 /// synchronized with the migration directory so readiness cannot silently lag
 /// behind a newly added schema change.
-pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260715000001";
+pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260715000002";
 
 #[derive(diesel::QueryableByName)]
 struct DatabaseSchemaReadiness {
@@ -596,6 +596,13 @@ pub fn init_pool(database_url: &str, max_size: u32) -> DbPool {
 }
 
 pub fn init_pool_with_settings(settings: &DatabasePoolSettings) -> DbPool {
+    if settings.acquire_timeout_ms == crate::config::DEFAULT_DB_POOL_ACQUIRE_TIMEOUT_MS {
+        return init_pool_with_statement_timeout(
+            &settings.database_url,
+            settings.max_size,
+            settings.statement_timeout_ms,
+        );
+    }
     init_pool_with_timeouts(
         &settings.database_url,
         settings.max_size,
@@ -608,9 +615,6 @@ pub fn init_pool_with_settings(settings: &DatabasePoolSettings) -> DbPool {
 /// applied to every connection on acquisition. A value of 0 disables the
 /// timeout. Exposed so tests can exercise the customizer without mutating the
 /// global config.
-// The server binary compiles this module directly as well as through the library;
-// this explicit-timeout constructor is consumed by the admin binary and DB tests.
-#[cfg_attr(not(test), allow(dead_code))]
 pub fn init_pool_with_statement_timeout(
     database_url: &str,
     max_size: u32,

--- a/src/db/traits/active_tokens.rs
+++ b/src/db/traits/active_tokens.rs
@@ -67,7 +67,6 @@ pub(crate) fn active_token_predicate(
 /// A token is active when it is not revoked and not expired: an explicit
 /// `expires_at` in the future, or (when null) within the global lifetime window
 /// from `issued`.
-#[allow(dead_code)]
 async fn active_tokens_by_principal_id(
     principal: i32,
     pool: &DbPool,

--- a/src/db/traits/events.rs
+++ b/src/db/traits/events.rs
@@ -1,6 +1,5 @@
 use crate::db::prelude::*;
-use diesel::dsl::sql;
-use diesel::sql_types::Bool;
+use std::collections::HashSet;
 
 use crate::apply_query_options;
 use crate::db::{DbPool, with_connection};
@@ -42,10 +41,18 @@ pub async fn list_events_with_total_count(
     let mut query = build_event_query(accessible_collection_ids, include_collection_less, filters)?;
     apply_query_options!(query, query_options, EventResponse);
     let rows = with_connection(pool, async |conn| query.load::<Event>(conn).await).await?;
+    let accessible_collection_ids = accessible_collection_ids
+        .iter()
+        .copied()
+        .collect::<HashSet<_>>();
     let rows = rows
         .into_iter()
         .map(|event| {
-            event_response_for_visibility(event, accessible_collection_ids, include_collection_less)
+            event_response_for_visibility(
+                event,
+                &accessible_collection_ids,
+                include_collection_less,
+            )
         })
         .collect();
 
@@ -57,16 +64,23 @@ fn build_event_query<'a>(
     include_collection_less: bool,
     filters: &EventListFilters,
 ) -> Result<crate::schema::events::BoxedQuery<'a, diesel::pg::Pg>, ApiError> {
+    use crate::schema::event_related_collections::dsl as related;
     use crate::schema::events::dsl::{
         action, actor_kind, actor_user_id, collection_id, entity_id, entity_type, events,
-        occurred_at,
+        id as event_row_id, occurred_at,
     };
 
     let mut query = events.into_boxed();
 
     if !include_collection_less && accessible_collection_ids.is_empty() {
-        return Ok(query.filter(sql::<Bool>("FALSE")));
+        return Ok(query.filter(event_row_id.eq(-1_i64)));
     }
+
+    let related_is_visible = diesel::dsl::exists(
+        related::event_related_collections
+            .filter(related::event_id.eq(event_row_id))
+            .filter(related::collection_id.eq_any(accessible_collection_ids)),
+    );
 
     if include_collection_less {
         if !accessible_collection_ids.is_empty() {
@@ -74,18 +88,14 @@ fn build_event_query<'a>(
                 collection_id
                     .eq_any(accessible_collection_ids)
                     .or(collection_id.is_null())
-                    .or(sql::<Bool>(&related_collection_filter_sql(
-                        accessible_collection_ids,
-                    ))),
+                    .or(related_is_visible),
             );
         }
     } else {
         query = query.filter(
             collection_id
                 .eq_any(accessible_collection_ids)
-                .or(sql::<Bool>(&related_collection_filter_sql(
-                    accessible_collection_ids,
-                ))),
+                .or(related_is_visible),
         );
     }
 
@@ -117,28 +127,9 @@ fn build_event_query<'a>(
     Ok(query)
 }
 
-fn related_collection_filter_sql(accessible_collection_ids: &[i32]) -> String {
-    if accessible_collection_ids.is_empty() {
-        return "FALSE".to_string();
-    }
-
-    accessible_collection_ids
-        .iter()
-        .map(|id| {
-            let numeric_probe = serde_json::json!({ "related_collection_ids": [id] });
-            let string_probe = serde_json::json!({ "related_collection_ids": [id.to_string()] });
-            format!(
-                "events.metadata @> '{}'::jsonb OR events.metadata @> '{}'::jsonb",
-                numeric_probe, string_probe
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(" OR ")
-}
-
 fn event_response_for_visibility(
     event: Event,
-    accessible_collection_ids: &[i32],
+    accessible_collection_ids: &HashSet<i32>,
     include_collection_less: bool,
 ) -> EventResponse {
     let is_directly_visible = event

--- a/src/db/traits/meta.rs
+++ b/src/db/traits/meta.rs
@@ -1,0 +1,98 @@
+use crate::db::prelude::*;
+use diesel::sql_types::{BigInt, Nullable, Timestamp};
+
+use crate::db::{DbPool, with_connection};
+use crate::errors::ApiError;
+
+#[derive(QueryableByName, Debug)]
+pub struct DatabaseState {
+    #[diesel(sql_type = BigInt)]
+    pub active_connections: i64,
+    #[diesel(sql_type = BigInt)]
+    pub db_size: i64,
+    #[diesel(sql_type = Nullable<Timestamp>)]
+    pub last_vacuum_time: Option<chrono::NaiveDateTime>,
+}
+
+#[derive(QueryableByName, Debug)]
+pub struct TaskQueueState {
+    #[diesel(sql_type = BigInt)]
+    pub total_tasks: i64,
+    #[diesel(sql_type = BigInt)]
+    pub queued_tasks: i64,
+    #[diesel(sql_type = BigInt)]
+    pub validating_tasks: i64,
+    #[diesel(sql_type = BigInt)]
+    pub running_tasks: i64,
+    #[diesel(sql_type = BigInt)]
+    pub succeeded_tasks: i64,
+    #[diesel(sql_type = BigInt)]
+    pub failed_tasks: i64,
+    #[diesel(sql_type = BigInt)]
+    pub partially_succeeded_tasks: i64,
+    #[diesel(sql_type = BigInt)]
+    pub cancelled_tasks: i64,
+    #[diesel(sql_type = BigInt)]
+    pub import_tasks: i64,
+    #[diesel(sql_type = BigInt)]
+    pub export_tasks: i64,
+    #[diesel(sql_type = BigInt)]
+    pub reindex_tasks: i64,
+    #[diesel(sql_type = BigInt)]
+    pub total_task_events: i64,
+    #[diesel(sql_type = BigInt)]
+    pub total_import_result_rows: i64,
+    #[diesel(sql_type = Nullable<Timestamp>)]
+    pub oldest_queued_at: Option<chrono::NaiveDateTime>,
+    #[diesel(sql_type = Nullable<Timestamp>)]
+    pub oldest_active_at: Option<chrono::NaiveDateTime>,
+}
+
+pub async fn load_database_state(pool: &DbPool) -> Result<DatabaseState, ApiError> {
+    const QUERY: &str = r#"
+        SELECT
+          (SELECT count(*) FROM pg_stat_activity WHERE state = 'active') AS active_connections,
+          pg_database_size(current_database()) AS db_size,
+          MAX(last_vacuum) AS last_vacuum_time
+        FROM pg_stat_user_tables
+    "#;
+
+    with_connection(pool, async |conn| {
+        diesel::sql_query(QUERY)
+            .get_result::<DatabaseState>(conn)
+            .await
+    })
+    .await
+    .map_err(|error| {
+        ApiError::InternalServerError(format!("Error getting state for the database: {error}"))
+    })
+}
+
+pub async fn load_task_queue_state(pool: &DbPool) -> Result<TaskQueueState, ApiError> {
+    const QUERY: &str = r#"
+        SELECT
+          COUNT(*)::bigint AS total_tasks,
+          COUNT(*) FILTER (WHERE status = 'queued')::bigint AS queued_tasks,
+          COUNT(*) FILTER (WHERE status = 'validating')::bigint AS validating_tasks,
+          COUNT(*) FILTER (WHERE status = 'running')::bigint AS running_tasks,
+          COUNT(*) FILTER (WHERE status = 'succeeded')::bigint AS succeeded_tasks,
+          COUNT(*) FILTER (WHERE status = 'failed')::bigint AS failed_tasks,
+          COUNT(*) FILTER (WHERE status = 'partially_succeeded')::bigint AS partially_succeeded_tasks,
+          COUNT(*) FILTER (WHERE status = 'cancelled')::bigint AS cancelled_tasks,
+          COUNT(*) FILTER (WHERE kind = 'import')::bigint AS import_tasks,
+          COUNT(*) FILTER (WHERE kind = 'export')::bigint AS export_tasks,
+          COUNT(*) FILTER (WHERE kind = 'reindex')::bigint AS reindex_tasks,
+          (SELECT COUNT(*) FROM events WHERE entity_type = 'task')::bigint AS total_task_events,
+          (SELECT COUNT(*) FROM import_task_results)::bigint AS total_import_result_rows,
+          MIN(created_at) FILTER (WHERE status = 'queued') AS oldest_queued_at,
+          MIN(started_at) FILTER (WHERE status IN ('validating', 'running')) AS oldest_active_at
+        FROM tasks
+    "#;
+
+    with_connection(pool, async |conn| {
+        diesel::sql_query(QUERY)
+            .get_result::<TaskQueueState>(conn)
+            .await
+    })
+    .await
+}

--- a/src/db/traits/mod.rs
+++ b/src/db/traits/mod.rs
@@ -16,6 +16,7 @@ pub mod group;
 pub mod history;
 pub mod identity;
 pub mod is_active;
+pub mod meta;
 pub mod metrics;
 pub mod object;
 pub mod permissions;
@@ -23,9 +24,11 @@ pub mod principal;
 pub mod relations;
 pub mod remote_target;
 pub mod restore;
+pub mod search;
 pub mod service_account;
 pub mod task;
 pub mod task_import;
+pub mod token;
 pub mod user;
 
 pub use user::UserPermissions;
@@ -62,7 +65,6 @@ pub trait Status<T> {
 /// active tokens, and this trait would allow us to get all of them.
 pub trait ActiveTokens {
     /// Get all active tokens for a given structure.
-    #[allow(dead_code)]
     async fn tokens(&self, pool: &DbPool) -> Result<Vec<PrincipalToken>, ApiError>;
     async fn tokens_paginated_with_total_count(
         &self,
@@ -94,7 +96,6 @@ pub trait GetClass<T = HubuumClass> {
 /// By default, this returns the singular object of the structure in question.
 /// For relations, where we have two objects (one for each structure), the
 /// trait is implemented to return a tuple of the two objects.
-#[allow(dead_code)]
 pub trait GetObject<T = HubuumObject> {
     async fn object_from_backend(&self, pool: &DbPool) -> Result<T, ApiError>;
 }
@@ -106,7 +107,6 @@ where
     C2: SelfAccessors<HubuumClass> + Clone + Send + Sync,
 {
     /// Check if a relation exists between two classes.
-    #[allow(dead_code)]
     async fn relations_between(
         pool: &DbPool,
         from: &C1,
@@ -122,14 +122,12 @@ where
     Self: SelfAccessors<HubuumClass>,
 {
     /// Check if a relation exists between self and another class
-    #[allow(dead_code)]
     async fn relations_to(
         &self,
         pool: &DbPool,
         other: &C2,
     ) -> Result<Vec<HubuumClassRelationTransitive>, ApiError>;
 
-    #[allow(dead_code)]
     async fn relations_to_paginated(
         &self,
         pool: &DbPool,
@@ -150,7 +148,6 @@ where
     C1: SelfAccessors<HubuumClass> + Clone + Send + Sync,
     Self: SelfAccessors<HubuumClass> + Clone + Send + Sync,
 {
-    #[allow(dead_code)]
     async fn transitive_relations(
         &self,
         pool: &DbPool,
@@ -158,7 +155,6 @@ where
         self.transitive_relations_from_backend(pool).await
     }
 
-    #[allow(dead_code)]
     async fn transitive_relations_paginated(
         &self,
         pool: &DbPool,
@@ -212,12 +208,10 @@ where
     }
 
     // We typically end up searching, so this interface is rarely used.
-    #[allow(dead_code)]
     async fn relations(&self, pool: &DbPool) -> Result<Vec<HubuumClassRelation>, ApiError> {
         self.relations_from_backend(pool).await
     }
 
-    #[allow(dead_code)]
     async fn search_relations(
         &self,
         pool: &DbPool,
@@ -228,7 +222,6 @@ where
     }
 }
 
-#[allow(dead_code)]
 pub trait ObjectRelationsFromUser: SelfAccessors<User> + GroupAccessors
 where
     for<'a> &'a Self: GroupAccessors,
@@ -244,7 +237,6 @@ where
         C: SelfAccessors<HubuumClass> + Clone + Send + Sync;
 }
 
-#[allow(dead_code)]
 pub trait ObjectRelationMemberships
 where
     Self: SelfAccessors<HubuumObject> + Clone + Send + Sync,

--- a/src/db/traits/object.rs
+++ b/src/db/traits/object.rs
@@ -1,6 +1,5 @@
 use crate::db::prelude::*;
 use diesel::sql_query;
-use jsonschema;
 use serde_json;
 
 use crate::db::traits::GetObject;
@@ -232,17 +231,13 @@ pub trait ValidateObjectSchema {
 
 impl ValidateObjectSchema for HubuumObject {
     fn validate_object_schema(&self, schema: &serde_json::Value) -> Result<(), ApiError> {
-        jsonschema::validate(schema, &self.data)
-            .map_err(|err| ApiError::ValidationError(err.to_string()))?;
-        Ok(())
+        crate::utilities::json_schema::validate_json_value(schema, &self.data)
     }
 }
 
 impl ValidateObjectSchema for NewHubuumObject {
     fn validate_object_schema(&self, schema: &serde_json::Value) -> Result<(), ApiError> {
-        jsonschema::validate(schema, &self.data)
-            .map_err(|err| ApiError::ValidationError(err.to_string()))?;
-        Ok(())
+        crate::utilities::json_schema::validate_json_value(schema, &self.data)
     }
 }
 

--- a/src/db/traits/relations.rs
+++ b/src/db/traits/relations.rs
@@ -373,7 +373,6 @@ pub trait SelfRelationsBackend {
         pool: &DbPool,
     ) -> Result<Vec<HubuumClassRelation>, ApiError>;
 
-    #[allow(dead_code)]
     async fn search_relations_from_backend(
         &self,
         pool: &DbPool,
@@ -565,7 +564,6 @@ where
     .await
 }
 
-#[allow(dead_code)]
 async fn fetch_relations<C1, C2>(
     pool: &DbPool,
     from: &C1,
@@ -600,7 +598,6 @@ where
     .await
 }
 
-#[allow(dead_code)]
 async fn fetch_relations_paginated<C1, C2>(
     pool: &DbPool,
     from: &C1,

--- a/src/db/traits/search.rs
+++ b/src/db/traits/search.rs
@@ -1,0 +1,83 @@
+use diesel::expression::{AppearsOnTable, Expression, SelectableExpression, ValidGrouping};
+use diesel::pg::Pg;
+use diesel::query_builder::{AstPass, QueryFragment, QueryId};
+use diesel::result::QueryResult;
+use diesel::sql_types::{Bool, Integer, Text, Timestamp};
+
+use crate::errors::ApiError;
+use crate::models::search::{ParsedQueryParam, ParsedQueryParamExt, SQLComponent, SQLValue};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct JsonSqlPredicate {
+    sql: String,
+    bind_variables: Vec<SQLValue>,
+}
+
+impl Expression for JsonSqlPredicate {
+    type SqlType = Bool;
+}
+
+impl QueryId for JsonSqlPredicate {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl QueryFragment<Pg> for JsonSqlPredicate {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+        let mut sql_parts = self.sql.split('?');
+        if let Some(first_part) = sql_parts.next() {
+            out.push_sql(first_part);
+        }
+        for (bind_variable, sql_part) in self.bind_variables.iter().zip(sql_parts) {
+            bind_sql_value(&mut out, bind_variable)?;
+            out.push_sql(sql_part);
+        }
+        Ok(())
+    }
+}
+
+impl<QS> SelectableExpression<QS> for JsonSqlPredicate {}
+impl<QS> AppearsOnTable<QS> for JsonSqlPredicate {}
+
+impl<GB> ValidGrouping<GB> for JsonSqlPredicate {
+    type IsAggregate = diesel::expression::is_aggregate::Never;
+}
+
+fn bind_sql_value<'b>(out: &mut AstPass<'_, 'b, Pg>, value: &'b SQLValue) -> QueryResult<()> {
+    match value {
+        SQLValue::String(value) => out.push_bind_param::<Text, _>(value),
+        SQLValue::Integer(value) => out.push_bind_param::<Integer, _>(value),
+        SQLValue::Date(value) => out.push_bind_param::<Timestamp, _>(value),
+        SQLValue::Boolean(value) => out.push_bind_param::<Bool, _>(value),
+    }
+}
+
+fn into_predicate(component: SQLComponent) -> Result<JsonSqlPredicate, ApiError> {
+    let placeholder_count = component
+        .sql
+        .chars()
+        .filter(|character| *character == '?')
+        .count();
+    if placeholder_count != component.bind_variables.len() {
+        return Err(ApiError::InternalServerError(format!(
+            "JSON SQL predicate has {placeholder_count} placeholders but {} bind values",
+            component.bind_variables.len()
+        )));
+    }
+    Ok(JsonSqlPredicate {
+        sql: component.sql,
+        bind_variables: component.bind_variables,
+    })
+}
+
+pub trait JsonPredicateExt {
+    fn as_json_predicate(&self) -> Result<JsonSqlPredicate, ApiError>;
+}
+
+impl JsonPredicateExt for ParsedQueryParam {
+    fn as_json_predicate(&self) -> Result<JsonSqlPredicate, ApiError> {
+        into_predicate(self.as_json_sql()?)
+    }
+}

--- a/src/db/traits/task_import.rs
+++ b/src/db/traits/task_import.rs
@@ -700,6 +700,23 @@ pub async fn upsert_principal_db(
     overwrite: bool,
 ) -> Result<i32, ApiError> {
     input.validate_credentials()?;
+    let supplied_password = match &input.subtype {
+        ImportPrincipalSubtype::Human {
+            password: Some(password),
+            password_hash: None,
+            ..
+        } => Some(
+            crate::utilities::auth::hash_password_async(password.clone())
+                .await
+                .map_err(|error| ApiError::HashError(error.to_string()))?,
+        ),
+        ImportPrincipalSubtype::Human {
+            password: None,
+            password_hash,
+            ..
+        } => password_hash.clone(),
+        _ => None,
+    };
     use crate::schema::principals::dsl as p;
     let expected_kind = match &input.subtype {
         ImportPrincipalSubtype::Human { .. } => "human",
@@ -773,26 +790,12 @@ pub async fn upsert_principal_db(
 
     match &input.subtype {
         ImportPrincipalSubtype::Human {
-            password,
-            password_hash,
+            password: _,
+            password_hash: _,
             proper_name,
             email,
             anonymized_at,
         } => {
-            if password.is_some() && password_hash.is_some() {
-                return Err(ApiError::BadRequest(
-                    "A human principal import accepts password or password_hash, not both"
-                        .to_string(),
-                ));
-            }
-            let supplied_password = match (password, password_hash) {
-                (Some(password), None) => Some(
-                    crate::utilities::auth::hash_password(password)
-                        .map_err(|error| ApiError::HashError(error.to_string()))?,
-                ),
-                (None, hash) => hash.clone(),
-                _ => None,
-            };
             use crate::schema::users::dsl as u;
             let existing_user = u::users
                 .filter(u::id.eq(principal.id))

--- a/src/db/traits/token.rs
+++ b/src/db/traits/token.rs
@@ -1,0 +1,209 @@
+use crate::db::prelude::*;
+
+use crate::db::{DbPool, with_connection, with_transaction};
+use crate::errors::ApiError;
+use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
+use crate::models::principal::PrincipalKind;
+use crate::models::{Permissions, PrincipalToken, Token};
+use crate::schema::{principals, service_accounts, token_scopes, tokens};
+
+#[derive(Insertable)]
+#[diesel(table_name = token_scopes)]
+struct NewTokenScope<'a> {
+    token_id: i32,
+    permission: &'a str,
+}
+
+fn token_snapshot(token: &PrincipalToken) -> serde_json::Value {
+    serde_json::json!({
+        "id": token.id,
+        "principal_id": token.principal_id,
+        "name": token.name,
+        "description": token.description,
+        "issued": token.issued,
+        "expires_at": token.expires_at,
+        "last_used_at": token.last_used_at,
+        "revoked_at": token.revoked_at,
+        "scoped": token.scoped,
+    })
+}
+
+fn token_event(
+    token: &PrincipalToken,
+    action: Action,
+    context: &EventContext,
+    summary: impl Into<String>,
+) -> Result<NewEvent, ApiError> {
+    Ok(
+        NewEvent::new(EntityType::Token, action, context.actor_kind(), summary)?
+            .with_context(context)
+            .with_entity_id(token.id)
+            .with_entity_name(token.name.clone().unwrap_or_else(|| token.id.to_string()))
+            .with_metadata(serde_json::json!({
+                "principal_id": token.principal_id,
+                "scoped": token.scoped,
+            })),
+    )
+}
+
+pub async fn revoke_token_by_id_for_principal_without_events_db(
+    pool: &DbPool,
+    token_id: i32,
+    principal: i32,
+) -> Result<usize, ApiError> {
+    use crate::schema::tokens::dsl::{id, principal_id, revoked_at, tokens};
+    with_connection(pool, async |conn| {
+        diesel::update(
+            tokens
+                .filter(id.eq(token_id))
+                .filter(principal_id.eq(principal))
+                .filter(revoked_at.is_null()),
+        )
+        .set(revoked_at.eq(diesel::dsl::now))
+        .execute(conn)
+        .await
+    })
+    .await
+}
+
+pub async fn revoke_token_by_id_for_principal_db(
+    pool: &DbPool,
+    token_id: i32,
+    principal: i32,
+    context: Option<&EventContext>,
+) -> Result<usize, ApiError> {
+    let Some(context) = context else {
+        return revoke_token_by_id_for_principal_without_events_db(pool, token_id, principal).await;
+    };
+
+    use crate::schema::tokens::dsl::{id, principal_id, revoked_at, tokens};
+    with_transaction(pool, async |conn| -> Result<usize, ApiError> {
+        let before = tokens
+            .filter(id.eq(token_id))
+            .filter(principal_id.eq(principal))
+            .filter(revoked_at.is_null())
+            .first::<PrincipalToken>(conn)
+            .await
+            .optional()?;
+
+        let updated = diesel::update(
+            tokens
+                .filter(id.eq(token_id))
+                .filter(principal_id.eq(principal))
+                .filter(revoked_at.is_null()),
+        )
+        .set(revoked_at.eq(diesel::dsl::now))
+        .get_result::<PrincipalToken>(conn)
+        .await
+        .optional()?;
+
+        if let (Some(before), Some(after)) = (before, updated) {
+            let event = token_event(
+                &after,
+                Action::Revoked,
+                context,
+                format!(
+                    "Token {} revoked for principal {}",
+                    after.id, after.principal_id
+                ),
+            )?
+            .with_before(token_snapshot(&before))
+            .with_after(token_snapshot(&after));
+            emit_event(conn, &event).await?;
+            Ok(1)
+        } else {
+            Ok(0)
+        }
+    })
+    .await
+}
+
+pub async fn create_principal_token_db(
+    pool: &DbPool,
+    principal: i32,
+    name: Option<&str>,
+    description: Option<&str>,
+    expires_at: Option<chrono::NaiveDateTime>,
+    scopes: Option<&[Permissions]>,
+    context: Option<&EventContext>,
+) -> Result<Token, ApiError> {
+    let raw = crate::utilities::auth::generate_token();
+    let hash = raw.storage_hash();
+    let scoped = scopes.is_some();
+    let scope_strings = scopes
+        .map(|permissions| {
+            permissions
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let name = name.map(ToOwned::to_owned);
+    let description = description.map(ToOwned::to_owned);
+
+    with_transaction(pool, async |conn| -> Result<(), ApiError> {
+        let principal_kind = principals::table
+            .filter(principals::id.eq(principal))
+            .select(principals::kind)
+            .first::<String>(conn)
+            .await?;
+
+        if principal_kind == PrincipalKind::ServiceAccount.as_str() {
+            let disabled_at = service_accounts::table
+                .filter(service_accounts::id.eq(principal))
+                .for_update()
+                .select(service_accounts::disabled_at)
+                .first::<Option<chrono::NaiveDateTime>>(conn)
+                .await?;
+            if disabled_at.is_some() {
+                return Err(ApiError::Conflict(
+                    "Service account is disabled".to_string(),
+                ));
+            }
+        }
+
+        let token = diesel::insert_into(tokens::table)
+            .values((
+                tokens::token.eq(&hash),
+                tokens::principal_id.eq(principal),
+                tokens::name.eq(&name),
+                tokens::description.eq(&description),
+                tokens::expires_at.eq(expires_at),
+                tokens::scoped.eq(scoped),
+            ))
+            .get_result::<PrincipalToken>(conn)
+            .await?;
+
+        if !scope_strings.is_empty() {
+            let rows = scope_strings
+                .iter()
+                .map(|permission| NewTokenScope {
+                    token_id: token.id,
+                    permission,
+                })
+                .collect::<Vec<_>>();
+            diesel::insert_into(token_scopes::table)
+                .values(&rows)
+                .execute(conn)
+                .await?;
+        }
+
+        if let Some(context) = context {
+            let event = token_event(
+                &token,
+                Action::Created,
+                context,
+                format!(
+                    "Token {} created for principal {}",
+                    token.id, token.principal_id
+                ),
+            )?
+            .with_after(token_snapshot(&token));
+            emit_event(conn, &event).await?;
+        }
+        Ok(())
+    })
+    .await?;
+
+    Ok(raw)
+}

--- a/src/db/traits/user/auth.rs
+++ b/src/db/traits/user/auth.rs
@@ -110,7 +110,8 @@ impl User {
     pub async fn set_password(&self, pool: &DbPool, new_password: &str) -> Result<(), ApiError> {
         use crate::schema::users::dsl::*;
         debug!(message = "Setting new password", id = self.id());
-        let new_password = hash_password(new_password)
+        let new_password = crate::utilities::auth::hash_password_async(new_password.to_string())
+            .await
             .map_err(|e| ApiError::HashError(format!("Failed to hash password: {e}")))?;
 
         with_connection(pool, async |conn| -> Result<usize, ApiError> {

--- a/src/db/traits/user/mod.rs
+++ b/src/db/traits/user/mod.rs
@@ -3,6 +3,9 @@ use std::iter::IntoIterator;
 
 use tracing::debug;
 
+use crate::db::{DbPool, with_connection, with_transaction};
+use crate::errors::ApiError;
+use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
 use crate::models::search::{
     FilterField, ParsedQueryParam, QueryOptions, QueryParamsExt, SearchOperator,
 };
@@ -15,11 +18,6 @@ use crate::models::{
     RelatedObjectGraphRow, RelatedObjectIncludeRow, Token, UpdateUser, User, UserID,
 };
 use crate::traits::{ClassAccessors, CollectionAccessors, GroupAccessors, SelfAccessors};
-use crate::utilities::auth::hash_password;
-
-use crate::db::{DbPool, with_connection, with_transaction};
-use crate::errors::ApiError;
-use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
 
 use crate::{date_search, numeric_search, string_search, trace_query};
 

--- a/src/db/traits/user/search.rs
+++ b/src/db/traits/user/search.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::db::traits::authz::scope_allows;
+use crate::db::traits::search::JsonPredicateExt;
 use crate::models::RelatedObjectForRootRow;
 use crate::models::permissions::PermissionFilter;
 use crate::models::search::{ParsedQueryParamExt, SQLValue};

--- a/src/events/db.rs
+++ b/src/events/db.rs
@@ -39,6 +39,5 @@ pub async fn emit_event(
             event.correlation_id.as_deref(),
         );
     }
-    super::notify_event_fanout(conn).await?;
     Ok(event)
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -34,7 +34,7 @@ pub use sink::{
     DefaultSinkResolver, EventEnvelope, NoopSinkResolver, Sink, SinkError, SinkResolver,
 };
 
-pub(crate) use pg_notify::{notify_event_delivery, notify_event_fanout};
+pub(crate) use pg_notify::notify_event_delivery;
 
 pub use hubuum_events_core::{
     Action, ActorKind, EntityType, EventCatalogError, EventContext, is_valid_pair, valid_actions,

--- a/src/events/pg_notify.rs
+++ b/src/events/pg_notify.rs
@@ -7,12 +7,8 @@ use tracing::{debug, error, info};
 use crate::db::DbPool;
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 
-pub const EVENT_FANOUT_CHANNEL: &str = "hubuum_event_fanout";
+pub const EVENT_FANOUT_CHANNEL: &str = "hubuum_events_fanout";
 pub const EVENT_DELIVERY_CHANNEL: &str = "hubuum_event_delivery";
-
-pub async fn notify_event_fanout(conn: &mut crate::db::DbConnection) -> QueryResult<usize> {
-    notify_channel(conn, EVENT_FANOUT_CHANNEL).await
-}
 
 pub async fn notify_event_delivery(conn: &mut crate::db::DbConnection) -> QueryResult<usize> {
     notify_channel(conn, EVENT_DELIVERY_CHANNEL).await
@@ -151,12 +147,18 @@ async fn poll_notifications(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
 
     use diesel::sql_types::Text;
+    use futures_util::StreamExt;
+    use rstest::rstest;
 
     use crate::config::get_config;
-    use crate::db::init_pool;
+    use crate::db::{init_pool, with_transaction};
+    use crate::errors::ApiError;
+    use crate::events::{Action, ActorKind, EntityType, NewEvent, emit_event};
+    use crate::tests::test_scope;
 
     use super::*;
 
@@ -171,6 +173,60 @@ mod tests {
 
     fn mark_listener_ready() {
         LISTENER_READY.fetch_add(1, Ordering::Release);
+    }
+
+    #[rstest]
+    #[case::commit(true)]
+    #[case::rollback(false)]
+    #[tokio::test]
+    async fn fanout_trigger_notifies_only_after_commit(#[case] commit: bool) {
+        let scope = test_scope();
+        let mut listener = scope.pool.get().await.expect("listener connection");
+        diesel::sql_query(format!("LISTEN {EVENT_FANOUT_CHANNEL}"))
+            .execute(&mut listener)
+            .await
+            .expect("listen on fanout channel");
+
+        let inserted_id = Arc::new(AtomicI64::new(0));
+        let captured_id = inserted_id.clone();
+        let event = NewEvent::new(
+            EntityType::Collection,
+            Action::Created,
+            ActorKind::System,
+            "notification transaction test",
+        )
+        .unwrap();
+        let result: Result<(), ApiError> = with_transaction(&scope.pool, async |conn| {
+            let event = emit_event(conn, &event).await?;
+            captured_id.store(event.id, Ordering::Release);
+            if commit {
+                Ok(())
+            } else {
+                Err(ApiError::InternalServerError(
+                    "notification rollback test".to_string(),
+                ))
+            }
+        })
+        .await;
+        assert_eq!(result.is_ok(), commit);
+
+        let target_payload = inserted_id.as_ref().load(Ordering::Acquire).to_string();
+        let notifications = listener.notifications_stream();
+        futures_util::pin_mut!(notifications);
+        let received = tokio::time::timeout(Duration::from_millis(500), async {
+            while let Some(notification) = notifications.next().await {
+                let notification = notification.expect("fanout notification");
+                if notification.channel == EVENT_FANOUT_CHANNEL
+                    && notification.payload == target_payload
+                {
+                    return true;
+                }
+            }
+            false
+        })
+        .await
+        .unwrap_or(false);
+        assert_eq!(received, commit);
     }
 
     #[actix_rt::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,5 +23,6 @@ pub mod schema;
 pub mod tasks;
 #[cfg(test)]
 pub mod tests;
+pub mod tls;
 pub mod traits;
 pub mod utilities;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,8 @@
-#![allow(async_fn_in_trait)]
-
-mod api;
-mod auth;
-mod backups;
-mod config;
-pub mod db;
-mod errors;
-pub mod events;
-mod exports;
-mod extractors;
-mod lifecycle;
-mod logger;
-mod macros;
-mod middlewares;
-pub mod models;
-mod observability;
-mod pagination;
-pub mod permissions;
-mod restores;
-mod schema;
-mod tasks;
 #[cfg(test)]
-mod tests;
-mod tls;
-mod traits;
-mod utilities;
+#[path = "tests/container_build.rs"]
+mod container_build;
 
 use actix_web::{App, HttpServer, middleware::from_fn, web, web::Data, web::JsonConfig};
-use db::{DatabasePoolSettings, init_pool_with_settings};
 #[cfg(feature = "swagger-ui")]
 use utoipa::OpenApi;
 #[cfg(feature = "swagger-ui")]
@@ -36,35 +11,37 @@ use utoipa_swagger_ui::SwaggerUi;
 use std::time::Duration;
 use tracing::{error, info, warn};
 
-use crate::api::openapi::openapi_json as openapi_json_handler;
-use crate::backups::BackupSettings;
+use hubuum::api::openapi::openapi_json as openapi_json_handler;
+use hubuum::backups::BackupSettings;
 #[cfg(test)]
-use crate::config::get_config;
+use hubuum::config::get_config;
 #[cfg(not(test))]
-use crate::config::initialize_config;
-use crate::config::running::RunningConfig;
-use crate::config::token_hash_key_is_ephemeral;
-use crate::config::{AppConfig, LoginRateLimitBackendKind};
-use crate::errors::{
+use hubuum::config::initialize_config;
+use hubuum::config::running::RunningConfig;
+use hubuum::config::token_hash_key_is_ephemeral;
+use hubuum::config::{AppConfig, LoginRateLimitBackendKind};
+use hubuum::db::{DatabasePoolSettings, init_pool_with_settings};
+use hubuum::errors::{
     EXIT_CODE_CONFIG_ERROR, EXIT_CODE_DATABASE_ERROR, EXIT_CODE_INIT_ERROR,
     EXIT_CODE_PERMISSION_BACKEND_ERROR, EXIT_CODE_TLS_ERROR, fatal_error, json_error_handler,
 };
-use crate::events::{
+use hubuum::events::{
     ensure_event_delivery_worker_running, ensure_event_fanout_worker_running,
     ensure_event_retention_worker_running,
 };
-use crate::lifecycle::{
+use hubuum::lifecycle::{
     background_worker_count, shutdown_background_workers, wait_for_background_worker_exit,
 };
-use crate::middlewares::rate_limit::{
+use hubuum::middlewares::rate_limit::{
     LoginRateLimitStoreSettings, initialize_login_rate_limit_store,
 };
-use crate::permissions::{AppContext, build_permission_backend};
-use crate::restores::{RestoreSettings, ensure_restore_coordinator_running};
-use crate::tasks::{
+use hubuum::permissions::{AppContext, build_permission_backend};
+use hubuum::restores::{RestoreSettings, ensure_restore_coordinator_running};
+use hubuum::tasks::{
     TaskWorkerSettings, ensure_task_worker_running_with_settings, initialize_task_worker_settings,
 };
-use crate::utilities::is_valid_log_level;
+use hubuum::utilities::is_valid_log_level;
+use hubuum::{api, db, logger, middlewares, observability, tls, utilities};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {

--- a/src/middlewares/client_allowlist.rs
+++ b/src/middlewares/client_allowlist.rs
@@ -50,7 +50,6 @@ pub struct ClientAllowlistMiddleware {
 }
 
 impl ClientAllowlistMiddleware {
-    #[allow(dead_code)]
     pub fn new(allowlist: ClientAllowlist) -> Self {
         Self {
             allowlist,

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -143,7 +143,6 @@ where
     total_class_count_from_backend(backend.db_pool()).await
 }
 
-#[allow(dead_code)]
 fn new_hubuum_class_example() -> NewHubuumClass {
     NewHubuumClass {
         name: "server".to_string(),
@@ -154,7 +153,6 @@ fn new_hubuum_class_example() -> NewHubuumClass {
     }
 }
 
-#[allow(dead_code)]
 fn update_hubuum_class_example() -> UpdateHubuumClass {
     UpdateHubuumClass {
         name: Some("server".to_string()),

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -95,7 +95,6 @@ pub struct UpdateCollectionParent {
     pub parent_collection_id: CollectionID,
 }
 
-#[allow(dead_code)]
 fn update_collection_example() -> UpdateCollection {
     UpdateCollection {
         name: Some("global-assets".to_string()),
@@ -103,7 +102,6 @@ fn update_collection_example() -> UpdateCollection {
     }
 }
 
-#[allow(dead_code)]
 fn new_collection_with_assignee_example() -> NewCollectionWithAssignee {
     NewCollectionWithAssignee {
         name: "global-assets".to_string(),
@@ -130,7 +128,6 @@ where
 /// ## Returns
 /// * Ok(Vec(Group, CollectionPermissions)) - List of groups and their permissions
 /// * Err(ApiError) - On query errors only.
-#[allow(dead_code)]
 pub async fn principal_on<C, S, T>(
     backend: &C,
     principal: S,
@@ -282,7 +279,6 @@ where
 /// ## Returns
 /// * Ok(Vec<Group>) - List of groups that have the requested permission
 /// * Err(ApiError) - On query errors only.
-#[allow(dead_code)]
 pub async fn groups_can_on<C>(
     backend: &C,
     target_collection_id: i32,
@@ -326,7 +322,6 @@ where
 /// ## Returns
 /// * Ok(Vec<(Group, CollectionPermissions)>) - List of groups and their permissions
 /// * Err(ApiError) - On query errors only.
-#[allow(dead_code)]
 pub async fn groups_on<C, T>(
     backend: &C,
     collection_ref: T,

--- a/src/models/export.rs
+++ b/src/models/export.rs
@@ -380,7 +380,6 @@ impl FromStr for ExportMissingDataPolicy {
 
 // Used by utoipa's `#[schema(example = ...)]` hooks to populate the generated OpenAPI examples.
 // The compiler does not see those macro references as normal function calls.
-#[allow(dead_code)]
 mod openapi_examples {
     use super::*;
 

--- a/src/models/export_template.rs
+++ b/src/models/export_template.rs
@@ -458,7 +458,6 @@ impl ExportTemplate {
     }
 
     /// The other export templates sharing this template's collection (this template excluded).
-    #[allow(dead_code)]
     pub async fn collection_siblings(
         &self,
         pool: &DbPool,
@@ -467,7 +466,6 @@ impl ExportTemplate {
     }
 
     /// Every export template across all collections.
-    #[allow(dead_code)]
     pub async fn list_all(pool: &DbPool) -> Result<Vec<ExportTemplate>, ApiError> {
         let rows = backend::load_all_rows(pool).await?;
 
@@ -1222,7 +1220,6 @@ impl CursorSqlMapping for ExportTemplate {
     }
 }
 
-#[allow(dead_code)]
 fn export_template_example() -> ExportTemplate {
     let example_timestamp = chrono::NaiveDate::from_ymd_opt(2026, 3, 6)
         .and_then(|date| date.and_hms_opt(12, 0, 0))
@@ -1252,7 +1249,6 @@ fn export_template_example() -> ExportTemplate {
     }
 }
 
-#[allow(dead_code)]
 fn new_export_template_example() -> NewExportTemplate {
     NewExportTemplate {
         collection_id: 7,
@@ -1275,7 +1271,6 @@ fn new_export_template_example() -> NewExportTemplate {
     }
 }
 
-#[allow(dead_code)]
 fn update_export_template_example() -> UpdateExportTemplate {
     UpdateExportTemplate {
         collection_id: Some(9),

--- a/src/models/group.rs
+++ b/src/models/group.rs
@@ -421,7 +421,6 @@ impl UpdateGroup {
     }
 }
 
-#[allow(dead_code)]
 fn new_group_example() -> NewGroup {
     NewGroup {
         identity_scope: None,
@@ -430,7 +429,6 @@ fn new_group_example() -> NewGroup {
     }
 }
 
-#[allow(dead_code)]
 fn update_group_example() -> UpdateGroup {
     UpdateGroup {
         groupname: Some("platform-ops".to_string()),

--- a/src/models/object.rs
+++ b/src/models/object.rs
@@ -122,7 +122,6 @@ where
     objects_per_class_count_from_backend(backend.db_pool()).await
 }
 
-#[allow(dead_code)]
 fn new_hubuum_object_example() -> NewHubuumObject {
     NewHubuumObject {
         name: "srv-01".to_string(),
@@ -133,7 +132,6 @@ fn new_hubuum_object_example() -> NewHubuumObject {
     }
 }
 
-#[allow(dead_code)]
 fn update_hubuum_object_example() -> UpdateHubuumObject {
     UpdateHubuumObject {
         name: Some("srv-01".to_string()),
@@ -191,45 +189,9 @@ impl AuthzTarget for HubuumObjectID {
 pub mod tests {
     use super::*;
     use crate::db::DbPool;
-    use crate::models::class::HubuumClass;
     use crate::models::class::tests::{create_class, verify_no_such_class};
-    use crate::models::collection::Collection;
     use crate::tests::TestScope;
     use crate::traits::{CanDelete, CanSave, SelfAccessors};
-
-    #[allow(dead_code)]
-    async fn setup_test_objects(
-        pool: &DbPool,
-        collection: &Collection,
-        class: &HubuumClass,
-    ) -> Vec<HubuumObject> {
-        let simple_data = serde_json::json!({"key": "value"});
-        let nested_data = serde_json::json!({"key": "value", "nested": {"key": "nested_value"}});
-        let list_data = serde_json::json!({"key": "value", "list": [1, 2, 3]});
-
-        let target_collection_id = collection.id;
-        let hid = class.id;
-
-        let test_objects = vec![
-            ("Object 1", hid, target_collection_id, simple_data.clone()),
-            ("Object 2", hid, target_collection_id, simple_data.clone()),
-            ("Object 3", hid, target_collection_id, simple_data.clone()),
-            ("Object 4", hid, target_collection_id, nested_data.clone()),
-            ("Object 5", hid, target_collection_id, nested_data.clone()),
-            ("Object 6", hid, target_collection_id, list_data.clone()),
-        ];
-
-        let mut ret_vec = Vec::new();
-
-        for (name, hid, target_collection_id, object_data) in test_objects {
-            ret_vec.push(
-                create_object(pool, hid, target_collection_id, name, object_data)
-                    .await
-                    .unwrap(),
-            );
-        }
-        ret_vec
-    }
 
     pub async fn verify_no_such_object(pool: &DbPool, object_id: i32) {
         use crate::schema::hubuumobject::dsl::*;

--- a/src/models/relation.rs
+++ b/src/models/relation.rs
@@ -287,7 +287,6 @@ pub struct RelatedClassGraph {
     pub relations: Vec<HubuumClassRelation>,
 }
 
-#[allow(dead_code)]
 fn new_hubuum_class_relation_example() -> NewHubuumClassRelation {
     NewHubuumClassRelation {
         from_hubuum_class_id: 1,
@@ -297,7 +296,6 @@ fn new_hubuum_class_relation_example() -> NewHubuumClassRelation {
     }
 }
 
-#[allow(dead_code)]
 fn new_hubuum_class_relation_from_class_example() -> NewHubuumClassRelationFromClass {
     NewHubuumClassRelationFromClass {
         to_hubuum_class_id: 2,
@@ -306,7 +304,6 @@ fn new_hubuum_class_relation_from_class_example() -> NewHubuumClassRelationFromC
     }
 }
 
-#[allow(dead_code)]
 fn new_hubuum_object_relation_example() -> NewHubuumObjectRelation {
     NewHubuumObjectRelation {
         from_hubuum_object_id: 10,

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -1,9 +1,4 @@
 use chrono::NaiveDateTime;
-use diesel::expression::{AppearsOnTable, Expression, SelectableExpression, ValidGrouping};
-use diesel::pg::Pg;
-use diesel::query_builder::{AstPass, QueryFragment, QueryId};
-use diesel::result::QueryResult;
-use diesel::sql_types::{Bool, Integer, Text, Timestamp};
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -74,80 +69,6 @@ impl From<hubuum_query::QueryError> for ApiError {
 pub struct SQLComponent {
     pub sql: String,
     pub bind_variables: Vec<SQLValue>,
-}
-
-impl SQLComponent {
-    fn placeholder_count(&self) -> usize {
-        self.sql.chars().filter(|c| *c == '?').count()
-    }
-
-    pub fn into_predicate(self) -> Result<JsonSqlPredicate, ApiError> {
-        let placeholder_count = self.placeholder_count();
-        if placeholder_count != self.bind_variables.len() {
-            return Err(ApiError::InternalServerError(format!(
-                "JSON SQL predicate has {placeholder_count} placeholders but {} bind values",
-                self.bind_variables.len()
-            )));
-        }
-
-        Ok(JsonSqlPredicate {
-            sql: self.sql,
-            bind_variables: self.bind_variables,
-        })
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct JsonSqlPredicate {
-    sql: String,
-    bind_variables: Vec<SQLValue>,
-}
-
-impl Expression for JsonSqlPredicate {
-    type SqlType = Bool;
-}
-
-impl QueryId for JsonSqlPredicate {
-    type QueryId = ();
-
-    const HAS_STATIC_QUERY_ID: bool = false;
-}
-
-impl QueryFragment<Pg> for JsonSqlPredicate {
-    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
-        out.unsafe_to_cache_prepared();
-
-        // `?` is reserved for bind placeholders in these generated fragments.
-        // `SQLComponent::into_predicate` checks that placeholder and bind counts match.
-        let mut sql_parts = self.sql.split('?');
-        if let Some(first_part) = sql_parts.next() {
-            out.push_sql(first_part);
-        }
-
-        for (bind_variable, sql_part) in self.bind_variables.iter().zip(sql_parts) {
-            bind_sql_value(&mut out, bind_variable)?;
-            out.push_sql(sql_part);
-        }
-
-        Ok(())
-    }
-}
-
-impl<QS> SelectableExpression<QS> for JsonSqlPredicate {}
-
-impl<QS> AppearsOnTable<QS> for JsonSqlPredicate {}
-
-impl<GB> ValidGrouping<GB> for JsonSqlPredicate {
-    type IsAggregate = diesel::expression::is_aggregate::Never;
-}
-
-fn bind_sql_value<'b>(out: &mut AstPass<'_, 'b, Pg>, value: &'b SQLValue) -> QueryResult<()> {
-    match value {
-        SQLValue::String(value) => out.push_bind_param::<Text, _>(value),
-        SQLValue::Integer(value) => out.push_bind_param::<Integer, _>(value),
-        SQLValue::Date(value) => out.push_bind_param::<Timestamp, _>(value),
-        SQLValue::Boolean(value) => out.push_bind_param::<Bool, _>(value),
-    }
 }
 
 /// ## An sql value for bind variables
@@ -285,8 +206,6 @@ pub trait ParsedQueryParamExt {
     ///   * ApiError::BadRequest if the value is not a key=value pair
     fn as_json_sql(&self) -> Result<SQLComponent, ApiError>;
 
-    fn as_json_predicate(&self) -> Result<JsonSqlPredicate, ApiError>;
-
     fn as_json_sql_for_field_expr(&self, jsonb_field_expr: &str) -> Result<SQLComponent, ApiError>;
 }
 
@@ -391,10 +310,6 @@ impl ParsedQueryParamExt for ParsedQueryParam {
     fn as_json_sql(&self) -> Result<SQLComponent, ApiError> {
         let field = self.field.clone();
         self.as_json_sql_for_field_expr(field.table_field())
-    }
-
-    fn as_json_predicate(&self) -> Result<JsonSqlPredicate, ApiError> {
-        self.as_json_sql()?.into_predicate()
     }
 
     fn as_json_sql_for_field_expr(&self, jsonb_field_expr: &str) -> Result<SQLComponent, ApiError> {
@@ -1031,17 +946,13 @@ fn ip_to_host_net(value: &str) -> Result<IpNet, ()> {
     }
 }
 
-// TODO: Rewrite to use rstest cases...
 #[cfg(test)]
 mod test {
     use std::vec;
 
-    use super::*;
+    use rstest::rstest;
 
-    struct TestCase {
-        query_string: &'static str,
-        expected: Vec<ParsedQueryParam>,
-    }
+    use super::*;
 
     fn pq(field: &str, operator: SearchOperator, value: &str) -> ParsedQueryParam {
         ParsedQueryParam {
@@ -1063,190 +974,88 @@ mod test {
         assert!(result.is_err());
     }
 
-    #[test]
-    fn test_parse_integer_list_single() {
-        let test_cases = vec![
-            ("1", vec![1]),
-            ("2,4", vec![2, 4]),
-            ("3,3,3,6", vec![3, 6]),
-            ("4,1,4,1,5", vec![1, 4, 5]),
-        ];
-
-        for (input, expected) in test_cases {
-            let result = input.as_integer();
-            assert_eq!(result, Ok(expected), "Failed test case for input: {input}");
-        }
+    #[rstest]
+    #[case("1", vec![1])]
+    #[case("2,4", vec![2, 4])]
+    #[case("3,3,3,6", vec![3, 6])]
+    #[case("4,1,4,1,5", vec![1, 4, 5])]
+    #[case("1-4", vec![1, 2, 3, 4])]
+    #[case("2-4", vec![2, 3, 4])]
+    #[case("3-4", vec![3, 4])]
+    #[case("4-4", vec![4])]
+    #[case("1,2,3,4", vec![1, 2, 3, 4])]
+    #[case("1-4,6-8", vec![1, 2, 3, 4, 6, 7, 8])]
+    #[case("1,2,3-5,7", vec![1, 2, 3, 4, 5, 7])]
+    #[case("1-4,3,3,8", vec![1, 2, 3, 4, 8])]
+    #[case("-4--2", vec![-4, -3, -2])]
+    #[case("-90", vec![-90])]
+    fn test_parse_integer_list(#[case] input: &str, #[case] expected: Vec<i32>) {
+        assert_eq!(input.as_integer(), Ok(expected));
     }
 
-    #[test]
-    fn test_parse_integer_list_range() {
-        let test_cases = vec![
-            ("1-4", vec![1, 2, 3, 4]),
-            ("2-4", vec![2, 3, 4]),
-            ("3-4", vec![3, 4]),
-            ("4-4", vec![4]),
-        ];
-
-        for (input, expected) in test_cases {
-            let result = input.as_integer();
-            assert_eq!(result, Ok(expected), "Failed test case for input: {input}");
-        }
+    #[rstest]
+    #[case("1-")]
+    #[case("-4--6")]
+    #[case("1-2-3")]
+    fn test_parse_integer_list_failures(#[case] input: &str) {
+        assert!(input.as_integer().is_err());
     }
 
-    #[test]
-    fn test_parse_integer_list_mixed() {
-        let test_cases = vec![
-            ("1,2,3,4", vec![1, 2, 3, 4]),
-            ("1-4,6-8", vec![1, 2, 3, 4, 6, 7, 8]),
-            ("1,2,3-5,7", vec![1, 2, 3, 4, 5, 7]),
-            ("1-4,3,3,8", vec![1, 2, 3, 4, 8]),
-            ("-4--2", vec![-4, -3, -2]),
-            ("-90", vec![-90]),
-        ];
-
-        for (input, expected) in test_cases {
-            let result = input.as_integer();
-            assert_eq!(result, Ok(expected), "Failed test case for input: {input}",);
-        }
+    #[rstest]
+    #[case(
+        "name__icontains=foo&description=bar&invalid",
+        "Invalid query parameter: 'invalid'"
+    )]
+    #[case(
+        "name__icontains=foo&description=bar&invalid=",
+        "Invalid query parameter: 'invalid', no value"
+    )]
+    #[case(
+        "name__icontains=foo&description=bar&invalid=foo&name__invalid=bar",
+        "Invalid search field: 'invalid'"
+    )]
+    fn test_query_string_bad_request(#[case] query: &str, #[case] expected: &str) {
+        assert_eq!(
+            parse_query_parameter(query),
+            Err(ApiError::BadRequest(expected.to_string()))
+        );
     }
 
-    #[test]
-    fn test_parse_integer_list_failures() {
-        let test_cases = vec!["1-", "-4--6", "1-2-3"];
-
-        for input in test_cases {
-            let result = input.as_integer();
-            assert!(
-                result.is_err(),
-                "Failed test case for input: {input} (no error) {result:?}",
-            );
-        }
-    }
-
-    #[test]
-    fn test_query_string_bad_request() {
-        let test_cases = vec![
-            "name__icontains=foo&description=bar&invalid",
-            "name__icontains=foo&description=bar&invalid=",
-            "name__icontains=foo&description=bar&invalid=foo&name__invalid=bar",
-        ];
-
-        let test_case_errors = [
-            "Invalid query parameter: 'invalid'",
-            "Invalid query parameter: 'invalid', no value",
-            "Invalid search field: 'invalid'",
-        ];
-
-        for (i, case) in test_cases.into_iter().enumerate() {
-            let result = parse_query_parameter(case);
-            assert!(
-                result.is_err(),
-                "Failed test case for query: {case} (no error) {result:?}",
-            );
-            let result_err = result.unwrap_err();
-            assert_eq!(
-                result_err,
-                ApiError::BadRequest(test_case_errors[i].to_string()),
-                "Failed test case for query: {case} ({} vs {})",
-                result_err,
-                test_case_errors[i]
-            );
-        }
-    }
-
-    #[test]
-    fn test_query_string_parsing() {
-        let test_cases = vec![
-            TestCase {
-                query_string: "name__icontains=foo&description=bar",
-                expected: vec![
-                    pq(
-                        "name",
-                        SearchOperator::IContains { is_negated: false },
-                        "foo",
-                    ),
-                    pq(
-                        "description",
-                        SearchOperator::Equals { is_negated: false },
-                        "bar",
-                    ),
-                ],
-            },
-            TestCase {
-                query_string: "name__contains=foo&description__icontains=bar&created_at__gte=2021-01-01&updated_at__lte=2021-12-31",
-                expected: vec![
-                    pq(
-                        "name",
-                        SearchOperator::Contains { is_negated: false },
-                        "foo",
-                    ),
-                    pq(
-                        "description",
-                        SearchOperator::IContains { is_negated: false },
-                        "bar",
-                    ),
-                    pq(
-                        "created_at",
-                        SearchOperator::Gte { is_negated: false },
-                        "2021-01-01",
-                    ),
-                    pq(
-                        "updated_at",
-                        SearchOperator::Lte { is_negated: false },
-                        "2021-12-31",
-                    ),
-                ],
-            },
-            TestCase {
-                query_string: "name__not_icontains=foo&description=bar&permissions=CanRead&validate_schema=true",
-                expected: vec![
-                    pq(
-                        "name",
-                        SearchOperator::IContains { is_negated: true },
-                        "foo",
-                    ),
-                    pq(
-                        "description",
-                        SearchOperator::Equals { is_negated: false },
-                        "bar",
-                    ),
-                    pq(
-                        "permissions",
-                        SearchOperator::Equals { is_negated: false },
-                        "CanRead",
-                    ),
-                    pq(
-                        "validate_schema",
-                        SearchOperator::Equals { is_negated: false },
-                        "true",
-                    ),
-                ],
-            },
-            TestCase {
-                query_string: "json_data__within_network=network,address=10.0.0.0/24&json_data__contains_ip=network,address=10.0.0.10",
-                expected: vec![
-                    pq(
-                        "json_data",
-                        SearchOperator::WithinNetwork { is_negated: false },
-                        "network,address=10.0.0.0/24",
-                    ),
-                    pq(
-                        "json_data",
-                        SearchOperator::ContainsIp { is_negated: false },
-                        "network,address=10.0.0.10",
-                    ),
-                ],
-            },
-        ];
-
-        for case in test_cases {
-            let parsed_query_params = parse_query_parameter(case.query_string).unwrap();
-            assert_eq!(
-                parsed_query_params.filters, case.expected,
-                "Failed test case for query: {}",
-                case.query_string
-            );
-        }
+    #[rstest]
+    #[case(
+        "name__icontains=foo&description=bar",
+        vec![
+            pq("name", SearchOperator::IContains { is_negated: false }, "foo"),
+            pq("description", SearchOperator::Equals { is_negated: false }, "bar"),
+        ]
+    )]
+    #[case(
+        "name__contains=foo&description__icontains=bar&created_at__gte=2021-01-01&updated_at__lte=2021-12-31",
+        vec![
+            pq("name", SearchOperator::Contains { is_negated: false }, "foo"),
+            pq("description", SearchOperator::IContains { is_negated: false }, "bar"),
+            pq("created_at", SearchOperator::Gte { is_negated: false }, "2021-01-01"),
+            pq("updated_at", SearchOperator::Lte { is_negated: false }, "2021-12-31"),
+        ]
+    )]
+    #[case(
+        "name__not_icontains=foo&description=bar&permissions=CanRead&validate_schema=true",
+        vec![
+            pq("name", SearchOperator::IContains { is_negated: true }, "foo"),
+            pq("description", SearchOperator::Equals { is_negated: false }, "bar"),
+            pq("permissions", SearchOperator::Equals { is_negated: false }, "CanRead"),
+            pq("validate_schema", SearchOperator::Equals { is_negated: false }, "true"),
+        ]
+    )]
+    #[case(
+        "json_data__within_network=network,address=10.0.0.0/24&json_data__contains_ip=network,address=10.0.0.10",
+        vec![
+            pq("json_data", SearchOperator::WithinNetwork { is_negated: false }, "network,address=10.0.0.0/24"),
+            pq("json_data", SearchOperator::ContainsIp { is_negated: false }, "network,address=10.0.0.10"),
+        ]
+    )]
+    fn test_query_string_parsing(#[case] query: &str, #[case] expected: Vec<ParsedQueryParam>) {
+        assert_eq!(parse_query_parameter(query).unwrap().filters, expected);
     }
 
     #[test]

--- a/src/models/service_account.rs
+++ b/src/models/service_account.rs
@@ -224,7 +224,6 @@ impl IdAccessor for ServiceAccountID {
     }
 }
 
-#[allow(dead_code)]
 fn new_service_account_example() -> NewServiceAccount {
     NewServiceAccount {
         identity_scope: None,

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -418,7 +418,6 @@ impl<T> ExportOutputLookup<T> {
 
 #[derive(Debug, Clone, Queryable, Selectable)]
 #[diesel(table_name = export_task_outputs)]
-#[allow(dead_code)]
 pub struct ExportTaskOutputSummaryRecord {
     pub id: i32,
     pub task_id: i32,

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -9,7 +9,7 @@ use utoipa::ToSchema;
 use crate::config::token_hash_key_bytes;
 use crate::db::traits::user::DeleteTokenRecord;
 use crate::errors::ApiError;
-use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
+use crate::events::EventContext;
 use crate::models::search::{FilterField, SortParam};
 use crate::schema::tokens;
 use crate::traits::{
@@ -61,38 +61,6 @@ impl From<PrincipalToken> for PrincipalTokenMetadata {
             scoped: value.scoped,
         }
     }
-}
-
-fn token_snapshot(token: &PrincipalToken) -> serde_json::Value {
-    serde_json::json!({
-        "id": token.id,
-        "principal_id": token.principal_id,
-        "name": token.name,
-        "description": token.description,
-        "issued": token.issued,
-        "expires_at": token.expires_at,
-        "last_used_at": token.last_used_at,
-        "revoked_at": token.revoked_at,
-        "scoped": token.scoped,
-    })
-}
-
-fn token_event(
-    token: &PrincipalToken,
-    action: Action,
-    context: &EventContext,
-    summary: impl Into<String>,
-) -> Result<NewEvent, ApiError> {
-    Ok(
-        NewEvent::new(EntityType::Token, action, context.actor_kind(), summary)?
-            .with_context(context)
-            .with_entity_id(token.id)
-            .with_entity_name(token.name.clone().unwrap_or_else(|| token.id.to_string()))
-            .with_metadata(serde_json::json!({
-                "principal_id": token.principal_id,
-                "scoped": token.scoped,
-            })),
-    )
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -152,19 +120,11 @@ pub async fn revoke_token_by_id_for_principal_without_events<C>(
 where
     C: BackendContext + ?Sized,
 {
-    use crate::db::with_connection;
-    use crate::schema::tokens::dsl::{id, principal_id, revoked_at, tokens};
-    with_connection(backend.db_pool(), async |conn| {
-        diesel::update(
-            tokens
-                .filter(id.eq(token_id))
-                .filter(principal_id.eq(principal))
-                .filter(revoked_at.is_null()),
-        )
-        .set(revoked_at.eq(diesel::dsl::now))
-        .execute(conn)
-        .await
-    })
+    crate::db::traits::token::revoke_token_by_id_for_principal_without_events_db(
+        backend.db_pool(),
+        token_id,
+        principal,
+    )
     .await
 }
 
@@ -177,51 +137,12 @@ pub async fn revoke_token_by_id_for_principal<C>(
 where
     C: BackendContext + ?Sized,
 {
-    let Some(context) = context else {
-        return revoke_token_by_id_for_principal_without_events(backend, token_id, principal).await;
-    };
-
-    use crate::db::with_transaction;
-    use crate::schema::tokens::dsl::{id, principal_id, revoked_at, tokens};
-
-    with_transaction(backend.db_pool(), async |conn| -> Result<usize, ApiError> {
-        let before = tokens
-            .filter(id.eq(token_id))
-            .filter(principal_id.eq(principal))
-            .filter(revoked_at.is_null())
-            .first::<PrincipalToken>(conn)
-            .await
-            .optional()?;
-
-        let updated = diesel::update(
-            tokens
-                .filter(id.eq(token_id))
-                .filter(principal_id.eq(principal))
-                .filter(revoked_at.is_null()),
-        )
-        .set(revoked_at.eq(diesel::dsl::now))
-        .get_result::<PrincipalToken>(conn)
-        .await
-        .optional()?;
-
-        if let (Some(before), Some(after)) = (before, updated) {
-            let event = token_event(
-                &after,
-                Action::Revoked,
-                context,
-                format!(
-                    "Token {} revoked for principal {}",
-                    after.id, after.principal_id
-                ),
-            )?
-            .with_before(token_snapshot(&before))
-            .with_after(token_snapshot(&after));
-            emit_event(conn, &event).await?;
-            Ok(1)
-        } else {
-            Ok(0)
-        }
-    })
+    crate::db::traits::token::revoke_token_by_id_for_principal_db(
+        backend.db_pool(),
+        token_id,
+        principal,
+        context,
+    )
     .await
 }
 
@@ -241,8 +162,8 @@ pub async fn create_principal_token<C>(
 where
     C: BackendContext + ?Sized,
 {
-    create_principal_token_inner(
-        backend,
+    crate::db::traits::token::create_principal_token_db(
+        backend.db_pool(),
         principal,
         name,
         description,
@@ -251,96 +172,6 @@ where
         context,
     )
     .await
-}
-
-async fn create_principal_token_inner<C>(
-    backend: &C,
-    principal: i32,
-    name: Option<&str>,
-    description: Option<&str>,
-    expires_at: Option<chrono::NaiveDateTime>,
-    scopes: Option<&[crate::models::Permissions]>,
-    context: Option<&EventContext>,
-) -> Result<Token, ApiError>
-where
-    C: BackendContext + ?Sized,
-{
-    use crate::db::with_transaction;
-    use crate::models::principal::PrincipalKind;
-    use crate::schema::{principals, service_accounts, tokens};
-
-    let raw = crate::utilities::auth::generate_token();
-    let hash = raw.storage_hash();
-    let scoped = scopes.is_some();
-    let scope_strings: Vec<String> = scopes
-        .map(|s| s.iter().map(|p| p.to_string()).collect())
-        .unwrap_or_default();
-    let name = name.map(|s| s.to_string());
-    let description = description.map(|s| s.to_string());
-
-    with_transaction(backend.db_pool(), async |conn| -> Result<(), ApiError> {
-        let principal_kind = principals::table
-            .filter(principals::id.eq(principal))
-            .select(principals::kind)
-            .first::<String>(conn)
-            .await?;
-
-        // Lock the SA row in the same transaction as insert so disable-vs-mint
-        // races fail closed.
-        if principal_kind == PrincipalKind::ServiceAccount.as_str() {
-            let disabled_at = service_accounts::table
-                .filter(service_accounts::id.eq(principal))
-                .for_update()
-                .select(service_accounts::disabled_at)
-                .first::<Option<chrono::NaiveDateTime>>(conn)
-                .await?;
-
-            if disabled_at.is_some() {
-                return Err(ApiError::Conflict(
-                    "Service account is disabled".to_string(),
-                ));
-            }
-        }
-
-        let token = diesel::insert_into(tokens::table)
-            .values((
-                tokens::token.eq(&hash),
-                tokens::principal_id.eq(principal),
-                tokens::name.eq(&name),
-                tokens::description.eq(&description),
-                tokens::expires_at.eq(expires_at),
-                tokens::scoped.eq(scoped),
-            ))
-            .get_result::<PrincipalToken>(conn)
-            .await?;
-
-        for permission in &scope_strings {
-            diesel::insert_into(crate::schema::token_scopes::table)
-                .values((
-                    crate::schema::token_scopes::token_id.eq(token.id),
-                    crate::schema::token_scopes::permission.eq(permission),
-                ))
-                .execute(conn)
-                .await?;
-        }
-        if let Some(context) = context {
-            let event = token_event(
-                &token,
-                Action::Created,
-                context,
-                format!(
-                    "Token {} created for principal {}",
-                    token.id, token.principal_id
-                ),
-            )?
-            .with_after(token_snapshot(&token));
-            emit_event(conn, &event).await?;
-        }
-        Ok(())
-    })
-    .await?;
-
-    Ok(raw)
 }
 
 impl CursorPaginated for PrincipalToken {

--- a/src/models/traits/class.rs
+++ b/src/models/traits/class.rs
@@ -1,5 +1,7 @@
 use crate::traits::accessors::{ClassAdapter, CollectionAdapter, IdAccessor, InstanceAdapter};
-use crate::traits::{CanUpdate, ClassAccessors, CollectionAccessors, PermissionController};
+use crate::traits::{
+    CanUpdate, ClassAccessors, CollectionAccessors, PermissionController, SelfAccessors,
+};
 
 use crate::db::DbPool;
 use crate::db::traits::class::{
@@ -12,6 +14,37 @@ use crate::traits::crud::{DeleteAdapter, SaveAdapter, UpdateAdapter};
 use crate::models::{
     Collection, CollectionID, HubuumClass, HubuumClassID, NewHubuumClass, UpdateHubuumClass,
 };
+
+fn validate_new_class_schema(class: &NewHubuumClass) -> Result<(), ApiError> {
+    let Some(schema) = class.json_schema.as_ref() else {
+        return Ok(());
+    };
+    crate::utilities::json_schema::validate_json_schema(schema)?;
+    if class.validate_schema.unwrap_or(false) {
+        crate::utilities::json_schema::compile_json_schema(schema)?;
+    }
+    Ok(())
+}
+
+async fn validate_class_schema_update(
+    update: &UpdateHubuumClass,
+    pool: &DbPool,
+    class_id: i32,
+) -> Result<(), ApiError> {
+    if update.json_schema.is_none() && update.validate_schema.is_none() {
+        return Ok(());
+    }
+
+    let class = HubuumClassID::new(class_id)?.instance(pool).await?;
+    let schema = update.json_schema.as_ref().or(class.json_schema.as_ref());
+    if let Some(schema) = schema {
+        crate::utilities::json_schema::validate_json_schema(schema)?;
+        if update.validate_schema.unwrap_or(class.validate_schema) {
+            crate::utilities::json_schema::compile_json_schema(schema)?;
+        }
+    }
+    Ok(())
+}
 
 impl SaveAdapter for HubuumClass {
     type Output = HubuumClass;
@@ -61,6 +94,7 @@ impl SaveAdapter for NewHubuumClass {
     type Output = HubuumClass;
 
     async fn save_adapter_without_events(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
+        validate_new_class_schema(self)?;
         self.create_class_record_without_events(pool).await
     }
 
@@ -69,6 +103,7 @@ impl SaveAdapter for NewHubuumClass {
         pool: &DbPool,
         context: &EventContext,
     ) -> Result<HubuumClass, ApiError> {
+        validate_new_class_schema(self)?;
         self.create_class_record(pool, Some(context)).await
     }
 }
@@ -81,6 +116,7 @@ impl UpdateAdapter for UpdateHubuumClass {
         pool: &DbPool,
         class_id: i32,
     ) -> Result<HubuumClass, ApiError> {
+        validate_class_schema_update(self, pool, class_id).await?;
         self.update_class_record_without_events(pool, class_id)
             .await
     }
@@ -91,6 +127,7 @@ impl UpdateAdapter for UpdateHubuumClass {
         class_id: i32,
         context: &EventContext,
     ) -> Result<HubuumClass, ApiError> {
+        validate_class_schema_update(self, pool, class_id).await?;
         self.update_class_record(pool, class_id, Some(context))
             .await
     }

--- a/src/models/traits/class_relation.rs
+++ b/src/models/traits/class_relation.rs
@@ -332,7 +332,6 @@ impl ObjectAdapter<(HubuumObject, HubuumObject), (HubuumObjectID, HubuumObjectID
 }
 
 impl ClassGraphRow {
-    #[allow(dead_code)]
     pub fn to_ascendant_class(&self) -> HubuumClass {
         HubuumClass {
             id: self.ancestor_class_id,
@@ -346,7 +345,6 @@ impl ClassGraphRow {
         }
     }
 
-    #[allow(dead_code)]
     pub fn to_descendant_class(&self) -> HubuumClass {
         HubuumClass {
             id: self.descendant_class_id,
@@ -360,7 +358,6 @@ impl ClassGraphRow {
         }
     }
 
-    #[allow(dead_code)]
     pub fn to_descendant_class_with_path(&self) -> HubuumClassWithPath {
         HubuumClassWithPath {
             id: self.descendant_class_id,
@@ -376,7 +373,6 @@ impl ClassGraphRow {
     }
 }
 
-#[allow(dead_code)]
 pub trait ToHubuumClasses {
     fn to_descendant_classes(self) -> Vec<HubuumClass>;
     fn to_descendant_classes_with_path(self) -> Vec<HubuumClassWithPath>;

--- a/src/models/traits/object.rs
+++ b/src/models/traits/object.rs
@@ -80,7 +80,6 @@ impl HubuumObject {
     }
 }
 
-// Validators
 impl Validate for HubuumObject {
     async fn validate<C>(&self, backend: &C) -> Result<(), ApiError>
     where

--- a/src/models/traits/user.rs
+++ b/src/models/traits/user.rs
@@ -390,7 +390,6 @@ pub trait GroupAccessors: AuthzSubject {
 /// Access collections that are visible to a user through direct or group-derived permissions.
 pub trait UserCollectionAccessors: GroupAccessors + AuthzSubject {
     /// Return all collections that the user has CollectionPermissions::ReadCollection on.
-    #[allow(dead_code)] // Lazy-used in tests.
     async fn collections_read<C>(&self, backend: &C) -> Result<Vec<Collection>, ApiError>
     where
         C: BackendContext + ?Sized,

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -397,17 +397,15 @@ impl UpdateUser {
                 .is_some_and(|value| Some(value) != current.email.as_ref())
     }
 
-    pub fn hash_password(self) -> Result<Self, ApiError> {
-        if let Some(ref pass) = self.password {
-            match crate::utilities::auth::hash_password(pass) {
-                Ok(hashed_password) => {
-                    return Ok(UpdateUser {
-                        password: Some(hashed_password),
-                        ..self
-                    });
-                }
-                Err(e) => return Err(ApiError::HashError(format!("Failed to hash password: {e}"))),
-            }
+    pub async fn hash_password(mut self) -> Result<Self, ApiError> {
+        if let Some(password) = self.password.take() {
+            self.password = Some(
+                crate::utilities::auth::hash_password_async(password)
+                    .await
+                    .map_err(|error| {
+                        ApiError::HashError(format!("Failed to hash password: {error}"))
+                    })?,
+            );
         }
         Ok(self)
     }
@@ -422,7 +420,7 @@ impl UpdateUser {
     where
         C: BackendContext + ?Sized,
     {
-        let hashed = self.hash_password()?;
+        let hashed = self.hash_password().await?;
         hashed
             .update_user_record_without_events(user_id, backend.db_pool())
             .await
@@ -437,7 +435,7 @@ impl UpdateUser {
     where
         C: BackendContext + ?Sized,
     {
-        let hashed = self.hash_password()?;
+        let hashed = self.hash_password().await?;
         hashed
             .update_user_record(user_id, backend.db_pool(), context)
             .await
@@ -467,7 +465,7 @@ impl NewUser {
     where
         C: BackendContext + ?Sized,
     {
-        let hashed = self.hash_password()?;
+        let hashed = self.hash_password().await?;
         hashed
             .create_user_record_without_events(backend.db_pool())
             .await
@@ -481,17 +479,14 @@ impl NewUser {
     where
         C: BackendContext + ?Sized,
     {
-        let hashed = self.hash_password()?;
+        let hashed = self.hash_password().await?;
         hashed.create_user_record(backend.db_pool(), context).await
     }
 
-    pub fn hash_password(mut self) -> Result<Self, ApiError> {
-        match crate::utilities::auth::hash_password(&self.password) {
-            Ok(hashed_password) => {
-                self.password = hashed_password;
-            }
-            Err(e) => return Err(ApiError::HashError(format!("Failed to hash password: {e}"))),
-        }
+    pub async fn hash_password(mut self) -> Result<Self, ApiError> {
+        self.password = crate::utilities::auth::hash_password_async(self.password)
+            .await
+            .map_err(|error| ApiError::HashError(format!("Failed to hash password: {error}")))?;
         Ok(self)
     }
 }
@@ -555,21 +550,19 @@ impl LoginUser {
             .identity_scope
             .as_deref()
             .unwrap_or(LOCAL_IDENTITY_SCOPE);
-        let user =
-            match User::get_by_name_in_scope(backend.db_pool(), identity_scope, &self.name).await {
-                Ok(user) => user,
-                Err(_) => {
-                    // Keep unknown-user and wrong-password paths comparable: both execute
-                    // one Argon2 verification before returning the same public error.
-                    let password = self.password.clone();
-                    let _ = tokio::task::spawn_blocking(move || {
-                        crate::utilities::auth::verify_dummy_password(&password)
-                    })
+        let user = match User::get_by_name_in_scope(backend.db_pool(), identity_scope, &self.name)
+            .await
+        {
+            Ok(user) => user,
+            Err(_) => {
+                // Keep unknown-user and wrong-password paths comparable: both execute
+                // one Argon2 verification before returning the same public error.
+                let _ = crate::utilities::auth::verify_dummy_password_async(self.password.clone())
                     .await;
-                    warn!(message = "Login failed (user not found)", user = self.name);
-                    return Err(auth_failure());
-                }
-            };
+                warn!(message = "Login failed (user not found)", user = self.name);
+                return Err(auth_failure());
+            }
+        };
 
         let plaintext_password = &self.password;
         let Some(hashed_password) = &user.password else {
@@ -582,25 +575,16 @@ impl LoginUser {
 
         let plaintext_password = plaintext_password.clone();
         let hashed_password = hashed_password.clone();
-        let verification = tokio::task::spawn_blocking(move || {
-            crate::utilities::auth::verify_password(&plaintext_password, &hashed_password)
-        })
-        .await;
+        let verification =
+            crate::utilities::auth::verify_password_async(plaintext_password, hashed_password)
+                .await;
 
         match verification {
-            Ok(Ok(true)) => Ok(user),
-            Ok(Ok(false)) => {
+            Ok(true) => Ok(user),
+            Ok(false) => {
                 warn!(
                     message = "Login failed (password mismatch)",
                     user = self.name
-                );
-                Err(auth_failure())
-            }
-            Ok(Err(e)) => {
-                error!(
-                    message = "Login failed (hashing error)",
-                    user = self.name,
-                    error = e.to_string()
                 );
                 Err(auth_failure())
             }
@@ -620,7 +604,6 @@ pub fn auth_failure() -> ApiError {
     ApiError::Unauthorized("Authentication failure".to_string())
 }
 
-#[allow(dead_code)]
 fn update_user_example() -> UpdateUser {
     UpdateUser {
         password: Some("new-password".to_string()),
@@ -629,7 +612,6 @@ fn update_user_example() -> UpdateUser {
     }
 }
 
-#[allow(dead_code)]
 fn new_user_example() -> NewUser {
     NewUser {
         identity_scope: None,
@@ -640,7 +622,6 @@ fn new_user_example() -> NewUser {
     }
 }
 
-#[allow(dead_code)]
 fn login_user_example() -> LoginUser {
     LoginUser {
         identity_scope: None,

--- a/src/pagination/mod.rs
+++ b/src/pagination/mod.rs
@@ -459,11 +459,6 @@ fn cursor_literal_sql(field: &CursorSqlField, value: &CursorValue) -> Result<Str
             "cursor contains null for field '{}'",
             field.column
         ))),
-        (CursorSqlType::Boolean, CursorValue::Boolean(value)) => Ok(if *value {
-            "TRUE".to_string()
-        } else {
-            "FALSE".to_string()
-        }),
         (CursorSqlType::Integer, CursorValue::Integer(value)) => Ok(value.to_string()),
         (CursorSqlType::String, CursorValue::String(value)) => {
             Ok(format!("'{}'", value.replace('\'', "''")))
@@ -497,7 +492,7 @@ fn cursor_literal_sql(field: &CursorSqlField, value: &CursorValue) -> Result<Str
 macro_rules! apply_cursor_ordering {
     ($query:ident, $sorts:expr, $ty:ty) => {{
         use diesel::dsl::sql;
-        use diesel::sql_types::{Array, Bool, Integer, Nullable, Text, Timestamp};
+        use diesel::sql_types::{Array, Integer, Nullable, Text, Timestamp};
 
         let mut is_first_order = true;
         for sort in $sorts.iter() {
@@ -505,18 +500,6 @@ macro_rules! apply_cursor_ordering {
             let order_sql = $crate::pagination::order_sql_clause::<$ty>(sort)?;
 
             $query = match (is_first_order, sql_field.sql_type, sql_field.nullable) {
-                (true, $crate::pagination::CursorSqlType::Boolean, false) => {
-                    $query.order_by(sql::<Bool>(&order_sql))
-                }
-                (false, $crate::pagination::CursorSqlType::Boolean, false) => {
-                    $query.then_order_by(sql::<Bool>(&order_sql))
-                }
-                (true, $crate::pagination::CursorSqlType::Boolean, true) => {
-                    $query.order_by(sql::<Nullable<Bool>>(&order_sql))
-                }
-                (false, $crate::pagination::CursorSqlType::Boolean, true) => {
-                    $query.then_order_by(sql::<Nullable<Bool>>(&order_sql))
-                }
                 (true, $crate::pagination::CursorSqlType::Integer, false) => {
                     $query.order_by(sql::<Integer>(&order_sql))
                 }

--- a/src/permissions/export.rs
+++ b/src/permissions/export.rs
@@ -10,11 +10,6 @@
 //! the operator uploads the file via Treetop's own tooling. See
 //! `docs/treetop/README.md` for the bootstrap workflow.
 
-// Consumed only by the `hubuum-admin` binary, not by `hubuum-server`. The
-// `hubuum-server` bin re-includes this file via `mod permissions;` and
-// therefore reports its functions as dead. Suppress that.
-#![allow(dead_code)]
-
 use std::io::Write;
 
 use crate::db::prelude::*;

--- a/src/permissions/local/queries.rs
+++ b/src/permissions/local/queries.rs
@@ -737,7 +737,6 @@ pub(crate) async fn groups_on_query<T: CollectionAccessors>(
     Ok(rows.into_iter().map(GroupPermission::from_tuple).collect())
 }
 
-#[allow(dead_code)]
 pub(crate) async fn groups_on_paginated_query<T: CollectionAccessors>(
     pool: &DbPool,
     collection_ref: T,
@@ -826,7 +825,6 @@ pub(crate) async fn groups_on_paginated_with_total_count_query<T: CollectionAcce
     ))
 }
 
-#[allow(dead_code)]
 pub(crate) async fn count_groups_on_paginated_query<T: CollectionAccessors>(
     pool: &DbPool,
     collection_ref: T,

--- a/src/permissions/observability.rs
+++ b/src/permissions/observability.rs
@@ -104,7 +104,6 @@ pub fn record_reverse_query(
 /// actually survived `offset`/`limit`. Both are interesting: the first
 /// tells you how much your candidate query filtered down to, the second
 /// tells you what the API actually shipped.
-#[allow(dead_code)]
 pub fn record_paginate_authorized(
     backend: &'static str,
     candidate_count: usize,

--- a/src/permissions/test_support/mock_treetop.rs
+++ b/src/permissions/test_support/mock_treetop.rs
@@ -195,7 +195,6 @@ pub struct MockTreetopBackend {
     group_candidates: Mutex<Option<Vec<Group>>>,
 }
 
-#[allow(dead_code)]
 impl MockTreetopBackend {
     pub fn new() -> Self {
         Self {

--- a/src/permissions/types.rs
+++ b/src/permissions/types.rs
@@ -214,7 +214,6 @@ impl ResourceRef {
     /// `is_admin` dispatches against it; the SQL backend reads the admin
     /// group directly. Marked `dead_code`-allow so a build without the
     /// optional Treetop backend doesn't lint the helper away.
-    #[allow(dead_code)]
     pub fn system() -> Self {
         Self {
             kind: ResourceKind::System,

--- a/src/permissions/visibility.rs
+++ b/src/permissions/visibility.rs
@@ -17,7 +17,6 @@ use super::types::{PermissionDecision, PermissionRequest, PrincipalRef, Resource
 /// join fast path instead. Marked `dead_code`-allow because a build without
 /// the optional Treetop backend has no caller for either type, and the lints
 /// would otherwise fire.
-#[allow(dead_code)]
 pub struct AuthorizedPage<T> {
     pub rows: Vec<T>,
     pub total_count: i64,
@@ -89,7 +88,6 @@ where
 /// semantics live a layer up; this helper concerns itself only with
 /// the authorize-then-page pipeline. The candidate set must already
 /// be sorted in the order the caller wants pagination to apply.
-#[allow(dead_code)]
 pub async fn paginate_authorized<T, F>(
     backend: &dyn PermissionBackend,
     principal: &PrincipalRef,

--- a/src/restores/mod.rs
+++ b/src/restores/mod.rs
@@ -150,6 +150,7 @@ fn validation_summary(document: &BackupDocument) -> Result<RestoreValidationSumm
         }
     }
     validate_required_seed_rows(document)?;
+    validate_backup_class_schemas(document)?;
     let total_items = document
         .state
         .sections
@@ -173,6 +174,41 @@ fn validation_summary(document: &BackupDocument) -> Result<RestoreValidationSumm
         includes_history: document.history.is_some(),
         total_items,
     })
+}
+
+fn validate_backup_class_schemas(document: &BackupDocument) -> Result<(), ApiError> {
+    let current_classes = required_state_section(document, "hubuumclass")?;
+    let historical_classes = document
+        .history
+        .as_ref()
+        .and_then(|history| history.sections.get("hubuumclass_history"))
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+
+    for row in current_classes.iter().chain(historical_classes) {
+        let Some(schema) = row.get("json_schema").filter(|value| !value.is_null()) else {
+            continue;
+        };
+        let validation = if row
+            .get("validate_schema")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            crate::utilities::json_schema::compile_json_schema(schema).map(|_| ())
+        } else {
+            crate::utilities::json_schema::validate_json_schema(schema)
+        };
+        validation.map_err(|error| {
+            let class_id = row.get("id").and_then(Value::as_i64);
+            ApiError::BadRequest(format!(
+                "Full backup class {} contains an invalid JSON schema: {error}",
+                class_id
+                    .map(|id| id.to_string())
+                    .unwrap_or_else(|| "with unknown id".to_string())
+            ))
+        })?;
+    }
+    Ok(())
 }
 
 fn required_state_section<'a>(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -65,6 +65,13 @@ diesel::table! {
 }
 
 diesel::table! {
+    event_related_collections (event_id, collection_id) {
+        event_id -> Int8,
+        collection_id -> Int4,
+    }
+}
+
+diesel::table! {
     event_sinks (id) {
         id -> Int4,
         name -> Varchar,
@@ -622,6 +629,7 @@ diesel::table! {
 diesel::joinable!(backup_task_outputs -> tasks (task_id));
 diesel::joinable!(event_deliveries -> event_subscriptions (subscription_id));
 diesel::joinable!(event_deliveries -> events (event_id));
+diesel::joinable!(event_related_collections -> events (event_id));
 diesel::joinable!(event_subscriptions -> collections (collection_id));
 diesel::joinable!(event_subscriptions -> event_sinks (sink_id));
 diesel::joinable!(export_task_outputs -> tasks (task_id));
@@ -657,6 +665,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     collections,
     collections_history,
     event_deliveries,
+    event_related_collections,
     event_sinks,
     event_subscriptions,
     events,

--- a/src/tasks/planning.rs
+++ b/src/tasks/planning.rs
@@ -1004,6 +1004,16 @@ where
     }
 }
 
+fn validate_planned_class_schema(class: &ClassResolution) -> Result<(), ApiError> {
+    if !class.validate_schema {
+        return Ok(());
+    }
+    let Some(schema) = class.json_schema.as_ref() else {
+        return Ok(());
+    };
+    crate::utilities::json_schema::compile_json_schema(schema).map(|_| ())
+}
+
 pub(super) async fn plan_class<C>(
     backend: &C,
     user: &impl crate::db::traits::authz::AuthzSubject,
@@ -1015,6 +1025,20 @@ where
     C: BackendContext + ?Sized,
 {
     let pool = backend.db_pool();
+    if let Some(schema) = input.json_schema.as_ref() {
+        crate::utilities::json_schema::validate_json_schema(schema).map_err(|error| {
+            PlanningFailure {
+                kind: FailureKind::Validation,
+                item: planned_result(
+                    "class",
+                    "validate",
+                    input.ref_.clone(),
+                    Some(input.name.clone()),
+                ),
+                message: error.to_string(),
+            }
+        })?;
+    }
     if let Some(reference) = &input.ref_
         && state.classes_by_ref.contains_key(reference)
     {
@@ -1135,6 +1159,16 @@ where
             validate_schema: input.validate_schema.unwrap_or(class.validate_schema),
             exists_in_db: true,
         };
+        validate_planned_class_schema(&updated).map_err(|error| PlanningFailure {
+            kind: FailureKind::Validation,
+            item: planned_result(
+                "class",
+                "validate",
+                input.ref_.clone(),
+                Some(input.name.clone()),
+            ),
+            message: error.to_string(),
+        })?;
         remember_class(state, input.ref_.clone(), updated.clone());
 
         Ok(PlannedItem {
@@ -1178,6 +1212,16 @@ where
             validate_schema: input.validate_schema.unwrap_or(false),
             exists_in_db: false,
         };
+        validate_planned_class_schema(&created).map_err(|error| PlanningFailure {
+            kind: FailureKind::Validation,
+            item: planned_result(
+                "class",
+                "validate",
+                input.ref_.clone(),
+                Some(input.name.clone()),
+            ),
+            message: error.to_string(),
+        })?;
         remember_class(state, input.ref_.clone(), created.clone());
 
         Ok(PlannedItem {
@@ -1234,15 +1278,17 @@ where
     if class.validate_schema
         && let Some(schema) = &class.json_schema
     {
-        jsonschema::validate(schema, &input.data).map_err(|err| PlanningFailure {
-            kind: FailureKind::Validation,
-            item: planned_result(
-                "object",
-                "validate",
-                input.ref_.clone(),
-                Some(format!("{}::{}", class.name, input.name)),
-            ),
-            message: err.to_string(),
+        crate::utilities::json_schema::validate_json_value(schema, &input.data).map_err(|err| {
+            PlanningFailure {
+                kind: FailureKind::Validation,
+                item: planned_result(
+                    "object",
+                    "validate",
+                    input.ref_.clone(),
+                    Some(format!("{}::{}", class.name, input.name)),
+                ),
+                message: err.to_string(),
+            }
         })?;
     }
 

--- a/src/tests/acl.rs
+++ b/src/tests/acl.rs
@@ -1,8 +1,5 @@
 use serde::Serialize;
 
-#[derive(Serialize)]
-struct NoData {}
-
 #[derive(PartialEq, Serialize)]
 enum AccessLevel {
     Open,
@@ -12,7 +9,6 @@ enum AccessLevel {
 
 #[derive(Serialize)]
 enum TestDataForEndpoint {
-    NoData,
     LoginUser(crate::models::user::LoginUser),
 }
 

--- a/src/tests/api/v1/auth.rs
+++ b/src/tests/api/v1/auth.rs
@@ -17,7 +17,6 @@ mod tests {
     const LOGIN_ENDPOINT: &str = "/api/v0/auth/login";
     const AUTH_PROVIDERS_ENDPOINT: &str = "/api/v0/auth/providers";
     const LOGOUT_ENDPOINT: &str = "/api/v0/auth/logout";
-    const LOGOUT_ALL_ENDPOINT: &str = "/api/v0/auth/logout_all";
     const LOGOUT_ALL_FOR_OTHER_USER_ENDPOINT: &str = "/api/v0/auth/logout/uid/";
     const LOGOUT_SPECIFIC_TOKEN: &str = "/api/v0/auth/logout/token";
     const VALIDATE_TOKEN_ENDPOINT: &str = "/api/v0/auth/validate";

--- a/src/tests/api/v1/classes.rs
+++ b/src/tests/api/v1/classes.rs
@@ -406,6 +406,36 @@ pub mod tests {
     }
 
     #[rstest]
+    #[case(serde_json::json!({"type": 7}))]
+    #[case(serde_json::json!({"$ref": "https://example.com/schema.json"}))]
+    #[case(serde_json::json!({"$ref": "file:///etc/passwd"}))]
+    #[actix_web::test]
+    async fn test_api_classes_rejects_unsafe_json_schemas(
+        #[case] json_schema: serde_json::Value,
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let collection = context.collection_fixture("reject_unsafe_schema").await;
+        let new_class = NewHubuumClass {
+            name: format!("unsafe_schema_{}", uuid::Uuid::new_v4().simple()),
+            description: "invalid schema must not be persisted".to_string(),
+            collection_id: collection.collection.id,
+            json_schema: Some(json_schema),
+            validate_schema: Some(true),
+        };
+
+        let response = post_request(
+            &context.pool,
+            &context.admin_token,
+            CLASSES_ENDPOINT,
+            &new_class,
+        )
+        .await;
+        assert_response_status(response, StatusCode::BAD_REQUEST).await;
+        collection.cleanup().await.unwrap();
+    }
+
+    #[rstest]
     #[actix_web::test]
     async fn test_api_classes_patch(#[future(awt)] test_context: TestContext) {
         use crate::models::UpdateHubuumClass;

--- a/src/tests/api/v1/events.rs
+++ b/src/tests/api/v1/events.rs
@@ -1,16 +1,17 @@
 #[cfg(test)]
 mod tests {
     use actix_web::{http::StatusCode, test};
+    use rstest::rstest;
     use serde_json::json;
 
     use crate::db::with_connection;
     use crate::events::{Action, ActorKind, EntityType, EventResponse, NewEvent, emit_event};
-    use crate::models::{Permissions, PermissionsList};
+    use crate::models::{NewHubuumClass, NewHubuumObject, Permissions, PermissionsList};
     use crate::tests::TestContext;
     use crate::tests::api_operations::get_request;
     use crate::tests::asserts::{assert_response_status, header_value};
     use crate::tests::{create_test_group, create_test_user};
-    use crate::traits::PermissionController;
+    use crate::traits::{CanSave, PermissionController};
 
     const EVENTS_ENDPOINT: &str = "/api/v1/events";
 
@@ -207,8 +208,13 @@ mod tests {
         assert_response_status(resp, StatusCode::BAD_REQUEST).await;
     }
 
+    #[rstest]
+    #[case::numeric(false)]
+    #[case::legacy_string(true)]
     #[actix_web::test]
-    async fn test_events_endpoint_includes_related_collection_events() {
+    async fn test_events_endpoint_includes_related_collection_events(
+        #[case] encode_as_string: bool,
+    ) {
         let context = TestContext::new().await;
         let collections = context.collection_fixtures("audit_related", 2).await;
         let source_collection = &collections[0].collection;
@@ -230,6 +236,11 @@ mod tests {
             .await
             .unwrap();
 
+        let related_collection_id = if encode_as_string {
+            json!(related_collection.id.to_string())
+        } else {
+            json!(related_collection.id)
+        };
         let event = emit_test_event(
             &context.pool,
             &NewEvent::new(
@@ -244,7 +255,7 @@ mod tests {
             .with_before(json!({"secret": "source-before"}))
             .with_after(json!({"secret": "source-after"}))
             .with_metadata(json!({
-                "related_collection_ids": [related_collection.id],
+                "related_collection_ids": [related_collection_id],
             })),
         )
         .await;
@@ -258,5 +269,60 @@ mod tests {
             .expect("related collection audit event should be visible");
         assert!(related_event.before.is_none());
         assert!(related_event.after.is_none());
+    }
+
+    #[rstest]
+    #[case::matching(true, StatusCode::OK)]
+    #[case::mismatching(false, StatusCode::NOT_FOUND)]
+    #[actix_web::test]
+    async fn object_event_route_enforces_path_class(
+        #[case] matching_class: bool,
+        #[case] expected_status: StatusCode,
+    ) {
+        let context = TestContext::new().await;
+        let collection = context.collection_fixture("object_event_path_class").await;
+        let class = NewHubuumClass {
+            name: format!("event_class_{}", uuid::Uuid::new_v4().simple()),
+            collection_id: collection.collection.id,
+            json_schema: None,
+            validate_schema: Some(false),
+            description: "event route class".to_string(),
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let other_class = NewHubuumClass {
+            name: format!("other_event_class_{}", uuid::Uuid::new_v4().simple()),
+            collection_id: collection.collection.id,
+            json_schema: None,
+            validate_schema: Some(false),
+            description: "other event route class".to_string(),
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let object = NewHubuumObject {
+            name: format!("event_object_{}", uuid::Uuid::new_v4().simple()),
+            collection_id: collection.collection.id,
+            hubuum_class_id: class.id,
+            data: json!({}),
+            description: "event route object".to_string(),
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let path_class_id = if matching_class {
+            class.id
+        } else {
+            other_class.id
+        };
+
+        let response = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/classes/{}/{}/events", path_class_id, object.id),
+        )
+        .await;
+        assert_response_status(response, expected_status).await;
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,14 +1,9 @@
-#![allow(dead_code)]
-// We allow dead code here because all of this is used in tests and it is
-// thus marked as dead. Doh.
-
 pub mod acl;
 pub mod api;
 pub mod api_operations;
 pub mod asserts;
 pub mod client_allowlist;
 pub mod constants;
-pub mod container_build;
 pub mod docs_examples;
 pub mod id_newtypes;
 pub mod permissions;

--- a/src/tests/validation.rs
+++ b/src/tests/validation.rs
@@ -3,11 +3,12 @@
 use rstest::rstest;
 use serde_json::Value;
 
+use crate::db::traits::object::{ValidateObjectRecord, ValidateObjectSchema};
 use crate::errors::ApiError;
 use crate::models::{NewHubuumClass, NewHubuumObject, UpdateHubuumObject};
 use crate::tests::constants::{SchemaType, get_schema};
 use crate::tests::{CollectionFixture, TestScope};
-use crate::traits::{CanSave, Validate, ValidateAgainstSchema};
+use crate::traits::CanSave;
 
 /// Sets up a Geo class (with its collection) for testing.
 /// The identifier string is used to create unique names.
@@ -82,13 +83,11 @@ async fn test_validate_object(#[case] json_data: &str, #[case] expected: bool) {
     };
 
     // First, test the direct schema validation.
-    let schema_validate = object
-        .validate_against_schema(class.json_schema.as_ref().unwrap())
-        .await;
+    let schema_validate = object.validate_object_schema(class.json_schema.as_ref().unwrap());
     assert_validation_result(schema_validate, expected, "Schema validation");
 
     // Then, test the full object validation that fetches the class from the DB.
-    let object_validate = object.validate(&pool).await;
+    let object_validate = object.validate_object_record(&pool).await;
     assert_validation_result(object_validate, expected, "Object validation");
 
     collection_fixture
@@ -141,7 +140,9 @@ async fn test_validate_update_object(#[case] json_data: &str, #[case] expected: 
         data: Some(updated_data.clone()),
     };
 
-    let validate = (&update_object, object.id).validate(&pool).await;
+    let validate = (&update_object, object.id)
+        .validate_object_record(&pool)
+        .await;
     assert_validation_result(validate, expected, "Update object validation");
 
     collection_fixture

--- a/src/traits/accessors.rs
+++ b/src/traits/accessors.rs
@@ -187,7 +187,6 @@ where
 /// This follows the same pattern as the other accessor traits, including relation cases where the
 /// returned object or identifier type may be a tuple rather than a single value.
 pub trait ObjectAccessors<O = HubuumObject, I = HubuumObjectID> {
-    #[allow(dead_code)]
     /// Return the object instance for this value.
     async fn object<B>(&self, backend: &B) -> Result<O, ApiError>
     where
@@ -201,7 +200,6 @@ pub trait ObjectAccessors<O = HubuumObject, I = HubuumObjectID> {
 
 #[doc(hidden)]
 pub(crate) trait ObjectAdapter<O = HubuumObject, I = HubuumObjectID> {
-    #[allow(dead_code)]
     async fn object_adapter(&self, pool: &DbPool) -> Result<O, ApiError>;
     async fn object_id_adapter(&self, pool: &DbPool) -> Result<I, ApiError>;
 }

--- a/src/traits/crud.rs
+++ b/src/traits/crud.rs
@@ -14,7 +14,6 @@ pub trait CanDelete {
     /// Intended only for internal infrastructure paths such as bootstrap/setup,
     /// fixture cleanup, and event-system tests. Normal application code should
     /// use [`CanDelete::delete`] so event subscribers observe the change.
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn delete_without_events<C>(&self, backend: &C) -> Result<(), ApiError>
     where
         C: BackendContext + ?Sized;
@@ -35,7 +34,6 @@ pub trait CanSave {
     /// Intended only for internal infrastructure paths such as bootstrap/setup,
     /// fixture construction, cleanup, and event-system tests. Normal application
     /// code should use [`CanSave::save`] so event subscribers observe the change.
-    #[cfg_attr(not(test), allow(dead_code))]
     async fn save_without_events<C>(&self, backend: &C) -> Result<Self::Output, ApiError>
     where
         C: BackendContext + ?Sized;
@@ -190,32 +188,17 @@ where
     }
 }
 
-#[allow(dead_code)]
 /// Validate a value in its full domain context.
 ///
-/// Unlike purely local validation, implementations may consult the backend when validation depends
-/// on related persisted state, such as a class schema or permissions.
+/// Implementations may consult the backend when validation depends on related
+/// persisted state, such as a class schema.
 pub trait Validate {
-    /// Complete validation of the object.
-    ///
-    /// This returns errors if:
-    /// - If the object's class requires validation (validate_schema), and the object's data
-    ///   fails validation against the class's JSON schema (json_schema).
     async fn validate<C>(&self, backend: &C) -> Result<(), ApiError>
     where
         C: BackendContext + ?Sized;
 }
 
-#[allow(dead_code)]
-/// Validate a value against a supplied schema without loading additional backend state.
+/// Validate a value against a supplied schema without loading backend state.
 pub trait ValidateAgainstSchema {
-    /// Validate the object's data against the class's JSON schema.
-    ///
-    /// This does not check if the class requires validation (validate_schema), it
-    /// only checks if the data is valid against the schema.
-    ///
-    /// Returns OK() if any of the following are true:
-    /// - The class does not have a schema (json_schema).
-    /// - The object data is valid against the schema.
     async fn validate_against_schema(&self, schema: &serde_json::Value) -> Result<(), ApiError>;
 }

--- a/src/traits/pagination.rs
+++ b/src/traits/pagination.rs
@@ -7,7 +7,6 @@ use crate::models::search::{FilterField, SortParam};
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
 pub enum CursorValue {
     Null,
-    Boolean(bool),
     Integer(i64),
     String(String),
     DateTime(chrono::NaiveDateTime),
@@ -21,10 +20,8 @@ pub trait CursorPaginated: Clone {
     fn tie_breaker_sort() -> Vec<SortParam>;
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CursorSqlType {
-    Boolean,
     Integer,
     String,
     DateTime,

--- a/src/traits/permissions.rs
+++ b/src/traits/permissions.rs
@@ -8,68 +8,7 @@ use crate::models::{Permission, Permissions, PermissionsList};
 
 use super::{BackendContext, CollectionAccessors};
 
-#[allow(dead_code)]
 pub trait PermissionController: Serialize + CollectionAccessors {
-    /// Check if the user has the given permission on the object.
-    ///
-    /// - If the trait is called on a collection, check against self.
-    /// - If the trait is called on a HubuumClass or a HubuumObject,
-    ///   check against the collection of the class or object.
-    /// - If the trait is called on a HubuumClassID or a HubuumObjectID,
-    ///   create a HubuumClass or HubuumObject and check against the collection
-    ///   of the class or object.
-    ///
-    /// If this is called on a *ID, a full class is created to extract
-    /// the collection_id. To avoid creating the class multiple times during use
-    /// do this:
-    /// ```text
-    /// class = class_id.class(backend).await?;
-    /// if (class.user_can(backend, subject, Permissions::ReadClass, scopes).await?) {
-    ///     return Ok(class);
-    /// }
-    /// ```
-    /// And not this:
-    /// ```text
-    /// if (class_id.user_can(backend, subject, Permissions::ReadClass, scopes).await?) {
-    ///    return Ok(class_id.class(backend).await?);
-    /// }
-    /// ```
-    ///
-    /// ## Arguments
-    ///
-    /// * `backend` - The backend context to use for the query.
-    /// * `subject` - The principal (impl `AuthzSubject`) to check permissions for.
-    /// * `permission` - The permission to check.
-    /// * `scopes` - The token scope set as `Option<&[Permissions]>`; `None` = unscoped
-    ///   (full authority), `Some(..)` intersects the check fail-closed (even for admins).
-    ///
-    /// ## Returns
-    ///
-    /// * `Ok(true)` if the subject has the given permission on this class.
-    /// * `Ok(false)` if the subject does not have the given permission on this class.
-    /// * `Err(_)` if the lookup fails or the permission is invalid.
-    ///
-    /// ## Example
-    ///
-    /// ```text
-    /// if (hubuum_class_or_classid.user_can(backend, subject, Permissions::ReadClass, scopes).await?) {
-    ///     // Do something
-    /// }
-    async fn user_can<C, S>(
-        &self,
-        backend: &C,
-        subject: S,
-        permission: Permissions,
-        scopes: Option<&[Permissions]>,
-    ) -> Result<bool, ApiError>
-    where
-        C: BackendContext + ?Sized,
-        S: AuthzSubject,
-    {
-        self.user_can_all(backend, subject, vec![permission], scopes)
-            .await
-    }
-
     /// Check if the user has all the given permissions on the object.
     ///
     /// - If the trait is called on a collection, check against self.
@@ -154,6 +93,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     /// infrastructure paths such as bootstrap/setup, fixture construction,
     /// cleanup, and event-system tests. Normal application code should use
     /// [`PermissionController::grant`] so event subscribers observe the change.
+    #[cfg(test)]
     async fn grant_without_events<C>(
         &self,
         backend: &C,
@@ -191,6 +131,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     /// cleanup, and event-system tests. Normal application code should use
     /// [`PermissionController::apply_permissions`] so event subscribers observe
     /// the change.
+    #[cfg(test)]
     async fn apply_permissions_without_events<C>(
         &self,
         backend: &C,
@@ -255,6 +196,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     /// infrastructure paths such as bootstrap/setup, fixture construction,
     /// cleanup, and event-system tests. Normal application code should use
     /// [`PermissionController::revoke`] so event subscribers observe the change.
+    #[cfg(test)]
     async fn revoke_without_events<C>(
         &self,
         backend: &C,
@@ -311,6 +253,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     /// ## Returns
     ///
     /// The permission object that holds the permissions for the group.
+    #[cfg(test)]
     async fn grant_one<C>(
         &self,
         backend: &C,
@@ -347,6 +290,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     ///
     /// The permission object that holds the permissions for the group. If the group
     /// did not have the permission, an ApiError::NotFound is returned.
+    #[cfg(test)]
     async fn revoke_one<C>(
         &self,
         backend: &C,
@@ -388,6 +332,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     /// cleanup, and event-system tests. Normal application code should use
     /// [`PermissionController::set_permissions`] so event subscribers observe
     /// the change.
+    #[cfg(test)]
     async fn set_permissions_without_events<C>(
         &self,
         backend: &C,
@@ -435,6 +380,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     /// event-system tests. Normal application code should use
     /// [`PermissionController::revoke_all`] so event subscribers observe the
     /// change.
+    #[cfg(test)]
     async fn revoke_all_without_events<C>(
         &self,
         backend: &C,

--- a/src/utilities/auth.rs
+++ b/src/utilities/auth.rs
@@ -9,7 +9,9 @@ use argon2::{
 
 use rand::{RngExt, distr::Alphanumeric, rng};
 use sha2::{Digest, Sha512};
-use std::sync::LazyLock;
+use std::fmt;
+use std::sync::{Arc, LazyLock};
+use tokio::sync::Semaphore;
 
 use tracing::debug;
 
@@ -17,6 +19,40 @@ static DUMMY_PASSWORD_HASH: LazyLock<String> = LazyLock::new(|| {
     hash_password("hubuum-dummy-password-verification-target")
         .expect("the built-in dummy password must be hashable")
 });
+
+const PASSWORD_WORK_MAX_CONCURRENCY: usize = 4;
+
+static PASSWORD_WORK_SEMAPHORE: LazyLock<Arc<Semaphore>> =
+    LazyLock::new(|| Arc::new(Semaphore::new(PASSWORD_WORK_MAX_CONCURRENCY)));
+
+#[derive(Debug)]
+pub struct PasswordWorkError(String);
+
+impl fmt::Display for PasswordWorkError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for PasswordWorkError {}
+
+async fn run_password_work<T, F>(work: F) -> Result<T, PasswordWorkError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, PasswordWorkError> + Send + 'static,
+{
+    let permit = PASSWORD_WORK_SEMAPHORE
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|error| PasswordWorkError(format!("Password worker is unavailable: {error}")))?;
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        work()
+    })
+    .await
+    .map_err(|error| PasswordWorkError(format!("Password worker failed: {error}")))?
+}
 
 /// Initialize the dummy verifier used to make unknown-user login attempts perform
 /// the same expensive password-hash work as wrong-password attempts.
@@ -28,6 +64,13 @@ pub fn verify_dummy_password(password: &str) -> Result<bool, argon2::Error> {
     verify_password(password, &DUMMY_PASSWORD_HASH)
 }
 
+pub async fn verify_dummy_password_async(password: String) -> Result<bool, PasswordWorkError> {
+    run_password_work(move || {
+        verify_dummy_password(&password).map_err(|error| PasswordWorkError(error.to_string()))
+    })
+    .await
+}
+
 /// Hash a plaintext password.
 pub fn hash_password(password: &str) -> Result<String, Box<dyn std::error::Error>> {
     let argon2 = Argon2::default();
@@ -37,6 +80,13 @@ pub fn hash_password(password: &str) -> Result<String, Box<dyn std::error::Error
         .to_string();
 
     Ok(password_hash)
+}
+
+pub async fn hash_password_async(password: String) -> Result<String, PasswordWorkError> {
+    run_password_work(move || {
+        hash_password(&password).map_err(|error| PasswordWorkError(error.to_string()))
+    })
+    .await
 }
 
 /// Verify a plaintext password against a hashed password.
@@ -72,6 +122,16 @@ pub fn verify_password(password: &str, hash: &str) -> Result<bool, argon2::Error
         .is_ok())
 }
 
+pub async fn verify_password_async(
+    password: String,
+    hash: String,
+) -> Result<bool, PasswordWorkError> {
+    run_password_work(move || {
+        verify_password(&password, &hash).map_err(|error| PasswordWorkError(error.to_string()))
+    })
+    .await
+}
+
 pub fn generate_random_password(length: usize) -> String {
     let mut rng = rng();
     std::iter::repeat(())
@@ -87,4 +147,30 @@ pub fn generate_token() -> Token {
     hasher.update(raw);
     let result = hasher.finalize();
     Token(result.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case("correct horse battery staple", true)]
+    #[case("wrong password", false)]
+    #[tokio::test]
+    async fn async_password_workers_hash_and_verify(
+        #[case] candidate: &str,
+        #[case] expected: bool,
+    ) {
+        let hash = hash_password_async("correct horse battery staple".to_string())
+            .await
+            .unwrap();
+        assert_eq!(
+            verify_password_async(candidate.to_string(), hash)
+                .await
+                .unwrap(),
+            expected
+        );
+    }
 }

--- a/src/utilities/db.rs
+++ b/src/utilities/db.rs
@@ -1,11 +1,9 @@
 use urlparse::urlparse;
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct DatabaseUrlComponents {
     pub vendor: String,
     pub username: String,
-    pub password: String,
     pub host: String,
     pub port: u16,
     pub database: String,
@@ -25,14 +23,12 @@ impl DatabaseUrlComponents {
         }?;
 
         let username = url.username.unwrap_or_default().to_string();
-        let password = url.password.unwrap_or_default().to_string();
         let host = url.hostname.ok_or("Missing host".to_string())?.to_string();
         let path = url.path.trim_start_matches('/').to_string();
 
         Ok(DatabaseUrlComponents {
             vendor: scheme.to_lowercase(),
             username,
-            password,
             host,
             port,
             database: path,
@@ -52,7 +48,6 @@ mod tests {
                 Ok(components) => {
                     assert_eq!(components.vendor, expected_components.vendor);
                     assert_eq!(components.username, expected_components.username);
-                    assert_eq!(components.password, expected_components.password);
                     assert_eq!(components.host, expected_components.host);
                     assert_eq!(components.port, expected_components.port);
                     assert_eq!(components.database, expected_components.database);
@@ -77,7 +72,6 @@ mod tests {
             Ok(DatabaseUrlComponents {
                 vendor: "postgres".to_string(),
                 username: "test".to_string(),
-                password: "test".to_string(),
                 host: "localhost".to_string(),
                 port: 5432,
                 database: "testdb".to_string(),
@@ -90,7 +84,6 @@ mod tests {
             Ok(DatabaseUrlComponents {
                 vendor: "postgres".to_string(),
                 username: "".to_string(),
-                password: "".to_string(),
                 host: "localhost".to_string(),
                 port: 5432,
                 database: "testdb".to_string(),
@@ -103,7 +96,6 @@ mod tests {
             Ok(DatabaseUrlComponents {
                 vendor: "postgres".to_string(),
                 username: "test".to_string(),
-                password: "test".to_string(),
                 host: "localhost".to_string(),
                 port: 5432,
                 database: "testdb".to_string(),

--- a/src/utilities/init.rs
+++ b/src/utilities/init.rs
@@ -6,7 +6,7 @@ use crate::db::DbPool;
 use crate::db::traits::bootstrap::{bootstrap_default_admin, default_admin_bootstrap_required};
 use crate::db::traits::identity::ensure_identity_scope;
 use crate::models::identity::{LOCAL_IDENTITY_SCOPE, LOCAL_PROVIDER_KIND};
-use crate::utilities::auth::{generate_random_password, hash_password};
+use crate::utilities::auth::{generate_random_password, hash_password_async};
 
 use tracing::{error, warn};
 
@@ -40,9 +40,10 @@ pub async fn init(pool: DbPool, settings: &InitializationSettings) -> InitResult
         return Err(err_msg);
     }
 
-    let created = bootstrap_default_admin_if_required(&pool, settings, || {
+    let created = bootstrap_default_admin_if_required(&pool, settings, || async {
         let default_password = generate_random_password(32);
-        hash_password(&default_password)
+        hash_password_async(default_password)
+            .await
             .map_err(|error| format!("Failed to hash default administrator password: {error}"))
     })
     .await?;
@@ -57,13 +58,14 @@ pub async fn init(pool: DbPool, settings: &InitializationSettings) -> InitResult
     Ok(())
 }
 
-async fn bootstrap_default_admin_if_required<F>(
+async fn bootstrap_default_admin_if_required<F, Fut>(
     pool: &DbPool,
     settings: &InitializationSettings,
     hash_default_password: F,
 ) -> Result<bool, InitError>
 where
-    F: FnOnce() -> Result<String, InitError>,
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<String, InitError>>,
 {
     let required = default_admin_bootstrap_required(pool)
         .await
@@ -72,7 +74,7 @@ where
         return Ok(false);
     }
 
-    let hashed_password = hash_default_password()?;
+    let hashed_password = hash_default_password().await?;
     bootstrap_default_admin(pool, &settings.admin_groupname, &hashed_password)
         .await
         .map_err(|error| format!("Failed to bootstrap default administrator: {error}"))
@@ -91,7 +93,7 @@ mod tests {
         let settings = InitializationSettings::new("unused-admin-group").unwrap();
         let hash_attempted = AtomicBool::new(false);
 
-        let created = bootstrap_default_admin_if_required(&context.pool, &settings, || {
+        let created = bootstrap_default_admin_if_required(&context.pool, &settings, || async {
             hash_attempted.store(true, Ordering::SeqCst);
             Ok("unused-password-hash".to_string())
         })

--- a/src/utilities/json_schema.rs
+++ b/src/utilities/json_schema.rs
@@ -1,0 +1,133 @@
+use std::num::NonZeroUsize;
+use std::sync::{Arc, OnceLock, RwLock};
+
+use lru::LruCache;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::errors::ApiError;
+
+const JSON_SCHEMA_CACHE_MAX_ENTRIES: usize = 128;
+
+type SchemaDigest = [u8; 32];
+
+static JSON_SCHEMA_CACHE: OnceLock<RwLock<LruCache<SchemaDigest, Arc<jsonschema::Validator>>>> =
+    OnceLock::new();
+
+fn schema_cache() -> &'static RwLock<LruCache<SchemaDigest, Arc<jsonschema::Validator>>> {
+    JSON_SCHEMA_CACHE.get_or_init(|| {
+        let capacity = NonZeroUsize::new(JSON_SCHEMA_CACHE_MAX_ENTRIES)
+            .expect("JSON_SCHEMA_CACHE_MAX_ENTRIES must be non-zero");
+        RwLock::new(LruCache::new(capacity))
+    })
+}
+
+fn schema_digest(schema: &Value) -> Result<SchemaDigest, ApiError> {
+    let encoded = serde_json::to_vec(schema).map_err(|error| {
+        ApiError::BadRequest(format!("JSON schema could not be encoded: {error}"))
+    })?;
+    Ok(Sha256::digest(encoded).into())
+}
+
+fn validate_reference_policy(value: &Value) -> Result<(), ApiError> {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                validate_reference_policy(value)?;
+            }
+        }
+        Value::Object(object) => {
+            for (key, value) in object {
+                if matches!(key.as_str(), "$ref" | "$dynamicRef" | "$recursiveRef") {
+                    let reference = value.as_str().ok_or_else(|| {
+                        ApiError::BadRequest(format!("JSON schema {key} must be a string"))
+                    })?;
+                    if !reference.starts_with('#') {
+                        return Err(ApiError::BadRequest(format!(
+                            "JSON schema {key} must be a local fragment reference"
+                        )));
+                    }
+                }
+                validate_reference_policy(value)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+pub fn compile_json_schema(schema: &Value) -> Result<Arc<jsonschema::Validator>, ApiError> {
+    validate_reference_policy(schema)?;
+    let digest = schema_digest(schema)?;
+
+    if let Some(validator) = schema_cache()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&digest)
+        .cloned()
+    {
+        return Ok(validator);
+    }
+
+    let validator = Arc::new(
+        jsonschema::options()
+            .build(schema)
+            .map_err(|error| ApiError::BadRequest(format!("Invalid JSON schema: {error}")))?,
+    );
+    schema_cache()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .put(digest, validator.clone());
+    Ok(validator)
+}
+
+pub fn validate_json_schema(schema: &Value) -> Result<(), ApiError> {
+    jsonschema::meta::validate(schema)
+        .map_err(|error| ApiError::BadRequest(format!("Invalid JSON schema: {error}")))
+}
+
+pub fn validate_json_value(schema: &Value, value: &Value) -> Result<(), ApiError> {
+    compile_json_schema(schema)?
+        .validate(value)
+        .map_err(|error| ApiError::ValidationError(error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use serde_json::json;
+
+    use super::*;
+
+    #[rstest]
+    #[case(json!({"type": "object"}), true)]
+    #[case(json!({"type": 7}), false)]
+    #[case(json!({"$ref": "https://example.com/schema.json"}), true)]
+    #[case(json!({"$ref": "file:///etc/passwd"}), true)]
+    #[case(json!({"$ref": "#/definitions/local"}), true)]
+    fn schema_documents_are_validated_without_external_resolution(
+        #[case] schema: Value,
+        #[case] expected_valid: bool,
+    ) {
+        assert_eq!(validate_json_schema(&schema).is_ok(), expected_valid);
+    }
+
+    #[rstest]
+    #[case(json!({"$ref": "https://example.com/schema.json"}))]
+    #[case(json!({"$ref": "file:///etc/passwd"}))]
+    fn external_references_cannot_be_compiled_for_validation(#[case] schema: Value) {
+        assert!(compile_json_schema(&schema).is_err());
+    }
+
+    #[rstest]
+    #[case(json!({"name": "hubuum"}), true)]
+    #[case(json!({"name": 42}), false)]
+    fn compiled_schemas_validate_instances(#[case] value: Value, #[case] expected_valid: bool) {
+        let schema = json!({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"]
+        });
+        assert_eq!(validate_json_value(&schema, &value).is_ok(), expected_valid);
+    }
+}

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -4,6 +4,7 @@ pub mod db;
 pub mod exporting;
 pub mod extensions;
 pub mod init;
+pub mod json_schema;
 
 pub fn is_valid_log_level(level: &str) -> bool {
     matches!(level, "error" | "warn" | "info" | "debug" | "trace")


### PR DESCRIPTION
## Summary

- validate class JSON Schemas as schema documents, reject non-local references for active object validation, and cache compiled local schemas with a bounded LRU
- bound Argon2 hashing and verification work through a shared semaphore and blocking worker pool
- replace generated JSON audit-visibility predicates with an indexed related-collection projection and transactional PostgreSQL notification delivery
- enforce typed event-route identifiers and verify that objects belong to the requested class
- move Diesel/PostgreSQL-heavy metadata, search, and token operations behind backend traits, while removing obsolete APIs and dead-code suppressions
- update tests, OpenAPI, operational documentation, and the Unreleased changelog

## Why

The review found several correctness, security, and performance risks whose common cause was that important invariants were enforced inconsistently across API, import, and restore paths. Schema compilation could resolve external resources, password work had no process-wide concurrency bound, audit visibility rebuilt predicates from JSON for every request, and notification behavior had two competing producers.

This change centralizes those invariants at the domain and database boundaries, adds database support for efficient audit visibility, and removes code made obsolete by the new boundaries.

## User and developer impact

- **Breaking:** class schemas used for object validation may contain only local `#...` references. External HTTP/file references, dynamic references, and recursive references must be inlined before validation is enabled.
- Stored schemas are always checked as valid JSON Schema documents. Disabled schemas may still retain otherwise valid documents containing unresolved references.
- The new migration backfills related collection IDs for existing audit events and maintains the projection for new events with a trigger.
- PostgreSQL commit/rollback semantics now determine event fan-out; rolled-back events do not produce notifications.
- Event convenience routes return `404` when the object is not part of the class named by the route.

## Verification

- `source .env && ./run_tests.sh` — 1,215 passed, 6 ignored
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- regenerated `docs/openapi.json` and passed the OpenAPI regression tests
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`
- `git diff --check`
