### PR TITLE
Fix LDAP identity refresh lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Changed
 
 - **Breaking (Rust API):** `ExternalIdentityProvider::refresh_user` now accepts
-  an `ExternalUserRefreshRequest` containing the current username and expected
-  stable subject. Provider implementations must locate the user by username
-  and reject a result whose subject does not match.
+  an `ExternalUserRefreshRequest` containing validated current-username and
+  expected-subject values. Provider implementations must locate the user by
+  username and reject a result whose subject does not match.
 - Newly issued tokens now materialize an explicit expiry when the request omits
   one, so later configuration changes cannot alter their lifetime. Login and
   token-mint responses now return that authoritative `expires_at` alongside the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Breaking (Rust API):** `ExternalIdentityProvider::refresh_user` now accepts
+  an `ExternalUserRefreshRequest` containing the current username and expected
+  stable subject. Provider implementations must locate the user by username
+  and reject a result whose subject does not match.
 - Newly issued tokens now materialize an explicit expiry when the request omits
   one, so later configuration changes cannot alter their lifetime. Login and
   token-mint responses now return that authoritative `expires_at` alongside the
@@ -31,6 +35,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   permission and resource boundary against live grants; stored-template exports
   require `ReadTemplate`, and identity, template, and integration imports remain
   restricted to unscoped administrators.
+- LDAP identity refresh now reuses the configured username lookup and verifies
+  the returned stable subject, avoiding directory-wide subject searches that
+  can exceed provider administrative limits. Provider errors are also logged
+  when cached memberships have exceeded the maximum stale window.
 
 ## [0.0.4] - 2026-07-25
 

