### PR TITLE
Add PostgreSQL storage performance baselines

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   benchmarks:
-    name: Benchmarks
+    name: Self-contained benchmarks
     uses: terjekv/github-action-iai-callgrind/.github/workflows/rust-pr-bench.yml@v2
     secrets: inherit
     with:
@@ -25,3 +25,88 @@ jobs:
         [
           {"name":"default","features":""}
         ]
+
+  postgres-storage:
+    name: PostgreSQL storage benchmarks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:17-alpine
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      BASE_DATABASE_URL: postgres://postgres:postgres@localhost:5432/hubuum_bench_base
+      HEAD_DATABASE_URL: postgres://postgres:postgres@localhost:5432/hubuum_bench_head
+      CARGO_TARGET_DIR: target
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Cache Cargo and target directories
+        uses: Swatinem/rust-cache@v2
+      - name: Install PostgreSQL build tools
+        run: |
+          sudo apt-get update --yes
+          sudo apt-get install --yes libpq-dev
+      - name: Create isolated benchmark databases
+        env:
+          PGPASSWORD: postgres
+        run: |
+          createdb --host localhost --username postgres hubuum_bench_base
+          createdb --host localhost --username postgres hubuum_bench_head
+      - name: Clear cached PostgreSQL benchmark results
+        run: rm -rf target/criterion/storage_postgres
+      - name: Detect an existing base benchmark
+        id: base_benchmark
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if git cat-file -e "$BASE_SHA:benches/postgres/storage_postgres_criterion.rs" 2>/dev/null; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Record base benchmark
+        if: steps.base_benchmark.outputs.available == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HUBUUM_BENCH_DATABASE_URL: ${{ env.BASE_DATABASE_URL }}
+        run: |
+          git checkout --detach "$BASE_SHA"
+          cargo run --locked --features embedded-migrations --bin hubuum-admin -- \
+            --migrate --database-url "$BASE_DATABASE_URL"
+          cargo bench --locked --features postgres-bench \
+            --bench storage_postgres_criterion -- \
+            --save-baseline pr-base --noplot --sample-size 40 --measurement-time 4
+      - name: Record and compare pull-request benchmark
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HUBUUM_BENCH_DATABASE_URL: ${{ env.HEAD_DATABASE_URL }}
+          BASE_AVAILABLE: ${{ steps.base_benchmark.outputs.available }}
+        run: |
+          git checkout --detach "$HEAD_SHA"
+          cargo run --locked --features embedded-migrations --bin hubuum-admin -- \
+            --migrate --database-url "$HEAD_DATABASE_URL"
+          if [[ "$BASE_AVAILABLE" == "true" ]]; then
+            cargo bench --locked --features postgres-bench \
+              --bench storage_postgres_criterion -- \
+              --baseline pr-base --noplot --sample-size 40 --measurement-time 4
+          else
+            cargo bench --locked --features postgres-bench \
+              --bench storage_postgres_criterion -- \
+              --save-baseline initial --noplot --sample-size 40 --measurement-time 4
+            echo "Initial PostgreSQL storage baseline recorded; base comparison starts after merge." \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Enforce credible PostgreSQL regressions
+        if: steps.base_benchmark.outputs.available == 'true'
+        run: scripts/check-criterion-regressions.sh target/criterion/storage_postgres 10 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,18 +233,6 @@ jobs:
             target: aarch64-apple-darwin
         toolchain:
           - stable
-          - beta
-          - nightly
-        exclude:
-          # Only test stable on Windows and macOS to reduce runner costs
-          - platform: { os_name: Windows-x86_64, os: windows-latest, target: x86_64-pc-windows-msvc }
-            toolchain: beta
-          - platform: { os_name: Windows-x86_64, os: windows-latest, target: x86_64-pc-windows-msvc }
-            toolchain: nightly
-          - platform: { os_name: macOS, os: macos-latest, target: aarch64-apple-darwin }
-            toolchain: beta
-          - platform: { os_name: macOS, os: macos-latest, target: aarch64-apple-darwin }
-            toolchain: nightly
     steps:
       - name: Check out repository
         uses: actions/checkout@v7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,13 @@ valkey = ["dep:hubuum-event-sink-valkey", "login-rate-limit-valkey"]
 permissions-treetop = ["dep:treetop-client"]
 embedded-migrations = ["dep:diesel_migrations", "pq-sys/bundled"]
 vendored-openssl = ["openssl/vendored"]
+# Test/diagnostic-only Diesel instrumentation used by PostgreSQL query-budget
+# checks. Keeping this opt-in avoids adding instrumentation work to production
+# pool checkouts.
+query-capture = []
+# Enables the opt-in PostgreSQL Criterion target. It remains separate from the
+# self-contained benchmark fan-out because it needs a migrated database.
+postgres-bench = []
 
 [profile.release]
 codegen-units = 1
@@ -186,3 +193,9 @@ harness = false
 [[bench]]
 name = "password_hashing_criterion"
 harness = false
+
+[[bench]]
+name = "storage_postgres_criterion"
+path = "benches/postgres/storage_postgres_criterion.rs"
+harness = false
+required-features = ["postgres-bench"]

