### PR TITLE
Harden and consolidate query input parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- JSON filters and object-aggregate dimensions now share one typed JSON-path
+  parser. Empty segments, whitespace, and characters outside ASCII letters,
+  digits, `_`, and `$` are rejected consistently before SQL generation.
+
+### Fixed
+
+- Unified search now uses the shared form-query decoder, so `+` and percent
+  escapes are interpreted consistently with other list and search endpoints.
+
+### Security
+
+- Integer list and range filters are limited to 1,024 unique expanded values,
+  and oversized ranges fail during bounded parsing instead of allocating an
+  attacker-controlled number of integers.
+
 ## [0.0.3] - 2026-07-21
 
 ### Added

--- a/crates/hubuum-query/src/lib.rs
+++ b/crates/hubuum-query/src/lib.rs
@@ -5,9 +5,16 @@
 //! [`QueryError`] into its public error surface at the boundary.
 
 use chrono::{DateTime, NaiveDate};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt;
 use std::str::FromStr;
+
+/// Maximum number of unique integers accepted from one list or range filter.
+///
+/// This bound is enforced while ranges are expanded so compact inputs cannot
+/// force unbounded allocation before an endpoint applies its operator-specific
+/// limits.
+pub const MAX_INTEGER_FILTER_VALUES: usize = 1_024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum QueryError {
@@ -152,19 +159,24 @@ fn parse_sort_param(piece: &str) -> Result<SortParam, QueryError> {
     }
 }
 
