### PR TITLE
Sync event archives before purging rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - OpenSSL TLS startup now rejects a certificate and private key that do not
   match instead of binding a server that cannot complete TLS handshakes.
+- Event-retention file archives are now durably synchronized before the
+  database transaction deletes the archived events.
 - Single-host rolling updates now wait for Caddy's passive upstream failure
   marks to clear between replica replacements, preserving continuous routing
   without reprovisioning an unchanged proxy configuration.

--- a/docs/events.md
+++ b/docs/events.md
@@ -484,6 +484,6 @@ HUBUUM_EVENT_RETENTION_ARCHIVE_PATH=/var/lib/hubuum/event-archive.jsonl
 ```
 
 Each archive line contains `archived_at` and the full event row. If archive
-writing fails, the worker does not delete that batch. On Unix, newly created
-archive files are created with mode `0600`; existing file permissions are not
-changed.
+writing or durable file synchronization fails, the worker does not delete that
+batch. On Unix, newly created archive files are created with mode `0600`;
+existing file permissions are not changed.

--- a/src/events/retention.rs
+++ b/src/events/retention.rs
@@ -1,5 +1,5 @@
-use std::fs::OpenOptions;
-use std::io::Write;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
@@ -41,6 +41,16 @@ struct EventRetentionWorkerConfig {
 struct ArchivedEventRecord<'a> {
     archived_at: chrono::NaiveDateTime,
     event: &'a Event,
+}
+
+trait EventArchiveOutput: Write {
+    fn sync_all(&self) -> io::Result<()>;
+}
+
+impl EventArchiveOutput for File {
+    fn sync_all(&self) -> io::Result<()> {
+        File::sync_all(self)
+    }
 }
 
 fn configured_event_retention_worker() -> EventRetentionWorkerConfig {
@@ -178,9 +188,17 @@ fn append_event_archive(path: &Path, events: &[Event]) -> Result<(), ApiError> {
         ApiError::InternalServerError(format!("Failed to open event archive: {error}"))
     })?;
 
+    write_event_archive(&mut file, archived_at, events)
+}
+
+fn write_event_archive(
+    file: &mut impl EventArchiveOutput,
+    archived_at: chrono::NaiveDateTime,
+    events: &[Event],
+) -> Result<(), ApiError> {
     for event in events {
         let record = ArchivedEventRecord { archived_at, event };
-        serde_json::to_writer(&mut file, &record).map_err(|error| {
+        serde_json::to_writer(&mut *file, &record).map_err(|error| {
             ApiError::InternalServerError(format!("Failed to serialize event archive: {error}"))
         })?;
         file.write_all(b"\n").map_err(|error| {
@@ -190,6 +208,9 @@ fn append_event_archive(path: &Path, events: &[Event]) -> Result<(), ApiError> {
 
     file.flush().map_err(|error| {
         ApiError::InternalServerError(format!("Failed to flush event archive: {error}"))
+    })?;
+    file.sync_all().map_err(|error| {
+        ApiError::InternalServerError(format!("Failed to sync event archive: {error}"))
     })
 }
 
@@ -203,9 +224,37 @@ impl EventRetentionWorkerConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use uuid::Uuid;
 
     use super::*;
+
+    #[derive(Default)]
+    struct ArchiveOutputSpy {
+        bytes: Vec<u8>,
+        sync_called: Cell<bool>,
+        sync_error: Option<io::ErrorKind>,
+    }
+
+    impl Write for ArchiveOutputSpy {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.bytes.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl EventArchiveOutput for ArchiveOutputSpy {
+        fn sync_all(&self) -> io::Result<()> {
+            self.sync_called.set(true);
+            self.sync_error
+                .map_or(Ok(()), |kind| Err(io::Error::from(kind)))
+        }
+    }
 
     fn event() -> Event {
         Event {
@@ -267,5 +316,31 @@ mod tests {
         assert!(archived.contains("\"event\""));
         assert!(archived.contains("\"entity_type\":\"collection\""));
         std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn event_archive_is_synced_after_writing() {
+        let mut output = ArchiveOutputSpy::default();
+
+        write_event_archive(&mut output, chrono::Utc::now().naive_utc(), &[event()]).unwrap();
+
+        assert!(output.sync_called.get());
+        assert_eq!(output.bytes.last(), Some(&b'\n'));
+    }
+
+    #[test]
+    fn event_archive_sync_failure_is_returned() {
+        let mut output = ArchiveOutputSpy {
+            sync_error: Some(io::ErrorKind::Other),
+            ..ArchiveOutputSpy::default()
+        };
+
+        let result = write_event_archive(&mut output, chrono::Utc::now().naive_utc(), &[event()]);
+
+        assert!(matches!(
+            result,
+            Err(ApiError::InternalServerError(message))
+                if message.starts_with("Failed to sync event archive:")
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- call `File::sync_all` after writing each non-empty event-retention archive batch and before its database transaction may delete the archived rows
- propagate synchronization failures through the existing retention error path so PostgreSQL keeps the batch
- document the stronger archive failure guarantee and add an `[Unreleased]` changelog entry
- cover both the successful sync call and the sync-error path with focused tests

## Rationale

The archive path previously ended with `File::flush`. For an unbuffered file, that does not request durable filesystem storage, so the PostgreSQL transaction could commit its destructive purge while the only archive copy was still in volatile kernel buffers. A host or storage failure in that window could lose audit records even though archival was enabled.

The sync remains inside the same transaction-scoped retention operation. If it fails, `process_event_retention_batch` returns an error and the selected events are not deleted.

## Behavior and compatibility

This does not change the API, configuration, archive format, or existing-file permission policy. File archival now pays one durable sync per non-empty retention batch. Storage that cannot complete that sync causes the worker to retain the rows and retry later instead of treating the archive as successful.

The existing at-least-once boundary between filesystem archival and the PostgreSQL commit is unchanged: a later database commit failure can still cause a safely duplicated archive record on retry.

## Changelog

Added a user-visible `[Unreleased] / Fixed` entry for the stronger retention archive durability guarantee.

## Verification

- `cargo test events::retention::tests -- --nocapture`
- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`

No OpenAPI regeneration or production container build is required because this changes neither endpoint schemas nor container build inputs.