### PR TITLE
Prepare v0.0.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.0.5] - 2026-07-26
+
 ### Added
 
 - Expired bearer-token rows are now purged automatically after a configurable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hubuum"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -2646,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a6cff806294a7699d48761d4ae2bdebab7fa2eef05e4a0b83320f0ff46901"
+checksum = "9cc9116a0f75b7336e55eb2a2a0ddef86c37cadf02924a571751aa123d5a0290"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2675,18 +2675,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84708dd3f6c5327478a96f37378adb27deed6a626cf84d19de780d9e8ae84b17"
+checksum = "628a1f02bda4651d9a6088ee6386a92f0ee96255b0c99e9dfe1be91bf83bd838"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8c04ab4ce60e42c4e302d3bd9d184652bb56f212495d2eea23573bcbf72556"
+checksum = "75d94a372f8d81d070fd405065c6b1168d8248d1d6adad073ac708de254698c6"
 dependencies = [
  "ahash",
  "bytecount",
@@ -3820,9 +3820,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980e77f5cfffc592c0e7dfb6d20770a0b96a6ab94d403de7454ed9799505e4ba"
+checksum = "978badf4419c9d0e1bc6e7466e99277f829d768257670c46d88121ca75e34bf7"
 dependencies = [
  "ahash",
  "fluent-uri",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hubuum"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2024"
 description = "Flexible asset management REST service."
 license = "MIT"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.0.4"
+    "version": "0.0.5"
   },
   "servers": [
     {


### PR DESCRIPTION
## Summary

- Cut the accumulated `[Unreleased]` changelog as `v0.0.5` dated 2026-07-26.
- Bump the package and generated OpenAPI versions from `0.0.4` to `0.0.5`.
- Refresh the lockfile, updating the `jsonschema` dependency family from 0.48.5 to 0.49.1.

## Release impact

This release adds coordinated expired-token cleanup and exposes the default token lifetime, materializes authoritative expiry on newly issued tokens, restores permission-aware import/export submission, and fixes LDAP identity refresh lookup behavior.

**Breaking Rust API:** `ExternalIdentityProvider::refresh_user` now accepts `ExternalUserRefreshRequest`. Provider implementations must update their method signature, locate users by the request's validated current username, and reject results whose subject differs from the expected subject before upgrading.

## Verification

- `./scripts/check-release-readiness.sh v0.0.5`
- `./scripts/check-version-bump.sh`
- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- Production container build is delegated to the required pull-request CI container check; local Docker Desktop exhausted its 8 GiB VM while fat-LTO linking, including with `-j 1`.