### PR TITLE
Type pagination limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   Downstream Rust callers must replace `DatabaseUrlComponents::new(url)` with
   `url.parse::<DatabaseUrlComponents>()` and read components through the new
   accessor methods.
+- **Breaking (Rust API):** Pagination limit helpers now use the validated
+  `PageLimits` value object instead of `(usize, usize)` tuples. Downstream Rust
+  callers must use `default_limit()`, `maximum_limit()`, `resolve()`, and
+  `clamp()`, and pass `PageLimits` to the config-free unified-search parser.
 - JSON filters and object-aggregate dimensions now share one typed JSON-path
   parser. Empty segments, whitespace, and characters outside ASCII letters,
   digits, `_`, and `$` are rejected consistently before SQL generation.

--- a/benches/unified_search_query_parsing_callgrind.rs
+++ b/benches/unified_search_query_parsing_callgrind.rs
@@ -1,4 +1,5 @@
 use hubuum::models::parse_unified_search_query_with_limits;
+use hubuum::pagination::PageLimits;
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 
@@ -18,7 +19,8 @@ const MAX_LIMIT: usize = 1000;
 
 #[library_benchmark]
 fn bench_parse_unified_search_query() -> usize {
-    let parsed = parse_unified_search_query_with_limits(black_box(QUERY), DEFAULT_LIMIT, MAX_LIMIT)
+    let page_limits = PageLimits::new(DEFAULT_LIMIT, MAX_LIMIT).unwrap();
+    let parsed = parse_unified_search_query_with_limits(black_box(QUERY), page_limits)
         .expect("benchmark unified query should parse");
 
     black_box(parsed.kinds.len() + parsed.limit_per_kind)

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -733,7 +733,9 @@ fn operation_has_cursor_pagination(operation: &Operation) -> bool {
 }
 
 fn add_cursor_pagination_docs(operation: &mut Operation) {
-    let (default_page_limit, max_page_limit) = page_limits_or_defaults();
+    let limits = page_limits_or_defaults();
+    let default_page_limit = limits.default_limit();
+    let max_page_limit = limits.maximum_limit();
     let parameters = operation.parameters.get_or_insert_with(Vec::new);
     upsert_page_limit_parameter(
         parameters,
@@ -780,7 +782,9 @@ fn add_cursor_pagination_docs(operation: &mut Operation) {
 }
 
 fn add_unified_search_pagination_docs(operation: &mut Operation) {
-    let (default_page_limit, max_page_limit) = page_limits_or_defaults();
+    let limits = page_limits_or_defaults();
+    let default_page_limit = limits.default_limit();
+    let max_page_limit = limits.maximum_limit();
     upsert_page_limit_parameter(
         operation.parameters.get_or_insert_with(Vec::new),
         "limit_per_kind",
@@ -1347,7 +1351,9 @@ mod tests {
     #[test]
     fn openapi_documents_cursor_pagination_for_list_endpoints() {
         let json = openapi_json();
-        let (default_page_limit, max_page_limit) = page_limits_or_defaults();
+        let limits = page_limits_or_defaults();
+        let default_page_limit = limits.default_limit();
+        let max_page_limit = limits.maximum_limit();
 
         for path in CURSOR_PAGINATED_GET_PATHS {
             let pointer_path = path.replace('~', "~0").replace('/', "~1");

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -26,7 +26,7 @@ use crate::models::collection as collection_model;
 use crate::models::traits::{ExpandCollection, ToHubuumObjects, check_if_object_in_class};
 use crate::pagination::{
     SKIPPED_TOTAL_COUNT, count_query_options, effective_page_limit, page_limits,
-    prepare_db_pagination, validate_page_limit,
+    prepare_db_pagination,
 };
 use crate::permissions::visibility::authorize_cursor_page;
 use crate::permissions::{
@@ -243,8 +243,7 @@ fn prepare_graph_query_options(
         ));
     }
 
-    let (default_limit, _) = page_limits()?;
-    let limit = validate_page_limit(params.limit.unwrap_or(default_limit))?;
+    let limit = page_limits()?.resolve(params.limit)?;
     params.limit = Some(limit + 1);
 
     Ok((params, limit))

--- a/src/db/traits/task.rs
+++ b/src/db/traits/task.rs
@@ -172,7 +172,7 @@ pub trait TaskBackend: TaskIdentifier {
         let task_id_value = self.task_id();
         let limit = query_options
             .limit
-            .unwrap_or(page_limits_or_defaults().0.saturating_add(1));
+            .unwrap_or(page_limits_or_defaults().default_limit().saturating_add(1));
         let descending = query_options
             .sort
             .as_slice()
@@ -239,7 +239,7 @@ pub trait TaskBackend: TaskIdentifier {
         let task_id_value = self.task_id();
         let limit = query_options
             .limit
-            .unwrap_or(page_limits_or_defaults().0.saturating_add(1));
+            .unwrap_or(page_limits_or_defaults().default_limit().saturating_add(1));
         let descending = query_options
             .sort
             .as_slice()

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -869,14 +869,14 @@ fn prepare_query_options(export: &ExportRequest) -> Result<QueryOptions, ApiErro
 
     validate_export_limits(export)?;
 
-    let (default_page_limit, max_page_limit) = page_limits_or_defaults();
+    let page_limits = page_limits_or_defaults();
     let configured_limit = export
         .limits
         .as_ref()
         .and_then(|limits| limits.max_items)
-        .unwrap_or(default_page_limit);
+        .unwrap_or(page_limits.default_limit());
     let requested_limit = query_options.limit.unwrap_or(configured_limit);
-    let effective_limit = requested_limit.min(configured_limit).min(max_page_limit);
+    let effective_limit = page_limits.clamp(requested_limit.min(configured_limit));
 
     query_options.limit = Some(effective_limit.saturating_add(1));
     Ok(query_options)

--- a/src/models/unified_search.rs
+++ b/src/models/unified_search.rs
@@ -9,7 +9,7 @@ use crate::db::traits::authz::scope_allows;
 use crate::db::traits::user::UnifiedSearchBackend;
 use crate::errors::ApiError;
 use crate::models::{Collection, HubuumClassExpanded, HubuumObject, Permissions};
-use crate::pagination::{page_limits, validate_page_limit_with_max};
+use crate::pagination::{PageLimits, page_limits};
 use crate::permissions::{
     PermissionBackend, PermissionDecision, PermissionRequest, PrincipalRef, ResourceAttrs,
     ResourceKind, ResourceRef,
@@ -260,11 +260,8 @@ impl UnifiedSearchQueryParts {
         Ok(())
     }
 
-    fn build(self, default_limit: usize, max_limit: usize) -> Result<UnifiedSearchQuery, ApiError> {
-        let limit_per_kind = match self.limit_per_kind {
-            Some(limit) => validate_page_limit_with_max(limit, max_limit)?,
-            None => default_limit,
-        };
+    fn build(self, page_limits: PageLimits) -> Result<UnifiedSearchQuery, ApiError> {
+        let limit_per_kind = page_limits.resolve(self.limit_per_kind)?;
 
         Ok(UnifiedSearchQuery {
             query: self
@@ -282,8 +279,7 @@ impl UnifiedSearchQueryParts {
 }
 
 pub fn parse_unified_search_query(qs: &str) -> Result<UnifiedSearchQuery, ApiError> {
-    let (default_limit, max_limit) = page_limits()?;
-    parse_unified_search_query_with_limits(qs, default_limit, max_limit)
+    parse_unified_search_query_with_limits(qs, page_limits()?)
 }
 
 /// Config-free variant of [`parse_unified_search_query`]. The page limits are
@@ -292,8 +288,7 @@ pub fn parse_unified_search_query(qs: &str) -> Result<UnifiedSearchQuery, ApiErr
 /// any caller that already holds the limits).
 pub fn parse_unified_search_query_with_limits(
     qs: &str,
-    default_limit: usize,
-    max_limit: usize,
+    page_limits: PageLimits,
 ) -> Result<UnifiedSearchQuery, ApiError> {
     let mut parts = UnifiedSearchQueryParts::default();
 
@@ -304,7 +299,7 @@ pub fn parse_unified_search_query_with_limits(
         }
     }
 
-    parts.build(default_limit, max_limit)
+    parts.build(page_limits)
 }
 
 fn default_kinds() -> BTreeSet<UnifiedSearchKind> {
@@ -832,7 +827,10 @@ mod tests {
     fn parse_unified_search_defaults() {
         let parsed = parse_unified_search_query("q=server").unwrap();
         assert_eq!(parsed.query, "server");
-        assert_eq!(parsed.limit_per_kind, page_limits().unwrap().0);
+        assert_eq!(
+            parsed.limit_per_kind,
+            page_limits().unwrap().default_limit()
+        );
         assert!(parsed.includes(UnifiedSearchKind::Collection));
         assert!(parsed.includes(UnifiedSearchKind::Class));
         assert!(parsed.includes(UnifiedSearchKind::Object));
@@ -912,18 +910,22 @@ mod tests {
 
     #[test]
     fn parse_with_limits_uses_default_when_absent() {
-        let parsed = parse_unified_search_query_with_limits("q=server", 25, 100).unwrap();
+        let page_limits = PageLimits::new(25, 100).unwrap();
+        let parsed = parse_unified_search_query_with_limits("q=server", page_limits).unwrap();
         assert_eq!(parsed.limit_per_kind, 25);
     }
 
     #[test]
     fn parse_with_limits_validates_against_provided_max() {
+        let page_limits = PageLimits::new(25, 100).unwrap();
         let parsed =
-            parse_unified_search_query_with_limits("q=server&limit_per_kind=50", 25, 100).unwrap();
+            parse_unified_search_query_with_limits("q=server&limit_per_kind=50", page_limits)
+                .unwrap();
         assert_eq!(parsed.limit_per_kind, 50);
 
         let clamped =
-            parse_unified_search_query_with_limits("q=server&limit_per_kind=101", 25, 100).unwrap();
+            parse_unified_search_query_with_limits("q=server&limit_per_kind=101", page_limits)
+                .unwrap();
         assert_eq!(clamped.limit_per_kind, 100);
     }
 

--- a/src/pagination/mod.rs
+++ b/src/pagination/mod.rs
@@ -60,52 +60,87 @@ struct CursorSort {
     descending: bool,
 }
 
-pub fn page_limits() -> Result<(usize, usize), ApiError> {
-    let config = get_config()?;
-    Ok((config.default_page_limit, config.max_page_limit))
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageLimits {
+    default: usize,
+    maximum: usize,
 }
 
-pub fn page_limits_or_defaults() -> (usize, usize) {
-    page_limits().unwrap_or((DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT))
+impl PageLimits {
+    pub fn new(default: usize, maximum: usize) -> Result<Self, ApiError> {
+        if default == 0 {
+            return Err(ApiError::BadRequest(
+                "default_page_limit must be greater than 0".to_string(),
+            ));
+        }
+        if maximum == 0 {
+            return Err(ApiError::BadRequest(
+                "max_page_limit must be greater than 0".to_string(),
+            ));
+        }
+        if default > maximum {
+            return Err(ApiError::BadRequest(format!(
+                "default_page_limit ({default}) must be less than or equal to max_page_limit ({maximum})"
+            )));
+        }
+
+        Ok(Self { default, maximum })
+    }
+
+    pub fn default_limit(self) -> usize {
+        self.default
+    }
+
+    pub fn maximum_limit(self) -> usize {
+        self.maximum
+    }
+
+    pub fn clamp(self, limit: usize) -> usize {
+        limit.min(self.maximum)
+    }
+
+    pub fn resolve(self, requested: Option<usize>) -> Result<usize, ApiError> {
+        let limit = requested.unwrap_or(self.default);
+        if limit == 0 {
+            return Err(ApiError::BadRequest(
+                "limit must be greater than 0".to_string(),
+            ));
+        }
+        Ok(self.clamp(limit))
+    }
+}
+
+impl Default for PageLimits {
+    fn default() -> Self {
+        Self {
+            default: DEFAULT_PAGE_LIMIT,
+            maximum: MAX_PAGE_LIMIT,
+        }
+    }
+}
+
+pub fn page_limits() -> Result<PageLimits, ApiError> {
+    let config = get_config()?;
+    PageLimits::new(config.default_page_limit, config.max_page_limit)
+}
+
+pub fn page_limits_or_defaults() -> PageLimits {
+    page_limits().unwrap_or_default()
 }
 
 pub fn validate_page_limit(limit: usize) -> Result<usize, ApiError> {
-    let (_, max_page_limit) = page_limits()?;
-    validate_page_limit_with_max(limit, max_page_limit)
-}
-
-/// Config-free variant of [`validate_page_limit`] that takes the maximum limit
-/// explicitly instead of reading it from the global configuration. Useful where
-/// the caller already holds the limits, or wants to avoid touching global config
-/// (for example, benchmarks).
-pub fn validate_page_limit_with_max(
-    limit: usize,
-    max_page_limit: usize,
-) -> Result<usize, ApiError> {
-    if limit == 0 {
-        return Err(ApiError::BadRequest(
-            "limit must be greater than 0".to_string(),
-        ));
-    }
-    if max_page_limit == 0 {
-        return Err(ApiError::BadRequest(
-            "max_page_limit must be greater than 0".to_string(),
-        ));
-    }
-
-    Ok(limit.min(max_page_limit))
+    page_limits()?.resolve(Some(limit))
 }
 
 pub fn effective_page_limit(query_options: &QueryOptions) -> Result<usize, ApiError> {
-    validate_page_limit(query_options.limit.unwrap_or(page_limits()?.0))
+    page_limits()?.resolve(query_options.limit)
 }
 
 pub fn prepare_db_pagination<T>(query_options: &QueryOptions) -> Result<QueryOptions, ApiError>
 where
     T: CursorPaginated,
 {
-    let (default_page_limit, _) = page_limits()?;
-    let limit = validate_page_limit(query_options.limit.unwrap_or(default_page_limit))?;
+    let limit = page_limits()?.resolve(query_options.limit)?;
     let sorts = normalized_sorts::<T>(&query_options.sort)?;
 
     if let Some(cursor) = &query_options.cursor {

--- a/src/pagination/tests.rs
+++ b/src/pagination/tests.rs
@@ -581,25 +581,44 @@ fn json_cursor_rejects_nesting_above_the_maximum() {
     );
 }
 
-#[test]
-fn validate_page_limit_with_max_accepts_within_range() {
-    assert_eq!(validate_page_limit_with_max(10, 100).unwrap(), 10);
-    assert_eq!(validate_page_limit_with_max(100, 100).unwrap(), 100);
+#[rstest]
+#[case(None, 10)]
+#[case(Some(1), 1)]
+#[case(Some(100), 100)]
+#[case(Some(101), 100)]
+fn page_limits_resolve_defaults_and_clamp(
+    #[case] requested: Option<usize>,
+    #[case] expected: usize,
+) {
+    let limits = PageLimits::new(10, 100).unwrap();
+
+    assert_eq!(limits.resolve(requested).unwrap(), expected);
+}
+
+#[rstest]
+#[case(0, 100, "default_page_limit must be greater than 0")]
+#[case(10, 0, "max_page_limit must be greater than 0")]
+#[case(
+    101,
+    100,
+    "default_page_limit (101) must be less than or equal to max_page_limit (100)"
+)]
+fn page_limits_reject_invalid_invariants(
+    #[case] default: usize,
+    #[case] maximum: usize,
+    #[case] expected: &str,
+) {
+    let error = PageLimits::new(default, maximum).unwrap_err();
+
+    assert_eq!(error.to_string(), expected);
 }
 
 #[test]
-fn validate_page_limit_with_max_rejects_zero() {
-    let error = validate_page_limit_with_max(0, 100).unwrap_err();
+fn page_limits_reject_a_zero_requested_limit() {
+    let error = PageLimits::new(10, 100)
+        .unwrap()
+        .resolve(Some(0))
+        .unwrap_err();
+
     assert_eq!(error.to_string(), "limit must be greater than 0");
-}
-
-#[test]
-fn validate_page_limit_with_max_rejects_zero_maximum() {
-    let error = validate_page_limit_with_max(1, 0).unwrap_err();
-    assert_eq!(error.to_string(), "max_page_limit must be greater than 0");
-}
-
-#[test]
-fn validate_page_limit_with_max_clamps_above_maximum() {
-    assert_eq!(validate_page_limit_with_max(101, 100).unwrap(), 100);
 }

--- a/tests/api_core_data_suite/collections.rs
+++ b/tests/api_core_data_suite/collections.rs
@@ -952,7 +952,7 @@ mod tests {
         #[future(awt)] test_context: TestContext,
     ) {
         let context = test_context;
-        let max_page_limit = page_limits().unwrap().1;
+        let max_page_limit = page_limits().unwrap().maximum_limit();
         let resp = get_request(
             &context.pool,
             &context.admin_token,


### PR DESCRIPTION
## Summary

- add a validated `PageLimits` value object with private default/maximum fields
- centralize configured default resolution, zero rejection, and maximum clamping on the type
- replace tuple destructuring and positional field access across pagination, OpenAPI generation, task queries, graph queries, exports, and unified search
- pass the value object through the config-free unified-search parser and its benchmark
- replace helper tests with parameterized invariant and resolution coverage

## Why

Pagination limits were passed as unrelated `usize` values or positional `(usize, usize)` tuples. That made default/maximum order implicit, duplicated clamping, and allowed config-free callers to construct invalid combinations. `PageLimits` makes the relationship explicit and keeps the invariant and behavior with the data.

## Breaking Rust API

**Breaking:** downstream Rust callers must:

- replace tuple destructuring or `.0`/`.1` access from `page_limits()` and `page_limits_or_defaults()` with `default_limit()` and `maximum_limit()`
- replace `validate_page_limit_with_max(limit, maximum)` with a validated `PageLimits` followed by `resolve(Some(limit))`
- pass `PageLimits` to `parse_unified_search_query_with_limits`

REST behavior, configured defaults, clamping, response headers, and generated OpenAPI values are unchanged. There is no database migration or endpoint/schema change.

## Verification

- `source .env && ./run_tests.sh`
- `cargo test --lib pagination::tests::page_limits --locked`
- `cargo test --lib models::unified_search::tests::parse_with_limits --locked`
- `cargo check --bench unified_search_query_parsing_callgrind --locked`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `git diff --check`

No workspace member, crate manifest, `Cargo.lock`, Docker build feature, `Dockerfile`, or `entrypoint.sh` changed, so the container-specific gate is not affected.
