### PR TITLE
Make group deletion conflicts atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   match instead of binding a server that cannot complete TLS handshakes.
 - Event-retention file archives are now durably synchronized before the
   database transaction deletes the archived events.
+- Group deletion now checks service-account ownership while holding the group
+  row lock, so concurrent account creation returns a stable `409 Conflict`;
+  conflict diagnostics also cap the number of account names they include.
 - Single-host rolling updates now wait for Caddy's passive upstream failure
   marks to clear between replica replacements, preserving continuous routing
   without reprovisioning an unchanged proxy configuration.

--- a/src/api/v1/handlers/groups.rs
+++ b/src/api/v1/handlers/groups.rs
@@ -2,7 +2,6 @@ use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
 use crate::db::DbPool;
-use crate::db::traits::service_account::service_accounts_owned_by_group;
 use crate::errors::ApiError;
 use crate::extractors::{AccessEventContext, AdminAccess, UserAccess};
 use crate::models::group::{GroupID, NewGroup, UpdateGroup};
@@ -209,20 +208,6 @@ pub async fn delete_group(
         target = group_id.id(),
         requestor = requestor.user.id
     );
-
-    // owner_group_id is ON DELETE RESTRICT: surface a clear 409 listing the owned
-    // service accounts instead of letting the FK violation become an opaque error.
-    let owned = service_accounts_owned_by_group(&pool, group_id.id()).await?;
-    if !owned.is_empty() {
-        let list = owned
-            .iter()
-            .map(|(id, name)| format!("{name} (id {id})"))
-            .collect::<Vec<_>>()
-            .join(", ");
-        return Err(ApiError::Conflict(format!(
-            "Group owns service accounts; reassign or delete them first: {list}"
-        )));
-    }
 
     let event_context = requestor.event_context(&req);
     group_id.delete(&pool, Some(&event_context)).await?;

--- a/src/db/traits/group.rs
+++ b/src/db/traits/group.rs
@@ -13,6 +13,8 @@ use crate::models::{
 };
 use crate::{date_search, numeric_search, string_search};
 
