### PR TITLE
Sync Unix backup directory replacements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Group deletion now checks service-account ownership while holding the group
   row lock, so concurrent account creation returns a stable `409 Conflict`;
   conflict diagnostics also cap the number of account names they include.
+- Unix admin CLI backups now synchronize the destination directory after
+  atomically replacing the output file.
 - Single-host rolling updates now wait for Caddy's passive upstream failure
   marks to clear between replica replacements, preserving continuous routing
   without reprovisioning an unchanged proxy configuration.

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -134,6 +134,10 @@ Create a full backup:
 hubuum-admin --database-url "$HUBUUM_DATABASE_URL" --backup backup.json
 ```
 
+The CLI writes an owner-only temporary file, synchronizes it, and atomically
+replaces the destination. On Unix, it also synchronizes the destination
+directory before reporting success.
+
 History is included by default. Add `--backup-without-history` only to create a
 backup whose eventual restore resets terminal task, audit, delivery, and
 temporal history.

--- a/src/bin/admin.rs
+++ b/src/bin/admin.rs
@@ -205,11 +205,14 @@ fn write_backup_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     Ok(())
 }
 
-fn create_backup_temporary_file(path: &Path) -> std::io::Result<(PathBuf, File)> {
-    let parent = path
-        .parent()
+fn backup_parent_directory(path: &Path) -> &Path {
+    path.parent()
         .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn create_backup_temporary_file(path: &Path) -> std::io::Result<(PathBuf, File)> {
+    let parent = backup_parent_directory(path);
     let file_name = path.file_name().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -290,7 +293,8 @@ fn secure_backup_temporary_file(_path: &Path, _file: &File) -> std::io::Result<(
 
 #[cfg(unix)]
 fn replace_backup_file(temporary_path: &Path, path: &Path) -> std::io::Result<()> {
-    std::fs::rename(temporary_path, path)
+    std::fs::rename(temporary_path, path)?;
+    File::open(backup_parent_directory(path))?.sync_all()
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
## Summary

- resolve the backup destination's parent directory through one shared helper
- on Unix, synchronize that directory after atomically renaming the fully synced temporary backup into place
- document the CLI's write/sync/replace guarantee and add an `[Unreleased]` changelog entry

## Rationale

The admin CLI already writes backups to an owner-only temporary file in the destination directory, calls `File::sync_all`, and atomically renames the temporary file over the target. On Unix, however, syncing the file does not make the directory-entry replacement durable. The command could report success before the new filename mapping reached stable storage, leaving a crash window after an otherwise successful backup.

Windows already uses `MoveFileExW` with `MOVEFILE_WRITE_THROUGH`. This change gives the Unix path the corresponding post-rename durability step.

## Behavior and compatibility

There are no API, schema, configuration, backup-format, or permission changes. Unix backup commands now report success only after both the backup file and its destination directory have synchronized successfully.

If the directory sync fails after the atomic rename, the command reports an error because it cannot confirm durability; it leaves the newly written target in place rather than deleting a potentially valid backup.

## Changelog

Added a user-visible `[Unreleased] / Fixed` entry for durable Unix backup replacement.

## Verification

- `source .env && ./run_tests.sh` (including `backup_files_are_owner_only_and_atomically_replaced`)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`

No OpenAPI regeneration or production container build is required because this changes neither endpoint schemas nor container build inputs.