### PR TITLE
Stabilize PostgreSQL performance smoke tests

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 45
     services:
       postgres:
-        image: postgres:17-alpine
+        image: postgres:18.4-alpine3.24@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
         ports:
           - 5432:5432
         env:
@@ -46,6 +46,10 @@ jobs:
       BASE_DATABASE_URL: postgres://postgres:postgres@localhost:5432/hubuum_bench_base
       HEAD_DATABASE_URL: postgres://postgres:postgres@localhost:5432/hubuum_bench_head
       CARGO_TARGET_DIR: target
+      POSTGRES_BENCH_WARNING_PCT: 10
+      POSTGRES_BENCH_FAILURE_PCT: 20
+      POSTGRES_BENCH_FAILURE_ABSOLUTE_NS: 25000
+      POSTGRES_BENCH_STABILITY_PCT: 10
     steps:
       - name: Check out pull request
         uses: actions/checkout@v7
@@ -58,7 +62,9 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
-            Cargo.toml Cargo.lock benches/postgres migrations crates src \
+            .github/workflows/benchmarks.yml Cargo.toml Cargo.lock \
+            benches/postgres migrations crates scripts/check-criterion-regressions.sh \
+            scripts/check-criterion-stability.sh src \
             ':(exclude)src/tests/**'; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No PostgreSQL storage benchmark inputs changed."
@@ -73,7 +79,7 @@ jobs:
         run: |
           sudo apt-get update --yes
           sudo apt-get install --yes libpq-dev
-      - name: Defer automatic checkpoints during benchmark comparison
+      - name: Disable nondeterministic PostgreSQL background work
         if: steps.storage_changes.outputs.changed == 'true'
         env:
           PGPASSWORD: postgres
@@ -81,7 +87,14 @@ jobs:
           psql --host localhost --username postgres --dbname postgres \
             --command "ALTER SYSTEM SET checkpoint_timeout = '30min'"
           psql --host localhost --username postgres --dbname postgres \
+            --command "ALTER SYSTEM SET autovacuum = 'off'"
+          psql --host localhost --username postgres --dbname postgres \
             --command "SELECT pg_reload_conf()"
+          autovacuum="$(
+            psql --host localhost --username postgres --dbname postgres \
+              --tuples-only --no-align --command "SELECT current_setting('autovacuum')"
+          )"
+          [[ "$autovacuum" == "off" ]]
       - name: Create isolated benchmark databases
         if: steps.storage_changes.outputs.changed == 'true'
         env:
@@ -138,8 +151,113 @@ jobs:
             echo "Initial PostgreSQL storage baseline recorded; base comparison starts after merge." \
               >> "$GITHUB_STEP_SUMMARY"
           fi
-      - name: Enforce credible PostgreSQL regressions
+      - name: Assess initial PostgreSQL regressions
         if: >-
           steps.storage_changes.outputs.changed == 'true' &&
           steps.base_benchmark.outputs.available == 'true'
-        run: scripts/check-criterion-regressions.sh target/criterion/storage_postgres 10 20
+        id: initial_assessment
+        env:
+          POSTGRES_BENCH_INITIAL_FAILURES: ${{ runner.temp }}/postgres-benchmark-initial-failures.txt
+          POSTGRES_BENCH_INITIAL_RESULTS: ${{ runner.temp }}/postgres-criterion-initial
+        run: |
+          set +e
+          scripts/check-criterion-regressions.sh \
+            target/criterion/storage_postgres \
+            "$POSTGRES_BENCH_WARNING_PCT" \
+            "$POSTGRES_BENCH_FAILURE_PCT" \
+            "$POSTGRES_BENCH_FAILURE_ABSOLUTE_NS" \
+            forward warning "$POSTGRES_BENCH_INITIAL_FAILURES"
+          assessment_status=$?
+          set -e
+
+          case "$assessment_status" in
+            0)
+              echo "suspected=false" >> "$GITHUB_OUTPUT"
+              ;;
+            1)
+              cp -R target/criterion/storage_postgres "$POSTGRES_BENCH_INITIAL_RESULTS"
+              echo "suspected=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              exit "$assessment_status"
+              ;;
+          esac
+      - name: Confirm PostgreSQL regressions in reverse order
+        if: steps.initial_assessment.outputs.suspected == 'true'
+        env:
+          PGPASSWORD: postgres
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CONFIRMED_FAILURES: ${{ runner.temp }}/postgres-benchmark-confirmed-failures.txt
+          POSTGRES_BENCH_INITIAL_FAILURES: ${{ runner.temp }}/postgres-benchmark-initial-failures.txt
+          POSTGRES_BENCH_INITIAL_RESULTS: ${{ runner.temp }}/postgres-criterion-initial
+        run: |
+          dropdb --host localhost --username postgres --if-exists --force hubuum_bench_base
+          dropdb --host localhost --username postgres --if-exists --force hubuum_bench_head
+          createdb --host localhost --username postgres hubuum_bench_base
+          createdb --host localhost --username postgres hubuum_bench_head
+          rm -rf target/criterion/storage_postgres
+
+          git checkout --detach "$HEAD_SHA"
+          cargo run --locked --features embedded-migrations --bin hubuum-admin -- \
+            --migrate --database-url "$HEAD_DATABASE_URL"
+          HUBUUM_BENCH_DATABASE_URL="$HEAD_DATABASE_URL" \
+            cargo bench --locked --features postgres-bench \
+              --bench storage_postgres_criterion -- \
+              --save-baseline pr-head-confirmation \
+              --noplot --sample-size 40 --measurement-time 4
+
+          git checkout --detach "$BASE_SHA"
+          cargo run --locked --features embedded-migrations --bin hubuum-admin -- \
+            --migrate --database-url "$BASE_DATABASE_URL"
+          HUBUUM_BENCH_DATABASE_URL="$BASE_DATABASE_URL" \
+            cargo bench --locked --features postgres-bench \
+              --bench storage_postgres_criterion -- \
+              --baseline pr-head-confirmation \
+              --noplot --sample-size 40 --measurement-time 4
+
+          git checkout --detach "$HEAD_SHA"
+          set +e
+          scripts/check-criterion-regressions.sh \
+            target/criterion/storage_postgres \
+            "$POSTGRES_BENCH_WARNING_PCT" \
+            "$POSTGRES_BENCH_FAILURE_PCT" \
+            "$POSTGRES_BENCH_FAILURE_ABSOLUTE_NS" \
+            reverse warning "$CONFIRMED_FAILURES" "$POSTGRES_BENCH_INITIAL_FAILURES"
+          confirmation_status=$?
+          set -e
+
+          if [[ "$confirmation_status" -eq 2 ]]; then
+            exit 2
+          fi
+          if [[ "$confirmation_status" -eq 0 ]]; then
+            echo "::warning title=Inconclusive PostgreSQL benchmark::The reverse-order comparison did not reproduce the initial regression."
+            echo "The PostgreSQL benchmark was noisy: its reverse-order confirmation did not reproduce the initial regression." \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          set +e
+          scripts/check-criterion-stability.sh \
+            "$POSTGRES_BENCH_INITIAL_RESULTS" \
+            target/criterion/storage_postgres \
+            "$POSTGRES_BENCH_STABILITY_PCT" \
+            "$POSTGRES_BENCH_INITIAL_FAILURES"
+          stability_status=$?
+          set -e
+
+          if [[ "$stability_status" -eq 2 ]]; then
+            exit 2
+          fi
+          if [[ "$stability_status" -eq 1 ]]; then
+            echo "The PostgreSQL benchmark was inconclusive because its bracketing base measurements were unstable." \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          scripts/check-criterion-regressions.sh \
+            target/criterion/storage_postgres \
+            "$POSTGRES_BENCH_WARNING_PCT" \
+            "$POSTGRES_BENCH_FAILURE_PCT" \
+            "$POSTGRES_BENCH_FAILURE_ABSOLUTE_NS" \
+            reverse error "$CONFIRMED_FAILURES" "$POSTGRES_BENCH_INITIAL_FAILURES"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -166,7 +166,7 @@ jobs:
             "$POSTGRES_BENCH_WARNING_PCT" \
             "$POSTGRES_BENCH_FAILURE_PCT" \
             "$POSTGRES_BENCH_FAILURE_ABSOLUTE_NS" \