+const OWNED_SERVICE_ACCOUNT_PREVIEW_LIMIT: i64 = 10;
+
 fn group_snapshot(group: &Group) -> serde_json::Value {
     serde_json::json!({
         "id": group.id,
@@ -150,6 +152,54 @@ async fn ensure_group_allows_local_write(
     Ok(())
 }
 
+async fn ensure_group_has_no_owned_service_accounts(
+    conn: &mut DbConnection,
+    group_id: i32,
+) -> Result<(), ApiError> {
+    use crate::schema::{principals, service_accounts};
+
+    let mut owned = service_accounts::table
+        .inner_join(principals::table.on(principals::id.eq(service_accounts::id)))
+        .filter(service_accounts::owner_group_id.eq(group_id))
+        .select((service_accounts::id, principals::name))
+        .order(service_accounts::id.asc())
+        .limit(OWNED_SERVICE_ACCOUNT_PREVIEW_LIMIT + 1)
+        .load::<(i32, String)>(conn)
+        .await?;
+    if owned.is_empty() {
+        return Ok(());
+    }
+
+    let additional_accounts_omitted = owned.len() > OWNED_SERVICE_ACCOUNT_PREVIEW_LIMIT as usize;
+    owned.truncate(OWNED_SERVICE_ACCOUNT_PREVIEW_LIMIT as usize);
+    let list = owned
+        .iter()
+        .map(|(id, name)| format!("{name} (id {id})"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let suffix = if additional_accounts_omitted {
+        "; additional service accounts omitted"
+    } else {
+        ""
+    };
+    Err(ApiError::Conflict(format!(
+        "Group owns service accounts; reassign or delete them first: {list}{suffix}"
+    )))
+}
+
+async fn lock_group_for_delete(conn: &mut DbConnection, group_id: i32) -> Result<Group, ApiError> {
+    use crate::schema::groups::dsl::{groups, id};
+
+    let group = groups
+        .filter(id.eq(group_id))
+        .for_update()
+        .first::<Group>(conn)
+        .await?;
+    ensure_group_has_no_owned_service_accounts(conn, group.id).await?;
+    ensure_group_allows_local_write(conn, group.id).await?;
+    Ok(group)
+}
+
 pub trait LoadGroupRecord {
     async fn load_group_record(&self, pool: &DbPool) -> Result<Group, ApiError>;
 }
@@ -206,8 +256,8 @@ impl DeleteGroupRecord for GroupID {
     async fn delete_group_record_without_events(&self, pool: &DbPool) -> Result<usize, ApiError> {
         use crate::schema::groups::dsl::{groups, id};
 
-        with_connection(pool, async |conn| -> Result<usize, ApiError> {
-            ensure_group_allows_local_write(conn, self.id()).await?;
+        with_transaction(pool, async |conn| -> Result<usize, ApiError> {
+            lock_group_for_delete(conn, self.id()).await?;
             Ok(diesel::delete(groups.filter(id.eq(self.id())))
                 .execute(conn)
                 .await?)
@@ -227,12 +277,7 @@ impl DeleteGroupRecord for GroupID {
         use crate::schema::groups::dsl::{groups, id};
 
         with_transaction(pool, async |conn| -> Result<usize, ApiError> {
-            let group = groups
-                .filter(id.eq(self.id()))
-                .for_update()
-                .first::<Group>(conn)
-                .await?;
-            ensure_group_allows_local_write(conn, group.id).await?;
+            let group = lock_group_for_delete(conn, self.id()).await?;
             let deleted = diesel::delete(groups.filter(id.eq(self.id())))
                 .execute(conn)
                 .await?;
@@ -254,8 +299,8 @@ impl DeleteGroupRecord for Group {
     async fn delete_group_record_without_events(&self, pool: &DbPool) -> Result<usize, ApiError> {
         use crate::schema::groups::dsl::{groups, id};
 
-        with_connection(pool, async |conn| -> Result<usize, ApiError> {
-            ensure_group_allows_local_write(conn, self.id).await?;
+        with_transaction(pool, async |conn| -> Result<usize, ApiError> {
+            lock_group_for_delete(conn, self.id).await?;
             Ok(diesel::delete(groups.filter(id.eq(self.id)))
                 .execute(conn)
                 .await?)
@@ -275,12 +320,7 @@ impl DeleteGroupRecord for Group {
         use crate::schema::groups::dsl::{groups, id};
 
         with_transaction(pool, async |conn| -> Result<usize, ApiError> {
-            let before = groups
-                .filter(id.eq(self.id))
-                .for_update()
-                .first::<Group>(conn)
-                .await?;
-            ensure_group_allows_local_write(conn, before.id).await?;
+            let before = lock_group_for_delete(conn, self.id).await?;
             let deleted = diesel::delete(groups.filter(id.eq(self.id)))
                 .execute(conn)
                 .await?;

--- a/tests/api_identity_suite/service_accounts.rs
+++ b/tests/api_identity_suite/service_accounts.rs
@@ -12,8 +12,11 @@
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use crate::db::prelude::*;
     use actix_web::{App, http::StatusCode, test, web};
+    use diesel::sql_types::{Bool, Integer};
     use rstest::rstest;
 
     use crate::api;
@@ -24,12 +27,12 @@ mod tests {
         DisableServiceAccount, SaveServiceAccount, cancel_pending_tasks_for_principal,
     };
     use crate::db::traits::task::scope_snapshot_json;
-    use crate::db::with_connection;
+    use crate::db::{DbPool, with_connection, with_transaction};
     use crate::errors::ApiError;
     use crate::events::{Action, EntityType};
     use crate::models::Collection;
     use crate::models::collection::user_can_on_any;
-    use crate::models::principal::load_principal_by_id;
+    use crate::models::principal::{PrincipalKind, load_principal_by_id};
     use crate::models::token::{Token, create_principal_token, create_principal_token_with_scope};
     use crate::models::user::{LoginUser, NewUser};
     use crate::models::{
@@ -87,6 +90,42 @@ mod tests {
             .await
             .unwrap();
         (classes, objects, sa)
+    }
+
+    #[derive(QueryableByName)]
+    struct BackendPid {
+        #[diesel(sql_type = Integer)]
+        pid: i32,
+    }
+
+    #[derive(QueryableByName)]
+    struct WaitingTransaction {
+        #[diesel(sql_type = Bool)]
+        waiting: bool,
+    }
+
+    async fn wait_for_transaction_blocked_by(pool: &DbPool, blocker_pid: i32) {
+        for _ in 0..100 {
+            let waiting = with_connection(pool, async |conn| {
+                diesel::sql_query(
+                    "SELECT EXISTS (\
+                        SELECT 1 FROM pg_stat_activity AS activity \
+                        WHERE $1 = ANY(pg_blocking_pids(activity.pid))\
+                    ) AS waiting",
+                )
+                .bind::<Integer, _>(blocker_pid)
+                .get_result::<WaitingTransaction>(conn)
+                .await
+            })
+            .await
+            .unwrap()
+            .waiting;
+            if waiting {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("group deletion did not wait for the service-account transaction");
     }
 
     // ----- Batch 1: identity / subtype invariants -----
@@ -2167,6 +2206,101 @@ mod tests {
         .await;
 
         assert_eq!(resp.status(), expected);
+    }
+
+    #[actix_web::test]
+    async fn test_group_delete_rechecks_owners_after_waiting_for_concurrent_creation() {
+        let context = TestContext::new().await;
+        let pool = &context.pool;
+        let group = create_test_group(pool).await;
+        let service_account_name = context.scoped_name("concurrent_group_owner");
+        let (inserted_tx, inserted_rx) = tokio::sync::oneshot::channel();
+        let (commit_tx, commit_rx) = tokio::sync::oneshot::channel();
+        let insert_pool = context.pool.clone();
+        let identity_scope_id = group.identity_scope_id;
+        let owner_group_id = group.id;
+
+        let insert_task = actix_web::rt::spawn(async move {
+            with_transaction(&insert_pool, async move |conn| -> Result<(), ApiError> {
+                use crate::schema::{principals, service_accounts};
+
+                let pid = diesel::sql_query("SELECT pg_backend_pid() AS pid")
+                    .get_result::<BackendPid>(conn)
+                    .await?
+                    .pid;
+                let principal_id = diesel::insert_into(principals::table)
+                    .values((
+                        principals::identity_scope_id.eq(identity_scope_id),
+                        principals::kind.eq(PrincipalKind::ServiceAccount.as_str()),
+                        principals::name.eq(&service_account_name),
+                    ))
+                    .returning(principals::id)
+                    .get_result::<i32>(conn)
+                    .await?;
+                diesel::insert_into(service_accounts::table)
+                    .values((
+                        service_accounts::id.eq(principal_id),
+                        service_accounts::description.eq(""),
+                        service_accounts::owner_group_id.eq(owner_group_id),
+                    ))
+                    .execute(conn)
+                    .await?;
+                inserted_tx
+                    .send(pid)
+                    .expect("group delete test should still be waiting for the insert");
+                commit_rx
+                    .await
+                    .expect("group delete test should release the insert transaction");
+                Ok(())
+            })
+            .await
+        });
+
+        let blocker_pid = inserted_rx
+            .await
+            .expect("service-account transaction ended before inserting");
+        let delete_pool = context.pool.clone();
+        let admin_token = context.admin_token.clone();
+        let endpoint = format!("{IAM_GROUPS_ENDPOINT}/{}", group.id);
+        let delete_task = actix_web::rt::spawn(async move {
+            delete_request(&delete_pool, &admin_token, &endpoint).await
+        });
+
+        wait_for_transaction_blocked_by(pool, blocker_pid).await;
+        commit_tx
+            .send(())
+            .expect("service-account transaction should still be waiting");
+        insert_task
+            .await
+            .expect("service-account insert task should complete")
+            .expect("service-account insert should commit");
+        let response = delete_task
+            .await
+            .expect("group deletion request should complete");
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[actix_web::test]
+    async fn test_group_delete_conflict_caps_service_account_preview() {
+        let context = TestContext::new().await;
+        let group = create_test_group(&context.pool).await;
+        for _ in 0..11 {
+            create_test_service_account(&context.pool, &group, None).await;
+        }
+
+        let response = delete_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("{IAM_GROUPS_ENDPOINT}/{}", group.id),
+        )
+        .await;
+        let response = assert_response_status(response, StatusCode::CONFLICT).await;
+        let error: serde_json::Value = test::read_body_json(response).await;
+        let message = error["message"].as_str().unwrap_or_default();
+
+        assert_eq!(message.matches("(id ").count(), 10);
+        assert!(message.ends_with("; additional service accounts omitted"));
     }
 
     // ----- Review fixes (round 2) -----


### PR DESCRIPTION
## Summary

- move the service-account ownership check into the group deletion transaction
- acquire the group row lock before evaluating ownership for both eventful and eventless deletion paths
- cap conflict diagnostics at ten service-account identities and indicate when more were omitted
- add deterministic coverage for a concurrent service-account insert racing group deletion

## Why

The endpoint previously queried owned service accounts before starting the deletion transaction. A concurrent service-account creation could remain uncommitted during that preflight check, commit while deletion waited for the group row lock, and then cause the `ON DELETE RESTRICT` foreign key to fail. The generic foreign-key mapping surfaced that race as a misleading `404 Not Found` even though the endpoint documents `409 Conflict` for ownership blockers.

The deletion path now locks the group first and performs the ownership query on the same connection and transaction. PostgreSQL serializes concurrent foreign-key inserts against that row lock, so the query observes any owner that commits before deletion proceeds and returns the stable conflict response.

Bounding the preview also prevents an administrator-facing error response from growing with every service account owned by the group.

## Compatibility

This does not change endpoint shapes or successful deletion behavior. Existing conflicts keep the same message prefix and status; groups with more than ten owned service accounts now receive a bounded preview with an omission marker. No OpenAPI regeneration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- targeted group-deletion integration tests, including PostgreSQL lock-wait detection