### PR TITLE
Add zero-downtime single-host application rollouts

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -57,6 +57,14 @@ jobs:
         run: |
           sudo apt-get update --yes
           sudo apt-get install --yes libpq-dev
+      - name: Defer automatic checkpoints during benchmark comparison
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql --host localhost --username postgres --dbname postgres \
+            --command "ALTER SYSTEM SET checkpoint_timeout = '30min'"
+          psql --host localhost --username postgres --dbname postgres \
+            --command "SELECT pg_reload_conf()"
       - name: Create isolated benchmark databases
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -51,13 +51,30 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      - name: Detect PostgreSQL storage benchmark changes
+        id: storage_changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
+            Cargo.toml Cargo.lock benches/postgres migrations crates src \
+            ':(exclude)src/tests/**'; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No PostgreSQL storage benchmark inputs changed."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Cache Cargo and target directories
+        if: steps.storage_changes.outputs.changed == 'true'
         uses: Swatinem/rust-cache@v2
       - name: Install PostgreSQL build tools
+        if: steps.storage_changes.outputs.changed == 'true'
         run: |
           sudo apt-get update --yes
           sudo apt-get install --yes libpq-dev
       - name: Defer automatic checkpoints during benchmark comparison
+        if: steps.storage_changes.outputs.changed == 'true'
         env:
           PGPASSWORD: postgres
         run: |
@@ -66,14 +83,17 @@ jobs:
           psql --host localhost --username postgres --dbname postgres \
             --command "SELECT pg_reload_conf()"
       - name: Create isolated benchmark databases
+        if: steps.storage_changes.outputs.changed == 'true'
         env:
           PGPASSWORD: postgres
         run: |
           createdb --host localhost --username postgres hubuum_bench_base
           createdb --host localhost --username postgres hubuum_bench_head
       - name: Clear cached PostgreSQL benchmark results
+        if: steps.storage_changes.outputs.changed == 'true'
         run: rm -rf target/criterion/storage_postgres
       - name: Detect an existing base benchmark
+        if: steps.storage_changes.outputs.changed == 'true'
         id: base_benchmark
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -84,7 +104,9 @@ jobs:
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Record base benchmark
-        if: steps.base_benchmark.outputs.available == 'true'
+        if: >-
+          steps.storage_changes.outputs.changed == 'true' &&
+          steps.base_benchmark.outputs.available == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HUBUUM_BENCH_DATABASE_URL: ${{ env.BASE_DATABASE_URL }}
@@ -96,6 +118,7 @@ jobs:
             --bench storage_postgres_criterion -- \
             --save-baseline pr-base --noplot --sample-size 40 --measurement-time 4
       - name: Record and compare pull-request benchmark
+        if: steps.storage_changes.outputs.changed == 'true'
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HUBUUM_BENCH_DATABASE_URL: ${{ env.HEAD_DATABASE_URL }}
@@ -116,5 +139,7 @@ jobs:
               >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: Enforce credible PostgreSQL regressions
-        if: steps.base_benchmark.outputs.available == 'true'
+        if: >-
+          steps.storage_changes.outputs.changed == 'true' &&
+          steps.base_benchmark.outputs.available == 'true'
         run: scripts/check-criterion-regressions.sh target/criterion/storage_postgres 10 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         run: cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked
       - name: Test deployment script refresh
         run: bash scripts/test-install-script-refresh.sh
+      - name: Test single-host rolling update
+        run: bash scripts/test-single-host-rollout.sh
       - name: Markdown lint
         uses: DavidAnson/markdownlint-cli2-action@v24
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,6 +556,7 @@ jobs:
       - name: Test live single-host zero-downtime rollout
         env:
           HUBUUM_TEST_IMAGE: hubuum-server:ci
+          HUBUUM_OLD_TEST_IMAGE: ghcr.io/hubuum/hubuum-server:v0.0.1@sha256:061fc4cb3af57e2db06c33012db93e60834d4618815e30af4ebb4aa05a21f445
         run: bash scripts/test-single-host-zero-downtime.sh
 
   verify-tag-main-ci-success:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,6 +553,10 @@ jobs:
             fi
             sleep 1
           done
+      - name: Test live single-host zero-downtime rollout
+        env:
+          HUBUUM_TEST_IMAGE: hubuum-server:ci
+        run: bash scripts/test-single-host-zero-downtime.sh
 
   verify-tag-main-ci-success:
     name: Verify tagged commit already passed CI on main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `worker` runtime roles, explicit one-shot migration ownership, supervised
   background workers, and a deployment guide for scaling API and worker
   replicas independently.
+- Added zero-HTTP-downtime single-host application updates with primary and
+  standby API/frontend containers, readiness-aware Caddy load balancing,
+  one-shot migrations, shared Valkey login throttling, and ordered rolling
+  replacement. PostgreSQL, Valkey, and Caddy now remain running during ordinary
+  backend and frontend updates. The distributed deployment guide now also
+  defines the Kubernetes and Helm rollout contract for HTTP availability.
 - Added durable PostgreSQL task leases with heartbeats, stale-worker fencing,
   terminal recovery without unsafe task replay, and lease recovery metrics.
 - Added an optional Valkey/Redis login-rate-limit backend for sharing login

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Breaking:** Existing single-host installations must rerun
+  `install-single-host.sh` once to generate the redundant API/frontend topology
+  before using `update-single-host.sh`; the updater now fails safely when those
+  rolling-update services are absent. Ordinary application updates use the
+  standby-first rollout helper, while explicit `systemctl restart` continues to
+  stop and start the whole stack.
 - Active task admission now uses a partial per-submitter and per-kind index so
   capacity checks remain bounded by queued, validating, and running work rather
   than scanning a submitter's completed task history.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -321,6 +321,15 @@ replacing the existing primary. A subsequent `update-single-host.sh` refuses to
 fall back to a destructive restart when the installed Compose file lacks the
 rolling-update services.
 
+The live container contract test covers adoption from the published v0.0.1
+image: the old API remains online while the candidate applies all newer
+migrations, starts a ready standby, and replaces the old primary. Before this
+specific upgrade, allow queued and running tasks to drain. v0.0.1 co-locates
+lease-unaware task workers with its API, and the task-lease migration cannot
+safely transfer an in-flight task to a new worker. The tested idle-queue upgrade
+preserves HTTP availability; it does not promise uninterrupted background task
+execution.
+
 ### Re-running The Installer To Update
 
 The installer is idempotent and doubles as an in-place updater. Re-running it against an existing install directory reuses the configuration recorded in `.env` (mode, hostnames, email, images, refs, ports, network subnet, container engine, and systemd service name) and preserves generated secrets and the managed database, so you only need to pass the arguments you want to change:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,6 +40,34 @@ sudo ./scripts/install-single-host.sh \
 
 This creates `/opt/hubuum` by default, generates `/opt/hubuum/.env`, writes `compose.yml` and `Caddyfile`, pulls published images, and starts the stack.
 