-            forward warning "$POSTGRES_BENCH_INITIAL_FAILURES"
+            forward warning "$POSTGRES_BENCH_INITIAL_FAILURES" "" pr-base
           assessment_status=$?
           set -e
 
@@ -223,7 +223,8 @@ jobs:
             "$POSTGRES_BENCH_WARNING_PCT" \
             "$POSTGRES_BENCH_FAILURE_PCT" \
             "$POSTGRES_BENCH_FAILURE_ABSOLUTE_NS" \
-            reverse warning "$CONFIRMED_FAILURES" "$POSTGRES_BENCH_INITIAL_FAILURES"
+            reverse warning "$CONFIRMED_FAILURES" \
+            "$POSTGRES_BENCH_INITIAL_FAILURES" pr-head-confirmation
           confirmation_status=$?
           set -e
 
@@ -242,7 +243,7 @@ jobs:
             "$POSTGRES_BENCH_INITIAL_RESULTS" \
             target/criterion/storage_postgres \
             "$POSTGRES_BENCH_STABILITY_PCT" \
-            "$POSTGRES_BENCH_INITIAL_FAILURES"
+            "$CONFIRMED_FAILURES" pr-base
           stability_status=$?
           set -e
 
@@ -260,4 +261,4 @@ jobs:
             "$POSTGRES_BENCH_WARNING_PCT" \
             "$POSTGRES_BENCH_FAILURE_PCT" \
             "$POSTGRES_BENCH_FAILURE_ABSOLUTE_NS" \
-            reverse error "$CONFIRMED_FAILURES" "$POSTGRES_BENCH_INITIAL_FAILURES"
+            reverse error "" "$CONFIRMED_FAILURES" pr-head-confirmation

--- a/scripts/check-criterion-regressions.sh
+++ b/scripts/check-criterion-regressions.sh
@@ -5,51 +5,137 @@ set -euo pipefail
 criterion_dir="${1:-target/criterion}"
 warning_threshold_pct="${2:-10}"
 failure_threshold_pct="${3:-20}"
+absolute_failure_threshold_ns="${4:-0}"
+direction="${5:-forward}"
+annotation_level="${6:-error}"
+failure_output="${7:-}"
+failure_filter="${8:-}"
 
 if ! command -v jq >/dev/null 2>&1; then
     echo "jq is required to evaluate Criterion comparison results" >&2
     exit 2
 fi
 
+case "$direction" in
+    forward | reverse) ;;
+    *)
+        echo "direction must be 'forward' or 'reverse', got '$direction'" >&2
+        exit 2
+        ;;
+esac
+
+case "$annotation_level" in
+    error | warning | none) ;;
+    *)
+        echo "annotation level must be 'error', 'warning', or 'none', got '$annotation_level'" >&2
+        exit 2
+        ;;
+esac
+
+if [[ -n "$failure_output" ]]; then
+    : > "$failure_output"
+fi
+
+benchmark_is_selected() {
+    local benchmark="$1"
+    local selected
+
+    [[ -z "$failure_filter" ]] && return 0
+    [[ -f "$failure_filter" ]] || return 1
+    while IFS= read -r selected; do
+        [[ "$selected" == "$benchmark" ]] && return 0
+    done < "$failure_filter"
+    return 1
+}
+
+annotate() {
+    local title="$1"
+    local message="$2"
+
+    [[ "$annotation_level" == "none" ]] && return
+    printf '::%s title=%s::%s\n' "$annotation_level" "$title" "$message"
+}
+
 result_count=0
 failure_count=0
 
 while IFS= read -r estimate_file; do