-fn decode_query_parameter_pairs(qs: &str) -> Result<Vec<(String, String)>, QueryError> {
+/// Decode an `application/x-www-form-urlencoded` query string into owned pairs.
+///
+/// Both percent escapes and `+` space encoding are handled consistently for
+/// keys and values so endpoint-specific parsers can reuse the common transport
+/// grammar without depending on a web framework.
+pub fn decode_query_parameter_pairs(qs: &str) -> Result<Vec<(String, String)>, QueryError> {
     let mut pairs = Vec::new();
+    if qs.is_empty() {
+        return Ok(pairs);
+    }
 
     for chunk in qs.split('&') {
-        let parts: Vec<_> = chunk.splitn(2, '=').collect();
-        if parts.len() != 2 {
-            return Err(QueryError::BadRequest(format!(
-                "Invalid query parameter: '{chunk}'"
-            )));
-        }
+        let (raw_key, raw_value) = chunk
+            .split_once('=')
+            .ok_or_else(|| QueryError::BadRequest(format!("Invalid query parameter: '{chunk}'")))?;
 
-        let key = decode_query_component(parts[0], chunk, "key")?;
-        let value = decode_query_component(parts[1], chunk, "value")?;
+        let key = decode_query_component(raw_key, chunk, "key")?;
+        let value = decode_query_component(raw_value, chunk, "value")?;
         pairs.push((key, value));
     }
 
@@ -276,6 +288,65 @@ pub struct QueryOptions {
     pub limit: Option<usize>,
     pub cursor: Option<String>,
     pub include_total: bool,
+}
+
+/// A validated, comma-separated path into a JSON object.
+///
+/// Paths are kept app-neutral here so query filters, aggregate dimensions, and
+/// future query-planning features share one grammar. Each segment must be
+/// non-empty and contain only ASCII letters, digits, `_`, or `$`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct JsonFieldPath {
+    segments: Vec<String>,
+}
+
+impl JsonFieldPath {
+    pub fn new(value: &str) -> Result<Self, QueryError> {
+        let segments = value.split(',').map(str::to_string).collect::<Vec<_>>();
+        let valid = !value.is_empty()
+            && segments.iter().all(|segment| {
+                !segment.is_empty()
+                    && segment
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$'))
+            });
+        if !valid {
+            return Err(QueryError::BadRequest(format!(
+                "Invalid JSON path '{value}'; use non-empty comma-separated ASCII path segments containing only letters, digits, '_', or '$'"
+            )));
+        }
+        Ok(Self { segments })
+    }
+
+    pub fn segments(&self) -> &[String] {
+        &self.segments
+    }
+
+    pub fn canonical(&self) -> String {
+        self.segments.join(",")
+    }
+}
+
+impl FromStr for JsonFieldPath {
+    type Err = QueryError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl fmt::Display for JsonFieldPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut segments = self.segments.iter();
+        if let Some(first) = segments.next() {
+            f.write_str(first)?;
+        }
+        for segment in segments {
+            f.write_str(",")?;
+            f.write_str(segment)?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -728,10 +799,11 @@ pub fn get_jsonb_field_type_from_json_schema(
     schema: &serde_json::Value,
     key: &str,
 ) -> Option<SQLMappedType> {
+    let path = JsonFieldPath::new(key).ok()?;
     use serde_json::Value;
     let mut current_schema = schema;
 
-    for key in key.split(',') {
+    for key in path.segments() {
         match current_schema {
             Value::Object(map) => {
                 if let Some(sub_schema) = map.get("properties").and_then(|p| p.get(key)) {
@@ -991,33 +1063,40 @@ filter_fields!(
 );
 
 pub fn parse_integer_list(input: &str) -> Result<Vec<i32>, QueryError> {
-    let mut numbers = Vec::new();
+    parse_integer_list_with_limit(input, MAX_INTEGER_FILTER_VALUES)
+}
+
+/// Parse an integer list while enforcing a caller-provided unique-value cap.
+///
+/// The limit is checked during insertion rather than after collecting and
+/// sorting, which keeps very large ranges and heavily duplicated inputs
+/// bounded in both memory and work.
+pub fn parse_integer_list_with_limit(
+    input: &str,
+    max_values: usize,
+) -> Result<Vec<i32>, QueryError> {
+    let mut numbers = BTreeSet::new();
 
     for segment in input.split(',') {
-        if segment.contains("--") {
-            let parts: Vec<&str> = segment.split("--").collect();
-            if parts.len() != 2 {
+        if let Some((start, negative_end)) = segment.split_once("--") {
+            if negative_end.contains("--") {
                 return Err(QueryError::InvalidIntegerRange(format!(
                     "Invalid format: '{segment}'"
                 )));
             }
-            let start = parts[0].parse::<i32>().map_err(|_| {
-                QueryError::InvalidIntegerRange(format!("Invalid start of range: '{}'", parts[0]))
+            let start = start.parse::<i32>().map_err(|_| {
+                QueryError::InvalidIntegerRange(format!("Invalid start of range: '{start}'"))
             })?;
-            let end = format!("-{}", parts[1]).parse::<i32>().map_err(|_| {
-                QueryError::InvalidIntegerRange(format!("Invalid end of range: '{}'", parts[1]))
+            let end = format!("-{negative_end}").parse::<i32>().map_err(|_| {
+                QueryError::InvalidIntegerRange(format!("Invalid end of range: '{negative_end}'"))
             })?;
-            if start > end {
-                return Err(QueryError::InvalidIntegerRange(format!(
-                    "Range start is greater than end: '{segment}'"
-                )));
-            }
-            numbers.extend(start..=end);
+            insert_integer_range(&mut numbers, start, end, max_values, input, segment)?;
         } else if let Some(idx) = segment.find('-') {
             if idx == 0 {
-                numbers.push(segment.parse::<i32>().map_err(|_| {
+                let value = segment.parse::<i32>().map_err(|_| {
                     QueryError::InvalidIntegerRange(format!("Invalid number: '{segment}'"))
-                })?);
+                })?;
+                insert_integer(&mut numbers, value, max_values, input)?;
             } else {
                 let (start, end) = segment.split_at(idx);
                 let end = &end[1..];
@@ -1027,23 +1106,51 @@ pub fn parse_integer_list(input: &str) -> Result<Vec<i32>, QueryError> {
                 let end = end.parse::<i32>().map_err(|_| {
                     QueryError::InvalidIntegerRange(format!("Invalid end of range: '{end}'"))
                 })?;
-                if start > end {
-                    return Err(QueryError::InvalidIntegerRange(format!(
-                        "Range start is greater than end: '{segment}'"
-                    )));
-                }
-                numbers.extend(start..=end);
+                insert_integer_range(&mut numbers, start, end, max_values, input, segment)?;
             }
         } else {
-            numbers.push(segment.parse::<i32>().map_err(|_| {
+            let value = segment.parse::<i32>().map_err(|_| {
                 QueryError::InvalidIntegerRange(format!("Invalid number: '{segment}'"))
-            })?);
+            })?;
+            insert_integer(&mut numbers, value, max_values, input)?;
         }
     }
 
-    numbers.sort_unstable();
-    numbers.dedup();
-    Ok(numbers)
+    Ok(numbers.into_iter().collect())
+}
+
+fn insert_integer_range(
+    numbers: &mut BTreeSet<i32>,
+    start: i32,
+    end: i32,
+    max_values: usize,
+    input: &str,
+    segment: &str,
+) -> Result<(), QueryError> {
+    if start > end {
+        return Err(QueryError::InvalidIntegerRange(format!(
+            "Range start is greater than end: '{segment}'"
+        )));
+    }
+    for value in start..=end {
+        insert_integer(numbers, value, max_values, input)?;
+    }
+    Ok(())
+}
+
+fn insert_integer(
+    numbers: &mut BTreeSet<i32>,
+    value: i32,
+    max_values: usize,
+    input: &str,
+) -> Result<(), QueryError> {
+    numbers.insert(value);
+    if numbers.len() > max_values {
+        return Err(QueryError::InvalidIntegerRange(format!(
+            "Integer filter '{input}' expands to more than {max_values} unique values"
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1276,10 +1383,79 @@ mod tests {
     }
 
     #[test]
+    fn shared_query_decoder_decodes_keys_and_values() {
+        let pairs = decode_query_parameter_pairs("search+term=core+router%2Fedge").unwrap();
+
+        assert_eq!(
+            pairs,
+            [("search term".to_string(), "core router/edge".to_string())]
+        );
+    }
+
+    #[test]
+    fn shared_query_decoder_accepts_an_empty_query_string() {
+        assert_eq!(decode_query_parameter_pairs("").unwrap(), []);
+    }
+
+    #[test]
     fn parses_integer_ranges() {
         assert_eq!(
             parse_integer_list("1-4,3,8,-4--2").unwrap(),
             vec![-4, -3, -2, 1, 2, 3, 4, 8]
+        );
+    }
+
+    #[test]
+    fn rejects_integer_ranges_above_the_expansion_limit() {
+        let error = parse_integer_list("0-2147483647").unwrap_err();
+
+        assert_eq!(
+            error,
+            QueryError::InvalidIntegerRange(format!(
+                "Integer filter '0-2147483647' expands to more than {MAX_INTEGER_FILTER_VALUES} unique values"
+            ))
+        );
+    }
+
+    #[test]
+    fn integer_list_limit_counts_unique_values() {
+        assert_eq!(
+            parse_integer_list_with_limit("1-3,1-3,2", 3).unwrap(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn rejects_an_integer_list_when_the_unique_value_limit_is_zero() {
+        let error = parse_integer_list_with_limit("1", 0).unwrap_err();
+
+        assert_eq!(
+            error,
+            QueryError::InvalidIntegerRange(
+                "Integer filter '1' expands to more than 0 unique values".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn json_path_preserves_valid_nested_segments() {
+        let path = JsonFieldPath::new("network,address_v4,$value").unwrap();
+
+        assert_eq!(path.segments(), ["network", "address_v4", "$value"]);
+        assert_eq!(path.canonical(), "network,address_v4,$value");
+        assert_eq!(path.to_string(), "network,address_v4,$value");
+    }
+
+    #[test]
+    fn json_path_rejects_empty_segments() {
+        let error = JsonFieldPath::new("network,,address").unwrap_err();
+
+        assert_eq!(
+            error,
+            QueryError::BadRequest(
+                "Invalid JSON path 'network,,address'; use non-empty comma-separated ASCII path segments containing only letters, digits, '_', or '$'"
+                    .to_string()
+            )
         );
     }
 

--- a/crates/hubuum-query/src/lib.rs
+++ b/crates/hubuum-query/src/lib.rs
@@ -5,7 +5,8 @@
 //! [`QueryError`] into its public error surface at the boundary.
 
 use chrono::{DateTime, NaiveDate};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::str::FromStr;
 
@@ -171,28 +172,42 @@ pub fn decode_query_parameter_pairs(qs: &str) -> Result<Vec<(String, String)>, Q
     }
 
     for chunk in qs.split('&') {
-        let (raw_key, raw_value) = chunk
-            .split_once('=')
-            .ok_or_else(|| QueryError::BadRequest(format!("Invalid query parameter: '{chunk}'")))?;
-
-        let key = decode_query_component(raw_key, chunk, "key")?;
-        let value = decode_query_component(raw_value, chunk, "value")?;
-        pairs.push((key, value));
+        let (key, value) = decode_query_parameter_pair(chunk)?;
+        pairs.push((key.into_owned(), value.into_owned()));
     }
 
     Ok(pairs)
 }
 
-fn decode_query_component(raw: &str, chunk: &str, component: &str) -> Result<String, QueryError> {
+/// Decode one `key=value` query-string component.
+///
+/// Components that need no form or percent decoding remain borrowed. This lets
+/// streaming endpoint parsers share the transport grammar without allocating a
+/// complete intermediate pair list.
+pub fn decode_query_parameter_pair(
+    chunk: &str,
+) -> Result<(Cow<'_, str>, Cow<'_, str>), QueryError> {
+    let (raw_key, raw_value) = chunk
+        .split_once('=')
+        .ok_or_else(|| QueryError::BadRequest(format!("Invalid query parameter: '{chunk}'")))?;
+
+    let key = decode_query_component(raw_key, chunk, "key")?;
+    let value = decode_query_component(raw_value, chunk, "value")?;
+    Ok((key, value))
+}
+
+fn decode_query_component<'a>(
+    raw: &'a str,
+    chunk: &str,
+    component: &str,
+) -> Result<Cow<'a, str>, QueryError> {
     let decoded = if raw.contains('+') {
         let form_encoded = raw.replace('+', " ");
         percent_encoding::percent_decode(form_encoded.as_bytes())
             .decode_utf8()
-            .map(|value| value.into_owned())
+            .map(|value| Cow::Owned(value.into_owned()))
     } else {
-        percent_encoding::percent_decode(raw.as_bytes())
-            .decode_utf8()
-            .map(|value| value.into_owned())
+        percent_encoding::percent_decode(raw.as_bytes()).decode_utf8()
     };
 
     decoded.map_err(|e| {
@@ -295,35 +310,70 @@ pub struct QueryOptions {
 /// Paths are kept app-neutral here so query filters, aggregate dimensions, and
 /// future query-planning features share one grammar. Each segment must be
 /// non-empty and contain only ASCII letters, digits, `_`, or `$`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct JsonFieldPath {
-    segments: Vec<String>,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct JsonFieldPathRef<'a> {
+    canonical: &'a str,
 }
 
-impl JsonFieldPath {
-    pub fn new(value: &str) -> Result<Self, QueryError> {
-        let segments = value.split(',').map(str::to_string).collect::<Vec<_>>();
+impl<'a> JsonFieldPathRef<'a> {
+    pub fn new(value: &'a str) -> Result<Self, QueryError> {
         let valid = !value.is_empty()
-            && segments.iter().all(|segment| {
+            && value.split(',').all(|segment| {
                 !segment.is_empty()
                     && segment
                         .bytes()
                         .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$'))
             });
         if !valid {
-            return Err(QueryError::BadRequest(format!(
-                "Invalid JSON path '{value}'; use non-empty comma-separated ASCII path segments containing only letters, digits, '_', or '$'"
-            )));
+            return Err(invalid_json_field_path(value));
         }
-        Ok(Self { segments })
+        Ok(Self { canonical: value })
     }
 
-    pub fn segments(&self) -> &[String] {
-        &self.segments
+    pub fn segments(self) -> impl Iterator<Item = &'a str> {
+        self.canonical.split(',')
     }
 
-    pub fn canonical(&self) -> String {
-        self.segments.join(",")
+    pub fn canonical(self) -> &'a str {
+        self.canonical
+    }
+}
+
+impl fmt::Display for JsonFieldPathRef<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.canonical)
+    }
+}
+
+/// An owned [`JsonFieldPathRef`].
+///
+/// Use the borrowed representation while parsing request-local values and this
+/// owned representation when a validated path must be retained in a model.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct JsonFieldPath {
+    canonical: String,
+}
+
+impl JsonFieldPath {
+    pub fn new(value: &str) -> Result<Self, QueryError> {
+        JsonFieldPathRef::new(value)?;
+        Ok(Self {
+            canonical: value.to_string(),
+        })
+    }
+
+    pub fn segments(&self) -> impl Iterator<Item = &str> {
+        self.as_ref().segments()
+    }
+
+    pub fn canonical(&self) -> &str {
+        &self.canonical
+    }
+
+    pub fn as_ref(&self) -> JsonFieldPathRef<'_> {
+        JsonFieldPathRef {
+            canonical: &self.canonical,
+        }
     }
 }
 
@@ -337,16 +387,14 @@ impl FromStr for JsonFieldPath {
 
 impl fmt::Display for JsonFieldPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut segments = self.segments.iter();
-        if let Some(first) = segments.next() {
-            f.write_str(first)?;
-        }
-        for segment in segments {
-            f.write_str(",")?;
-            f.write_str(segment)?;
-        }
-        Ok(())
+        f.write_str(&self.canonical)
     }
+}
+
+fn invalid_json_field_path(value: &str) -> QueryError {
+    QueryError::BadRequest(format!(
+        "Invalid JSON path '{value}'; use non-empty comma-separated ASCII path segments containing only letters, digits, '_', or '$'"
+    ))
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -799,7 +847,7 @@ pub fn get_jsonb_field_type_from_json_schema(
     schema: &serde_json::Value,
     key: &str,
 ) -> Option<SQLMappedType> {
-    let path = JsonFieldPath::new(key).ok()?;
+    let path = JsonFieldPathRef::new(key).ok()?;
     use serde_json::Value;
     let mut current_schema = schema;
 
@@ -1075,7 +1123,7 @@ pub fn parse_integer_list_with_limit(
     input: &str,
     max_values: usize,
 ) -> Result<Vec<i32>, QueryError> {
-    let mut numbers = BTreeSet::new();
+    let mut numbers = IntegerAccumulator::new(max_values);
 
     for segment in input.split(',') {
         if let Some((start, negative_end)) = segment.split_once("--") {
@@ -1090,13 +1138,13 @@ pub fn parse_integer_list_with_limit(
             let end = format!("-{negative_end}").parse::<i32>().map_err(|_| {
                 QueryError::InvalidIntegerRange(format!("Invalid end of range: '{negative_end}'"))
             })?;
-            insert_integer_range(&mut numbers, start, end, max_values, input, segment)?;
+            insert_integer_range(&mut numbers, start, end, input, segment)?;
         } else if let Some(idx) = segment.find('-') {
             if idx == 0 {
                 let value = segment.parse::<i32>().map_err(|_| {
                     QueryError::InvalidIntegerRange(format!("Invalid number: '{segment}'"))
                 })?;
-                insert_integer(&mut numbers, value, max_values, input)?;
+                insert_integer(&mut numbers, value, input)?;
             } else {
                 let (start, end) = segment.split_at(idx);
                 let end = &end[1..];
@@ -1106,24 +1154,101 @@ pub fn parse_integer_list_with_limit(
                 let end = end.parse::<i32>().map_err(|_| {
                     QueryError::InvalidIntegerRange(format!("Invalid end of range: '{end}'"))
                 })?;
-                insert_integer_range(&mut numbers, start, end, max_values, input, segment)?;
+                insert_integer_range(&mut numbers, start, end, input, segment)?;
             }
         } else {
             let value = segment.parse::<i32>().map_err(|_| {
                 QueryError::InvalidIntegerRange(format!("Invalid number: '{segment}'"))
             })?;
-            insert_integer(&mut numbers, value, max_values, input)?;
+            insert_integer(&mut numbers, value, input)?;
         }
     }
 
-    Ok(numbers.into_iter().collect())
+    Ok(numbers.finish())
+}
+
+enum IntegerAccumulator {
+    Values {
+        values: Vec<i32>,
+        max_values: usize,
+    },
+    Unique {
+        values: HashSet<i32>,
+        max_values: usize,
+    },
+}
+
+impl IntegerAccumulator {
+    fn new(max_values: usize) -> Self {
+        Self::Values {
+            values: Vec::new(),
+            max_values,
+        }
+    }
+
+    fn insert(&mut self, value: i32, input: &str) -> Result<(), QueryError> {
+        if let Self::Values { values, max_values } = self {
+            if values.len() < *max_values {
+                values.push(value);
+                return Ok(());
+            }
+            self.promote();
+        }
+
+        let Self::Unique { values, max_values } = self else {
+            unreachable!("integer accumulator must be promoted")
+        };
+        values.insert(value);
+        if values.len() > *max_values {
+            return Err(integer_filter_limit_error(input, *max_values));
+        }
+        Ok(())
+    }
+
+    fn extend_range(&mut self, start: i32, end: i32, input: &str) -> Result<(), QueryError> {
+        if let Self::Values { values, max_values } = self {
+            let range_len = (i64::from(end) - i64::from(start) + 1) as u64;
+            let available = max_values.saturating_sub(values.len()) as u64;
+            if range_len <= available {
+                values.extend(start..=end);
+                return Ok(());
+            }
+            self.promote();
+        }
+
+        for value in start..=end {
+            self.insert(value, input)?;
+        }
+        Ok(())
+    }
+
+    fn promote(&mut self) {
+        let Self::Values { values, max_values } = self else {
+            return;
+        };
+        let max_values = *max_values;
+        let unique = std::mem::take(values).into_iter().collect();
+        *self = Self::Unique {
+            values: unique,
+            max_values,
+        };
+    }
+
+    fn finish(self) -> Vec<i32> {
+        let mut values = match self {
+            Self::Values { values, .. } => values,
+            Self::Unique { values, .. } => values.into_iter().collect(),
+        };
+        values.sort_unstable();
+        values.dedup();
+        values
+    }
 }
 
 fn insert_integer_range(
-    numbers: &mut BTreeSet<i32>,
+    numbers: &mut IntegerAccumulator,
     start: i32,
     end: i32,
-    max_values: usize,
     input: &str,
     segment: &str,
 ) -> Result<(), QueryError> {
@@ -1132,25 +1257,21 @@ fn insert_integer_range(
             "Range start is greater than end: '{segment}'"
         )));
     }
-    for value in start..=end {
-        insert_integer(numbers, value, max_values, input)?;
-    }
-    Ok(())
+    numbers.extend_range(start, end, input)
 }
 
 fn insert_integer(
-    numbers: &mut BTreeSet<i32>,
+    numbers: &mut IntegerAccumulator,
     value: i32,
-    max_values: usize,
     input: &str,
 ) -> Result<(), QueryError> {
-    numbers.insert(value);
-    if numbers.len() > max_values {
-        return Err(QueryError::InvalidIntegerRange(format!(
-            "Integer filter '{input}' expands to more than {max_values} unique values"
-        )));
-    }
-    Ok(())
+    numbers.insert(value, input)
+}
+
+fn integer_filter_limit_error(input: &str, max_values: usize) -> QueryError {
+    QueryError::InvalidIntegerRange(format!(
+        "Integer filter '{input}' expands to more than {max_values} unique values"
+    ))
 }
 
 #[cfg(test)]
@@ -1398,6 +1519,14 @@ mod tests {
     }
 
     #[test]
+    fn shared_query_decoder_borrows_unchanged_components() {
+        let (key, value) = decode_query_parameter_pair("kind=object").unwrap();
+
+        assert!(matches!(key, Cow::Borrowed("kind")));
+        assert!(matches!(value, Cow::Borrowed("object")));
+    }
+
+    #[test]
     fn parses_integer_ranges() {
         assert_eq!(
             parse_integer_list("1-4,3,8,-4--2").unwrap(),
@@ -1441,7 +1570,10 @@ mod tests {
     fn json_path_preserves_valid_nested_segments() {
         let path = JsonFieldPath::new("network,address_v4,$value").unwrap();
 
-        assert_eq!(path.segments(), ["network", "address_v4", "$value"]);
+        assert_eq!(
+            path.segments().collect::<Vec<_>>(),
+            ["network", "address_v4", "$value"]
+        );
         assert_eq!(path.canonical(), "network,address_v4,$value");
         assert_eq!(path.to_string(), "network,address_v4,$value");
     }

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -49,6 +49,12 @@ Example:
 - `in`
 - `is_null`
 
+Integer lists accept comma-separated values and inclusive ranges, including
+negative ranges such as `-6--2`. A single filter may expand to at most 1,024
+unique integers; larger ranges are rejected before they are materialized. Some
+operators and endpoints enforce smaller limits. Prefer `between` for one large
+continuous interval.
+
 ### Array fields
 
 - `equals`
@@ -242,7 +248,8 @@ You can also use string-oriented operators for textual JSON values:
 /api/v1/classes/12/?json_data__contains=hostname=srv
 ```
 
-Nested JSON paths use comma-separated keys:
+Nested JSON paths use comma-separated keys. Every path segment must be
+non-empty and contain only ASCII letters, digits, `_`, or `$`:
 
 ```text
 /api/v1/classes/12/?json_data__equals=network,address=10.0.0.10

--- a/src/db/traits/user/object_aggregate/sql.rs
+++ b/src/db/traits/user/object_aggregate/sql.rs
@@ -387,8 +387,7 @@ fn dimension_sql_for_source(
         ObjectAggregateDimension::JsonData(path) => {
             let path = path
                 .segments()
-                .iter()
-                .map(|segment| sql_string_literal(segment))
+                .map(sql_string_literal)
                 .collect::<Vec<_>>()
                 .join(", ");
             let value = format!("{source}.data #> ARRAY[{path}]::text[]");

--- a/src/models/object_aggregate/mod.rs
+++ b/src/models/object_aggregate/mod.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use base64::Engine;
 use hubuum_computed_fields::FieldKey;
+use hubuum_query::JsonFieldPath;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -93,37 +94,7 @@ impl ObjectAggregateScalarField {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ObjectAggregateJsonPath {
-    segments: Vec<String>,
-}
-
-impl ObjectAggregateJsonPath {
-    pub fn new(value: &str) -> Result<Self, ApiError> {
-        let segments = value.split(',').map(str::to_string).collect::<Vec<_>>();
-        let valid = !value.is_empty()
-            && segments.iter().all(|segment| {
-                !segment.is_empty()
-                    && segment
-                        .bytes()
-                        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$'))
-            });
-        if !valid {
-            return Err(ApiError::BadRequest(format!(
-                "Invalid object aggregate JSON path '{value}'; use non-empty comma-separated ASCII path segments"
-            )));
-        }
-        Ok(Self { segments })
-    }
-
-    pub fn segments(&self) -> &[String] {
-        &self.segments
-    }
-
-    pub fn canonical(&self) -> String {
-        self.segments.join(",")
-    }
-}
+pub type ObjectAggregateJsonPath = JsonFieldPath;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ComputedFieldSelector {

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use tracing::debug;
 
 pub use hubuum_query::{
-    ComputedFieldScope, ComputedQueryValueType, DataType, FilterField, JsonFieldPath, Operator,
+    ComputedFieldScope, ComputedQueryValueType, DataType, FilterField, JsonFieldPathRef, Operator,
     ParsedQueryParam, QueryOptions, SQLMappedType, SearchOperator, SortParam, StatementTimeoutMs,
     get_jsonb_field_type_from_value_and_operator,
 };
@@ -241,7 +241,7 @@ trait ParsedQueryParamSqlExt {
     fn as_json_has_key_sql(
         &self,
         jsonb_field_expr: &str,
-        path: &JsonFieldPath,
+        path: JsonFieldPathRef<'_>,
         key_name: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError>;
@@ -250,7 +250,7 @@ trait ParsedQueryParamSqlExt {
         &self,
         jsonb_field_expr: &str,
         field_expr: &str,
-        path: &JsonFieldPath,
+        path: JsonFieldPathRef<'_>,
         value: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError>;
@@ -258,7 +258,7 @@ trait ParsedQueryParamSqlExt {
     fn as_json_all_sql(
         &self,
         jsonb_field_expr: &str,
-        path: &JsonFieldPath,
+        path: JsonFieldPathRef<'_>,
         value: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError>;
@@ -266,7 +266,7 @@ trait ParsedQueryParamSqlExt {
     fn as_json_array_length_sql(
         &self,
         jsonb_field_expr: &str,
-        path: &JsonFieldPath,
+        path: JsonFieldPathRef<'_>,
         value: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError>;
@@ -346,7 +346,7 @@ impl ParsedQueryParamExt for ParsedQueryParam {
         let (key, value) = self.value.split_once('=').ok_or_else(|| {
             ApiError::BadRequest("Expected exactly two parts of key=value".to_string())
         })?;
-        let path = JsonFieldPath::new(key)?;
+        let path = JsonFieldPathRef::new(key)?;
 
         // Validate the value, no longer needed as we're using bind variables
         /*
@@ -358,7 +358,7 @@ impl ParsedQueryParamExt for ParsedQueryParam {
         }
         */
 
-        let field_expr = json_text_path_expression(jsonb_field_expr, &path);
+        let field_expr = json_text_path_expression(jsonb_field_expr, path);
 
         // The bind variables for the SQL query. We can't bind the key as using
         // bind variables for the key itself is not supported in Postgres.
@@ -374,19 +374,19 @@ impl ParsedQueryParamExt for ParsedQueryParam {
         }
 
         if op == Operator::HasKey {
-            return self.as_json_has_key_sql(jsonb_field_expr, &path, value, neg);
+            return self.as_json_has_key_sql(jsonb_field_expr, path, value, neg);
         }
 
         if op == Operator::All {
-            return self.as_json_all_sql(jsonb_field_expr, &path, value, neg);
+            return self.as_json_all_sql(jsonb_field_expr, path, value, neg);
         }
 
         if op == Operator::ArrayLength {
-            return self.as_json_array_length_sql(jsonb_field_expr, &path, value, neg);
+            return self.as_json_array_length_sql(jsonb_field_expr, path, value, neg);
         }
 
         if op == Operator::In {
-            return self.as_json_in_sql(jsonb_field_expr, &field_expr, &path, value, neg);
+            return self.as_json_in_sql(jsonb_field_expr, &field_expr, path, value, neg);
         }
 
         let sql_type = get_jsonb_field_type_from_value_and_operator(value, op.clone());
@@ -494,8 +494,8 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
         negated: bool,
     ) -> Result<SQLComponent, ApiError> {
         let path = &self.value;
-        let path = JsonFieldPath::new(path)?;
-        let field_expr = json_text_path_expression(jsonb_field_expr, &path);
+        let path = JsonFieldPathRef::new(path)?;
+        let field_expr = json_text_path_expression(jsonb_field_expr, path);
         let sql = if negated {
             format!("{field_expr} IS NOT NULL")
         } else {
@@ -510,7 +510,7 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
     fn as_json_has_key_sql(
         &self,
         jsonb_field_expr: &str,
-        path: &JsonFieldPath,
+        path: JsonFieldPathRef<'_>,
         key_name: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError> {
@@ -531,7 +531,7 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
         &self,
         jsonb_field_expr: &str,
         field_expr: &str,
-        path: &JsonFieldPath,
+        path: JsonFieldPathRef<'_>,
         value: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError> {
@@ -578,7 +578,7 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
     fn as_json_all_sql(
         &self,
         jsonb_field_expr: &str,
-        path: &JsonFieldPath,
+        path: JsonFieldPathRef<'_>,
         value: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError> {
@@ -609,7 +609,7 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
     fn as_json_array_length_sql(
         &self,
         jsonb_field_expr: &str,
-        path: &JsonFieldPath,
+        path: JsonFieldPathRef<'_>,
         value: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError> {
@@ -764,15 +764,15 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
     }
 }
 
-fn json_path_sql_literal(path: &JsonFieldPath) -> String {
+fn json_path_sql_literal(path: JsonFieldPathRef<'_>) -> String {
     format!("'{{{path}}}'")
 }
 
-fn json_text_path_expression(jsonb_field_expr: &str, path: &JsonFieldPath) -> String {
+fn json_text_path_expression(jsonb_field_expr: &str, path: JsonFieldPathRef<'_>) -> String {
     format!("{jsonb_field_expr} #>> {}", json_path_sql_literal(path))
 }
 
-fn json_value_path_expression(jsonb_field_expr: &str, path: &JsonFieldPath) -> String {
+fn json_value_path_expression(jsonb_field_expr: &str, path: JsonFieldPathRef<'_>) -> String {
     format!("{jsonb_field_expr} #> {}", json_path_sql_literal(path))
 }
 

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -7,8 +7,8 @@ use std::str::FromStr;
 use tracing::debug;
 
 pub use hubuum_query::{
-    ComputedFieldScope, ComputedQueryValueType, DataType, FilterField, Operator, ParsedQueryParam,
-    QueryOptions, SQLMappedType, SearchOperator, SortParam, StatementTimeoutMs,
+    ComputedFieldScope, ComputedQueryValueType, DataType, FilterField, JsonFieldPath, Operator,
+    ParsedQueryParam, QueryOptions, SQLMappedType, SearchOperator, SortParam, StatementTimeoutMs,
     get_jsonb_field_type_from_value_and_operator,
 };
 #[cfg(test)]
@@ -241,7 +241,7 @@ trait ParsedQueryParamSqlExt {
     fn as_json_has_key_sql(
         &self,
         jsonb_field_expr: &str,
-        path: &str,
+        path: &JsonFieldPath,
         key_name: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError>;
@@ -250,7 +250,7 @@ trait ParsedQueryParamSqlExt {
         &self,
         jsonb_field_expr: &str,
         field_expr: &str,
-        path: &str,
+        path: &JsonFieldPath,
         value: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError>;
@@ -258,7 +258,7 @@ trait ParsedQueryParamSqlExt {
     fn as_json_all_sql(
         &self,
         jsonb_field_expr: &str,
-        path: &str,
+        path: &JsonFieldPath,
         value: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError>;
@@ -266,7 +266,7 @@ trait ParsedQueryParamSqlExt {
     fn as_json_array_length_sql(
         &self,
         jsonb_field_expr: &str,
-        path: &str,
+        path: &JsonFieldPath,
         value: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError>;
@@ -343,24 +343,10 @@ impl ParsedQueryParamExt for ParsedQueryParam {
             return self.as_json_is_null_sql(jsonb_field_expr, neg);
         }
 
-        // split the value on key=value
-        let parts: Vec<&str> = self.value.splitn(2, '=').collect();
-
-        let (key, value) = match parts.as_slice() {
-            [key, value] => (*key, *value),
-            _ => {
-                return Err(ApiError::BadRequest(
-                    "Expected exactly two parts of key=value".to_string(),
-                ));
-            }
-        };
-
-        // Validate the key
-        if !key.is_valid_jsonb_search_key() {
-            return Err(ApiError::BadRequest(format!(
-                "Invalid JSON search key: '{key}'"
-            )));
-        }
+        let (key, value) = self.value.split_once('=').ok_or_else(|| {
+            ApiError::BadRequest("Expected exactly two parts of key=value".to_string())
+        })?;
+        let path = JsonFieldPath::new(key)?;
 
         // Validate the value, no longer needed as we're using bind variables
         /*
@@ -372,9 +358,7 @@ impl ParsedQueryParamExt for ParsedQueryParam {
         }
         */
 
-        let raw_key = key;
-        let key = format!("'{{{raw_key}}}'");
-        let field_expr = format!("{jsonb_field_expr} #>> {key}");
+        let field_expr = json_text_path_expression(jsonb_field_expr, &path);
 
         // The bind variables for the SQL query. We can't bind the key as using
         // bind variables for the key itself is not supported in Postgres.
@@ -390,19 +374,19 @@ impl ParsedQueryParamExt for ParsedQueryParam {
         }
 
         if op == Operator::HasKey {
-            return self.as_json_has_key_sql(jsonb_field_expr, raw_key, value, neg);
+            return self.as_json_has_key_sql(jsonb_field_expr, &path, value, neg);
         }
 
         if op == Operator::All {
-            return self.as_json_all_sql(jsonb_field_expr, raw_key, value, neg);
+            return self.as_json_all_sql(jsonb_field_expr, &path, value, neg);
         }
 
         if op == Operator::ArrayLength {
-            return self.as_json_array_length_sql(jsonb_field_expr, raw_key, value, neg);
+            return self.as_json_array_length_sql(jsonb_field_expr, &path, value, neg);
         }
 
         if op == Operator::In {
-            return self.as_json_in_sql(jsonb_field_expr, &field_expr, raw_key, value, neg);
+            return self.as_json_in_sql(jsonb_field_expr, &field_expr, &path, value, neg);
         }
 
         let sql_type = get_jsonb_field_type_from_value_and_operator(value, op.clone());
@@ -449,7 +433,7 @@ impl ParsedQueryParamExt for ParsedQueryParam {
             None => {
                 return Err(ApiError::BadRequest(format!(
                     "Invalid JSON type mapping between key '{}' and operator '{:?}'",
-                    key, self.operator
+                    path, self.operator
                 )));
             }
             Some(SQLMappedType::String) | Some(SQLMappedType::None) => {
@@ -510,13 +494,8 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
         negated: bool,
     ) -> Result<SQLComponent, ApiError> {
         let path = &self.value;
-        if !path.is_valid_jsonb_search_key() {
-            return Err(ApiError::BadRequest(format!(
-                "Invalid JSON search key: '{path}'"
-            )));
-        }
-        let key = format!("'{{{path}}}'");
-        let field_expr = format!("{jsonb_field_expr} #>> {key}");
+        let path = JsonFieldPath::new(path)?;
+        let field_expr = json_text_path_expression(jsonb_field_expr, &path);
         let sql = if negated {
             format!("{field_expr} IS NOT NULL")
         } else {
@@ -531,12 +510,11 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
     fn as_json_has_key_sql(
         &self,
         jsonb_field_expr: &str,
-        path: &str,
+        path: &JsonFieldPath,
         key_name: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError> {
-        let key = format!("'{{{path}}}'");
-        let jsonb_expr = format!("{jsonb_field_expr} #> {key}");
+        let jsonb_expr = json_value_path_expression(jsonb_field_expr, path);
         let predicate = format!("jsonb_has_key({jsonb_expr}, ?)");
         let sql = if negated {
             format!("NOT ({predicate})")
@@ -553,7 +531,7 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
         &self,
         jsonb_field_expr: &str,
         field_expr: &str,
-        path: &str,
+        path: &JsonFieldPath,
         value: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError> {
@@ -570,8 +548,7 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
 
         // Array check: jsonb containment
         let array_placeholders = values.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-        let key = format!("'{{{path}}}'");
-        let jsonb_expr = format!("{jsonb_field_expr} #> {key}");
+        let jsonb_expr = json_value_path_expression(jsonb_field_expr, path);
         let array_check = format!("jsonb_contains_any({jsonb_expr}, ARRAY[{array_placeholders}])");
 
         let combined = format!("({scalar_check} OR {array_check})");
@@ -601,7 +578,7 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
     fn as_json_all_sql(
         &self,
         jsonb_field_expr: &str,
-        path: &str,
+        path: &JsonFieldPath,
         value: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError> {
@@ -612,8 +589,7 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
             ));
         }
         let placeholders = values.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-        let key = format!("'{{{path}}}'");
-        let jsonb_expr = format!("{jsonb_field_expr} #> {key}");
+        let jsonb_expr = json_value_path_expression(jsonb_field_expr, path);
         let predicate = format!("jsonb_contains_all({jsonb_expr}, ARRAY[{placeholders}])");
         let sql = if negated {
             format!("NOT ({predicate})")
@@ -633,15 +609,14 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
     fn as_json_array_length_sql(
         &self,
         jsonb_field_expr: &str,
-        path: &str,
+        path: &JsonFieldPath,
         value: &str,
         negated: bool,
     ) -> Result<SQLComponent, ApiError> {
         let length: i32 = value.parse().map_err(|_| {
             ApiError::BadRequest(format!("array_length requires an integer, got '{value}'"))
         })?;
-        let key = format!("'{{{path}}}'");
-        let jsonb_expr = format!("{jsonb_field_expr} #> {key}");
+        let jsonb_expr = json_value_path_expression(jsonb_field_expr, path);
         let len_expr = format!("jsonb_array_length({jsonb_expr})");
         let cmp = if negated { "!=" } else { "=" };
         let sql = format!("jsonb_typeof({jsonb_expr}) = 'array' AND {len_expr} {cmp} ?");
@@ -787,6 +762,18 @@ impl ParsedQueryParamSqlExt for ParsedQueryParam {
             bind_variables,
         })
     }
+}
+
+fn json_path_sql_literal(path: &JsonFieldPath) -> String {
+    format!("'{{{path}}}'")
+}
+
+fn json_text_path_expression(jsonb_field_expr: &str, path: &JsonFieldPath) -> String {
+    format!("{jsonb_field_expr} #>> {}", json_path_sql_literal(path))
+}
+
+fn json_value_path_expression(jsonb_field_expr: &str, path: &JsonFieldPath) -> String {
+    format!("{jsonb_field_expr} #> {}", json_path_sql_literal(path))
 }
 
 pub trait QueryParamsExt {
@@ -1014,6 +1001,14 @@ mod test {
         assert!(input.as_integer().is_err());
     }
 
+    #[test]
+    fn oversized_integer_range_maps_to_the_public_validation_error() {
+        let error = "0-2147483647".as_integer().unwrap_err();
+
+        assert!(matches!(error, ApiError::InvalidIntegerRange(_)));
+        assert!(error.to_string().contains("more than 1024 unique values"));
+    }
+
     #[rstest]
     #[case(
         "name__icontains=foo&description=bar&invalid",
@@ -1069,6 +1064,39 @@ mod test {
     )]
     fn test_query_string_parsing(#[case] query: &str, #[case] expected: Vec<ParsedQueryParam>) {
         assert_eq!(parse_query_parameter(query).unwrap().filters, expected);
+    }
+
+    #[rstest]
+    #[case("=value")]
+    #[case("network,,address=value")]
+    #[case(",network=value")]
+    #[case("network,=value")]
+    #[case("network address=value")]
+    fn json_filter_rejects_malformed_paths(#[case] value: &str) {
+        let error = pq(
+            "json_data",
+            SearchOperator::Equals { is_negated: false },
+            value,
+        )
+        .as_json_sql()
+        .unwrap_err();
+
+        assert!(matches!(error, ApiError::BadRequest(_)));
+        assert!(error.to_string().contains("JSON path"));
+    }
+
+    #[test]
+    fn json_is_null_filter_uses_the_shared_path_validation() {
+        let error = pq(
+            "json_data",
+            SearchOperator::IsNull { is_negated: false },
+            "network,,address",
+        )
+        .as_json_sql()
+        .unwrap_err();
+
+        assert!(matches!(error, ApiError::BadRequest(_)));
+        assert!(error.to_string().contains("JSON path"));
     }
 
     #[test]

--- a/src/models/unified_search.rs
+++ b/src/models/unified_search.rs
@@ -178,26 +178,6 @@ pub struct UnifiedSearchErrorEvent {
     pub message: String,
 }
 
-fn parse_query_chunk(chunk: &str) -> Result<(&str, String), ApiError> {
-    let parts: Vec<_> = chunk.splitn(2, '=').collect();
-    if parts.len() != 2 {
-        return Err(ApiError::BadRequest(format!(
-            "Invalid query parameter: '{chunk}'"
-        )));
-    }
-
-    let value = percent_encoding::percent_decode(parts[1].as_bytes())
-        .decode_utf8()
-        .map_err(|error| {
-            ApiError::BadRequest(format!(
-                "Invalid query parameter: '{chunk}', invalid value: {error}",
-            ))
-        })?
-        .to_string();
-
-    Ok((parts[0], value))
-}
-
 fn reject_duplicate<T>(slot: &Option<T>, name: &str) -> Result<(), ApiError> {
     if slot.is_some() {
         return Err(ApiError::BadRequest(format!("duplicate {name}")));
@@ -317,9 +297,8 @@ pub fn parse_unified_search_query_with_limits(
 ) -> Result<UnifiedSearchQuery, ApiError> {
     let mut parts = UnifiedSearchQueryParts::default();
 
-    for chunk in qs.split('&').filter(|chunk| !chunk.is_empty()) {
-        let (key, value) = parse_query_chunk(chunk)?;
-        parts.apply(key, value)?;
+    for (key, value) in hubuum_query::decode_query_parameter_pairs(qs)? {
+        parts.apply(&key, value)?;
     }
 
     parts.build(default_limit, max_limit)
@@ -856,6 +835,13 @@ mod tests {
         assert!(parsed.includes(UnifiedSearchKind::Object));
         assert!(!parsed.search_class_schema);
         assert!(!parsed.search_object_data);
+    }
+
+    #[test]
+    fn parse_unified_search_decodes_form_encoded_query_text() {
+        let parsed = parse_unified_search_query("q=core+router%2Fedge").unwrap();
+
+        assert_eq!(parsed.query, "core router/edge");
     }
 
     #[test]

--- a/src/models/unified_search.rs
+++ b/src/models/unified_search.rs
@@ -297,8 +297,11 @@ pub fn parse_unified_search_query_with_limits(
 ) -> Result<UnifiedSearchQuery, ApiError> {
     let mut parts = UnifiedSearchQueryParts::default();
 
-    for (key, value) in hubuum_query::decode_query_parameter_pairs(qs)? {
-        parts.apply(&key, value)?;
+    if !qs.is_empty() {
+        for chunk in qs.split('&') {
+            let (key, value) = hubuum_query::decode_query_parameter_pair(chunk)?;
+            parts.apply(key.as_ref(), value.into_owned())?;
+        }
     }
 
     parts.build(default_limit, max_limit)

--- a/src/utilities/extensions.rs
+++ b/src/utilities/extensions.rs
@@ -4,16 +4,6 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use tracing::error;
 
 pub trait CustomStringExtensions {
-    /// ## Check if the value is a valid json key for hubuum
-    ///
-    /// We support only ASCII alphanumeric characters, underscores, `$`, and
-    /// comma separators for nested keys. No spaces are allowed.
-    ///
-    /// ### Returns
-    ///
-    /// * A boolean
-    fn is_valid_jsonb_search_key(&self) -> bool;
-
     /// ## Coerce the value into a boolean
     ///
     /// Accepted values are "true" and "false" (case insensitive)
@@ -88,12 +78,6 @@ impl<T: AsRef<str>> CustomStringExtensions for T {
             }
         }
         result
-    }
-
-    fn is_valid_jsonb_search_key(&self) -> bool {
-        self.as_ref()
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == ',' || c == '$')
     }
 
     fn as_integer(&self) -> Result<Vec<i32>, ApiError> {


### PR DESCRIPTION
## Summary

- move comma-separated JSON field-path validation into an app-neutral `JsonFieldPath` newtype in `hubuum-query`
- use that type consistently for JSON filters, schema traversal, and object-aggregate dimensions, with shared SQL path-expression helpers
- cap integer list/range expansion at 1,024 unique values and fail while parsing instead of after unbounded allocation
- expose the workspace crate's form-query decoder and reuse it for unified search so percent escapes and `+` spaces behave consistently
- document the validation rules and record the behavior/security changes in the Unreleased changelog

## Why

The broad query-layer review found three related boundary problems.

First, numeric filters expanded every requested integer range into a `Vec<i32>` before endpoint-specific operator limits ran. A compact value such as `0-2147483647` could therefore consume effectively unbounded CPU and memory even though the eventual query would be rejected.

Second, JSON path grammar was duplicated between ordinary JSON filters and object aggregation. The filter-side character predicate treated empty strings and empty comma-separated segments as valid, while aggregate dimensions already rejected them. That divergence also left no reusable typed path boundary for planned class-scoped JSON index declarations.

Third, unified search maintained a separate query-string decoder. Unlike the common parser, it did not implement form-encoded `+` as a space.

## Behavior and security

Integer lists still accept individual values, duplicates, inclusive ranges, and negative ranges. They are deduplicated and returned in sorted order as before, but requests expanding beyond 1,024 unique integers now return the existing public invalid-range response before allocating beyond the cap. Callers that need a different bound can use the config-free `parse_integer_list_with_limit` helper.

JSON field paths now require one or more non-empty comma-separated segments. Segments may contain ASCII letters, digits, `_`, and `$`. Valid existing filters and aggregate dimensions keep the same SQL shape; malformed and ambiguous paths now fail consistently before SQL generation.

Unified search now follows standard form-query decoding. A literal plus remains representable as `%2B`, while `q=core+router` is interpreted as `core router`.

There are no database migrations, API schema changes, container-input changes, or breaking response-shape changes.

## Roadmap alignment

This keeps transport and query-domain behavior in the existing app-neutral workspace crate. It is a small step toward the boundary described in #27 without prematurely introducing a broad persistence interface.

The typed JSON field path is directly reusable by the validation and query-planning work proposed in #41, helping future declared indexes use the same canonical path grammar as filters and aggregates.

Centralizing query grammar also avoids embedding more filter parsing in handlers as class traversal evolves for #26. This PR does not implement inheritance or declarative indexes.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test -p hubuum-query`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- generated OpenAPI output exactly matches `docs/openapi.json`
- `git diff --check`

The Docker parity test and production image build are not applicable because workspace membership, manifests, `Cargo.lock`, Docker features, `Dockerfile`, and `entrypoint.sh` are unchanged.
