### PR TITLE
Coordinate and bound event retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Event-retention workers now coordinate one transaction-scoped batch across
+  replicas, keep selected event rows locked through archival and deletion, and
+  limit terminal-delivery cleanup to the configured batch size. A partial
+  retention index is added for old `succeeded` and `dead` deliveries.
 - Unified search now uses the shared form-query decoder, so `+` and percent
   escapes are interpreted consistently with other list and search endpoints.
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -457,6 +457,14 @@ The purge path is the only application path allowed to bypass the append-only
 before deleting eligible event rows. Normal `DELETE` statements against
 `events` continue to fail.
 
+Worker replicas coordinate each retention batch with a transaction-scoped
+PostgreSQL advisory lock. One replica selects and locks eligible events through
+optional archival and deletion; other replicas skip that iteration instead of
+duplicating archive records or competing over the same rows. The configured
+batch size bounds both event deletion and independent terminal-delivery
+cleanup. A partial index on terminal delivery age keeps the latter lookup
+bounded to its eligible queue.
+
 Events become purge-eligible after `HUBUUM_EVENT_RETENTION_DAYS`, but the purge
 will not delete an event while it has active `pending`, `failed`, or
 `in_flight` deliveries. Deleting an eligible event cascades to its remaining

--- a/migrations/2026-07-21-000001_event_retention_coordination/down.sql
+++ b/migrations/2026-07-21-000001_event_retention_coordination/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_event_deliveries_terminal_retention;

--- a/migrations/2026-07-21-000001_event_retention_coordination/metadata.toml
+++ b/migrations/2026-07-21-000001_event_retention_coordination/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-07-21-000001_event_retention_coordination/up.sql
+++ b/migrations/2026-07-21-000001_event_retention_coordination/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_event_deliveries_terminal_retention
+    ON event_deliveries (updated_at, id)
+    WHERE status IN ('succeeded', 'dead');

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -58,7 +58,7 @@ pub type DbPool = Pool<DbConnection>;
 /// Latest migration required by this binary. The test below keeps this value
 /// synchronized with the migration directory so readiness cannot silently lag
 /// behind a newly added schema change.
-pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260718000001";
+pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260721000001";
 
 #[derive(diesel::QueryableByName)]
 struct DatabaseSchemaReadiness {

--- a/src/db/traits/event_retention.rs
+++ b/src/db/traits/event_retention.rs
@@ -1,11 +1,12 @@
 use crate::db::prelude::*;
 use chrono::{Duration, NaiveDateTime, Utc};
-use diesel::sql_types::{Array, BigInt, Timestamp};
+use diesel::sql_types::{Array, BigInt, Bool, Timestamp};
 
-use crate::db::{DbPool, with_connection, with_transaction};
+use crate::db::DbConnection;
+#[cfg(test)]
+use crate::db::{DbPool, with_transaction};
 use crate::errors::ApiError;
 use crate::events::Event;
-use crate::models::EventDeliveryStatus;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EventRetentionSettings {
@@ -20,14 +21,39 @@ pub struct EventRetentionPurgeSummary {
     pub purged_terminal_deliveries: usize,
 }
 
+const EVENT_RETENTION_LOCK_KEY: i64 = 4_850_188_191_125_218;
+
+#[derive(Debug, QueryableByName)]
+struct AdvisoryLockRow {
+    #[diesel(sql_type = Bool)]
+    locked: bool,
+}
+
 #[derive(Debug, QueryableByName)]
 struct EventIdRow {
     #[diesel(sql_type = BigInt)]
     id: i64,
 }
 
-pub async fn select_events_for_retention_purge(
-    pool: &DbPool,
+/// Try to become the one event-retention coordinator for this transaction.
+///
+/// Retention runs in every background-worker replica. A transaction-scoped
+/// advisory lock ensures only one replica selects, archives, and purges a
+/// batch at a time without making idle replicas wait for the active worker.
+pub(crate) async fn try_acquire_event_retention_lock(
+    conn: &mut DbConnection,
+) -> Result<bool, ApiError> {
+    Ok(
+        diesel::sql_query("SELECT pg_try_advisory_xact_lock($1) AS locked")
+            .bind::<BigInt, _>(EVENT_RETENTION_LOCK_KEY)
+            .get_result::<AdvisoryLockRow>(conn)
+            .await?
+            .locked,
+    )
+}
+
+pub(crate) async fn select_events_for_retention_purge_conn(
+    conn: &mut DbConnection,
     settings: EventRetentionSettings,
 ) -> Result<Vec<Event>, ApiError> {
     if settings.batch_size == 0 {
@@ -35,47 +61,38 @@ pub async fn select_events_for_retention_purge(
     }
 
     let cutoff = Utc::now().naive_utc() - Duration::days(settings.event_retention_days);
-    let ids = with_connection(pool, async |conn| {
-        select_event_ids_for_retention_purge(conn, cutoff, settings.batch_size).await
-    })
-    .await?;
+    let batch_size = i64::try_from(settings.batch_size)
+        .map_err(|_| ApiError::BadRequest("event retention batch size is too large".to_string()))?;
+    let ids = select_event_ids_for_retention_purge(conn, cutoff, batch_size).await?;
 
     if ids.is_empty() {
         return Ok(Vec::new());
     }
 
     use crate::schema::events::dsl::{events, id};
-    with_connection(pool, async |conn| {
-        events
-            .filter(id.eq_any(ids))
-            .order(id.asc())
-            .load::<Event>(conn)
-            .await
-    })
-    .await
+    Ok(events
+        .filter(id.eq_any(ids))
+        .order(id.asc())
+        .load::<Event>(conn)
+        .await?)
 }
 
-pub async fn purge_event_retention_batch(
-    pool: &DbPool,
+pub(crate) async fn purge_event_retention_batch_conn(
+    conn: &mut DbConnection,
     settings: EventRetentionSettings,
     event_ids: &[i64],
 ) -> Result<EventRetentionPurgeSummary, ApiError> {
-    with_transaction(
-        pool,
-        async |conn| -> Result<EventRetentionPurgeSummary, ApiError> {
-            let delivery_cutoff =
-                Utc::now().naive_utc() - Duration::days(settings.delivery_retention_days);
-            let purged_terminal_deliveries =
-                purge_terminal_event_deliveries(conn, delivery_cutoff).await?;
-            let purged_events = purge_events_by_id(conn, event_ids).await?;
+    let delivery_cutoff = Utc::now().naive_utc() - Duration::days(settings.delivery_retention_days);
+    let batch_size = i64::try_from(settings.batch_size)
+        .map_err(|_| ApiError::BadRequest("event retention batch size is too large".to_string()))?;
+    let purged_terminal_deliveries =
+        purge_terminal_event_deliveries(conn, delivery_cutoff, batch_size).await?;
+    let purged_events = purge_events_by_id(conn, event_ids).await?;
 
-            Ok(EventRetentionPurgeSummary {
-                purged_events,
-                purged_terminal_deliveries,
-            })
-        },
-    )
-    .await
+    Ok(EventRetentionPurgeSummary {
+        purged_events,
+        purged_terminal_deliveries,
+    })
 }
 
 #[cfg(test)]
@@ -83,15 +100,21 @@ pub async fn purge_event_retention_without_archive(
     pool: &DbPool,
     settings: EventRetentionSettings,
 ) -> Result<EventRetentionPurgeSummary, ApiError> {
-    let events = select_events_for_retention_purge(pool, settings).await?;
-    let event_ids = events.iter().map(|event| event.id).collect::<Vec<_>>();
-    purge_event_retention_batch(pool, settings, &event_ids).await
+    with_transaction(pool, async |conn| -> Result<_, ApiError> {
+        if !try_acquire_event_retention_lock(conn).await? {
+            return Ok(EventRetentionPurgeSummary::default());
+        }
+        let events = select_events_for_retention_purge_conn(conn, settings).await?;
+        let event_ids = events.iter().map(|event| event.id).collect::<Vec<_>>();
+        purge_event_retention_batch_conn(conn, settings, &event_ids).await
+    })
+    .await
 }
 
 async fn select_event_ids_for_retention_purge(
-    conn: &mut crate::db::DbConnection,
+    conn: &mut DbConnection,
     cutoff: NaiveDateTime,
-    batch_size: usize,
+    batch_size: i64,
 ) -> Result<Vec<i64>, diesel::result::Error> {
     diesel::sql_query(
         "SELECT e.id
@@ -103,37 +126,45 @@ async fn select_event_ids_for_retention_purge(
              FROM event_deliveries d
              WHERE d.event_id = e.id
                AND d.status IN ('pending', 'failed', 'in_flight')
-           )
+         )
          ORDER BY e.occurred_at ASC, e.id ASC
-         LIMIT $2",
+         LIMIT $2
+         FOR UPDATE OF e SKIP LOCKED",
     )
     .bind::<Timestamp, _>(cutoff)
-    .bind::<BigInt, _>(batch_size as i64)
+    .bind::<BigInt, _>(batch_size)
     .load::<EventIdRow>(conn)
     .await
     .map(|rows| rows.into_iter().map(|row| row.id).collect())
 }
 
 async fn purge_terminal_event_deliveries(
-    conn: &mut crate::db::DbConnection,
+    conn: &mut DbConnection,
     cutoff: NaiveDateTime,
+    batch_size: i64,
 ) -> Result<usize, diesel::result::Error> {
-    use crate::schema::event_deliveries::dsl::{event_deliveries, status, updated_at};
-
-    diesel::delete(
-        event_deliveries
-            .filter(updated_at.lt(cutoff))
-            .filter(status.eq_any([
-                EventDeliveryStatus::Succeeded.as_str(),
-                EventDeliveryStatus::Dead.as_str(),
-            ])),
+    diesel::sql_query(
+        "WITH candidates AS (
+             SELECT id
+             FROM event_deliveries
+             WHERE updated_at < $1
+               AND status IN ('succeeded', 'dead')
+             ORDER BY updated_at ASC, id ASC
+             LIMIT $2
+             FOR UPDATE SKIP LOCKED
+         )
+         DELETE FROM event_deliveries AS delivery
+         USING candidates
+         WHERE delivery.id = candidates.id",
     )
+    .bind::<Timestamp, _>(cutoff)
+    .bind::<BigInt, _>(batch_size)
     .execute(conn)
     .await
 }
 
 async fn purge_events_by_id(
-    conn: &mut crate::db::DbConnection,
+    conn: &mut DbConnection,
     event_ids: &[i64],
 ) -> Result<usize, diesel::result::Error> {
     if event_ids.is_empty() {

--- a/src/events/retention.rs
+++ b/src/events/retention.rs
@@ -17,9 +17,10 @@ use crate::config::{
 };
 use crate::db::DbPool;
 use crate::db::traits::event_retention::{
-    EventRetentionPurgeSummary, EventRetentionSettings, purge_event_retention_batch,
-    select_events_for_retention_purge,
+    EventRetentionPurgeSummary, EventRetentionSettings, purge_event_retention_batch_conn,
+    select_events_for_retention_purge_conn, try_acquire_event_retention_lock,
 };
+use crate::db::with_transaction;
 use crate::errors::ApiError;
 use crate::events::Event;
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
@@ -77,15 +78,22 @@ pub async fn process_event_retention_batch(
     if maintenance_state(pool).await? != "normal" {
         return Ok(EventRetentionPurgeSummary::default());
     }
-    let events = select_events_for_retention_purge(pool, settings).await?;
-    if let Some(path) = archive_path
-        && !events.is_empty()
-    {
-        append_event_archive(path, &events)?;
-    }
+    with_transaction(pool, async |conn| -> Result<_, ApiError> {
+        if !try_acquire_event_retention_lock(conn).await? {
+            return Ok(EventRetentionPurgeSummary::default());
+        }
 
-    let event_ids = events.iter().map(|event| event.id).collect::<Vec<_>>();
-    purge_event_retention_batch(pool, settings, &event_ids).await
+        let events = select_events_for_retention_purge_conn(conn, settings).await?;
+        if let Some(path) = archive_path
+            && !events.is_empty()
+        {
+            append_event_archive(path, &events)?;
+        }
+
+        let event_ids = events.iter().map(|event| event.id).collect::<Vec<_>>();
+        purge_event_retention_batch_conn(conn, settings, &event_ids).await
+    })
+    .await
 }
 
 fn retention_worker_should_continue(result: &Result<EventRetentionPurgeSummary, ApiError>) -> bool {

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -21,7 +21,7 @@ use crate::db::traits::event_fanout::{
     fanout_events,
 };
 use crate::db::traits::event_retention::{
-    EventRetentionSettings, purge_event_retention_without_archive,
+    EventRetentionSettings, purge_event_retention_without_archive, try_acquire_event_retention_lock,
 };
 use crate::db::traits::event_subscription::{SaveEventSinkRecord, SaveEventSubscriptionRecord};
 use crate::db::traits::remote_target::{
@@ -30,6 +30,7 @@ use crate::db::traits::remote_target::{
 };
 use crate::db::{capture_queries, with_connection, with_transaction};
 use crate::errors::ApiError;
+use crate::events::retention::process_event_retention_batch;
 use crate::events::{
     Action, ActorKind, EntityType, Event, EventContext, NewEvent, RequestProvenance, emit_event,
 };
@@ -195,6 +196,31 @@ async fn fanout_backlog_index_exists() {
         .await
         .map(|r| r.exists)?;
         assert!(exists, "events_fanout_backlog_idx partial index is missing");
+        Ok::<_, diesel::result::Error>(())
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn event_delivery_terminal_retention_index_exists() {
+    let scope = test_scope();
+    with_connection(&scope.pool, async |conn| {
+        let exists: bool = diesel::sql_query(
+            "SELECT EXISTS (
+                SELECT 1 FROM pg_indexes
+                WHERE schemaname = 'public'
+                  AND tablename = 'event_deliveries'
+                  AND indexname = 'idx_event_deliveries_terminal_retention'
+                  AND indexdef LIKE '%(updated_at, id)%'
+                  AND indexdef LIKE '%succeeded%'
+                  AND indexdef LIKE '%dead%'
+            )",
+        )
+        .get_result::<IndexExistsRow>(conn)
+        .await
+        .map(|row| row.exists)?;
+        assert!(exists, "terminal event-delivery retention index is missing");
         Ok::<_, diesel::result::Error>(())
     })
     .await
@@ -619,6 +645,42 @@ async fn ordinary_event_delete_is_rejected_by_append_only_trigger() {
 }
 
 #[actix_web::test]
+async fn event_retention_skips_a_batch_while_another_replica_holds_the_coordinator_lock() {
+    let _lock = lock_test_mutex(&EVENT_RETENTION_TEST_LOCK).await;
+    let scope = test_scope();
+    let old_event = insert_collection_created_event_at(
+        &scope,
+        1,
+        chrono::Utc::now().naive_utc() - chrono::Duration::days(400),
+    )
+    .await;
+    mark_event_dispatched(&scope, old_event.id).await;
+
+    with_transaction(&scope.pool, async |conn| -> Result<(), ApiError> {
+        assert!(try_acquire_event_retention_lock(conn).await?);
+
+        let skipped =
+            process_event_retention_batch(&scope.pool, make_retention_settings(), None).await?;
+
+        assert_eq!(skipped, Default::default());
+        Ok(())
+    })
+    .await
+    .unwrap();
+
+    let remaining = with_connection(&scope.pool, async |conn| {
+        events
+            .filter(crate::schema::events::dsl::id.eq(old_event.id))
+            .count()
+            .get_result::<i64>(conn)
+            .await
+    })
+    .await
+    .unwrap();
+    assert_eq!(remaining, 1);
+}
+
+#[actix_web::test]
 async fn event_retention_purge_deletes_old_events_through_guarded_path() {
     let _lock = lock_test_mutex(&EVENT_RETENTION_TEST_LOCK).await;
     let scope = test_scope();
@@ -759,6 +821,74 @@ async fn event_retention_purge_deletes_old_terminal_deliveries_without_deleting_
     .await
     .unwrap();
     assert_eq!(remaining_events, 1);
+}
+
+#[actix_web::test]
+async fn event_retention_bounds_terminal_delivery_deletes_to_the_batch_size() {
+    let _lock = lock_test_mutex(&EVENT_RETENTION_TEST_LOCK).await;
+    let scope = test_scope();
+    let fixture = scope.with_collection().await;
+    let subscription_id = create_collection_event_subscription(
+        &scope,
+        fixture.collection.id,
+        "retention_bounded_terminal",
+        true,
+    )
+    .await;
+    let mut event_ids = Vec::new();
+    for _ in 0..3 {
+        event_ids.push(
+            emit_collection_created_event(&scope, fixture.collection.id)
+                .await
+                .id,
+        );
+    }
+    let old_timestamp = chrono::Utc::now().naive_utc() - chrono::Duration::days(40);
+    use crate::schema::event_deliveries::dsl::{
+        created_at, event_deliveries, event_id, status,
+        subscription_id as delivery_subscription_id, updated_at,
+    };
+    with_connection(
+        &scope.pool,
+        async |conn| -> Result<(), diesel::result::Error> {
+            for event_id_value in &event_ids {
+                diesel::insert_into(event_deliveries)
+                    .values((
+                        event_id.eq(event_id_value),
+                        delivery_subscription_id.eq(subscription_id),
+                        status.eq(EventDeliveryStatus::Succeeded.as_str()),
+                        created_at.eq(old_timestamp),
+                        updated_at.eq(old_timestamp),
+                    ))
+                    .execute(&mut *conn)
+                    .await?;
+            }
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+    let settings = EventRetentionSettings {
+        batch_size: 2,
+        ..make_retention_settings()
+    };
+
+    let first = purge_event_retention_without_archive(&scope.pool, settings)
+        .await
+        .unwrap();
+
+    assert_eq!(first.purged_terminal_deliveries, 2);
+    assert_eq!(
+        count_event_deliveries_for_event(&scope.pool, event_ids[2])
+            .await
+            .unwrap(),
+        1
+    );
+
+    let second = purge_event_retention_without_archive(&scope.pool, settings)
+        .await
+        .unwrap();
+    assert_eq!(second.purged_terminal_deliveries, 1);
 }
 
 #[actix_web::test]


### PR DESCRIPTION
## Summary

- coordinate event-retention batches across worker replicas with a transaction-scoped PostgreSQL advisory lock
- keep selected event rows locked through optional archival and deletion
- cap terminal-delivery cleanup at the configured retention batch size
- add a partial `(updated_at, id)` index for terminal delivery retention scans
- document the distributed behavior and record the fix in the changelog

## Why

Each worker replica previously selected purge candidates independently, released that selection before archival, and opened a separate transaction for deletion. Concurrent replicas could therefore archive the same event rows or compete to purge overlapping work. Terminal `succeeded` and `dead` delivery cleanup was also unbounded, so one retention iteration could delete an arbitrarily large backlog and hold locks longer than intended.

This change makes one transaction the unit of coordination. A non-blocking advisory lock elects one retention coordinator per iteration, candidate rows remain locked until the transaction completes, and both event and independent delivery cleanup honor the configured batch size. The partial index supports the ordered terminal-delivery candidate lookup without indexing active delivery states.

## Impact

Retention remains disabled by default and its configuration surface is unchanged. Deployments that enable retention must apply migration `20260721000001` before starting this binary. Other worker replicas skip an iteration while a coordinator is active and resume normally on the next poll. There are no API or OpenAPI changes and no breaking changes.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `cargo audit` (no vulnerabilities; two existing unmaintained warnings are dev-only transitive dependencies of the latest `iai-callgrind`)