### PR TITLE
Fix Podman Compose single-host rollouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   service discovery no longer passes unsupported names to `compose ps`,
   migrations do not consume piped installer input, and Caddy no longer holds
   hard Podman dependencies that block rolling replica replacement. Existing
-  Caddy containers with legacy dependency metadata are recreated once.
+  Caddy containers with legacy dependency metadata are recreated once. Routine
+  external-provider notices and successful Caddy reload logs are suppressed,
+  while reload failures retain their diagnostic output.
 - Fixed an unbound `BASH_SOURCE` warning when running the installer through
   `curl | bash`.
+- Generated Caddyfiles now use canonical formatting, no longer emit a
+  formatting warning during reload, and use valid prefixed-route redirect
+  syntax.
 
 ## [0.0.2] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-- Fixed single-host install and update rollouts with older `podman-compose`
-  providers that do not accept service names after `compose ps -q`.
+- Fixed single-host installs and updates with older `podman-compose` providers:
+  service discovery no longer passes unsupported names to `compose ps`,
+  migrations do not consume piped installer input, and Caddy no longer holds
+  hard Podman dependencies that block rolling replica replacement. Existing
+  Caddy containers with legacy dependency metadata are recreated once.
+- Fixed an unbound `BASH_SOURCE` warning when running the installer through
+  `curl | bash`.
 
 ## [0.0.2] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed single-host install and update rollouts with older `podman-compose`
+  providers that do not accept service names after `compose ps -q`.
+
 ## [0.0.2] - 2026-07-17
 
 ### Added

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR=""
+if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+  SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+fi
 INSTALL_DIR="/opt/hubuum"
 MODE="all"
 WEB_FQDN=""