--- a/benches/postgres/storage_postgres_criterion.rs
+++ b/benches/postgres/storage_postgres_criterion.rs
@@ -1,0 +1,193 @@
+use std::hint::black_box;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use hubuum::db::{DbPool, ensure_database_schema_ready, init_pool_with_statement_timeout};
+use hubuum::events::EventContext;
+use hubuum::models::{
+    Collection, CollectionID, Group, NewCollectionWithAssignee, NewGroup, collection_ancestors,
+};
+use hubuum::traits::{CanDelete, CanSave, CollectionAccessors};
+use tokio::runtime::{Builder, Runtime};
+
+static NEXT_NAME_ID: AtomicU64 = AtomicU64::new(1);
+
+fn unique_name(prefix: &str) -> String {
+    let id = NEXT_NAME_ID.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{}-{id}", std::process::id())
+}
+
+fn benchmark_database_url() -> Option<String> {
+    std::env::var("HUBUUM_BENCH_DATABASE_URL").ok()
+}
+
+fn runtime() -> Runtime {
+    Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("benchmark runtime should build")
+}
+
+struct StorageFixture {
+    pool: DbPool,
+    owner_group: Group,
+    collections: Vec<Collection>,
+}
+
+impl StorageFixture {
+    fn new(runtime: &Runtime, database_url: &str) -> Self {
+        let pool = {
+            let _runtime_guard = runtime.enter();
+            init_pool_with_statement_timeout(database_url, 4, 0)
+        };
+        runtime
+            .block_on(ensure_database_schema_ready(&pool))
+            .expect("benchmark database should be migrated");
+
+        let owner_group = runtime
+            .block_on(
+                NewGroup {
+                    identity_scope: None,
+                    groupname: unique_name("storage-bench-group"),
+                    description: Some("PostgreSQL storage benchmark owner".to_string()),
+                }
+                .save_without_events(&pool),
+            )
+            .expect("benchmark owner group should save");
+
+        let first = runtime
+            .block_on(
+                NewCollectionWithAssignee {
+                    name: unique_name("storage-bench-collection"),
+                    description: "PostgreSQL storage point-read benchmark".to_string(),
+                    group_id: owner_group.id,
+                    parent_collection_id: None,
+                }
+                .save_without_events(&pool),
+            )
+            .expect("benchmark collection should save");
+        let mut collections = vec![first];
+
+        for depth in 1..=16 {
+            let parent_id = collections.last().expect("parent collection").id;
+            let collection = runtime
+                .block_on(
+                    NewCollectionWithAssignee {
+                        name: unique_name(&format!("storage-bench-depth-{depth}")),
+                        description: format!("PostgreSQL storage ancestor level {depth}"),
+                        group_id: owner_group.id,
+                        parent_collection_id: Some(
+                            CollectionID::new(parent_id).expect("valid parent id"),
+                        ),
+                    }
+                    .save_without_events(&pool),
+                )
+                .expect("nested benchmark collection should save");
+            collections.push(collection);
+        }
+
+        Self {
+            pool,
+            owner_group,
+            collections,
+        }
+    }
+
+    fn point_read_id(&self) -> CollectionID {
+        CollectionID::new(self.collections[0].id).expect("valid point-read id")
+    }
+
+    fn leaf_id(&self) -> CollectionID {
+        CollectionID::new(self.collections.last().expect("leaf collection").id)
+            .expect("valid leaf id")
+    }
+
+    fn cleanup_created_collection(&self, runtime: &Runtime, collection: &Collection) {
+        runtime
+            .block_on(collection.delete_without_events(&self.pool))
+            .expect("created benchmark collection should delete");
+    }
+
+    fn cleanup(self, runtime: &Runtime) {
+        for collection in self.collections.iter().rev() {
+            runtime
+                .block_on(collection.delete_without_events(&self.pool))
+                .expect("benchmark collection should delete");
+        }
+        runtime
+            .block_on(self.owner_group.delete_without_events(&self.pool))
+            .expect("benchmark owner group should delete");
+    }
+}
+
+fn benchmark_postgres_storage(c: &mut Criterion) {
+    let Some(database_url) = benchmark_database_url() else {
+        eprintln!(
+            "Skipping storage_postgres_criterion: set HUBUUM_BENCH_DATABASE_URL to a migrated, \
+             disposable benchmark database"
+        );
+        return;
+    };
+
+    let runtime = runtime();
+    let fixture = StorageFixture::new(&runtime, &database_url);
+    let point_read_id = fixture.point_read_id();
+    let leaf_id = fixture.leaf_id();
+
+    runtime
+        .block_on(point_read_id.collection(&fixture.pool))
+        .expect("point-read warmup should succeed");
+    runtime
+        .block_on(collection_ancestors(&fixture.pool, leaf_id))
+        .expect("ancestor warmup should succeed");
+
+    let mut group = c.benchmark_group("storage_postgres");
+    group.bench_function("collection_point_read", |b| {
+        b.iter(|| {
+            let collection = runtime
+                .block_on(black_box(point_read_id).collection(black_box(&fixture.pool)))
+                .expect("point read should succeed");
+            black_box(collection);
+        });
+    });
+    group.bench_function("collection_ancestors_depth_16", |b| {
+        b.iter(|| {
+            let ancestors = runtime
+                .block_on(collection_ancestors(
+                    black_box(&fixture.pool),
+                    black_box(leaf_id),
+                ))
+                .expect("ancestor read should succeed");
+            black_box(ancestors);
+        });
+    });
+    group.bench_function("collection_create_with_event", |b| {
+        b.iter_custom(|iterations| {
+            let mut measured = Duration::ZERO;
+            for _ in 0..iterations {
+                let command = NewCollectionWithAssignee {
+                    name: unique_name("storage-bench-create"),
+                    description: "PostgreSQL storage create benchmark".to_string(),
+                    group_id: fixture.owner_group.id,
+                    parent_collection_id: Some(point_read_id),
+                };
+                let started = Instant::now();
+                let collection = runtime
+                    .block_on(command.save(&fixture.pool, &EventContext::system()))
+                    .expect("timed collection create should succeed");
+                measured += started.elapsed();
+
+                fixture.cleanup_created_collection(&runtime, &collection);
+            }
+            measured
+        });
+    });
+    group.finish();
+
+    fixture.cleanup(&runtime);
+}
+
+criterion_group!(benches, benchmark_postgres_storage);
+criterion_main!(benches);

--- a/docs/development.md
+++ b/docs/development.md
@@ -122,12 +122,54 @@ cargo bench --bench password_hashing_criterion -- --noplot
 
 `iai-callgrind` requires `valgrind` to be installed locally.
 
+The PostgreSQL storage benchmark is opt-in and requires an empty, migrated,
+disposable benchmark database. Fixture creation, cleanup, and warmup happen
+outside the timed regions. The create scenario intentionally leaves its
+append-only audit events behind:
+
+```bash
+export HUBUUM_BENCH_DATABASE_URL=postgres://postgres:postgres@localhost/hubuum_bench
+cargo run --features embedded-migrations --bin hubuum-admin -- \
+  --migrate --database-url "$HUBUUM_BENCH_DATABASE_URL"
+cargo bench --features postgres-bench \
+  --bench storage_postgres_criterion -- --noplot
+```
+
+The deterministic PostgreSQL query budgets use the normal isolated test
+database runner. The central storage suite covers point reads, hierarchy and
+permission traversal, paginated object and history reads, and event-producing
+writes:
+
+```bash
+source .env && ./run_tests.sh storage_performance
+```
+
+Import planning, export hydration, and event fan-out budgets live beside those
+private execution paths and run as part of the full test suite. Fixed-size
+operations pin exact domain, transaction-control, query-fingerprint, and
+connection-checkout counts. Cardinality tests compare small and large inputs to
+pin either constant query shapes or an explicit bounded-linear slope.
+
+The capture excludes the pool's internal `SELECT $1` checkout-validation probe
+from application query totals. Each checkout is counted separately, which
+keeps pool-use regressions visible without attributing a connection-health
+query nondeterministically to the next operation.
+
 ### CI behavior
 
-- The benchmark workflow runs both backends in one combined `backend: all` job, so PRs get a single consolidated benchmark export.
+- The self-contained benchmark job runs both backends in one combined
+  `backend: all` job, so PRs get a single consolidated benchmark export.
 - `iai-callgrind` remains the practical gating signal with a low regression threshold.
 - Criterion still runs in the same combined job, but uses a very high regression threshold so it exports timing changes without acting as a meaningful gate.
-- The current benchmark set is fully self-contained and does not require a database in CI.
+- A separate PostgreSQL 17 job runs storage Criterion benchmarks against
+  isolated base and pull-request databases. It warns above a 10% median change
+  and fails above 20% only when the 95% confidence interval also indicates a
+  regression.
+- The PostgreSQL query-budget tests are the stricter gate: fixed operation
+  totals, control/domain splits, query fingerprints, connection checkouts, and
+  declared scaling slopes must remain stable.
+- On the harness's first pull request there is no base target to execute, so CI
+  records the initial baseline. Later pull requests compare base and head.
 
 ### Adding or modifying benchmarks
 
@@ -137,4 +179,10 @@ cargo bench --bench password_hashing_criterion -- --noplot
 - Include `callgrind` in the benchmark filename when it should be auto-discovered by the CI workflow.
 - Include `criterion` in the benchmark filename when it should be Criterion-only in CI autodiscovery.
 - Prefer deterministic library-level code paths such as parsers, query builders, and serialization helpers over handlers that require network or database setup.
+- Put database-backed targets behind the `postgres-bench` feature so the
+  self-contained benchmark fan-out does not try to execute them without a
+  database.
+- Seed, migrate, warm, and clean PostgreSQL fixtures outside measured regions.
+  Mutation benchmarks run last against fresh isolated base/head databases;
+  emitted audit events remain append-only, as they do in production.
 - Avoid code paths that read the global `CONFIG` (the clap-backed application configuration). Initialising it inside a benchmark binary panics on the harness's own CLI arguments (for example `--iai-run`). Where a function needs configuration values such as page limits, prefer a config-free entry point that takes them as parameters (see `parse_unified_search_query_with_limits` and `validate_page_limit_with_max`).