--- a/crates/hubuum-auth-core/src/lib.rs
+++ b/crates/hubuum-auth-core/src/lib.rs
@@ -55,26 +55,71 @@ pub struct AuthenticatedExternalUser {
     pub groups: Vec<ExternalGroup>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ExternalUsername(String);
+
+impl ExternalUsername {
+    fn new(value: impl Into<String>) -> Result<Self, ExternalIdentityValueError> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(ExternalIdentityValueError::EmptyUsername);
+        }
+        Ok(Self(value))
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ExternalSubject(String);
+
+impl ExternalSubject {
+    fn new(value: impl Into<String>) -> Result<Self, ExternalIdentityValueError> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(ExternalIdentityValueError::EmptySubject);
+        }
+        Ok(Self(value))
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+pub enum ExternalIdentityValueError {
+    #[error("external username must not be empty")]
+    EmptyUsername,
+    #[error("external subject must not be empty")]
+    EmptySubject,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExternalUserRefreshRequest {
-    username: String,
-    expected_subject: String,
+    username: ExternalUsername,
+    expected_subject: ExternalSubject,
 }
 
 impl ExternalUserRefreshRequest {
-    pub fn new(username: impl Into<String>, expected_subject: impl Into<String>) -> Self {
-        Self {
-            username: username.into(),
-            expected_subject: expected_subject.into(),
-        }
+    pub fn new(
+        username: impl Into<String>,
+        expected_subject: impl Into<String>,
+    ) -> Result<Self, ExternalIdentityValueError> {
+        Ok(Self {
+            username: ExternalUsername::new(username)?,
+            expected_subject: ExternalSubject::new(expected_subject)?,
+        })
     }
 
     pub fn username(&self) -> &str {
-        &self.username
+        self.username.as_str()
     }
 
     pub fn expected_subject(&self) -> &str {
-        &self.expected_subject
+        self.expected_subject.as_str()
     }
 }
 
@@ -103,4 +148,31 @@ pub trait ExternalIdentityProvider: Send + Sync {
         &self,
         request: &ExternalUserRefreshRequest,
     ) -> Result<AuthenticatedExternalUser, AuthProviderError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refresh_request_rejects_an_empty_username() {
+        let error = ExternalUserRefreshRequest::new("", "stable-subject").unwrap_err();
+
+        assert_eq!(error, ExternalIdentityValueError::EmptyUsername);
+    }
+
+    #[test]
+    fn refresh_request_rejects_an_empty_subject() {
+        let error = ExternalUserRefreshRequest::new("alice", "").unwrap_err();
+
+        assert_eq!(error, ExternalIdentityValueError::EmptySubject);
+    }
+
+    #[test]
+    fn refresh_request_exposes_validated_identity_values() {
+        let request = ExternalUserRefreshRequest::new("alice", "stable-subject").unwrap();
+
+        assert_eq!(request.username(), "alice");
+        assert_eq!(request.expected_subject(), "stable-subject");
+    }
 }

--- a/crates/hubuum-auth-core/src/lib.rs
+++ b/crates/hubuum-auth-core/src/lib.rs
@@ -55,6 +55,29 @@ pub struct AuthenticatedExternalUser {
     pub groups: Vec<ExternalGroup>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalUserRefreshRequest {
+    username: String,
+    expected_subject: String,
+}
+
+impl ExternalUserRefreshRequest {
+    pub fn new(username: impl Into<String>, expected_subject: impl Into<String>) -> Self {
+        Self {
+            username: username.into(),
+            expected_subject: expected_subject.into(),
+        }
+    }
+
+    pub fn username(&self) -> &str {
+        &self.username
+    }
+
+    pub fn expected_subject(&self) -> &str {
+        &self.expected_subject
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum AuthProviderError {
     #[error("authentication failed")]
@@ -78,6 +101,6 @@ pub trait ExternalIdentityProvider: Send + Sync {
 
     async fn refresh_user(
         &self,
-        subject: &str,
+        request: &ExternalUserRefreshRequest,
     ) -> Result<AuthenticatedExternalUser, AuthProviderError>;
 }

--- a/crates/hubuum-auth-ldap/src/lib.rs
+++ b/crates/hubuum-auth-ldap/src/lib.rs
@@ -2,7 +2,7 @@
 
 use hubuum_auth_core::{
     AuthProviderError, AuthenticatedExternalUser, ExternalGroup, ExternalIdentityProvider,
-    ExternalUserProfile, IdentityScopeName,
+    ExternalUserProfile, ExternalUserRefreshRequest, IdentityScopeName,
 };
 use ldap3::{LdapConnAsync, LdapConnSettings, Scope, SearchEntry};
 use regex::Regex;
@@ -208,6 +208,10 @@ impl LdapIdentityProvider {
             .replace("{username}", &escape_filter_value(username))
     }
 
+    fn refresh_filter(&self, request: &ExternalUserRefreshRequest) -> String {
+        self.user_filter(request.username())
+    }
+
     fn search_attributes(&self) -> Vec<String> {
         let mut attrs = BTreeSet::new();
         attrs.insert(self.config.username_attribute.clone());
@@ -342,6 +346,24 @@ impl LdapIdentityProvider {
         groups.into_values().collect()
     }
 
+    fn refreshed_user_from_entry(
+        &self,
+        request: &ExternalUserRefreshRequest,
+        dn: &str,
+        entry: &SearchEntry,
+    ) -> Result<AuthenticatedExternalUser, AuthProviderError> {
+        let profile = self.profile_from_entry(request.username(), dn, entry)?;
+        if profile.subject != request.expected_subject() {
+            return Err(AuthProviderError::Protocol(
+                "ldap refresh returned a different external subject".to_string(),
+            ));
+        }
+        Ok(AuthenticatedExternalUser {
+            profile,
+            groups: self.groups_from_entry(entry),
+        })
+    }
+
     async fn bind_user(&self, dn: &str, password: &str) -> Result<(), AuthProviderError> {
         if password.is_empty() {
             return Err(AuthProviderError::AuthenticationFailed);
@@ -382,42 +404,11 @@ impl ExternalIdentityProvider for LdapIdentityProvider {
 
     async fn refresh_user(
         &self,
-        subject: &str,
+        request: &ExternalUserRefreshRequest,
     ) -> Result<AuthenticatedExternalUser, AuthProviderError> {
-        let filter = if self.subject_is_dn() {
-            "(objectClass=*)".to_string()
-        } else {
-            format!(
-                "({}={})",
-                self.config.subject_attribute,
-                escape_filter_value(subject)
-            )
-        };
-        let (dn, entry) = if self.subject_is_dn() {
-            let mut ldap = self.ldap().await?;
-            self.bind_service(&mut ldap).await?;
-            let attrs = self.search_attributes();
-            let (entries, _) = ldap
-                .with_timeout(self.operation_timeout())
-                .search(subject, Scope::Base, &filter, attrs)
-                .await
-                .map_err(|e| AuthProviderError::Unavailable(e.to_string()))?
-                .success()
-                .map_err(|e| AuthProviderError::Protocol(e.to_string()))?;
-            if entries.len() != 1 {
-                return Err(AuthProviderError::AuthenticationFailed);
-            }
-            let entry = SearchEntry::construct(entries.into_iter().next().unwrap());
-            (entry.dn.clone(), entry)
-        } else {
-            self.load_user_by_filter(&filter).await?
-        };
-        let username = first_attr(&entry, &self.config.username_attribute)
-            .unwrap_or_else(|| subject.to_string());
-        Ok(AuthenticatedExternalUser {
-            profile: self.profile_from_entry(&username, &dn, &entry)?,
-            groups: self.groups_from_entry(&entry),
-        })
+        let filter = self.refresh_filter(request);
+        let (dn, entry) = self.load_user_by_filter(&filter).await?;
+        self.refreshed_user_from_entry(request, &dn, &entry)
     }
 }
 
@@ -590,6 +581,77 @@ mod tests {
         assert_eq!(profile.name, "alice");
         assert_eq!(profile.proper_name.as_deref(), Some("Alice Example"));
         assert_eq!(profile.email.as_deref(), Some("alice@example.org"));
+    }
+
+    #[test]
+    fn refresh_filter_uses_username_instead_of_stable_subject() {
+        let provider = LdapIdentityProvider::new(LdapScopeConfig {
+            subject_attribute: "entryUUID".into(),
+            ..ldap_config("ldaps://localhost")
+        })
+        .unwrap();
+        let request = ExternalUserRefreshRequest::new(
+            "alice*(admin)",
+            "66a9137d-2c10-4cc0-948f-6f589a25f9d9",
+        );
+
+        assert_eq!(
+            provider.refresh_filter(&request),
+            "(uid=alice\\2a\\28admin\\29)"
+        );
+    }
+
+    #[test]
+    fn refreshed_user_must_match_expected_stable_subject() {
+        let provider = LdapIdentityProvider::new(LdapScopeConfig {
+            subject_attribute: "entryUUID".into(),
+            ..ldap_config("ldaps://localhost")
+        })
+        .unwrap();
+        let entry = SearchEntry {
+            dn: "uid=alice,ou=people,dc=example,dc=org".into(),
+            attrs: HashMap::from([
+                ("uid".into(), vec!["alice".into()]),
+                ("entryUUID".into(), vec!["actual-subject".into()]),
+            ]),
+            bin_attrs: HashMap::new(),
+        };
+        let request = ExternalUserRefreshRequest::new("alice", "expected-subject");
+
+        let error = provider
+            .refreshed_user_from_entry(&request, &entry.dn, &entry)
+            .unwrap_err();
+
+        assert!(matches!(error, AuthProviderError::Protocol(_)));
+        assert_eq!(
+            error.to_string(),
+            "provider protocol error: ldap refresh returned a different external subject"
+        );
+    }
+
+    #[test]
+    fn refreshed_user_accepts_matching_stable_subject() {
+        let provider = LdapIdentityProvider::new(LdapScopeConfig {
+            subject_attribute: "entryUUID".into(),
+            ..ldap_config("ldaps://localhost")
+        })
+        .unwrap();
+        let entry = SearchEntry {
+            dn: "uid=alice,ou=people,dc=example,dc=org".into(),
+            attrs: HashMap::from([
+                ("uid".into(), vec!["alice".into()]),
+                ("entryUUID".into(), vec!["stable-subject".into()]),
+            ]),
+            bin_attrs: HashMap::new(),
+        };
+        let request = ExternalUserRefreshRequest::new("alice", "stable-subject");
+
+        let refreshed = provider
+            .refreshed_user_from_entry(&request, &entry.dn, &entry)
+            .unwrap();
+
+        assert_eq!(refreshed.profile.subject, "stable-subject");
+        assert_eq!(refreshed.profile.name, "alice");
     }
 
     #[test]

--- a/crates/hubuum-auth-ldap/src/lib.rs
+++ b/crates/hubuum-auth-ldap/src/lib.rs
@@ -593,7 +593,8 @@ mod tests {
         let request = ExternalUserRefreshRequest::new(
             "alice*(admin)",
             "66a9137d-2c10-4cc0-948f-6f589a25f9d9",
-        );
+        )
+        .unwrap();
 
         assert_eq!(
             provider.refresh_filter(&request),
@@ -616,7 +617,7 @@ mod tests {
             ]),
             bin_attrs: HashMap::new(),
         };
-        let request = ExternalUserRefreshRequest::new("alice", "expected-subject");
+        let request = ExternalUserRefreshRequest::new("alice", "expected-subject").unwrap();
 
         let error = provider
             .refreshed_user_from_entry(&request, &entry.dn, &entry)
@@ -644,7 +645,7 @@ mod tests {
             ]),
             bin_attrs: HashMap::new(),
         };
-        let request = ExternalUserRefreshRequest::new("alice", "stable-subject");
+        let request = ExternalUserRefreshRequest::new("alice", "stable-subject").unwrap();
 
         let refreshed = provider
             .refreshed_user_from_entry(&request, &entry.dn, &entry)

--- a/docs/external_auth.md
+++ b/docs/external_auth.md
@@ -112,12 +112,16 @@ Local users can omit `identity_scope` or use `local`.
 
 The response is the normal bearer token response. Token validation may refresh
 provider-managed group membership when the cached sync is older than the scope
-TTL. If refresh fails, cached membership remains usable only inside the
-configured max-stale window. Further requests back off for the scope refresh TTL
-before retrying the provider, so one outage does not serialize every request on
-repeated LDAP timeouts. Once the cache exceeds `max_stale_seconds`, requests fail
-with `503 Service Unavailable` during that backoff instead of using stale
-membership.
+TTL. Refresh locates the current directory entry with `user_filter` and the
+materialized principal name, then verifies that the entry's
+`subject_attribute` still matches the stable subject stored at login. The
+subject attribute therefore does not need to support an efficient
+directory-wide search. If refresh fails, cached membership remains usable only
+inside the configured max-stale window. Further requests back off for the scope
+refresh TTL before retrying the provider, so one outage does not serialize
+every request on repeated LDAP timeouts. Once the cache exceeds
+`max_stale_seconds`, requests fail with `503 Service Unavailable` during that
+backoff instead of using stale membership.
 
 ## Users And Groups
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -13,7 +13,7 @@ use tokio::sync::Mutex;
 
 use crate::db::DbPool;
 use crate::db::traits::external_identity::{
-    external_principal_state, mark_external_sync_attempted,
+    ExternalPrincipalState, external_principal_state, mark_external_sync_attempted,
     sync_external_user as sync_external_user_from_backend,
 };
 use crate::db::traits::identity::ensure_identity_scope;
@@ -73,13 +73,12 @@ pub struct ConfiguredLdapScope {
 }
 
 impl ConfiguredLdapScope {
-    pub fn refresh_ttl_seconds(&self) -> i64 {
-        self.refresh_ttl_seconds
-            .unwrap_or(DEFAULT_REFRESH_TTL_SECONDS)
-    }
-
-    pub fn max_stale_seconds(&self) -> i64 {
-        self.max_stale_seconds.unwrap_or(DEFAULT_MAX_STALE_SECONDS)
+    fn refresh_policy(&self) -> Result<RefreshPolicy, ApiError> {
+        RefreshPolicy::new(
+            self.refresh_ttl_seconds
+                .unwrap_or(DEFAULT_REFRESH_TTL_SECONDS),
+            self.max_stale_seconds.unwrap_or(DEFAULT_MAX_STALE_SECONDS),
+        )
     }
 }
 
@@ -120,8 +119,53 @@ struct RegisteredAuthProvider {
 
 #[derive(Clone, Copy)]
 struct RefreshPolicy {
-    refresh_ttl_seconds: i64,
-    max_stale_seconds: i64,
+    refresh_ttl: RefreshTtl,
+    max_stale: MaxStale,
+}
+
+impl RefreshPolicy {
+    fn new(refresh_ttl_seconds: i64, max_stale_seconds: i64) -> Result<Self, ApiError> {
+        Ok(Self {
+            refresh_ttl: RefreshTtl::new(refresh_ttl_seconds)?,
+            max_stale: MaxStale::new(max_stale_seconds)?,
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+struct RefreshTtl(chrono::Duration);
+
+impl RefreshTtl {
+    fn new(seconds: i64) -> Result<Self, ApiError> {
+        if seconds <= 0 {
+            return Err(ApiError::BadRequest(
+                "ldap refresh_ttl_seconds must be positive".to_string(),
+            ));
+        }
+        Ok(Self(chrono::Duration::seconds(seconds)))
+    }
+
+    fn contains(self, elapsed: chrono::Duration) -> bool {
+        elapsed < self.0
+    }
+}
+
+#[derive(Clone, Copy)]
+struct MaxStale(chrono::Duration);
+
+impl MaxStale {
+    fn new(seconds: i64) -> Result<Self, ApiError> {
+        if seconds <= 0 {
+            return Err(ApiError::BadRequest(
+                "ldap max_stale_seconds must be positive".to_string(),
+            ));
+        }
+        Ok(Self(chrono::Duration::seconds(seconds)))
+    }
+
+    fn contains(self, elapsed: chrono::Duration) -> bool {
+        elapsed < self.0
+    }
 }
 
 struct LocalAuthProvider;
@@ -222,28 +266,14 @@ impl LdapAuthProvider {
         configured: ConfiguredLdapScope,
         registry: &mut AuthProviderRegistry,
     ) -> Result<(), ApiError> {
-        let refresh_ttl_seconds = configured.refresh_ttl_seconds();
-        let max_stale_seconds = configured.max_stale_seconds();
-        if refresh_ttl_seconds <= 0 {
-            return Err(ApiError::BadRequest(
-                "ldap refresh_ttl_seconds must be positive".to_string(),
-            ));
-        }
-        if max_stale_seconds <= 0 {
-            return Err(ApiError::BadRequest(
-                "ldap max_stale_seconds must be positive".to_string(),
-            ));
-        }
+        let refresh_policy = configured.refresh_policy()?;
         let scope = configured.ldap.scope.clone();
         let provider = LdapIdentityProvider::new(configured.ldap).map_err(provider_config_error)?;
         registry.register(RegisteredAuthProvider {
             name: scope.clone(),
             kind: LDAP_PROVIDER_KIND.to_string(),
             display_order: 100,
-            refresh_policy: Some(RefreshPolicy {
-                refresh_ttl_seconds,
-                max_stale_seconds,
-            }),
+            refresh_policy: Some(refresh_policy),
             backend: Box::new(Self { scope, provider }),
         })
     }
@@ -272,13 +302,9 @@ impl AuthProviderBackend for LdapAuthProvider {
         state: &'a ExternalUserState,
     ) -> AuthProviderRefreshFuture<'a> {
         Box::pin(async move {
-            let refresh_request = ExternalUserRefreshRequest::new(
-                state.username.clone(),
-                state.external_subject.clone(),
-            );
             let refreshed = self
                 .provider
-                .refresh_user(&refresh_request)
+                .refresh_user(&state.refresh_request)
                 .await
                 .map_err(|error| AuthProviderRefreshError::Provider(provider_error(error)))?;
             sync_external_user_from_backend(pool, &self.scope, LDAP_PROVIDER_KIND, refreshed)
@@ -342,7 +368,7 @@ pub async fn refresh_principal_if_needed(pool: &DbPool, principal_id: i32) -> Re
                                 Ok(()) => {
                                     if within_max_stale(
                                         state.last_sync_success_at,
-                                        state.max_stale_seconds,
+                                        state.refresh_policy.max_stale,
                                     ) {
                                         tracing::warn!(
                                             principal_id,
@@ -451,7 +477,7 @@ fn refresh_status(state: &ExternalUserState) -> RefreshStatus {
         now(),
         state.last_sync_success_at,
         state.last_sync_attempted_at,
-        state.refresh_ttl_seconds,
+        state.refresh_policy.refresh_ttl,
     )
 }
 
@@ -459,10 +485,9 @@ fn refresh_status_at(
     current: NaiveDateTime,
     last_success: Option<NaiveDateTime>,
     last_attempt: Option<NaiveDateTime>,
-    ttl_seconds: i64,
+    refresh_ttl: RefreshTtl,
 ) -> RefreshStatus {
-    let ttl = chrono::Duration::seconds(ttl_seconds);
-    if last_success.is_some_and(|success| current - success < ttl) {
+    if last_success.is_some_and(|success| refresh_ttl.contains(current - success)) {
         return RefreshStatus::Fresh;
     }
 
@@ -471,26 +496,26 @@ fn refresh_status_at(
         (Some(attempt), None) => Some(attempt),
         _ => None,
     };
-    if failed_attempt.is_some_and(|attempt| current - attempt < ttl) {
+    if failed_attempt.is_some_and(|attempt| refresh_ttl.contains(current - attempt)) {
         RefreshStatus::Backoff
     } else {
         RefreshStatus::Due
     }
 }
 
-fn within_max_stale(last_success: Option<NaiveDateTime>, max_stale_seconds: i64) -> bool {
-    within_max_stale_at(now(), last_success, max_stale_seconds)
+fn within_max_stale(last_success: Option<NaiveDateTime>, max_stale: MaxStale) -> bool {
+    within_max_stale_at(now(), last_success, max_stale)
 }
 
 fn within_max_stale_at(
     current: NaiveDateTime,
     last_success: Option<NaiveDateTime>,
-    max_stale_seconds: i64,
+    max_stale: MaxStale,
 ) -> bool {
     let Some(last_success) = last_success else {
         return false;
     };
-    current - last_success < chrono::Duration::seconds(max_stale_seconds)
+    max_stale.contains(current - last_success)
 }
 
 fn cached_external_state_result(state: &ExternalUserState) -> Result<(), ApiError> {
@@ -501,7 +526,11 @@ fn cached_external_state_result_at(
     current: NaiveDateTime,
     state: &ExternalUserState,
 ) -> Result<(), ApiError> {
-    if within_max_stale_at(current, state.last_sync_success_at, state.max_stale_seconds) {
+    if within_max_stale_at(
+        current,
+        state.last_sync_success_at,
+        state.refresh_policy.max_stale,
+    ) {
         tracing::debug!(
             identity_scope = state.identity_scope,
             "External identity refresh is in retry backoff; using cached memberships"
@@ -526,12 +555,31 @@ fn stale_external_state_error() -> Result<(), ApiError> {
 
 struct ExternalUserState {
     identity_scope: String,
-    username: String,
-    external_subject: String,
+    refresh_request: ExternalUserRefreshRequest,
     last_sync_attempted_at: Option<NaiveDateTime>,
     last_sync_success_at: Option<NaiveDateTime>,
-    refresh_ttl_seconds: i64,
-    max_stale_seconds: i64,
+    refresh_policy: RefreshPolicy,
+}
+
+impl ExternalUserState {
+    fn new(state: ExternalPrincipalState, refresh_policy: RefreshPolicy) -> Result<Self, ApiError> {
+        let refresh_request =
+            match ExternalUserRefreshRequest::new(state.username, state.external_subject) {
+                Ok(request) => request,
+                Err(error) => {
+                    return Err(ApiError::InternalServerError(format!(
+                        "Invalid external identity state: {error}"
+                    )));
+                }
+            };
+        Ok(Self {
+            identity_scope: state.identity_scope,
+            refresh_request,
+            last_sync_attempted_at: state.last_sync_attempted_at,
+            last_sync_success_at: state.last_sync_success_at,
+            refresh_policy,
+        })
+    }
 }
 
 async fn external_user_state(
@@ -548,15 +596,7 @@ async fn external_user_state(
             configured.name
         ))
     })?;
-    Ok(Some(ExternalUserState {
-        identity_scope: state.identity_scope,
-        username: state.username,
-        external_subject: state.external_subject,
-        last_sync_attempted_at: state.last_sync_attempted_at,
-        last_sync_success_at: state.last_sync_success_at,
-        refresh_ttl_seconds: refresh_policy.refresh_ttl_seconds,
-        max_stale_seconds: refresh_policy.max_stale_seconds,
-    }))
+    ExternalUserState::new(state, refresh_policy).map(Some)
 }
 
 #[cfg(feature = "integration-test-support")]
@@ -611,6 +651,14 @@ mod tests {
             .unwrap()
     }
 
+    fn refresh_ttl(seconds: i64) -> RefreshTtl {
+        RefreshTtl::new(seconds).unwrap()
+    }
+
+    fn refresh_policy() -> RefreshPolicy {
+        RefreshPolicy::new(300, 3600).unwrap()
+    }
+
     #[test]
     fn provider_names_include_local_and_sorted_external_scopes() {
         let registry = AuthProviderRegistry::from_config(AuthProvidersConfig {
@@ -627,7 +675,7 @@ mod tests {
         let success = current - chrono::Duration::seconds(299);
 
         assert_eq!(
-            refresh_status_at(current, Some(success), Some(success), 300),
+            refresh_status_at(current, Some(success), Some(success), refresh_ttl(300)),
             RefreshStatus::Fresh
         );
     }
@@ -639,7 +687,12 @@ mod tests {
         let failed_attempt = current - chrono::Duration::seconds(1);
 
         assert_eq!(
-            refresh_status_at(current, Some(success), Some(failed_attempt), 300),
+            refresh_status_at(
+                current,
+                Some(success),
+                Some(failed_attempt),
+                refresh_ttl(300)
+            ),
             RefreshStatus::Backoff
         );
     }
@@ -651,7 +704,12 @@ mod tests {
         let failed_attempt = current - chrono::Duration::seconds(300);
 
         assert_eq!(
-            refresh_status_at(current, Some(success), Some(failed_attempt), 300),
+            refresh_status_at(
+                current,
+                Some(success),
+                Some(failed_attempt),
+                refresh_ttl(300)
+            ),
             RefreshStatus::Due
         );
     }
@@ -662,7 +720,7 @@ mod tests {
         let success = current - chrono::Duration::seconds(300);
 
         assert_eq!(
-            refresh_status_at(current, Some(success), Some(success), 300),
+            refresh_status_at(current, Some(success), Some(success), refresh_ttl(300)),
             RefreshStatus::Due
         );
     }
@@ -672,17 +730,55 @@ mod tests {
         let current = timestamp();
         let state = ExternalUserState {
             identity_scope: "directory".to_string(),
-            username: "alice".to_string(),
-            external_subject: "subject".to_string(),
+            refresh_request: ExternalUserRefreshRequest::new("alice", "subject").unwrap(),
             last_sync_attempted_at: Some(current - chrono::Duration::seconds(1)),
             last_sync_success_at: Some(current - chrono::Duration::seconds(3600)),
-            refresh_ttl_seconds: 300,
-            max_stale_seconds: 3600,
+            refresh_policy: refresh_policy(),
         };
 
         assert!(matches!(
             cached_external_state_result_at(current, &state),
             Err(ApiError::ServiceUnavailable(_))
         ));
+    }
+
+    #[test]
+    fn refresh_policy_rejects_a_non_positive_ttl() {
+        let error = RefreshPolicy::new(0, 3600).err().unwrap();
+
+        assert!(matches!(error, ApiError::BadRequest(_)));
+        assert_eq!(
+            error.to_string(),
+            "ldap refresh_ttl_seconds must be positive"
+        );
+    }
+
+    #[test]
+    fn refresh_policy_rejects_a_non_positive_max_stale_window() {
+        let error = RefreshPolicy::new(300, 0).err().unwrap();
+
+        assert!(matches!(error, ApiError::BadRequest(_)));
+        assert_eq!(error.to_string(), "ldap max_stale_seconds must be positive");
+    }
+
+    #[test]
+    fn external_user_state_rejects_an_empty_provider_subject() {
+        let state = ExternalPrincipalState {
+            identity_scope: "directory".to_string(),
+            username: "alice".to_string(),
+            external_subject: String::new(),
+            last_sync_attempted_at: None,
+            last_sync_success_at: None,
+        };
+
+        let error = ExternalUserState::new(state, refresh_policy())
+            .err()
+            .unwrap();
+
+        assert!(matches!(error, ApiError::InternalServerError(_)));
+        assert_eq!(
+            error.to_string(),
+            "Invalid external identity state: external subject must not be empty"
+        );
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 #[cfg(feature = "integration-test-support")]
 use hubuum_auth_core::AuthenticatedExternalUser;
-use hubuum_auth_core::{AuthProviderError, ExternalIdentityProvider};
+use hubuum_auth_core::{AuthProviderError, ExternalIdentityProvider, ExternalUserRefreshRequest};
 use hubuum_auth_ldap::{LdapIdentityProvider, LdapScopeConfig};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -272,9 +272,13 @@ impl AuthProviderBackend for LdapAuthProvider {
         state: &'a ExternalUserState,
     ) -> AuthProviderRefreshFuture<'a> {
         Box::pin(async move {
+            let refresh_request = ExternalUserRefreshRequest::new(
+                state.username.clone(),
+                state.external_subject.clone(),
+            );
             let refreshed = self
                 .provider
-                .refresh_user(&state.external_subject)
+                .refresh_user(&refresh_request)
                 .await
                 .map_err(|error| AuthProviderRefreshError::Provider(provider_error(error)))?;
             sync_external_user_from_backend(pool, &self.scope, LDAP_PROVIDER_KIND, refreshed)
@@ -348,6 +352,12 @@ pub async fn refresh_principal_if_needed(pool: &DbPool, principal_id: i32) -> Re
                                         );
                                         Ok(())
                                     } else {
+                                        tracing::error!(
+                                            principal_id,
+                                            identity_scope = state.identity_scope,
+                                            error = %err,
+                                            "External identity refresh failed; cached memberships exceed max-stale window"
+                                        );
                                         stale_external_state_error()
                                     }
                                 }
@@ -498,6 +508,12 @@ fn cached_external_state_result_at(
         );
         Ok(())
     } else {
+        tracing::warn!(
+            identity_scope = state.identity_scope,
+            last_sync_attempted_at = ?state.last_sync_attempted_at,
+            last_sync_success_at = ?state.last_sync_success_at,
+            "External identity refresh is in retry backoff; cached memberships exceed max-stale window"
+        );
         stale_external_state_error()
     }
 }
@@ -510,6 +526,7 @@ fn stale_external_state_error() -> Result<(), ApiError> {
 
 struct ExternalUserState {
     identity_scope: String,
+    username: String,
     external_subject: String,
     last_sync_attempted_at: Option<NaiveDateTime>,
     last_sync_success_at: Option<NaiveDateTime>,
@@ -533,6 +550,7 @@ async fn external_user_state(
     })?;
     Ok(Some(ExternalUserState {
         identity_scope: state.identity_scope,
+        username: state.username,
         external_subject: state.external_subject,
         last_sync_attempted_at: state.last_sync_attempted_at,
         last_sync_success_at: state.last_sync_success_at,
@@ -654,6 +672,7 @@ mod tests {
         let current = timestamp();
         let state = ExternalUserState {
             identity_scope: "directory".to_string(),
+            username: "alice".to_string(),
             external_subject: "subject".to_string(),
             last_sync_attempted_at: Some(current - chrono::Duration::seconds(1)),
             last_sync_success_at: Some(current - chrono::Duration::seconds(3600)),

--- a/src/db/traits/external_identity.rs
+++ b/src/db/traits/external_identity.rs
@@ -13,6 +13,7 @@ use crate::models::{
 
 pub struct ExternalPrincipalState {
     pub identity_scope: String,
+    pub username: String,
     pub external_subject: String,
     pub last_sync_attempted_at: Option<NaiveDateTime>,
     pub last_sync_success_at: Option<NaiveDateTime>,
@@ -38,6 +39,7 @@ pub async fn external_principal_state(
                 principals::last_sync_attempted_at,
                 principals::last_sync_success_at,
                 identity_scopes::name,
+                principals::name,
             ))
             .first::<(
                 String,
@@ -45,6 +47,7 @@ pub async fn external_principal_state(
                 Option<String>,
                 Option<NaiveDateTime>,
                 Option<NaiveDateTime>,
+                String,
                 String,
             )>(conn)
             .await
@@ -59,6 +62,7 @@ pub async fn external_principal_state(
         last_sync_attempted_at,
         last_sync_success_at,
         identity_scope,
+        username,
     )) = row
     else {
         return Ok(None);
@@ -73,6 +77,7 @@ pub async fn external_principal_state(
     };
     Ok(Some(ExternalPrincipalState {
         identity_scope,
+        username,
         external_subject,
         last_sync_attempted_at,
         last_sync_success_at,


### PR DESCRIPTION
## Summary

- refresh LDAP identities through the configured `user_filter` using the materialized principal name
- verify that the refreshed directory entry still has the stable subject stored at login
- validate refresh usernames and subjects with private domain newtypes at the database-to-domain boundary
- represent refresh TTL and maximum-stale windows with distinct validated duration types so they cannot be interchanged or constructed with non-positive values
- add explicit diagnostics when cached memberships exceed the maximum stale window
- document the refresh contract and cover username escaping, identity validation, subject mismatches, and refresh-policy validation with focused regression tests

## Root cause

LDAP login used the selective configured username filter, but subsequent refreshes searched the complete user subtree by `subject_attribute`. With UiO's anonymous LDAP service, a subtree query such as `(entryUUID=...)` exceeds the server's administrative/lookthrough limit and returns `adminLimitExceeded` (`rc=11`).

While the cached membership state was inside `max_stale_seconds`, requests continued with a warning. Once it became older than the maximum stale window, `/api/v1/iam/me` returned `503 Service Unavailable`; requests inside the refresh retry-backoff window failed immediately without another LDAP attempt.

The refreshed entry is now located with the same configured username lookup used at login. Its subject is checked against the stored stable subject before memberships are accepted, preserving identity continuity without requiring an efficient directory-wide subject search.

## Impact

No LDAP configuration migration is required for existing scopes with a valid `user_filter`.

**Breaking Rust API change:** `ExternalIdentityProvider::refresh_user` now accepts `ExternalUserRefreshRequest`, containing validated current-username and expected-subject values. External provider implementations must update their method signature and reject refresh results whose subject does not match.

## Verification

- `source .env && ./run_tests.sh`
- `cargo test --locked -p hubuum-auth-core -p hubuum-auth-ldap`
- `cargo test --locked --lib auth::tests`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