@@ -365,11 +368,14 @@ AUTH_CONFIG_HOST_PATH="$(absolute_config_path "$AUTH_CONFIG_HOST_PATH")"
 
 install_management_script() {
   local script_name="$1"
-  local local_path="$SCRIPT_DIR/$script_name"
+  local local_path=""
   local dest_path="$INSTALL_DIR/$script_name"
   local temp_path
 
-  if [[ -f "$local_path" && "$local_path" != "$dest_path" ]]; then
+  if [[ -n "$SCRIPT_DIR" ]]; then
+    local_path="$SCRIPT_DIR/$script_name"
+  fi
+  if [[ -n "$local_path" && -f "$local_path" && "$local_path" != "$dest_path" ]]; then
     install -m 0755 "$local_path" "$dest_path"
     return 0
   fi
@@ -817,17 +823,7 @@ cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
-    depends_on:
-      - hubuum-api
-      - hubuum-api-standby
 EOF
-
-if [[ "$MODE" == "all" ]]; then
-  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
-      - hubuum-web
-      - hubuum-web-standby
-EOF
-fi
 
 cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
     networks:

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -330,6 +330,9 @@ uninstall_stack() {
 load_existing_runtime
 detect_engine
 ENGINE_PATH="$(command -v "$ENGINE_BIN")"
+if [[ "$ENGINE_BIN" == "podman" ]]; then
+  export PODMAN_COMPOSE_WARNING_LOGS=false
+fi
 COMPOSE_CMD=("$ENGINE_PATH" compose --env-file .env -f compose.yml)
 
 if [[ "$ACTION" == "stop" ]]; then
@@ -524,42 +527,42 @@ chmod 0600 "$ENV_FILE"
 CADDYFILE_TEMP="$(mktemp "$INSTALL_DIR/.Caddyfile.XXXXXX")"
 cat > "$CADDYFILE_TEMP" <<EOF
 {
-    email ${LETSENCRYPT_EMAIL}
+	email ${LETSENCRYPT_EMAIL}
 }
 
 (api_proxy) {
-    reverse_proxy hubuum-api:${API_PORT} hubuum-api-standby:${API_PORT} {
-        health_uri /readyz
-        health_interval 5s
-        health_timeout 3s
-        fail_duration 30s
-        max_fails 1
-        lb_try_duration 5s
-        lb_try_interval 250ms
-        stream_close_delay 5m
-    }
+	reverse_proxy hubuum-api:${API_PORT} hubuum-api-standby:${API_PORT} {
+		health_uri /readyz
+		health_interval 5s
+		health_timeout 3s
+		fail_duration 30s
+		max_fails 1
+		lb_try_duration 5s
+		lb_try_interval 250ms
+		stream_close_delay 5m
+	}
 }
 EOF
 
 if [[ "$MODE" == "all" ]]; then
   cat >> "$CADDYFILE_TEMP" <<'EOF'
 (web_proxy) {
-    reverse_proxy hubuum-web:3000 hubuum-web-standby:3000 {
-        health_uri /
-        health_status 2xx
-        health_follow_redirects
-        health_interval 5s
-        health_timeout 3s
-        fail_duration 30s
-        max_fails 1
-        lb_try_duration 5s
-        lb_try_interval 250ms
-        stream_close_delay 5m
-    }
+	reverse_proxy hubuum-web:3000 hubuum-web-standby:3000 {
+		health_uri /
+		health_status 2xx
+		health_follow_redirects
+		health_interval 5s
+		health_timeout 3s
+		fail_duration 30s
+		max_fails 1
+		lb_try_duration 5s
+		lb_try_interval 250ms
+		stream_close_delay 5m
+	}
 }
 
 :8081 {
-    import api_proxy
+	import api_proxy
 }
 EOF
 fi
@@ -567,71 +570,71 @@ fi
 if [[ "$MODE" == "all" && -z "$SHARED_HOST_ROUTING" ]]; then
   cat >> "$CADDYFILE_TEMP" <<EOF
 ${WEB_FQDN} {
-    encode zstd gzip
-    import web_proxy
+	encode zstd gzip
+	import web_proxy
 }
 
 ${API_FQDN} {
-    encode zstd gzip
-    import api_proxy
+	encode zstd gzip
+	import api_proxy
 }
 EOF
 elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "bff" ]]; then
   cat >> "$CADDYFILE_TEMP" <<EOF
 ${WEB_FQDN} {
-    encode zstd gzip
-    import web_proxy
+	encode zstd gzip
+	import web_proxy
 }
 EOF
 elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "direct" ]]; then
   cat >> "$CADDYFILE_TEMP" <<EOF
 ${WEB_FQDN} {
-    encode zstd gzip
+	encode zstd gzip
 
-    handle /api/v0* {
-        import api_proxy
-    }
+	handle /api/v0* {
+		import api_proxy
+	}
 
-    handle /api/v1* {
-        import api_proxy
-    }
+	handle /api/v1* {
+		import api_proxy
+	}
 
-    handle /api-doc* {
-        import api_proxy
-    }
+	handle /api-doc* {
+		import api_proxy
+	}
 
-    handle /swagger-ui* {
-        import api_proxy
-    }
+	handle /swagger-ui* {
+		import api_proxy
+	}
 
-    handle {
-        import web_proxy
-    }
+	handle {
+		import web_proxy
+	}
 }
 EOF
 elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "prefixed" ]]; then
   cat >> "$CADDYFILE_TEMP" <<EOF
 ${WEB_FQDN} {
-    encode zstd gzip
+	encode zstd gzip
 
-    handle /hubuum-api {
-        redir /hubuum-api/
-    }
+	handle /hubuum-api {
+		redir * /hubuum-api/
+	}
 
-    handle_path /hubuum-api/* {
-        import api_proxy
-    }
+	handle_path /hubuum-api/* {
+		import api_proxy
+	}
 
-    handle {
-        import web_proxy
-    }
+	handle {
+		import web_proxy
+	}
 }
 EOF
 else
   cat >> "$CADDYFILE_TEMP" <<EOF
 ${API_FQDN} {
-    encode zstd gzip
-    import api_proxy
+	encode zstd gzip
+	import api_proxy
 }
 EOF
 fi
@@ -884,6 +887,7 @@ After=network-online.target docker.service podman.service
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=${INSTALL_DIR}
+Environment=PODMAN_COMPOSE_WARNING_LOGS=false
 ExecStart=${ENGINE_PATH} compose --env-file .env -f compose.yml up -d
 ExecStop=${ENGINE_PATH} compose --env-file .env -f compose.yml down
 TimeoutStartSec=0

--- a/scripts/single-host-rollout.sh
+++ b/scripts/single-host-rollout.sh
@@ -6,8 +6,24 @@
 
 hubuum_service_container_id() {
   local service="$1"
+  local container_id
+  local container_service
 
-  "${COMPOSE_CMD[@]}" ps -q "$service"
+  # Older podman-compose releases do not accept a service argument for `ps`,
+  # unlike Docker Compose. List this project's containers and select the
+  # requested service through the Compose label shared by both providers.
+  while IFS= read -r container_id; do
+    [[ -n "$container_id" ]] || continue
+    container_service="$(
+      "$ENGINE_PATH" inspect \
+        --format '{{ index .Config.Labels "com.docker.compose.service" }}' \
+        "$container_id" 2>/dev/null || true
+    )"
+    if [[ "$container_service" == "$service" ]]; then
+      printf '%s\n' "$container_id"
+      return 0
+    fi
+  done < <("${COMPOSE_CMD[@]}" ps -q)
 }
 
 hubuum_service_health() {

--- a/scripts/single-host-rollout.sh
+++ b/scripts/single-host-rollout.sh
@@ -105,6 +105,28 @@ hubuum_caddy_is_running() {
   [[ -n "$(hubuum_service_container_id caddy)" ]]
 }
 
+hubuum_caddy_has_container_dependencies() {
+  local container_id
+  local dependencies
+
+  container_id="$(hubuum_service_container_id caddy)"
+  [[ -n "$container_id" ]] || return 1
+  dependencies="$(
+    "$ENGINE_PATH" inspect \
+      --format '{{range .Dependencies}}{{println .}}{{end}}' \
+      "$container_id" 2>/dev/null || true
+  )"
+  [[ -n "$dependencies" ]]
+}
+
+hubuum_remove_legacy_caddy_dependencies() {
+  hubuum_caddy_has_container_dependencies || return 0
+
+  echo "Recreating Caddy once to remove legacy Podman container dependencies..."
+  "${COMPOSE_CMD[@]}" up -d --no-deps --force-recreate caddy
+  hubuum_wait_for_healthy caddy "${HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS:-180}"
+}
+
 hubuum_reload_caddy() {
   echo "Reloading Caddy to refresh its upstream health state..."
   "${COMPOSE_CMD[@]}" exec -T caddy \
@@ -113,7 +135,7 @@ hubuum_reload_caddy() {
 
 hubuum_run_migrations() {
   echo "Running one-shot database migrations while the primary remains online..."
-  "${COMPOSE_CMD[@]}" run --rm --no-deps \
+  "${COMPOSE_CMD[@]}" run --rm --no-deps -T \
     --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
 }
 
@@ -149,6 +171,7 @@ hubuum_rollout() {
     return 0
   fi
 
+  hubuum_remove_legacy_caddy_dependencies
   hubuum_ensure_infrastructure
   hubuum_run_migrations
 

--- a/scripts/single-host-rollout.sh
+++ b/scripts/single-host-rollout.sh
@@ -128,9 +128,17 @@ hubuum_remove_legacy_caddy_dependencies() {
 }
 
 hubuum_reload_caddy() {
+  local output
+
   echo "Reloading Caddy to refresh its upstream health state..."
-  "${COMPOSE_CMD[@]}" exec -T caddy \
-    caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
+  if ! output="$(
+    "${COMPOSE_CMD[@]}" exec -T caddy \
+      caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile 2>&1
+  )"; then
+    echo "ERROR: Caddy reload failed" >&2
+    printf '%s\n' "$output" >&2
+    return 1
+  fi
 }
 
 hubuum_run_migrations() {

--- a/scripts/test-install-script-refresh.sh
+++ b/scripts/test-install-script-refresh.sh
@@ -11,6 +11,15 @@ REMOTE_DIR="$TEST_ROOT/remote"
 export SCRIPT_BASE_URL="https://example.invalid/scripts"
 mkdir -p "$INSTALL_DIR" "$REMOTE_DIR"
 
+installer_preamble="$(
+  sed -n '1,/^INSTALL_DIR=/p' "$REPOSITORY_ROOT/scripts/install-single-host.sh"
+)"
+piped_output="$(printf '%s\n' "$installer_preamble" | bash 2>&1)"
+[[ -z "$piped_output" ]] || {
+  printf 'installer preamble emitted output under curl-style execution:\n%s\n' "$piped_output" >&2
+  exit 1
+}
+
 curl() {
   local output_path=""
   local url=""

--- a/scripts/test-single-host-rollout.sh
+++ b/scripts/test-single-host-rollout.sh
@@ -14,6 +14,12 @@ set -euo pipefail
 
 printf '%s\n' "$*" >> "$COMMAND_LOG"
 
+if [[ "$*" == *" exec -T caddy caddy reload "* ]]; then
+  printf '{"level":"info","msg":"fake reload diagnostic"}\n' >&2
+  [[ "$FAKE_CADDY_RELOAD_FAIL" != "true" ]]
+  exit
+fi
+
 if [[ "${1:-}" == "inspect" && "$*" == *".Dependencies"* ]]; then
   if [[ "$FAKE_CADDY_DEPENDENCIES" == "true" && "${*: -1}" == "container-caddy" ]]; then
     printf 'container-hubuum-api\n'
@@ -62,7 +68,9 @@ EOF
 chmod +x "$FAKE_ENGINE"
 
 FAKE_CADDY_DEPENDENCIES="false"
-export COMMAND_LOG FAKE_CADDY_DEPENDENCIES FAKE_CADDY_RUNNING TEST_ROOT
+FAKE_CADDY_RELOAD_FAIL="false"
+export COMMAND_LOG FAKE_CADDY_DEPENDENCIES FAKE_CADDY_RELOAD_FAIL
+export FAKE_CADDY_RUNNING TEST_ROOT
 export FAKE_MISSING_SERVICES=""
 export FAKE_UNHEALTHY_SERVICES=""
 ENGINE_PATH="$FAKE_ENGINE"
@@ -156,5 +164,19 @@ compose --env-file .env -f compose.yml up -d --no-deps hubuum-api-standby
 compose --env-file .env -f compose.yml up -d --no-deps caddy
 EOF
 assert_commands "$TEST_ROOT/expected-initial.log"
+
+reload_output="$(hubuum_reload_caddy 2>&1)"
+[[ "$reload_output" == "Reloading Caddy to refresh its upstream health state..." ]] || {
+  printf 'successful Caddy reload emitted unexpected output:\n%s\n' "$reload_output" >&2
+  exit 1
+}
+
+FAKE_CADDY_RELOAD_FAIL="true"
+if reload_output="$(hubuum_reload_caddy 2>&1)"; then
+  echo "failed Caddy reload unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ "$reload_output" == *"ERROR: Caddy reload failed"* ]]
+[[ "$reload_output" == *'fake reload diagnostic'* ]]
 
 echo "Single-host rolling update test passed"

--- a/scripts/test-single-host-rollout.sh
+++ b/scripts/test-single-host-rollout.sh
@@ -14,6 +14,12 @@ set -euo pipefail
 
 printf '%s\n' "$*" >> "$COMMAND_LOG"
 
+if [[ "${1:-}" == "inspect" && "$*" == *"Config.Labels"* ]]; then
+  service="${*: -1}"
+  printf '%s\n' "${service#container-}"
+  exit 0
+fi
+
 if [[ "${1:-}" == "inspect" ]]; then
   service="${*: -1}"
   service="${service#container-}"
@@ -25,14 +31,20 @@ if [[ "${1:-}" == "inspect" ]]; then
   exit 0
 fi
 
-if [[ "$*" == *" ps -q "* ]]; then
-  service="${*: -1}"
-  if [[ "$service" == "caddy" && "$FAKE_CADDY_RUNNING" != "true" && ! -e "$TEST_ROOT/started-caddy" ]]; then
-    exit 0
-  fi
-  if [[ " ${FAKE_MISSING_SERVICES:-} " != *" $service "* || -e "$TEST_ROOT/started-$service" ]]; then
-    printf 'container-%s\n' "$service"
-  fi
+if [[ "$*" == *" ps -q"* ]]; then
+  [[ "$*" == *" ps -q" ]] || {
+    echo "service arguments to compose ps are unsupported" >&2
+    exit 2
+  }
+
+  for service in caddy postgres valkey hubuum-api hubuum-api-standby hubuum-web hubuum-web-standby; do
+    if [[ "$service" == "caddy" && "$FAKE_CADDY_RUNNING" != "true" && ! -e "$TEST_ROOT/started-caddy" ]]; then
+      continue
+    fi
+    if [[ " ${FAKE_MISSING_SERVICES:-} " != *" $service "* || -e "$TEST_ROOT/started-$service" ]]; then
+      printf 'container-%s\n' "$service"
+    fi
+  done
 fi
 
 if [[ "$*" == *" up "* ]]; then

--- a/scripts/test-single-host-rollout.sh
+++ b/scripts/test-single-host-rollout.sh
@@ -14,6 +14,13 @@ set -euo pipefail
 
 printf '%s\n' "$*" >> "$COMMAND_LOG"
 
+if [[ "${1:-}" == "inspect" && "$*" == *".Dependencies"* ]]; then
+  if [[ "$FAKE_CADDY_DEPENDENCIES" == "true" && "${*: -1}" == "container-caddy" ]]; then
+    printf 'container-hubuum-api\n'
+  fi
+  exit 0
+fi
+
 if [[ "${1:-}" == "inspect" && "$*" == *"Config.Labels"* ]]; then
   service="${*: -1}"
   printf '%s\n' "${service#container-}"
@@ -54,7 +61,8 @@ fi
 EOF
 chmod +x "$FAKE_ENGINE"
 
-export COMMAND_LOG FAKE_CADDY_RUNNING TEST_ROOT
+FAKE_CADDY_DEPENDENCIES="false"
+export COMMAND_LOG FAKE_CADDY_DEPENDENCIES FAKE_CADDY_RUNNING TEST_ROOT
 export FAKE_MISSING_SERVICES=""
 export FAKE_UNHEALTHY_SERVICES=""
 ENGINE_PATH="$FAKE_ENGINE"
@@ -72,11 +80,13 @@ assert_commands() {
 }
 
 FAKE_CADDY_RUNNING="true"
+FAKE_CADDY_DEPENDENCIES="true"
 INSTALL_MODE="all"
 : > "$COMMAND_LOG"
 hubuum_rollout
 cat > "$TEST_ROOT/expected-rolling.log" <<EOF
-compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate caddy
+compose --env-file .env -f compose.yml run --rm --no-deps -T --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web-standby
 compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
@@ -86,11 +96,12 @@ compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --conf
 EOF
 assert_commands "$TEST_ROOT/expected-rolling.log"
 
+FAKE_CADDY_DEPENDENCIES="false"
 INSTALL_MODE="backend"
 : > "$COMMAND_LOG"
 hubuum_rollout
 cat > "$TEST_ROOT/expected-reload.log" <<EOF
-compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+compose --env-file .env -f compose.yml run --rm --no-deps -T --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
 compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
@@ -105,7 +116,7 @@ rm -f "$TEST_ROOT/started-hubuum-api"
 : > "$COMMAND_LOG"
 hubuum_rollout
 cat > "$TEST_ROOT/expected-recovery.log" <<EOF
-compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+compose --env-file .env -f compose.yml run --rm --no-deps -T --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
 compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
@@ -123,7 +134,7 @@ rm -f "$TEST_ROOT/started-valkey"
 hubuum_rollout
 cat > "$TEST_ROOT/expected-missing-infrastructure.log" <<EOF
 compose --env-file .env -f compose.yml up -d --no-deps --no-recreate valkey
-compose --env-file .env -f compose.yml run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+compose --env-file .env -f compose.yml run --rm --no-deps -T --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api-standby
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-web-standby
 compose --env-file .env -f compose.yml exec -T caddy caddy reload --force --config /etc/caddy/Caddyfile --adapter caddyfile
@@ -136,6 +147,7 @@ assert_commands "$TEST_ROOT/expected-missing-infrastructure.log"
 FAKE_CADDY_RUNNING="false"
 FAKE_MISSING_SERVICES=""
 INSTALL_MODE="backend"
+rm -f "$TEST_ROOT/started-caddy"
 : > "$COMMAND_LOG"
 hubuum_rollout
 cat > "$TEST_ROOT/expected-initial.log" <<EOF

--- a/scripts/update-single-host.sh
+++ b/scripts/update-single-host.sh
@@ -162,6 +162,9 @@ update_source_checkout() {
 
 detect_engine
 ENGINE_PATH="$(command -v "$ENGINE_BIN")"
+if [[ "$ENGINE_BIN" == "podman" ]]; then
+  export PODMAN_COMPOSE_WARNING_LOGS=false
+fi
 COMPOSE_CMD=("$ENGINE_PATH" compose --env-file .env -f compose.yml)
 
 cd "$INSTALL_DIR"

--- a/src/tests/container_build.rs
+++ b/src/tests/container_build.rs
@@ -263,12 +263,33 @@ fn single_host_installer_generates_redundant_http_upstreams() {
     assert!(!installer.contains("    depends_on:\n      - hubuum-api\n      - hubuum-api-standby"));
     assert!(installer.contains("command: [\"--runtime-role\", \"api\"]"));
     assert!(installer.contains("reverse_proxy hubuum-api:${API_PORT}"));
+    assert!(installer.contains("redir * /hubuum-api/"));
     assert!(!installer.contains("{$HUBUUM_BIND_PORT}"));
     assert!(installer.contains("health_uri /readyz"));
     assert!(installer.contains("BACKEND_BASE_URL=http://caddy:8081"));
     assert!(
         installer.contains("HUBUUM_LOGIN_RATE_LIMIT_BACKEND: ${HUBUUM_LOGIN_RATE_LIMIT_BACKEND}")
     );
+    assert!(installer.contains("export PODMAN_COMPOSE_WARNING_LOGS=false"));
+    assert!(installer.contains("Environment=PODMAN_COMPOSE_WARNING_LOGS=false"));
+}
+
+#[test]
+fn single_host_installer_emits_canonical_caddyfile_indentation() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let installer = fs::read_to_string(repository.join("scripts/install-single-host.sh"))
+        .expect("single-host installer should be readable");
+    let template_start = installer
+        .find("CADDYFILE_TEMP=")
+        .expect("installer should generate a Caddyfile");
+    let template_end = installer[template_start..]
+        .find("# Caddy bind-mounts")
+        .map(|offset| template_start + offset)
+        .expect("Caddyfile generation should have a known end marker");
+    let template = &installer[template_start..template_end];
+
+    assert!(template.lines().any(|line| line.starts_with('\t')));
+    assert!(!template.lines().any(|line| line.starts_with("    ")));
 }
 
 #[test]
@@ -290,6 +311,7 @@ fn single_host_updater_never_tears_down_the_stack() {
         .expect("single-host rollout helper should be readable");
 
     assert!(updater.contains("hubuum_rollout"));
+    assert!(updater.contains("export PODMAN_COMPOSE_WARNING_LOGS=false"));
     assert!(!updater.contains("systemctl restart"));
     assert!(!updater.contains("down --remove-orphans"));
     assert!(!rollout.contains("down --remove-orphans"));

--- a/src/tests/container_build.rs
+++ b/src/tests/container_build.rs
@@ -260,6 +260,7 @@ fn single_host_installer_generates_redundant_http_upstreams() {
 
     assert!(installer.contains("hubuum-api-standby:"));
     assert!(installer.contains("hubuum-web-standby:"));
+    assert!(!installer.contains("    depends_on:\n      - hubuum-api\n      - hubuum-api-standby"));
     assert!(installer.contains("command: [\"--runtime-role\", \"api\"]"));
     assert!(installer.contains("reverse_proxy hubuum-api:${API_PORT}"));
     assert!(!installer.contains("{$HUBUUM_BIND_PORT}"));


### PR DESCRIPTION
## Summary

- make single-host service discovery compatible with older external `podman-compose` providers
- keep `curl | bash` execution quiet and prevent migration containers from consuming installer stdin
- remove Caddy's Compose dependency edges so Podman can recreate API and frontend replicas independently
- detect persisted legacy Caddy dependencies and recreate Caddy once before the next rolling update
- suppress routine Podman provider notices and successful Caddy reload logs while preserving failure diagnostics
- generate canonically formatted, valid Caddyfiles, including prefixed-route redirects
- add regression coverage and document the fixes in the `[Unreleased]` changelog

## Root cause

The rollout helper used Docker Compose's `compose ps -q SERVICE` form, but older `podman-compose` releases accept `ps -q` without a positional service name. The failed probes made running services appear missing.

A piped installer has no `BASH_SOURCE[0]`, and the interactive one-shot migration container inherited the installer's stdin. This produced an unbound-variable warning and allowed Podman to echo or consume the remaining installer source.

`podman-compose` translates Caddy's `depends_on` entries into persistent Podman container dependencies. Podman then refuses to replace an upstream API or frontend container while the dependent Caddy container exists.

Podman's Compose dispatcher prints an external-provider notice for every invocation unless `PODMAN_COMPOSE_WARNING_LOGS=false` is set. Successful Caddy reload output was also passed through verbatim, and the generated Caddyfile used noncanonical indentation that triggered a formatter warning.

## Impact

Fresh single-host installs and subsequent updates can roll application replicas under Docker Compose and older `podman-compose` providers.

Existing Podman installations whose Caddy container still has the old dependency metadata recreate Caddy once before rolling the replicas. This one-time proxy restart removes the persisted dependency graph; later application rollouts keep Caddy running.

Routine provider notices and successful reload diagnostics are now quiet. Reload failures still print the captured Caddy output. Generated configurations match `caddy fmt` and all supported routing variants validate, including prefixed routing.

There is no API or application configuration change.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `bash scripts/test-single-host-rollout.sh`
- `bash scripts/test-install-script-refresh.sh`
- `shellcheck scripts/install-single-host.sh scripts/update-single-host.sh scripts/single-host-rollout.sh scripts/test-single-host-rollout.sh scripts/test-install-script-refresh.sh`
- generated Caddyfiles for separate-host, BFF, direct, prefixed, and backend modes compared byte-for-byte with `caddy fmt` and passed `caddy validate` using `caddy:2-alpine`
- GitHub CI, production container build, live zero-downtime rollout, and benchmarks

## Live testing

Successive live Podman runs confirmed the service-discovery fix, exposed and verified the stdin and persisted Caddy dependency fixes, and confirmed commit `e37765b` removes the remaining provider banners and successful Caddy reload noise.