--- a/scripts/check-criterion-regressions.sh
+++ b/scripts/check-criterion-regressions.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+criterion_dir="${1:-target/criterion}"
+warning_threshold_pct="${2:-10}"
+failure_threshold_pct="${3:-20}"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required to evaluate Criterion comparison results" >&2
+    exit 2
+fi
+
+result_count=0
+failure_count=0
+
+while IFS= read -r estimate_file; do
+    result_count=$((result_count + 1))
+    benchmark="${estimate_file#"$criterion_dir"/}"
+    benchmark="${benchmark%/change/estimates.json}"
+    median_pct="$(jq -r '.median.point_estimate * 100' "$estimate_file")"
+    lower_pct="$(jq -r '.median.confidence_interval.lower_bound * 100' "$estimate_file")"
+    credible_failure="$(
+        jq -r --argjson threshold "$failure_threshold_pct" \
+            '(.median.point_estimate * 100 > $threshold) and
+             (.median.confidence_interval.lower_bound > 0)' \
+            "$estimate_file"
+    )"
+    warning="$(
+        jq -r --argjson threshold "$warning_threshold_pct" \
+            '.median.point_estimate * 100 > $threshold' \
+            "$estimate_file"
+    )"
+
+    printf '%s: median change %.2f%% (95%% CI lower bound %.2f%%)\n' \
+        "$benchmark" "$median_pct" "$lower_pct"
+
+    if [[ "$credible_failure" == "true" ]]; then
+        failure_count=$((failure_count + 1))
+        echo "::error title=PostgreSQL benchmark regression::$benchmark regressed by ${median_pct}%"
+    elif [[ "$warning" == "true" ]]; then
+        echo "::warning title=PostgreSQL benchmark warning::$benchmark changed by ${median_pct}%"
+    fi
+done < <(find "$criterion_dir" -type f -path '*/change/estimates.json' | sort)
+
+if [[ "$result_count" -eq 0 ]]; then
+    echo "No Criterion base/head comparison results were found under $criterion_dir" >&2
+    exit 2
+fi
+
+if [[ "$failure_count" -gt 0 ]]; then
+    echo "$failure_count credible PostgreSQL benchmark regression(s) exceeded ${failure_threshold_pct}%" >&2
+    exit 1
+fi
+
+echo "PostgreSQL benchmark comparison passed ($result_count result(s))."

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,10 @@
 pub mod traits;
 
+#[cfg(any(test, feature = "query-capture"))]
+mod query_capture;
+#[cfg(any(test, feature = "query-capture"))]
+pub use query_capture::{QueryCaptureSnapshot, capture_queries};
+
 /// Diesel query-building traits paired with diesel-async's I/O traits.
 ///
 /// Importing this prelude avoids bringing the synchronous `Connection` and