-    result_count=$((result_count + 1))
-    benchmark="${estimate_file#"$criterion_dir"/}"
-    benchmark="${benchmark%/change/estimates.json}"
-    median_pct="$(jq -r '.median.point_estimate * 100' "$estimate_file")"
-    lower_pct="$(jq -r '.median.confidence_interval.lower_bound * 100' "$estimate_file")"
-    credible_failure="$(
-        jq -r --argjson threshold "$failure_threshold_pct" \
-            '(.median.point_estimate * 100 > $threshold) and
-             (.median.confidence_interval.lower_bound > 0)' \
-            "$estimate_file"
-    )"
-    warning="$(
-        jq -r --argjson threshold "$warning_threshold_pct" \
-            '.median.point_estimate * 100 > $threshold' \
-            "$estimate_file"
-    )"
+    benchmark_dir="${estimate_file%/change/estimates.json}"
+    benchmark="${benchmark_dir#"$criterion_dir"/}"
+    benchmark_is_selected "$benchmark" || continue
 
-    printf '%s: median change %.2f%% (95%% CI lower bound %.2f%%)\n' \
-        "$benchmark" "$median_pct" "$lower_pct"
+    base_estimate_file="$benchmark_dir/base/estimates.json"
+    new_estimate_file="$benchmark_dir/new/estimates.json"
+    if [[ ! -f "$base_estimate_file" || ! -f "$new_estimate_file" ]]; then
+        echo "Missing Criterion base/new estimates for $benchmark" >&2
+        exit 2
+    fi
+
+    result_count=$((result_count + 1))
+    metrics="$({
+        jq -nr \
+            --arg direction "$direction" \
+            --slurpfile change "$estimate_file" \
+            --slurpfile base "$base_estimate_file" \
+            --slurpfile new "$new_estimate_file" '
+                if $direction == "forward" then
+                    [
+                        ($change[0].median.point_estimate * 100),
+                        ($change[0].median.confidence_interval.lower_bound * 100),
+                        ($new[0].median.point_estimate - $base[0].median.point_estimate)
+                    ]
+                else
+                    [
+                        ((1 / (1 + $change[0].median.point_estimate) - 1) * 100),
+                        ((1 / (1 + $change[0].median.confidence_interval.upper_bound) - 1) * 100),
+                        ($base[0].median.point_estimate - $new[0].median.point_estimate)
+                    ]
+                end
+                | @tsv
+            '
+    })"
+    IFS=$'\t' read -r median_pct lower_pct absolute_change_ns <<< "$metrics"
+
+    credible_failure="$({
+        jq -nr \
+            --argjson lower_pct "$lower_pct" \
+            --argjson failure_pct "$failure_threshold_pct" \
+            --argjson absolute_ns "$absolute_change_ns" \
+            --argjson absolute_threshold_ns "$absolute_failure_threshold_ns" \
+            '($lower_pct > $failure_pct) and ($absolute_ns > $absolute_threshold_ns)'
+    })"
+    warning="$({
+        jq -nr \
+            --argjson median_pct "$median_pct" \
+            --argjson warning_pct "$warning_threshold_pct" \
+            '$median_pct > $warning_pct'
+    })"
+
+    printf '%s: median regression %.2f%% (95%% CI lower bound %.2f%%, absolute change %.0f ns)\n' \
+        "$benchmark" "$median_pct" "$lower_pct" "$absolute_change_ns"
 
     if [[ "$credible_failure" == "true" ]]; then
         failure_count=$((failure_count + 1))
-        echo "::error title=PostgreSQL benchmark regression::$benchmark regressed by ${median_pct}%"
+        if [[ -n "$failure_output" ]]; then
+            printf '%s\n' "$benchmark" >> "$failure_output"
+        fi
+        annotate \
+            "PostgreSQL benchmark regression" \
+            "$benchmark credibly regressed by ${median_pct}% (${absolute_change_ns} ns)"
     elif [[ "$warning" == "true" ]]; then
-        echo "::warning title=PostgreSQL benchmark warning::$benchmark changed by ${median_pct}%"
+        annotate \
+            "PostgreSQL benchmark warning" \
+            "$benchmark changed by ${median_pct}% (${absolute_change_ns} ns)"
     fi
 done < <(find "$criterion_dir" -type f -path '*/change/estimates.json' | sort)
 
 if [[ "$result_count" -eq 0 ]]; then
-    echo "No Criterion base/head comparison results were found under $criterion_dir" >&2
+    echo "No selected Criterion base/head comparison results were found under $criterion_dir" >&2
     exit 2
 fi
 
 if [[ "$failure_count" -gt 0 ]]; then
-    echo "$failure_count credible PostgreSQL benchmark regression(s) exceeded ${failure_threshold_pct}%" >&2
+    echo "$failure_count credible PostgreSQL benchmark regression(s) exceeded both the ${failure_threshold_pct}% and ${absolute_failure_threshold_ns} ns thresholds" >&2
     exit 1
 fi
 

--- a/scripts/check-criterion-regressions.sh
+++ b/scripts/check-criterion-regressions.sh
@@ -10,6 +10,7 @@ direction="${5:-forward}"
 annotation_level="${6:-error}"
 failure_output="${7:-}"
 failure_filter="${8:-}"
