### PR TITLE
Filter LDAP groups by mapped name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Breaking:** LDAP `group_filters` now match group names produced by
+  `group_rules` instead of raw LDAP attribute values. Replace filters containing
+  raw directory structure, such as distinguished-name components, with patterns
+  matching the configured `name` template.
 - Pagination now clamps positive client limits above the configured maximum
   instead of returning `400 Bad Request`, and paginated responses expose the
   effective value in `X-Page-Limit`.

--- a/crates/hubuum-auth-ldap/src/lib.rs
+++ b/crates/hubuum-auth-ldap/src/lib.rs
@@ -307,18 +307,18 @@ impl LdapIdentityProvider {
                 continue;
             };
             for value in values {
-                if !self.group_filters.is_empty()
-                    && !self
-                        .group_filters
-                        .iter()
-                        .any(|filter| filter.is_match(value))
-                {
-                    continue;
-                }
                 for rule in &self.rules {
                     if let Some(captures) = rule.pattern.captures(value) {
                         let name = expand_template(&rule.name, &captures);
                         if name.trim().is_empty() {
+                            continue;
+                        }
+                        if !self.group_filters.is_empty()
+                            && !self
+                                .group_filters
+                                .iter()
+                                .any(|filter| filter.is_match(&name))
+                        {
                             continue;
                         }
                         let key = rule
@@ -624,10 +624,10 @@ mod tests {
     }
 
     #[test]
-    fn group_filters_include_values_matching_any_configured_regex() {
+    fn group_filters_include_mapped_names_matching_any_configured_regex() {
         let provider = LdapIdentityProvider::new(LdapScopeConfig {
             group_attributes: vec!["memberOf".into()],
-            group_filters: vec!["^cn=hubuum-".into(), "^cn=admin,".into()],
+            group_filters: vec!["-editors$".into(), "^admin$".into()],
             group_rules: vec![GroupMappingRuleConfig {
                 pattern: "^cn=([^,]+),ou=groups,dc=example,dc=org$".into(),
                 name: "$1".into(),

--- a/docs/external_auth.md
+++ b/docs/external_auth.md
@@ -29,7 +29,7 @@ subject_attribute = "entryUUID"
 display_name_attribute = "cn"
 email_attribute = "mail"
 group_attributes = ["memberOf"]
-group_filters = ["^cn=hubuum-", "^cn=admin,"]
+group_filters = ["^hubuum-", "^admin$"]
 refresh_ttl_seconds = 300
 max_stale_seconds = 3600
 
@@ -50,10 +50,10 @@ startup.
 All group extraction is configuration-driven. Use `group_attributes` and
 `group_rules` to map provider attributes to Hubuum groups; do not hard-code
 directory-specific group formats in code. The optional `group_filters` list
-filters the raw values read from `group_attributes` before mapping. When the
-list is non-empty, a value must match at least one regular expression to be
-included. Omitting the list or setting it to an empty list preserves all values
-that match a group rule.
+filters the group names produced by `group_rules`. When the list is non-empty,
+a mapped name must match at least one regular expression to be included.
+Omitting the list or setting it to an empty list preserves all groups produced
+by a group rule.
 
 ### Multiple LDAP scopes
 


### PR DESCRIPTION
## Summary

- apply LDAP `group_filters` to names produced by `group_rules`
- keep group-rule patterns responsible for recognizing raw LDAP attribute values
- update regression coverage, configuration documentation, examples, and the changelog

## Rationale

The filter previously ran against the complete raw LDAP attribute value before group mapping. That made a filter such as `drift$` fail for a mapped group named `matinst-drift` when the raw value was a distinguished name ending in `dc=no`. It also duplicated the raw-value recognition already expressed by each mapping rule.

Filtering after expansion makes the rule responsible for parsing the directory representation and makes the filter a policy over the resulting Hubuum group name.

## Behavior and upgrade impact

This is a breaking configuration-semantics change: existing `group_filters` containing raw LDAP structure must be rewritten to match the configured group-rule `name` output. For example, a raw-DN filter such as `^cn=hubuum-` becomes `^hubuum-`.

Filters retain any-match regex semantics. An empty filter list still includes every group produced by a matching rule.

## Verification

- `source .env && ./run_tests.sh` — all preceding targets passed; the final `restore_roundtrip` target had one transient bb8 pool timeout
- `source .env && ./run_tests.sh --test restore_roundtrip --locked` — passed on retry
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