@@ -287,6 +292,10 @@ async fn acquire_connection(pool: &DbPool) -> Result<PooledConnection<'_, DbConn
     let start = std::time::Instant::now();
     match pool.get().await {
         Ok(conn) => {
+            #[cfg(any(test, feature = "query-capture"))]
+            let mut conn = conn;
+            #[cfg(any(test, feature = "query-capture"))]
+            query_capture::configure_connection(&mut conn);
             metrics::db_connection_acquired(start.elapsed());
             Ok(conn)
         }

--- a/src/db/query_capture.rs
+++ b/src/db/query_capture.rs
@@ -1,0 +1,217 @@
+//! Opt-in PostgreSQL query capture for deterministic performance tests.
+//!
+//! Capture is task-scoped and installed on every pool checkout. This lets one
+//! snapshot cover an operation that acquires several connections while also
+//! clearing stale instrumentation before a pooled connection is reused.
+
+use std::collections::{BTreeMap, HashMap};
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use diesel::connection::{Instrumentation, InstrumentationEvent};
+use diesel_async::AsyncConnection;
+
+use super::{DbConnection, PooledConnection};
+
+tokio::task_local! {
+    static ACTIVE_QUERY_CAPTURE_ID: u64;
+}
+
+static NEXT_QUERY_CAPTURE_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct QueryCaptureSnapshot {
+    total_queries: usize,
+    control_queries: usize,
+    connection_checkouts: usize,
+    query_counts: BTreeMap<String, usize>,
+}
+
+impl QueryCaptureSnapshot {
+    pub fn total_queries(&self) -> usize {
+        self.total_queries
+    }
+
+    pub fn control_queries(&self) -> usize {
+        self.control_queries
+    }
+
+    pub fn domain_queries(&self) -> usize {
+        self.total_queries.saturating_sub(self.control_queries)
+    }
+
+    pub fn connection_checkouts(&self) -> usize {
+        self.connection_checkouts
+    }
+
+    pub fn query_counts(&self) -> &BTreeMap<String, usize> {
+        &self.query_counts
+    }
+
+    pub fn queries_matching(&self, needle: &str) -> usize {
+        self.query_counts
+            .iter()
+            .filter(|(query, _)| query.contains(needle))
+            .map(|(_, count)| *count)
+            .sum()
+    }
+}
+
+#[derive(Default)]
+struct QueryCaptureRegistry {
+    captures: HashMap<u64, QueryCaptureSnapshot>,
+}
+
+fn registry() -> &'static Mutex<QueryCaptureRegistry> {
+    static REGISTRY: OnceLock<Mutex<QueryCaptureRegistry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(QueryCaptureRegistry::default()))
+}
+
+fn normalize_query(query: &str) -> String {
+    query
+        .split_once(" -- binds:")
+        .map_or(query, |(statement, _)| statement)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn is_control_query(query: &str) -> bool {
+    let query = query.trim_start().to_ascii_uppercase();
+    [
+        "BEGIN",
+        "COMMIT",
+        "ROLLBACK",
+        "SAVEPOINT",
+        "RELEASE SAVEPOINT",
+        "SET TRANSACTION",
+        "SELECT SET_CONFIG(",
+    ]
+    .iter()
+    .any(|prefix| query.starts_with(prefix))
+}
+
+fn is_pool_validation_query(query: &str) -> bool {
+    query == "SELECT $1"
+}
+
+fn active_capture_id() -> Option<u64> {
+    ACTIVE_QUERY_CAPTURE_ID.try_with(|id| *id).ok()
+}
+
+fn record_query(capture_id: u64, query: &str) {
+    let query = normalize_query(query);
+    // bb8's test-on-checkout probe runs before `acquire_connection` can replace
+    // instrumentation on a reused connection. Pool use is captured separately
+    // through `connection_checkouts`, so do not attribute this internal probe
+    // to the application operation that happens to receive the connection.
+    if is_pool_validation_query(&query) {
+        return;
+    }
+    let mut registry = registry()
+        .lock()
+        .expect("query capture registry should not be poisoned");
+    let Some(snapshot) = registry.captures.get_mut(&capture_id) else {
+        // A pooled connection may retain instrumentation after its capture has
+        // ended. Ignore that stale id until the next checkout reconfigures it.
+        return;
+    };
+    snapshot.total_queries += 1;
+    if is_control_query(&query) {
+        snapshot.control_queries += 1;
+    }
+    *snapshot.query_counts.entry(query).or_insert(0) += 1;
+}
+
+fn record_connection_checkout(capture_id: u64) {
+    let mut registry = registry()
+        .lock()
+        .expect("query capture registry should not be poisoned");
+    registry
+        .captures
+        .entry(capture_id)
+        .or_default()
+        .connection_checkouts += 1;
+}
+
+struct QueryCaptureInstrumentation {
+    capture_id: Option<u64>,
+}
+
+impl Instrumentation for QueryCaptureInstrumentation {
+    fn on_connection_event(&mut self, event: InstrumentationEvent<'_>) {
+        let Some(capture_id) = self.capture_id else {
+            return;
+        };
+        if let InstrumentationEvent::StartQuery { query, .. } = event {
+            record_query(capture_id, &query.to_string());
+        }
+    }
+}
+
+pub(super) fn configure_connection(conn: &mut PooledConnection<'_, DbConnection>) {
+    let capture_id = active_capture_id();
+    if let Some(capture_id) = capture_id {
+        record_connection_checkout(capture_id);
+    }
+    conn.set_instrumentation(QueryCaptureInstrumentation { capture_id });
+}
+
+/// Capture every Diesel query started by `future` on the current task.
+///
+/// Fixture setup should happen before entering this scope. Futures polled on
+/// the same task, including `join!` branches, inherit the capture; independently
+/// spawned tasks intentionally do not.
+pub async fn capture_queries<T>(future: impl Future<Output = T>) -> (T, QueryCaptureSnapshot) {
+    let capture_id = NEXT_QUERY_CAPTURE_ID.fetch_add(1, Ordering::Relaxed);
+    registry()
+        .lock()
+        .expect("query capture registry should not be poisoned")
+        .captures
+        .insert(capture_id, QueryCaptureSnapshot::default());
+
+    let output = ACTIVE_QUERY_CAPTURE_ID.scope(capture_id, future).await;
+    let snapshot = registry()
+        .lock()
+        .expect("query capture registry should not be poisoned")
+        .captures
+        .remove(&capture_id)
+        .unwrap_or_default();
+
+    (output, snapshot)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_control_query, is_pool_validation_query, normalize_query};
+
+    #[test]
+    fn query_normalization_collapses_whitespace() {
+        assert_eq!(
+            normalize_query("SELECT  *\n  FROM widgets\tWHERE id = $1 -- binds: [42]"),
+            "SELECT * FROM widgets WHERE id = $1"
+        );
+    }
+
+    #[test]
+    fn transaction_and_session_statements_are_control_queries() {
+        for query in [
+            "BEGIN",
+            "COMMIT",
+            "ROLLBACK",
+            "SAVEPOINT diesel_savepoint_1",
+            "RELEASE SAVEPOINT diesel_savepoint_1",
+            "SELECT set_config('statement_timeout', $1, true)",
+        ] {
+            assert!(is_control_query(query), "expected control query: {query}");
+        }
+        assert!(!is_control_query("SELECT * FROM collections"));
+    }
+
+    #[test]
+    fn pool_validation_probe_is_not_an_application_query() {
+        assert!(is_pool_validation_query("SELECT $1"));
+        assert!(!is_pool_validation_query("SELECT * FROM collections"));
+    }
+}

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -18,6 +18,7 @@ use crate::db::traits::event_delivery::{
 };
 use crate::db::traits::event_fanout::{
     EventFanoutSettings, claim_events_for_fanout, count_event_deliveries_for_event, fanout_event,
+    fanout_events,
 };
 use crate::db::traits::event_retention::{
     EventRetentionSettings, purge_event_retention_without_archive,
@@ -27,7 +28,7 @@ use crate::db::traits::remote_target::{
     DeleteRemoteTargetRecord, SaveRemoteTargetRecord, UpdateRemoteTargetRecord,
     emit_remote_target_invoked_event,
 };
-use crate::db::{with_connection, with_transaction};
+use crate::db::{capture_queries, with_connection, with_transaction};
 use crate::errors::ApiError;
 use crate::events::{
     Action, ActorKind, EntityType, Event, EventContext, NewEvent, RequestProvenance, emit_event,
@@ -436,6 +437,67 @@ async fn event_fanout_creates_delivery_for_each_matching_subscription_once() {
             .unwrap(),
         2
     );
+}
+
+#[actix_web::test]
+async fn event_fanout_query_growth_is_bounded_to_one_insert_per_event() {
+    let scope = test_scope();
+    let fixture = scope.with_collection().await;
+    create_collection_event_subscription(
+        &scope,
+        fixture.collection.id,
+        "fanout_query_budget",
+        true,
+    )
+    .await;
+    let small_event = emit_collection_created_event(&scope, fixture.collection.id).await;
+    let mut large_events = Vec::new();
+    for _ in 0..10 {
+        large_events.push(emit_collection_created_event(&scope, fixture.collection.id).await);
+    }
+
+    let (small_result, small_queries) =
+        capture_queries(fanout_events(&scope.pool, &[small_event.id])).await;
+    assert_eq!(small_result.expect("small fanout should succeed"), 1);
+
+    let large_event_ids = large_events
+        .iter()
+        .map(|event| event.id)
+        .collect::<Vec<_>>();
+    let (large_result, large_queries) =
+        capture_queries(fanout_events(&scope.pool, &large_event_ids)).await;
+    assert_eq!(large_result.expect("large fanout should succeed"), 10);
+
+    assert_eq!(
+        small_queries.total_queries(),
+        7,
+        "{:#?}",
+        small_queries.query_counts()
+    );
+    assert_eq!(small_queries.domain_queries(), 5);
+    assert_eq!(small_queries.control_queries(), 2);
+    assert_eq!(small_queries.connection_checkouts(), 1);
+    assert_eq!(
+        large_queries.total_queries(),
+        16,
+        "{:#?}",
+        large_queries.query_counts()
+    );
+    assert_eq!(large_queries.domain_queries(), 14);
+    assert_eq!(large_queries.control_queries(), 2);
+    assert_eq!(large_queries.connection_checkouts(), 1);
+    assert_eq!(
+        large_queries
+            .total_queries()
+            .saturating_sub(small_queries.total_queries()),
+        large_events.len().saturating_sub(1)
+    );
+    assert_eq!(
+        large_queries.queries_matching("INSERT INTO \"event_deliveries\""),
+        large_events.len()
+    );
+
+    fixture.cleanup().await.expect("fanout fixture cleanup");
 }
 
 #[actix_web::test]

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -2167,15 +2167,19 @@ mod tests {
     use crate::models::{
         ExportContentType, ExportInclude, ExportIncludeRelatedObject, ExportLimits,
         ExportMissingDataPolicy, ExportRelationContext, ExportRequest, ExportScope,
-        ExportScopeKind, ExportTemplate, ExportTemplateKind,
+        ExportScopeKind, ExportTemplate, ExportTemplateKind, NewHubuumClass,
+        NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, UserID,
     };
 
     use super::{
-        ExportRuntime, HydrationBudget, inferred_relation_alias, normalize_alias_segment,
-        pluralize_alias, take_related_within_budget, validate_export_limits,
-        validate_export_submission,
+        ExportRuntime, HydrationBudget, RelationHydrationPlan, build_template_items,
+        inferred_relation_alias, normalize_alias_segment, pluralize_alias,
+        take_related_within_budget, validate_export_limits, validate_export_submission,
     };
+    use crate::db::capture_queries;
     use crate::errors::ApiError;
+    use crate::tests::TestScope;
+    use crate::traits::CanSave;
 
     fn test_timestamp() -> chrono::NaiveDateTime {
         chrono::DateTime::from_timestamp(1_700_000_000, 0)
@@ -2307,6 +2311,157 @@ mod tests {
             }),
             collection_templates: Vec::new(),
         }
+    }
+
+    #[actix_web::test]
+    async fn object_hydration_query_count_is_constant_with_root_count() {
+        let scope = TestScope::new();
+        let fixture = scope
+            .collection_fixture("query_budget_export_hydration")
+            .await;
+        let host_class = NewHubuumClass {
+            collection_id: fixture.collection.id,
+            name: scope.scoped_name("query_budget_export_host"),
+            description: "query budget export host".to_string(),
+            json_schema: None,
+            validate_schema: None,
+        }
+        .save_without_events(&scope.pool)
+        .await
+        .expect("host class should save");
+        let room_class = NewHubuumClass {
+            collection_id: fixture.collection.id,
+            name: scope.scoped_name("query_budget_export_room"),
+            description: "query budget export room".to_string(),
+            json_schema: None,
+            validate_schema: None,
+        }
+        .save_without_events(&scope.pool)
+        .await
+        .expect("room class should save");
+        let class_relation = NewHubuumClassRelation {
+            from_hubuum_class_id: host_class.id,
+            to_hubuum_class_id: room_class.id,
+            forward_template_alias: Some("rooms".to_string()),
+            reverse_template_alias: Some("hosts".to_string()),
+        }
+        .save_without_events(&scope.pool)
+        .await
+        .expect("class relation should save");
+
+        let mut hosts = Vec::new();
+        for index in 0..10 {
+            let host = NewHubuumObject {
+                collection_id: fixture.collection.id,
+                hubuum_class_id: host_class.id,
+                name: scope.scoped_name(&format!("query_budget_export_host_{index:02}")),
+                description: "query budget export host".to_string(),
+                data: serde_json::json!({"index": index}),
+            }
+            .save_without_events(&scope.pool)
+            .await
+            .expect("host should save");
+            let room = NewHubuumObject {
+                collection_id: fixture.collection.id,
+                hubuum_class_id: room_class.id,
+                name: scope.scoped_name(&format!("query_budget_export_room_{index:02}")),
+                description: "query budget export room".to_string(),
+                data: serde_json::json!({"index": index}),
+            }
+            .save_without_events(&scope.pool)
+            .await
+            .expect("room should save");
+            NewHubuumObjectRelation {
+                from_hubuum_object_id: host.id,
+                to_hubuum_object_id: room.id,
+                class_relation_id: class_relation.id,
+            }
+            .save_without_events(&scope.pool)
+            .await
+            .expect("object relation should save");
+            hosts.push(serde_json::to_value(host).expect("host should serialize"));
+        }
+
+        let runtime = export_runtime(ExportRequest {
+            scope: ExportScope {
+                kind: ExportScopeKind::ObjectsInClass,
+                class_id: Some(host_class.id),
+                object_id: None,
+            },
+            query: None,
+            missing_data_policy: None,
+            limits: None,
+            include: None,
+            relation_context: Some(ExportRelationContext { depth: Some(1) }),
+        });
+        let subject = UserID::new(1).expect("valid synthetic runtime-admin subject id");
+
+        let (small_hydration, small_queries) = capture_queries(build_template_items(
+            &scope.pool,
+            &subject,
+            &runtime,
+            &hosts[..1],
+            Some(RelationHydrationPlan {
+                depth_limit: 1,
+                enabled_for_scope: true,
+            }),
+        ))
+        .await;
+        assert_eq!(
+            small_hydration
+                .expect("small hydration should succeed")
+                .0
+                .len(),
+            1
+        );
+
+        let (large_hydration, large_queries) = capture_queries(build_template_items(
+            &scope.pool,
+            &subject,
+            &runtime,
+            &hosts,
+            Some(RelationHydrationPlan {
+                depth_limit: 1,
+                enabled_for_scope: true,
+            }),
+        ))
+        .await;
+        assert_eq!(
+            large_hydration
+                .expect("large hydration should succeed")
+                .0
+                .len(),
+            10
+        );
+
+        assert_eq!(large_queries.total_queries(), small_queries.total_queries());
+        assert_eq!(
+            large_queries.domain_queries(),
+            small_queries.domain_queries()
+        );
+        assert_eq!(
+            large_queries.control_queries(),
+            small_queries.control_queries()
+        );
+        assert_eq!(
+            large_queries.connection_checkouts(),
+            small_queries.connection_checkouts()
+        );
+        assert_eq!(
+            large_queries.total_queries(),
+            6,
+            "{:#?}",
+            large_queries.query_counts()
+        );
+        assert_eq!(large_queries.domain_queries(), 6);
+        assert_eq!(large_queries.control_queries(), 0);
+        assert_eq!(large_queries.connection_checkouts(), 6);
+        assert_eq!(
+            large_queries.queries_matching("FROM \"hubuumclass_relation\""),
+            1
+        );
+
+        fixture.cleanup().await.expect("export fixture cleanup");
     }
 
     #[test]

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -9,7 +9,9 @@ use super::helpers::{
     class_to_resolution, planned_result, sanitize_error_for_storage,
     should_abort_best_effort_execution,
 };