+baseline_name="${9:-base}"
 
 if ! command -v jq >/dev/null 2>&1; then
     echo "jq is required to evaluate Criterion comparison results" >&2
@@ -31,6 +32,11 @@ case "$annotation_level" in
         exit 2
         ;;
 esac
+
+if [[ -z "$baseline_name" || "$baseline_name" == */* ]]; then
+    echo "Criterion baseline name must be a non-empty directory name, got '$baseline_name'" >&2
+    exit 2
+fi
 
 if [[ -n "$failure_output" ]]; then
     : > "$failure_output"
@@ -64,10 +70,10 @@ while IFS= read -r estimate_file; do
     benchmark="${benchmark_dir#"$criterion_dir"/}"
     benchmark_is_selected "$benchmark" || continue
 
-    base_estimate_file="$benchmark_dir/base/estimates.json"
+    base_estimate_file="$benchmark_dir/$baseline_name/estimates.json"
     new_estimate_file="$benchmark_dir/new/estimates.json"
     if [[ ! -f "$base_estimate_file" || ! -f "$new_estimate_file" ]]; then
-        echo "Missing Criterion base/new estimates for $benchmark" >&2
+        echo "Missing Criterion '$baseline_name'/new estimates for $benchmark" >&2
         exit 2
     fi
 

--- a/scripts/check-criterion-stability.sh
+++ b/scripts/check-criterion-stability.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+initial_dir="${1:?initial Criterion directory is required}"
+confirmation_dir="${2:?confirmation Criterion directory is required}"
+stability_threshold_pct="${3:-10}"
+benchmark_filter="${4:?benchmark filter is required}"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required to evaluate Criterion estimates" >&2
+    exit 2
+fi
+
+if [[ ! -s "$benchmark_filter" ]]; then
+    echo "The benchmark filter is empty: $benchmark_filter" >&2
+    exit 2
+fi
+
+result_count=0
+unstable_count=0
+
+while IFS= read -r benchmark; do
+    [[ -n "$benchmark" ]] || continue
+    initial_estimate="$initial_dir/$benchmark/base/estimates.json"
+    confirmation_estimate="$confirmation_dir/$benchmark/new/estimates.json"
+    if [[ ! -f "$initial_estimate" || ! -f "$confirmation_estimate" ]]; then
+        echo "Missing base-run stability estimates for $benchmark" >&2
+        exit 2
+    fi
+
+    result_count=$((result_count + 1))
+    drift_pct="$({
+        jq -nr \
+            --slurpfile initial "$initial_estimate" \
+            --slurpfile confirmation "$confirmation_estimate" '
+                (($confirmation[0].median.point_estimate
+                    / $initial[0].median.point_estimate) - 1) * 100
+            '
+    })"
+    absolute_drift_pct="$(
+        jq -nr --argjson drift "$drift_pct" \
+            'if $drift < 0 then -$drift else $drift end'
+    )"
+
+    printf '%s: base-to-base drift %+.2f%%\n' "$benchmark" "$drift_pct"
+    if [[ "$(
+        jq -nr \
+            --argjson drift "$absolute_drift_pct" \
+            --argjson threshold "$stability_threshold_pct" \
+            '$drift > $threshold'
+    )" == "true" ]]; then
+        unstable_count=$((unstable_count + 1))
+        echo "::warning title=Unstable PostgreSQL benchmark runner::$benchmark base measurements drifted by ${drift_pct}%"
+    fi
+done < "$benchmark_filter"
+
+if [[ "$result_count" -eq 0 ]]; then
+    echo "No benchmark stability results were evaluated" >&2
+    exit 2
+fi
+
+if [[ "$unstable_count" -gt 0 ]]; then
+    echo "$unstable_count PostgreSQL benchmark base measurement(s) drifted by more than ${stability_threshold_pct}%" >&2
+    exit 1
+fi
+
+echo "PostgreSQL benchmark runner was stable ($result_count result(s))."

--- a/scripts/check-criterion-stability.sh
+++ b/scripts/check-criterion-stability.sh
@@ -6,6 +6,7 @@ initial_dir="${1:?initial Criterion directory is required}"
 confirmation_dir="${2:?confirmation Criterion directory is required}"
 stability_threshold_pct="${3:-10}"
 benchmark_filter="${4:?benchmark filter is required}"
+initial_baseline_name="${5:-base}"
 
 if ! command -v jq >/dev/null 2>&1; then
     echo "jq is required to evaluate Criterion estimates" >&2
@@ -17,12 +18,17 @@ if [[ ! -s "$benchmark_filter" ]]; then
     exit 2
 fi
 
+if [[ -z "$initial_baseline_name" || "$initial_baseline_name" == */* ]]; then
+    echo "Criterion baseline name must be a non-empty directory name, got '$initial_baseline_name'" >&2
+    exit 2
+fi
+
 result_count=0
 unstable_count=0
 
 while IFS= read -r benchmark; do
     [[ -n "$benchmark" ]] || continue
-    initial_estimate="$initial_dir/$benchmark/base/estimates.json"
+    initial_estimate="$initial_dir/$benchmark/$initial_baseline_name/estimates.json"
     confirmation_estimate="$confirmation_dir/$benchmark/new/estimates.json"
     if [[ ! -f "$initial_estimate" || ! -f "$confirmation_estimate" ]]; then
         echo "Missing base-run stability estimates for $benchmark" >&2