+### HTTP Availability Model
+
+Single-host installations run a primary and standby backend behind Caddy. The
+primary retains the default `all` runtime role, including background workers;
+the standby uses the HTTP-only `api` role. All-mode installations likewise run
+two frontend containers. Caddy actively checks backend `/readyz` and frontend
+HTTP health, excludes unavailable replicas, and retries connection failures
+against a healthy replica.
+
+The frontend BFF reaches the backend through a private Caddy listener, so it
+uses the same readiness-aware backend pool as direct API traffic. All-mode
+installs also use the bundled Valkey service for shared backend login throttling
+across the two API replicas.
+
+This removes planned HTTP interruption during ordinary application updates. It
+does not provide host, Caddy, PostgreSQL, or Valkey high availability because
+those components still have one instance on the same machine. Background work
+also pauses while the primary is replaced. Database migrations must remain
+compatible with the old application version for the duration of the rolling
+update; a migration that blocks application queries can still cause request
+latency even though an HTTP replica remains online.
+
+The standby owns its own database pool and application memory. Capacity-plan
+external PostgreSQL servers for both API pools, the primary's task-lease
+connection, migration/administration work, and operational headroom. See
+[Distributed Deployment](distributed_deployment.md#capacity-planning) for the
+connection-budget formula.
+
 The installer also creates an empty `/opt/hubuum/auth.toml` for local-only
 authentication. Use `--auth-config` to point the deployment at an existing
 external-auth TOML file instead.
@@ -205,11 +233,11 @@ cd /opt/hubuum
 sudo ./update-single-host.sh --auth-config /etc/hubuum/auth-next.toml
 ```
 
-The update helper validates and persists the new path before recreating the API
-container. Editing the currently mounted host file still requires an API
-container restart because auth-provider configuration is loaded at startup.
-Run `update-single-host.sh` without `--auth-config` to restart after such an
-edit.
+The update helper validates and persists the new path before rolling both API
+containers. Editing the currently mounted host file still requires the API
+containers to be replaced because auth-provider configuration is loaded at
+startup. Run `update-single-host.sh` without `--auth-config` to roll them after
+such an edit.
 
 See [External Authentication](external_auth.md) for the TOML schema and LDAP
 examples.
@@ -241,27 +269,54 @@ sudo systemctl stop hubuum
 sudo systemctl start hubuum
 ```
 
-The containers use `restart: unless-stopped`; a systemd unit adds an explicit host-boot contract. It runs `compose up -d` on start and `compose down` on stop from the install directory.
+The containers use `restart: unless-stopped`; a systemd unit adds an explicit
+host-boot contract. It runs `compose up -d` on start and `compose down` on stop
+from the install directory. An explicit `systemctl restart` therefore restarts
+the entire stack and is not the zero-downtime update path; use
+`update-single-host.sh` for application updates.
 
 Use `--service-name NAME` to install the unit under a different name. Without `--systemd`, manage the stack directly with Compose.
 
 ## Updates
 
 The installer copies `install-single-host.sh`, `update-single-host.sh`,
-`stop-single-host.sh`, and `uninstall-single-host.sh` into the install directory. A curl-based
-installer rerun refreshes all four management scripts before updating the deployment:
+`single-host-rollout.sh`, `stop-single-host.sh`, and
+`uninstall-single-host.sh` into the install directory. A curl-based installer
+rerun refreshes all five management scripts before updating the deployment:
 
 ```bash
 cd /opt/hubuum
 sudo ./update-single-host.sh
 ```
 
-For image-based installs, the update command pulls the latest configured images and restarts the stack. For source-build installs, it fetches the source checkouts, rebuilds the local app images, and restarts the stack.
+For image-based installs, the update command pulls the latest configured
+images. For source-build installs, it fetches the source checkouts and rebuilds
+the local app images. It then performs a rolling application update:
+
+1. Run embedded database migrations as a one-shot command while the current
+   primary continues serving HTTP.
+2. Replace the HTTP-only backend standby and wait for `/readyz`.
+3. Replace the frontend standby in all mode and wait for its health check.
+4. Replace the primary backend, then the primary frontend in all mode.
+
+Caddy, PostgreSQL, and Valkey remain running throughout this sequence. Newly
+pulled images for those infrastructure services are not activated by the
+rolling application update; schedule a maintenance window when those services
+themselves need replacement.
 
 Pass `--auth-config /absolute/host/path.toml` to change the read-only external
-authentication file as part of the same update and restart.
+authentication file as part of the same update and rolling replacement.
 
-If the systemd unit exists, updates restart through systemd, whose stop/start steps recreate the containers. Otherwise the update tears the stack down and brings it back up (`compose down` then `compose up -d`) so the freshly pulled images are actually picked up; a plain `compose up -d` does not reliably recreate running containers, particularly under Podman.
+Updates use Compose directly even when the optional systemd unit exists. The
+unit remains active and continues to provide the host-boot and explicit-stop
+contract; it is not restarted during an application rollout.
+
+Installations created before rolling updates were introduced must re-run
+`install-single-host.sh` once to generate the standby services and
+readiness-aware Caddy configuration. The installer brings up the standby before
+replacing the existing primary. A subsequent `update-single-host.sh` refuses to
+fall back to a destructive restart when the installed Compose file lacks the
+rolling-update services.
 
 ### Re-running The Installer To Update
 
@@ -276,7 +331,10 @@ curl -fsSL https://raw.githubusercontent.com/hubuum/hubuum/main/scripts/install-
 sudo ./install-single-host.sh --backend-image ghcr.io/hubuum/hubuum-server:v1.2.3
 ```
 
-Any value passed explicitly on the command line overrides the stored one; everything else is taken from the existing `.env`. Compose applies only the services whose definition or image changed. For a clean recreate of every container (useful under Podman), use `update-single-host.sh` instead.
+Any value passed explicitly on the command line overrides the stored one;
+everything else is taken from the existing `.env`. Application containers are
+rolled in standby-then-primary order. Infrastructure-container changes remain
+pending until the operator schedules their replacement.
 
 ## Stop And Uninstall
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -89,10 +89,12 @@ All-in-one installs expose both public hostnames:
 The frontend is still configured as a BFF-style service. Browser clients can call frontend-owned routes such as `/api/v0/auth/login`, `/api/v1/...`, and `/api/hubuum/...`; the frontend reaches the backend over the private compose network with:
 
 ```env
-BACKEND_BASE_URL=http://hubuum-api:8080
+BACKEND_BASE_URL=http://caddy:8081
 ```
 
-That keeps backend bearer tokens server-side for frontend browser flows, while still leaving the backend API publicly available on the API hostname.
+The private Caddy listener load-balances both ready API replicas. Backend bearer
+tokens remain server-side for frontend browser flows, while the backend API is
+still publicly available on the API hostname.
 
 ## Shared Host Routing
 
@@ -151,6 +153,7 @@ The script installs management helpers into the install directory:
 
 - `install-single-host.sh`
 - `update-single-host.sh`
+- `single-host-rollout.sh`
 - `stop-single-host.sh`
 - `uninstall-single-host.sh`
 
@@ -302,6 +305,11 @@ the local app images. It then performs a rolling application update:
 5. Replace the primary backend, then the primary frontend in all mode, and
    reload Caddy once more after both are healthy.
 
+If a previous attempt left a primary unhealthy while its standby is healthy,
+the next run recovers and reloads that primary before touching the only usable
+standby. The helper also starts a missing or stopped managed PostgreSQL or
+Valkey service without recreating an existing infrastructure container.
+
 Caddy, PostgreSQL, and Valkey remain running throughout this sequence. Newly
 pulled images for those infrastructure services are not activated by the
 rolling application update; schedule a maintenance window when those services
@@ -428,12 +436,15 @@ Backend:
 - `HUBUUM_TOKEN_LIFETIME_HOURS=24`
 - `HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS=5`
 - `HUBUUM_LOGIN_RATE_LIMIT_WINDOW_SECONDS=300`
+- `HUBUUM_LOGIN_RATE_LIMIT_BACKEND`: `valkey` in all-in-one mode and `memory`
+  in backend-only mode.
+- `HUBUUM_LOGIN_RATE_LIMIT_VALKEY_URL=redis://valkey:6379/1`
 - `HUBUUM_AUTH_CONFIG_HOST_PATH`: absolute source path on the container host.
 - `HUBUUM_AUTH_CONFIG_PATH=/etc/hubuum/auth.toml`: read-only path inside the API container.
 
 Frontend, all-in-one mode only:
 
-- `BACKEND_BASE_URL`: internal backend URL, derived from `--api-port`.
+- `BACKEND_BASE_URL=http://caddy:8081`: private readiness-aware API listener.
 - `VALKEY_URL=redis://valkey:6379/0`
 - `SESSION_TTL_SECONDS=28800`
 - `SESSION_PREFIX=hubuum:sess:`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -297,7 +297,10 @@ the local app images. It then performs a rolling application update:
    primary continues serving HTTP.
 2. Replace the HTTP-only backend standby and wait for `/readyz`.
 3. Replace the frontend standby in all mode and wait for its health check.
-4. Replace the primary backend, then the primary frontend in all mode.
+4. Reload Caddy after all standbys are healthy. This clears passive failure
+   state recorded while their old containers were unavailable.
+5. Replace the primary backend, then the primary frontend in all mode, and
+   reload Caddy once more after both are healthy.
 
 Caddy, PostgreSQL, and Valkey remain running throughout this sequence. Newly
 pulled images for those infrastructure services are not activated by the

--- a/docs/distributed_deployment.md
+++ b/docs/distributed_deployment.md
@@ -86,6 +86,108 @@ migration required by the binary. API `/readyz` performs the same schema check.
 This prevents a missed or incomplete migration job from making a replica appear
 ready, while keeping migration ownership in the one-shot job.
 
+## Kubernetes And Helm HTTP Availability
+
+This repository does not currently publish a Helm chart. Direct Kubernetes
+manifests and externally maintained charts should implement the following
+contract for application upgrades without HTTP downtime:
+
+- Run API and worker processes in separate Deployments with the `api` and
+  `worker` runtime roles. Do not put `all`-role pods behind the API Service.
+- Run at least two API replicas and use a `RollingUpdate` strategy with
+  `maxUnavailable: 0` and `maxSurge: 1` or greater. The default 25% values do
+  not state the availability requirement clearly and can behave differently as
+  the replica count changes.
+- Use `/readyz` for readiness and `/healthz` for startup and liveness. Only
+  ready API pods should receive Service or ingress traffic.
+- Allow endpoint and ingress changes to propagate before terminating the
+  process. A short `preStop` delay is a practical starting point, and the pod's
+  termination grace period must cover that delay plus Hubuum's 30-second
+  graceful worker-shutdown bound. Start with 60 seconds and tune the drain
+  delay for the actual ingress implementation.
+- Add a PodDisruptionBudget that keeps at least one API replica available, and
+  spread replicas across nodes or failure domains. A disruption budget protects
+  against voluntary evictions; the Deployment strategy still controls rolling
+  updates.
+
+The relevant API Deployment settings look like this. This is a fragment rather
+than a complete manifest:
+
+```yaml
+spec:
+  replicas: 2
+  minReadySeconds: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: hubuum-api
+          env:
+            - name: HUBUUM_RUNTIME_ROLE
+              value: api
+            - name: HUBUUM_SKIP_MIGRATIONS
+              value: "true"
+          ports:
+            - name: http
+              containerPort: 8080
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
+```
+
+For Helm, make the one-shot migration Job a blocking `pre-install` and
+`pre-upgrade` hook, or run and await an equivalent uniquely named Job in the
+release pipeline before `helm upgrade`:
+
+```yaml
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+```
+
+The migration Job must use the new application image and the same database
+credentials as the Deployments. If the chart creates those credentials, make
+them available before the hook runs or keep migration ownership in the release
+pipeline. A failed migration must stop the rollout while the old API replicas
+remain online.
+
+Every migration used in this sequence must be compatible with both the old and
+new API versions. Use expand/backfill/switch/contract changes across releases;
+do not drop or reinterpret schema that the old pods still use. Helm rollback
+does not undo a completed database migration, so the previous application image
+must also remain compatible with the migrated schema. The task-lease migration
+still requires the worker drain order described above.
+
+These settings protect the HTTP application rollout. They do not make the
+ingress controller, Kubernetes nodes, PostgreSQL, or Valkey highly available;
+those layers need their own redundancy and maintenance procedures.
+
 ## Shared Configuration And Secrets
 
 All replicas must use the same values for settings that define cluster-wide

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -395,6 +395,7 @@ install_management_script() {
 
 install_management_script install-single-host.sh
 install_management_script update-single-host.sh
+install_management_script single-host-rollout.sh
 install_management_script stop-single-host.sh
 install_management_script uninstall-single-host.sh
 
@@ -460,6 +461,11 @@ if [[ -n "$EXTERNAL_DATABASE_URL" ]]; then
   HUBUUM_DATABASE_URL="$EXTERNAL_DATABASE_URL"
 fi
 
+LOGIN_RATE_LIMIT_BACKEND="memory"
+if [[ "$MODE" == "all" ]]; then
+  LOGIN_RATE_LIMIT_BACKEND="valkey"
+fi
+
 {
   printf 'INSTALL_MODE=%s\n' "$MODE"
   printf 'WEB_FQDN=%s\n' "$WEB_FQDN"
@@ -495,10 +501,12 @@ fi
   printf 'HUBUUM_TOKEN_LIFETIME_HOURS=24\n'
   printf 'HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS=5\n'
   printf 'HUBUUM_LOGIN_RATE_LIMIT_WINDOW_SECONDS=300\n'
+  printf 'HUBUUM_LOGIN_RATE_LIMIT_BACKEND=%s\n' "$LOGIN_RATE_LIMIT_BACKEND"
+  printf 'HUBUUM_LOGIN_RATE_LIMIT_VALKEY_URL=redis://valkey:6379/1\n'
   printf 'HUBUUM_AUTH_CONFIG_HOST_PATH=%s\n' "$(quote_env "$AUTH_CONFIG_HOST_PATH")"
   printf 'HUBUUM_AUTH_CONFIG_PATH=%s\n' "$AUTH_CONFIG_CONTAINER_PATH"
   printf '\n'
-  printf 'BACKEND_BASE_URL=http://hubuum-api:%s\n' "$API_PORT"
+  printf 'BACKEND_BASE_URL=http://caddy:8081\n'
   printf 'VALKEY_URL=redis://valkey:6379/0\n'
   printf 'SESSION_TTL_SECONDS=28800\n'
   printf 'SESSION_PREFIX=hubuum:sess:\n'
@@ -507,69 +515,96 @@ fi
 
 chmod 0600 "$ENV_FILE"
 
-if [[ "$MODE" == "all" && -z "$SHARED_HOST_ROUTING" ]]; then
-  cat > "$INSTALL_DIR/Caddyfile" <<'EOF'
+CADDYFILE_TEMP="$(mktemp "$INSTALL_DIR/.Caddyfile.XXXXXX")"
+cat > "$CADDYFILE_TEMP" <<'EOF'
 {
     email {$LETSENCRYPT_EMAIL}
 }
 
+(api_proxy) {
+    reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT} hubuum-api-standby:{$HUBUUM_BIND_PORT} {
+        health_uri /readyz
+        health_interval 5s
+        health_timeout 3s
+        fail_duration 30s
+        max_fails 1
+        lb_try_duration 5s
+        lb_try_interval 250ms
+        stream_close_delay 5m
+    }
+}
+EOF
+
+if [[ "$MODE" == "all" ]]; then
+  cat >> "$CADDYFILE_TEMP" <<'EOF'
+(web_proxy) {
+    reverse_proxy hubuum-web:3000 hubuum-web-standby:3000 {
+        health_uri /
+        health_status 2xx
+        health_follow_redirects
+        health_interval 5s
+        health_timeout 3s
+        fail_duration 30s
+        max_fails 1
+        lb_try_duration 5s
+        lb_try_interval 250ms
+        stream_close_delay 5m
+    }
+}
+
+:8081 {
+    import api_proxy
+}
+EOF
+fi
+
+if [[ "$MODE" == "all" && -z "$SHARED_HOST_ROUTING" ]]; then
+  cat >> "$CADDYFILE_TEMP" <<'EOF'
 {$WEB_FQDN} {
     encode zstd gzip
-    reverse_proxy hubuum-web:3000
+    import web_proxy
 }
 
 {$API_FQDN} {
     encode zstd gzip
-    reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
+    import api_proxy
 }
 EOF
 elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "bff" ]]; then
-  cat > "$INSTALL_DIR/Caddyfile" <<'EOF'
-{
-    email {$LETSENCRYPT_EMAIL}
-}
-
+  cat >> "$CADDYFILE_TEMP" <<'EOF'
 {$WEB_FQDN} {
     encode zstd gzip
-    reverse_proxy hubuum-web:3000
+    import web_proxy
 }
 EOF
 elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "direct" ]]; then
-  cat > "$INSTALL_DIR/Caddyfile" <<'EOF'
-{
-    email {$LETSENCRYPT_EMAIL}
-}
-
+  cat >> "$CADDYFILE_TEMP" <<'EOF'
 {$WEB_FQDN} {
     encode zstd gzip
 
     handle /api/v0* {
-        reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
+        import api_proxy
     }
 
     handle /api/v1* {
-        reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
+        import api_proxy
     }
 
     handle /api-doc* {
-        reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
+        import api_proxy
     }
 
     handle /swagger-ui* {
-        reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
+        import api_proxy
     }
 
     handle {
-        reverse_proxy hubuum-web:3000
+        import web_proxy
     }
 }
 EOF
 elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "prefixed" ]]; then