-use super::planning::{plan_class, plan_collection, plan_import, plan_object};
+use super::planning::{
+    plan_class, plan_collection, plan_import, plan_object, plan_runtime_admin_import,
+};
 use super::request_hash;
 use super::resolution::{
     remember_class, remember_collection, resolve_class_planning, resolve_collection_by_id_planning,
@@ -25,7 +27,7 @@ use crate::db::traits::task_import::{
     create_class_db, create_object_db, upsert_export_template_db, upsert_group_membership_db,
     upsert_identity_scope_db,
 };
-use crate::db::with_connection;
+use crate::db::{capture_queries, with_connection};
 use crate::errors::ApiError;
 use crate::models::{
     CURRENT_IMPORT_VERSION, ClassKey, CollectionID, CollectionKey, ExportContentType,
@@ -33,8 +35,9 @@ use crate::models::{
     ImportCollisionPolicy, ImportExportTemplateInput, ImportGraph, ImportGroupMembershipInput,
     ImportIdentityScopeInput, ImportMembershipSourceInput, ImportMode, ImportObjectInput,
     ImportPermissionPolicy, ImportRemoteTargetInput, ImportRequest, NewCollectionWithAssignee,
-    NewImportTaskResultRecord, NewTaskRecord, ObjectKey, RemoteAuthConfig, RemoteHttpMethod,
-    RemoteTargetSubjectType, RestoreTimestamps, TaskKind, TaskStatus,
+    NewHubuumClass, NewHubuumObject, NewImportTaskResultRecord, NewTaskRecord, ObjectKey,
+    RemoteAuthConfig, RemoteHttpMethod, RemoteTargetSubjectType, RestoreTimestamps, TaskKind,
+    TaskStatus,
 };
 use crate::permissions::test_support::MockTreetopBackend;
 use crate::permissions::{AppContext, PermissionBackend};
@@ -43,6 +46,138 @@ use crate::schema::hubuumclass::dsl::{hubuumclass, name as class_name};
 use crate::schema::tasks::dsl::{created_at, id as task_id, tasks};
 use crate::tests::{TestContext, create_test_group};
 use crate::traits::CanSave;
+
+#[tokio::test]
+async fn import_planning_query_growth_is_bounded_per_object_in_one_class() {
+    let context = TestContext::new().await;
+    let fixture = context
+        .collection_fixture("query_budget_import_preload")
+        .await;
+    let class = NewHubuumClass {
+        collection_id: fixture.collection.id,
+        name: context.scoped_name("query_budget_import_class"),
+        description: "query budget import class".to_string(),
+        json_schema: None,
+        validate_schema: None,
+    }
+    .save_without_events(&context.pool)
+    .await
+    .expect("import class should save");
+    let mut objects = Vec::new();
+    for index in 0..20 {
+        objects.push(
+            NewHubuumObject {
+                collection_id: fixture.collection.id,
+                hubuum_class_id: class.id,
+                name: context.scoped_name(&format!("query_budget_import_object_{index:02}")),
+                description: "existing import object".to_string(),
+                data: serde_json::json!({"index": index}),
+            }
+            .save_without_events(&context.pool)
+            .await
+            .expect("import object should save"),
+        );
+    }
+
+    let request_for = |count: usize| ImportRequest {
+        version: CURRENT_IMPORT_VERSION,
+        dry_run: Some(false),
+        mode: Some(ImportMode {
+            collision_policy: Some(ImportCollisionPolicy::Overwrite),
+            ..ImportMode::default()
+        }),
+        graph: ImportGraph {
+            objects: objects
+                .iter()
+                .take(count)
+                .enumerate()
+                .map(|(index, object)| ImportObjectInput {
+                    ref_: Some(format!("object:query-budget-{index}")),
+                    name: object.name.clone(),
+                    description: "planned import update".to_string(),
+                    data: serde_json::json!({"index": index, "planned": true}),
+                    class_ref: None,
+                    class_key: Some(ClassKey {
+                        name: class.name.clone(),
+                        collection_ref: None,
+                        collection_key: Some(CollectionKey {
+                            name: fixture.collection.name.clone(),
+                            path: None,
+                        }),
+                    }),
+                })
+                .collect(),
+            ..ImportGraph::default()
+        },
+    };
+
+    let small_request = request_for(1);
+    let (small_plan, small_queries) = capture_queries(plan_runtime_admin_import(
+        &context.pool,
+        &context.admin_user,
+        &small_request,
+    ))
+    .await;
+    assert!(!small_plan.aborted);
+    assert!(small_plan.failures.is_empty());
+    assert_eq!(small_plan.planned_items.len(), 1);
+
+    let large_request = request_for(20);
+    let (large_plan, large_queries) = capture_queries(plan_runtime_admin_import(
+        &context.pool,
+        &context.admin_user,
+        &large_request,
+    ))
+    .await;
+    assert!(!large_plan.aborted);
+    assert!(large_plan.failures.is_empty());
+    assert_eq!(large_plan.planned_items.len(), 20);
+
+    // Current before-refactor shape: three fixed batch queries (collection,
+    // class, object), plus three collection-name resolutions per object across
+    // class preload, object preload, and object planning. Keep that slope
+    // explicit so a storage-boundary rewrite cannot make it worse unnoticed.
+    let fixed_queries = 3;
+    let queries_per_object = 3;
+    assert_eq!(
+        small_queries.total_queries(),
+        fixed_queries + queries_per_object,
+        "{:#?}",
+        small_queries.query_counts()
+    );
+    assert_eq!(
+        large_queries.total_queries(),
+        fixed_queries + queries_per_object * 20,
+        "{:#?}",
+        large_queries.query_counts()
+    );
+    assert_eq!(
+        small_queries.domain_queries(),
+        small_queries.total_queries()
+    );
+    assert_eq!(
+        large_queries.domain_queries(),
+        large_queries.total_queries()
+    );
+    assert_eq!(small_queries.control_queries(), 0);
+    assert_eq!(large_queries.control_queries(), 0);
+    assert_eq!(
+        small_queries.connection_checkouts(),
+        small_queries.total_queries()
+    );
+    assert_eq!(
+        large_queries.connection_checkouts(),
+        large_queries.total_queries()
+    );
+    assert_eq!(large_queries.queries_matching("FROM \"hubuumclass\""), 1);
+    assert_eq!(large_queries.queries_matching("FROM \"hubuumobject\""), 1);
+    assert_eq!(
+        large_queries.queries_matching("FROM \"collections\""),
+        queries_per_object * 20 + 1
+    );
+
+    fixture.cleanup().await.expect("import fixture cleanup");
+}
 
 #[tokio::test]
 async fn import_planning_uses_the_task_execution_permission_backend() {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8,6 +8,7 @@ pub mod docs_examples;
 pub mod id_newtypes;
 pub mod permissions;
 pub mod search;
+pub mod storage_performance;
 pub mod temporal;
 pub mod validation;
 pub mod workspace_boundaries;

--- a/src/tests/storage_performance.rs
+++ b/src/tests/storage_performance.rs
@@ -1,0 +1,469 @@
+//! Pre-refactor PostgreSQL query budgets for the storage boundary.
+//!
+//! These are deliberately model/storage-level checks rather than HTTP tests:
+//! authentication and routing should not hide an extra pool checkout or an
+//! N+1 introduced while storage capabilities are extracted.
+
+use crate::db::capture_queries;
+use crate::db::traits::history::{
+    collection_history_paginated_with_total_count, resolve_actor_usernames,
+};
+use crate::db::traits::user::UserSearchBackend;
+use crate::db::with_actor_scope;
+use crate::events::EventContext;
+use crate::models::collection::effective_group_on;
+use crate::models::search::parse_query_parameter;
+use crate::models::{
+    CollectionID, NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation,
+    NewHubuumObject, NewHubuumObjectRelation, UpdateCollection, UserID, collection_ancestors,
+};
+use crate::tests::{TestScope, ensure_admin_user};
+use crate::traits::{CanDelete, CanSave, CanUpdate, CollectionAccessors};
+
+fn assert_same_query_shape(
+    smaller: &crate::db::QueryCaptureSnapshot,
+    larger: &crate::db::QueryCaptureSnapshot,
+) {
+    assert_eq!(
+        larger.total_queries(),
+        smaller.total_queries(),
+        "small: {:#?}\nlarge: {:#?}",
+        smaller.query_counts(),
+        larger.query_counts()
+    );
+    assert_eq!(larger.domain_queries(), smaller.domain_queries());
+    assert_eq!(larger.control_queries(), smaller.control_queries());
+    assert_eq!(
+        larger.connection_checkouts(),
+        smaller.connection_checkouts()
+    );
+    assert_eq!(larger.query_counts(), smaller.query_counts());
+}
+
+#[actix_web::test]
+async fn collection_point_read_uses_one_query() {
+    let scope = TestScope::new();
+    let fixture = scope.collection_fixture("query_budget_point_read").await;
+    let collection_id = CollectionID::new(fixture.collection.id).expect("valid collection id");
+
+    let (loaded, queries) = capture_queries(collection_id.collection(&scope.pool)).await;
+    assert_eq!(loaded.expect("collection should load"), fixture.collection);
+    assert_eq!(queries.total_queries(), 1, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 1);
+    assert_eq!(queries.control_queries(), 0);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(queries.queries_matching("FROM \"collections\""), 1);
+
+    fixture.cleanup().await.expect("fixture cleanup");
+}
+
+#[actix_web::test]
+async fn collection_ancestor_query_count_is_constant_with_depth() {
+    let scope = TestScope::new();
+    let root_fixture = scope.collection_fixture("query_budget_ancestors").await;
+    let mut collections = vec![root_fixture.collection.clone()];
+
+    for depth in 1..=32 {
+        let parent = collections.last().expect("parent collection");
+        let collection = NewCollectionWithAssignee {
+            name: scope.scoped_name(&format!("query_budget_ancestor_{depth}")),
+            description: format!("query budget ancestor level {depth}"),
+            group_id: root_fixture.owner_group.id,
+            parent_collection_id: Some(
+                CollectionID::new(parent.id).expect("valid parent collection id"),
+            ),
+        }
+        .save_without_events(&scope.pool)
+        .await
+        .expect("collection should save");
+        collections.push(collection);
+    }
+
+    let shallow_id = CollectionID::new(collections[1].id).expect("valid shallow collection id");
+    let (shallow_ancestors, shallow_queries) =
+        capture_queries(collection_ancestors(&scope.pool, shallow_id)).await;
+    assert_eq!(shallow_ancestors.expect("shallow ancestors").len(), 2);
+
+    let leaf_id =
+        CollectionID::new(collections.last().expect("leaf").id).expect("valid leaf collection id");
+    let (ancestors, queries) = capture_queries(collection_ancestors(&scope.pool, leaf_id)).await;
+    let ancestors = ancestors.expect("ancestors should load");
+
+    assert_eq!(ancestors.len(), 33);
+    assert_eq!(queries.total_queries(), shallow_queries.total_queries());
+    assert_eq!(queries.domain_queries(), shallow_queries.domain_queries());
+    assert_eq!(queries.total_queries(), 1, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 1);
+    assert_eq!(queries.control_queries(), 0);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(queries.queries_matching("collection_closure"), 1);
+
+    for collection in collections.iter().skip(1).rev() {
+        collection
+            .delete_without_events(&scope.pool)
+            .await
+            .expect("nested collection cleanup");
+    }
+    root_fixture.cleanup().await.expect("root fixture cleanup");
+}
+
+#[actix_web::test]
+async fn collection_create_with_event_has_a_fixed_query_budget() {
+    let scope = TestScope::new();
+    let parent = scope.collection_fixture("query_budget_create_parent").await;
+    let command = NewCollectionWithAssignee {
+        name: scope.scoped_name("query_budget_create_child"),
+        description: "query budget create child".to_string(),
+        group_id: parent.owner_group.id,
+        parent_collection_id: Some(
+            CollectionID::new(parent.collection.id).expect("valid parent collection id"),
+        ),
+    };
+
+    let (created, queries) =
+        capture_queries(command.save(&scope.pool, &EventContext::system())).await;
+    let created = created.expect("collection should save with an event");
+
+    assert_eq!(queries.total_queries(), 7, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 5, "{:#?}", queries.query_counts());
+    assert_eq!(queries.control_queries(), 2);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(queries.queries_matching("SELECT \"collections\".\"id\""), 1);
+    assert_eq!(queries.queries_matching("INSERT INTO \"collections\""), 1);
+    assert_eq!(
+        queries.queries_matching("INSERT INTO collection_closure"),
+        1
+    );
+    assert_eq!(queries.queries_matching("INSERT INTO \"permissions\""), 1);
+    assert_eq!(queries.queries_matching("INSERT INTO \"events\""), 1);
+
+    created
+        .delete_without_events(&scope.pool)
+        .await
+        .expect("created collection cleanup");
+    parent.cleanup().await.expect("parent fixture cleanup");
+}
+
+#[actix_web::test]
+async fn collection_no_op_update_does_not_write_or_emit_an_event() {
+    let scope = TestScope::new();
+    let fixture = scope.collection_fixture("query_budget_no_op_update").await;
+    let update = UpdateCollection {
+        name: Some(fixture.collection.name.clone()),
+        description: Some(fixture.collection.description.clone()),
+    };
+
+    let (updated, queries) =
+        capture_queries(update.update(&scope.pool, fixture.collection.id, &EventContext::system()))
+            .await;
+    assert_eq!(
+        updated.expect("no-op update should return current row"),
+        fixture.collection
+    );
+
+    assert_eq!(queries.total_queries(), 3, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 1, "{:#?}", queries.query_counts());
+    assert_eq!(queries.control_queries(), 2);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(queries.queries_matching("UPDATE \"collections\""), 0);
+    assert_eq!(queries.queries_matching("INSERT INTO \"events\""), 0);
+
+    fixture.cleanup().await.expect("fixture cleanup");
+}
+
+#[actix_web::test]
+async fn object_page_query_count_is_constant_with_page_size() {
+    let scope = TestScope::new();
+    let fixture = scope
+        .object_fixture(
+            "query_budget_object_page",
+            NewHubuumClass {
+                collection_id: 0,
+                name: scope.scoped_name("query_budget_object_page_class"),
+                description: "query budget object page class".to_string(),
+                json_schema: None,
+                validate_schema: None,
+            },
+            (0..20)
+                .map(|index| NewHubuumObject {
+                    collection_id: 0,
+                    hubuum_class_id: 0,
+                    name: scope.scoped_name(&format!("query_budget_object_{index:02}")),
+                    description: "query budget object".to_string(),
+                    data: serde_json::json!({"index": index}),
+                })
+                .collect(),
+        )
+        .await
+        .expect("object fixture should save");
+    let subject = UserID::new(1).expect("valid synthetic runtime-admin subject id");
+
+    let run_page = |limit: usize| {
+        let query = parse_query_parameter(&format!(
+            "classes={}&sort=id&limit={limit}",
+            fixture.class.id
+        ))
+        .expect("valid object page query");
+        async {
+            let total = subject
+                .count_objects_from_backend_with_admin_status(
+                    &scope.pool,
+                    query.clone(),
+                    true,
+                    None,
+                )
+                .await?;
+            let rows = subject
+                .search_objects_from_backend_with_admin_status(&scope.pool, query, true, None)
+                .await?;
+            Ok::<_, crate::errors::ApiError>((rows, total))
+        }
+    };
+
+    let (small_page, small_queries) = capture_queries(run_page(1)).await;
+    let (small_rows, small_total) = small_page.expect("small object page should load");
+    assert_eq!(small_rows.len(), 1);
+    assert_eq!(small_total, 20);
+
+    let (large_page, large_queries) = capture_queries(run_page(20)).await;
+    let (large_rows, large_total) = large_page.expect("large object page should load");
+    assert_eq!(large_rows.len(), 20);
+    assert_eq!(large_total, 20);
+
+    assert_same_query_shape(&small_queries, &large_queries);
+    assert_eq!(large_queries.total_queries(), 4);
+    assert_eq!(large_queries.domain_queries(), 4);
+    assert_eq!(large_queries.control_queries(), 0);
+    assert_eq!(large_queries.connection_checkouts(), 4);
+
+    fixture.cleanup().await.expect("object fixture cleanup");
+}
+
+#[actix_web::test]
+async fn effective_permission_query_count_is_constant_with_collection_depth() {
+    let scope = TestScope::new();
+    let root = scope
+        .collection_fixture("query_budget_effective_permission")
+        .await;
+    let mut collections = vec![root.collection.clone()];
+
+    for depth in 1..=16 {
+        let parent = collections.last().expect("parent collection");
+        let collection = NewCollectionWithAssignee {
+            name: scope.scoped_name(&format!("query_budget_permission_depth_{depth}")),
+            description: format!("query budget permission depth {depth}"),
+            group_id: root.owner_group.id,
+            parent_collection_id: Some(
+                CollectionID::new(parent.id).expect("valid parent collection id"),
+            ),
+        }
+        .save_without_events(&scope.pool)
+        .await
+        .expect("collection should save");
+        collections.push(collection);
+    }
+
+    let (shallow_permissions, shallow_queries) = capture_queries(effective_group_on(
+        &scope.pool,
+        collections[1].id,
+        root.owner_group.id,
+    ))
+    .await;
+    assert!(
+        !shallow_permissions
+            .expect("shallow permissions should load")
+            .is_empty()
+    );
+
+    let (deep_permissions, deep_queries) = capture_queries(effective_group_on(
+        &scope.pool,
+        collections.last().expect("deep collection").id,
+        root.owner_group.id,
+    ))
+    .await;
+    assert!(
+        !deep_permissions
+            .expect("deep permissions should load")
+            .is_empty()
+    );
+
+    assert_same_query_shape(&shallow_queries, &deep_queries);
+    assert_eq!(deep_queries.total_queries(), 3);
+    assert_eq!(deep_queries.domain_queries(), 3);
+    assert_eq!(deep_queries.control_queries(), 0);
+    assert_eq!(deep_queries.connection_checkouts(), 1);
+
+    for collection in collections.iter().skip(1).rev() {
+        collection
+            .delete_without_events(&scope.pool)
+            .await
+            .expect("nested collection cleanup");
+    }
+    root.cleanup().await.expect("root fixture cleanup");
+}
+
+#[actix_web::test]
+async fn changed_collection_update_writes_once_and_emits_one_event() {
+    let scope = TestScope::new();
+    let fixture = scope
+        .collection_fixture("query_budget_changed_update")
+        .await;
+    let update = UpdateCollection {
+        name: None,
+        description: Some("changed query budget description".to_string()),
+    };
+
+    let (updated, queries) =
+        capture_queries(update.update(&scope.pool, fixture.collection.id, &EventContext::system()))
+            .await;
+    assert_eq!(
+        updated.expect("changed update should succeed").description,
+        "changed query budget description"
+    );
+
+    assert_eq!(queries.total_queries(), 5, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 3, "{:#?}", queries.query_counts());
+    assert_eq!(queries.control_queries(), 2);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(queries.queries_matching("UPDATE \"collections\""), 1);
+    assert_eq!(queries.queries_matching("INSERT INTO \"events\""), 1);
+
+    fixture.cleanup().await.expect("fixture cleanup");
+}
+
+#[actix_web::test]
+async fn object_relation_create_has_a_fixed_query_and_checkout_budget() {
+    let scope = TestScope::new();
+    let fixture = scope
+        .collection_fixture("query_budget_object_relation")
+        .await;
+    let class_one = NewHubuumClass {
+        collection_id: fixture.collection.id,
+        name: scope.scoped_name("query_budget_relation_class_one"),
+        description: "query budget relation class one".to_string(),
+        json_schema: None,
+        validate_schema: None,
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("first class should save");
+    let class_two = NewHubuumClass {
+        collection_id: fixture.collection.id,
+        name: scope.scoped_name("query_budget_relation_class_two"),
+        description: "query budget relation class two".to_string(),
+        json_schema: None,
+        validate_schema: None,
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("second class should save");
+    let class_relation = NewHubuumClassRelation {
+        from_hubuum_class_id: class_one.id,
+        to_hubuum_class_id: class_two.id,
+        forward_template_alias: Some("seconds".to_string()),
+        reverse_template_alias: Some("firsts".to_string()),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("class relation should save");
+    let object_one = NewHubuumObject {
+        collection_id: fixture.collection.id,
+        hubuum_class_id: class_one.id,
+        name: scope.scoped_name("query_budget_relation_object_one"),
+        description: "query budget relation object one".to_string(),
+        data: serde_json::json!({}),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("first object should save");
+    let object_two = NewHubuumObject {
+        collection_id: fixture.collection.id,
+        hubuum_class_id: class_two.id,
+        name: scope.scoped_name("query_budget_relation_object_two"),
+        description: "query budget relation object two".to_string(),
+        data: serde_json::json!({}),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("second object should save");
+
+    let relation = NewHubuumObjectRelation {
+        from_hubuum_object_id: object_one.id,
+        to_hubuum_object_id: object_two.id,
+        class_relation_id: class_relation.id,
+    };
+    let (saved, queries) =
+        capture_queries(relation.save(&scope.pool, &EventContext::system())).await;
+    saved.expect("object relation should save with an event");
+
+    assert_eq!(queries.total_queries(), 6, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 4, "{:#?}", queries.query_counts());
+    assert_eq!(queries.control_queries(), 2);
+    assert_eq!(queries.connection_checkouts(), 3);
+    assert_eq!(queries.queries_matching("FROM \"hubuumobject\""), 2);
+    assert_eq!(
+        queries.queries_matching("INSERT INTO \"hubuumobject_relation\""),
+        1
+    );
+    assert_eq!(queries.queries_matching("INSERT INTO \"events\""), 1);
+
+    fixture.cleanup().await.expect("fixture cleanup");
+}
+
+#[actix_web::test]
+async fn collection_history_query_count_is_constant_with_page_size() {
+    let scope = TestScope::new();
+    let fixture = scope.collection_fixture("query_budget_history_page").await;
+    let actor = ensure_admin_user(&scope.pool).await;
+
+    for version in 0..12 {
+        with_actor_scope(
+            Some(actor.id),
+            UpdateCollection {
+                name: None,
+                description: Some(format!("query budget history version {version}")),
+            }
+            .update_without_events(&scope.pool, fixture.collection.id),
+        )
+        .await
+        .expect("history-generating update should succeed");
+    }
+
+    let history_pool = scope.pool.clone();
+    let history_collection_id = fixture.collection.id;
+    let load_history = |limit: usize| {
+        let pool = history_pool.clone();
+        let query = parse_query_parameter(&format!("limit={limit}&sort=history_id.desc"))
+            .expect("valid history query");
+        async move {
+            let (rows, total) =
+                collection_history_paginated_with_total_count(history_collection_id, &pool, &query)
+                    .await?;
+            let actor_ids = rows.iter().filter_map(|row| row.actor_id).collect();
+            let actors = resolve_actor_usernames(&pool, actor_ids).await?;
+            Ok::<_, crate::errors::ApiError>((rows, total, actors))
+        }
+    };
+
+    let (small_page, small_queries) = capture_queries(load_history(1)).await;
+    let (small_rows, small_total, small_actors) =
+        small_page.expect("small history page should load");
+    assert_eq!(small_rows.len(), 1);
+    assert!(small_total >= 12);
+    assert!(small_actors.contains_key(&actor.id));
+
+    let (large_page, large_queries) = capture_queries(load_history(20)).await;
+    let (large_rows, large_total, large_actors) =
+        large_page.expect("large history page should load");
+    assert!(large_rows.len() >= 12);
+    assert_eq!(large_total, small_total);
+    assert!(large_actors.contains_key(&actor.id));
+
+    assert_same_query_shape(&small_queries, &large_queries);
+    assert_eq!(large_queries.total_queries(), 3);
+    assert_eq!(large_queries.domain_queries(), 3);
+    assert_eq!(large_queries.control_queries(), 0);
+    assert_eq!(large_queries.connection_checkouts(), 3);
+
+    fixture.cleanup().await.expect("fixture cleanup");
+}


### PR DESCRIPTION
## Summary

- add task-local Diesel instrumentation that captures PostgreSQL query totals, normalized fingerprints, domain/control-query splits, and pool checkout counts
- add fixed and scaling query budgets across representative storage paths: point reads, hierarchy traversal, effective permissions, mutations and their events, import planning, export hydration, event fanout, and paginated history
- add an opt-in PostgreSQL Criterion benchmark target for latency baselines
- compare isolated base/head PostgreSQL 17 benchmark results in CI, warning at 10% regression and failing only credible regressions at 20%
- run the cross-platform Rust test matrix on stable only, removing the beta and nightly Linux jobs
- document how to run, interpret, and intentionally update the budgets

## Why

Issue #27 may introduce a broad storage/service trait boundary and potentially move storage implementations into workspace crates. Before that refactor, we need a durable picture of both wall-clock performance and database behavior so an abstraction boundary cannot quietly introduce N+1 queries, extra connection checkouts, or materially slower hot paths.

The fixed query-budget tests provide fast structural regression protection. Criterion remains the noisy but useful latency layer, with base and head measured against separate disposable databases in the same CI job.

## Baselines captured

The tests intentionally preserve current behavior rather than optimize it:

- import planning currently scales as `3 + 3N` queries (6 for one item, 63 for twenty), exposing repeated collection-name lookups
- export hydration remains constant at 6 queries and one checkout from one to ten roots
- event fanout scales as `6 + N` queries with one event insert per recipient and one checkout
- ancestor traversal, object-page loading, effective-permission depth, mutation/event paths, relation creation, and history pagination all have explicit fixed or scaling assertions

These baselines give the storage-boundary work concrete before/after targets and identify import planning as a likely future optimization candidate.

## Developer impact

The new instrumentation is test-only and does not affect production request paths. The Criterion target is opt-in and requires a disposable PostgreSQL database. CI records base/head artifacts and publishes the comparison summary. The existing cross-platform test job continues to cover Linux x86_64, Linux aarch64, Windows, and macOS on stable Rust, while no longer spending runners on beta/nightly compatibility checks.

No public API or schema changes are included.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `actionlint .github/workflows/benchmarks.yml`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- shortened live PostgreSQL Criterion run
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- production Docker image build with the published feature combination

## Changelog

No changelog entry: this adds internal benchmark and regression-test infrastructure and reduces redundant CI coverage without user-visible behavior changes.

Refs #27