### PR TITLE
Validate export scopes into typed state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `PageLimits` value object instead of `(usize, usize)` tuples. Downstream Rust
   callers must use `default_limit()`, `maximum_limit()`, `resolve()`, and
   `clamp()`, and pass `PageLimits` to the config-free unified-search parser.
+- **Breaking:** Export scope `class_id` and `object_id` values must now be
+  positive integers. Clients sending zero or negative export scope IDs must
+  replace them with valid resource IDs.
+- **Breaking (Rust API):** `ExportScope::validate` now returns a
+  `ValidatedExportScope`, and the raw `class_id_required` and
+  `object_id_required` helpers have been removed. Integrations should validate
+  once and retain the returned typed scope during execution.
 - JSON filters and object-aggregate dimensions now share one typed JSON-path
   parser. Empty segments, whitespace, and characters outside ASCII letters,
   digits, `_`, and `$` are rejected consistently before SQL generation.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -19405,7 +19405,8 @@
               "integer",
               "null"
             ],
-            "format": "int32"
+            "format": "int32",
+            "minimum": 1
           },
           "kind": {
             "$ref": "#/components/schemas/ExportScopeKind"
@@ -19415,7 +19416,8 @@
               "integer",
               "null"
             ],
-            "format": "int32"
+            "format": "int32",
+            "minimum": 1
           }
         },
         "example": {

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -1246,6 +1246,21 @@ mod tests {
     }
 
     #[test]
+    fn export_scope_ids_document_positive_minimum() {
+        let json = openapi_json();
+
+        for field in ["class_id", "object_id"] {
+            assert_eq!(
+                json.pointer(&format!(
+                    "/components/schemas/ExportScope/properties/{field}/minimum"
+                )),
+                Some(&Value::from(1)),
+                "ExportScope.{field} should document its positive-ID invariant"
+            );
+        }
+    }
+
+    #[test]
     fn object_data_json_patch_media_type_limits_and_statuses_are_documented() {
         let json = openapi_json();
         let operation_pointers = [

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -22,12 +22,12 @@ use crate::models::search::{
 use crate::models::{
     ClassIdSet, Collection, CollectionExportTemplates, CollectionID, ExportContentType,
     ExportIncludeRelatedDirection, ExportIncludeRelatedQuery, ExportIncludeRelatedSort,
-    ExportJsonResponse, ExportMeta, ExportMissingDataPolicy, ExportRequest, ExportScope,
-    ExportScopeKind, ExportTemplate, ExportTemplateID, ExportWarning, HubuumClassExpanded,
-    HubuumClassID, HubuumClassRelation, HubuumObject, HubuumObjectID, HubuumObjectRelation,
-    HubuumObjectWithPath, NewExportTaskOutputRecord, NewTaskEventRecord,
-    RELATED_INCLUDE_DEFAULT_LIMIT, RELATED_INCLUDE_DEFAULT_MAX_DEPTH, RelatedObjectForRootRow,
-    RelatedObjectGraphRow, RelatedObjectIncludeRow, TaskKind, TaskRecord,
+    ExportJsonResponse, ExportMeta, ExportMissingDataPolicy, ExportRequest, ExportTemplate,
+    ExportTemplateID, ExportWarning, HubuumClassExpanded, HubuumClassRelation, HubuumObject,
+    HubuumObjectID, HubuumObjectRelation, HubuumObjectWithPath, NewExportTaskOutputRecord,
+    NewTaskEventRecord, RELATED_INCLUDE_DEFAULT_LIMIT, RELATED_INCLUDE_DEFAULT_MAX_DEPTH,
+    RelatedObjectForRootRow, RelatedObjectGraphRow, RelatedObjectIncludeRow, TaskKind, TaskRecord,
+    ValidatedExportScope,
 };
 use crate::observability::metrics;
 use crate::pagination::page_limits_or_defaults;
@@ -55,6 +55,7 @@ struct ExportArtifact {
 
 struct ExportRuntime {
     export: ExportRequest,
+    scope: ValidatedExportScope,
     content_type: ExportContentType,
     missing_data_policy: ExportMissingDataPolicy,
     template: Option<ExportTemplate>,
@@ -343,8 +344,8 @@ async fn prepare_export_runtime(
     export: ExportRequest,
     template: Option<ExportTemplate>,
 ) -> Result<ExportRuntime, ApiError> {
-    export.scope.validate()?;
-    validate_export_include(&export)?;
+    let scope = export.scope.validate()?;
+    validate_export_include(&export, scope)?;
 
     let collection_templates = match &template {
         Some(template) => {
@@ -360,6 +361,7 @@ async fn prepare_export_runtime(
         .unwrap_or(ExportContentType::ApplicationJson);
 
     Ok(ExportRuntime {
+        scope,
         content_type,
         missing_data_policy: export
             .missing_data_policy
@@ -477,7 +479,7 @@ pub(crate) async fn execute_export_task(
         event_type: "running".to_string(),
         message: "Query execution started".to_string(),
         data: Some(serde_json::json!({
-            "scope": runtime.export.scope.kind.as_str(),
+            "scope": runtime.scope.kind().as_str(),
             "content_type": runtime.content_type.as_mime(),
         })),
     }
@@ -494,7 +496,7 @@ pub(crate) async fn execute_export_task(
     let query_start = Instant::now();
     let (items, mut warnings, truncated) = with_statement_timeout_scope(
         statement_timeout,
-        execute_scope(pool, subject, &runtime.export.scope, query_options),
+        execute_scope(pool, subject, runtime.scope, query_options),
     )
     .await?;
     let mut items = items;
@@ -671,7 +673,10 @@ fn artifact_to_output_record(
     })
 }
 
-fn validate_export_include(export: &ExportRequest) -> Result<(), ApiError> {
+fn validate_export_include(
+    export: &ExportRequest,
+    scope: ValidatedExportScope,
+) -> Result<(), ApiError> {
     let Some(include) = &export.include else {
         return Ok(());
     };
@@ -680,7 +685,7 @@ fn validate_export_include(export: &ExportRequest) -> Result<(), ApiError> {
         return Ok(());
     };
 
-    if !related_objects.is_empty() && export.scope.kind != ExportScopeKind::ObjectsInClass {
+    if !related_objects.is_empty() && !matches!(scope, ValidatedExportScope::ObjectsInClass(_)) {
         return Err(ApiError::BadRequest(
             "include.related_objects is only supported for scope 'objects_in_class'".to_string(),
         ));
@@ -833,7 +838,7 @@ fn log_export_stage_metrics(
     tracing::info!(
         message = "Export execution timings recorded",
         task_id = task_id,
-        scope = runtime.export.scope.kind.as_str(),
+        scope = runtime.scope.kind().as_str(),
         content_type = runtime.content_type.as_mime(),
         template_name = runtime
             .template
@@ -916,7 +921,7 @@ fn resolve_relation_hydration_plan(
     query_options: &mut QueryOptions,
 ) -> Result<Option<RelationHydrationPlan>, ApiError> {
     let has_template = runtime.template.is_some();
-    let scope = &runtime.export.scope;
+    let scope = runtime.scope;
     let relation_context = runtime.export.relation_context.as_ref();
 
     if relation_context.is_some() && !has_template {
@@ -927,8 +932,8 @@ fn resolve_relation_hydration_plan(
 
     if relation_context.is_some()
         && !matches!(
-            scope.kind,
-            ExportScopeKind::ObjectsInClass | ExportScopeKind::RelatedObjects
+            scope,
+            ValidatedExportScope::ObjectsInClass(_) | ValidatedExportScope::RelatedObjects { .. }
         )
     {
         return Err(ApiError::BadRequest(
@@ -941,8 +946,8 @@ fn resolve_relation_hydration_plan(
         return Ok(None);
     }
 
-    match scope.kind {
-        ExportScopeKind::ObjectsInClass => {
+    match scope {
+        ValidatedExportScope::ObjectsInClass(_) => {
             let Some(context) = relation_context else {
                 return Ok(None);
             };
@@ -951,7 +956,7 @@ fn resolve_relation_hydration_plan(
                 enabled_for_scope: true,
             }))
         }
-        ExportScopeKind::RelatedObjects => {
+        ValidatedExportScope::RelatedObjects { .. } => {
             let depth_limit = validate_relation_depth(
                 relation_context
                     .and_then(|context| context.depth)
@@ -1004,8 +1009,8 @@ async fn build_template_items(
 
     let mut hydration_budget = HydrationBudget::new(max_hydrated_template_objects());
 
-    match runtime.export.scope.kind {
-        ExportScopeKind::ObjectsInClass => {
+    match runtime.scope {
+        ValidatedExportScope::ObjectsInClass(_) => {
             let admin = RuntimeAdminExport::new(user);
             let roots = items
                 .iter()
@@ -1097,10 +1102,8 @@ async fn build_template_items(
 
             Ok((hydrated_items, None))
         }
-        ExportScopeKind::RelatedObjects => {
-            let source_object = HubuumObjectID::new(runtime.export.scope.object_id_required()?)?
-                .instance(pool)
-                .await?;
+        ValidatedExportScope::RelatedObjects { object_id, .. } => {
+            let source_object = object_id.instance(pool).await?;
             let source = object_with_root_path(&source_object);
             let related_objects = items
                 .iter()
@@ -1915,34 +1918,31 @@ fn object_with_root_path(object: &HubuumObject) -> HubuumObjectWithPath {
 async fn execute_scope(
     pool: &DbPool,
     subject: &impl crate::traits::Search,
-    scope: &ExportScope,
+    scope: ValidatedExportScope,
     mut query_options: QueryOptions,
 ) -> Result<(Vec<serde_json::Value>, Vec<ExportWarning>, bool), ApiError> {
     let item_limit = query_options.limit.unwrap_or(1).saturating_sub(1).max(1);
     let admin = RuntimeAdminExport::new(subject);
 
-    let data = match scope.kind {
-        ExportScopeKind::Collections => {
+    let data = match scope {
+        ValidatedExportScope::Collections => {
             to_json_items(admin.collections(pool, query_options).await?)?
         }
-        ExportScopeKind::Classes => to_json_items(admin.classes(pool, query_options).await?)?,
-        ExportScopeKind::ObjectsInClass => {
-            push_exact_filter(
-                &mut query_options,
-                FilterField::ClassId,
-                scope.class_id_required()?,
-            )?;
+        ValidatedExportScope::Classes => to_json_items(admin.classes(pool, query_options).await?)?,
+        ValidatedExportScope::ObjectsInClass(class_id) => {
+            push_exact_filter(&mut query_options, FilterField::ClassId, class_id.id())?;
             to_json_items(admin.objects(pool, query_options).await?)?
         }
-        ExportScopeKind::ClassRelations => {
+        ValidatedExportScope::ClassRelations => {
             to_json_items(admin.class_relations(pool, query_options).await?)?
         }
-        ExportScopeKind::ObjectRelations => {
+        ValidatedExportScope::ObjectRelations => {
             to_json_items(admin.object_relations(pool, query_options).await?)?
         }
-        ExportScopeKind::RelatedObjects => {
-            let class_id = HubuumClassID::new(scope.class_id_required()?)?;
-            let object_id = HubuumObjectID::new(scope.object_id_required()?)?;
+        ValidatedExportScope::RelatedObjects {
+            class_id,
+            object_id,
+        } => {
             check_if_object_in_class(pool, &class_id, &object_id).await?;
             let related = admin
                 .related_objects(pool, object_id, query_options)
@@ -2288,8 +2288,10 @@ mod tests {
     }
 
     fn export_runtime(export: ExportRequest) -> ExportRuntime {
+        let scope = export.scope.validate().unwrap();
         ExportRuntime {
             export,
+            scope,
             content_type: ExportContentType::TextPlain,
             missing_data_policy: ExportMissingDataPolicy::Strict,
             template: Some(ExportTemplate {

--- a/src/models/export.rs
+++ b/src/models/export.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::errors::ApiError;
+use crate::models::{HubuumClassID, HubuumObjectID};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "snake_case")]
@@ -21,58 +22,92 @@ pub enum ExportScopeKind {
 #[schema(example = openapi_examples::export_scope_example)]
 pub struct ExportScope {
     pub kind: ExportScopeKind,
+    #[schema(minimum = 1)]
     pub class_id: Option<i32>,
+    #[schema(minimum = 1)]
     pub object_id: Option<i32>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValidatedExportScope {
+    Collections,
+    Classes,
+    ObjectsInClass(HubuumClassID),
+    ClassRelations,
+    ObjectRelations,
+    RelatedObjects {
+        class_id: HubuumClassID,
+        object_id: HubuumObjectID,
+    },
+}
+
+impl ValidatedExportScope {
+    pub fn kind(self) -> ExportScopeKind {
+        match self {
+            Self::Collections => ExportScopeKind::Collections,
+            Self::Classes => ExportScopeKind::Classes,
+            Self::ObjectsInClass(_) => ExportScopeKind::ObjectsInClass,
+            Self::ClassRelations => ExportScopeKind::ClassRelations,
+            Self::ObjectRelations => ExportScopeKind::ObjectRelations,
+            Self::RelatedObjects { .. } => ExportScopeKind::RelatedObjects,
+        }
+    }
+}
+
 impl ExportScope {
-    pub fn validate(&self) -> Result<(), ApiError> {
+    pub fn validate(&self) -> Result<ValidatedExportScope, ApiError> {
         match self.kind {
-            ExportScopeKind::Collections
-            | ExportScopeKind::Classes
-            | ExportScopeKind::ClassRelations
-            | ExportScopeKind::ObjectRelations => {
-                if self.class_id.is_some() || self.object_id.is_some() {
-                    return Err(ApiError::BadRequest(format!(
-                        "Scope '{}' does not accept class_id or object_id",
-                        self.kind.as_str()
-                    )));
-                }
+            ExportScopeKind::Collections => {
+                self.reject_ids()?;
+                Ok(ValidatedExportScope::Collections)
+            }
+            ExportScopeKind::Classes => {
+                self.reject_ids()?;
+                Ok(ValidatedExportScope::Classes)
             }
             ExportScopeKind::ObjectsInClass => {
-                if self.class_id.is_none() {
-                    return Err(ApiError::BadRequest(
-                        "Scope 'objects_in_class' requires class_id".to_string(),
-                    ));
-                }
+                let class_id = self.class_id.ok_or_else(|| {
+                    ApiError::BadRequest("Scope 'objects_in_class' requires class_id".to_string())
+                })?;
                 if self.object_id.is_some() {
                     return Err(ApiError::BadRequest(
                         "Scope 'objects_in_class' does not accept object_id".to_string(),
                     ));
                 }
+                Ok(ValidatedExportScope::ObjectsInClass(HubuumClassID::new(
+                    class_id,
+                )?))
+            }
+            ExportScopeKind::ClassRelations => {
+                self.reject_ids()?;
+                Ok(ValidatedExportScope::ClassRelations)
+            }
+            ExportScopeKind::ObjectRelations => {
+                self.reject_ids()?;
+                Ok(ValidatedExportScope::ObjectRelations)
             }
             ExportScopeKind::RelatedObjects => {
-                if self.class_id.is_none() || self.object_id.is_none() {
+                let (Some(class_id), Some(object_id)) = (self.class_id, self.object_id) else {
                     return Err(ApiError::BadRequest(
                         "Scope 'related_objects' requires both class_id and object_id".to_string(),
                     ));
-                }
+                };
+                Ok(ValidatedExportScope::RelatedObjects {
+                    class_id: HubuumClassID::new(class_id)?,
+                    object_id: HubuumObjectID::new(object_id)?,
+                })
             }
         }
+    }
 
+    fn reject_ids(&self) -> Result<(), ApiError> {
+        if self.class_id.is_some() || self.object_id.is_some() {
+            return Err(ApiError::BadRequest(format!(
+                "Scope '{}' does not accept class_id or object_id",
+                self.kind.as_str()
+            )));
+        }
         Ok(())
-    }
-
-    pub fn class_id_required(&self) -> Result<i32, ApiError> {
-        self.class_id.ok_or_else(|| {
-            ApiError::BadRequest(format!("Scope '{}' requires class_id", self.kind.as_str()))
-        })
-    }
-
-    pub fn object_id_required(&self) -> Result<i32, ApiError> {
-        self.object_id.ok_or_else(|| {
-            ApiError::BadRequest(format!("Scope '{}' requires object_id", self.kind.as_str()))
-        })
     }
 }
 
@@ -374,6 +409,105 @@ impl FromStr for ExportMissingDataPolicy {
             _ => Err(ApiError::BadRequest(format!(
                 "Unsupported export missing data policy: '{value}'"
             ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case::collections(
+        ExportScopeKind::Collections,
+        None,
+        None,
+        ValidatedExportScope::Collections
+    )]
+    #[case::objects_in_class(
+        ExportScopeKind::ObjectsInClass,
+        Some(11),
+        None,
+        ValidatedExportScope::ObjectsInClass(HubuumClassID::new(11).unwrap())
+    )]
+    #[case::related_objects(
+        ExportScopeKind::RelatedObjects,
+        Some(11),
+        Some(22),
+        ValidatedExportScope::RelatedObjects {
+            class_id: HubuumClassID::new(11).unwrap(),
+            object_id: HubuumObjectID::new(22).unwrap(),
+        }
+    )]
+    fn scope_validation_returns_typed_domain_state(
+        #[case] kind: ExportScopeKind,
+        #[case] class_id: Option<i32>,
+        #[case] object_id: Option<i32>,
+        #[case] expected: ValidatedExportScope,
+    ) {
+        let scope = ExportScope {
+            kind,
+            class_id,
+            object_id,
+        };
+
+        assert_eq!(scope.validate().unwrap(), expected);
+    }
+
+    #[rstest]
+    #[case::ids_on_collection(
+        ExportScopeKind::Collections,
+        Some(1),
+        None,
+        "Scope 'collections' does not accept class_id or object_id"
+    )]
+    #[case::missing_class(
+        ExportScopeKind::ObjectsInClass,
+        None,
+        None,
+        "Scope 'objects_in_class' requires class_id"
+    )]
+    #[case::extra_object(
+        ExportScopeKind::ObjectsInClass,
+        Some(1),
+        Some(2),
+        "Scope 'objects_in_class' does not accept object_id"
+    )]
+    #[case::incomplete_relation(
+        ExportScopeKind::RelatedObjects,
+        Some(1),
+        None,
+        "Scope 'related_objects' requires both class_id and object_id"
+    )]
+    #[case::invalid_class(
+        ExportScopeKind::ObjectsInClass,
+        Some(0),
+        None,
+        "Invalid class id '0': must be a positive integer"
+    )]
+    #[case::invalid_object(
+        ExportScopeKind::RelatedObjects,
+        Some(1),
+        Some(-1),
+        "Invalid object id '-1': must be a positive integer"
+    )]
+    fn scope_validation_rejects_invalid_domain_state(
+        #[case] kind: ExportScopeKind,
+        #[case] class_id: Option<i32>,
+        #[case] object_id: Option<i32>,
+        #[case] expected_message: &str,
+    ) {
+        let scope = ExportScope {
+            kind,
+            class_id,
+            object_id,
+        };
+
+        match scope.validate().unwrap_err() {
+            ApiError::BadRequest(message) => assert_eq!(message, expected_message),
+            error => panic!("unexpected error: {error:?}"),
         }
     }
 }

--- a/tests/api_jobs_suite/exports.rs
+++ b/tests/api_jobs_suite/exports.rs
@@ -68,6 +68,43 @@ mod tests {
     }
 
     #[rstest]
+    #[case::zero_class_id(ExportScopeKind::ObjectsInClass, Some(0), None)]
+    #[case::negative_class_id(ExportScopeKind::ObjectsInClass, Some(-1), None)]
+    #[case::zero_object_id(ExportScopeKind::RelatedObjects, Some(1), Some(0))]
+    #[actix_web::test]
+    async fn test_export_rejects_non_positive_scope_ids(
+        #[future(awt)] test_context: TestContext,
+        #[case] kind: ExportScopeKind,
+        #[case] class_id: Option<i32>,
+        #[case] object_id: Option<i32>,
+    ) {
+        let context = test_context;
+        let body = ExportRequest {
+            scope: ExportScope {
+                kind,
+                class_id,
+                object_id,
+            },
+            query: None,
+            missing_data_policy: None,
+            limits: None,
+            include: None,
+            relation_context: None,
+        };
+
+        let response = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            EXPORTS_ENDPOINT,
+            &body,
+            vec![],
+        )
+        .await;
+
+        assert_response_status(response, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[rstest]
     #[actix_web::test]
     async fn test_export_accepts_unscoped_admin_service_account(
         #[future(awt)] test_context: TestContext,


### PR DESCRIPTION
## Summary

- add `ValidatedExportScope` as the domain representation for executable export scopes
- validate optional wire-format IDs once, then carry positive `HubuumClassID` and `HubuumObjectID` values through query and hydration paths
- document the positive-ID invariant in OpenAPI and add model, schema, and endpoint regression coverage

## Breaking changes

- API clients can no longer submit zero or negative `scope.class_id` or `scope.object_id` values; they must send valid positive resource IDs
- Rust callers must retain the `ValidatedExportScope` returned by `ExportScope::validate`; the raw `class_id_required` and `object_id_required` helpers were removed

## Changelog

Updated the `[Unreleased]` section with both breaking changes and their migration actions.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- regenerated `docs/openapi.json` with `cargo run --quiet --bin hubuum-openapi`