-  cat > "$INSTALL_DIR/Caddyfile" <<'EOF'
-{
-    email {$LETSENCRYPT_EMAIL}
-}
-
+  cat >> "$CADDYFILE_TEMP" <<'EOF'
 {$WEB_FQDN} {
     encode zstd gzip
 
@@ -578,26 +613,28 @@ elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "prefixed" ]]; then
     }
 
     handle_path /hubuum-api/* {
-        reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
+        import api_proxy
     }
 
     handle {
-        reverse_proxy hubuum-web:3000
+        import web_proxy
     }
 }
 EOF
 else
-  cat > "$INSTALL_DIR/Caddyfile" <<'EOF'
-{
-    email {$LETSENCRYPT_EMAIL}
-}
-
+  cat >> "$CADDYFILE_TEMP" <<'EOF'
 {$API_FQDN} {
     encode zstd gzip
-    reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT}
+    import api_proxy
 }
 EOF
 fi
+
+CADDY_CONFIG_CHANGED="true"
+if [[ -f "$INSTALL_DIR/Caddyfile" ]] && cmp -s "$CADDYFILE_TEMP" "$INSTALL_DIR/Caddyfile"; then
+  CADDY_CONFIG_CHANGED="false"
+fi
+mv "$CADDYFILE_TEMP" "$INSTALL_DIR/Caddyfile"
 
 cat > "$INSTALL_DIR/compose.yml" <<'EOF'
 services:
@@ -628,7 +665,7 @@ EOF
 fi
 
 cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
-  hubuum-api:
+  hubuum-api: &hubuum-api
 EOF
 
 if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
@@ -653,6 +690,8 @@ cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
       - ALL
     security_opt:
       - no-new-privileges:true
+    # Allow Actix request draining and the separately bounded worker shutdown.
+    stop_grace_period: 75s
     environment:
       HUBUUM_BIND_IP: ${HUBUUM_BIND_IP}
       HUBUUM_BIND_PORT: ${HUBUUM_BIND_PORT}
@@ -665,6 +704,8 @@ cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
       HUBUUM_TOKEN_LIFETIME_HOURS: ${HUBUUM_TOKEN_LIFETIME_HOURS}
       HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS: ${HUBUUM_LOGIN_RATE_LIMIT_MAX_ATTEMPTS}
       HUBUUM_LOGIN_RATE_LIMIT_WINDOW_SECONDS: ${HUBUUM_LOGIN_RATE_LIMIT_WINDOW_SECONDS}
+      HUBUUM_LOGIN_RATE_LIMIT_BACKEND: ${HUBUUM_LOGIN_RATE_LIMIT_BACKEND}
+      HUBUUM_LOGIN_RATE_LIMIT_VALKEY_URL: ${HUBUUM_LOGIN_RATE_LIMIT_VALKEY_URL}
       HUBUUM_AUTH_CONFIG_PATH: ${HUBUUM_AUTH_CONFIG_PATH}
     volumes:
       - type: bind
@@ -686,6 +727,16 @@ cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
       - "${HUBUUM_BIND_PORT}"
     networks:
       - hubuum_net
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --output-document=/dev/null http://127.0.0.1:${HUBUUM_BIND_PORT}/readyz"]
+      interval: 5s
+      timeout: 3s
+      retries: 36
+
+  hubuum-api-standby:
+    <<: *hubuum-api
+    container_name: hubuum-api-standby
+    command: ["--runtime-role", "api"]
 EOF
 
 if [[ "$MODE" == "all" ]]; then
@@ -706,7 +757,7 @@ if [[ "$MODE" == "all" ]]; then
       timeout: 5s
       retries: 10
 
-  hubuum-web:
+  hubuum-web: &hubuum-web
 EOF
 
   if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
@@ -724,6 +775,7 @@ EOF
   cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
     container_name: hubuum-web
     restart: unless-stopped
+    stop_grace_period: 30s
     environment:
       NODE_ENV: production
       PORT: 3000
@@ -734,14 +786,21 @@ EOF
       SESSION_PREFIX: ${SESSION_PREFIX}
       NEXT_PUBLIC_APP_NAME: ${NEXT_PUBLIC_APP_NAME}
     depends_on:
-      hubuum-api:
-        condition: service_started
       valkey:
         condition: service_healthy
     expose:
       - "3000"
     networks:
       - hubuum_net
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/').then(response => { if (!response.ok) process.exit(1) }).catch(() => process.exit(1))"]
+      interval: 5s
+      timeout: 3s
+      retries: 36
+
+  hubuum-web-standby:
+    <<: *hubuum-web
+    container_name: hubuum-web-standby
 EOF
 fi
 
@@ -765,11 +824,13 @@ cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
       - caddy_config:/config
     depends_on:
       - hubuum-api
+      - hubuum-api-standby
 EOF
 
 if [[ "$MODE" == "all" ]]; then
   cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
       - hubuum-web
+      - hubuum-web-standby
 EOF
 fi
 
@@ -843,18 +904,24 @@ EOF
 
   systemctl daemon-reload
   systemctl enable "$SERVICE_NAME"
-  systemctl restart "$SERVICE_NAME"
 }
 
 SYSTEMD_STATUS="not installed"
 if [[ "$INSTALL_SYSTEMD" == "true" && -d /run/systemd/system && "$(command -v systemctl || true)" ]]; then
   install_systemd_unit
   SYSTEMD_STATUS="enabled as ${SERVICE_NAME}.service"
-else
-  "${COMPOSE_CMD[@]}" up -d
-  if [[ "$INSTALL_SYSTEMD" == "true" ]]; then
-    SYSTEMD_STATUS="skipped; systemd is not available"
-  fi
+elif [[ "$INSTALL_SYSTEMD" == "true" ]]; then
+  SYSTEMD_STATUS="skipped; systemd is not available"
+fi
+
+# shellcheck source=scripts/single-host-rollout.sh
+source "$INSTALL_DIR/single-host-rollout.sh"
+INSTALL_MODE="$MODE"
+hubuum_rollout "$CADDY_CONFIG_CHANGED"
+
+if [[ "$SYSTEMD_STATUS" == enabled* ]]; then
+  # Mark the oneshot unit active without restarting the already-rolled stack.
+  systemctl start "$SERVICE_NAME"
 fi
 
 cat <<EOF
@@ -913,18 +980,7 @@ if [[ "$MODE" == "all" ]]; then
 EOF
 fi
 
-PULL_SERVICES_DISPLAY="caddy"
-[[ "$BUILD_FROM_SOURCE" != "true" ]] && PULL_SERVICES_DISPLAY="${PULL_SERVICES_DISPLAY} hubuum-api"
-[[ "$BUILD_FROM_SOURCE" != "true" && "$MODE" == "all" ]] && PULL_SERVICES_DISPLAY="${PULL_SERVICES_DISPLAY} hubuum-web"
-[[ "$DATABASE_MANAGED" == "true" ]] && PULL_SERVICES_DISPLAY="${PULL_SERVICES_DISPLAY} postgres"
-[[ "$MODE" == "all" ]] && PULL_SERVICES_DISPLAY="${PULL_SERVICES_DISPLAY} valkey"
-
-UP_COMMAND="up -d"
-[[ "$BUILD_FROM_SOURCE" == "true" ]] && UP_COMMAND="up -d --build"
-
 cat <<EOF
-  ${ENGINE_BIN} compose --env-file .env -f compose.yml pull ${PULL_SERVICES_DISPLAY}
-  ${ENGINE_BIN} compose --env-file .env -f compose.yml ${UP_COMMAND}
 
 Important:
   Make sure DNS for ${API_FQDN} points to this host.

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -630,7 +630,11 @@ else
 EOF
 fi
 
-mv "$CADDYFILE_TEMP" "$INSTALL_DIR/Caddyfile"
+# Caddy bind-mounts this file directly. Preserve an existing destination inode
+# so a running container sees the new contents when hubuum_reload_caddy reads
+# /etc/caddy/Caddyfile on Linux.
+cp "$CADDYFILE_TEMP" "$INSTALL_DIR/Caddyfile"
+rm -f "$CADDYFILE_TEMP"
 
 cat > "$INSTALL_DIR/compose.yml" <<'EOF'
 services:

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -516,13 +516,13 @@ fi
 chmod 0600 "$ENV_FILE"
 
 CADDYFILE_TEMP="$(mktemp "$INSTALL_DIR/.Caddyfile.XXXXXX")"
-cat > "$CADDYFILE_TEMP" <<'EOF'
+cat > "$CADDYFILE_TEMP" <<EOF
 {
-    email {$LETSENCRYPT_EMAIL}
+    email ${LETSENCRYPT_EMAIL}
 }
 
 (api_proxy) {
-    reverse_proxy hubuum-api:{$HUBUUM_BIND_PORT} hubuum-api-standby:{$HUBUUM_BIND_PORT} {
+    reverse_proxy hubuum-api:${API_PORT} hubuum-api-standby:${API_PORT} {
         health_uri /readyz
         health_interval 5s
         health_timeout 3s
@@ -559,27 +559,27 @@ EOF
 fi
 
 if [[ "$MODE" == "all" && -z "$SHARED_HOST_ROUTING" ]]; then
-  cat >> "$CADDYFILE_TEMP" <<'EOF'
-{$WEB_FQDN} {
+  cat >> "$CADDYFILE_TEMP" <<EOF
+${WEB_FQDN} {
     encode zstd gzip
     import web_proxy
 }
 
-{$API_FQDN} {
+${API_FQDN} {
     encode zstd gzip
     import api_proxy
 }
 EOF
 elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "bff" ]]; then
-  cat >> "$CADDYFILE_TEMP" <<'EOF'
-{$WEB_FQDN} {
+  cat >> "$CADDYFILE_TEMP" <<EOF
+${WEB_FQDN} {
     encode zstd gzip
     import web_proxy
 }
 EOF
 elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "direct" ]]; then
-  cat >> "$CADDYFILE_TEMP" <<'EOF'
-{$WEB_FQDN} {
+  cat >> "$CADDYFILE_TEMP" <<EOF
+${WEB_FQDN} {
     encode zstd gzip
 
     handle /api/v0* {
@@ -604,8 +604,8 @@ elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "direct" ]]; then
 }
 EOF
 elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "prefixed" ]]; then
-  cat >> "$CADDYFILE_TEMP" <<'EOF'
-{$WEB_FQDN} {
+  cat >> "$CADDYFILE_TEMP" <<EOF
+${WEB_FQDN} {
     encode zstd gzip
 
     handle /hubuum-api {
@@ -622,8 +622,8 @@ elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "prefixed" ]]; then
 }
 EOF
 else
-  cat >> "$CADDYFILE_TEMP" <<'EOF'
-{$API_FQDN} {
+  cat >> "$CADDYFILE_TEMP" <<EOF
+${API_FQDN} {
     encode zstd gzip
     import api_proxy
 }
@@ -810,11 +810,6 @@ cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
     image: ${CADDY_IMAGE}
     container_name: hubuum-caddy
     restart: unless-stopped
-    environment:
-      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
-      WEB_FQDN: ${WEB_FQDN}
-      API_FQDN: ${API_FQDN}
-      HUBUUM_BIND_PORT: ${HUBUUM_BIND_PORT}
     ports:
       - "80:80"
       - "443:443"

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -630,10 +630,6 @@ else
 EOF
 fi
 
-CADDY_CONFIG_CHANGED="true"
-if [[ -f "$INSTALL_DIR/Caddyfile" ]] && cmp -s "$CADDYFILE_TEMP" "$INSTALL_DIR/Caddyfile"; then
-  CADDY_CONFIG_CHANGED="false"
-fi
 mv "$CADDYFILE_TEMP" "$INSTALL_DIR/Caddyfile"
 
 cat > "$INSTALL_DIR/compose.yml" <<'EOF'
@@ -917,7 +913,7 @@ fi
 # shellcheck source=scripts/single-host-rollout.sh
 source "$INSTALL_DIR/single-host-rollout.sh"
 INSTALL_MODE="$MODE"
-hubuum_rollout "$CADDY_CONFIG_CHANGED"
+hubuum_rollout
 
 if [[ "$SYSTEMD_STATUS" == enabled* ]]; then
   # Mark the oneshot unit active without restarting the already-rolled stack.

--- a/scripts/single-host-rollout.sh
+++ b/scripts/single-host-rollout.sh
@@ -56,7 +56,7 @@ hubuum_roll_service() {
 
   echo "Rolling $service..."
   "${COMPOSE_CMD[@]}" up -d --no-deps --force-recreate "$service"
-  hubuum_wait_for_healthy "$service"
+  hubuum_wait_for_healthy "$service" "${HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS:-180}"
 }
 
 hubuum_caddy_is_running() {
@@ -64,7 +64,7 @@ hubuum_caddy_is_running() {
 }
 
 hubuum_reload_caddy() {
-  echo "Reloading Caddy with the redundant upstream configuration..."
+  echo "Reloading Caddy to refresh its upstream health state..."
   "${COMPOSE_CMD[@]}" exec -T caddy \
     caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
 }
@@ -81,23 +81,21 @@ hubuum_start_stack() {
   # Start the migration-owning primary first. Starting both API containers at
   # once could make two fresh containers race to apply the same migrations.
   "${COMPOSE_CMD[@]}" up -d hubuum-api
-  hubuum_wait_for_healthy hubuum-api
+  hubuum_wait_for_healthy hubuum-api "${HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS:-180}"
 
   "${COMPOSE_CMD[@]}" up -d --no-deps hubuum-api-standby
-  hubuum_wait_for_healthy hubuum-api-standby
+  hubuum_wait_for_healthy hubuum-api-standby "${HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS:-180}"
 
   if [[ "$INSTALL_MODE" == "all" ]]; then
     "${COMPOSE_CMD[@]}" up -d hubuum-web hubuum-web-standby
-    hubuum_wait_for_healthy hubuum-web
-    hubuum_wait_for_healthy hubuum-web-standby
+    hubuum_wait_for_healthy hubuum-web "${HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS:-180}"
+    hubuum_wait_for_healthy hubuum-web-standby "${HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS:-180}"
   fi
 
   "${COMPOSE_CMD[@]}" up -d --no-deps caddy
 }
 
 hubuum_rollout() {
-  local reload_caddy="${1:-false}"
-
   if ! hubuum_caddy_is_running; then
     hubuum_start_stack
     return 0
@@ -105,21 +103,20 @@ hubuum_rollout() {
 
   hubuum_run_migrations
 
-  # The standby is upgraded and proven ready while the primary remains the
-  # currently configured upstream. On first adoption, reload Caddy only after
-  # that safety copy exists. Routine updates keep Caddy and its configuration
-  # untouched, preserving long-lived connections.
+  # Upgrade every standby while its primary remains available. Caddy can retain
+  # a passive failure mark for a container that was unavailable during
+  # replacement, so reload only after all standbys are proven healthy. The
+  # configured stream_close_delay protects long-lived connections across this
+  # zero-downtime configuration reload.
   hubuum_roll_service hubuum-api-standby
-  if [[ "$reload_caddy" == "true" ]]; then
-    hubuum_reload_caddy
-  fi
-
   if [[ "$INSTALL_MODE" == "all" ]]; then
     hubuum_roll_service hubuum-web-standby
   fi
+  hubuum_reload_caddy
 
   hubuum_roll_service hubuum-api
   if [[ "$INSTALL_MODE" == "all" ]]; then
     hubuum_roll_service hubuum-web
   fi
+  hubuum_reload_caddy
 }

--- a/scripts/single-host-rollout.sh
+++ b/scripts/single-host-rollout.sh
@@ -92,7 +92,7 @@ hubuum_caddy_is_running() {
 hubuum_reload_caddy() {
   echo "Reloading Caddy to refresh its upstream health state..."
   "${COMPOSE_CMD[@]}" exec -T caddy \
-    caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+    caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
 }
 
 hubuum_run_migrations() {

--- a/scripts/single-host-rollout.sh
+++ b/scripts/single-host-rollout.sh
@@ -2,7 +2,7 @@
 
 # Shared rolling-update primitives for the single-host installer and updater.
 # The caller must define COMPOSE_CMD, ENGINE_PATH, and INSTALL_MODE before
-# invoking hubuum_rollout.
+# invoking hubuum_rollout. DATABASE_MANAGED defaults to true for legacy callers.
 
 hubuum_service_container_id() {
   local service="$1"
@@ -51,6 +51,32 @@ hubuum_wait_for_healthy() {
   return 1
 }
 
+hubuum_service_is_healthy() {
+  local health
+
+  health="$(hubuum_service_health "$1")"
+  [[ "$health" == "healthy" || "$health" == "running" ]]
+}
+
+hubuum_ensure_infrastructure_service() {
+  local service="$1"
+
+  if [[ -z "$(hubuum_service_container_id "$service")" ]]; then
+    echo "Starting required infrastructure service $service..."
+    "${COMPOSE_CMD[@]}" up -d --no-deps --no-recreate "$service"
+  fi
+  hubuum_wait_for_healthy "$service" "${HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS:-180}"
+}
+
+hubuum_ensure_infrastructure() {
+  if [[ "${DATABASE_MANAGED:-true}" == "true" ]]; then
+    hubuum_ensure_infrastructure_service postgres
+  fi
+  if [[ "$INSTALL_MODE" == "all" ]]; then
+    hubuum_ensure_infrastructure_service valkey
+  fi
+}
+
 hubuum_roll_service() {
   local service="$1"
 
@@ -96,12 +122,47 @@ hubuum_start_stack() {
 }
 
 hubuum_rollout() {
+  local api_primary_recovered="false"
+  local primary_rolled="false"
+  local web_primary_recovered="false"
+  local web_primary_health
+  local web_standby_health
+
   if ! hubuum_caddy_is_running; then
     hubuum_start_stack
     return 0
   fi
 
+  hubuum_ensure_infrastructure
   hubuum_run_migrations
+
+  # A previous rollout may have failed after replacing a primary. Recover that
+  # primary while the healthy standby still owns traffic; recreating the
+  # standby first would otherwise remove the only usable upstream.
+  if ! hubuum_service_is_healthy hubuum-api; then
+    if ! hubuum_service_is_healthy hubuum-api-standby; then
+      echo "ERROR: neither backend replica is healthy; refusing to replace either one" >&2
+      return 1
+    fi
+    hubuum_roll_service hubuum-api
+    api_primary_recovered="true"
+  fi
+
+  if [[ "$INSTALL_MODE" == "all" ]] && ! hubuum_service_is_healthy hubuum-web; then
+    web_primary_health="$(hubuum_service_health hubuum-web)"
+    web_standby_health="$(hubuum_service_health hubuum-web-standby)"
+    if hubuum_service_is_healthy hubuum-web-standby; then
+      hubuum_roll_service hubuum-web
+      web_primary_recovered="true"
+    elif [[ "$web_primary_health" != "missing" || "$web_standby_health" != "missing" ]]; then
+      echo "ERROR: neither frontend replica is healthy; refusing to replace either one" >&2
+      return 1
+    fi
+  fi
+
+  if [[ "$api_primary_recovered" == "true" || "$web_primary_recovered" == "true" ]]; then
+    hubuum_reload_caddy
+  fi
 
   # Upgrade every standby while its primary remains available. Caddy can retain
   # a passive failure mark for a container that was unavailable during
@@ -114,9 +175,15 @@ hubuum_rollout() {
   fi
   hubuum_reload_caddy
 
-  hubuum_roll_service hubuum-api
-  if [[ "$INSTALL_MODE" == "all" ]]; then
-    hubuum_roll_service hubuum-web
+  if [[ "$api_primary_recovered" != "true" ]]; then
+    hubuum_roll_service hubuum-api
+    primary_rolled="true"
   fi
-  hubuum_reload_caddy
+  if [[ "$INSTALL_MODE" == "all" && "$web_primary_recovered" != "true" ]]; then
+    hubuum_roll_service hubuum-web
+    primary_rolled="true"
+  fi
+  if [[ "$primary_rolled" == "true" ]]; then
+    hubuum_reload_caddy
+  fi
 }

--- a/scripts/single-host-rollout.sh
+++ b/scripts/single-host-rollout.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# Shared rolling-update primitives for the single-host installer and updater.
+# The caller must define COMPOSE_CMD, ENGINE_PATH, and INSTALL_MODE before
+# invoking hubuum_rollout.
+
+hubuum_service_container_id() {
+  local service="$1"
+
+  "${COMPOSE_CMD[@]}" ps -q "$service"
+}
+
+hubuum_service_health() {
+  local service="$1"
+  local container_id
+
+  container_id="$(hubuum_service_container_id "$service")"
+  [[ -n "$container_id" ]] || {
+    printf 'missing\n'
+    return 0
+  }
+
+  "$ENGINE_PATH" inspect \
+    --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' \
+    "$container_id" 2>/dev/null || printf 'missing\n'
+}
+
+hubuum_wait_for_healthy() {
+  local service="$1"
+  local timeout_seconds="${2:-180}"
+  local deadline=$((SECONDS + timeout_seconds))
+  local health
+
+  while (( SECONDS < deadline )); do
+    health="$(hubuum_service_health "$service")"
+    case "$health" in
+      healthy|running)
+        return 0
+        ;;
+      exited|dead)
+        echo "ERROR: $service stopped while waiting for readiness" >&2
+        "${COMPOSE_CMD[@]}" logs --tail 100 "$service" >&2 || true
+        return 1
+        ;;
+    esac
+    sleep 2
+  done
+
+  echo "ERROR: $service did not become healthy within ${timeout_seconds}s" >&2
+  "${COMPOSE_CMD[@]}" logs --tail 100 "$service" >&2 || true
+  return 1
+}
+
+hubuum_roll_service() {
+  local service="$1"
+
+  echo "Rolling $service..."
+  "${COMPOSE_CMD[@]}" up -d --no-deps --force-recreate "$service"
+  hubuum_wait_for_healthy "$service"
+}
+
+hubuum_caddy_is_running() {
+  [[ -n "$(hubuum_service_container_id caddy)" ]]
+}
+
+hubuum_reload_caddy() {
+  echo "Reloading Caddy with the redundant upstream configuration..."
+  "${COMPOSE_CMD[@]}" exec -T caddy \
+    caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+}
+
+hubuum_run_migrations() {
+  echo "Running one-shot database migrations while the primary remains online..."
+  "${COMPOSE_CMD[@]}" run --rm --no-deps \
+    --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+}
+
+hubuum_start_stack() {
+  echo "Starting the initial Hubuum stack..."
+
+  # Start the migration-owning primary first. Starting both API containers at
+  # once could make two fresh containers race to apply the same migrations.
+  "${COMPOSE_CMD[@]}" up -d hubuum-api
+  hubuum_wait_for_healthy hubuum-api
+
+  "${COMPOSE_CMD[@]}" up -d --no-deps hubuum-api-standby
+  hubuum_wait_for_healthy hubuum-api-standby
+
+  if [[ "$INSTALL_MODE" == "all" ]]; then
+    "${COMPOSE_CMD[@]}" up -d hubuum-web hubuum-web-standby
+    hubuum_wait_for_healthy hubuum-web
+    hubuum_wait_for_healthy hubuum-web-standby
+  fi
+
+  "${COMPOSE_CMD[@]}" up -d --no-deps caddy
+}
+
+hubuum_rollout() {
+  local reload_caddy="${1:-false}"
+
+  if ! hubuum_caddy_is_running; then
+    hubuum_start_stack
+    return 0
+  fi
+
+  hubuum_run_migrations
+
+  # The standby is upgraded and proven ready while the primary remains the
+  # currently configured upstream. On first adoption, reload Caddy only after
+  # that safety copy exists. Routine updates keep Caddy and its configuration
+  # untouched, preserving long-lived connections.
+  hubuum_roll_service hubuum-api-standby
+  if [[ "$reload_caddy" == "true" ]]; then
+    hubuum_reload_caddy
+  fi
+
+  if [[ "$INSTALL_MODE" == "all" ]]; then
+    hubuum_roll_service hubuum-web-standby
+  fi
+
+  hubuum_roll_service hubuum-api
+  if [[ "$INSTALL_MODE" == "all" ]]; then
+    hubuum_roll_service hubuum-web
+  fi
+}

--- a/scripts/test-install-script-refresh.sh
+++ b/scripts/test-install-script-refresh.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 SCRIPT_DIR="$TEST_ROOT/installed"
 INSTALL_DIR="$SCRIPT_DIR"
 REMOTE_DIR="$TEST_ROOT/remote"
-SCRIPT_BASE_URL="https://example.invalid/scripts"
+export SCRIPT_BASE_URL="https://example.invalid/scripts"
 mkdir -p "$INSTALL_DIR" "$REMOTE_DIR"
 
 curl() {

--- a/scripts/test-install-script-refresh.sh
+++ b/scripts/test-install-script-refresh.sh
@@ -45,6 +45,7 @@ eval "$function_source"
 management_scripts=(
   install-single-host.sh
   update-single-host.sh
+  single-host-rollout.sh
   stop-single-host.sh
   uninstall-single-host.sh
 )

--- a/scripts/test-single-host-rollout.sh
+++ b/scripts/test-single-host-rollout.sh
@@ -67,10 +67,10 @@ cat > "$TEST_ROOT/expected-rolling.log" <<EOF
 compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web-standby
-compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web
-compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
 EOF
 assert_commands "$TEST_ROOT/expected-rolling.log"
 
@@ -80,9 +80,9 @@ hubuum_rollout
 cat > "$TEST_ROOT/expected-reload.log" <<EOF
 compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
-compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
-compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
 EOF
 assert_commands "$TEST_ROOT/expected-reload.log"
 
@@ -95,12 +95,12 @@ hubuum_rollout
 cat > "$TEST_ROOT/expected-recovery.log" <<EOF
 compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
-compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web-standby
-compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web
-compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
 EOF
 assert_commands "$TEST_ROOT/expected-recovery.log"
 
@@ -114,10 +114,10 @@ compose --env-file .env -f compose.yml up -d --no-deps --no-recreate valkey
 compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web-standby
-compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web
-compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
 EOF
 assert_commands "$TEST_ROOT/expected-missing-infrastructure.log"
 

--- a/scripts/test-single-host-rollout.sh
+++ b/scripts/test-single-host-rollout.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPOSITORY_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+COMMAND_LOG="$TEST_ROOT/commands.log"
+FAKE_ENGINE="$TEST_ROOT/engine"
+
+cat > "$FAKE_ENGINE" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$COMMAND_LOG"
+
+if [[ "${1:-}" == "inspect" ]]; then
+  printf 'healthy\n'
+  exit 0
+fi
+
+if [[ "$*" == *" ps -q "* ]]; then
+  service="${*: -1}"
+  if [[ "$service" != "caddy" || "$FAKE_CADDY_RUNNING" == "true" ]]; then
+    printf 'container-%s\n' "$service"
+  fi
+fi
+EOF
+chmod +x "$FAKE_ENGINE"
+
+export COMMAND_LOG FAKE_CADDY_RUNNING
+ENGINE_PATH="$FAKE_ENGINE"
+COMPOSE_CMD=("$FAKE_ENGINE" compose --env-file .env -f compose.yml)
+
+# shellcheck source=scripts/single-host-rollout.sh
+source "$REPOSITORY_ROOT/scripts/single-host-rollout.sh"
+
+assert_commands() {
+  local expected="$1"
+  local actual="$TEST_ROOT/actual.log"
+
+  grep -E '(^| )(run|up|exec) ' "$COMMAND_LOG" > "$actual"
+  diff -u "$expected" "$actual"
+}
+
+FAKE_CADDY_RUNNING="true"
+INSTALL_MODE="all"
+: > "$COMMAND_LOG"
+hubuum_rollout false
+cat > "$TEST_ROOT/expected-rolling.log" <<EOF
+compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web-standby
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web
+EOF
+assert_commands "$TEST_ROOT/expected-rolling.log"
+
+INSTALL_MODE="backend"
+: > "$COMMAND_LOG"
+hubuum_rollout true
+cat > "$TEST_ROOT/expected-reload.log" <<EOF
+compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
+EOF
+assert_commands "$TEST_ROOT/expected-reload.log"
+
+FAKE_CADDY_RUNNING="false"
+INSTALL_MODE="backend"
+: > "$COMMAND_LOG"
+hubuum_rollout false
+cat > "$TEST_ROOT/expected-initial.log" <<EOF
+compose --env-file .env -f compose.yml up -d hubuum-api
+compose --env-file .env -f compose.yml up -d --no-deps hubuum-api-standby
+compose --env-file .env -f compose.yml up -d --no-deps caddy
+EOF
+assert_commands "$TEST_ROOT/expected-initial.log"
+
+echo "Single-host rolling update test passed"

--- a/scripts/test-single-host-rollout.sh
+++ b/scripts/test-single-host-rollout.sh
@@ -46,31 +46,34 @@ assert_commands() {
 FAKE_CADDY_RUNNING="true"
 INSTALL_MODE="all"
 : > "$COMMAND_LOG"
-hubuum_rollout false
+hubuum_rollout
 cat > "$TEST_ROOT/expected-rolling.log" <<EOF
 compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web-standby
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
 EOF
 assert_commands "$TEST_ROOT/expected-rolling.log"
 
 INSTALL_MODE="backend"
 : > "$COMMAND_LOG"
-hubuum_rollout true
+hubuum_rollout
 cat > "$TEST_ROOT/expected-reload.log" <<EOF
 compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
 compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
 EOF
 assert_commands "$TEST_ROOT/expected-reload.log"
 
 FAKE_CADDY_RUNNING="false"
 INSTALL_MODE="backend"
 : > "$COMMAND_LOG"
-hubuum_rollout false
+hubuum_rollout
 cat > "$TEST_ROOT/expected-initial.log" <<EOF
 compose --env-file .env -f compose.yml up -d hubuum-api
 compose --env-file .env -f compose.yml up -d --no-deps hubuum-api-standby

--- a/scripts/test-single-host-rollout.sh
+++ b/scripts/test-single-host-rollout.sh
@@ -15,20 +15,36 @@ set -euo pipefail
 printf '%s\n' "$*" >> "$COMMAND_LOG"
 
 if [[ "${1:-}" == "inspect" ]]; then
-  printf 'healthy\n'
+  service="${*: -1}"
+  service="${service#container-}"
+  if [[ " ${FAKE_UNHEALTHY_SERVICES:-} " == *" $service "* && ! -e "$TEST_ROOT/started-$service" ]]; then
+    printf 'unhealthy\n'
+  else
+    printf 'healthy\n'
+  fi
   exit 0
 fi
 
 if [[ "$*" == *" ps -q "* ]]; then
   service="${*: -1}"
-  if [[ "$service" != "caddy" || "$FAKE_CADDY_RUNNING" == "true" ]]; then
+  if [[ "$service" == "caddy" && "$FAKE_CADDY_RUNNING" != "true" && ! -e "$TEST_ROOT/started-caddy" ]]; then
+    exit 0
+  fi
+  if [[ " ${FAKE_MISSING_SERVICES:-} " != *" $service "* || -e "$TEST_ROOT/started-$service" ]]; then
     printf 'container-%s\n' "$service"
   fi
+fi
+
+if [[ "$*" == *" up "* ]]; then
+  service="${*: -1}"
+  touch "$TEST_ROOT/started-$service"
 fi
 EOF
 chmod +x "$FAKE_ENGINE"
 
-export COMMAND_LOG FAKE_CADDY_RUNNING
+export COMMAND_LOG FAKE_CADDY_RUNNING TEST_ROOT
+export FAKE_MISSING_SERVICES=""
+export FAKE_UNHEALTHY_SERVICES=""
 ENGINE_PATH="$FAKE_ENGINE"
 COMPOSE_CMD=("$FAKE_ENGINE" compose --env-file .env -f compose.yml)
 
@@ -70,7 +86,43 @@ compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/
 EOF
 assert_commands "$TEST_ROOT/expected-reload.log"
 
+FAKE_CADDY_RUNNING="true"
+FAKE_UNHEALTHY_SERVICES="hubuum-api"
+INSTALL_MODE="all"
+rm -f "$TEST_ROOT/started-hubuum-api"
+: > "$COMMAND_LOG"
+hubuum_rollout
+cat > "$TEST_ROOT/expected-recovery.log" <<EOF
+compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web-standby
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+EOF
+assert_commands "$TEST_ROOT/expected-recovery.log"
+
+FAKE_UNHEALTHY_SERVICES=""
+FAKE_MISSING_SERVICES="valkey"
+rm -f "$TEST_ROOT/started-valkey"
+: > "$COMMAND_LOG"
+hubuum_rollout
+cat > "$TEST_ROOT/expected-missing-infrastructure.log" <<EOF
+compose --env-file .env -f compose.yml up -d --no-deps --no-recreate valkey
+compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web-standby
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web
+compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+EOF
+assert_commands "$TEST_ROOT/expected-missing-infrastructure.log"
+
 FAKE_CADDY_RUNNING="false"
+FAKE_MISSING_SERVICES=""
 INSTALL_MODE="backend"
 : > "$COMMAND_LOG"
 hubuum_rollout

--- a/scripts/test-single-host-zero-downtime.sh
+++ b/scripts/test-single-host-zero-downtime.sh
@@ -81,7 +81,7 @@ write_old_caddyfile() {
 }
 
 :8080 {
-    reverse_proxy hubuum-api:8080 hubuum-api-standby:8080 {
+    reverse_proxy hubuum-api:8080 {
         health_uri /healthz
         health_interval 5s
         health_timeout 3s
@@ -96,7 +96,10 @@ EOF
 }
 
 write_candidate_caddyfile() {
-  cat > "$TEST_ROOT/Caddyfile" <<'EOF'
+  local caddyfile_temp
+
+  caddyfile_temp="$(mktemp "$TEST_ROOT/.Caddyfile.XXXXXX")"
+  cat > "$caddyfile_temp" <<'EOF'
 {
     auto_https off
 }
@@ -114,6 +117,11 @@ write_candidate_caddyfile() {
     }
 }
 EOF
+
+  # Match the installer: update the contents without replacing the inode that
+  # the already-running Caddy container bind-mounted from the legacy fixture.
+  cp "$caddyfile_temp" "$TEST_ROOT/Caddyfile"
+  rm -f "$caddyfile_temp"
 }
 
 write_old_caddyfile
@@ -233,20 +241,21 @@ wait_for_public_endpoint() {
 
 probe_worker() {
   local worker="$1"
-  local path="healthz"
+  local path
   local status
 
-  if (( worker % 2 == 0 )) && [[ -e "$READY_PROBES_FILE" ]]; then
-    path="readyz"
-  fi
-
   while [[ ! -e "$PROBE_STOP_FILE" ]]; do
+    path="healthz"
+    if (( worker % 2 == 0 )) && [[ -e "$READY_PROBES_FILE" ]]; then
+      path="readyz"
+    fi
+
     if status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
       --connect-timeout 1 --max-time 2 "$PUBLIC_URL/$path" \
       2>> "$TEST_ROOT/probe-${worker}.stderr")"; then
-      printf '%s\n' "$status" >> "$TEST_ROOT/probe-${worker}.log"
+      printf '%s %s\n' "$path" "$status" >> "$TEST_ROOT/probe-${worker}.log"
     else
-      printf 'curl-error\n' >> "$TEST_ROOT/probe-${worker}.log"
+      printf '%s curl-error\n' "$path" >> "$TEST_ROOT/probe-${worker}.log"
     fi
     sleep 0.05
   done
@@ -264,11 +273,15 @@ start_probes() {
 }
 
 assert_probes_succeeded() {
+  local health_request_count
+  local ready_request_count
   local request_count
   local failures="$TEST_ROOT/probe-failures.log"
 
   request_count="$(awk 'END { print NR }' "$TEST_ROOT"/probe-*.log)"
-  grep -Hnv '^200$' "$TEST_ROOT"/probe-*.log > "$failures" || true
+  health_request_count="$(awk '$1 == "healthz" && $2 == "200" { count++ } END { print count + 0 }' "$TEST_ROOT"/probe-*.log)"
+  ready_request_count="$(awk '$1 == "readyz" && $2 == "200" { count++ } END { print count + 0 }' "$TEST_ROOT"/probe-*.log)"
+  grep -HnvE '^(healthz|readyz) 200$' "$TEST_ROOT"/probe-*.log > "$failures" || true
 
   if [[ -s "$failures" ]]; then
     echo "ERROR: public HTTP requests failed during the rollout:" >&2
@@ -279,7 +292,11 @@ assert_probes_succeeded() {
     echo "ERROR: expected at least 100 probe requests, observed $request_count" >&2
     return 1
   fi
-  echo "Observed $request_count successful HTTP requests with no failures."
+  if (( health_request_count == 0 || ready_request_count == 0 )); then
+    echo "ERROR: expected successful health and readiness probes, observed healthz=$health_request_count readyz=$ready_request_count" >&2
+    return 1
+  fi
+  echo "Observed $request_count successful HTTP requests with no failures (healthz=$health_request_count, readyz=$ready_request_count)."
 }
 
 expect_rollout_failure() {

--- a/scripts/test-single-host-zero-downtime.sh
+++ b/scripts/test-single-host-zero-downtime.sh
@@ -4,11 +4,13 @@ set -Eeuo pipefail
 REPOSITORY_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 ENGINE_PATH="$(command -v docker)"
 HUBUUM_TEST_IMAGE="${HUBUUM_TEST_IMAGE:-hubuum-server:ci}"
+HUBUUM_OLD_TEST_IMAGE="${HUBUUM_OLD_TEST_IMAGE:-ghcr.io/hubuum/hubuum-server:v0.0.1@sha256:061fc4cb3af57e2db06c33012db93e60834d4618815e30af4ebb4aa05a21f445}"
 POSTGRES_TEST_IMAGE="${POSTGRES_TEST_IMAGE:-postgres:18.4@sha256:22c89fe0d0f507606260237fd55e51f6137f58b2d5bcf6152242b96d9fe8f9a4}"
 CADDY_TEST_IMAGE="${CADDY_TEST_IMAGE:-caddy:2-alpine}"
 TEST_ROOT="$(mktemp -d)"
 PROJECT_NAME="hubuum-zero-downtime-${RANDOM}-${RANDOM}"
 PROBE_STOP_FILE="$TEST_ROOT/stop-probes"
+READY_PROBES_FILE="$TEST_ROOT/enable-ready-probes"
 PROBE_PIDS=""
 HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS="${HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS:-12}"
 INSTALL_MODE="backend"
@@ -18,6 +20,7 @@ docker image inspect "$HUBUUM_TEST_IMAGE" >/dev/null 2>&1 || {
   echo "Build it first or set HUBUUM_TEST_IMAGE to an existing Hubuum image." >&2
   exit 1
 }
+docker image inspect "$HUBUUM_OLD_TEST_IMAGE" >/dev/null 2>&1 || docker pull "$HUBUUM_OLD_TEST_IMAGE"
 
 COMPOSE_CMD=(
   "$ENGINE_PATH" compose
@@ -61,6 +64,7 @@ write_environment() {
 
   cat > "$TEST_ROOT/.env" <<EOF
 HUBUUM_TEST_IMAGE=$HUBUUM_TEST_IMAGE
+HUBUUM_OLD_TEST_IMAGE=$HUBUUM_OLD_TEST_IMAGE
 POSTGRES_TEST_IMAGE=$POSTGRES_TEST_IMAGE
 CADDY_TEST_IMAGE=$CADDY_TEST_IMAGE
 HUBUUM_DATABASE_URL=$database_url
@@ -70,7 +74,29 @@ EOF
 DATABASE_URL="postgres://hubuum:zero-downtime-test@postgres/hubuum?sslmode=disable"
 write_environment "$DATABASE_URL"
 
-cat > "$TEST_ROOT/Caddyfile" <<'EOF'
+write_old_caddyfile() {
+  cat > "$TEST_ROOT/Caddyfile" <<'EOF'
+{
+    auto_https off
+}
+
+:8080 {
+    reverse_proxy hubuum-api:8080 hubuum-api-standby:8080 {
+        health_uri /healthz
+        health_interval 5s
+        health_timeout 3s
+        fail_duration 30s
+        max_fails 1
+        lb_try_duration 5s
+        lb_try_interval 250ms
+        stream_close_delay 5m
+    }
+}
+EOF
+}
+
+write_candidate_caddyfile() {
+  cat > "$TEST_ROOT/Caddyfile" <<'EOF'
 {
     auto_https off
 }
@@ -88,6 +114,9 @@ cat > "$TEST_ROOT/Caddyfile" <<'EOF'
     }
 }
 EOF
+}
+
+write_old_caddyfile
 
 cat > "$TEST_ROOT/compose.yml" <<'EOF'
 services:
@@ -152,6 +181,19 @@ services:
       HUBUUM_DATABASE_URL: postgres://hubuum:zero-downtime-test@127.0.0.1:1/hubuum
 EOF
 
+cat > "$TEST_ROOT/old-version.yml" <<'EOF'
+services:
+  hubuum-api:
+    image: ${HUBUUM_OLD_TEST_IMAGE}
+    healthcheck:
+      # v0.0.1 exposes /healthz but does not contain wget or curl. The external
+      # Caddy probe below is the HTTP readiness gate for this historical image.
+      test: ["CMD-SHELL", "kill -0 1"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+EOF
+
 service_id() {
   "${BASE_COMPOSE_CMD[@]}" ps -q "$1"
 }
@@ -176,15 +218,16 @@ assert_changed_id() {
   }
 }
 
-wait_for_public_readiness() {
+wait_for_public_endpoint() {
+  local path="$1"
   local attempt
   for (( attempt = 1; attempt <= 60; attempt++ )); do
-    if curl --fail --silent --show-error --max-time 2 "$PUBLIC_URL/readyz" >/dev/null; then
+    if curl --fail --silent --show-error --max-time 2 "$PUBLIC_URL/$path" >/dev/null; then
       return 0
     fi
     sleep 1
   done
-  echo "ERROR: Caddy did not expose a ready API within 60 seconds" >&2
+  echo "ERROR: Caddy did not expose $path within 60 seconds" >&2
   return 1
 }
 
@@ -193,7 +236,7 @@ probe_worker() {
   local path="healthz"
   local status
 
-  if (( worker % 2 == 0 )); then
+  if (( worker % 2 == 0 )) && [[ -e "$READY_PROBES_FILE" ]]; then
     path="readyz"
   fi
 
@@ -259,21 +302,84 @@ expect_rollout_failure() {
   fi
 }
 
+migration_count() {
+  "${BASE_COMPOSE_CMD[@]}" exec -T postgres \
+    psql --username hubuum --dbname hubuum --tuples-only --no-align \
+    --command 'SELECT count(*) FROM __diesel_schema_migrations'
+}
+
+migration_is_applied() {
+  local version="$1"
+  "${BASE_COMPOSE_CMD[@]}" exec -T postgres \
+    psql --username hubuum --dbname hubuum --tuples-only --no-align \
+    --command "SELECT EXISTS (SELECT 1 FROM __diesel_schema_migrations WHERE version = '$version')"
+}
+
+container_uses_candidate_image() {
+  local service="$1"
+  local container_id
+  local candidate_image_id
+
+  container_id="$(service_id "$service")"
+  candidate_image_id="$(docker image inspect "$HUBUUM_TEST_IMAGE" --format '{{.Id}}')"
+  [[ "$(docker inspect "$container_id" --format '{{.Image}}')" == "$candidate_image_id" ]]
+}
+
 # shellcheck source=scripts/single-host-rollout.sh
 source "$REPOSITORY_ROOT/scripts/single-host-rollout.sh"
 
-echo "Starting the live single-host fixture..."
-hubuum_rollout
+echo "Starting the live single-host fixture on Hubuum v0.0.1..."
+COMPOSE_CMD=("${BASE_COMPOSE_CMD[@]}" --file "$TEST_ROOT/old-version.yml")
+"${COMPOSE_CMD[@]}" up -d hubuum-api
+hubuum_wait_for_healthy hubuum-api "$HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS"
+"${COMPOSE_CMD[@]}" up -d --no-deps caddy
+COMPOSE_CMD=("${BASE_COMPOSE_CMD[@]}")
 PUBLIC_ADDRESS="$("${BASE_COMPOSE_CMD[@]}" port caddy 8080)"
 PUBLIC_URL="http://${PUBLIC_ADDRESS}"
-wait_for_public_readiness
+wait_for_public_endpoint healthz
+
+old_primary_id="$(service_id hubuum-api)"
+initial_caddy_id="$(service_id caddy)"
+initial_postgres_id="$(service_id postgres)"
+old_migration_count="$(migration_count)"
+expected_migration_version="$(find "$REPOSITORY_ROOT/migrations" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort | tail -n 1 | cut -d_ -f1 | tr -d '-')"
+[[ "$(migration_is_applied "$expected_migration_version")" == "f" ]] || {
+  echo "ERROR: v0.0.1 unexpectedly applied candidate migration $expected_migration_version" >&2
+  exit 1
+}
+
+start_probes
+
+echo "Migrating the v0.0.1 database and rolling to the candidate image..."
+write_candidate_caddyfile
+hubuum_rollout
+touch "$READY_PROBES_FILE"
+wait_for_public_endpoint readyz
+
+candidate_migration_count="$(migration_count)"
+(( candidate_migration_count > old_migration_count )) || {
+  echo "ERROR: candidate did not apply migrations after v0.0.1" >&2
+  exit 1
+}
+echo "Candidate applied $((candidate_migration_count - old_migration_count)) migration(s) after v0.0.1."
+[[ "$(migration_is_applied "$expected_migration_version")" == "t" ]] || {
+  echo "ERROR: candidate migration $expected_migration_version was not applied" >&2
+  exit 1
+}
+assert_changed_id "v0.0.1 primary API" "$old_primary_id" "$(service_id hubuum-api)"
+container_uses_candidate_image hubuum-api || {
+  echo "ERROR: primary API does not use the candidate image" >&2
+  exit 1
+}
+container_uses_candidate_image hubuum-api-standby || {
+  echo "ERROR: standby API does not use the candidate image" >&2
+  exit 1
+}
+assert_same_id "Caddy during version upgrade" "$initial_caddy_id" "$(service_id caddy)"
+assert_same_id "PostgreSQL during version upgrade" "$initial_postgres_id" "$(service_id postgres)"
 
 initial_primary_id="$(service_id hubuum-api)"
 initial_standby_id="$(service_id hubuum-api-standby)"
-initial_caddy_id="$(service_id caddy)"
-initial_postgres_id="$(service_id postgres)"
-
-start_probes
 
 echo "Verifying that a failed migration leaves both API replicas untouched..."
 write_environment "postgres://hubuum:zero-downtime-test@127.0.0.1:1/hubuum"
@@ -299,7 +405,7 @@ hubuum_rollout
 sleep 2
 stop_probes
 assert_probes_succeeded
-wait_for_public_readiness
+wait_for_public_endpoint readyz
 
 assert_changed_id "primary API" "$before_rollout_primary_id" "$(service_id hubuum-api)"
 assert_changed_id "standby API" "$before_rollout_standby_id" "$(service_id hubuum-api-standby)"

--- a/scripts/test-single-host-zero-downtime.sh
+++ b/scripts/test-single-host-zero-downtime.sh
@@ -67,7 +67,7 @@ HUBUUM_TEST_IMAGE=$HUBUUM_TEST_IMAGE
 HUBUUM_OLD_TEST_IMAGE=$HUBUUM_OLD_TEST_IMAGE
 POSTGRES_TEST_IMAGE=$POSTGRES_TEST_IMAGE
 CADDY_TEST_IMAGE=$CADDY_TEST_IMAGE
-HUBUUM_DATABASE_URL=$database_url
+HUBUUM_ZERO_DOWNTIME_DATABASE_URL=$database_url
 EOF
 }
 
@@ -154,7 +154,7 @@ services:
     environment:
       HUBUUM_BIND_IP: 0.0.0.0
       HUBUUM_BIND_PORT: 8080
-      HUBUUM_DATABASE_URL: ${HUBUUM_DATABASE_URL}
+      HUBUUM_DATABASE_URL: ${HUBUUM_ZERO_DOWNTIME_DATABASE_URL}
       HUBUUM_CLIENT_ALLOWLIST: "*"
       HUBUUM_LOG_LEVEL: info
     depends_on:
@@ -187,6 +187,14 @@ services:
     stop_grace_period: 2s
     environment:
       HUBUUM_DATABASE_URL: postgres://hubuum:zero-downtime-test@127.0.0.1:1/hubuum
+EOF
+
+cat > "$TEST_ROOT/unhealthy-primary.yml" <<'EOF'
+services:
+  hubuum-api:
+    stop_grace_period: 2s
+    environment:
+      HUBUUM_BIND_PORT: 18081
 EOF
 
 cat > "$TEST_ROOT/old-version.yml" <<'EOF'
@@ -417,6 +425,16 @@ echo "Recovering the standby and performing a successful live rollout..."
 hubuum_roll_service hubuum-api-standby
 before_rollout_primary_id="$(service_id hubuum-api)"
 before_rollout_standby_id="$(service_id hubuum-api-standby)"
+hubuum_rollout
+
+echo "Verifying that retrying a failed primary replacement preserves the healthy standby..."
+COMPOSE_CMD=("${BASE_COMPOSE_CMD[@]}" --file "$TEST_ROOT/unhealthy-primary.yml")
+expect_rollout_failure primary-failure
+COMPOSE_CMD=("${BASE_COMPOSE_CMD[@]}")
+hubuum_service_is_healthy hubuum-api-standby || {
+  echo "ERROR: standby API was not healthy after the primary replacement failed" >&2
+  exit 1
+}
 hubuum_rollout
 
 sleep 2

--- a/scripts/test-single-host-zero-downtime.sh
+++ b/scripts/test-single-host-zero-downtime.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPOSITORY_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+ENGINE_PATH="$(command -v docker)"
+HUBUUM_TEST_IMAGE="${HUBUUM_TEST_IMAGE:-hubuum-server:ci}"
+POSTGRES_TEST_IMAGE="${POSTGRES_TEST_IMAGE:-postgres:18.4@sha256:22c89fe0d0f507606260237fd55e51f6137f58b2d5bcf6152242b96d9fe8f9a4}"
+CADDY_TEST_IMAGE="${CADDY_TEST_IMAGE:-caddy:2-alpine}"
+TEST_ROOT="$(mktemp -d)"
+PROJECT_NAME="hubuum-zero-downtime-${RANDOM}-${RANDOM}"
+PROBE_STOP_FILE="$TEST_ROOT/stop-probes"
+PROBE_PIDS=""
+HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS="${HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS:-12}"
+INSTALL_MODE="backend"
+
+docker image inspect "$HUBUUM_TEST_IMAGE" >/dev/null 2>&1 || {
+  echo "ERROR: missing test image $HUBUUM_TEST_IMAGE" >&2
+  echo "Build it first or set HUBUUM_TEST_IMAGE to an existing Hubuum image." >&2
+  exit 1
+}
+
+COMPOSE_CMD=(
+  "$ENGINE_PATH" compose
+  --project-name "$PROJECT_NAME"
+  --env-file "$TEST_ROOT/.env"
+  --file "$TEST_ROOT/compose.yml"
+)
+BASE_COMPOSE_CMD=("${COMPOSE_CMD[@]}")
+
+stop_probes() {
+  touch "$PROBE_STOP_FILE"
+  local pid
+  for pid in $PROBE_PIDS; do
+    wait "$pid" 2>/dev/null || true
+  done
+  PROBE_PIDS=""
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  set +e
+  stop_probes
+  if [[ "$status" -ne 0 ]]; then
+    echo "Live zero-downtime test failed; container state and logs follow." >&2
+    "${BASE_COMPOSE_CMD[@]}" ps >&2
+    "${BASE_COMPOSE_CMD[@]}" logs --no-color --tail 200 >&2
+  fi
+  "${BASE_COMPOSE_CMD[@]}" down --volumes --remove-orphans >/dev/null 2>&1
+  if [[ "${HUBUUM_KEEP_ZERO_DOWNTIME_TEST_ROOT:-false}" == "true" ]]; then
+    echo "Preserved test files in $TEST_ROOT" >&2
+  else
+    rm -rf "$TEST_ROOT"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+write_environment() {
+  local database_url="$1"
+
+  cat > "$TEST_ROOT/.env" <<EOF
+HUBUUM_TEST_IMAGE=$HUBUUM_TEST_IMAGE
+POSTGRES_TEST_IMAGE=$POSTGRES_TEST_IMAGE
+CADDY_TEST_IMAGE=$CADDY_TEST_IMAGE
+HUBUUM_DATABASE_URL=$database_url
+EOF
+}
+
+DATABASE_URL="postgres://hubuum:zero-downtime-test@postgres/hubuum?sslmode=disable"
+write_environment "$DATABASE_URL"
+
+cat > "$TEST_ROOT/Caddyfile" <<'EOF'
+{
+    auto_https off
+}
+
+:8080 {
+    reverse_proxy hubuum-api:8080 hubuum-api-standby:8080 {
+        health_uri /readyz
+        health_interval 5s
+        health_timeout 3s
+        fail_duration 30s
+        max_fails 1
+        lb_try_duration 5s
+        lb_try_interval 250ms
+        stream_close_delay 5m
+    }
+}
+EOF
+
+cat > "$TEST_ROOT/compose.yml" <<'EOF'
+services:
+  postgres:
+    image: ${POSTGRES_TEST_IMAGE}
+    environment:
+      POSTGRES_DB: hubuum
+      POSTGRES_USER: hubuum
+      POSTGRES_PASSWORD: zero-downtime-test
+      PGUSER: hubuum
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U hubuum -d hubuum"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  hubuum-api: &hubuum-api
+    image: ${HUBUUM_TEST_IMAGE}
+    stop_grace_period: 75s
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      HUBUUM_BIND_IP: 0.0.0.0
+      HUBUUM_BIND_PORT: 8080
+      HUBUUM_DATABASE_URL: ${HUBUUM_DATABASE_URL}
+      HUBUUM_CLIENT_ALLOWLIST: "*"
+      HUBUUM_LOG_LEVEL: info
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --output-document=/dev/null http://127.0.0.1:8080/readyz"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  hubuum-api-standby:
+    <<: *hubuum-api
+    command: ["--runtime-role", "api"]
+
+  caddy:
+    image: ${CADDY_TEST_IMAGE}
+    ports:
+      - "127.0.0.1::8080"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+    depends_on:
+      - hubuum-api
+      - hubuum-api-standby
+EOF
+
+cat > "$TEST_ROOT/unhealthy-standby.yml" <<'EOF'
+services:
+  hubuum-api-standby:
+    stop_grace_period: 2s
+    environment:
+      HUBUUM_DATABASE_URL: postgres://hubuum:zero-downtime-test@127.0.0.1:1/hubuum
+EOF
+
+service_id() {
+  "${BASE_COMPOSE_CMD[@]}" ps -q "$1"
+}
+
+assert_same_id() {
+  local description="$1"
+  local before="$2"
+  local after="$3"
+  [[ -n "$before" && "$before" == "$after" ]] || {
+    echo "ERROR: $description was unexpectedly replaced" >&2
+    return 1
+  }
+}
+
+assert_changed_id() {
+  local description="$1"
+  local before="$2"
+  local after="$3"
+  [[ -n "$before" && -n "$after" && "$before" != "$after" ]] || {
+    echo "ERROR: $description was not replaced" >&2
+    return 1
+  }
+}
+
+wait_for_public_readiness() {
+  local attempt
+  for (( attempt = 1; attempt <= 60; attempt++ )); do
+    if curl --fail --silent --show-error --max-time 2 "$PUBLIC_URL/readyz" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: Caddy did not expose a ready API within 60 seconds" >&2
+  return 1
+}
+
+probe_worker() {
+  local worker="$1"
+  local path="healthz"
+  local status
+
+  if (( worker % 2 == 0 )); then
+    path="readyz"
+  fi
+
+  while [[ ! -e "$PROBE_STOP_FILE" ]]; do
+    if status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+      --connect-timeout 1 --max-time 2 "$PUBLIC_URL/$path" \
+      2>> "$TEST_ROOT/probe-${worker}.stderr")"; then
+      printf '%s\n' "$status" >> "$TEST_ROOT/probe-${worker}.log"
+    else
+      printf 'curl-error\n' >> "$TEST_ROOT/probe-${worker}.log"
+    fi
+    sleep 0.05
+  done
+}
+
+start_probes() {
+  rm -f "$PROBE_STOP_FILE"
+  local worker
+  for worker in 1 2 3 4; do
+    : > "$TEST_ROOT/probe-${worker}.log"
+    : > "$TEST_ROOT/probe-${worker}.stderr"
+    probe_worker "$worker" &
+    PROBE_PIDS="$PROBE_PIDS $!"
+  done
+}
+
+assert_probes_succeeded() {
+  local request_count
+  local failures="$TEST_ROOT/probe-failures.log"
+
+  request_count="$(awk 'END { print NR }' "$TEST_ROOT"/probe-*.log)"
+  grep -Hnv '^200$' "$TEST_ROOT"/probe-*.log > "$failures" || true
+
+  if [[ -s "$failures" ]]; then
+    echo "ERROR: public HTTP requests failed during the rollout:" >&2
+    cat "$failures" >&2
+    return 1
+  fi
+  if (( request_count < 100 )); then
+    echo "ERROR: expected at least 100 probe requests, observed $request_count" >&2
+    return 1
+  fi
+  echo "Observed $request_count successful HTTP requests with no failures."
+}
+
+expect_rollout_failure() {
+  local description="$1"
+  local output="$TEST_ROOT/${description}.log"
+  local status
+
+  set +e
+  (
+    set -Eeuo pipefail
+    hubuum_rollout
+  ) > "$output" 2>&1
+  status=$?
+  set -e
+
+  if [[ "$status" -eq 0 ]]; then
+    echo "ERROR: $description rollout unexpectedly succeeded" >&2
+    cat "$output" >&2
+    return 1
+  fi
+}
+
+# shellcheck source=scripts/single-host-rollout.sh
+source "$REPOSITORY_ROOT/scripts/single-host-rollout.sh"
+
+echo "Starting the live single-host fixture..."
+hubuum_rollout
+PUBLIC_ADDRESS="$("${BASE_COMPOSE_CMD[@]}" port caddy 8080)"
+PUBLIC_URL="http://${PUBLIC_ADDRESS}"
+wait_for_public_readiness
+
+initial_primary_id="$(service_id hubuum-api)"
+initial_standby_id="$(service_id hubuum-api-standby)"
+initial_caddy_id="$(service_id caddy)"
+initial_postgres_id="$(service_id postgres)"
+
+start_probes
+
+echo "Verifying that a failed migration leaves both API replicas untouched..."
+write_environment "postgres://hubuum:zero-downtime-test@127.0.0.1:1/hubuum"
+expect_rollout_failure migration-failure
+write_environment "$DATABASE_URL"
+assert_same_id "primary API after migration failure" "$initial_primary_id" "$(service_id hubuum-api)"
+assert_same_id "standby API after migration failure" "$initial_standby_id" "$(service_id hubuum-api-standby)"
+
+echo "Verifying that an unhealthy standby aborts before replacing the primary..."
+COMPOSE_CMD=("${BASE_COMPOSE_CMD[@]}" --file "$TEST_ROOT/unhealthy-standby.yml")
+expect_rollout_failure standby-failure
+COMPOSE_CMD=("${BASE_COMPOSE_CMD[@]}")
+assert_same_id "primary API after standby failure" "$initial_primary_id" "$(service_id hubuum-api)"
+assert_same_id "Caddy after standby failure" "$initial_caddy_id" "$(service_id caddy)"
+assert_same_id "PostgreSQL after standby failure" "$initial_postgres_id" "$(service_id postgres)"
+
+echo "Recovering the standby and performing a successful live rollout..."
+hubuum_roll_service hubuum-api-standby
+before_rollout_primary_id="$(service_id hubuum-api)"
+before_rollout_standby_id="$(service_id hubuum-api-standby)"
+hubuum_rollout
+
+sleep 2
+stop_probes
+assert_probes_succeeded
+wait_for_public_readiness
+
+assert_changed_id "primary API" "$before_rollout_primary_id" "$(service_id hubuum-api)"
+assert_changed_id "standby API" "$before_rollout_standby_id" "$(service_id hubuum-api-standby)"
+assert_same_id "Caddy" "$initial_caddy_id" "$(service_id caddy)"
+assert_same_id "PostgreSQL" "$initial_postgres_id" "$(service_id postgres)"
+
+echo "Live single-host zero-downtime test passed."

--- a/scripts/update-single-host.sh
+++ b/scripts/update-single-host.sh
@@ -184,7 +184,7 @@ fi
 
 # shellcheck source=scripts/single-host-rollout.sh
 source "$SCRIPT_DIR/single-host-rollout.sh"
-hubuum_rollout false
+hubuum_rollout
 
 if [[ "$USE_SYSTEMD" == "true" && -d /run/systemd/system && "$(command -v systemctl || true)" ]] && systemctl cat "${SERVICE_NAME}.service" >/dev/null 2>&1; then
   echo "Hubuum rolled via ${ENGINE_BIN} compose; ${SERVICE_NAME}.service remained active"

--- a/scripts/update-single-host.sh
+++ b/scripts/update-single-host.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_DIR="/opt/hubuum"
 ENGINE="auto"
 SERVICE_NAME=""
@@ -15,9 +16,9 @@ Usage:
 Options:
   --dir PATH              Install directory. Default: /opt/hubuum
   --engine ENGINE         Container engine: auto, docker, or podman. Default: auto
-  --auth-config PATH      Replace the host auth-provider TOML path before restarting
+  --auth-config PATH      Replace the host auth-provider TOML path before rolling the replicas
   --service-name NAME     systemd service name. Defaults to value in .env or hubuum
-  --no-systemd            Restart with compose directly even if a systemd service exists
+  --no-systemd            Retained for compatibility; rolling updates always use Compose directly
   -h, --help              Show this help
 EOF
 }
@@ -103,6 +104,8 @@ fi
 ENV_FILE="$INSTALL_DIR/.env"
 [[ -f "$ENV_FILE" ]] || die "missing $ENV_FILE; run install-single-host.sh first"
 [[ -f "$INSTALL_DIR/compose.yml" ]] || die "missing $INSTALL_DIR/compose.yml; run install-single-host.sh first"
+[[ -f "$SCRIPT_DIR/single-host-rollout.sh" ]] || die "missing $SCRIPT_DIR/single-host-rollout.sh; re-run install-single-host.sh first"
+grep -q '^  hubuum-api-standby:' "$INSTALL_DIR/compose.yml" || die "installed compose.yml does not support rolling updates; re-run install-single-host.sh first"
 
 if [[ -n "$AUTH_CONFIG_HOST_PATH" ]]; then
   grep -q 'HUBUUM_AUTH_CONFIG_PATH' "$INSTALL_DIR/compose.yml" || die "installed compose.yml does not support auth configuration; re-run install-single-host.sh first"
@@ -179,16 +182,12 @@ else
   "${COMPOSE_CMD[@]}" pull
 fi
 
+# shellcheck source=scripts/single-host-rollout.sh
+source "$SCRIPT_DIR/single-host-rollout.sh"
+hubuum_rollout false
+
 if [[ "$USE_SYSTEMD" == "true" && -d /run/systemd/system && "$(command -v systemctl || true)" ]] && systemctl cat "${SERVICE_NAME}.service" >/dev/null 2>&1; then
-  # The systemd unit's ExecStop/ExecStart run compose down then up, so a
-  # restart recreates containers against the freshly pulled images.
-  systemctl restart "$SERVICE_NAME"
-  echo "Hubuum updated and restarted via ${SERVICE_NAME}.service"
+  echo "Hubuum rolled via ${ENGINE_BIN} compose; ${SERVICE_NAME}.service remained active"
 else
-  # `compose up -d` on its own does not reliably recreate containers after a
-  # pull (notably under podman compose, which leaves running containers on the
-  # previous image). Tear the stack down first so the new images are picked up.
-  "${COMPOSE_CMD[@]}" down --remove-orphans
-  "${COMPOSE_CMD[@]}" up -d
-  echo "Hubuum updated and restarted via ${ENGINE_BIN} compose"
+  echo "Hubuum rolled via ${ENGINE_BIN} compose"
 fi

--- a/src/tests/container_build.rs
+++ b/src/tests/container_build.rs
@@ -261,6 +261,8 @@ fn single_host_installer_generates_redundant_http_upstreams() {
     assert!(installer.contains("hubuum-api-standby:"));
     assert!(installer.contains("hubuum-web-standby:"));
     assert!(installer.contains("command: [\"--runtime-role\", \"api\"]"));
+    assert!(installer.contains("reverse_proxy hubuum-api:${API_PORT}"));
+    assert!(!installer.contains("{$HUBUUM_BIND_PORT}"));
     assert!(installer.contains("health_uri /readyz"));
     assert!(installer.contains("BACKEND_BASE_URL=http://caddy:8081"));
     assert!(

--- a/src/tests/container_build.rs
+++ b/src/tests/container_build.rs
@@ -251,3 +251,33 @@ fn single_host_installer_limits_api_container_privileges() {
     assert!(installer.contains("cap_drop:"));
     assert!(installer.contains("no-new-privileges:true"));
 }
+
+#[test]
+fn single_host_installer_generates_redundant_http_upstreams() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let installer = fs::read_to_string(repository.join("scripts/install-single-host.sh"))
+        .expect("single-host installer should be readable");
+
+    assert!(installer.contains("hubuum-api-standby:"));
+    assert!(installer.contains("hubuum-web-standby:"));
+    assert!(installer.contains("command: [\"--runtime-role\", \"api\"]"));
+    assert!(installer.contains("health_uri /readyz"));
+    assert!(installer.contains("BACKEND_BASE_URL=http://caddy:8081"));
+    assert!(
+        installer.contains("HUBUUM_LOGIN_RATE_LIMIT_BACKEND: ${HUBUUM_LOGIN_RATE_LIMIT_BACKEND}")
+    );
+}
+
+#[test]
+fn single_host_updater_never_tears_down_the_stack() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let updater = fs::read_to_string(repository.join("scripts/update-single-host.sh"))
+        .expect("single-host updater should be readable");
+    let rollout = fs::read_to_string(repository.join("scripts/single-host-rollout.sh"))
+        .expect("single-host rollout helper should be readable");
+
+    assert!(updater.contains("hubuum_rollout false"));
+    assert!(!updater.contains("systemctl restart"));
+    assert!(!updater.contains("down --remove-orphans"));
+    assert!(!rollout.contains("down --remove-orphans"));
+}

--- a/src/tests/container_build.rs
+++ b/src/tests/container_build.rs
@@ -269,6 +269,16 @@ fn single_host_installer_generates_redundant_http_upstreams() {
 }
 
 #[test]
+fn single_host_installer_preserves_the_bind_mounted_caddyfile_inode() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let installer = fs::read_to_string(repository.join("scripts/install-single-host.sh"))
+        .expect("single-host installer should be readable");
+
+    assert!(installer.contains("cp \"$CADDYFILE_TEMP\" \"$INSTALL_DIR/Caddyfile\""));
+    assert!(!installer.contains("mv \"$CADDYFILE_TEMP\" \"$INSTALL_DIR/Caddyfile\""));
+}
+
+#[test]
 fn single_host_updater_never_tears_down_the_stack() {
     let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let updater = fs::read_to_string(repository.join("scripts/update-single-host.sh"))

--- a/src/tests/container_build.rs
+++ b/src/tests/container_build.rs
@@ -276,8 +276,19 @@ fn single_host_updater_never_tears_down_the_stack() {
     let rollout = fs::read_to_string(repository.join("scripts/single-host-rollout.sh"))
         .expect("single-host rollout helper should be readable");
 
-    assert!(updater.contains("hubuum_rollout false"));
+    assert!(updater.contains("hubuum_rollout"));
     assert!(!updater.contains("systemctl restart"));
     assert!(!updater.contains("down --remove-orphans"));
     assert!(!rollout.contains("down --remove-orphans"));
+}
+
+#[test]
+fn container_ci_exercises_live_single_host_http_continuity() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workflow = fs::read_to_string(repository.join(".github/workflows/ci.yml"))
+        .expect("CI workflow should be readable");
+    let live_test = repository.join("scripts/test-single-host-zero-downtime.sh");
+
+    assert!(live_test.is_file());
+    assert!(workflow.contains("bash scripts/test-single-host-zero-downtime.sh"));
 }


### PR DESCRIPTION
## Summary

- keep PostgreSQL, Valkey, Caddy, and the existing application replica online while updating the single-host deployment
- add primary and standby API/frontend services with readiness-aware Caddy upstreams
- run embedded migrations once, then roll standby replicas before primary replicas
- recover an unhealthy primary before replacing the only healthy standby, and start missing managed infrastructure without recreating existing containers
- refresh Caddy's upstream state after healthy standbys and again after healthy primaries
- share login-throttle state through the bundled Valkey service when both API replicas are active
- add scripted ordering coverage plus a live Docker acceptance test that upgrades the published v0.0.1 image while continuously probing Caddy
- document the single-host and Kubernetes/Helm availability contracts
- isolate the live acceptance fixture from workflow-global database settings, run PostgreSQL comparisons only for storage-relevant changes, and defer automatic checkpoints during those comparisons

## Why

The previous updater either ran `compose down` or restarted the systemd unit. Both paths removed the only API and frontend containers before their replacements were ready, guaranteeing an HTTP outage during every ordinary application update.

The new rollout helper keeps the current primary serving while the standby is replaced and proven healthy, then replaces the primary. Caddy remains online and removes unready upstreams through active `/readyz` checks.

The first live acceptance-test run exposed another real gap: Caddy retained a passive failure mark for a standby that had just been recreated. The helper could therefore stop the primary before Caddy considered the healthy standby eligible, producing approximately five seconds of request timeouts. The rollout now force-reloads Caddy only after all standbys are healthy, then force-reloads it again after all primaries are healthy. Forcing the otherwise identical configuration to reprovision clears stale passive failure state and refreshes container addresses. Caddy itself is never restarted, and `stream_close_delay` protects long-lived connections across the configuration reload.

A review also identified a retry hazard: if a primary replacement failed, rerunning the standby-first sequence could remove the only healthy upstream. The helper now recovers and reloads an unhealthy primary while its standby is still serving, and refuses to replace either replica when neither is healthy.

## Behavior and operator impact

The installer now creates primary and standby API containers. All-mode installs also create primary and standby frontend containers. The frontend BFF reaches the API through Caddy's internal readiness-aware listener.

**Breaking:** Existing installations must rerun `install-single-host.sh` once to generate the redundant topology before using `update-single-host.sh`. Until then, the updater fails safely instead of falling back to a destructive restart. This is the required upgrade action.

Ordinary application rollouts do not activate newly pulled PostgreSQL, Valkey, or Caddy images. Those infrastructure replacements still require a separately scheduled maintenance procedure. This change removes planned HTTP interruption; it does not provide host or database high availability.

Database migrations must remain compatible with both application versions during the rolling interval. The distributed deployment documentation now records the corresponding Kubernetes and Helm contract, including a blocking one-shot migration hook.

## Live availability and migration test

The container-build job now runs `scripts/test-single-host-zero-downtime.sh` against the production candidate image and the digest-pinned published v0.0.1 image. The test:

- starts v0.0.1 against a fresh PostgreSQL database and verifies the candidate's latest migration is absent
- continuously probes public `/healthz` and `/readyz` paths through Caddy
- runs the candidate's one-shot migration while the v0.0.1 API remains online
- verifies six newer migrations are applied
- starts a ready candidate standby before replacing the v0.0.1 primary
- verifies both API replicas use the candidate image
- verifies Caddy and PostgreSQL container IDs remain unchanged
- verifies a failed migration replaces neither API replica
- verifies an unhealthy standby aborts before the primary is touched
- verifies a failed primary replacement can be retried without replacing the healthy standby first
- verifies every observed public HTTP request returns `200`

The latest local cross-version run completed 8,934 requests with zero failures, including a conflicting workflow-style `HUBUUM_DATABASE_URL` in the shell environment and immediate post-rollout failure/retry scenarios.

v0.0.1 co-locates lease-unaware task workers with its API. Queued and running tasks must therefore drain before this specific upgrade. The acceptance test uses an idle task queue and proves HTTP availability plus schema migration; it does not promise uninterrupted in-flight background task execution.

## Compatibility and breaking changes

There are no HTTP API or database-schema changes introduced by this pull request. The candidate does apply the six migrations added since the published v0.0.1 image when exercising the documented upgrade path.

**Breaking:** The single-host operational update contract changes: application updates use the rolling helper, while explicit `systemctl restart` continues to stop and start the whole stack. Existing installations must perform the one-time `install-single-host.sh` rerun described above before their next scripted update.

## Changelog

The `[Unreleased]` section explicitly documents the breaking one-time installer rerun, the zero-HTTP-downtime rollout, and the Kubernetes/Helm guidance.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- production Docker image build with `-F tls-rustls -F tls-openssl --locked --release`
- `bash scripts/test-install-script-refresh.sh`
- `bash scripts/test-single-host-rollout.sh`
- `HUBUUM_DATABASE_URL=postgres://postgres:postgres@localhost:5432/hubuum_rust_test HUBUUM_TEST_IMAGE=hubuum-server:verify bash scripts/test-single-host-zero-downtime.sh`
- ShellCheck for all modified rollout/install/update scripts
- `actionlint .github/workflows/benchmarks.yml`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- generated Caddy configuration validated with the Caddy adapter
- representative generated Compose configuration validated with `docker compose config`