--- a/src/tests/container_build.rs
+++ b/src/tests/container_build.rs
@@ -27,12 +27,13 @@ fn test_directory(prefix: &str) -> PathBuf {
 fn write_criterion_estimates(
     criterion_directory: &std::path::Path,
     benchmark: &str,
+    baseline_name: &str,
     change: (f64, f64, f64),
     base_median_ns: f64,
     new_median_ns: f64,
 ) {
     let benchmark_directory = criterion_directory.join(benchmark);
-    for estimate_kind in ["change", "base", "new"] {
+    for estimate_kind in ["change", baseline_name, "new"] {
         fs::create_dir_all(benchmark_directory.join(estimate_kind))
             .expect("Criterion estimate directory should be created");
     }
@@ -50,7 +51,7 @@ fn write_criterion_estimates(
         .to_string(),
     )
     .expect("Criterion change estimate should be written");
-    for (estimate_kind, median_ns) in [("base", base_median_ns), ("new", new_median_ns)] {
+    for (estimate_kind, median_ns) in [(baseline_name, base_median_ns), ("new", new_median_ns)] {
         fs::write(
             benchmark_directory.join(format!("{estimate_kind}/estimates.json")),
             serde_json::json!({"median": {"point_estimate": median_ns}}).to_string(),
@@ -283,6 +284,17 @@ fn postgres_benchmark_workflow_confirms_regressions_on_stable_base_runs() {
     assert!(workflow.contains("check-criterion-stability.sh"));
     assert!(workflow.contains("ALTER SYSTEM SET autovacuum = 'off'"));
     assert!(workflow.contains("POSTGRES_BENCH_FAILURE_ABSOLUTE_NS"));
+    let stability_invocation = workflow
+        .rsplit_once("scripts/check-criterion-stability.sh")
+        .expect("workflow should invoke the stability checker")
+        .1
+        .lines()
+        .take(6)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(stability_invocation.contains("$CONFIRMED_FAILURES"));
+    assert!(!stability_invocation.contains("$POSTGRES_BENCH_INITIAL_FAILURES"));
+    assert!(stability_invocation.contains("pr-base"));
 }
 
 #[cfg(unix)]
@@ -302,6 +314,7 @@ fn criterion_regression_requires_confident_relative_and_absolute_changes(
     write_criterion_estimates(
         &criterion_directory,
         "point_read",
+        "pr-base",
         (0.40, relative_lower_bound, 0.50),
         100_000.0,
         100_000.0 + absolute_change_ns,
@@ -311,6 +324,8 @@ fn criterion_regression_requires_confident_relative_and_absolute_changes(
         .arg(&criterion_directory)
         .args(["10", "20", "25000", "forward", "none"])
         .arg(&failures)
+        .arg("")
+        .arg("pr-base")
         .output()
         .expect("Criterion regression checker should run");
     let diagnostics = format!(
@@ -340,6 +355,7 @@ fn criterion_reverse_comparison_reports_the_same_head_regression() {
     write_criterion_estimates(
         &criterion_directory,
         "point_read",
+        "pr-head-confirmation",
         (-0.285_714, -0.35, -0.25),
         140_000.0,
         100_000.0,
@@ -350,6 +366,7 @@ fn criterion_reverse_comparison_reports_the_same_head_regression() {
         .args(["10", "20", "25000", "reverse", "none"])
         .arg(&failures)
         .arg(&filter)
+        .arg("pr-head-confirmation")
         .output()
         .expect("Criterion reverse regression checker should run");
     let diagnostics = format!(
@@ -380,6 +397,7 @@ fn criterion_stability_rejects_excessive_base_to_base_drift(
     write_criterion_estimates(
         &initial_directory,
         "point_read",
+        "pr-base",
         (0.0, 0.0, 0.0),
         100_000.0,
         100_000.0,
@@ -387,6 +405,7 @@ fn criterion_stability_rejects_excessive_base_to_base_drift(
     write_criterion_estimates(
         &confirmation_directory,
         "point_read",
+        "pr-head-confirmation",
         (0.0, 0.0, 0.0),
         140_000.0,
         confirmation_base_median_ns,
@@ -398,6 +417,7 @@ fn criterion_stability_rejects_excessive_base_to_base_drift(
             &confirmation_directory,
             std::path::Path::new("10"),
             &filter,
+            std::path::Path::new("pr-base"),
         ])
         .output()
         .expect("Criterion stability checker should run");

--- a/src/tests/container_build.rs
+++ b/src/tests/container_build.rs
@@ -10,6 +10,56 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use rstest::rstest;
 
 #[cfg(unix)]
+static TEST_DIRECTORY_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(unix)]
+fn test_directory(prefix: &str) -> PathBuf {
+    let directory = std::env::temp_dir().join(format!(
+        "hubuum-{prefix}-{}-{}",
+        std::process::id(),
+        TEST_DIRECTORY_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir(&directory).expect("test directory should be created");
+    directory
+}
+
+#[cfg(unix)]
+fn write_criterion_estimates(
+    criterion_directory: &std::path::Path,
+    benchmark: &str,
+    change: (f64, f64, f64),
+    base_median_ns: f64,
+    new_median_ns: f64,
+) {
+    let benchmark_directory = criterion_directory.join(benchmark);
+    for estimate_kind in ["change", "base", "new"] {
+        fs::create_dir_all(benchmark_directory.join(estimate_kind))
+            .expect("Criterion estimate directory should be created");
+    }
+    fs::write(
+        benchmark_directory.join("change/estimates.json"),
+        serde_json::json!({
+            "median": {
+                "point_estimate": change.0,
+                "confidence_interval": {
+                    "lower_bound": change.1,
+                    "upper_bound": change.2
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("Criterion change estimate should be written");
+    for (estimate_kind, median_ns) in [("base", base_median_ns), ("new", new_median_ns)] {
+        fs::write(
+            benchmark_directory.join(format!("{estimate_kind}/estimates.json")),
+            serde_json::json!({"median": {"point_estimate": median_ns}}).to_string(),
+        )
+        .expect("Criterion median estimate should be written");
+    }
+}
+
+#[cfg(unix)]
 fn run_entrypoint(runtime_role: &str, arguments: &[&str]) -> Output {
     use std::os::unix::fs::PermissionsExt;
 
@@ -212,11 +262,153 @@ fn container_dependency_images_are_pinned() {
     let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let workflow = fs::read_to_string(repository.join(".github/workflows/ci.yml"))
         .expect("CI workflow should be readable");
+    let benchmark_workflow =
+        fs::read_to_string(repository.join(".github/workflows/benchmarks.yml"))
+            .expect("benchmark workflow should be readable");
     let installer = fs::read_to_string(repository.join("scripts/install-single-host.sh"))
         .expect("single-host installer should be readable");
 
     assert!(workflow.contains("postgres:18.4@sha256:"));
+    assert!(benchmark_workflow.contains("postgres:18.4-alpine3.24@sha256:"));
     assert!(installer.contains("postgres:18.4-alpine3.24@sha256:"));
+}
+
+#[test]
+fn postgres_benchmark_workflow_confirms_regressions_on_stable_base_runs() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workflow = fs::read_to_string(repository.join(".github/workflows/benchmarks.yml"))
+        .expect("benchmark workflow should be readable");
+
+    assert!(workflow.contains("Confirm PostgreSQL regressions in reverse order"));
+    assert!(workflow.contains("check-criterion-stability.sh"));
+    assert!(workflow.contains("ALTER SYSTEM SET autovacuum = 'off'"));
+    assert!(workflow.contains("POSTGRES_BENCH_FAILURE_ABSOLUTE_NS"));
+}
+
+#[cfg(unix)]
+#[rstest]
+#[case(0.05, 50_000.0, true)]
+#[case(0.25, 10_000.0, true)]
+#[case(0.25, 50_000.0, false)]
+fn criterion_regression_requires_confident_relative_and_absolute_changes(
+    #[case] relative_lower_bound: f64,
+    #[case] absolute_change_ns: f64,
+    #[case] expected_success: bool,
+) {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let test_directory = test_directory("criterion-regression");
+    let criterion_directory = test_directory.join("criterion");
+    let failures = test_directory.join("failures.txt");
+    write_criterion_estimates(
+        &criterion_directory,
+        "point_read",
+        (0.40, relative_lower_bound, 0.50),
+        100_000.0,
+        100_000.0 + absolute_change_ns,
+    );
+
+    let output = Command::new(repository.join("scripts/check-criterion-regressions.sh"))
+        .arg(&criterion_directory)
+        .args(["10", "20", "25000", "forward", "none"])
+        .arg(&failures)
+        .output()
+        .expect("Criterion regression checker should run");
+    let diagnostics = format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(output.status.success(), expected_success, "{diagnostics}");
+    if expected_success {
+        assert_eq!(fs::read_to_string(&failures).unwrap(), "");
+    } else {
+        assert_eq!(fs::read_to_string(&failures).unwrap(), "point_read\n");
+    }
+    fs::remove_dir_all(test_directory).expect("test directory should be removed");
+}
+
+#[cfg(unix)]
+#[test]
+fn criterion_reverse_comparison_reports_the_same_head_regression() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let test_directory = test_directory("criterion-reverse");
+    let criterion_directory = test_directory.join("criterion");
+    let failures = test_directory.join("failures.txt");
+    let filter = test_directory.join("filter.txt");
+    fs::write(&filter, "point_read\n").expect("benchmark filter should be written");
+    write_criterion_estimates(
+        &criterion_directory,
+        "point_read",
+        (-0.285_714, -0.35, -0.25),
+        140_000.0,
+        100_000.0,
+    );
+
+    let output = Command::new(repository.join("scripts/check-criterion-regressions.sh"))
+        .arg(&criterion_directory)
+        .args(["10", "20", "25000", "reverse", "none"])
+        .arg(&failures)
+        .arg(&filter)
+        .output()
+        .expect("Criterion reverse regression checker should run");
+    let diagnostics = format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(output.status.code(), Some(1), "{diagnostics}");
+    assert_eq!(fs::read_to_string(&failures).unwrap(), "point_read\n");
+    fs::remove_dir_all(test_directory).expect("test directory should be removed");
+}
+
+#[cfg(unix)]
+#[rstest]
+#[case(109_000.0, true)]
+#[case(111_000.0, false)]
+fn criterion_stability_rejects_excessive_base_to_base_drift(
+    #[case] confirmation_base_median_ns: f64,
+    #[case] expected_success: bool,
+) {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let test_directory = test_directory("criterion-stability");
+    let initial_directory = test_directory.join("initial");
+    let confirmation_directory = test_directory.join("confirmation");
+    let filter = test_directory.join("filter.txt");
+    fs::write(&filter, "point_read\n").expect("benchmark filter should be written");
+    write_criterion_estimates(
+        &initial_directory,
+        "point_read",
+        (0.0, 0.0, 0.0),
+        100_000.0,
+        100_000.0,
+    );
+    write_criterion_estimates(
+        &confirmation_directory,
+        "point_read",
+        (0.0, 0.0, 0.0),
+        140_000.0,
+        confirmation_base_median_ns,
+    );
+
+    let output = Command::new(repository.join("scripts/check-criterion-stability.sh"))
+        .args([
+            &initial_directory,
+            &confirmation_directory,
+            std::path::Path::new("10"),
+            &filter,
+        ])
+        .output()
+        .expect("Criterion stability checker should run");
+    let diagnostics = format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(output.status.success(), expected_success, "{diagnostics}");
+    fs::remove_dir_all(test_directory).expect("test directory should be removed");
 }
 
 #[test]

--- a/src/tests/storage_performance.rs
+++ b/src/tests/storage_performance.rs
@@ -4,12 +4,16 @@
 //! authentication and routing should not hide an extra pool checkout or an
 //! N+1 introduced while storage capabilities are extracted.
 
-use crate::db::capture_queries;
+use diesel::sql_types::{Integer, Json, Text};
+use serde_json::Value;
+
+use crate::db::prelude::{QueryableByName, RunQueryDsl};
 use crate::db::traits::history::{
     collection_history_paginated_with_total_count, resolve_actor_usernames,
 };
 use crate::db::traits::user::UserSearchBackend;
 use crate::db::with_actor_scope;
+use crate::db::{DbPool, capture_queries, with_connection};
 use crate::events::EventContext;
 use crate::models::collection::effective_group_on;
 use crate::models::search::parse_query_parameter;
@@ -19,6 +23,103 @@ use crate::models::{
 };
 use crate::tests::{TestScope, ensure_admin_user};
 use crate::traits::{CanDelete, CanSave, CanUpdate, CollectionAccessors};
+
+const REPRESENTATIVE_COLLECTION_ROWS: i32 = 2_000;
+
+#[derive(QueryableByName)]
+struct ExplainPlanRow {
+    #[diesel(sql_type = Json)]
+    #[diesel(column_name = "QUERY PLAN")]
+    query_plan: Value,
+}
+
+fn plan_uses_index(plan: &Value, index_name_prefix: &str) -> bool {
+    match plan {
+        Value::Array(values) => values
+            .iter()
+            .any(|value| plan_uses_index(value, index_name_prefix)),
+        Value::Object(fields) => {
+            fields
+                .get("Index Name")
+                .and_then(Value::as_str)
+                .is_some_and(|name| name.starts_with(index_name_prefix))
+                || fields
+                    .values()
+                    .any(|value| plan_uses_index(value, index_name_prefix))
+        }
+        _ => false,
+    }
+}
+
+fn root_plan(plan: &Value) -> &Value {
+    plan.as_array()
+        .and_then(|plans| plans.as_slice().first())
+        .and_then(|explain| explain.get("Plan"))
+        .expect("EXPLAIN JSON should contain a root plan")
+}
+
+fn root_shared_blocks(plan: &Value) -> u64 {
+    let root = root_plan(plan);
+    root.get("Shared Hit Blocks")
+        .and_then(Value::as_u64)
+        .unwrap_or_default()
+        + root
+            .get("Shared Read Blocks")
+            .and_then(Value::as_u64)
+            .unwrap_or_default()
+}
+
+async fn add_representative_collection_rows(pool: &DbPool, name_prefix: &str, parent_id: i32) {
+    with_connection(pool, async |conn| {
+        diesel::sql_query(
+            "WITH inserted AS (\
+                INSERT INTO collections (name, description, parent_collection_id) \
+                SELECT $1 || '-' || sequence::text, 'query plan scale row', $2 \
+                FROM generate_series(1, $3) AS sequence \
+                RETURNING id\
+            ) \
+            INSERT INTO collection_closure \
+                (ancestor_collection_id, descendant_collection_id, depth) \
+            SELECT id, id, 0 FROM inserted",
+        )
+        .bind::<Text, _>(name_prefix)
+        .bind::<Integer, _>(parent_id)
+        .bind::<Integer, _>(REPRESENTATIVE_COLLECTION_ROWS)
+        .execute(conn)
+        .await?;
+        diesel::sql_query("ANALYZE collections")
+            .execute(conn)
+            .await?;
+        diesel::sql_query("ANALYZE collection_closure")
+            .execute(conn)
+            .await
+    })
+    .await
+    .expect("representative query-plan rows should be created");
+}
+
+async fn remove_representative_collection_rows(pool: &DbPool, name_prefix: &str) {
+    with_connection(pool, async |conn| {
+        diesel::sql_query("DELETE FROM collections WHERE left(name, length($1)) = $1")
+            .bind::<Text, _>(name_prefix)
+            .execute(conn)
+            .await
+    })
+    .await
+    .expect("representative query-plan rows should be removed");
+}
+
+async fn explain_storage_query(pool: &DbPool, query: &'static str, collection_id: i32) -> Value {
+    with_connection(pool, async |conn| {
+        diesel::sql_query(query)
+            .bind::<Integer, _>(collection_id)
+            .get_result::<ExplainPlanRow>(conn)
+            .await
+    })
+    .await
+    .expect("storage query should produce an EXPLAIN plan")
+    .query_plan
+}
 
 fn assert_same_query_shape(
     smaller: &crate::db::QueryCaptureSnapshot,
@@ -54,6 +155,37 @@ async fn collection_point_read_uses_one_query() {
     assert_eq!(queries.connection_checkouts(), 1);
     assert_eq!(queries.queries_matching("FROM \"collections\""), 1);
 
+    fixture.cleanup().await.expect("fixture cleanup");
+}
+
+#[actix_web::test]
+async fn collection_point_read_plan_has_bounded_logical_work_at_representative_scale() {
+    let scope = TestScope::new();
+    let fixture = scope.collection_fixture("query_plan_point_read").await;
+    let scale_prefix = scope.scoped_name("query_plan_point_read_scale");
+    add_representative_collection_rows(scope.pool.get_ref(), &scale_prefix, fixture.collection.id)
+        .await;
+
+    let plan = explain_storage_query(
+        scope.pool.get_ref(),
+        "EXPLAIN (ANALYZE, BUFFERS, TIMING OFF, SUMMARY OFF, FORMAT JSON) \
+         SELECT id, name, description, created_at, updated_at, parent_collection_id \
+         FROM collections WHERE id = $1",
+        fixture.collection.id,
+    )
+    .await;
+
+    assert!(
+        plan_uses_index(&plan, "collections_pkey"),
+        "point read should use the collections primary-key index: {plan:#}"
+    );
+    assert_eq!(root_plan(&plan)["Actual Rows"].as_f64(), Some(1.0));
+    assert!(
+        root_shared_blocks(&plan) <= 8,
+        "point read touched too many shared blocks: {plan:#}"
+    );
+
+    remove_representative_collection_rows(scope.pool.get_ref(), &scale_prefix).await;
     fixture.cleanup().await.expect("fixture cleanup");
 }
 
@@ -105,6 +237,68 @@ async fn collection_ancestor_query_count_is_constant_with_depth() {
             .expect("nested collection cleanup");
     }
     root_fixture.cleanup().await.expect("root fixture cleanup");
+}
+
+#[actix_web::test]
+async fn collection_ancestor_plan_has_bounded_logical_work_at_representative_scale() {
+    let scope = TestScope::new();
+    let fixture = scope.collection_fixture("query_plan_ancestors").await;
+    let mut collections = vec![fixture.collection.clone()];
+
+    for depth in 1..=16 {
+        let parent_id = collections.last().expect("parent collection").id;
+        let collection = NewCollectionWithAssignee {
+            name: scope.scoped_name(&format!("query_plan_ancestor_{depth}")),
+            description: format!("query plan ancestor level {depth}"),
+            group_id: fixture.owner_group.id,
+            parent_collection_id: Some(
+                CollectionID::new(parent_id).expect("valid parent collection id"),
+            ),
+        }
+        .save_without_events(&scope.pool)
+        .await
+        .expect("nested collection should save");
+        collections.push(collection);
+    }
+
+    let scale_prefix = scope.scoped_name("query_plan_ancestor_scale");
+    add_representative_collection_rows(scope.pool.get_ref(), &scale_prefix, fixture.collection.id)
+        .await;
+    let leaf_id = collections.last().expect("leaf collection").id;
+    let plan = explain_storage_query(
+        scope.pool.get_ref(),
+        "EXPLAIN (ANALYZE, BUFFERS, TIMING OFF, SUMMARY OFF, FORMAT JSON) \
+         SELECT collections.id, collections.name, collections.description, \
+                collections.created_at, collections.updated_at, \
+                collections.parent_collection_id \
+         FROM collection_closure \
+         INNER JOIN collections \
+             ON collections.id = collection_closure.ancestor_collection_id \
+         WHERE collection_closure.descendant_collection_id = $1 \
+           AND collection_closure.depth > 0 \
+         ORDER BY collection_closure.depth ASC",
+        leaf_id,
+    )
+    .await;
+
+    assert!(
+        plan_uses_index(&plan, "collection_closure_descendant"),
+        "ancestor read should use a descendant-first closure index: {plan:#}"
+    );
+    assert_eq!(root_plan(&plan)["Actual Rows"].as_f64(), Some(17.0));
+    assert!(
+        root_shared_blocks(&plan) <= 128,
+        "ancestor read touched too many shared blocks: {plan:#}"
+    );
+
+    remove_representative_collection_rows(scope.pool.get_ref(), &scale_prefix).await;
+    for collection in collections.iter().skip(1).rev() {
+        collection
+            .delete_without_events(&scope.pool)
+            .await
+            .expect("nested collection cleanup");
+    }
+    fixture.cleanup().await.expect("fixture cleanup");
 }
 
 #[actix_web::test]


### PR DESCRIPTION
## Summary

- upgrade the PostgreSQL storage benchmark service from the floating PostgreSQL 17 Alpine tag to digest-pinned PostgreSQL 18.4 on Alpine 3.24
- require the 95% confidence interval to clear the relative regression threshold and require a 25 microsecond absolute increase before treating a result as suspect
- confirm suspected regressions with fresh databases and reversed execution order, then block only when both comparisons agree and the bracketing base measurements remain within 10%
- disable benchmark-only autovacuum and defer checkpoints to reduce random PostgreSQL background work
- add deterministic representative-scale query-plan checks for primary-key reads and collection ancestor traversal, including index and logical-buffer budgets
- add regression tests for forward/reverse Criterion interpretation, absolute thresholds, runner stability checks, workflow configuration, and image pinning

## Why

The existing workflow ran base before head and treated a point estimate above 20% as a failure whenever its confidence interval merely excluded zero. A runner that slowed between those sequential phases could therefore produce a statistically consistent but environmental regression.

The new flow treats the first result as a suspected regression. It runs `base -> head -> head -> base`, using fresh databases for the reversed pair, and verifies that the two base measurements are stable. A repeated regression on a stable runner fails; an order-dependent result or unstable base reports an inconclusive warning without adding PR noise.

## Impact

This changes developer CI behavior and test coverage only. It does not change the Hubuum API or runtime behavior, introduces no breaking change, and has no user-facing changelog entry.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `actionlint .github/workflows/benchmarks.yml`
- `shellcheck scripts/check-criterion-regressions.sh scripts/check-criterion-stability.sh`
- `source .env && ./run_tests.sh` (1,282 passed, 6 expected ignored)
- all eight migrations applied successfully to the pinned PostgreSQL 18.4 Alpine image
- the point-read, depth-16 ancestor, and event-backed create Criterion benchmarks completed successfully against PostgreSQL 18.4 Alpine with the benchmark noise controls enabled
