### PR TITLE
Prepare v0.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.0.4] - 2026-07-25
+
 ### Added
 
 - Token-list responses now include each visible token's exact permission and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "brotli",
  "bytes",
@@ -178,7 +178,7 @@ dependencies = [
  "foldhash",
  "futures-core",
  "futures-util",
- "impl-more 0.3.1",
+ "impl-more 0.3.5",
  "itoa",
  "language-tags",
  "log",
@@ -563,7 +563,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -615,6 +615,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "base64ct"
@@ -803,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -889,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -911,14 +917,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1438,9 +1444,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "email-encoding"
@@ -1448,7 +1454,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "memchr",
 ]
 
@@ -1798,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
@@ -2012,7 +2018,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hubuum"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -2020,7 +2026,7 @@ dependencies = [
  "actix-web",
  "argon2",
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "clap",
@@ -2060,7 +2066,7 @@ dependencies = [
  "rand",
  "redis",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "rstest",
  "rustls",
  "rustls-platform-verifier",
@@ -2071,7 +2077,7 @@ dependencies = [
  "tokio-postgres",
  "tokio-postgres-rustls",
  "tokio-rustls",
- "toml",
+ "toml 1.1.3+spec-1.1.0",
  "tracing",
  "tracing-serde",
  "tracing-subscriber",
@@ -2162,7 +2168,7 @@ dependencies = [
 name = "hubuum-event-sink-webhook"
 version = "0.0.1"
 dependencies = [
- "base64",
+ "base64 0.23.0",
  "chrono",
  "futures",
  "hubuum-event-sinks-common",
@@ -2203,7 +2209,7 @@ name = "hubuum-outbound-http"
 version = "0.0.1"
 dependencies = [
  "ipnet",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "tokio",
 ]
@@ -2274,7 +2280,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2283,7 +2288,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2477,9 +2482,9 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "impl-more"
-version = "0.3.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a84fd5aa25fae5c0f4a33d9cac2ca017fc622cbd089be2229993514990f870"
+checksum = "277ff51754a3f68f12f58446c5d006aa8baa4914ea273cce24a599cfaff33d4f"
 
 [[package]]
 name = "indexmap"
@@ -2641,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d785c0683d1027839f1ac6a43b6d07c63d58ecd363d8146dda4531d53465a1"
+checksum = "f05a6cff806294a7699d48761d4ae2bdebab7fa2eef05e4a0b83320f0ff46901"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2655,6 +2660,7 @@ dependencies = [
  "idna",
  "itoa",
  "jsonschema-regex",
+ "jsonschema-value",
  "num-cmp",
  "num-traits",
  "percent-encoding",
@@ -2669,11 +2675,25 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917b3be16b2662538aafb55201790561e1f1ad1a0454baf42f33bd9de343778b"
+checksum = "84708dd3f6c5327478a96f37378adb27deed6a626cf84d19de780d9e8ae84b17"
 dependencies = [
  "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8c04ab4ce60e42c4e302d3bd9d184652bb56f212495d2eea23573bcbf72556"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
 ]
 
 [[package]]
@@ -2748,7 +2768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -2771,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.187"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -2887,7 +2907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c791ecdf977c99f45f23280405d7723727470f6689a5e6dbf513ac547ae10d"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -3241,7 +3261,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb9bf5222606eb712d3bb30e01bc9420545b00859970897e70c682353a034f2"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "cbc",
  "cms",
  "der",
@@ -3455,7 +3475,7 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -3795,14 +3815,14 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "referencing"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2b21a85c07fcf1cb95ff7ab8a687fcd37fa70db59975b5a032abdaadfdf42e"
+checksum = "980e77f5cfffc592c0e7dfb6d20770a0b96a6ab94d403de7454ed9799505e4ba"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -3858,49 +3878,11 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http 1.4.2",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http 1.4.2",
@@ -4084,9 +4066,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4253,7 +4235,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4501,9 +4483,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4607,7 +4589,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4772,13 +4754,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres-rustls"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
+checksum = "4c2ad44aa0ae96db89c4742212ed41645b2f597311ff6e1945542a4d9fadc2fb"
 dependencies = [
- "const-oid 0.9.6",
- "ring",
  "rustls",
+ "sha2 0.11.0",
  "tokio",
  "tokio-postgres",
  "tokio-rustls",
@@ -4797,9 +4778,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4808,13 +4789,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4825,13 +4807,26 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5005,7 +5000,7 @@ name = "treetop-client"
 version = "0.0.1"
 source = "git+https://github.com/terjekv/treetop-client#5a1d176df790216983127b18af70f6ac6a91ce28"
 dependencies = [
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -5144,7 +5139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
  "actix-web",
- "base64",
+ "base64 0.22.1",
  "mime_guess",
  "regex",
  "rust-embed",
@@ -5613,9 +5608,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hubuum"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 description = "Flexible asset management REST service."
 license = "MIT"
@@ -38,7 +38,7 @@ actix-http = { version = "3" }
 argon2 = "0.6.0-rc.8"
 async-trait = "0.1"
 bytes = "1"
-base64 = "0.22"
+base64 = "0.23"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["env", "derive"] }
 diesel = { version = "2", features = [
@@ -57,7 +57,7 @@ futures-util = "0.3"
 jsonschema = { version = "0", default-features = false }
 json-patch = { version = "4.2", default-features = false, features = ["utoipa"] }
 rand = "0.10"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 redis = { version = "1.3.0", default-features = false, features = ["connection-manager", "tokio-rustls-comp"], optional = true }
 rustls-platform-verifier = "0.7"
 serde = { version = "1", features = ["derive"] }
@@ -83,7 +83,7 @@ opentelemetry-prometheus = "0.32"
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["metrics"] }
 tokio = { version = "1", features = ["sync", "macros", "rt-multi-thread", "net", "io-util", "signal"] }
 tokio-postgres = "0.7"
-tokio-postgres-rustls = "0.13"
+tokio-postgres-rustls = "0.14"
 tracing = "0.1"
 tracing-serde = "0"
 tracing-subscriber = { version = "0.3", features = [
@@ -106,7 +106,7 @@ lru = "0.18.0"
 # treetop-client is currently consumed from git at version 0.0.1. Cargo.lock
 # pins the exact revision; bump explicitly when the upstream API stabilizes.
 treetop-client = { git = "https://github.com/terjekv/treetop-client", optional = true }
-toml = "0.9"
+toml = "1.1"
 
 [dev-dependencies]
 criterion = "0.8.2"

--- a/crates/hubuum-event-sink-webhook/Cargo.toml
+++ b/crates/hubuum-event-sink-webhook/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1"
 tracing = "0.1"
 
 [dev-dependencies]
-base64 = "0.22"
+base64 = "0.23"
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "sync"] }
 tokio-rustls = "0.26"

--- a/crates/hubuum-outbound-http/Cargo.toml
+++ b/crates/hubuum-outbound-http/Cargo.toml
@@ -8,6 +8,6 @@ repository = "https://github.com/hubuum/hubuum"
 
 [dependencies]
 ipnet = "2.12"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 serde_json = "1"
 tokio = { version = "1", features = ["net"] }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.0.3"
+    "version": "0.0.4"
   },
   "servers": [
     {

--- a/src/models/unified_search.rs
+++ b/src/models/unified_search.rs
@@ -1,4 +1,5 @@
 use crate::models::token_scope::TokenScope;
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::str::FromStr;
 
@@ -212,19 +213,19 @@ fn parse_required_query(value: &str) -> Result<String, ApiError> {
 }
 
 impl UnifiedSearchQueryParts {
-    fn apply(&mut self, key: &str, value: String) -> Result<(), ApiError> {
+    fn apply(&mut self, key: &str, value: Cow<'_, str>) -> Result<(), ApiError> {
         match key {
             "q" => {
                 reject_duplicate(&self.query, "q")?;
-                self.query = Some(parse_required_query(&value)?);
+                self.query = Some(parse_required_query(value.as_ref())?);
             }
             "kinds" => {
                 reject_duplicate(&self.kinds, "kinds")?;
-                self.kinds = Some(parse_kinds(&value)?);
+                self.kinds = Some(parse_kinds(value.as_ref())?);
             }
             "limit_per_kind" => {
                 reject_duplicate(&self.limit_per_kind, "limit_per_kind")?;
-                let parsed_limit = value.parse::<usize>().map_err(|error| {
+                let parsed_limit = value.as_ref().parse::<usize>().map_err(|error| {
                     ApiError::BadRequest(format!("bad limit_per_kind: {error}"))
                 })?;
                 // Validation against the max limit is deferred to `build`, which
@@ -233,23 +234,23 @@ impl UnifiedSearchQueryParts {
             }
             "search_class_schema" => {
                 reject_duplicate(&self.search_class_schema, "search_class_schema")?;
-                self.search_class_schema = Some(value.as_boolean()?);
+                self.search_class_schema = Some(value.as_ref().as_boolean()?);
             }
             "search_object_data" => {
                 reject_duplicate(&self.search_object_data, "search_object_data")?;
-                self.search_object_data = Some(value.as_boolean()?);
+                self.search_object_data = Some(value.as_ref().as_boolean()?);
             }
             "cursor_collections" => {
                 reject_duplicate(&self.collection_cursor, "cursor_collections")?;
-                self.collection_cursor = Some(decode_cursor(&value)?);
+                self.collection_cursor = Some(decode_cursor(value.as_ref())?);
             }
             "cursor_classes" => {
                 reject_duplicate(&self.class_cursor, "cursor_classes")?;
-                self.class_cursor = Some(decode_cursor(&value)?);
+                self.class_cursor = Some(decode_cursor(value.as_ref())?);
             }
             "cursor_objects" => {
                 reject_duplicate(&self.object_cursor, "cursor_objects")?;
-                self.object_cursor = Some(decode_cursor(&value)?);
+                self.object_cursor = Some(decode_cursor(value.as_ref())?);
             }
             _ => {
                 return Err(ApiError::BadRequest(format!(
@@ -296,7 +297,7 @@ pub fn parse_unified_search_query_with_limits(
     if !qs.is_empty() {
         for chunk in qs.split('&') {
             let (key, value) = hubuum_query::decode_query_parameter_pair(chunk)?;
-            parts.apply(key.as_ref(), value.into_owned())?;
+            parts.apply(key.as_ref(), value)?;
         }
     }
 
@@ -346,7 +347,8 @@ pub fn decode_cursor(cursor: &str) -> Result<UnifiedSearchCursorToken, ApiError>
             .try_into()
             .expect("validated unified-search cursor header"),
     );
-    let name = String::from_utf8(bytes.split_off(9))
+    bytes.drain(..9);
+    let name = String::from_utf8(bytes)
         .map_err(|error| ApiError::BadRequest(format!("Invalid search cursor: {error}")))?;
     Ok(UnifiedSearchCursorToken { rank, name, id })
 }


### PR DESCRIPTION
## Summary

Prepare Hubuum v0.0.4 by bumping the package and generated OpenAPI versions, rolling the complete Unreleased changelog into the dated v0.0.4 section, and refreshing the full Cargo dependency graph. The release branch is rebased onto squash-merged PR #173 so its unified token-scope API is included.

The dependency refresh includes all updates permitted by the existing manifests plus the remaining direct major-version upgrades: base64 0.23, reqwest 0.13, tokio-postgres-rustls 0.14, and toml 1.1. No direct workspace dependency remains outdated. The sole newer transitive release reported by Cargo, generic-array 0.14.9, cannot be selected because crypto-common 0.1.7 pins 0.14.7 exactly.

## Release scope

This release adds durable root-task provenance throughout audit history, subscriptions, backups, archives, and event sinks; unified token-scope requests and metadata; hierarchical collection/class/object scopes for human and service-account bearer tokens; and multi-measure numeric object aggregation.

It also ships stronger history authorization, safer remote-target headers, bounded async idempotency keys and integer-list expansion, OpenSSL certificate/key validation, durable archive and backup synchronization, atomic group deletion conflicts, coordinated event retention, and safer zero-downtime single-host rollouts.

## Breaking changes and upgrade actions

- Token-mint clients must replace top-level `scopes` and `resource_scopes` with `scope.permissions` and `scope.resources`. Token metadata consumers must replace the flat scope fields with `scope` and replace checks of `scoped` with `scope != null`. Legacy flat mint fields are rejected with `400`.
- Rust token integrations must use `TokenScopeDetails`, typed `TokenID` and `PrincipalID` values, `TokenScope::resources()`, and `PrincipalTokenCreateRequest`. The long-positional token creation helpers are removed, token revocation requires typed IDs, and synchronous `PrincipalTokenMetadata` conversion must be replaced with `PrincipalTokenMetadata::load_for_tokens(&backend, &[token]).await?`.
- Before applying the task-provenance migration, stop old worker replicas and let their bounded graceful shutdown finish or fail active tasks. Old API-only replicas may remain online. The single-host updater performs the required primary drain automatically when its standby is available.
- Rust callers of `DatabaseUrlComponents` must parse through `FromStr` and use its accessors instead of `DatabaseUrlComponents::new` or public representation fields.
- Rust callers of pagination helpers must use `PageLimits` and its `default_limit`, `maximum_limit`, `resolve`, and `clamp` methods instead of `(usize, usize)` tuples.
- Export clients must send positive `class_id` and `object_id` scope values. Rust integrations must retain the `ValidatedExportScope` returned by `ExportScope::validate`; the old raw required-ID helpers are removed.
- History consumers must account for historically reauthorized, potentially partial result sets and grant access to the historical collections they need. Deleted-history principals must be unscoped administrators in the configured permission backend.
- Remote targets must remove routing, framing, connection-specific, and proxy-authentication headers and let Hubuum derive them from the target URL and body.
- Async clients must use non-empty `Idempotency-Key` values no longer than 255 bytes.

## Verification

- `cargo outdated --workspace --root-deps-only --format json`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `source .env && ./run_tests.sh`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `./scripts/check-version-bump.sh`
- `./scripts/check-release-readiness.sh v0.0.4`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`