### PR TITLE
Use typed network configuration parsing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,8 +17,7 @@ mod client_network;
 mod defaults;
 mod tls_backend;
 mod token_hash;
-pub use client_network::{ClientAllowlist, TrustedProxies};
-use client_network::{parse_client_allowlist, parse_trusted_proxies};
+pub use client_network::{ClientAllowlist, ClientNetworkParseError, TrustedProxies};
 pub use defaults::*;
 pub use tls_backend::TlsBackend;
 pub use token_hash::{token_hash_key_bytes, token_hash_key_is_ephemeral};
@@ -833,7 +832,7 @@ pub struct AppConfig {
     /// Trusted reverse-proxy IPs/CIDRs. When `trust_ip_headers` is set, hops in this set
     /// are skipped (from the connection peer inward) and the first untrusted hop is taken
     /// as the client. Comma-separated; empty disables allowlist-based resolution.
-    #[clap(long, default_value = "", env = "HUBUUM_TRUSTED_PROXIES", value_parser = parse_trusted_proxies)]
+    #[clap(long, default_value = "", env = "HUBUUM_TRUSTED_PROXIES")]
     pub trusted_proxies: TrustedProxies,
 
     /// Number of trusted proxy hops in front of the server. Used only when
@@ -847,7 +846,7 @@ pub struct AppConfig {
     pub trusted_proxy_hops: usize,
 
     /// Whitelist of client IPs or CIDRs ("*" allows all)
-    #[clap(long, default_value = "127.0.0.1,::1", env = "HUBUUM_CLIENT_ALLOWLIST", value_parser = parse_client_allowlist)]
+    #[clap(long, default_value = "127.0.0.1,::1", env = "HUBUUM_CLIENT_ALLOWLIST")]
     pub client_allowlist: ClientAllowlist,
 }
 
@@ -1475,14 +1474,14 @@ fn get_config_from_env() -> Result<AppConfig, ApiError> {
         env::var(key)
             .unwrap_or_else(|_| default.to_string())
             .parse()
-            .unwrap_or_else(|e: ApiError| panic!("Invalid client allowlist in {key}: {e}"))
+            .unwrap_or_else(|error| panic!("Invalid client allowlist in {key}: {error}"))
     }
 
     fn env_or_default_trusted_proxies(key: &str, default: &str) -> TrustedProxies {
         env::var(key)
             .unwrap_or_else(|_| default.to_string())
             .parse()
-            .unwrap_or_else(|e: ApiError| panic!("Invalid trusted proxies in {key}: {e}"))
+            .unwrap_or_else(|error| panic!("Invalid trusted proxies in {key}: {error}"))
     }
 
     let config = AppConfig {

--- a/src/config/client_network.rs
+++ b/src/config/client_network.rs
@@ -1,18 +1,26 @@
+use std::fmt;
 use std::net::IpAddr;
 use std::str::FromStr;
 
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use serde::{Deserialize, Serialize};
 
-use crate::errors::ApiError;
-
-pub fn parse_client_allowlist(s: &str) -> Result<ClientAllowlist, String> {
-    ClientAllowlist::from_str(s).map_err(|e| e.to_string())
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClientNetworkParseError {
+    EmptyClientAllowlist,
+    InvalidIpOrCidr(String),
 }
 
-pub fn parse_trusted_proxies(s: &str) -> Result<TrustedProxies, String> {
-    TrustedProxies::from_str(s).map_err(|e| e.to_string())
+impl fmt::Display for ClientNetworkParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyClientAllowlist => formatter.write_str("client allowlist cannot be empty"),
+            Self::InvalidIpOrCidr(value) => write!(formatter, "Invalid IP/CIDR: {value}"),
+        }
+    }
 }
+
+impl std::error::Error for ClientNetworkParseError {}
 
 /// Client IP allowlist - either allow all (`*`) or specific IPs/CIDRs
 #[derive(Debug, Clone)]
@@ -51,8 +59,39 @@ impl<'de> Deserialize<'de> for ClientAllowlist {
 }
 
 impl ClientAllowlist {
-    /// Parse a CLI/env string into a ClientAllowlist
-    pub fn parse_cli(input: &str) -> Result<Self, ApiError> {
+    /// Check if an IP address is allowed
+    pub fn allows(&self, ip: IpAddr) -> bool {
+        match self {
+            ClientAllowlist::Any => true,
+            ClientAllowlist::Nets(nets) => nets.iter().any(|net| match (net, ip) {
+                (IpNet::V4(net), IpAddr::V4(addr)) => net.contains(&addr),
+                (IpNet::V6(net), IpAddr::V6(addr)) => net.contains(&addr),
+                _ => false,
+            }),
+        }
+    }
+
+    /// Parse a network CIDR or single IP
+    fn parse_net(raw: &str) -> Result<IpNet, ClientNetworkParseError> {
+        IpNet::from_str(raw)
+            .or_else(|_| Self::ip_to_host_net(raw))
+            .map_err(|_| ClientNetworkParseError::InvalidIpOrCidr(raw.to_string()))
+    }
+
+    /// Convert a single IP address to a /32 or /128 network
+    fn ip_to_host_net(raw: &str) -> Result<IpNet, ()> {
+        let ip: IpAddr = raw.parse().map_err(|_| ())?;
+        match ip {
+            IpAddr::V4(addr) => Ipv4Net::new(addr, 32).map(IpNet::from).map_err(|_| ()),
+            IpAddr::V6(addr) => Ipv6Net::new(addr, 128).map(IpNet::from).map_err(|_| ()),
+        }
+    }
+}
+
+impl FromStr for ClientAllowlist {
+    type Err = ClientNetworkParseError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         let trimmed = input.trim();
 
         if trimmed == "*" {
@@ -67,48 +106,10 @@ impl ClientAllowlist {
             .collect::<Result<_, _>>()?;
 
         if nets.is_empty() {
-            return Err(ApiError::BadRequest(
-                "client allowlist cannot be empty".into(),
-            ));
+            return Err(ClientNetworkParseError::EmptyClientAllowlist);
         }
 
         Ok(Self::Nets(nets))
-    }
-
-    /// Check if an IP address is allowed
-    pub fn allows(&self, ip: IpAddr) -> bool {
-        match self {
-            ClientAllowlist::Any => true,
-            ClientAllowlist::Nets(nets) => nets.iter().any(|net| match (net, ip) {
-                (IpNet::V4(net), IpAddr::V4(addr)) => net.contains(&addr),
-                (IpNet::V6(net), IpAddr::V6(addr)) => net.contains(&addr),
-                _ => false,
-            }),
-        }
-    }
-
-    /// Parse a network CIDR or single IP
-    fn parse_net(raw: &str) -> Result<IpNet, ApiError> {
-        IpNet::from_str(raw)
-            .or_else(|_| Self::ip_to_host_net(raw))
-            .map_err(|_| ApiError::BadRequest(format!("Invalid IP/CIDR: {}", raw)))
-    }
-
-    /// Convert a single IP address to a /32 or /128 network
-    fn ip_to_host_net(raw: &str) -> Result<IpNet, ()> {
-        let ip: IpAddr = raw.parse().map_err(|_| ())?;
-        match ip {
-            IpAddr::V4(addr) => Ipv4Net::new(addr, 32).map(IpNet::from).map_err(|_| ()),
-            IpAddr::V6(addr) => Ipv6Net::new(addr, 128).map(IpNet::from).map_err(|_| ()),
-        }
-    }
-}
-
-impl FromStr for ClientAllowlist {
-    type Err = ApiError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::parse_cli(s)
     }
 }
 
@@ -126,7 +127,7 @@ impl TrustedProxies {
 }
 
 impl FromStr for TrustedProxies {
-    type Err = ApiError;
+    type Err = ClientNetworkParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let nets = s


### PR DESCRIPTION
## Summary

- let Clap parse `ClientAllowlist` and `TrustedProxies` through their existing `FromStr` implementations
- replace the adapter functions with a dedicated `ClientNetworkParseError`
- remove the configuration parser's dependency on the Actix-facing `ApiError`

## Why

The network value types already owned their parsing rules, but Clap reached them through two bare adapter functions because their `FromStr` error was the public API error type. Giving the configuration domain its own standard error makes the trait implementation usable directly and keeps HTTP concerns out of command-line and environment parsing.

## Impact

Accepted values, validation messages, defaults, serialization, and runtime behavior are unchanged. This is an internal refactor with no API, schema, migration, OpenAPI, container-build, or changelog-worthy impact.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
