### PR TITLE
Proxy metrics in direct shared-host routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- Shared-host installations using direct routing now proxy `/metrics` to the
+  backend instead of letting the request fall through to the frontend.
+
 ## [0.0.5] - 2026-07-26
 
 ### Added

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -110,7 +110,7 @@ sudo ./scripts/install-single-host.sh \
 
 Modes:
 
-- `direct`: sends backend-owned paths such as `/api/v0...`, `/api/v1...`, `/api-doc...`, and `/swagger-ui...` directly to the backend, with everything else going to the frontend. This is the recommended shared-host mode now that frontend-owned BFF routes live under `/_hubuum-bff/...`.
+- `direct`: sends backend-owned paths such as `/api/v0...`, `/api/v1...`, `/api-doc...`, `/swagger-ui...`, and `/metrics` directly to the backend, with everything else going to the frontend. This is the recommended shared-host mode now that frontend-owned BFF routes live under `/_hubuum-bff/...`.
 - `prefixed`: exposes the backend under `/hubuum-api/` and sends everything else to the frontend. This is useful if you want to avoid exposing backend routes at their native paths.
 - `bff`: sends all traffic to the frontend. The backend is not directly exposed by Caddy in this mode; use it only when frontend proxy coverage is the intended public API surface.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,6 +15,8 @@ Database-backed gauges are refreshed on a short in-process cache and are best-ef
 
 The metrics endpoint uses the main HTTP listener and is subject to `HUBUUM_CLIENT_ALLOWLIST`. Put it behind network-level access controls appropriate for operational data.
 
+For single-host deployments using shared-host `direct` routing, Caddy sends `/metrics` to the backend. With shared-host `prefixed` routing, scrape `/hubuum-api/metrics` instead. Shared-host `bff` routing does not expose the backend metrics endpoint publicly.
+
 ## Cardinality Rules
 
 Metric labels must stay bounded. Hubuum metrics do not use usernames, user IDs, client IPs, raw URL paths, object IDs, class names, collection names, rendered remote URLs, template names, idempotency keys, or error messages.

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -613,6 +613,10 @@ ${WEB_FQDN} {
 		import api_proxy
 	}
 
+	handle /metrics {
+		import api_proxy
+	}
+
 	handle {
 		import web_proxy
 	}

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -501,6 +501,23 @@ fn single_host_installer_generates_redundant_http_upstreams() {
 }
 
 #[test]
+fn single_host_direct_routing_proxies_metrics_to_the_api() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let installer = fs::read_to_string(repository.join("scripts/install-single-host.sh"))
+        .expect("single-host installer should be readable");
+    let direct_start = installer
+        .find(r#"elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "direct" ]]; then"#)
+        .expect("installer should generate direct shared-host routing");
+    let direct_end = installer[direct_start..]
+        .find(r#"elif [[ "$MODE" == "all" && "$SHARED_HOST_ROUTING" == "prefixed" ]]; then"#)
+        .map(|offset| direct_start + offset)
+        .expect("direct shared-host routing should end before prefixed routing");
+    let direct_template = &installer[direct_start..direct_end];
+
+    assert!(direct_template.contains("handle /metrics {\n\t\timport api_proxy\n\t}"));
+}
+
+#[test]
 fn single_host_installer_emits_canonical_caddyfile_indentation() {
     let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let installer = fs::read_to_string(repository.join("scripts/install-single-host.sh"))


### PR DESCRIPTION
## Summary

- Route `/metrics` to the redundant API upstream in generated shared-host `direct` Caddy configurations.
- Add a focused installer regression test that keeps the metrics matcher inside the `direct` routing template.
- Document metrics behavior for `direct`, `prefixed`, and `bff` shared-host modes.
- Record the user-facing fix in the Unreleased changelog.

## Rationale

The Hubuum server still exposes Prometheus metrics at `/metrics`, but the single-host installer's shared-host `direct` Caddy configuration only forwarded API, OpenAPI, and Swagger paths. Its catch-all handler sent `/metrics` to the frontend instead, so scrapes received a frontend response or 404 despite metrics being enabled in the backend.

After this change, shared-host `direct` installations proxy `/metrics` through the same readiness-aware API pool as other backend-owned paths. `prefixed` installations continue to expose metrics at `/hubuum-api/metrics`, while `bff` mode continues not to expose the backend publicly.

## Verification

- `bash -n scripts/install-single-host.sh`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `cargo clippy --all-targets -- -D warnings`
- `source .env && ./run_tests.sh`
