### PR TITLE
Make Prometheus runtime metrics actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   retention, restore-coordinator, lease, and metrics-refresh work.
 - Queued task transactions now wake task workers across processes with
   transactional PostgreSQL notifications.
+- Export phase metrics now identify the stored template ID, with a separate
+  template-info metric mapping observed IDs to names. Export task details also
+  expose the persisted total, query, hydration, and render timings.
 
 ### Changed
 
 - **Breaking (metrics):** database metric series now include the `caller`
   label. Update recording rules or exact label-set matches that assume the old
   unlabeled acquisition series.
+- Duration histograms now use workload-specific fractional-second buckets for
+  useful HTTP, database, remote-call, and background-task percentiles instead
+  of OpenTelemetry's unit-agnostic defaults.
 - Task, event fan-out, and event delivery safety polling now default to five
   seconds. Transactional notifications preserve prompt normal wakeups, and
   delivery workers still wake at scheduled retry deadlines below that interval.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   retention, restore-coordinator, lease, and metrics-refresh work.
 - Queued task transactions now wake task workers across processes with
   transactional PostgreSQL notifications.
-- Export phase metrics now identify the stored template ID, with a separate
-  template-info metric mapping observed IDs to names. Export task details also
-  expose the persisted total, query, hydration, and render timings.
+- Added build, runtime-role, and process-start metrics so every scrape target
+  can be identified and counter resets can be correlated with restarts.
+- Worker-only processes now expose their own metrics-only HTTP listener at the
+  configured bind address, port, and path, allowing Prometheus to scrape task
+  and event workers directly.
+- Added scrape-refresh duration and freshness metrics, route-labelled in-flight
+  requests, bounded database component attribution, and per-task-kind oldest
+  queued and active ages.
+- Export metrics now expose aggregate phase outcomes and a per-template total
+  duration histogram. A resettable database snapshot maps template IDs to
+  current names, while export task details persist total, query, hydration, and
+  render timings.
 
 ### Changed
 
@@ -32,6 +41,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Single-host `/metrics` now targets the worker-enabled primary deterministically,
   and `/metrics/standby` exposes the HTTP-only standby. Prefixed routing exposes
   the equivalent `/hubuum-api/metrics` and `/hubuum-api/metrics/standby` paths.
+- **Breaking (Prometheus metric contract):** configuration and cleanup metrics
+  now use dimensionally typed names, event wakeups are a counter, and the HTTP
+  in-flight, database, task-age, export-phase, and import-phase families have
+  new bounded labels. Dashboard and alert owners must migrate from
+  `hubuum_task_worker_config`, `hubuum_event_worker_config`,
+  `hubuum_event_worker_wakeups`, and `hubuum_export_output_cleanup_*` to the
+  replacement families documented in `docs/metrics.md`, and update queries for
+  the changed label sets before deploying this version.
 
 ### Fixed
 
@@ -52,6 +69,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   restore drain barrier.
 - Worker notification listeners now use dedicated connections so task-only or
   event-only workers with a one-connection execution pool can still claim work.
+- Database-backed template identity no longer retains deleted or renamed
+  templates in a process, and import and export phase timings record error
+  outcomes.
 
 ## [0.0.5] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   configured bind address, port, and path, allowing Prometheus to scrape task
   and event workers directly.
 - Added scrape-refresh duration and freshness metrics, route-labelled in-flight
-  requests, bounded database component attribution, and per-task-kind oldest
-  queued and active ages.
+  requests, and per-task-kind oldest queued and active ages.
 - Export metrics now expose aggregate phase outcomes and a per-template total
   duration histogram. A resettable database snapshot maps template IDs to
   current names, while export task details persist total, query, hydration, and
@@ -43,7 +42,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   the equivalent `/hubuum-api/metrics` and `/hubuum-api/metrics/standby` paths.
 - **Breaking (Prometheus metric contract):** configuration and cleanup metrics
   now use dimensionally typed names, event wakeups are a counter, and the HTTP
-  in-flight, database, task-age, export-phase, and import-phase families have
+  in-flight, task-age, export-phase, and import-phase families have
   new bounded labels. Dashboard and alert owners must migrate from
   `hubuum_task_worker_config`, `hubuum_event_worker_config`,
   `hubuum_event_worker_wakeups`, and `hubuum_export_output_cleanup_*` to the

--- a/docs/distributed_deployment.md
+++ b/docs/distributed_deployment.md
@@ -22,11 +22,16 @@ Set `HUBUUM_RUNTIME_ROLE` on each long-running process:
 | `api` | Yes | No | Horizontally scaled stateless API replicas |
 | `worker` | No | Yes | Independently scaled task and event workers |
 
-An `api` process cannot start workers through a later queue notification. A
-`worker` process does not bind an HTTP port. Use process/container liveness for
+An `api` process cannot start workers through a later queue notification. When
+metrics are enabled, a `worker` process binds the configured address and port
+with only `HUBUUM_METRICS_PATH`; it does not expose the application API or
+health probes. Scrape every worker directly so worker counters and histograms
+are not hidden behind an API load balancer. Use process/container liveness for
 worker replicas rather than `/healthz`; the image's built-in Docker health check
 accounts for the worker role. API replicas expose `/healthz` and `/readyz` as
-documented in [Quick Start](quick_start.md#health-probes).
+documented in [Quick Start](quick_start.md#health-probes). See
+[Runtime Metrics](metrics.md#scrape-each-process-directly) for aggregation
+semantics.
 
 Worker-only processes require at least one configured background worker and
 supervise every worker thread they start. If any worker stops unexpectedly, the

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -204,6 +204,11 @@ The bounded database `caller` values are `event_delivery`, `event_fanout`,
 | `hubuum_remote_call_duration_seconds` | `method`, `status_family`, `outcome` | Remote HTTP execution duration |
 | `hubuum_remote_call_results_total` | `method`, `status_family`, `outcome` | Remote outcomes such as success, failure, timeout, or validation rejection |
 
+Export timer phases are limited to `total`, `query`, `hydration`, and `render`;
+their outcomes are `success`, `error`, or `timeout`. Import timer phases are
+limited to `total`, `planning`, and `execution`; their outcomes are `success`,
+`failed`, `partially_succeeded`, or `error`.
+
 ### Computed Fields, Security, Events, And Inventory
 
 | Metric | Labels | Description |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -29,9 +29,66 @@ The bounded `caller` database label uses one of `event_delivery`,
 
 ## Cardinality Rules
 
-Metric labels must stay bounded. Hubuum metrics do not use usernames, user IDs, client IPs, raw URL paths, object IDs, class names, collection names, rendered remote URLs, template names, idempotency keys, or error messages.
+Metric labels must stay bounded. Hubuum metrics do not use usernames, user IDs, client IPs, raw URL paths, object IDs, class names, collection names, rendered remote URLs, idempotency keys, or error messages.
 
-Use admin JSON/API endpoints for detailed high-cardinality views.
+Export duration histograms use the stored template ID as a controlled operational dimension. `hubuum_export_template_info` maps IDs to the names observed by the current process without repeating the mutable name across every histogram bucket. Do not use task IDs as metric labels.
+
+Use admin JSON/API endpoints for detailed per-task views.
+
+## Histograms
+
+Durations are recorded as fractional seconds. For example, a 4.7 millisecond request is recorded as `0.0047`, preserving sub-millisecond precision while following Prometheus naming conventions.
+
+Hubuum uses three explicit duration bucket profiles:
+
+- HTTP and database latency: `0.0005` seconds through `30` seconds
+- outbound remote calls: `0.01` seconds through `120` seconds
+- queued and background work: `0.01` seconds through `3600` seconds
+
+Prometheus histogram buckets are cumulative. Use `histogram_quantile` for an estimated percentile. The following query calculates HTTP p95 latency by route over five minutes:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, route) (
+    rate(hubuum_http_request_duration_seconds_bucket[5m])
+  )
+)
+```
+
+The histogram sum divided by its count gives the mean. Apply `rate` before division when querying a time window:
+
+```promql
+sum by (route) (
+  rate(hubuum_http_request_duration_seconds_sum[5m])
+)
+/
+sum by (route) (
+  rate(hubuum_http_request_duration_seconds_count[5m])
+)
+```
+
+Classic Prometheus histograms do not export exact minimum or maximum observations. Percentiles are bounded by the configured buckets and remain aggregatable across Hubuum instances, unlike client-calculated summary quantiles.
+
+Counter and histogram label sets appear only after the current process observes a matching event. Seeing `/readyz` without application routes means that the process has handled readiness probes but has not yet observed those application routes; it does not indicate that application routes are filtered out.
+
+For stored-template exports, join the phase histogram to the template-info gauge to display names without placing mutable names on every histogram bucket:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, template_id) (
+    rate(
+      hubuum_export_phase_duration_seconds_bucket{
+        phase="total",
+        template_id!="none"
+      }[15m]
+    )
+  )
+)
+* on (template_id) group_left (template_name)
+hubuum_export_template_info
+```
 
 ## Metrics
 
@@ -67,7 +124,8 @@ Use admin JSON/API endpoints for detailed high-cardinality views.
 | `hubuum_export_output_cleanup_runs_total` | none | Stored export and backup artifact cleanup runs (legacy metric name) |
 | `hubuum_export_output_cleanup_failures_total` | none | Stored export and backup artifact cleanup failures (legacy metric name) |
 | `hubuum_export_output_cleanup_deleted_total` | none | Stored export and backup artifacts deleted by cleanup (legacy metric name) |
-| `hubuum_export_phase_duration_seconds` | `phase` | Export query, hydration, render, and total phase duration |
+| `hubuum_export_template_info` | `template_id`, `template_name` | Stored export template identities observed by the current process |
+| `hubuum_export_phase_duration_seconds` | `phase`, `template_id` | Export query, hydration, render, and total phase duration; untemplated exports use `template_id="none"` |
 | `hubuum_export_completions_total` | `scope`, `content_type` | Successfully persisted export outputs |
 | `hubuum_export_truncations_total` | `scope`, `content_type` | Successfully persisted truncated exports |
 | `hubuum_export_warnings_total` | `scope`, `content_type` | Warning count on successfully persisted exports |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,51 +1,98 @@
 # Runtime Metrics
 
-Hubuum exposes low-cardinality runtime metrics through OpenTelemetry instruments and a Prometheus scrape endpoint. The endpoint is enabled by default at `/metrics`.
+Hubuum exposes low-cardinality runtime metrics through a Prometheus scrape
+endpoint. The endpoint is enabled by default at `/metrics`.
 
 ## Configuration
 
 | Variable | Default | Description |
-| -------- | ------- | ----------- |
+| --- | --- | --- |
 | `HUBUUM_METRICS_ENABLED` | `true` | Enables the Prometheus metrics scrape endpoint |
-| `HUBUUM_METRICS_PATH` | `/metrics` | Literal absolute non-root endpoint path. It must not contain route patterns or collide with API, probe, OpenAPI, or Swagger UI routes |
+| `HUBUUM_METRICS_PATH` | `/metrics` | Literal absolute non-root endpoint path; it must not contain route patterns or collide with API, probe, OpenAPI, or Swagger UI routes |
 
-Metrics are ephemeral operational signals for alerting, dashboards, and capacity planning. Durable audit and business facts stay in the event stream.
+The endpoint is subject to `HUBUUM_CLIENT_ALLOWLIST` and uses the configured TLS
+settings. Put it behind network-level access controls appropriate for
+operational data.
 
-Database-backed gauges are refreshed on a short in-process cache and are best-effort. If a refresh fails, `/metrics` still returns the runtime metrics it has and keeps the last successful database gauge values when available. Concurrent scrapes do not start duplicate database refreshes.
+Processes with the `all` or `api` runtime role serve metrics on the main HTTP
+listener. A `worker` process serves only the configured metrics path on
+`HUBUUM_BIND_IP:HUBUUM_PORT` when metrics are enabled; it does not expose the
+application API or health probes. Give API and worker containers separate
+network namespaces or ports if they run on the same host.
 
-The metrics endpoint uses the main HTTP listener and is subject to `HUBUUM_CLIENT_ALLOWLIST`. Put it behind network-level access controls appropriate for operational data.
+## Scrape Each Process Directly
 
-Process-local counters must be scraped from stable per-process targets rather
-than through the load-balanced API upstream. Single-host deployments therefore
-route `/metrics` to the worker-enabled primary and `/metrics/standby` to the
-HTTP-only standby. With shared-host `prefixed` routing, use
-`/hubuum-api/metrics` and `/hubuum-api/metrics/standby`. Shared-host `bff`
-routing does not expose either backend metrics endpoint publicly.
+Counters, histograms, connection-pool gauges, and worker configuration describe
+one process. Configure Prometheus with a stable target for every API and worker
+process. Do not scrape a load-balanced public URL: successive scrapes can land
+on different processes, producing apparent counter resets and hiding
+worker-only activity.
 
-The bounded `caller` database label uses one of `event_delivery`,
-`event_fanout`, `event_retention`, `http_request`, `metrics_refresh`, `readiness`,
-`request_maintenance`, `restore_coordinator`, `task_lease`, `task_worker`,
-`token_retention`, or `unattributed`.
+Use these metrics to identify a target:
+
+- `hubuum_build_info{version,git_sha}`
+- `hubuum_runtime_info{role}`
+- `hubuum_process_start_time_seconds`
+
+Inventory, task backlog, export-template identity, and event-queue gauges are
+database-wide snapshots. Every replica connected to the same database reports
+the same logical values. Aggregate those series with `max` or `avg`, not `sum`,
+unless replica multiplication is intentional. Process-local gauges such as
+database-pool state should normally be summed when calculating deployment-wide
+capacity.
+
+Database-backed gauges use a 30-second in-process cache and refresh on a
+best-effort basis. If a refresh fails, `/metrics` still returns process metrics
+and retains the last successful database snapshot when one exists. The refresh
+duration, last-success timestamp, failures, and skipped concurrent refreshes
+make stale values visible.
+
+Single-host deployments provide deterministic convenience routes.
+Shared-host `direct` routing sends `/metrics` to the worker-enabled primary and
+`/metrics/standby` to the HTTP-only standby. With shared-host `prefixed`
+routing, use `/hubuum-api/metrics` and
+`/hubuum-api/metrics/standby`. Shared-host `bff` routing does not expose either
+backend metrics endpoint publicly.
 
 ## Cardinality Rules
 
-Metric labels must stay bounded. Hubuum metrics do not use usernames, user IDs, client IPs, raw URL paths, object IDs, class names, collection names, rendered remote URLs, idempotency keys, or error messages.
+Metric labels must stay bounded. Hubuum metrics do not use usernames, user IDs,
+client IPs, raw URL paths, object IDs, class names, collection names, rendered
+remote URLs, task IDs, idempotency keys, or error messages.
 
-Export duration histograms use the stored template ID as a controlled operational dimension. `hubuum_export_template_info` maps IDs to the names observed by the current process without repeating the mutable name across every histogram bucket. Do not use task IDs as metric labels.
+HTTP metrics use Actix route templates such as
+`/api/v1/classes/{class_id}/objects/{object_id}`. Requests that do not resolve
+to a registered route use a coarse route group instead of their raw path.
 
-Use admin JSON/API endpoints for detailed per-task views.
+Export phase timing is aggregated by phase and outcome. Only the total export
+histogram carries `template_id`; this keeps template identity useful without
+multiplying every query, hydration, and render bucket by every stored template.
+`hubuum_export_template_info` maps current database IDs to mutable names and is
+reset on every inventory snapshot, so renames and deletions do not leave stale
+series in a process.
 
-## Histograms
+Use admin JSON/API endpoints and task logs for per-task detail.
 
-Durations are recorded as fractional seconds. For example, a 4.7 millisecond request is recorded as `0.0047`, preserving sub-millisecond precision while following Prometheus naming conventions.
+## Duration Units And Histograms
 
-Hubuum uses three explicit duration bucket profiles:
+Prometheus duration metric names and observations use seconds. A 4.7
+millisecond request is recorded as `0.0047`; using seconds does not discard
+millisecond or sub-millisecond precision.
 
-- HTTP and database latency: `0.0005` seconds through `30` seconds
-- outbound remote calls: `0.01` seconds through `120` seconds
-- queued and background work: `0.01` seconds through `3600` seconds
+Hubuum uses three explicit bucket profiles:
 
-Prometheus histogram buckets are cumulative. Use `histogram_quantile` for an estimated percentile. The following query calculates HTTP p95 latency by route over five minutes:
+- HTTP and database latency: `0.0005` seconds through `30` seconds.
+- Outbound remote calls: `0.01` seconds through `120` seconds.
+- Queued and background work: `0.01` seconds through `3600` seconds.
+
+The long background buckets are intentional: most buckets should be empty for
+fast work, while imports, exports, backups, remote dependencies, or a
+constrained worker can legitimately take seconds or minutes. Empty upper
+buckets are cheap and preserve visibility when an exceptional slow operation
+occurs.
+
+Prometheus histogram buckets are cumulative. This query calculates HTTP p95
+latency by route over five minutes:
 
 ```promql
 histogram_quantile(
@@ -56,7 +103,8 @@ histogram_quantile(
 )
 ```
 
-The histogram sum divided by its count gives the mean. Apply `rate` before division when querying a time window:
+The histogram sum divided by its count gives the mean. Apply `rate` before
+division for a time window:
 
 ```promql
 sum by (route) (
@@ -68,35 +116,47 @@ sum by (route) (
 )
 ```
 
-Classic Prometheus histograms do not export exact minimum or maximum observations. Percentiles are bounded by the configured buckets and remain aggregatable across Hubuum instances, unlike client-calculated summary quantiles.
+The exported `_sum` is therefore useful, but only together with `_count`.
+Classic Prometheus histograms do not expose exact minimum or maximum
+observations. `histogram_quantile` estimates percentiles from bucket boundaries
+and remains aggregatable across processes.
 
-Counter and histogram label sets appear only after the current process observes a matching event. Seeing `/readyz` without application routes means that the process has handled readiness probes but has not yet observed those application routes; it does not indicate that application routes are filtered out.
+Counter and histogram series appear only after a process observes a matching
+event. Seeing only `/readyz` means that target handled readiness probes but not
+application requests; it does not mean other routes are filtered out.
 
-For stored-template exports, join the phase histogram to the template-info gauge to display names without placing mutable names on every histogram bucket:
+For stored-template exports, join the total-duration histogram to the current
+template-info gauge:
 
 ```promql
 histogram_quantile(
   0.95,
   sum by (le, template_id) (
     rate(
-      hubuum_export_phase_duration_seconds_bucket{
-        phase="total",
+      hubuum_export_duration_seconds_bucket{
         template_id!="none"
       }[15m]
     )
   )
 )
 * on (template_id) group_left (template_name)
-hubuum_export_template_info
+max by (template_id, template_name) (
+  hubuum_export_template_info
+)
 ```
 
 ## Metrics
 
+### Process, HTTP, And Database
+
 | Metric | Labels | Description |
-| ------ | ------ | ----------- |
+| --- | --- | --- |
+| `hubuum_build_info` | `version`, `git_sha` | Build identity for the scraped process |
+| `hubuum_runtime_info` | `role` | Runtime role for the scraped process |
+| `hubuum_process_start_time_seconds` | none | Unix timestamp when the process initialized metrics |
 | `hubuum_http_requests_total` | `method`, `route`, `status_code`, `status_family` | HTTP requests by stable route template or coarse route group |
 | `hubuum_http_request_duration_seconds` | `method`, `route`, `status_family` | HTTP request duration histogram |
-| `hubuum_http_requests_in_flight` | none | Requests currently being handled |
+| `hubuum_http_requests_in_flight` | `route` | Requests currently being handled by stable route |
 | `hubuum_api_errors_total` | `class` | API errors by public error class |
 | `hubuum_extraction_failures_total` | `kind` | JSON and path extraction failures |
 | `hubuum_db_pool_connections` | `state` | Database pool connections by configured, open, idle, and checked-out state |
@@ -104,16 +164,50 @@ hubuum_export_template_info
 | `hubuum_db_connection_acquire_failures_total` | `caller` | Pool connection acquisition failures |
 | `hubuum_db_operation_duration_seconds` | `caller`, `operation`, `result` | `with_connection` and `with_transaction` helper duration |
 | `hubuum_db_operation_errors_total` | `caller`, `operation`, `result` | Database helper failures by broad public error class |
-| `hubuum_metrics_refresh_failures_total` | `source` | Best-effort scrape refresh failures by inventory, tasks, or events source |
-| `hubuum_task_worker_iterations_total` | `outcome` | Worker iterations by claimed, idle, or error |
+| `hubuum_metrics_refresh_duration_seconds` | `source` | Duration of the latest refresh attempt |
+| `hubuum_metrics_refresh_last_success_timestamp_seconds` | `source` | Unix timestamp of the latest successful refresh |
+| `hubuum_metrics_refresh_failures_total` | `source` | Best-effort refresh failures |
+| `hubuum_metrics_refresh_skipped_total` | `source`, `reason` | Refreshes skipped because another scrape was already refreshing |
+
+The bounded database `caller` values are `event_delivery`, `event_fanout`,
+`event_retention`, `http_request`, `metrics_refresh`, `readiness`,
+`request_maintenance`, `restore_coordinator`, `task_lease`, `task_worker`,
+`token_retention`, and `unattributed`.
+
+### Tasks, Exports, Imports, And Remote Calls
+
+| Metric | Labels | Description |
+| --- | --- | --- |
+| `hubuum_task_worker_iterations_total` | `outcome` | Worker iterations by claimed, idle, or error outcome |
 | `hubuum_task_claims_total` | `kind` | Tasks claimed by workers |
 | `hubuum_task_lease_recoveries_total` | `kind` | Tasks failed after their owning worker lease expired |
 | `hubuum_task_completions_total` | `kind`, `final_status` | Tasks reaching a terminal status |
 | `hubuum_task_queue_wait_duration_seconds` | `kind` | Time from task creation to claim |
 | `hubuum_task_execution_duration_seconds` | `kind`, `final_status` | Time from task start to finish |
-| `hubuum_task_worker_config` | `setting` | Configured task worker count and poll interval |
-| `hubuum_tasks` | `kind`, `status` | Current tasks by bounded kind and status |
-| `hubuum_task_oldest_age_seconds` | `state` | Oldest queued and active task age |
+| `hubuum_task_workers_configured` | none | Task workers configured in this process; zero on API-only processes |
+| `hubuum_task_poll_interval_seconds` | none | Configured task-worker poll interval |
+| `hubuum_tasks` | `kind`, `status` | Current database-wide task counts |
+| `hubuum_task_oldest_age_seconds` | `kind`, `state` | Oldest queued and active task age per task kind |
+| `hubuum_task_output_cleanup_runs_total` | `kind` | Stored output cleanup runs for export or backup artifacts |
+| `hubuum_task_output_cleanup_failures_total` | `kind` | Stored output cleanup failures |
+| `hubuum_task_output_cleanup_deleted_total` | `kind` | Stored outputs deleted by cleanup |
+| `hubuum_export_template_info` | `template_id`, `template_name` | Current stored export-template identities from the shared database |
+| `hubuum_export_phase_duration_seconds` | `phase`, `outcome` | Aggregate export query, hydration, render, and total phase duration |
+| `hubuum_export_duration_seconds` | `template_id`, `outcome` | Total export duration by stored template ID; ad-hoc exports use `none` |
+| `hubuum_export_completions_total` | `scope`, `content_type` | Successfully persisted export outputs |
+| `hubuum_export_truncations_total` | `scope`, `content_type` | Successfully persisted truncated exports |
+| `hubuum_export_warnings_total` | `scope`, `content_type` | Warning count on successfully persisted exports |
+| `hubuum_import_phase_duration_seconds` | `phase`, `outcome` | Import planning, execution, and total phase duration, including failures |
+| `hubuum_import_processed_items_total` | none | Items processed by terminal import tasks |
+| `hubuum_import_succeeded_items_total` | none | Import items completed successfully |
+| `hubuum_import_failed_items_total` | none | Import items completed with failure |
+| `hubuum_remote_call_duration_seconds` | `method`, `status_family`, `outcome` | Remote HTTP execution duration |
+| `hubuum_remote_call_results_total` | `method`, `status_family`, `outcome` | Remote outcomes such as success, failure, timeout, or validation rejection |
+
+### Computed Fields, Security, Events, And Inventory
+
+| Metric | Labels | Description |
+| --- | --- | --- |
 | `hubuum_computed_field_evaluations_total` | `scope`, `outcome` | Computed-field evaluations by shared, personal, or preview scope and outcome |
 | `hubuum_computed_field_errors_total` | `scope`, `code` | Computed-field runtime errors by stable bounded code |
 | `hubuum_computed_field_live_fallbacks_total` | none | Stale shared materializations evaluated live during reads |
@@ -121,45 +215,38 @@ hubuum_export_template_info
 | `hubuum_computed_field_rebuild_batches_total` | `items` | Computed-field rebuild batches classified as empty or non-empty |
 | `hubuum_computed_field_rebuild_completions_total` | `status` | Computed-field rebuild terminal outcomes |
 | `hubuum_computed_field_rebuild_duration_seconds` | `status` | Computed-field rebuild duration histogram |
-| `hubuum_export_output_cleanup_runs_total` | none | Stored export and backup artifact cleanup runs (legacy metric name) |
-| `hubuum_export_output_cleanup_failures_total` | none | Stored export and backup artifact cleanup failures (legacy metric name) |
-| `hubuum_export_output_cleanup_deleted_total` | none | Stored export and backup artifacts deleted by cleanup (legacy metric name) |
-| `hubuum_export_template_info` | `template_id`, `template_name` | Stored export template identities observed by the current process |
-| `hubuum_export_phase_duration_seconds` | `phase`, `template_id` | Export query, hydration, render, and total phase duration; untemplated exports use `template_id="none"` |
-| `hubuum_export_completions_total` | `scope`, `content_type` | Successfully persisted export outputs |
-| `hubuum_export_truncations_total` | `scope`, `content_type` | Successfully persisted truncated exports |
-| `hubuum_export_warnings_total` | `scope`, `content_type` | Warning count on successfully persisted exports |
-| `hubuum_import_phase_duration_seconds` | `phase` | Import planning, execution, and total phase duration |
-| `hubuum_import_processed_items_total` | none | Items processed by terminal import tasks |
-| `hubuum_import_succeeded_items_total` | none | Import items completed successfully |
-| `hubuum_import_failed_items_total` | none | Import items completed with failure |
-| `hubuum_remote_call_duration_seconds` | `method`, `status_family`, `outcome` | Remote call duration |
-| `hubuum_remote_call_results_total` | `method`, `status_family`, `outcome` | Remote call outcomes: success, failure, timeout, validation rejection, or private-target rejection |
 | `hubuum_login_attempts_total` | `outcome` | Login attempts by success, bad credentials, rate-limited, or internal error |
 | `hubuum_login_lockouts_total` | `scope` | Login limiter lockout transitions by principal/IP, IP, or subnet scope |
-| `hubuum_login_limiter_backend_failures_total` | `backend`, `operation` | Shared login limiter failures while local enforcement remains active |
-| `hubuum_login_limiter_entries` | `state` | Active and locked login limiter entries |
+| `hubuum_login_limiter_backend_failures_total` | `backend`, `operation` | Shared login-limiter failures while local enforcement remains active |
+| `hubuum_login_limiter_entries` | `state` | Active and locked login-limiter entries in this process |
 | `hubuum_client_allowlist_rejections_total` | `reason` | Requests rejected for a disallowed or missing client IP |
-| `hubuum_event_queue_items` | `queue`, `state` | Fan-out and delivery queue items by bounded state |
+| `hubuum_event_queue_items` | `queue`, `state` | Database-wide fan-out and delivery queue items by bounded state |
 | `hubuum_event_stale_claims` | `queue` | Stale fan-out and delivery worker claims |
 | `hubuum_event_oldest_age_seconds` | `queue` | Oldest actionable fan-out or delivery item age |
-| `hubuum_event_worker_config` | `worker`, `setting` | Fan-out and delivery worker configuration |
-| `hubuum_event_worker_wakeups` | `worker`, `kind` | Notification and polling wakeup counters reported as gauges |
-| `hubuum_inventory_entities` | `entity_type` | Total collections, classes, objects, users, groups, service accounts, and remote targets |
+| `hubuum_event_workers_configured` | `worker` | Event workers configured in this process |
+| `hubuum_event_worker_batch_size` | `worker` | Configured event-worker batch size |
+| `hubuum_event_worker_poll_interval_seconds` | `worker` | Configured event-worker poll interval |
+| `hubuum_event_worker_lock_timeout_seconds` | `worker` | Configured event-worker claim lock timeout |
+| `hubuum_event_worker_wakeups_total` | `worker`, `kind` | Notification, poll, and notification-send wakeups observed by this process |
+| `hubuum_inventory_entities` | `entity_type` | Database-wide collections, classes, objects, users, groups, service accounts, and remote targets |
 
 ## Alert Starting Points
 
 These thresholds are deployment starting points, not universal defaults:
 
 | Signal | Suggested alert |
-| ------ | --------------- |
+| --- | --- |
+| Missing target | `up == 0`, grouped by expected API and worker target |
+| Counter reset | Unexpected `resets(hubuum_http_requests_total[15m])`, correlated with process start time |
+| Stale snapshots | Current time minus `hubuum_metrics_refresh_last_success_timestamp_seconds` exceeds the cache and scrape tolerance |
 | DB acquisition failures | Any sustained non-zero `hubuum_db_connection_acquire_failures_total` rate |
-| DB pool pressure | `checked_out / configured` above 0.8 for several minutes |
-| HTTP 5xx rate | `5xx` status family above normal baseline |
-| Task queue age | Oldest queued task age above expected worker latency |
-| Task worker errors | Sustained non-zero `outcome="error"` worker iteration rate |
+| DB pool pressure | Checked-out divided by configured connections above `0.8` for several minutes |
+| HTTP 5xx rate | `5xx` status family above the normal route-specific baseline |
+| Task queue age | Oldest queued task age above the expected latency for that task kind |
+| Task worker errors | Sustained non-zero worker iteration `outcome="error"` rate |
 | Task lease recovery | Any unexpected `hubuum_task_lease_recoveries_total` increase |
-| Login lockouts | Sudden increase in `hubuum_login_lockouts_total` or sustained locked entries |
-| Shared limiter degradation | Any sustained non-zero `hubuum_login_limiter_backend_failures_total` rate |
-| Remote call failures | Failure or timeout rate above target-specific baseline |
-| Event backlog | Oldest fan-out or delivery age above the configured processing objective |
+| Export or import failures | Failure or timeout outcomes above the task-kind baseline |
+| Login lockouts | Sudden increase in lockouts or sustained locked entries |
+| Shared limiter degradation | Sustained non-zero login-limiter backend failure rate |
+| Remote call failures | Failure or timeout rate above the remote-call baseline |
+| Event backlog | Oldest fan-out or delivery age above the processing objective |

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -19592,6 +19592,13 @@
           "output_expired"
         ],
         "properties": {
+          "hydration_duration_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
           "output_available": {
             "type": "boolean"
           },
@@ -19615,11 +19622,32 @@
           "output_url": {
             "type": "string"
           },
+          "query_duration_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
+          "render_duration_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
           "template_name": {
             "type": [
               "string",
               "null"
             ]
+          },
+          "total_duration_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
           },
           "truncated": {
             "type": [

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -46,7 +46,7 @@ the standalone Diesel CLI are not installed. Set
 | `HUBUUM_ACTIX_WORKERS` | Detected CPU count | Number of Actix worker threads |
 | `HUBUUM_RUNTIME_ROLE` | `all` | Process role: `all`, `api`, or `worker` |
 | `HUBUUM_METRICS_ENABLED` | `true` | Enables the Prometheus metrics scrape endpoint |
-| `HUBUUM_METRICS_PATH` | `/metrics` | Literal absolute path for the Prometheus metrics scrape endpoint |
+| `HUBUUM_METRICS_PATH` | `/metrics` | Literal absolute path for the Prometheus metrics scrape endpoint; worker-only processes expose just this route on their configured listener |
 
 Logs are newline-delimited JSON only and are configured through `HUBUUM_LOG_LEVEL`. Release
 builds include their Git SHA in the structured startup event; local builders may set

--- a/docs/task_api.md
+++ b/docs/task_api.md
@@ -254,10 +254,16 @@ Export example:
     "template_name": "export.host_room_people",
     "output_content_type": "text/plain",
     "warning_count": 1,
-    "truncated": false
+    "truncated": false,
+    "total_duration_ms": 148,
+    "query_duration_ms": 42,
+    "hydration_duration_ms": 31,
+    "render_duration_ms": 68
   }
 }
 ```
+
+The export phase timings are returned while the stored export output remains available; after output expiry these fields are `null`. `total_duration_ms` covers query execution, relation-aware hydration, and rendering plus the intervening task bookkeeping. It does not include initial template preparation or final output persistence.
 
 ## Task events
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -845,6 +845,42 @@ mod tests {
     }
 
     #[test]
+    fn database_call_sites_have_stable_bounded_labels() {
+        let call_sites = [
+            DbCallSite::EventDelivery,
+            DbCallSite::EventFanout,
+            DbCallSite::EventRetention,
+            DbCallSite::HttpRequest,
+            DbCallSite::MetricsRefresh,
+            DbCallSite::Readiness,
+            DbCallSite::RequestMaintenance,
+            DbCallSite::RestoreCoordinator,
+            DbCallSite::TaskLease,
+            DbCallSite::TaskWorker,
+            DbCallSite::TokenRetention,
+            DbCallSite::Unattributed,
+        ];
+
+        assert_eq!(
+            call_sites.map(DbCallSite::as_str),
+            [
+                "event_delivery",
+                "event_fanout",
+                "event_retention",
+                "http_request",
+                "metrics_refresh",
+                "readiness",
+                "request_maintenance",
+                "restore_coordinator",
+                "task_lease",
+                "task_worker",
+                "token_retention",
+                "unattributed",
+            ]
+        );
+    }
+
+    #[test]
     fn required_database_migration_matches_latest_migration_directory() {
         let migrations = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
         let latest = std::fs::read_dir(migrations)

--- a/src/db/traits/metrics.rs
+++ b/src/db/traits/metrics.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use chrono::NaiveDateTime;
 use diesel::dsl::{count_star, min};
 use diesel::sql_types::BigInt;
@@ -5,26 +7,44 @@ use diesel::sql_types::BigInt;
 use crate::db::prelude::*;
 use crate::db::with_connection;
 use crate::errors::ApiError;
-use crate::models::{EventDeliveryQueueHealth, EventFanoutHealth, TaskStatus};
+use crate::models::{EventDeliveryQueueHealth, EventFanoutHealth, TaskKind, TaskStatus};
 use crate::schema::tasks;
 use crate::traits::BackendContext;
 
 #[derive(Debug, Clone, Copy, QueryableByName)]
+struct InventoryMetricsCountRow {
+    #[diesel(sql_type = BigInt)]
+    collections: i64,
+    #[diesel(sql_type = BigInt)]
+    classes: i64,
+    #[diesel(sql_type = BigInt)]
+    objects: i64,
+    #[diesel(sql_type = BigInt)]
+    users: i64,
+    #[diesel(sql_type = BigInt)]
+    groups: i64,
+    #[diesel(sql_type = BigInt)]
+    service_accounts: i64,
+    #[diesel(sql_type = BigInt)]
+    remote_targets: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExportTemplateMetricIdentity {
+    pub id: i32,
+    pub name: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct InventoryMetricsSnapshot {
-    #[diesel(sql_type = BigInt)]
     pub collections: i64,
-    #[diesel(sql_type = BigInt)]
     pub classes: i64,
-    #[diesel(sql_type = BigInt)]
     pub objects: i64,
-    #[diesel(sql_type = BigInt)]
     pub users: i64,
-    #[diesel(sql_type = BigInt)]
     pub groups: i64,
-    #[diesel(sql_type = BigInt)]
     pub service_accounts: i64,
-    #[diesel(sql_type = BigInt)]
     pub remote_targets: i64,
+    pub export_templates: Vec<ExportTemplateMetricIdentity>,
 }
 
 #[derive(Debug, Clone)]
@@ -35,10 +55,16 @@ pub struct TaskMetricsCount {
 }
 
 #[derive(Debug, Clone)]
-pub struct TaskMetricsSnapshot {
-    pub counts: Vec<TaskMetricsCount>,
+pub struct TaskMetricsAge {
+    pub kind: String,
     pub oldest_queued_at: Option<NaiveDateTime>,
     pub oldest_active_at: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskMetricsSnapshot {
+    pub counts: Vec<TaskMetricsCount>,
+    pub ages: Vec<TaskMetricsAge>,
 }
 
 #[derive(Debug, Clone)]
@@ -58,7 +84,7 @@ where
 {
     async fn metrics_inventory_snapshot(&self) -> Result<InventoryMetricsSnapshot, ApiError> {
         with_connection(self.db_pool(), async |conn| {
-            diesel::sql_query(
+            let counts = diesel::sql_query(
                 r#"
                 SELECT
                     (SELECT COUNT(*) FROM collections) AS collections,
@@ -70,8 +96,30 @@ where
                     (SELECT COUNT(*) FROM remote_targets) AS remote_targets
                 "#,
             )
-            .get_result::<InventoryMetricsSnapshot>(conn)
-            .await
+            .get_result::<InventoryMetricsCountRow>(conn)
+            .await?;
+            let export_templates = crate::schema::export_templates::table
+                .select((
+                    crate::schema::export_templates::id,
+                    crate::schema::export_templates::name,
+                ))
+                .order(crate::schema::export_templates::id)
+                .load::<(i32, String)>(conn)
+                .await?
+                .into_iter()
+                .map(|(id, name)| ExportTemplateMetricIdentity { id, name })
+                .collect();
+
+            Ok::<_, diesel::result::Error>(InventoryMetricsSnapshot {
+                collections: counts.collections,
+                classes: counts.classes,
+                objects: counts.objects,
+                users: counts.users,
+                groups: counts.groups,
+                service_accounts: counts.service_accounts,
+                remote_targets: counts.remote_targets,
+                export_templates,
+            })
         })
         .await
     }
@@ -91,26 +139,45 @@ where
                 })
                 .collect();
 
-            let oldest_queued_at = tasks::table
+            let oldest_queued = tasks::table
                 .filter(tasks::status.eq(TaskStatus::Queued.as_str()))
-                .select(min(tasks::created_at))
-                .get_result::<Option<NaiveDateTime>>(conn)
+                .group_by(tasks::kind)
+                .select((tasks::kind, min(tasks::created_at)))
+                .load::<(String, Option<NaiveDateTime>)>(conn)
                 .await?;
 
-            let oldest_active_at = tasks::table
+            let oldest_active = tasks::table
                 .filter(tasks::status.eq_any([
                     TaskStatus::Validating.as_str(),
                     TaskStatus::Running.as_str(),
                 ]))
-                .select(min(tasks::started_at))
-                .get_result::<Option<NaiveDateTime>>(conn)
+                .group_by(tasks::kind)
+                .select((tasks::kind, min(tasks::started_at)))
+                .load::<(String, Option<NaiveDateTime>)>(conn)
                 .await?;
 
-            Ok::<_, diesel::result::Error>(TaskMetricsSnapshot {
-                counts,
-                oldest_queued_at,
-                oldest_active_at,
-            })
+            let mut ages_by_kind = HashMap::new();
+            for (kind, timestamp) in oldest_queued {
+                ages_by_kind.entry(kind).or_insert((None, None)).0 = timestamp;
+            }
+            for (kind, timestamp) in oldest_active {
+                ages_by_kind.entry(kind).or_insert((None, None)).1 = timestamp;
+            }
+            let ages = TaskKind::ALL
+                .into_iter()
+                .map(|kind| {
+                    let kind = kind.as_str();
+                    let (oldest_queued_at, oldest_active_at) =
+                        ages_by_kind.remove(kind).unwrap_or((None, None));
+                    TaskMetricsAge {
+                        kind: kind.to_string(),
+                        oldest_queued_at,
+                        oldest_active_at,
+                    }
+                })
+                .collect();
+
+            Ok::<_, diesel::result::Error>(TaskMetricsSnapshot { counts, ages })
         })
         .await
     }

--- a/src/db/traits/metrics.rs
+++ b/src/db/traits/metrics.rs
@@ -7,7 +7,9 @@ use diesel::sql_types::BigInt;
 use crate::db::prelude::*;
 use crate::db::with_connection;
 use crate::errors::ApiError;
-use crate::models::{EventDeliveryQueueHealth, EventFanoutHealth, TaskKind, TaskStatus};
+use crate::models::{
+    EventDeliveryQueueHealth, EventFanoutHealth, ExportTemplateID, TaskKind, TaskStatus,
+};
 use crate::schema::tasks;
 use crate::traits::BackendContext;
 
@@ -31,7 +33,7 @@ struct InventoryMetricsCountRow {
 
 #[derive(Debug, Clone)]
 pub struct ExportTemplateMetricIdentity {
-    pub id: i32,
+    pub id: ExportTemplateID,
     pub name: String,
 }
 
@@ -49,14 +51,14 @@ pub struct InventoryMetricsSnapshot {
 
 #[derive(Debug, Clone)]
 pub struct TaskMetricsCount {
-    pub kind: String,
-    pub status: String,
+    pub kind: TaskKind,
+    pub status: TaskStatus,
     pub count: i64,
 }
 
 #[derive(Debug, Clone)]
 pub struct TaskMetricsAge {
-    pub kind: String,
+    pub kind: TaskKind,
     pub oldest_queued_at: Option<NaiveDateTime>,
     pub oldest_active_at: Option<NaiveDateTime>,
 }
@@ -107,10 +109,15 @@ where
                 .load::<(i32, String)>(conn)
                 .await?
                 .into_iter()
-                .map(|(id, name)| ExportTemplateMetricIdentity { id, name })
-                .collect();
+                .map(|(id, name)| {
+                    Ok(ExportTemplateMetricIdentity {
+                        id: ExportTemplateID::new(id)?,
+                        name,
+                    })
+                })
+                .collect::<Result<Vec<_>, ApiError>>()?;
 
-            Ok::<_, diesel::result::Error>(InventoryMetricsSnapshot {
+            Ok::<_, ApiError>(InventoryMetricsSnapshot {
                 collections: counts.collections,
                 classes: counts.classes,
                 objects: counts.objects,
@@ -132,12 +139,14 @@ where
                 .load::<(String, String, i64)>(conn)
                 .await?
                 .into_iter()
-                .map(|(kind, status, count)| TaskMetricsCount {
-                    kind,
-                    status,
-                    count,
+                .map(|(kind, status, count)| {
+                    Ok(TaskMetricsCount {
+                        kind: TaskKind::from_db(&kind)?,
+                        status: TaskStatus::from_db(&status)?,
+                        count,
+                    })
                 })
-                .collect();
+                .collect::<Result<Vec<_>, ApiError>>()?;
 
             let oldest_queued = tasks::table
                 .filter(tasks::status.eq(TaskStatus::Queued.as_str()))
@@ -158,26 +167,31 @@ where
 
             let mut ages_by_kind = HashMap::new();
             for (kind, timestamp) in oldest_queued {
-                ages_by_kind.entry(kind).or_insert((None, None)).0 = timestamp;
+                ages_by_kind
+                    .entry(TaskKind::from_db(&kind)?)
+                    .or_insert((None, None))
+                    .0 = timestamp;
             }
             for (kind, timestamp) in oldest_active {
-                ages_by_kind.entry(kind).or_insert((None, None)).1 = timestamp;
+                ages_by_kind
+                    .entry(TaskKind::from_db(&kind)?)
+                    .or_insert((None, None))
+                    .1 = timestamp;
             }
             let ages = TaskKind::ALL
                 .into_iter()
                 .map(|kind| {
-                    let kind = kind.as_str();
                     let (oldest_queued_at, oldest_active_at) =
-                        ages_by_kind.remove(kind).unwrap_or((None, None));
+                        ages_by_kind.remove(&kind).unwrap_or((None, None));
                     TaskMetricsAge {
-                        kind: kind.to_string(),
+                        kind,
                         oldest_queued_at,
                         oldest_active_at,
                     }
                 })
                 .collect();
 
-            Ok::<_, diesel::result::Error>(TaskMetricsSnapshot { counts, ages })
+            Ok::<_, ApiError>(TaskMetricsSnapshot { counts, ages })
         })
         .await
     }

--- a/src/db/traits/metrics.rs
+++ b/src/db/traits/metrics.rs
@@ -5,68 +5,76 @@ use diesel::dsl::{count_star, min};
 use diesel::sql_types::BigInt;
 
 use crate::db::prelude::*;
-use crate::db::with_connection;
+use crate::db::{DbConnection, with_connection};
 use crate::errors::ApiError;
 use crate::models::{
     EventDeliveryQueueHealth, EventFanoutHealth, ExportTemplateID, TaskKind, TaskStatus,
 };
-use crate::schema::tasks;
+use crate::schema::{export_templates, tasks};
 use crate::traits::BackendContext;
 
 #[derive(Debug, Clone, Copy, QueryableByName)]
-struct InventoryMetricsCountRow {
-    #[diesel(sql_type = BigInt)]
-    collections: i64,
-    #[diesel(sql_type = BigInt)]
-    classes: i64,
-    #[diesel(sql_type = BigInt)]
-    objects: i64,
-    #[diesel(sql_type = BigInt)]
-    users: i64,
-    #[diesel(sql_type = BigInt)]
-    groups: i64,
-    #[diesel(sql_type = BigInt)]
-    service_accounts: i64,
-    #[diesel(sql_type = BigInt)]
-    remote_targets: i64,
-}
-
-#[derive(Debug, Clone)]
-pub struct ExportTemplateMetricIdentity {
-    pub id: ExportTemplateID,
-    pub name: String,
-}
-
-#[derive(Debug, Clone)]
 pub struct InventoryMetricsSnapshot {
+    #[diesel(sql_type = BigInt)]
     pub collections: i64,
+    #[diesel(sql_type = BigInt)]
     pub classes: i64,
+    #[diesel(sql_type = BigInt)]
     pub objects: i64,
+    #[diesel(sql_type = BigInt)]
     pub users: i64,
+    #[diesel(sql_type = BigInt)]
     pub groups: i64,
+    #[diesel(sql_type = BigInt)]
     pub service_accounts: i64,
+    #[diesel(sql_type = BigInt)]
     pub remote_targets: i64,
-    pub export_templates: Vec<ExportTemplateMetricIdentity>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ExportTemplateMetricIdentity {
+    pub(crate) id: ExportTemplateID,
+    pub(crate) name: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct InventoryGaugeSnapshot {
+    pub(crate) counts: InventoryMetricsSnapshot,
+    pub(crate) export_templates: Vec<ExportTemplateMetricIdentity>,
 }
 
 #[derive(Debug, Clone)]
 pub struct TaskMetricsCount {
-    pub kind: TaskKind,
-    pub status: TaskStatus,
+    pub kind: String,
+    pub status: String,
     pub count: i64,
-}
-
-#[derive(Debug, Clone)]
-pub struct TaskMetricsAge {
-    pub kind: TaskKind,
-    pub oldest_queued_at: Option<NaiveDateTime>,
-    pub oldest_active_at: Option<NaiveDateTime>,
 }
 
 #[derive(Debug, Clone)]
 pub struct TaskMetricsSnapshot {
     pub counts: Vec<TaskMetricsCount>,
-    pub ages: Vec<TaskMetricsAge>,
+    pub oldest_queued_at: Option<NaiveDateTime>,
+    pub oldest_active_at: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TaskGaugeCount {
+    pub(crate) kind: TaskKind,
+    pub(crate) status: TaskStatus,
+    pub(crate) count: i64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TaskGaugeAge {
+    pub(crate) kind: TaskKind,
+    pub(crate) oldest_queued_at: Option<NaiveDateTime>,
+    pub(crate) oldest_active_at: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TaskGaugeSnapshot {
+    pub(crate) counts: Vec<TaskGaugeCount>,
+    pub(crate) ages: Vec<TaskGaugeAge>,
 }
 
 #[derive(Debug, Clone)]
@@ -80,32 +88,64 @@ pub trait MetricsBackend {
     async fn metrics_task_snapshot(&self) -> Result<TaskMetricsSnapshot, ApiError>;
 }
 
+pub(crate) trait MetricsRefreshBackend {
+    async fn metrics_inventory_gauge_snapshot(&self) -> Result<InventoryGaugeSnapshot, ApiError>;
+    async fn metrics_task_gauge_snapshot(&self) -> Result<TaskGaugeSnapshot, ApiError>;
+}
+
 impl<T> MetricsBackend for T
 where
     T: BackendContext + Sync + ?Sized,
 {
     async fn metrics_inventory_snapshot(&self) -> Result<InventoryMetricsSnapshot, ApiError> {
+        with_connection(self.db_pool(), load_inventory_counts).await
+    }
+
+    async fn metrics_task_snapshot(&self) -> Result<TaskMetricsSnapshot, ApiError> {
         with_connection(self.db_pool(), async |conn| {
-            let counts = diesel::sql_query(
-                r#"
-                SELECT
-                    (SELECT COUNT(*) FROM collections) AS collections,
-                    (SELECT COUNT(*) FROM hubuumclass) AS classes,
-                    (SELECT COUNT(*) FROM hubuumobject) AS objects,
-                    (SELECT COUNT(*) FROM users) AS users,
-                    (SELECT COUNT(*) FROM groups) AS groups,
-                    (SELECT COUNT(*) FROM service_accounts) AS service_accounts,
-                    (SELECT COUNT(*) FROM remote_targets) AS remote_targets
-                "#,
-            )
-            .get_result::<InventoryMetricsCountRow>(conn)
-            .await?;
-            let export_templates = crate::schema::export_templates::table
-                .select((
-                    crate::schema::export_templates::id,
-                    crate::schema::export_templates::name,
-                ))
-                .order(crate::schema::export_templates::id)
+            let counts = load_task_count_rows(conn)
+                .await?
+                .into_iter()
+                .map(|(kind, status, count)| TaskMetricsCount {
+                    kind,
+                    status,
+                    count,
+                })
+                .collect();
+            let oldest_queued_at = tasks::table
+                .filter(tasks::status.eq(TaskStatus::Queued.as_str()))
+                .select(min(tasks::created_at))
+                .get_result::<Option<NaiveDateTime>>(conn)
+                .await?;
+            let oldest_active_at = tasks::table
+                .filter(tasks::status.eq_any([
+                    TaskStatus::Validating.as_str(),
+                    TaskStatus::Running.as_str(),
+                ]))
+                .select(min(tasks::started_at))
+                .get_result::<Option<NaiveDateTime>>(conn)
+                .await?;
+
+            Ok::<_, ApiError>(TaskMetricsSnapshot {
+                counts,
+                oldest_queued_at,
+                oldest_active_at,
+            })
+        })
+        .await
+    }
+}
+
+impl<T> MetricsRefreshBackend for T
+where
+    T: BackendContext + Sync + ?Sized,
+{
+    async fn metrics_inventory_gauge_snapshot(&self) -> Result<InventoryGaugeSnapshot, ApiError> {
+        with_connection(self.db_pool(), async |conn| {
+            let counts = load_inventory_counts(conn).await?;
+            let export_templates = export_templates::table
+                .select((export_templates::id, export_templates::name))
+                .order(export_templates::id)
                 .load::<(i32, String)>(conn)
                 .await?
                 .into_iter()
@@ -117,30 +157,21 @@ where
                 })
                 .collect::<Result<Vec<_>, ApiError>>()?;
 
-            Ok::<_, ApiError>(InventoryMetricsSnapshot {
-                collections: counts.collections,
-                classes: counts.classes,
-                objects: counts.objects,
-                users: counts.users,
-                groups: counts.groups,
-                service_accounts: counts.service_accounts,
-                remote_targets: counts.remote_targets,
+            Ok::<_, ApiError>(InventoryGaugeSnapshot {
+                counts,
                 export_templates,
             })
         })
         .await
     }
 
-    async fn metrics_task_snapshot(&self) -> Result<TaskMetricsSnapshot, ApiError> {
+    async fn metrics_task_gauge_snapshot(&self) -> Result<TaskGaugeSnapshot, ApiError> {
         with_connection(self.db_pool(), async |conn| {
-            let counts = tasks::table
-                .group_by((tasks::kind, tasks::status))
-                .select((tasks::kind, tasks::status, count_star()))
-                .load::<(String, String, i64)>(conn)
+            let counts = load_task_count_rows(conn)
                 .await?
                 .into_iter()
                 .map(|(kind, status, count)| {
-                    Ok(TaskMetricsCount {
+                    Ok(TaskGaugeCount {
                         kind: TaskKind::from_db(&kind)?,
                         status: TaskStatus::from_db(&status)?,
                         count,
@@ -154,7 +185,6 @@ where
                 .select((tasks::kind, min(tasks::created_at)))
                 .load::<(String, Option<NaiveDateTime>)>(conn)
                 .await?;
-
             let oldest_active = tasks::table
                 .filter(tasks::status.eq_any([
                     TaskStatus::Validating.as_str(),
@@ -183,7 +213,7 @@ where
                 .map(|kind| {
                     let (oldest_queued_at, oldest_active_at) =
                         ages_by_kind.remove(&kind).unwrap_or((None, None));
-                    TaskMetricsAge {
+                    TaskGaugeAge {
                         kind,
                         oldest_queued_at,
                         oldest_active_at,
@@ -191,8 +221,37 @@ where
                 })
                 .collect();
 
-            Ok::<_, ApiError>(TaskMetricsSnapshot { counts, ages })
+            Ok::<_, ApiError>(TaskGaugeSnapshot { counts, ages })
         })
         .await
     }
+}
+
+async fn load_inventory_counts(
+    conn: &mut DbConnection,
+) -> Result<InventoryMetricsSnapshot, ApiError> {
+    Ok(diesel::sql_query(
+        r#"
+        SELECT
+            (SELECT COUNT(*) FROM collections) AS collections,
+            (SELECT COUNT(*) FROM hubuumclass) AS classes,
+            (SELECT COUNT(*) FROM hubuumobject) AS objects,
+            (SELECT COUNT(*) FROM users) AS users,
+            (SELECT COUNT(*) FROM groups) AS groups,
+            (SELECT COUNT(*) FROM service_accounts) AS service_accounts,
+            (SELECT COUNT(*) FROM remote_targets) AS remote_targets
+        "#,
+    )
+    .get_result::<InventoryMetricsSnapshot>(conn)
+    .await?)
+}
+
+async fn load_task_count_rows(
+    conn: &mut DbConnection,
+) -> Result<Vec<(String, String, i64)>, ApiError> {
+    Ok(tasks::table
+        .group_by((tasks::kind, tasks::status))
+        .select((tasks::kind, tasks::status, count_star()))
+        .load::<(String, String, i64)>(conn)
+        .await?)
 }

--- a/src/events/delivery.rs
+++ b/src/events/delivery.rs
@@ -27,6 +27,7 @@ use crate::events::sink::{
 use crate::events::{EntityType, PrincipalNames};
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::{EventSink, EventSubscription, EventWorkerWakeupStats};
+use crate::observability::metrics;
 use crate::restores::MaintenanceActivityGuard;
 
 static EVENT_DELIVERY_WORKER: Once = Once::new();
@@ -267,10 +268,12 @@ async fn wait_for_event_delivery_wakeup(
         _ = shutdown.requested() => false,
         _ = sleep(wait_duration) => {
             EVENT_DELIVERY_POLL_WAKEUPS.fetch_add(1, Ordering::Relaxed);
+            metrics::event_worker_wakeup("delivery", "poll");
             true
         }
         _ = get_event_delivery_notify().notified() => {
             EVENT_DELIVERY_NOTIFICATION_WAKEUPS.fetch_add(1, Ordering::Relaxed);
+            metrics::event_worker_wakeup("delivery", "notification");
             true
         }
     }
@@ -377,6 +380,7 @@ pub fn ensure_event_delivery_worker_running(pool: DbPool) {
 pub fn kick_event_delivery_worker(pool: DbPool) {
     ensure_event_delivery_worker_running(pool);
     EVENT_DELIVERY_NOTIFICATIONS_SENT.fetch_add(1, Ordering::Relaxed);
+    metrics::event_worker_wakeup("delivery", "notifications_sent");
     get_event_delivery_notify().notify_one();
 }
 

--- a/src/events/fanout.rs
+++ b/src/events/fanout.rs
@@ -15,6 +15,7 @@ use crate::db::{DbCallSite, DbPool, with_db_call_site};
 use crate::errors::ApiError;
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::EventWorkerWakeupStats;
+use crate::observability::metrics;
 use crate::restores::MaintenanceActivityGuard;
 
 static EVENT_FANOUT_WORKER: Once = Once::new();
@@ -77,10 +78,12 @@ async fn wait_for_event_fanout_wakeup(poll_interval: Duration, shutdown: &Shutdo
         _ = shutdown.requested() => false,
         _ = sleep(poll_interval) => {
             EVENT_FANOUT_POLL_WAKEUPS.fetch_add(1, Ordering::Relaxed);
+            metrics::event_worker_wakeup("fanout", "poll");
             true
         }
         _ = get_event_fanout_notify().notified() => {
             EVENT_FANOUT_NOTIFICATION_WAKEUPS.fetch_add(1, Ordering::Relaxed);
+            metrics::event_worker_wakeup("fanout", "notification");
             true
         }
     }
@@ -173,6 +176,7 @@ pub fn ensure_event_fanout_worker_running(pool: DbPool) {
 pub fn kick_event_fanout_worker(pool: DbPool) {
     ensure_event_fanout_worker_running(pool);
     EVENT_FANOUT_NOTIFICATIONS_SENT.fetch_add(1, Ordering::Relaxed);
+    metrics::event_worker_wakeup("fanout", "notifications_sent");
     get_event_fanout_notify().notify_one();
 }
 

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
-use std::time::Instant;
+use std::time::Duration;
 
 use hubuum_task_core::IdempotencyKey;
 use hubuum_templates::SizeLimitedWriter;
@@ -85,10 +85,28 @@ struct ExportExecution {
 
 #[derive(Debug, Clone, Copy, Default)]
 struct ExportExecutionTimings {
-    total_duration_ms: i32,
-    query_duration_ms: i32,
-    hydration_duration_ms: i32,
-    render_duration_ms: i32,
+    total: Duration,
+    query: Duration,
+    hydration: Duration,
+    render: Duration,
+}
+
+impl ExportExecutionTimings {
+    fn total_millis(self) -> i32 {
+        duration_to_millis_i32(self.total)
+    }
+
+    fn query_millis(self) -> i32 {
+        duration_to_millis_i32(self.query)
+    }
+
+    fn hydration_millis(self) -> i32 {
+        duration_to_millis_i32(self.hydration)
+    }
+
+    fn render_millis(self) -> i32 {
+        duration_to_millis_i32(self.render)
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1109,9 +1127,13 @@ where
     let runtime = prepare_export_runtime(pool, payload.export, template).await?;
     validate_export_submission(&runtime)?;
     let exporter = PermissionAwareExport::new(backend, subject, scopes).await?;
-    let metric_template_id = runtime.template.as_ref().map(|template| template.id);
-    let total_start = Instant::now();
-    let total_metric = metrics::export_phase_timer("total", metric_template_id);
+    let metric_template_id = runtime
+        .template
+        .as_ref()
+        .map(|template| ExportTemplateID::new(template.id))
+        .transpose()?;
+    let total_metric =
+        metrics::export_phase_timer(metrics::ExportMetricPhase::Total, metric_template_id);
     let mut timings = ExportExecutionTimings::default();
 
     NewTaskEventRecord {
@@ -1148,8 +1170,8 @@ where
     let statement_timeout = export_statement_timeout();
     let mut query_options = prepare_query_options(&runtime.export)?;
     let relation_hydration = resolve_relation_hydration_plan(&runtime, &mut query_options)?;
-    let query_start = Instant::now();
-    let query_metric = metrics::export_phase_timer("query", metric_template_id);
+    let query_metric =
+        metrics::export_phase_timer(metrics::ExportMetricPhase::Query, metric_template_id);
     let (items, mut warnings, truncated) = with_statement_timeout_scope(
         statement_timeout,
         execute_scope(&exporter, runtime.scope, query_options),
@@ -1161,12 +1183,12 @@ where
         apply_export_includes(&exporter, &runtime.export, &mut items),
     )
     .await?;
-    if let Err(error) = enforce_export_stage_timeout(query_start, "query execution") {
-        query_metric.finish("timeout");
+    if let Err(error) = enforce_export_stage_timeout(query_metric.elapsed(), "query execution") {
+        query_metric.finish(metrics::ExportMetricOutcome::Timeout);
         return Err(error);
     }
-    let query_elapsed = query_metric.finish("success");
-    timings.query_duration_ms = duration_to_millis_i32(query_elapsed);
+    let query_elapsed = query_metric.finish(metrics::ExportMetricOutcome::Success);
+    timings.query = query_elapsed;
 
     if relation_hydration
         .as_ref()
@@ -1187,19 +1209,21 @@ where
     }
 
     add_truncation_warning(&mut warnings, truncated);
-    let hydration_start = Instant::now();
-    let hydration_metric = metrics::export_phase_timer("hydration", metric_template_id);
+    let hydration_metric =
+        metrics::export_phase_timer(metrics::ExportMetricPhase::Hydration, metric_template_id);
     let (template_items, source) = with_statement_timeout_scope(
         statement_timeout,
         build_template_items(&exporter, &runtime, &items, relation_hydration),
     )
     .await?;
-    if let Err(error) = enforce_export_stage_timeout(hydration_start, "relation hydration") {
-        hydration_metric.finish("timeout");
+    if let Err(error) =
+        enforce_export_stage_timeout(hydration_metric.elapsed(), "relation hydration")
+    {
+        hydration_metric.finish(metrics::ExportMetricOutcome::Timeout);
         return Err(error);
     }
-    let hydration_elapsed = hydration_metric.finish("success");
-    timings.hydration_duration_ms = duration_to_millis_i32(hydration_elapsed);
+    let hydration_elapsed = hydration_metric.finish(metrics::ExportMetricOutcome::Success);
+    timings.hydration = hydration_elapsed;
     let template_export = runtime.template.is_some();
     let item_count = if template_export {
         template_items.len()
@@ -1234,18 +1258,19 @@ where
     .append(pool)
     .await?;
 
-    let render_start = Instant::now();
-    let render_metric = metrics::export_phase_timer("render", metric_template_id);
+    let render_metric =
+        metrics::export_phase_timer(metrics::ExportMetricPhase::Render, metric_template_id);
     let artifact = build_export_artifact(&runtime, execution, timings)?;
     let mut timings = artifact.timings;
-    if let Err(error) = enforce_export_stage_timeout(render_start, "template rendering") {
-        render_metric.finish("timeout");
+    if let Err(error) = enforce_export_stage_timeout(render_metric.elapsed(), "template rendering")
+    {
+        render_metric.finish(metrics::ExportMetricOutcome::Timeout);
         return Err(error);
     }
-    let render_elapsed = render_metric.finish("success");
-    let total_elapsed = total_metric.finish("success");
-    timings.render_duration_ms = duration_to_millis_i32(render_elapsed);
-    timings.total_duration_ms = duration_to_millis_i32(total_elapsed);
+    let render_elapsed = render_metric.finish(metrics::ExportMetricOutcome::Success);
+    let total_elapsed = total_metric.finish(metrics::ExportMetricOutcome::Success);
+    timings.render = render_elapsed;
+    timings.total = total_elapsed;
     log_export_stage_metrics(task.id, &runtime, timings);
     let artifact = ExportArtifact {
         timings,
@@ -1276,19 +1301,16 @@ where
         NewTaskEventRecord {
             task_id: task.id,
             event_type: TaskStatus::Succeeded.as_str().to_string(),
-            message: format!(
-                "Export completed successfully in {:?}",
-                total_start.elapsed()
-            ),
+            message: format!("Export completed successfully in {total_elapsed:?}"),
             data: Some(serde_json::json!({
                 "content_type": artifact.content_type.as_mime(),
                 "template_name": artifact.template_name.clone(),
                 "warning_count": artifact.warnings.len(),
                 "truncated": artifact.meta.truncated,
-                "total_duration_ms": artifact.timings.total_duration_ms,
-                "query_duration_ms": artifact.timings.query_duration_ms,
-                "hydration_duration_ms": artifact.timings.hydration_duration_ms,
-                "render_duration_ms": artifact.timings.render_duration_ms,
+                "total_duration_ms": artifact.timings.total_millis(),
+                "query_duration_ms": artifact.timings.query_millis(),
+                "hydration_duration_ms": artifact.timings.hydration_millis(),
+                "render_duration_ms": artifact.timings.render_millis(),
             })),
         },
         artifact_to_output_record(task.id, artifact)?,
@@ -1326,10 +1348,10 @@ fn artifact_to_output_record(
         warning_count: i32::try_from(artifact.warnings.len()).unwrap_or(i32::MAX),
         truncated: artifact.meta.truncated,
         output_expires_at,
-        total_duration_ms: artifact.timings.total_duration_ms,
-        query_duration_ms: artifact.timings.query_duration_ms,
-        hydration_duration_ms: artifact.timings.hydration_duration_ms,
-        render_duration_ms: artifact.timings.render_duration_ms,
+        total_duration_ms: artifact.timings.total_millis(),
+        query_duration_ms: artifact.timings.query_millis(),
+        hydration_duration_ms: artifact.timings.hydration_millis(),
+        render_duration_ms: artifact.timings.render_millis(),
     })
 }
 
@@ -1450,7 +1472,7 @@ fn required_template(
     })
 }
 
-fn duration_to_millis_i32(duration: std::time::Duration) -> i32 {
+fn duration_to_millis_i32(duration: Duration) -> i32 {
     i32::try_from(duration.as_millis()).unwrap_or(i32::MAX)
 }
 
@@ -1475,11 +1497,10 @@ fn export_statement_timeout() -> Option<StatementTimeoutMs> {
 /// budget, `export_template_max_objects`, the output byte caps, the pool-global
 /// `db_statement_timeout_ms`, and the export-scoped `export_db_statement_timeout_ms`
 /// (both of which cancel slow queries server-side).
-fn enforce_export_stage_timeout(stage_start: Instant, stage_name: &str) -> Result<(), ApiError> {
+fn enforce_export_stage_timeout(elapsed: Duration, stage_name: &str) -> Result<(), ApiError> {
     let stage_timeout_ms = get_config()
         .map(|config| config.export_stage_timeout_ms)
         .unwrap_or(DEFAULT_EXPORT_STAGE_TIMEOUT_MS);
-    let elapsed = stage_start.elapsed();
     if elapsed.as_millis() > u128::from(stage_timeout_ms) {
         return Err(ApiError::BadRequest(format!(
             "Export {stage_name} exceeded the configured time budget ({}ms > {}ms)",
@@ -1504,10 +1525,10 @@ fn log_export_stage_metrics(
             .template
             .as_ref()
             .map(|template| template.name.as_str()),
-        total_duration_ms = timings.total_duration_ms,
-        query_duration_ms = timings.query_duration_ms,
-        hydration_duration_ms = timings.hydration_duration_ms,
-        render_duration_ms = timings.render_duration_ms
+        total_duration_ms = timings.total_millis(),
+        query_duration_ms = timings.query_millis(),
+        hydration_duration_ms = timings.hydration_millis(),
+        render_duration_ms = timings.render_millis()
     );
 }
 

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -1110,10 +1110,8 @@ where
     validate_export_submission(&runtime)?;
     let exporter = PermissionAwareExport::new(backend, subject, scopes).await?;
     let metric_template_id = runtime.template.as_ref().map(|template| template.id);
-    if let Some(template) = &runtime.template {
-        metrics::export_template_observed(template.id, &template.name);
-    }
     let total_start = Instant::now();
+    let total_metric = metrics::export_phase_timer("total", metric_template_id);
     let mut timings = ExportExecutionTimings::default();
 
     NewTaskEventRecord {
@@ -1151,6 +1149,7 @@ where
     let mut query_options = prepare_query_options(&runtime.export)?;
     let relation_hydration = resolve_relation_hydration_plan(&runtime, &mut query_options)?;
     let query_start = Instant::now();
+    let query_metric = metrics::export_phase_timer("query", metric_template_id);
     let (items, mut warnings, truncated) = with_statement_timeout_scope(
         statement_timeout,
         execute_scope(&exporter, runtime.scope, query_options),
@@ -1162,10 +1161,12 @@ where
         apply_export_includes(&exporter, &runtime.export, &mut items),
     )
     .await?;
-    let query_elapsed = query_start.elapsed();
+    if let Err(error) = enforce_export_stage_timeout(query_start, "query execution") {
+        query_metric.finish("timeout");
+        return Err(error);
+    }
+    let query_elapsed = query_metric.finish("success");
     timings.query_duration_ms = duration_to_millis_i32(query_elapsed);
-    metrics::export_phase_duration("query", query_elapsed, metric_template_id);
-    enforce_export_stage_timeout(query_start, "query execution")?;
 
     if relation_hydration
         .as_ref()
@@ -1187,15 +1188,18 @@ where
 
     add_truncation_warning(&mut warnings, truncated);
     let hydration_start = Instant::now();
+    let hydration_metric = metrics::export_phase_timer("hydration", metric_template_id);
     let (template_items, source) = with_statement_timeout_scope(
         statement_timeout,
         build_template_items(&exporter, &runtime, &items, relation_hydration),
     )
     .await?;
-    let hydration_elapsed = hydration_start.elapsed();
+    if let Err(error) = enforce_export_stage_timeout(hydration_start, "relation hydration") {
+        hydration_metric.finish("timeout");
+        return Err(error);
+    }
+    let hydration_elapsed = hydration_metric.finish("success");
     timings.hydration_duration_ms = duration_to_millis_i32(hydration_elapsed);
-    metrics::export_phase_duration("hydration", hydration_elapsed, metric_template_id);
-    enforce_export_stage_timeout(hydration_start, "relation hydration")?;
     let template_export = runtime.template.is_some();
     let item_count = if template_export {
         template_items.len()
@@ -1231,15 +1235,17 @@ where
     .await?;
 
     let render_start = Instant::now();
+    let render_metric = metrics::export_phase_timer("render", metric_template_id);
     let artifact = build_export_artifact(&runtime, execution, timings)?;
     let mut timings = artifact.timings;
-    let render_elapsed = render_start.elapsed();
-    let total_elapsed = total_start.elapsed();
+    if let Err(error) = enforce_export_stage_timeout(render_start, "template rendering") {
+        render_metric.finish("timeout");
+        return Err(error);
+    }
+    let render_elapsed = render_metric.finish("success");
+    let total_elapsed = total_metric.finish("success");
     timings.render_duration_ms = duration_to_millis_i32(render_elapsed);
     timings.total_duration_ms = duration_to_millis_i32(total_elapsed);
-    metrics::export_phase_duration("render", render_elapsed, metric_template_id);
-    metrics::export_phase_duration("total", total_elapsed, metric_template_id);
-    enforce_export_stage_timeout(render_start, "template rendering")?;
     log_export_stage_metrics(task.id, &runtime, timings);
     let artifact = ExportArtifact {
         timings,

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -1185,6 +1185,7 @@ where
     .await?;
     if let Err(error) = enforce_export_stage_timeout(query_metric.elapsed(), "query execution") {
         query_metric.finish(metrics::ExportMetricOutcome::Timeout);
+        total_metric.finish(metrics::ExportMetricOutcome::Timeout);
         return Err(error);
     }
     let query_elapsed = query_metric.finish(metrics::ExportMetricOutcome::Success);
@@ -1220,6 +1221,7 @@ where
         enforce_export_stage_timeout(hydration_metric.elapsed(), "relation hydration")
     {
         hydration_metric.finish(metrics::ExportMetricOutcome::Timeout);
+        total_metric.finish(metrics::ExportMetricOutcome::Timeout);
         return Err(error);
     }
     let hydration_elapsed = hydration_metric.finish(metrics::ExportMetricOutcome::Success);
@@ -1265,10 +1267,11 @@ where
     if let Err(error) = enforce_export_stage_timeout(render_metric.elapsed(), "template rendering")
     {
         render_metric.finish(metrics::ExportMetricOutcome::Timeout);
+        total_metric.finish(metrics::ExportMetricOutcome::Timeout);
         return Err(error);
     }
     let render_elapsed = render_metric.finish(metrics::ExportMetricOutcome::Success);
-    let total_elapsed = total_metric.finish(metrics::ExportMetricOutcome::Success);
+    let total_elapsed = total_metric.elapsed();
     timings.render = render_elapsed;
     timings.total = total_elapsed;
     log_export_stage_metrics(task.id, &runtime, timings);
@@ -1317,6 +1320,10 @@ where
     )
     .await?;
 
+    // Only label the total phase successful after the output and terminal task
+    // state have been persisted. If finalization fails, the timer's drop path
+    // records an error outcome instead.
+    total_metric.finish(metrics::ExportMetricOutcome::Success);
     metrics::export_completed(metric_scope, metric_content_type);
     if metric_truncated {
         metrics::export_truncated(metric_scope, metric_content_type);

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -1109,6 +1109,10 @@ where
     let runtime = prepare_export_runtime(pool, payload.export, template).await?;
     validate_export_submission(&runtime)?;
     let exporter = PermissionAwareExport::new(backend, subject, scopes).await?;
+    let metric_template_id = runtime.template.as_ref().map(|template| template.id);
+    if let Some(template) = &runtime.template {
+        metrics::export_template_observed(template.id, &template.name);
+    }
     let total_start = Instant::now();
     let mut timings = ExportExecutionTimings::default();
 
@@ -1160,7 +1164,7 @@ where
     .await?;
     let query_elapsed = query_start.elapsed();
     timings.query_duration_ms = duration_to_millis_i32(query_elapsed);
-    metrics::export_phase_duration("query", query_elapsed);
+    metrics::export_phase_duration("query", query_elapsed, metric_template_id);
     enforce_export_stage_timeout(query_start, "query execution")?;
 
     if relation_hydration
@@ -1190,7 +1194,7 @@ where
     .await?;
     let hydration_elapsed = hydration_start.elapsed();
     timings.hydration_duration_ms = duration_to_millis_i32(hydration_elapsed);
-    metrics::export_phase_duration("hydration", hydration_elapsed);
+    metrics::export_phase_duration("hydration", hydration_elapsed, metric_template_id);
     enforce_export_stage_timeout(hydration_start, "relation hydration")?;
     let template_export = runtime.template.is_some();
     let item_count = if template_export {
@@ -1233,8 +1237,8 @@ where
     let total_elapsed = total_start.elapsed();
     timings.render_duration_ms = duration_to_millis_i32(render_elapsed);
     timings.total_duration_ms = duration_to_millis_i32(total_elapsed);
-    metrics::export_phase_duration("render", render_elapsed);
-    metrics::export_phase_duration("total", total_elapsed);
+    metrics::export_phase_duration("render", render_elapsed, metric_template_id);
+    metrics::export_phase_duration("total", total_elapsed, metric_template_id);
     enforce_export_stage_timeout(render_start, "template rendering")?;
     log_export_stage_metrics(task.id, &runtime, timings);
     let artifact = ExportArtifact {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 mod container_build;
 
-use actix_web::{App, HttpServer, middleware::from_fn, web, web::Data, web::JsonConfig};
+use actix_web::{
+    App, HttpServer, dev::Server, middleware::from_fn, web, web::Data, web::JsonConfig,
+};
 #[cfg(feature = "swagger-ui")]
 use utoipa::OpenApi;
 #[cfg(feature = "swagger-ui")]
@@ -85,13 +87,14 @@ async fn main() -> std::io::Result<()> {
         );
     }
 
-    if config.metrics_enabled
-        && let Err(e) = observability::metrics::init()
-    {
-        fatal_error(
-            &format!("Failed to initialize metrics: {}", e),
-            EXIT_CODE_INIT_ERROR,
-        );
+    if config.metrics_enabled {
+        if let Err(e) = observability::metrics::init() {
+            fatal_error(
+                &format!("Failed to initialize metrics: {}", e),
+                EXIT_CODE_INIT_ERROR,
+            );
+        }
+        observability::metrics::runtime_identity(config.runtime_role.as_str());
     }
     utilities::auth::initialize_dummy_password_hash();
     let database_settings = DatabasePoolSettings::builder(config.database_url.clone())
@@ -138,6 +141,10 @@ async fn main() -> std::io::Result<()> {
     .unwrap_or_else(|error| fatal_error(&error, EXIT_CODE_CONFIG_ERROR));
     initialize_task_worker_settings(task_worker_settings)
         .unwrap_or_else(|error| fatal_error(&error, EXIT_CODE_INIT_ERROR));
+    observability::metrics::task_worker_config(
+        task_worker_count,
+        Duration::from_millis(config.task_poll_interval_ms),
+    );
 
     let initialization_settings =
         utilities::init::InitializationSettings::new(config.admin_groupname.clone())
@@ -178,6 +185,7 @@ async fn main() -> std::io::Result<()> {
         };
 
     if !config.runtime_role.serves_http() {
+        let metrics_server = start_worker_metrics_server(&config, pool.clone())?;
         start_background_workers(&app_context, &backup_settings);
         info!(
             message = "worker startup",
@@ -190,27 +198,43 @@ async fn main() -> std::io::Result<()> {
             db_backend = "postgresql",
             authorization_backend,
             active_event_sinks,
+            metrics_listener = metrics_server.is_some(),
         );
-        let worker_exit = tokio::select! {
-            shutdown = wait_for_shutdown_signal() => {
-                shutdown?;
-                None
+        let unexpected_error = if let Some(metrics_server) = metrics_server {
+            let metrics_server_handle = metrics_server.handle();
+            let result = tokio::select! {
+                shutdown = wait_for_shutdown_signal() => shutdown.err(),
+                exit = wait_for_background_worker_exit() => Some(std::io::Error::other(format!(
+                    "Background worker supervision failed: {exit}"
+                ))),
+                result = metrics_server => match result {
+                    Ok(()) => Some(std::io::Error::other(
+                        "Worker metrics HTTP server stopped unexpectedly",
+                    )),
+                    Err(error) => Some(error),
+                },
+            };
+            metrics_server_handle.stop(true).await;
+            result
+        } else {
+            tokio::select! {
+                shutdown = wait_for_shutdown_signal() => shutdown.err(),
+                exit = wait_for_background_worker_exit() => Some(std::io::Error::other(format!(
+                    "Background worker supervision failed: {exit}"
+                ))),
             }
-            exit = wait_for_background_worker_exit() => Some(exit),
         };
-        if let Some(exit) = &worker_exit {
+        if let Some(error) = &unexpected_error {
             error!(
-                message = "Background worker supervision failed",
-                reason = %exit,
+                message = "Worker process supervision failed",
+                reason = %error,
             );
         }
         shutdown_background_workers(Duration::from_secs(30)).await;
         drop(app_context);
         drop(pool);
-        if let Some(exit) = worker_exit {
-            return Err(std::io::Error::other(format!(
-                "Background worker supervision failed: {exit}"
-            )));
+        if let Some(error) = unexpected_error {
+            return Err(error);
         }
         return Ok(());
     }
@@ -361,6 +385,61 @@ fn start_background_workers(context: &AppContext, backup_settings: &BackupSettin
     ensure_event_delivery_worker_running(context.db_pool.clone());
     ensure_event_retention_worker_running(context.db_pool.clone());
     ensure_token_retention_worker_running(context.db_pool.clone());
+}
+
+fn start_worker_metrics_server(
+    config: &AppConfig,
+    pool: db::DbPool,
+) -> std::io::Result<Option<Server>> {
+    if !config.metrics_enabled {
+        return Ok(None);
+    }
+
+    let client_allowlist = config.client_allowlist.clone();
+    let proxy_trust = middlewares::ProxyTrust::new(
+        config.trust_ip_headers,
+        config.trusted_proxies.nets().to_vec(),
+        config.trusted_proxy_hops,
+    );
+    let metrics_path = config.metrics_path.clone();
+    let server = HttpServer::new(move || {
+        App::new()
+            .wrap(middlewares::ClientAllowlistMiddleware::new_with_trust(
+                client_allowlist.clone(),
+                proxy_trust.clone(),
+            ))
+            .app_data(Data::new(pool.clone()))
+            .route(
+                metrics_path.as_str(),
+                web::get().to(observability::metrics::scrape),
+            )
+    });
+    let bind_address = format!("{}:{}", config.bind_ip, config.port);
+    let server = match (&config.tls_cert_path, &config.tls_key_path) {
+        (Some(cert), Some(key)) => tls::configure_server(
+            server,
+            &bind_address,
+            cert,
+            key,
+            config.tls_key_passphrase.as_deref(),
+            config.tls_backend,
+        )?,
+        (Some(_), None) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "TLS certificate specified but key is missing",
+            ));
+        }
+        (None, Some(_)) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "TLS key specified but certificate is missing",
+            ));
+        }
+        _ => server.bind(&bind_address)?,
+    };
+
+    Ok(Some(server.workers(1).run()))
 }
 
 fn login_rate_limit_store_settings(

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ async fn main() -> std::io::Result<()> {
                 EXIT_CODE_INIT_ERROR,
             );
         }
-        observability::metrics::runtime_identity(config.runtime_role.as_str());
+        observability::metrics::runtime_identity(config.runtime_role);
     }
     utilities::auth::initialize_dummy_password_hash();
     let database_settings = DatabasePoolSettings::builder(config.database_url.clone())
@@ -205,31 +205,8 @@ async fn main() -> std::io::Result<()> {
             active_event_sinks,
             metrics_listener = metrics_server.is_some(),
         );
-        let unexpected_error = if let Some(metrics_server) = metrics_server {
-            let metrics_server_handle = metrics_server.handle();
-            let result = tokio::select! {
-                shutdown = wait_for_shutdown_signal() => shutdown.err(),
-                exit = wait_for_background_worker_exit() => Some(std::io::Error::other(format!(
-                    "Background worker supervision failed: {exit}"
-                ))),
-                result = metrics_server => match result {
-                    Ok(()) => Some(std::io::Error::other(
-                        "Worker metrics HTTP server stopped unexpectedly",
-                    )),
-                    Err(error) => Some(error),
-                },
-            };
-            metrics_server_handle.stop(true).await;
-            result
-        } else {
-            tokio::select! {
-                shutdown = wait_for_shutdown_signal() => shutdown.err(),
-                exit = wait_for_background_worker_exit() => Some(std::io::Error::other(format!(
-                    "Background worker supervision failed: {exit}"
-                ))),
-            }
-        };
-        if let Some(error) = &unexpected_error {
+        let supervision_result = supervise_worker_process(metrics_server).await;
+        if let Err(error) = &supervision_result {
             error!(
                 message = "Worker process supervision failed",
                 reason = %error,
@@ -238,9 +215,7 @@ async fn main() -> std::io::Result<()> {
         shutdown_background_workers(Duration::from_secs(30)).await;
         drop(app_context);
         drop(pool);
-        if let Some(error) = unexpected_error {
-            return Err(error);
-        }
+        supervision_result?;
         return Ok(());
     }
 
@@ -390,6 +365,33 @@ fn start_background_workers(context: &AppContext, backup_settings: &BackupSettin
     ensure_event_delivery_worker_running(context.db_pool.clone());
     ensure_event_retention_worker_running(context.db_pool.clone());
     ensure_token_retention_worker_running(context.db_pool.clone());
+}
+
+async fn supervise_worker_process(metrics_server: Option<Server>) -> std::io::Result<()> {
+    let Some(metrics_server) = metrics_server else {
+        return tokio::select! {
+            shutdown = wait_for_shutdown_signal() => shutdown,
+            exit = wait_for_background_worker_exit() => Err(std::io::Error::other(format!(
+                "Background worker supervision failed: {exit}"
+            ))),
+        };
+    };
+
+    let metrics_server_handle = metrics_server.handle();
+    let result = tokio::select! {
+        shutdown = wait_for_shutdown_signal() => shutdown,
+        exit = wait_for_background_worker_exit() => Err(std::io::Error::other(format!(
+            "Background worker supervision failed: {exit}"
+        ))),
+        result = metrics_server => match result {
+            Ok(()) => Err(std::io::Error::other(
+                "Worker metrics HTTP server stopped unexpectedly",
+            )),
+            Err(error) => Err(error),
+        },
+    };
+    metrics_server_handle.stop(true).await;
+    result
 }
 
 fn worker_metrics_service(
@@ -559,23 +561,5 @@ mod tests {
             "hubuum_http_requests_total{method=\"GET\",route=\"/metrics\",status_code=\"200\",status_family=\"2xx\"}"
         ));
         assert!(body.contains("hubuum_http_requests_in_flight{route=\"/metrics\"} 1"));
-    }
-
-    #[test]
-    fn worker_metrics_server_leaves_signal_handling_to_supervisor() {
-        let source = include_str!("main.rs");
-        let function_start = source
-            .find("fn start_worker_metrics_server(")
-            .expect("worker metrics server function should exist");
-        let function_end = source[function_start..]
-            .find("\nfn login_rate_limit_store_settings(")
-            .map(|offset| function_start + offset)
-            .expect("worker metrics server function should have a stable boundary");
-        let function = &source[function_start..function_end];
-
-        assert!(
-            function.contains("server.disable_signals()"),
-            "worker metrics server must not compete with supervisor signal handling"
-        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,14 +340,12 @@ async fn main() -> std::io::Result<()> {
     let result = if background_worker_count() > 0 {
         tokio::select! {
             result = server => result,
-            exit = wait_for_background_worker_exit() => {
+            error = wait_for_background_worker_failure() => {
                 error!(
                     message = "Background worker supervision failed",
-                    reason = %exit,
+                    reason = %error,
                 );
-                Err(std::io::Error::other(format!(
-                    "Background worker supervision failed: {exit}"
-                )))
+                Err(error)
             }
         }
     } else {
@@ -367,22 +365,23 @@ fn start_background_workers(context: &AppContext, backup_settings: &BackupSettin
     ensure_token_retention_worker_running(context.db_pool.clone());
 }
 
+async fn wait_for_background_worker_failure() -> std::io::Error {
+    let exit = wait_for_background_worker_exit().await;
+    std::io::Error::other(format!("Background worker supervision failed: {exit}"))
+}
+
 async fn supervise_worker_process(metrics_server: Option<Server>) -> std::io::Result<()> {
     let Some(metrics_server) = metrics_server else {
         return tokio::select! {
             shutdown = wait_for_shutdown_signal() => shutdown,
-            exit = wait_for_background_worker_exit() => Err(std::io::Error::other(format!(
-                "Background worker supervision failed: {exit}"
-            ))),
+            error = wait_for_background_worker_failure() => Err(error),
         };
     };
 
     let metrics_server_handle = metrics_server.handle();
     let result = tokio::select! {
         shutdown = wait_for_shutdown_signal() => shutdown,
-        exit = wait_for_background_worker_exit() => Err(std::io::Error::other(format!(
-            "Background worker supervision failed: {exit}"
-        ))),
+        error = wait_for_background_worker_failure() => Err(error),
         result = metrics_server => match result {
             Ok(()) => Err(std::io::Error::other(
                 "Worker metrics HTTP server stopped unexpectedly",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,12 @@
 mod container_build;
 
 use actix_web::{
-    App, HttpServer, dev::Server, middleware::from_fn, web, web::Data, web::JsonConfig,
+    App, HttpServer,
+    dev::{HttpServiceFactory, Server},
+    middleware::from_fn,
+    web,
+    web::Data,
+    web::JsonConfig,
 };
 #[cfg(feature = "swagger-ui")]
 use utoipa::OpenApi;
@@ -20,7 +25,7 @@ use hubuum::config::get_config;
 use hubuum::config::initialize_config;
 use hubuum::config::running::RunningConfig;
 use hubuum::config::token_hash_key_is_ephemeral;
-use hubuum::config::{AppConfig, LoginRateLimitBackendKind};
+use hubuum::config::{AppConfig, ClientAllowlist, LoginRateLimitBackendKind, MetricsPath};
 use hubuum::db::{DatabasePoolSettings, init_pool_with_settings};
 use hubuum::errors::{
     EXIT_CODE_CONFIG_ERROR, EXIT_CODE_DATABASE_ERROR, EXIT_CODE_INIT_ERROR,
@@ -387,6 +392,25 @@ fn start_background_workers(context: &AppContext, backup_settings: &BackupSettin
     ensure_token_retention_worker_running(context.db_pool.clone());
 }
 
+fn worker_metrics_service(
+    client_allowlist: ClientAllowlist,
+    proxy_trust: middlewares::ProxyTrust,
+    metrics_path: MetricsPath,
+    pool: db::DbPool,
+) -> impl HttpServiceFactory {
+    web::scope("")
+        .wrap(middlewares::ClientAllowlistMiddleware::new_with_trust(
+            client_allowlist,
+            proxy_trust.clone(),
+        ))
+        .wrap(middlewares::TracingMiddleware::new_with_trust(proxy_trust))
+        .app_data(Data::new(pool))
+        .route(
+            metrics_path.as_str(),
+            web::get().to(observability::metrics::scrape),
+        )
+}
+
 fn start_worker_metrics_server(
     config: &AppConfig,
     pool: db::DbPool,
@@ -403,16 +427,12 @@ fn start_worker_metrics_server(
     );
     let metrics_path = config.metrics_path.clone();
     let server = HttpServer::new(move || {
-        App::new()
-            .wrap(middlewares::ClientAllowlistMiddleware::new_with_trust(
-                client_allowlist.clone(),
-                proxy_trust.clone(),
-            ))
-            .app_data(Data::new(pool.clone()))
-            .route(
-                metrics_path.as_str(),
-                web::get().to(observability::metrics::scrape),
-            )
+        App::new().service(worker_metrics_service(
+            client_allowlist.clone(),
+            proxy_trust.clone(),
+            metrics_path.clone(),
+            pool.clone(),
+        ))
     });
     let bind_address = format!("{}:{}", config.bind_ip, config.port);
     let server = match (&config.tls_cert_path, &config.tls_key_path) {
@@ -439,7 +459,11 @@ fn start_worker_metrics_server(
         _ => server.bind(&bind_address)?,
     };
 
-    Ok(Some(server.workers(1).run()))
+    // The worker supervisor owns SIGINT/SIGTERM handling and initiates a
+    // graceful stop through the server handle. Letting Actix install a second
+    // signal handler creates a race that can misclassify normal shutdown as an
+    // unexpected metrics-server exit.
+    Ok(Some(server.disable_signals().workers(1).run()))
 }
 
 fn login_rate_limit_store_settings(
@@ -479,4 +503,79 @@ async fn wait_for_shutdown_signal() -> std::io::Result<()> {
 #[cfg(not(unix))]
 async fn wait_for_shutdown_signal() -> std::io::Result<()> {
     tokio::signal::ctrl_c().await
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::{http::StatusCode, test as actix_test};
+
+    use super::*;
+
+    fn unreachable_pool() -> db::DbPool {
+        let settings = DatabasePoolSettings::builder(
+            "postgres://hubuum:hubuum@127.0.0.1:1/hubuum_worker_metrics_unreachable",
+        )
+        .max_size(1)
+        .statement_timeout_ms(0)
+        .acquire_timeout_ms(5)
+        .build()
+        .expect("unreachable test pool settings should be valid");
+        init_pool_with_settings(&settings)
+    }
+
+    #[actix_web::test]
+    async fn worker_metrics_service_instruments_scrape_requests() {
+        observability::metrics::init().expect("metrics should initialize");
+        let app = actix_test::init_service(App::new().service(worker_metrics_service(
+            ClientAllowlist::Any,
+            middlewares::ProxyTrust::peer_only(),
+            MetricsPath::new("/metrics").expect("metrics path should be valid"),
+            unreachable_pool(),
+        )))
+        .await;
+        let metrics_request = || {
+            actix_test::TestRequest::get()
+                .uri("/metrics")
+                .peer_addr(
+                    "127.0.0.1:4242"
+                        .parse()
+                        .expect("test peer address should parse"),
+                )
+                .to_request()
+        };
+
+        let response = actix_test::call_service(&app, metrics_request()).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().contains_key("x-request-id"));
+        actix_test::read_body(response).await;
+
+        let response = actix_test::call_service(&app, metrics_request()).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().contains_key("x-request-id"));
+        let body = actix_test::read_body(response).await;
+        let body = std::str::from_utf8(&body).expect("metrics body should be UTF-8");
+
+        assert!(body.contains(
+            "hubuum_http_requests_total{method=\"GET\",route=\"/metrics\",status_code=\"200\",status_family=\"2xx\"}"
+        ));
+        assert!(body.contains("hubuum_http_requests_in_flight{route=\"/metrics\"} 1"));
+    }
+
+    #[test]
+    fn worker_metrics_server_leaves_signal_handling_to_supervisor() {
+        let source = include_str!("main.rs");
+        let function_start = source
+            .find("fn start_worker_metrics_server(")
+            .expect("worker metrics server function should exist");
+        let function_end = source[function_start..]
+            .find("\nfn login_rate_limit_store_settings(")
+            .map(|offset| function_start + offset)
+            .expect("worker metrics server function should have a stable boundary");
+        let function = &source[function_start..function_end];
+
+        assert!(
+            function.contains("server.disable_signals()"),
+            "worker metrics server must not compete with supervisor signal handling"
+        );
+    }
 }

--- a/src/middlewares/tracing.rs
+++ b/src/middlewares/tracing.rs
@@ -165,7 +165,7 @@ where
             ));
 
         let start_time = Instant::now();
-        let in_flight_guard = metrics::http_request_started();
+        let in_flight_guard = metrics::http_request_started_for_route(&route);
         let fut = span.in_scope(|| self.service.call(req));
 
         Box::pin(

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -354,6 +354,10 @@ pub struct ExportTaskDetails {
     pub output_content_type: Option<String>,
     pub warning_count: Option<i32>,
     pub truncated: Option<bool>,
+    pub total_duration_ms: Option<i32>,
+    pub query_duration_ms: Option<i32>,
+    pub hydration_duration_ms: Option<i32>,
+    pub render_duration_ms: Option<i32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
@@ -565,6 +569,12 @@ impl TaskRecord {
                             .map(|summary| summary.content_type.clone()),
                         warning_count: output_summary.map(|summary| summary.warning_count),
                         truncated: output_summary.map(|summary| summary.truncated),
+                        total_duration_ms: output_summary.map(|summary| summary.total_duration_ms),
+                        query_duration_ms: output_summary.map(|summary| summary.query_duration_ms),
+                        hydration_duration_ms: output_summary
+                            .map(|summary| summary.hydration_duration_ms),
+                        render_duration_ms: output_summary
+                            .map(|summary| summary.render_duration_ms),
                     }),
                     backup: None,
                 }
@@ -943,6 +953,12 @@ impl AuthzTarget for TaskID {
 mod tests {
     use super::*;
 
+    fn test_timestamp() -> NaiveDateTime {
+        chrono::DateTime::from_timestamp(1_700_000_000, 0)
+            .unwrap()
+            .naive_utc()
+    }
+
     #[test]
     fn task_result_counts_derive_processed_from_terminal_outcomes() {
         let counts = TaskResultCounts::from_outcomes(2, 1).unwrap();
@@ -984,5 +1000,67 @@ mod tests {
         assert_eq!(serde_json::from_str::<TaskID>("7").unwrap().id(), 7);
         assert!(serde_json::from_str::<TaskID>("0").is_err());
         assert!(serde_json::from_str::<TaskID>("-3").is_err());
+    }
+
+    #[test]
+    fn export_task_details_include_persisted_phase_timings() {
+        let timestamp = test_timestamp();
+        let task = TaskRecord {
+            id: 7,
+            kind: TaskKind::Export.as_str().to_string(),
+            status: TaskStatus::Succeeded.as_str().to_string(),
+            submitted_by: Some(1),
+            idempotency_key: None,
+            request_hash: None,
+            request_payload: None,
+            summary: None,
+            total_items: 1,
+            processed_items: 1,
+            success_items: 1,
+            failed_items: 0,
+            submitted_token_id: None,
+            submitted_token_scoped: false,
+            submitted_token_scopes: serde_json::json!([]),
+            request_redacted_at: Some(timestamp),
+            started_at: Some(timestamp),
+            finished_at: Some(timestamp),
+            deleted_at: None,
+            deleted_by: None,
+            created_at: timestamp,
+            updated_at: timestamp,
+            lease_token: None,
+            lease_expires_at: None,
+            attempt_count: 1,
+            initiator_user_id: Some(1),
+        };
+        let output = ExportTaskOutputSummaryRecord {
+            id: 3,
+            task_id: task.id,
+            template_name: Some("inventory".to_string()),
+            content_type: "text/plain".to_string(),
+            warning_count: 0,
+            truncated: false,
+            output_expires_at: timestamp,
+            total_duration_ms: 150,
+            query_duration_ms: 40,
+            hydration_duration_ms: 30,
+            render_duration_ms: 70,
+            created_at: timestamp,
+        };
+
+        let response = task
+            .to_response_with_export_output(ExportOutputLookup::Available(&output))
+            .unwrap();
+        let details = response.details.unwrap().export.unwrap();
+
+        assert_eq!(
+            (
+                details.total_duration_ms,
+                details.query_duration_ms,
+                details.hydration_duration_ms,
+                details.render_duration_ms,
+            ),
+            (Some(150), Some(40), Some(30), Some(70))
+        );
     }
 }

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -19,7 +19,7 @@ use crate::traits::{
     CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
 };
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskKind {
     Import,
@@ -62,7 +62,7 @@ impl TaskKind {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskStatus {
     Queued,

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -32,7 +32,8 @@ pub(crate) use self::db::{
 };
 pub use self::export::{
     export_completed, export_output_cleanup_deleted, export_output_cleanup_failed,
-    export_output_cleanup_run, export_phase_duration, export_truncated, export_warnings,
+    export_output_cleanup_run, export_phase_duration, export_template_observed, export_truncated,
+    export_warnings,
 };
 pub use self::http::{api_error, extraction_failure, http_request_finished, http_request_started};
 pub use self::import::{import_items, import_phase_duration};
@@ -101,6 +102,7 @@ struct Metrics {
     export_output_cleanup_runs: Counter<u64>,
     export_output_cleanup_failures: Counter<u64>,
     export_output_cleanup_deleted: Counter<u64>,
+    export_template_info: Gauge<u64>,
     export_duration: Histogram<f64>,
     export_completions: Counter<u64>,
     export_truncations: Counter<u64>,

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -12,6 +12,7 @@ mod remote_call;
 mod scrape;
 mod security;
 mod task;
+mod timer;
 
 use std::sync::{Mutex, OnceLock};
 
@@ -32,15 +33,17 @@ pub(crate) use self::db::{
 };
 pub use self::event::event_worker_wakeup;
 pub use self::export::{
-    export_completed, export_output_cleanup_deleted, export_output_cleanup_failed,
-    export_output_cleanup_run, export_phase_duration, export_phase_timer, export_truncated,
-    export_warnings,
+    ExportMetricOutcome, ExportMetricPhase, export_completed, export_output_cleanup_deleted,
+    export_output_cleanup_failed, export_output_cleanup_run, export_phase_duration,
+    export_phase_timer, export_truncated, export_warnings,
 };
 pub use self::http::{
     api_error, extraction_failure, http_request_finished, http_request_started,
     http_request_started_for_route,
 };
-pub use self::import::{import_items, import_phase_duration, import_phase_timer};
+pub use self::import::{
+    ImportMetricOutcome, ImportMetricPhase, import_items, import_phase_duration, import_phase_timer,
+};
 #[cfg(feature = "login-rate-limit-valkey")]
 pub use self::login::login_limiter_backend_failure;
 pub use self::login::{login_attempt, login_lockout};
@@ -49,8 +52,9 @@ pub use self::remote_call::remote_call_finished;
 pub use self::scrape::scrape;
 pub use self::security::client_allowlist_rejected;
 pub use self::task::{
-    task_claimed, task_completed, task_lease_recovered, task_output_cleanup_deleted,
-    task_output_cleanup_failed, task_output_cleanup_run, task_worker_config, task_worker_iteration,
+    TaskOutputKind, task_claimed, task_completed, task_lease_recovered,
+    task_output_cleanup_deleted, task_output_cleanup_failed, task_output_cleanup_run,
+    task_worker_config, task_worker_iteration,
 };
 
 static METRICS: OnceLock<Metrics> = OnceLock::new();

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -17,7 +17,7 @@ use std::sync::{Mutex, OnceLock};
 
 use opentelemetry::metrics::{Counter, Gauge, Histogram, UpDownCounter};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
-use prometheus::Registry;
+use prometheus::{IntGaugeVec, Registry};
 
 use crate::errors::ApiError;
 
@@ -30,42 +30,47 @@ pub use self::computed_field::{
 pub(crate) use self::db::{
     ResultKind, db_connection_acquire_failed, db_connection_acquired, db_operation_finished,
 };
+pub use self::event::event_worker_wakeup;
 pub use self::export::{
     export_completed, export_output_cleanup_deleted, export_output_cleanup_failed,
-    export_output_cleanup_run, export_phase_duration, export_template_observed, export_truncated,
+    export_output_cleanup_run, export_phase_duration, export_phase_timer, export_truncated,
     export_warnings,
 };
-pub use self::http::{api_error, extraction_failure, http_request_finished, http_request_started};
-pub use self::import::{import_items, import_phase_duration};
+pub use self::http::{
+    api_error, extraction_failure, http_request_finished, http_request_started,
+    http_request_started_for_route,
+};
+pub use self::import::{import_items, import_phase_duration, import_phase_timer};
 #[cfg(feature = "login-rate-limit-valkey")]
 pub use self::login::login_limiter_backend_failure;
 pub use self::login::{login_attempt, login_lockout};
-pub use self::registry::init;
+pub use self::registry::{init, runtime_identity};
 pub use self::remote_call::remote_call_finished;
 pub use self::scrape::scrape;
 pub use self::security::client_allowlist_rejected;
 pub use self::task::{
-    task_claimed, task_completed, task_lease_recovered, task_worker_config, task_worker_iteration,
+    task_claimed, task_completed, task_lease_recovered, task_output_cleanup_deleted,
+    task_output_cleanup_failed, task_output_cleanup_run, task_worker_config, task_worker_iteration,
 };
 
 static METRICS: OnceLock<Metrics> = OnceLock::new();
 
 pub struct HttpInFlightGuard {
-    active: bool,
+    route: Option<String>,
 }
 
 impl HttpInFlightGuard {
-    pub(super) fn new(active: bool) -> Self {
-        Self { active }
+    pub(super) fn new(route: Option<String>) -> Self {
+        Self { route }
     }
 }
 
 impl Drop for HttpInFlightGuard {
     fn drop(&mut self) {
-        if self.active
-            && let Some(metrics) = current()
-        {
-            metrics.http_in_flight.add(-1, &[]);
+        if let (Some(metrics), Some(route)) = (current(), self.route.as_ref()) {
+            metrics
+                .http_in_flight
+                .add(-1, &[opentelemetry::KeyValue::new("route", route.clone())]);
         }
     }
 }
@@ -73,6 +78,9 @@ impl Drop for HttpInFlightGuard {
 struct Metrics {
     registry: Registry,
     _provider: SdkMeterProvider,
+    build_info: Gauge<u64>,
+    runtime_info: Gauge<u64>,
+    process_start_time: Gauge<f64>,
     http_requests: Counter<u64>,
     http_request_duration: Histogram<f64>,
     http_in_flight: UpDownCounter<i64>,
@@ -89,7 +97,8 @@ struct Metrics {
     task_completions: Counter<u64>,
     task_queue_wait_duration: Histogram<f64>,
     task_execution_duration: Histogram<f64>,
-    task_config: Gauge<u64>,
+    task_workers_configured: Gauge<u64>,
+    task_poll_interval: Gauge<f64>,
     task_counts: Gauge<i64>,
     task_oldest_age: Gauge<f64>,
     computed_evaluations: Counter<u64>,
@@ -99,11 +108,12 @@ struct Metrics {
     computed_rebuild_batches: Counter<u64>,
     computed_rebuild_completions: Counter<u64>,
     computed_rebuild_duration: Histogram<f64>,
-    export_output_cleanup_runs: Counter<u64>,
-    export_output_cleanup_failures: Counter<u64>,
-    export_output_cleanup_deleted: Counter<u64>,
-    export_template_info: Gauge<u64>,
-    export_duration: Histogram<f64>,
+    task_output_cleanup_runs: Counter<u64>,
+    task_output_cleanup_failures: Counter<u64>,
+    task_output_cleanup_deleted: Counter<u64>,
+    export_template_info: IntGaugeVec,
+    export_phase_duration: Histogram<f64>,
+    export_template_duration: Histogram<f64>,
     export_completions: Counter<u64>,
     export_truncations: Counter<u64>,
     export_warnings: Counter<u64>,
@@ -122,10 +132,16 @@ struct Metrics {
     event_queue_items: Gauge<i64>,
     event_stale_claims: Gauge<i64>,
     event_oldest_age: Gauge<f64>,
-    event_worker_config: Gauge<u64>,
-    event_worker_wakeups: Gauge<u64>,
+    event_workers_configured: Gauge<u64>,
+    event_worker_batch_size: Gauge<u64>,
+    event_worker_poll_interval: Gauge<f64>,
+    event_worker_lock_timeout: Gauge<f64>,
+    event_worker_wakeups: Counter<u64>,
     inventory_entities: Gauge<i64>,
     refresh_failures: Counter<u64>,
+    refresh_duration: Gauge<f64>,
+    refresh_last_success: Gauge<f64>,
+    refresh_skipped: Counter<u64>,
     scrape_cache: Mutex<ScrapeCache>,
     db_refresh_lock: tokio::sync::Mutex<()>,
 }

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -121,7 +121,7 @@ struct Metrics {
     export_completions: Counter<u64>,
     export_truncations: Counter<u64>,
     export_warnings: Counter<u64>,
-    import_duration: Histogram<f64>,
+    import_phase_duration: Histogram<f64>,
     import_processed_items: Counter<u64>,
     import_succeeded_items: Counter<u64>,
     import_failed_items: Counter<u64>,

--- a/src/observability/metrics/cache.rs
+++ b/src/observability/metrics/cache.rs
@@ -1,15 +1,13 @@
 use std::time::{Duration, Instant};
 
-use crate::db::traits::metrics::{
-    EventMetricsSnapshot, InventoryMetricsSnapshot, TaskMetricsSnapshot,
-};
+use crate::db::traits::metrics::{EventMetricsSnapshot, InventoryGaugeSnapshot, TaskGaugeSnapshot};
 
 const DB_SCRAPE_CACHE_TTL: Duration = Duration::from_secs(30);
 
 #[derive(Default)]
 pub(super) struct ScrapeCache {
-    pub(super) inventory: CachedSnapshot<InventoryMetricsSnapshot>,
-    pub(super) tasks: CachedSnapshot<TaskMetricsSnapshot>,
+    pub(super) inventory: CachedSnapshot<InventoryGaugeSnapshot>,
+    pub(super) tasks: CachedSnapshot<TaskGaugeSnapshot>,
     pub(super) events: CachedSnapshot<EventMetricsSnapshot>,
 }
 
@@ -46,5 +44,34 @@ impl<T: Clone> CachedSnapshot<T> {
     pub(super) fn store(&mut self, value: T, now: Instant) {
         self.value = Some(value);
         self.refreshed_at = Some(now);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::{CachedSnapshot, DB_SCRAPE_CACHE_TTL};
+
+    #[test]
+    fn cached_snapshot_is_fresh_before_the_ttl() {
+        let stored_at = Instant::now();
+        let mut snapshot = CachedSnapshot::default();
+        snapshot.store("value", stored_at);
+
+        assert_eq!(
+            snapshot.fresh_value(stored_at + Duration::from_secs(29)),
+            Some("value")
+        );
+    }
+
+    #[test]
+    fn expired_snapshot_remains_available_as_a_stale_fallback() {
+        let stored_at = Instant::now();
+        let mut snapshot = CachedSnapshot::default();
+        snapshot.store("value", stored_at);
+
+        assert_eq!(snapshot.fresh_value(stored_at + DB_SCRAPE_CACHE_TTL), None);
+        assert_eq!(snapshot.cached_value(), Some("value"));
     }
 }

--- a/src/observability/metrics/event.rs
+++ b/src/observability/metrics/event.rs
@@ -7,6 +7,7 @@ use crate::db::traits::event_observability::load_event_metrics_snapshot;
 use crate::db::traits::metrics::EventMetricsSnapshot;
 use crate::models::{EventDeliveryStatusCounts, EventWorkerHealth};
 
+use super::scrape::{RefreshOutcome, record_refresh_attempt};
 use super::{Metrics, current};
 
 pub fn event_worker_wakeup(worker: &'static str, kind: &'static str) {
@@ -27,12 +28,22 @@ pub(super) async fn refresh_event_gauges(metrics: &Metrics, pool: &DbPool) {
     let refresh_started_at = Instant::now();
     match load_event_metrics_snapshot(pool).await {
         Ok(snapshot) => {
-            super::scrape::record_refresh_attempt(metrics, "events", refresh_started_at, true);
+            record_refresh_attempt(
+                metrics,
+                "events",
+                refresh_started_at,
+                RefreshOutcome::Succeeded,
+            );
             record_event_snapshot(metrics, &snapshot);
             store_event_snapshot(metrics, snapshot);
         }
         Err(_) => {
-            super::scrape::record_refresh_attempt(metrics, "events", refresh_started_at, false);
+            record_refresh_attempt(
+                metrics,
+                "events",
+                refresh_started_at,
+                RefreshOutcome::Failed,
+            );
             if let Some(snapshot) = stale_event_snapshot(metrics) {
                 record_event_snapshot(metrics, &snapshot);
             }

--- a/src/observability/metrics/event.rs
+++ b/src/observability/metrics/event.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use opentelemetry::KeyValue;
 
@@ -7,7 +7,16 @@ use crate::db::traits::event_observability::load_event_metrics_snapshot;
 use crate::db::traits::metrics::EventMetricsSnapshot;
 use crate::models::{EventDeliveryStatusCounts, EventWorkerHealth};
 
-use super::Metrics;
+use super::{Metrics, current};
+
+pub fn event_worker_wakeup(worker: &'static str, kind: &'static str) {
+    if let Some(metrics) = current() {
+        metrics.event_worker_wakeups.add(
+            1,
+            &[KeyValue::new("worker", worker), KeyValue::new("kind", kind)],
+        );
+    }
+}
 
 pub(super) async fn refresh_event_gauges(metrics: &Metrics, pool: &DbPool) {
     if let Some(snapshot) = cached_event_snapshot(metrics) {
@@ -15,15 +24,15 @@ pub(super) async fn refresh_event_gauges(metrics: &Metrics, pool: &DbPool) {
         return;
     }
 
+    let refresh_started_at = Instant::now();
     match load_event_metrics_snapshot(pool).await {
         Ok(snapshot) => {
+            super::scrape::record_refresh_attempt(metrics, "events", refresh_started_at, true);
             record_event_snapshot(metrics, &snapshot);
             store_event_snapshot(metrics, snapshot);
         }
         Err(_) => {
-            metrics
-                .refresh_failures
-                .add(1, &[KeyValue::new("source", "events")]);
+            super::scrape::record_refresh_attempt(metrics, "events", refresh_started_at, false);
             if let Some(snapshot) = stale_event_snapshot(metrics) {
                 record_event_snapshot(metrics, &snapshot);
             }
@@ -114,35 +123,20 @@ fn record_oldest_age(metrics: &Metrics, queue: &'static str, age: Option<i64>) {
 }
 
 fn record_worker(metrics: &Metrics, worker: &'static str, health: &EventWorkerHealth) {
-    for (setting, value) in [
-        (
-            "workers",
-            u64::try_from(health.workers_configured).unwrap_or(u64::MAX),
-        ),
-        (
-            "batch_size",
-            u64::try_from(health.batch_size).unwrap_or(u64::MAX),
-        ),
-        ("poll_interval_ms", health.poll_interval_ms),
-        ("lock_timeout_ms", health.lock_timeout_ms),
-    ] {
-        metrics.event_worker_config.record(
-            value,
-            &[
-                KeyValue::new("worker", worker),
-                KeyValue::new("setting", setting),
-            ],
-        );
-    }
-
-    for (kind, value) in [
-        ("notifications_sent", health.wakeups.notifications_sent),
-        ("notification", health.wakeups.notification_wakeups),
-        ("poll", health.wakeups.poll_wakeups),
-    ] {
-        metrics.event_worker_wakeups.record(
-            value,
-            &[KeyValue::new("worker", worker), KeyValue::new("kind", kind)],
-        );
-    }
+    let attrs = [KeyValue::new("worker", worker)];
+    metrics.event_workers_configured.record(
+        u64::try_from(health.workers_configured).unwrap_or(u64::MAX),
+        &attrs,
+    );
+    metrics
+        .event_worker_batch_size
+        .record(u64::try_from(health.batch_size).unwrap_or(u64::MAX), &attrs);
+    metrics.event_worker_poll_interval.record(
+        Duration::from_millis(health.poll_interval_ms).as_secs_f64(),
+        &attrs,
+    );
+    metrics.event_worker_lock_timeout.record(
+        Duration::from_millis(health.lock_timeout_ms).as_secs_f64(),
+        &attrs,
+    );
 }

--- a/src/observability/metrics/event.rs
+++ b/src/observability/metrics/event.rs
@@ -7,7 +7,7 @@ use crate::db::traits::event_observability::load_event_metrics_snapshot;
 use crate::db::traits::metrics::EventMetricsSnapshot;
 use crate::models::{EventDeliveryStatusCounts, EventWorkerHealth};
 
-use super::scrape::{RefreshOutcome, record_refresh_attempt};
+use super::scrape::{RefreshOutcome, RefreshSource, record_refresh_attempt};
 use super::{Metrics, current};
 
 pub fn event_worker_wakeup(worker: &'static str, kind: &'static str) {
@@ -30,7 +30,7 @@ pub(super) async fn refresh_event_gauges(metrics: &Metrics, pool: &DbPool) {
         Ok(snapshot) => {
             record_refresh_attempt(
                 metrics,
-                "events",
+                RefreshSource::Events,
                 refresh_started_at,
                 RefreshOutcome::Succeeded,
             );
@@ -40,7 +40,7 @@ pub(super) async fn refresh_event_gauges(metrics: &Metrics, pool: &DbPool) {
         Err(_) => {
             record_refresh_attempt(
                 metrics,
-                "events",
+                RefreshSource::Events,
                 refresh_started_at,
                 RefreshOutcome::Failed,
             );

--- a/src/observability/metrics/export.rs
+++ b/src/observability/metrics/export.rs
@@ -11,6 +11,25 @@ fn export_attrs(scope: &'static str, content_type: &'static str) -> [KeyValue; 2
     ]
 }
 
+fn template_attrs(template_id: i32, template_name: &str) -> [KeyValue; 2] {
+    [
+        KeyValue::new("template_id", template_id.to_string()),
+        KeyValue::new("template_name", template_name.to_string()),
+    ]
+}
+
+fn export_phase_attrs(phase: &'static str, template_id: Option<i32>) -> [KeyValue; 2] {
+    [
+        KeyValue::new("phase", phase),
+        KeyValue::new(
+            "template_id",
+            template_id
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+        ),
+    ]
+}
+
 pub fn export_output_cleanup_run() {
     if let Some(metrics) = current() {
         metrics.export_output_cleanup_runs.add(1, &[]);
@@ -31,11 +50,20 @@ pub fn export_output_cleanup_deleted(count: usize) {
     }
 }
 
-pub fn export_phase_duration(phase: &'static str, duration: Duration) {
+pub fn export_template_observed(template_id: i32, template_name: &str) {
     if let Some(metrics) = current() {
         metrics
-            .export_duration
-            .record(duration.as_secs_f64(), &[KeyValue::new("phase", phase)]);
+            .export_template_info
+            .record(1, &template_attrs(template_id, template_name));
+    }
+}
+
+pub fn export_phase_duration(phase: &'static str, duration: Duration, template_id: Option<i32>) {
+    if let Some(metrics) = current() {
+        metrics.export_duration.record(
+            duration.as_secs_f64(),
+            &export_phase_attrs(phase, template_id),
+        );
     }
 }
 
@@ -60,6 +88,44 @@ pub fn export_warnings(scope: &'static str, content_type: &'static str, count: u
         metrics.export_warnings.add(
             u64::try_from(count).unwrap_or(u64::MAX),
             &export_attrs(scope, content_type),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn export_phase_attributes_use_stable_template_id() {
+        assert_eq!(
+            export_phase_attrs("render", Some(42)),
+            [
+                KeyValue::new("phase", "render"),
+                KeyValue::new("template_id", "42"),
+            ]
+        );
+    }
+
+    #[test]
+    fn untemplated_export_phase_attributes_use_none_identity() {
+        assert_eq!(
+            export_phase_attrs("render", None),
+            [
+                KeyValue::new("phase", "render"),
+                KeyValue::new("template_id", "none"),
+            ]
+        );
+    }
+
+    #[test]
+    fn template_info_attributes_map_id_to_name() {
+        assert_eq!(
+            template_attrs(42, "inventory"),
+            [
+                KeyValue::new("template_id", "42"),
+                KeyValue::new("template_name", "inventory"),
+            ]
         );
     }
 }

--- a/src/observability/metrics/export.rs
+++ b/src/observability/metrics/export.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use opentelemetry::KeyValue;
 
@@ -11,59 +11,100 @@ fn export_attrs(scope: &'static str, content_type: &'static str) -> [KeyValue; 2
     ]
 }
 
-fn template_attrs(template_id: i32, template_name: &str) -> [KeyValue; 2] {
+fn export_phase_attrs(phase: &'static str, outcome: &'static str) -> [KeyValue; 2] {
     [
-        KeyValue::new("template_id", template_id.to_string()),
-        KeyValue::new("template_name", template_name.to_string()),
+        KeyValue::new("phase", phase),
+        KeyValue::new("outcome", outcome),
     ]
 }
 
-fn export_phase_attrs(phase: &'static str, template_id: Option<i32>) -> [KeyValue; 2] {
+fn template_duration_attrs(template_id: Option<i32>, outcome: &'static str) -> [KeyValue; 2] {
     [
-        KeyValue::new("phase", phase),
         KeyValue::new(
             "template_id",
             template_id
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "none".to_string()),
         ),
+        KeyValue::new("outcome", outcome),
     ]
 }
 
-pub fn export_output_cleanup_run() {
+fn record_export_phase_duration(
+    phase: &'static str,
+    outcome: &'static str,
+    duration: Duration,
+    template_id: Option<i32>,
+) {
     if let Some(metrics) = current() {
-        metrics.export_output_cleanup_runs.add(1, &[]);
+        metrics
+            .export_phase_duration
+            .record(duration.as_secs_f64(), &export_phase_attrs(phase, outcome));
+        if phase == "total" {
+            metrics.export_template_duration.record(
+                duration.as_secs_f64(),
+                &template_duration_attrs(template_id, outcome),
+            );
+        }
     }
+}
+
+pub fn export_phase_duration(phase: &'static str, duration: Duration) {
+    record_export_phase_duration(phase, "success", duration, None);
+}
+
+pub fn export_output_cleanup_run() {
+    super::task::task_output_cleanup_run("export");
 }
 
 pub fn export_output_cleanup_failed() {
-    if let Some(metrics) = current() {
-        metrics.export_output_cleanup_failures.add(1, &[]);
-    }
+    super::task::task_output_cleanup_failed("export");
 }
 
 pub fn export_output_cleanup_deleted(count: usize) {
-    if let Some(metrics) = current() {
-        metrics
-            .export_output_cleanup_deleted
-            .add(u64::try_from(count).unwrap_or(u64::MAX), &[]);
+    super::task::task_output_cleanup_deleted("export", count);
+}
+
+#[must_use = "an export phase timer must be finished or dropped to record its outcome"]
+pub struct ExportPhaseTimer {
+    phase: &'static str,
+    template_id: Option<i32>,
+    started_at: Instant,
+    finished: bool,
+}
+
+impl ExportPhaseTimer {
+    pub fn elapsed(&self) -> Duration {
+        self.started_at.elapsed()
+    }
+
+    pub fn finish(mut self, outcome: &'static str) -> Duration {
+        let elapsed = self.started_at.elapsed();
+        record_export_phase_duration(self.phase, outcome, elapsed, self.template_id);
+        self.finished = true;
+        elapsed
     }
 }
 
-pub fn export_template_observed(template_id: i32, template_name: &str) {
-    if let Some(metrics) = current() {
-        metrics
-            .export_template_info
-            .record(1, &template_attrs(template_id, template_name));
+impl Drop for ExportPhaseTimer {
+    fn drop(&mut self) {
+        if !self.finished {
+            record_export_phase_duration(
+                self.phase,
+                "error",
+                self.started_at.elapsed(),
+                self.template_id,
+            );
+        }
     }
 }
 
-pub fn export_phase_duration(phase: &'static str, duration: Duration, template_id: Option<i32>) {
-    if let Some(metrics) = current() {
-        metrics.export_duration.record(
-            duration.as_secs_f64(),
-            &export_phase_attrs(phase, template_id),
-        );
+pub fn export_phase_timer(phase: &'static str, template_id: Option<i32>) -> ExportPhaseTimer {
+    ExportPhaseTimer {
+        phase,
+        template_id,
+        started_at: Instant::now(),
+        finished: false,
     }
 }
 
@@ -97,34 +138,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn export_phase_attributes_use_stable_template_id() {
+    fn export_phase_attributes_are_bounded() {
         assert_eq!(
-            export_phase_attrs("render", Some(42)),
+            export_phase_attrs("render", "success"),
             [
                 KeyValue::new("phase", "render"),
-                KeyValue::new("template_id", "42"),
+                KeyValue::new("outcome", "success"),
             ]
         );
     }
 
     #[test]
-    fn untemplated_export_phase_attributes_use_none_identity() {
+    fn template_duration_attributes_use_stable_template_id() {
         assert_eq!(
-            export_phase_attrs("render", None),
+            template_duration_attrs(Some(42), "success"),
             [
-                KeyValue::new("phase", "render"),
+                KeyValue::new("template_id", "42"),
+                KeyValue::new("outcome", "success"),
+            ]
+        );
+    }
+
+    #[test]
+    fn untemplated_duration_attributes_use_none_identity() {
+        assert_eq!(
+            template_duration_attrs(None, "error"),
+            [
                 KeyValue::new("template_id", "none"),
-            ]
-        );
-    }
-
-    #[test]
-    fn template_info_attributes_map_id_to_name() {
-        assert_eq!(
-            template_attrs(42, "inventory"),
-            [
-                KeyValue::new("template_id", "42"),
-                KeyValue::new("template_name", "inventory"),
+                KeyValue::new("outcome", "error"),
             ]
         );
     }

--- a/src/observability/metrics/export.rs
+++ b/src/observability/metrics/export.rs
@@ -91,13 +91,12 @@ fn record_export_phase_duration(
     }
 }
 
-pub fn export_phase_duration(phase: ExportMetricPhase, duration: Duration) {
-    record_export_phase_duration(
-        phase.as_str(),
-        ExportMetricOutcome::Success.as_str(),
-        duration,
-        None,
-    );
+/// Record a successful export phase using the legacy direct-observation API.
+///
+/// New task instrumentation should prefer [`export_phase_timer`] so failures
+/// and unfinished phases are recorded automatically.
+pub fn export_phase_duration(phase: &'static str, duration: Duration) {
+    record_export_phase_duration(phase, ExportMetricOutcome::Success.as_str(), duration, None);
 }
 
 pub fn export_output_cleanup_run() {

--- a/src/observability/metrics/export.rs
+++ b/src/observability/metrics/export.rs
@@ -1,8 +1,47 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use opentelemetry::KeyValue;
 
+use crate::models::ExportTemplateID;
+
 use super::current;
+use super::timer::OutcomeTimer;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExportMetricPhase {
+    Total,
+    Query,
+    Hydration,
+    Render,
+}
+
+impl ExportMetricPhase {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Total => "total",
+            Self::Query => "query",
+            Self::Hydration => "hydration",
+            Self::Render => "render",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExportMetricOutcome {
+    Success,
+    Error,
+    Timeout,
+}
+
+impl ExportMetricOutcome {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Error => "error",
+            Self::Timeout => "timeout",
+        }
+    }
+}
 
 fn export_attrs(scope: &'static str, content_type: &'static str) -> [KeyValue; 2] {
     [
@@ -18,12 +57,15 @@ fn export_phase_attrs(phase: &'static str, outcome: &'static str) -> [KeyValue; 
     ]
 }
 
-fn template_duration_attrs(template_id: Option<i32>, outcome: &'static str) -> [KeyValue; 2] {
+fn template_duration_attrs(
+    template_id: Option<ExportTemplateID>,
+    outcome: &'static str,
+) -> [KeyValue; 2] {
     [
         KeyValue::new(
             "template_id",
             template_id
-                .map(|value| value.to_string())
+                .map(|value| value.id().to_string())
                 .unwrap_or_else(|| "none".to_string()),
         ),
         KeyValue::new("outcome", outcome),
@@ -34,7 +76,7 @@ fn record_export_phase_duration(
     phase: &'static str,
     outcome: &'static str,
     duration: Duration,
-    template_id: Option<i32>,
+    template_id: Option<ExportTemplateID>,
 ) {
     if let Some(metrics) = current() {
         metrics
@@ -49,62 +91,72 @@ fn record_export_phase_duration(
     }
 }
 
-pub fn export_phase_duration(phase: &'static str, duration: Duration) {
-    record_export_phase_duration(phase, "success", duration, None);
+pub fn export_phase_duration(phase: ExportMetricPhase, duration: Duration) {
+    record_export_phase_duration(
+        phase.as_str(),
+        ExportMetricOutcome::Success.as_str(),
+        duration,
+        None,
+    );
 }
 
 pub fn export_output_cleanup_run() {
-    super::task::task_output_cleanup_run("export");
+    super::task::task_output_cleanup_run(super::task::TaskOutputKind::Export);
 }
 
 pub fn export_output_cleanup_failed() {
-    super::task::task_output_cleanup_failed("export");
+    super::task::task_output_cleanup_failed(super::task::TaskOutputKind::Export);
 }
 
 pub fn export_output_cleanup_deleted(count: usize) {
-    super::task::task_output_cleanup_deleted("export", count);
+    super::task::task_output_cleanup_deleted(super::task::TaskOutputKind::Export, count);
 }
 
 #[must_use = "an export phase timer must be finished or dropped to record its outcome"]
 pub struct ExportPhaseTimer {
-    phase: &'static str,
-    template_id: Option<i32>,
-    started_at: Instant,
-    finished: bool,
+    phase: ExportMetricPhase,
+    template_id: Option<ExportTemplateID>,
+    timer: OutcomeTimer,
 }
 
 impl ExportPhaseTimer {
     pub fn elapsed(&self) -> Duration {
-        self.started_at.elapsed()
+        self.timer.elapsed()
     }
 
-    pub fn finish(mut self, outcome: &'static str) -> Duration {
-        let elapsed = self.started_at.elapsed();
-        record_export_phase_duration(self.phase, outcome, elapsed, self.template_id);
-        self.finished = true;
+    pub fn finish(mut self, outcome: ExportMetricOutcome) -> Duration {
+        let elapsed = self.timer.finish();
+        record_export_phase_duration(
+            self.phase.as_str(),
+            outcome.as_str(),
+            elapsed,
+            self.template_id,
+        );
         elapsed
     }
 }
 
 impl Drop for ExportPhaseTimer {
     fn drop(&mut self) {
-        if !self.finished {
+        if let Some(elapsed) = self.timer.unfinished_elapsed() {
             record_export_phase_duration(
-                self.phase,
-                "error",
-                self.started_at.elapsed(),
+                self.phase.as_str(),
+                ExportMetricOutcome::Error.as_str(),
+                elapsed,
                 self.template_id,
             );
         }
     }
 }
 
-pub fn export_phase_timer(phase: &'static str, template_id: Option<i32>) -> ExportPhaseTimer {
+pub fn export_phase_timer(
+    phase: ExportMetricPhase,
+    template_id: Option<ExportTemplateID>,
+) -> ExportPhaseTimer {
     ExportPhaseTimer {
         phase,
         template_id,
-        started_at: Instant::now(),
-        finished: false,
+        timer: OutcomeTimer::start(),
     }
 }
 
@@ -149,9 +201,32 @@ mod tests {
     }
 
     #[test]
+    fn export_timer_labels_are_stable_and_bounded() {
+        assert_eq!(
+            [
+                ExportMetricPhase::Total,
+                ExportMetricPhase::Query,
+                ExportMetricPhase::Hydration,
+                ExportMetricPhase::Render,
+            ]
+            .map(ExportMetricPhase::as_str),
+            ["total", "query", "hydration", "render"]
+        );
+        assert_eq!(
+            [
+                ExportMetricOutcome::Success,
+                ExportMetricOutcome::Error,
+                ExportMetricOutcome::Timeout,
+            ]
+            .map(ExportMetricOutcome::as_str),
+            ["success", "error", "timeout"]
+        );
+    }
+
+    #[test]
     fn template_duration_attributes_use_stable_template_id() {
         assert_eq!(
-            template_duration_attrs(Some(42), "success"),
+            template_duration_attrs(Some(ExportTemplateID::new(42).unwrap()), "success"),
             [
                 KeyValue::new("template_id", "42"),
                 KeyValue::new("outcome", "success"),

--- a/src/observability/metrics/http.rs
+++ b/src/observability/metrics/http.rs
@@ -5,10 +5,17 @@ use opentelemetry::{KeyValue, Value};
 use super::{HttpInFlightGuard, current};
 
 pub fn http_request_started() -> HttpInFlightGuard {
+    http_request_started_for_route("unknown")
+}
+
+pub fn http_request_started_for_route(route: &str) -> HttpInFlightGuard {
     if let Some(metrics) = current() {
-        metrics.http_in_flight.add(1, &[]);
+        metrics
+            .http_in_flight
+            .add(1, &[KeyValue::new("route", Value::from(route.to_owned()))]);
+        return HttpInFlightGuard::new(Some(route.to_owned()));
     }
-    HttpInFlightGuard::new(current().is_some())
+    HttpInFlightGuard::new(None)
 }
 
 pub fn http_request_finished(method: &str, route: &str, status_code: u16, duration: Duration) {

--- a/src/observability/metrics/import.rs
+++ b/src/observability/metrics/import.rs
@@ -1,8 +1,45 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use opentelemetry::KeyValue;
 
 use super::current;
+use super::timer::OutcomeTimer;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ImportMetricPhase {
+    Total,
+    Planning,
+    Execution,
+}
+
+impl ImportMetricPhase {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Total => "total",
+            Self::Planning => "planning",
+            Self::Execution => "execution",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ImportMetricOutcome {
+    Success,
+    Failed,
+    PartiallySucceeded,
+    Error,
+}
+
+impl ImportMetricOutcome {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Failed => "failed",
+            Self::PartiallySucceeded => "partially_succeeded",
+            Self::Error => "error",
+        }
+    }
+}
 
 fn import_phase_attrs(phase: &'static str, outcome: &'static str) -> [KeyValue; 2] {
     [
@@ -19,43 +56,48 @@ fn record_import_phase_duration(phase: &'static str, outcome: &'static str, dura
     }
 }
 
-pub fn import_phase_duration(phase: &'static str, duration: Duration) {
-    record_import_phase_duration(phase, "success", duration);
+pub fn import_phase_duration(phase: ImportMetricPhase, duration: Duration) {
+    record_import_phase_duration(
+        phase.as_str(),
+        ImportMetricOutcome::Success.as_str(),
+        duration,
+    );
 }
 
 #[must_use = "an import phase timer must be finished or dropped to record its outcome"]
 pub struct ImportPhaseTimer {
-    phase: &'static str,
-    started_at: Instant,
-    finished: bool,
+    phase: ImportMetricPhase,
+    timer: OutcomeTimer,
 }
 
 impl ImportPhaseTimer {
     pub fn elapsed(&self) -> Duration {
-        self.started_at.elapsed()
+        self.timer.elapsed()
     }
 
-    pub fn finish(mut self, outcome: &'static str) -> Duration {
-        let elapsed = self.started_at.elapsed();
-        record_import_phase_duration(self.phase, outcome, elapsed);
-        self.finished = true;
+    pub fn finish(mut self, outcome: ImportMetricOutcome) -> Duration {
+        let elapsed = self.timer.finish();
+        record_import_phase_duration(self.phase.as_str(), outcome.as_str(), elapsed);
         elapsed
     }
 }
 
 impl Drop for ImportPhaseTimer {
     fn drop(&mut self) {
-        if !self.finished {
-            record_import_phase_duration(self.phase, "error", self.started_at.elapsed());
+        if let Some(elapsed) = self.timer.unfinished_elapsed() {
+            record_import_phase_duration(
+                self.phase.as_str(),
+                ImportMetricOutcome::Error.as_str(),
+                elapsed,
+            );
         }
     }
 }
 
-pub fn import_phase_timer(phase: &'static str) -> ImportPhaseTimer {
+pub fn import_phase_timer(phase: ImportMetricPhase) -> ImportPhaseTimer {
     ImportPhaseTimer {
         phase,
-        started_at: Instant::now(),
-        finished: false,
+        timer: OutcomeTimer::start(),
     }
 }
 
@@ -85,6 +127,29 @@ mod tests {
                 KeyValue::new("phase", "execution"),
                 KeyValue::new("outcome", "partially_succeeded"),
             ]
+        );
+    }
+
+    #[test]
+    fn import_timer_labels_are_stable_and_bounded() {
+        assert_eq!(
+            [
+                ImportMetricPhase::Total,
+                ImportMetricPhase::Planning,
+                ImportMetricPhase::Execution,
+            ]
+            .map(ImportMetricPhase::as_str),
+            ["total", "planning", "execution"]
+        );
+        assert_eq!(
+            [
+                ImportMetricOutcome::Success,
+                ImportMetricOutcome::Failed,
+                ImportMetricOutcome::PartiallySucceeded,
+                ImportMetricOutcome::Error,
+            ]
+            .map(ImportMetricOutcome::as_str),
+            ["success", "failed", "partially_succeeded", "error",]
         );
     }
 }

--- a/src/observability/metrics/import.rs
+++ b/src/observability/metrics/import.rs
@@ -51,17 +51,17 @@ fn import_phase_attrs(phase: &'static str, outcome: &'static str) -> [KeyValue; 
 fn record_import_phase_duration(phase: &'static str, outcome: &'static str, duration: Duration) {
     if let Some(metrics) = current() {
         metrics
-            .import_duration
+            .import_phase_duration
             .record(duration.as_secs_f64(), &import_phase_attrs(phase, outcome));
     }
 }
 
-pub fn import_phase_duration(phase: ImportMetricPhase, duration: Duration) {
-    record_import_phase_duration(
-        phase.as_str(),
-        ImportMetricOutcome::Success.as_str(),
-        duration,
-    );
+/// Record a successful import phase using the legacy direct-observation API.
+///
+/// New task instrumentation should prefer [`import_phase_timer`] so failures
+/// and unfinished phases are recorded automatically.
+pub fn import_phase_duration(phase: &'static str, duration: Duration) {
+    record_import_phase_duration(phase, ImportMetricOutcome::Success.as_str(), duration);
 }
 
 #[must_use = "an import phase timer must be finished or dropped to record its outcome"]

--- a/src/observability/metrics/import.rs
+++ b/src/observability/metrics/import.rs
@@ -1,14 +1,61 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use opentelemetry::KeyValue;
 
 use super::current;
 
-pub fn import_phase_duration(phase: &'static str, duration: Duration) {
+fn import_phase_attrs(phase: &'static str, outcome: &'static str) -> [KeyValue; 2] {
+    [
+        KeyValue::new("phase", phase),
+        KeyValue::new("outcome", outcome),
+    ]
+}
+
+fn record_import_phase_duration(phase: &'static str, outcome: &'static str, duration: Duration) {
     if let Some(metrics) = current() {
         metrics
             .import_duration
-            .record(duration.as_secs_f64(), &[KeyValue::new("phase", phase)]);
+            .record(duration.as_secs_f64(), &import_phase_attrs(phase, outcome));
+    }
+}
+
+pub fn import_phase_duration(phase: &'static str, duration: Duration) {
+    record_import_phase_duration(phase, "success", duration);
+}
+
+#[must_use = "an import phase timer must be finished or dropped to record its outcome"]
+pub struct ImportPhaseTimer {
+    phase: &'static str,
+    started_at: Instant,
+    finished: bool,
+}
+
+impl ImportPhaseTimer {
+    pub fn elapsed(&self) -> Duration {
+        self.started_at.elapsed()
+    }
+
+    pub fn finish(mut self, outcome: &'static str) -> Duration {
+        let elapsed = self.started_at.elapsed();
+        record_import_phase_duration(self.phase, outcome, elapsed);
+        self.finished = true;
+        elapsed
+    }
+}
+
+impl Drop for ImportPhaseTimer {
+    fn drop(&mut self) {
+        if !self.finished {
+            record_import_phase_duration(self.phase, "error", self.started_at.elapsed());
+        }
+    }
+}
+
+pub fn import_phase_timer(phase: &'static str) -> ImportPhaseTimer {
+    ImportPhaseTimer {
+        phase,
+        started_at: Instant::now(),
+        finished: false,
     }
 }
 
@@ -23,5 +70,21 @@ pub fn import_items(processed: i32, succeeded: i32, failed: i32) {
         metrics
             .import_failed_items
             .add(u64::try_from(failed).unwrap_or(0), &[]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn import_phase_attributes_are_bounded() {
+        assert_eq!(
+            import_phase_attrs("execution", "partially_succeeded"),
+            [
+                KeyValue::new("phase", "execution"),
+                KeyValue::new("outcome", "partially_succeeded"),
+            ]
+        );
     }
 }

--- a/src/observability/metrics/inventory.rs
+++ b/src/observability/metrics/inventory.rs
@@ -3,10 +3,10 @@ use std::time::Instant;
 use opentelemetry::KeyValue;
 
 use crate::db::DbPool;
-use crate::db::traits::metrics::{InventoryMetricsSnapshot, MetricsBackend};
+use crate::db::traits::metrics::{InventoryGaugeSnapshot, MetricsRefreshBackend};
 
 use super::Metrics;
-use super::scrape::{RefreshOutcome, record_refresh_attempt};
+use super::scrape::{RefreshOutcome, RefreshSource, record_refresh_attempt};
 
 pub(super) async fn refresh_inventory_gauges(metrics: &Metrics, pool: &DbPool) {
     if let Some(row) = cached_inventory_snapshot(metrics) {
@@ -15,11 +15,11 @@ pub(super) async fn refresh_inventory_gauges(metrics: &Metrics, pool: &DbPool) {
     }
 
     let refresh_started_at = Instant::now();
-    match pool.metrics_inventory_snapshot().await {
+    match pool.metrics_inventory_gauge_snapshot().await {
         Ok(row) => {
             record_refresh_attempt(
                 metrics,
-                "inventory",
+                RefreshSource::Inventory,
                 refresh_started_at,
                 RefreshOutcome::Succeeded,
             );
@@ -29,7 +29,7 @@ pub(super) async fn refresh_inventory_gauges(metrics: &Metrics, pool: &DbPool) {
         Err(_) => {
             record_refresh_attempt(
                 metrics,
-                "inventory",
+                RefreshSource::Inventory,
                 refresh_started_at,
                 RefreshOutcome::Failed,
             );
@@ -40,7 +40,7 @@ pub(super) async fn refresh_inventory_gauges(metrics: &Metrics, pool: &DbPool) {
     }
 }
 
-fn cached_inventory_snapshot(metrics: &Metrics) -> Option<InventoryMetricsSnapshot> {
+fn cached_inventory_snapshot(metrics: &Metrics) -> Option<InventoryGaugeSnapshot> {
     let now = Instant::now();
     metrics
         .scrape_cache
@@ -49,7 +49,7 @@ fn cached_inventory_snapshot(metrics: &Metrics) -> Option<InventoryMetricsSnapsh
         .and_then(|cache| cache.inventory.fresh_value(now))
 }
 
-fn stale_inventory_snapshot(metrics: &Metrics) -> Option<InventoryMetricsSnapshot> {
+fn stale_inventory_snapshot(metrics: &Metrics) -> Option<InventoryGaugeSnapshot> {
     metrics
         .scrape_cache
         .lock()
@@ -57,23 +57,24 @@ fn stale_inventory_snapshot(metrics: &Metrics) -> Option<InventoryMetricsSnapsho
         .and_then(|cache| cache.inventory.cached_value())
 }
 
-fn store_inventory_snapshot(metrics: &Metrics, snapshot: InventoryMetricsSnapshot) {
+fn store_inventory_snapshot(metrics: &Metrics, snapshot: InventoryGaugeSnapshot) {
     if let Ok(mut cache) = metrics.scrape_cache.lock() {
         cache.inventory.store(snapshot, Instant::now());
     }
 }
 
-fn record_inventory_snapshot(metrics: &Metrics, row: &InventoryMetricsSnapshot) {
-    record_inventory(metrics, "collections", row.collections);
-    record_inventory(metrics, "classes", row.classes);
-    record_inventory(metrics, "objects", row.objects);
-    record_inventory(metrics, "users", row.users);
-    record_inventory(metrics, "groups", row.groups);
-    record_inventory(metrics, "service_accounts", row.service_accounts);
-    record_inventory(metrics, "remote_targets", row.remote_targets);
+fn record_inventory_snapshot(metrics: &Metrics, snapshot: &InventoryGaugeSnapshot) {
+    let counts = &snapshot.counts;
+    record_inventory(metrics, "collections", counts.collections);
+    record_inventory(metrics, "classes", counts.classes);
+    record_inventory(metrics, "objects", counts.objects);
+    record_inventory(metrics, "users", counts.users);
+    record_inventory(metrics, "groups", counts.groups);
+    record_inventory(metrics, "service_accounts", counts.service_accounts);
+    record_inventory(metrics, "remote_targets", counts.remote_targets);
 
     metrics.export_template_info.reset();
-    for template in &row.export_templates {
+    for template in &snapshot.export_templates {
         metrics
             .export_template_info
             .with_label_values(&[&template.id.id().to_string(), &template.name])

--- a/src/observability/metrics/inventory.rs
+++ b/src/observability/metrics/inventory.rs
@@ -13,15 +13,15 @@ pub(super) async fn refresh_inventory_gauges(metrics: &Metrics, pool: &DbPool) {
         return;
     }
 
+    let refresh_started_at = Instant::now();
     match pool.metrics_inventory_snapshot().await {
         Ok(row) => {
-            store_inventory_snapshot(metrics, row);
+            super::scrape::record_refresh_attempt(metrics, "inventory", refresh_started_at, true);
             record_inventory_snapshot(metrics, &row);
+            store_inventory_snapshot(metrics, row);
         }
         Err(_) => {
-            metrics
-                .refresh_failures
-                .add(1, &[KeyValue::new("source", "inventory")]);
+            super::scrape::record_refresh_attempt(metrics, "inventory", refresh_started_at, false);
             if let Some(row) = stale_inventory_snapshot(metrics) {
                 record_inventory_snapshot(metrics, &row);
             }
@@ -60,6 +60,14 @@ fn record_inventory_snapshot(metrics: &Metrics, row: &InventoryMetricsSnapshot) 
     record_inventory(metrics, "groups", row.groups);
     record_inventory(metrics, "service_accounts", row.service_accounts);
     record_inventory(metrics, "remote_targets", row.remote_targets);
+
+    metrics.export_template_info.reset();
+    for template in &row.export_templates {
+        metrics
+            .export_template_info
+            .with_label_values(&[&template.id.to_string(), &template.name])
+            .set(1);
+    }
 }
 
 fn record_inventory(metrics: &Metrics, entity_type: &'static str, count: i64) {

--- a/src/observability/metrics/inventory.rs
+++ b/src/observability/metrics/inventory.rs
@@ -6,6 +6,7 @@ use crate::db::DbPool;
 use crate::db::traits::metrics::{InventoryMetricsSnapshot, MetricsBackend};
 
 use super::Metrics;
+use super::scrape::{RefreshOutcome, record_refresh_attempt};
 
 pub(super) async fn refresh_inventory_gauges(metrics: &Metrics, pool: &DbPool) {
     if let Some(row) = cached_inventory_snapshot(metrics) {
@@ -16,12 +17,22 @@ pub(super) async fn refresh_inventory_gauges(metrics: &Metrics, pool: &DbPool) {
     let refresh_started_at = Instant::now();
     match pool.metrics_inventory_snapshot().await {
         Ok(row) => {
-            super::scrape::record_refresh_attempt(metrics, "inventory", refresh_started_at, true);
+            record_refresh_attempt(
+                metrics,
+                "inventory",
+                refresh_started_at,
+                RefreshOutcome::Succeeded,
+            );
             record_inventory_snapshot(metrics, &row);
             store_inventory_snapshot(metrics, row);
         }
         Err(_) => {
-            super::scrape::record_refresh_attempt(metrics, "inventory", refresh_started_at, false);
+            record_refresh_attempt(
+                metrics,
+                "inventory",
+                refresh_started_at,
+                RefreshOutcome::Failed,
+            );
             if let Some(row) = stale_inventory_snapshot(metrics) {
                 record_inventory_snapshot(metrics, &row);
             }
@@ -65,7 +76,7 @@ fn record_inventory_snapshot(metrics: &Metrics, row: &InventoryMetricsSnapshot) 
     for template in &row.export_templates {
         metrics
             .export_template_info
-            .with_label_values(&[&template.id.to_string(), &template.name])
+            .with_label_values(&[&template.id.id().to_string(), &template.name])
             .set(1);
     }
 }

--- a/src/observability/metrics/login.rs
+++ b/src/observability/metrics/login.rs
@@ -4,6 +4,7 @@ use opentelemetry::KeyValue;
 
 use crate::middlewares::rate_limit;
 
+use super::scrape::{RefreshOutcome, record_refresh_attempt};
 use super::{Metrics, current};
 
 pub fn login_attempt(outcome: &'static str) {
@@ -39,20 +40,20 @@ pub(super) async fn refresh_login_limiter_gauges(metrics: &Metrics) {
     let refresh_started_at = Instant::now();
     let snapshots = match rate_limit::snapshot().await {
         Ok(snapshots) => {
-            super::scrape::record_refresh_attempt(
+            record_refresh_attempt(
                 metrics,
                 "login_limiter",
                 refresh_started_at,
-                true,
+                RefreshOutcome::Succeeded,
             );
             snapshots
         }
         Err(_) => {
-            super::scrape::record_refresh_attempt(
+            record_refresh_attempt(
                 metrics,
                 "login_limiter",
                 refresh_started_at,
-                false,
+                RefreshOutcome::Failed,
             );
             return;
         }

--- a/src/observability/metrics/login.rs
+++ b/src/observability/metrics/login.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use opentelemetry::KeyValue;
 
 use crate::middlewares::rate_limit;
@@ -34,8 +36,26 @@ pub fn login_limiter_backend_failure(operation: &'static str) {
 }
 
 pub(super) async fn refresh_login_limiter_gauges(metrics: &Metrics) {
-    let Ok(snapshots) = rate_limit::snapshot().await else {
-        return;
+    let refresh_started_at = Instant::now();
+    let snapshots = match rate_limit::snapshot().await {
+        Ok(snapshots) => {
+            super::scrape::record_refresh_attempt(
+                metrics,
+                "login_limiter",
+                refresh_started_at,
+                true,
+            );
+            snapshots
+        }
+        Err(_) => {
+            super::scrape::record_refresh_attempt(
+                metrics,
+                "login_limiter",
+                refresh_started_at,
+                false,
+            );
+            return;
+        }
     };
     let locked = snapshots.iter().filter(|entry| entry.locked).count();
     metrics.login_limiter_entries.record(

--- a/src/observability/metrics/login.rs
+++ b/src/observability/metrics/login.rs
@@ -4,7 +4,7 @@ use opentelemetry::KeyValue;
 
 use crate::middlewares::rate_limit;
 
-use super::scrape::{RefreshOutcome, record_refresh_attempt};
+use super::scrape::{RefreshOutcome, RefreshSource, record_refresh_attempt};
 use super::{Metrics, current};
 
 pub fn login_attempt(outcome: &'static str) {
@@ -42,7 +42,7 @@ pub(super) async fn refresh_login_limiter_gauges(metrics: &Metrics) {
         Ok(snapshots) => {
             record_refresh_attempt(
                 metrics,
-                "login_limiter",
+                RefreshSource::LoginLimiter,
                 refresh_started_at,
                 RefreshOutcome::Succeeded,
             );
@@ -51,7 +51,7 @@ pub(super) async fn refresh_login_limiter_gauges(metrics: &Metrics) {
         Err(_) => {
             record_refresh_attempt(
                 metrics,
-                "login_limiter",
+                RefreshSource::LoginLimiter,
                 refresh_started_at,
                 RefreshOutcome::Failed,
             );

--- a/src/observability/metrics/registry.rs
+++ b/src/observability/metrics/registry.rs
@@ -6,6 +6,7 @@ use opentelemetry::metrics::MeterProvider as _;
 use opentelemetry_sdk::metrics::{Aggregation, Instrument, SdkMeterProvider, Stream};
 use prometheus::{IntGaugeVec, Opts, Registry};
 
+use crate::config::RuntimeRole;
 use crate::errors::ApiError;
 use crate::logger;
 
@@ -388,11 +389,11 @@ pub fn init() -> Result<(), ApiError> {
         .map_err(|_| ApiError::InternalServerError("Metrics already initialized".to_string()))
 }
 
-pub fn runtime_identity(role: &'static str) {
+pub fn runtime_identity(role: RuntimeRole) {
     if let Some(metrics) = super::current() {
         metrics
             .runtime_info
-            .record(1, &[KeyValue::new("role", role)]);
+            .record(1, &[KeyValue::new("role", role.as_str())]);
     }
 }
 

--- a/src/observability/metrics/registry.rs
+++ b/src/observability/metrics/registry.rs
@@ -2,7 +2,7 @@ use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use opentelemetry::KeyValue;
-use opentelemetry::metrics::MeterProvider as _;
+use opentelemetry::metrics::{Histogram, Meter, MeterProvider as _};
 use opentelemetry_sdk::metrics::{Aggregation, Instrument, SdkMeterProvider, Stream};
 use prometheus::{IntGaugeVec, Opts, Registry};
 
@@ -24,18 +24,29 @@ const BACKGROUND_BUCKETS_SECONDS: &[f64] = &[
     1800.0, 3600.0,
 ];
 
+const HTTP_REQUEST_DURATION: &str = "hubuum_http_request_duration";
+const DB_CONNECTION_ACQUIRE_DURATION: &str = "hubuum_db_connection_acquire_duration";
+const DB_OPERATION_DURATION: &str = "hubuum_db_operation_duration";
+const REMOTE_CALL_DURATION: &str = "hubuum_remote_call_duration";
+const TASK_QUEUE_WAIT_DURATION: &str = "hubuum_task_queue_wait_duration";
+const TASK_EXECUTION_DURATION: &str = "hubuum_task_execution_duration";
+const COMPUTED_REBUILD_DURATION: &str = "hubuum_computed_field_rebuild_duration";
+const EXPORT_PHASE_DURATION: &str = "hubuum_export_phase_duration";
+const EXPORT_DURATION: &str = "hubuum_export_duration";
+const IMPORT_PHASE_DURATION: &str = "hubuum_import_phase_duration";
+
 fn duration_histogram_view(instrument: &Instrument) -> Option<Stream> {
     let boundaries = match instrument.name() {
-        "hubuum_http_request_duration"
-        | "hubuum_db_connection_acquire_duration"
-        | "hubuum_db_operation_duration" => LATENCY_BUCKETS_SECONDS,
-        "hubuum_remote_call_duration" => OUTBOUND_BUCKETS_SECONDS,
-        "hubuum_task_queue_wait_duration"
-        | "hubuum_task_execution_duration"
-        | "hubuum_computed_field_rebuild_duration"
-        | "hubuum_export_phase_duration"
-        | "hubuum_export_duration"
-        | "hubuum_import_phase_duration" => BACKGROUND_BUCKETS_SECONDS,
+        HTTP_REQUEST_DURATION | DB_CONNECTION_ACQUIRE_DURATION | DB_OPERATION_DURATION => {
+            LATENCY_BUCKETS_SECONDS
+        }
+        REMOTE_CALL_DURATION => OUTBOUND_BUCKETS_SECONDS,
+        TASK_QUEUE_WAIT_DURATION
+        | TASK_EXECUTION_DURATION
+        | COMPUTED_REBUILD_DURATION
+        | EXPORT_PHASE_DURATION
+        | EXPORT_DURATION
+        | IMPORT_PHASE_DURATION => BACKGROUND_BUCKETS_SECONDS,
         _ => return None,
     };
 
@@ -43,11 +54,25 @@ fn duration_histogram_view(instrument: &Instrument) -> Option<Stream> {
         Stream::builder()
             .with_aggregation(Aggregation::ExplicitBucketHistogram {
                 boundaries: boundaries.to_vec(),
-                record_min_max: true,
+                // The Prometheus classic-histogram format exports buckets,
+                // count, and sum, but not exact minima or maxima.
+                record_min_max: false,
             })
             .build()
             .expect("hard-coded duration histogram boundaries should be valid"),
     )
+}
+
+fn duration_histogram(
+    meter: &Meter,
+    name: &'static str,
+    description: &'static str,
+) -> Histogram<f64> {
+    meter
+        .f64_histogram(name)
+        .with_description(description)
+        .with_unit("s")
+        .build()
 }
 
 fn build_provider(registry: &Registry) -> Result<SdkMeterProvider, ApiError> {
@@ -114,11 +139,11 @@ pub fn init() -> Result<(), ApiError> {
             .u64_counter("hubuum_http_requests")
             .with_description("HTTP requests handled")
             .build(),
-        http_request_duration: meter
-            .f64_histogram("hubuum_http_request_duration")
-            .with_description("HTTP request duration")
-            .with_unit("s")
-            .build(),
+        http_request_duration: duration_histogram(
+            &meter,
+            HTTP_REQUEST_DURATION,
+            "HTTP request duration",
+        ),
         http_in_flight: meter
             .i64_up_down_counter("hubuum_http_requests_in_flight")
             .with_description("HTTP requests currently in flight")
@@ -135,20 +160,20 @@ pub fn init() -> Result<(), ApiError> {
             .u64_gauge("hubuum_db_pool_connections")
             .with_description("Database pool connections by state")
             .build(),
-        db_connection_acquire_duration: meter
-            .f64_histogram("hubuum_db_connection_acquire_duration")
-            .with_description("Database connection acquisition duration")
-            .with_unit("s")
-            .build(),
+        db_connection_acquire_duration: duration_histogram(
+            &meter,
+            DB_CONNECTION_ACQUIRE_DURATION,
+            "Database connection acquisition duration",
+        ),
         db_connection_acquire_failures: meter
             .u64_counter("hubuum_db_connection_acquire_failures")
             .with_description("Database connection acquisition failures")
             .build(),
-        db_operation_duration: meter
-            .f64_histogram("hubuum_db_operation_duration")
-            .with_description("Database helper operation duration")
-            .with_unit("s")
-            .build(),
+        db_operation_duration: duration_histogram(
+            &meter,
+            DB_OPERATION_DURATION,
+            "Database helper operation duration",
+        ),
         db_operation_errors: meter
             .u64_counter("hubuum_db_operation_errors")
             .with_description("Database helper operation failures")
@@ -169,16 +194,16 @@ pub fn init() -> Result<(), ApiError> {
             .u64_counter("hubuum_task_completions")
             .with_description("Tasks completed by terminal status")
             .build(),
-        task_queue_wait_duration: meter
-            .f64_histogram("hubuum_task_queue_wait_duration")
-            .with_description("Task queue wait duration")
-            .with_unit("s")
-            .build(),
-        task_execution_duration: meter
-            .f64_histogram("hubuum_task_execution_duration")
-            .with_description("Task execution duration")
-            .with_unit("s")
-            .build(),
+        task_queue_wait_duration: duration_histogram(
+            &meter,
+            TASK_QUEUE_WAIT_DURATION,
+            "Task queue wait duration",
+        ),
+        task_execution_duration: duration_histogram(
+            &meter,
+            TASK_EXECUTION_DURATION,
+            "Task execution duration",
+        ),
         task_workers_configured: meter
             .u64_gauge("hubuum_task_workers_configured")
             .with_description("Configured task workers in this process")
@@ -221,11 +246,11 @@ pub fn init() -> Result<(), ApiError> {
             .u64_counter("hubuum_computed_field_rebuild_completions")
             .with_description("Computed-field rebuild terminal outcomes")
             .build(),
-        computed_rebuild_duration: meter
-            .f64_histogram("hubuum_computed_field_rebuild_duration")
-            .with_description("Computed-field rebuild duration")
-            .with_unit("s")
-            .build(),
+        computed_rebuild_duration: duration_histogram(
+            &meter,
+            COMPUTED_REBUILD_DURATION,
+            "Computed-field rebuild duration",
+        ),
         task_output_cleanup_runs: meter
             .u64_counter("hubuum_task_output_cleanup_runs")
             .with_description("Stored task output cleanup runs")
@@ -239,16 +264,16 @@ pub fn init() -> Result<(), ApiError> {
             .with_description("Stored task outputs deleted by cleanup")
             .build(),
         export_template_info,
-        export_phase_duration: meter
-            .f64_histogram("hubuum_export_phase_duration")
-            .with_description("Export phase duration")
-            .with_unit("s")
-            .build(),
-        export_template_duration: meter
-            .f64_histogram("hubuum_export_duration")
-            .with_description("Overall export duration by stored template identity")
-            .with_unit("s")
-            .build(),
+        export_phase_duration: duration_histogram(
+            &meter,
+            EXPORT_PHASE_DURATION,
+            "Export phase duration",
+        ),
+        export_template_duration: duration_histogram(
+            &meter,
+            EXPORT_DURATION,
+            "Overall export duration by stored template identity",
+        ),
         export_completions: meter
             .u64_counter("hubuum_export_completions")
             .with_description("Successfully persisted export outputs")
@@ -261,11 +286,11 @@ pub fn init() -> Result<(), ApiError> {
             .u64_counter("hubuum_export_warnings")
             .with_description("Warnings on successfully persisted exports")
             .build(),
-        import_duration: meter
-            .f64_histogram("hubuum_import_phase_duration")
-            .with_description("Import phase duration")
-            .with_unit("s")
-            .build(),
+        import_phase_duration: duration_histogram(
+            &meter,
+            IMPORT_PHASE_DURATION,
+            "Import phase duration",
+        ),
         import_processed_items: meter
             .u64_counter("hubuum_import_processed_items")
             .with_description("Import items processed by terminal tasks")
@@ -278,11 +303,11 @@ pub fn init() -> Result<(), ApiError> {
             .u64_counter("hubuum_import_failed_items")
             .with_description("Import items completed with failure")
             .build(),
-        remote_call_duration: meter
-            .f64_histogram("hubuum_remote_call_duration")
-            .with_description("Remote call duration")
-            .with_unit("s")
-            .build(),
+        remote_call_duration: duration_histogram(
+            &meter,
+            REMOTE_CALL_DURATION,
+            "Remote call duration",
+        ),
         remote_call_results: meter
             .u64_counter("hubuum_remote_call_results")
             .with_description("Remote call outcomes")
@@ -433,7 +458,7 @@ mod tests {
 
     #[test]
     fn request_histograms_use_subsecond_latency_buckets() {
-        let bounds = histogram_bucket_bounds("hubuum_http_request_duration", 0.004);
+        let bounds = histogram_bucket_bounds(HTTP_REQUEST_DURATION, 0.004);
 
         assert_eq!(
             bounds,
@@ -446,7 +471,7 @@ mod tests {
 
     #[test]
     fn task_histograms_cover_long_running_background_work() {
-        let bounds = histogram_bucket_bounds("hubuum_task_execution_duration", 75.0);
+        let bounds = histogram_bucket_bounds(TASK_EXECUTION_DURATION, 75.0);
 
         assert_eq!(
             bounds,

--- a/src/observability/metrics/registry.rs
+++ b/src/observability/metrics/registry.rs
@@ -1,7 +1,7 @@
 use std::sync::Mutex;
 
 use opentelemetry::metrics::MeterProvider as _;
-use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::metrics::{Aggregation, Instrument, SdkMeterProvider, Stream};
 use prometheus::Registry;
 
 use crate::errors::ApiError;
@@ -9,12 +9,43 @@ use crate::errors::ApiError;
 use super::cache::ScrapeCache;
 use super::{METRICS, Metrics};
 
-pub fn init() -> Result<(), ApiError> {
-    if METRICS.get().is_some() {
-        return Ok(());
-    }
+const LATENCY_BUCKETS_SECONDS: &[f64] = &[
+    0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
+];
+const OUTBOUND_BUCKETS_SECONDS: &[f64] = &[
+    0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0,
+];
+const BACKGROUND_BUCKETS_SECONDS: &[f64] = &[
+    0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0,
+    1800.0, 3600.0,
+];
 
-    let registry = Registry::new();
+fn duration_histogram_view(instrument: &Instrument) -> Option<Stream> {
+    let boundaries = match instrument.name() {
+        "hubuum_http_request_duration"
+        | "hubuum_db_connection_acquire_duration"
+        | "hubuum_db_operation_duration" => LATENCY_BUCKETS_SECONDS,
+        "hubuum_remote_call_duration" => OUTBOUND_BUCKETS_SECONDS,
+        "hubuum_task_queue_wait_duration"
+        | "hubuum_task_execution_duration"
+        | "hubuum_computed_field_rebuild_duration"
+        | "hubuum_export_phase_duration"
+        | "hubuum_import_phase_duration" => BACKGROUND_BUCKETS_SECONDS,
+        _ => return None,
+    };
+
+    Some(
+        Stream::builder()
+            .with_aggregation(Aggregation::ExplicitBucketHistogram {
+                boundaries: boundaries.to_vec(),
+                record_min_max: true,
+            })
+            .build()
+            .expect("hard-coded duration histogram boundaries should be valid"),
+    )
+}
+
+fn build_provider(registry: &Registry) -> Result<SdkMeterProvider, ApiError> {
     let exporter = opentelemetry_prometheus::exporter()
         .with_registry(registry.clone())
         .without_scope_info()
@@ -23,7 +54,20 @@ pub fn init() -> Result<(), ApiError> {
         .map_err(|error| {
             ApiError::InternalServerError(format!("Failed to initialize metrics exporter: {error}"))
         })?;
-    let provider = SdkMeterProvider::builder().with_reader(exporter).build();
+
+    Ok(SdkMeterProvider::builder()
+        .with_reader(exporter)
+        .with_view(duration_histogram_view)
+        .build())
+}
+
+pub fn init() -> Result<(), ApiError> {
+    if METRICS.get().is_some() {
+        return Ok(());
+    }
+
+    let registry = Registry::new();
+    let provider = build_provider(&registry)?;
     let meter = provider.meter("hubuum");
 
     let metrics = Metrics {
@@ -152,6 +196,10 @@ pub fn init() -> Result<(), ApiError> {
             .u64_counter("hubuum_export_output_cleanup_deleted")
             .with_description("Stored export and backup outputs deleted by cleanup")
             .build(),
+        export_template_info: meter
+            .u64_gauge("hubuum_export_template_info")
+            .with_description("Stored export templates observed by this process")
+            .build(),
         export_duration: meter
             .f64_histogram("hubuum_export_phase_duration")
             .with_description("Export phase duration")
@@ -252,4 +300,65 @@ pub fn init() -> Result<(), ApiError> {
     METRICS
         .set(metrics)
         .map_err(|_| ApiError::InternalServerError("Metrics already initialized".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry::metrics::MeterProvider as _;
+    use prometheus::{Encoder, TextEncoder};
+
+    use super::*;
+
+    fn histogram_bucket_bounds(instrument_name: &'static str, value: f64) -> Vec<String> {
+        let registry = Registry::new();
+        let provider = build_provider(&registry).unwrap();
+        let meter = provider.meter("hubuum-test");
+        meter
+            .f64_histogram(instrument_name)
+            .with_unit("s")
+            .build()
+            .record(value, &[]);
+
+        let mut encoded = Vec::new();
+        TextEncoder::new()
+            .encode(&registry.gather(), &mut encoded)
+            .unwrap();
+        let body = String::from_utf8(encoded).unwrap();
+        let exported_name = format!("{instrument_name}_seconds_bucket");
+
+        body.lines()
+            .filter(|line| line.starts_with(&exported_name))
+            .filter_map(|line| {
+                line.split_once("le=\"")
+                    .and_then(|(_, suffix)| suffix.split_once('"'))
+                    .map(|(bound, _)| bound.to_string())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn request_histograms_use_subsecond_latency_buckets() {
+        let bounds = histogram_bucket_bounds("hubuum_http_request_duration", 0.004);
+
+        assert_eq!(
+            bounds,
+            [
+                "0.0005", "0.001", "0.0025", "0.005", "0.01", "0.025", "0.05", "0.1", "0.25",
+                "0.5", "1", "2.5", "5", "10", "30", "+Inf",
+            ]
+        );
+    }
+
+    #[test]
+    fn task_histograms_cover_long_running_background_work() {
+        let bounds = histogram_bucket_bounds("hubuum_task_execution_duration", 75.0);
+
+        assert_eq!(
+            bounds,
+            [
+                "0.01", "0.025", "0.05", "0.1", "0.25", "0.5", "1", "2.5", "5", "10", "30", "60",
+                "120", "300", "600", "1800", "3600", "+Inf",
+            ]
+        );
+    }
 }

--- a/src/observability/metrics/registry.rs
+++ b/src/observability/metrics/registry.rs
@@ -1,10 +1,13 @@
 use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use opentelemetry::KeyValue;
 use opentelemetry::metrics::MeterProvider as _;
 use opentelemetry_sdk::metrics::{Aggregation, Instrument, SdkMeterProvider, Stream};
-use prometheus::Registry;
+use prometheus::{IntGaugeVec, Opts, Registry};
 
 use crate::errors::ApiError;
+use crate::logger;
 
 use super::cache::ScrapeCache;
 use super::{METRICS, Metrics};
@@ -30,6 +33,7 @@ fn duration_histogram_view(instrument: &Instrument) -> Option<Stream> {
         | "hubuum_task_execution_duration"
         | "hubuum_computed_field_rebuild_duration"
         | "hubuum_export_phase_duration"
+        | "hubuum_export_duration"
         | "hubuum_import_phase_duration" => BACKGROUND_BUCKETS_SECONDS,
         _ => return None,
     };
@@ -69,10 +73,42 @@ pub fn init() -> Result<(), ApiError> {
     let registry = Registry::new();
     let provider = build_provider(&registry)?;
     let meter = provider.meter("hubuum");
+    let export_template_info = IntGaugeVec::new(
+        Opts::new(
+            "hubuum_export_template_info",
+            "Current stored export template identities from the shared database",
+        ),
+        &["template_id", "template_name"],
+    )
+    .map_err(|error| {
+        ApiError::InternalServerError(format!(
+            "Failed to create export template info metric: {error}"
+        ))
+    })?;
+    registry
+        .register(Box::new(export_template_info.clone()))
+        .map_err(|error| {
+            ApiError::InternalServerError(format!(
+                "Failed to register export template info metric: {error}"
+            ))
+        })?;
 
     let metrics = Metrics {
         registry,
         _provider: provider,
+        build_info: meter
+            .u64_gauge("hubuum_build_info")
+            .with_description("Hubuum build identity")
+            .build(),
+        runtime_info: meter
+            .u64_gauge("hubuum_runtime_info")
+            .with_description("Hubuum process runtime role")
+            .build(),
+        process_start_time: meter
+            .f64_gauge("hubuum_process_start_time")
+            .with_description("Unix timestamp when this Hubuum process initialized metrics")
+            .with_unit("s")
+            .build(),
         http_requests: meter
             .u64_counter("hubuum_http_requests")
             .with_description("HTTP requests handled")
@@ -142,9 +178,14 @@ pub fn init() -> Result<(), ApiError> {
             .with_description("Task execution duration")
             .with_unit("s")
             .build(),
-        task_config: meter
-            .u64_gauge("hubuum_task_worker_config")
-            .with_description("Configured task worker settings")
+        task_workers_configured: meter
+            .u64_gauge("hubuum_task_workers_configured")
+            .with_description("Configured task workers in this process")
+            .build(),
+        task_poll_interval: meter
+            .f64_gauge("hubuum_task_poll_interval")
+            .with_description("Configured task worker poll interval")
+            .with_unit("s")
             .build(),
         task_counts: meter
             .i64_gauge("hubuum_tasks")
@@ -184,25 +225,27 @@ pub fn init() -> Result<(), ApiError> {
             .with_description("Computed-field rebuild duration")
             .with_unit("s")
             .build(),
-        export_output_cleanup_runs: meter
-            .u64_counter("hubuum_export_output_cleanup_runs")
-            .with_description("Stored export and backup output cleanup runs")
+        task_output_cleanup_runs: meter
+            .u64_counter("hubuum_task_output_cleanup_runs")
+            .with_description("Stored task output cleanup runs")
             .build(),
-        export_output_cleanup_failures: meter
-            .u64_counter("hubuum_export_output_cleanup_failures")
-            .with_description("Stored export and backup output cleanup failures")
+        task_output_cleanup_failures: meter
+            .u64_counter("hubuum_task_output_cleanup_failures")
+            .with_description("Stored task output cleanup failures")
             .build(),
-        export_output_cleanup_deleted: meter
-            .u64_counter("hubuum_export_output_cleanup_deleted")
-            .with_description("Stored export and backup outputs deleted by cleanup")
+        task_output_cleanup_deleted: meter
+            .u64_counter("hubuum_task_output_cleanup_deleted")
+            .with_description("Stored task outputs deleted by cleanup")
             .build(),
-        export_template_info: meter
-            .u64_gauge("hubuum_export_template_info")
-            .with_description("Stored export templates observed by this process")
-            .build(),
-        export_duration: meter
+        export_template_info,
+        export_phase_duration: meter
             .f64_histogram("hubuum_export_phase_duration")
             .with_description("Export phase duration")
+            .with_unit("s")
+            .build(),
+        export_template_duration: meter
+            .f64_histogram("hubuum_export_duration")
+            .with_description("Overall export duration by stored template identity")
             .with_unit("s")
             .build(),
         export_completions: meter
@@ -277,13 +320,27 @@ pub fn init() -> Result<(), ApiError> {
             .with_description("Oldest actionable event item age by queue")
             .with_unit("s")
             .build(),
-        event_worker_config: meter
-            .u64_gauge("hubuum_event_worker_config")
-            .with_description("Configured event worker settings")
+        event_workers_configured: meter
+            .u64_gauge("hubuum_event_workers_configured")
+            .with_description("Configured event workers in this process")
+            .build(),
+        event_worker_batch_size: meter
+            .u64_gauge("hubuum_event_worker_batch_size")
+            .with_description("Configured event worker batch size")
+            .build(),
+        event_worker_poll_interval: meter
+            .f64_gauge("hubuum_event_worker_poll_interval")
+            .with_description("Configured event worker poll interval")
+            .with_unit("s")
+            .build(),
+        event_worker_lock_timeout: meter
+            .f64_gauge("hubuum_event_worker_lock_timeout")
+            .with_description("Configured event worker claim lock timeout")
+            .with_unit("s")
             .build(),
         event_worker_wakeups: meter
-            .u64_gauge("hubuum_event_worker_wakeups")
-            .with_description("Event worker wakeup counters")
+            .u64_counter("hubuum_event_worker_wakeups")
+            .with_description("Event worker wakeups")
             .build(),
         inventory_entities: meter
             .i64_gauge("hubuum_inventory_entities")
@@ -293,13 +350,50 @@ pub fn init() -> Result<(), ApiError> {
             .u64_counter("hubuum_metrics_refresh_failures")
             .with_description("Metrics scrape refresh failures by source")
             .build(),
+        refresh_duration: meter
+            .f64_gauge("hubuum_metrics_refresh_duration")
+            .with_description("Duration of the latest metrics source refresh attempt")
+            .with_unit("s")
+            .build(),
+        refresh_last_success: meter
+            .f64_gauge("hubuum_metrics_refresh_last_success_timestamp")
+            .with_description("Unix timestamp of the latest successful metrics source refresh")
+            .with_unit("s")
+            .build(),
+        refresh_skipped: meter
+            .u64_counter("hubuum_metrics_refresh_skipped")
+            .with_description("Metrics source refreshes skipped by reason")
+            .build(),
         scrape_cache: Mutex::new(ScrapeCache::default()),
         db_refresh_lock: tokio::sync::Mutex::new(()),
     };
 
+    metrics.build_info.record(
+        1,
+        &[
+            KeyValue::new("version", env!("CARGO_PKG_VERSION")),
+            KeyValue::new("git_sha", logger::build_git_sha()),
+        ],
+    );
+    metrics.process_start_time.record(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs_f64(),
+        &[],
+    );
+
     METRICS
         .set(metrics)
         .map_err(|_| ApiError::InternalServerError("Metrics already initialized".to_string()))
+}
+
+pub fn runtime_identity(role: &'static str) {
+    if let Some(metrics) = super::current() {
+        metrics
+            .runtime_info
+            .record(1, &[KeyValue::new("role", role)]);
+    }
 }
 
 #[cfg(test)]

--- a/src/observability/metrics/scrape.rs
+++ b/src/observability/metrics/scrape.rs
@@ -1,4 +1,7 @@
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
 use actix_web::{HttpResponse, Responder, http::header, web};
+use opentelemetry::KeyValue;
 use prometheus::{Encoder, TextEncoder};
 
 use crate::db::{DbCallSite, DbPool, with_db_call_site};
@@ -36,5 +39,36 @@ async fn refresh_scrape_gauges(metrics: &Metrics, pool: &DbPool) {
         inventory::refresh_inventory_gauges(metrics, pool).await;
         task::refresh_task_gauges(metrics, pool).await;
         event::refresh_event_gauges(metrics, pool).await;
+    } else {
+        metrics.refresh_skipped.add(
+            1,
+            &[
+                KeyValue::new("source", "database"),
+                KeyValue::new("reason", "concurrent"),
+            ],
+        );
+    }
+}
+
+pub(super) fn record_refresh_attempt(
+    metrics: &Metrics,
+    source: &'static str,
+    started_at: Instant,
+    succeeded: bool,
+) {
+    let attrs = [KeyValue::new("source", source)];
+    metrics
+        .refresh_duration
+        .record(started_at.elapsed().as_secs_f64(), &attrs);
+    if succeeded {
+        metrics.refresh_last_success.record(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs_f64(),
+            &attrs,
+        );
+    } else {
+        metrics.refresh_failures.add(1, &attrs);
     }
 }

--- a/src/observability/metrics/scrape.rs
+++ b/src/observability/metrics/scrape.rs
@@ -16,6 +16,27 @@ pub(super) enum RefreshOutcome {
     Failed,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RefreshSource {
+    Database,
+    Events,
+    Inventory,
+    LoginLimiter,
+    Tasks,
+}
+
+impl RefreshSource {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Database => "database",
+            Self::Events => "events",
+            Self::Inventory => "inventory",
+            Self::LoginLimiter => "login_limiter",
+            Self::Tasks => "tasks",
+        }
+    }
+}
+
 pub async fn scrape(pool: web::Data<DbPool>) -> Result<impl Responder, ApiError> {
     let metrics = get()?;
     with_db_call_site(
@@ -49,7 +70,7 @@ async fn refresh_scrape_gauges(metrics: &Metrics, pool: &DbPool) {
         metrics.refresh_skipped.add(
             1,
             &[
-                KeyValue::new("source", "database"),
+                KeyValue::new("source", RefreshSource::Database.as_str()),
                 KeyValue::new("reason", "concurrent"),
             ],
         );
@@ -58,11 +79,11 @@ async fn refresh_scrape_gauges(metrics: &Metrics, pool: &DbPool) {
 
 pub(super) fn record_refresh_attempt(
     metrics: &Metrics,
-    source: &'static str,
+    source: RefreshSource,
     started_at: Instant,
     outcome: RefreshOutcome,
 ) {
-    let attrs = [KeyValue::new("source", source)];
+    let attrs = [KeyValue::new("source", source.as_str())];
     metrics
         .refresh_duration
         .record(started_at.elapsed().as_secs_f64(), &attrs);
@@ -77,5 +98,25 @@ pub(super) fn record_refresh_attempt(
             );
         }
         RefreshOutcome::Failed => metrics.refresh_failures.add(1, &attrs),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RefreshSource;
+
+    #[test]
+    fn refresh_sources_have_stable_bounded_labels() {
+        assert_eq!(
+            [
+                RefreshSource::Database,
+                RefreshSource::Events,
+                RefreshSource::Inventory,
+                RefreshSource::LoginLimiter,
+                RefreshSource::Tasks,
+            ]
+            .map(RefreshSource::as_str),
+            ["database", "events", "inventory", "login_limiter", "tasks",]
+        );
     }
 }

--- a/src/observability/metrics/scrape.rs
+++ b/src/observability/metrics/scrape.rs
@@ -10,6 +10,12 @@ use crate::errors::ApiError;
 use super::Metrics;
 use super::{db, event, get, inventory, login, task};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RefreshOutcome {
+    Succeeded,
+    Failed,
+}
+
 pub async fn scrape(pool: web::Data<DbPool>) -> Result<impl Responder, ApiError> {
     let metrics = get()?;
     with_db_call_site(
@@ -54,21 +60,22 @@ pub(super) fn record_refresh_attempt(
     metrics: &Metrics,
     source: &'static str,
     started_at: Instant,
-    succeeded: bool,
+    outcome: RefreshOutcome,
 ) {
     let attrs = [KeyValue::new("source", source)];
     metrics
         .refresh_duration
         .record(started_at.elapsed().as_secs_f64(), &attrs);
-    if succeeded {
-        metrics.refresh_last_success.record(
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs_f64(),
-            &attrs,
-        );
-    } else {
-        metrics.refresh_failures.add(1, &attrs);
+    match outcome {
+        RefreshOutcome::Succeeded => {
+            metrics.refresh_last_success.record(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs_f64(),
+                &attrs,
+            );
+        }
+        RefreshOutcome::Failed => metrics.refresh_failures.add(1, &attrs),
     }
 }

--- a/src/observability/metrics/task.rs
+++ b/src/observability/metrics/task.rs
@@ -54,13 +54,36 @@ pub fn task_completed(kind: &str, final_status: &str, execution: Option<Duration
 
 pub fn task_worker_config(worker_count: usize, poll_interval: Duration) {
     if let Some(metrics) = current() {
-        metrics.task_config.record(
-            u64::try_from(worker_count).unwrap_or(u64::MAX),
-            &[KeyValue::new("setting", "workers")],
-        );
-        metrics.task_config.record(
-            u64::try_from(poll_interval.as_millis()).unwrap_or(u64::MAX),
-            &[KeyValue::new("setting", "poll_interval_ms")],
+        metrics
+            .task_workers_configured
+            .record(u64::try_from(worker_count).unwrap_or(u64::MAX), &[]);
+        metrics
+            .task_poll_interval
+            .record(poll_interval.as_secs_f64(), &[]);
+    }
+}
+
+pub fn task_output_cleanup_run(kind: &'static str) {
+    if let Some(metrics) = current() {
+        metrics
+            .task_output_cleanup_runs
+            .add(1, &[KeyValue::new("kind", kind)]);
+    }
+}
+
+pub fn task_output_cleanup_failed(kind: &'static str) {
+    if let Some(metrics) = current() {
+        metrics
+            .task_output_cleanup_failures
+            .add(1, &[KeyValue::new("kind", kind)]);
+    }
+}
+
+pub fn task_output_cleanup_deleted(kind: &'static str, count: usize) {
+    if let Some(metrics) = current() {
+        metrics.task_output_cleanup_deleted.add(
+            u64::try_from(count).unwrap_or(u64::MAX),
+            &[KeyValue::new("kind", kind)],
         );
     }
 }
@@ -71,15 +94,15 @@ pub(super) async fn refresh_task_gauges(metrics: &Metrics, pool: &DbPool) {
         return;
     }
 
+    let refresh_started_at = Instant::now();
     match pool.metrics_task_snapshot().await {
         Ok(snapshot) => {
+            super::scrape::record_refresh_attempt(metrics, "tasks", refresh_started_at, true);
             record_task_snapshot(metrics, &snapshot);
             store_task_snapshot(metrics, snapshot);
         }
         Err(_) => {
-            metrics
-                .refresh_failures
-                .add(1, &[KeyValue::new("source", "tasks")]);
+            super::scrape::record_refresh_attempt(metrics, "tasks", refresh_started_at, false);
             if let Some(snapshot) = stale_task_snapshot(metrics) {
                 record_task_snapshot(metrics, &snapshot);
             } else {
@@ -132,14 +155,22 @@ fn record_task_snapshot(metrics: &Metrics, snapshot: &TaskMetricsSnapshot) {
         }
     }
 
-    metrics.task_oldest_age.record(
-        age_seconds(snapshot.oldest_queued_at, now).unwrap_or(0.0),
-        &[KeyValue::new("state", "queued")],
-    );
-    metrics.task_oldest_age.record(
-        age_seconds(snapshot.oldest_active_at, now).unwrap_or(0.0),
-        &[KeyValue::new("state", "active")],
-    );
+    for age in &snapshot.ages {
+        metrics.task_oldest_age.record(
+            age_seconds(age.oldest_queued_at, now).unwrap_or(0.0),
+            &[
+                KeyValue::new("kind", age.kind.clone()),
+                KeyValue::new("state", "queued"),
+            ],
+        );
+        metrics.task_oldest_age.record(
+            age_seconds(age.oldest_active_at, now).unwrap_or(0.0),
+            &[
+                KeyValue::new("kind", age.kind.clone()),
+                KeyValue::new("state", "active"),
+            ],
+        );
+    }
 }
 
 fn record_empty_task_snapshot(metrics: &Metrics) {
@@ -155,12 +186,22 @@ fn record_empty_task_snapshot(metrics: &Metrics) {
         }
     }
 
-    metrics
-        .task_oldest_age
-        .record(0.0, &[KeyValue::new("state", "queued")]);
-    metrics
-        .task_oldest_age
-        .record(0.0, &[KeyValue::new("state", "active")]);
+    for kind in TaskKind::ALL {
+        metrics.task_oldest_age.record(
+            0.0,
+            &[
+                KeyValue::new("kind", kind.as_str()),
+                KeyValue::new("state", "queued"),
+            ],
+        );
+        metrics.task_oldest_age.record(
+            0.0,
+            &[
+                KeyValue::new("kind", kind.as_str()),
+                KeyValue::new("state", "active"),
+            ],
+        );
+    }
 }
 
 fn age_seconds(

--- a/src/observability/metrics/task.rs
+++ b/src/observability/metrics/task.rs
@@ -7,7 +7,38 @@ use crate::db::DbPool;
 use crate::db::traits::metrics::{MetricsBackend, TaskMetricsSnapshot};
 use crate::models::{TaskKind, TaskStatus};
 
+use super::scrape::{RefreshOutcome, record_refresh_attempt};
 use super::{Metrics, current};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TaskOutputKind {
+    Export,
+    Backup,
+}
+
+impl TaskOutputKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Export => "export",
+            Self::Backup => "backup",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TaskAgeState {
+    Queued,
+    Active,
+}
+
+impl TaskAgeState {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Active => "active",
+        }
+    }
+}
 
 pub fn task_worker_iteration(outcome: &'static str) {
     if let Some(metrics) = current() {
@@ -63,27 +94,27 @@ pub fn task_worker_config(worker_count: usize, poll_interval: Duration) {
     }
 }
 
-pub fn task_output_cleanup_run(kind: &'static str) {
+pub fn task_output_cleanup_run(kind: TaskOutputKind) {
     if let Some(metrics) = current() {
         metrics
             .task_output_cleanup_runs
-            .add(1, &[KeyValue::new("kind", kind)]);
+            .add(1, &[KeyValue::new("kind", kind.as_str())]);
     }
 }
 
-pub fn task_output_cleanup_failed(kind: &'static str) {
+pub fn task_output_cleanup_failed(kind: TaskOutputKind) {
     if let Some(metrics) = current() {
         metrics
             .task_output_cleanup_failures
-            .add(1, &[KeyValue::new("kind", kind)]);
+            .add(1, &[KeyValue::new("kind", kind.as_str())]);
     }
 }
 
-pub fn task_output_cleanup_deleted(kind: &'static str, count: usize) {
+pub fn task_output_cleanup_deleted(kind: TaskOutputKind, count: usize) {
     if let Some(metrics) = current() {
         metrics.task_output_cleanup_deleted.add(
             u64::try_from(count).unwrap_or(u64::MAX),
-            &[KeyValue::new("kind", kind)],
+            &[KeyValue::new("kind", kind.as_str())],
         );
     }
 }
@@ -97,12 +128,17 @@ pub(super) async fn refresh_task_gauges(metrics: &Metrics, pool: &DbPool) {
     let refresh_started_at = Instant::now();
     match pool.metrics_task_snapshot().await {
         Ok(snapshot) => {
-            super::scrape::record_refresh_attempt(metrics, "tasks", refresh_started_at, true);
+            record_refresh_attempt(
+                metrics,
+                "tasks",
+                refresh_started_at,
+                RefreshOutcome::Succeeded,
+            );
             record_task_snapshot(metrics, &snapshot);
             store_task_snapshot(metrics, snapshot);
         }
         Err(_) => {
-            super::scrape::record_refresh_attempt(metrics, "tasks", refresh_started_at, false);
+            record_refresh_attempt(metrics, "tasks", refresh_started_at, RefreshOutcome::Failed);
             if let Some(snapshot) = stale_task_snapshot(metrics) {
                 record_task_snapshot(metrics, &snapshot);
             } else {
@@ -140,35 +176,28 @@ fn record_task_snapshot(metrics: &Metrics, snapshot: &TaskMetricsSnapshot) {
     let mut counts = HashMap::new();
 
     for row in &snapshot.counts {
-        counts.insert((row.kind.as_str(), row.status.as_str()), row.count);
+        counts.insert((row.kind, row.status), row.count);
     }
 
     for kind in TaskKind::ALL {
         for status in TaskStatus::ALL {
-            let kind = kind.as_str();
-            let status = status.as_str();
             let count = counts.get(&(kind, status)).copied().unwrap_or(0);
-            metrics.task_counts.record(
-                count,
-                &[KeyValue::new("kind", kind), KeyValue::new("status", status)],
-            );
+            record_task_count(metrics, kind, status, count);
         }
     }
 
     for age in &snapshot.ages {
-        metrics.task_oldest_age.record(
+        record_task_age(
+            metrics,
+            age.kind,
+            TaskAgeState::Queued,
             age_seconds(age.oldest_queued_at, now).unwrap_or(0.0),
-            &[
-                KeyValue::new("kind", age.kind.clone()),
-                KeyValue::new("state", "queued"),
-            ],
         );
-        metrics.task_oldest_age.record(
+        record_task_age(
+            metrics,
+            age.kind,
+            TaskAgeState::Active,
             age_seconds(age.oldest_active_at, now).unwrap_or(0.0),
-            &[
-                KeyValue::new("kind", age.kind.clone()),
-                KeyValue::new("state", "active"),
-            ],
         );
     }
 }
@@ -176,32 +205,31 @@ fn record_task_snapshot(metrics: &Metrics, snapshot: &TaskMetricsSnapshot) {
 fn record_empty_task_snapshot(metrics: &Metrics) {
     for kind in TaskKind::ALL {
         for status in TaskStatus::ALL {
-            metrics.task_counts.record(
-                0,
-                &[
-                    KeyValue::new("kind", kind.as_str()),
-                    KeyValue::new("status", status.as_str()),
-                ],
-            );
+            record_task_count(metrics, kind, status, 0);
         }
+        record_task_age(metrics, kind, TaskAgeState::Queued, 0.0);
+        record_task_age(metrics, kind, TaskAgeState::Active, 0.0);
     }
+}
 
-    for kind in TaskKind::ALL {
-        metrics.task_oldest_age.record(
-            0.0,
-            &[
-                KeyValue::new("kind", kind.as_str()),
-                KeyValue::new("state", "queued"),
-            ],
-        );
-        metrics.task_oldest_age.record(
-            0.0,
-            &[
-                KeyValue::new("kind", kind.as_str()),
-                KeyValue::new("state", "active"),
-            ],
-        );
-    }
+fn record_task_count(metrics: &Metrics, kind: TaskKind, status: TaskStatus, count: i64) {
+    metrics.task_counts.record(
+        count,
+        &[
+            KeyValue::new("kind", kind.as_str()),
+            KeyValue::new("status", status.as_str()),
+        ],
+    );
+}
+
+fn record_task_age(metrics: &Metrics, kind: TaskKind, state: TaskAgeState, age: f64) {
+    metrics.task_oldest_age.record(
+        age,
+        &[
+            KeyValue::new("kind", kind.as_str()),
+            KeyValue::new("state", state.as_str()),
+        ],
+    );
 }
 
 fn age_seconds(
@@ -209,4 +237,25 @@ fn age_seconds(
     now: chrono::NaiveDateTime,
 ) -> Option<f64> {
     timestamp.map(|timestamp| (now - timestamp).num_milliseconds().max(0) as f64 / 1000.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TaskAgeState, TaskOutputKind};
+
+    #[test]
+    fn task_output_kinds_have_stable_bounded_labels() {
+        assert_eq!(
+            [TaskOutputKind::Export, TaskOutputKind::Backup].map(TaskOutputKind::as_str),
+            ["export", "backup"]
+        );
+    }
+
+    #[test]
+    fn task_age_states_have_stable_bounded_labels() {
+        assert_eq!(
+            [TaskAgeState::Queued, TaskAgeState::Active].map(TaskAgeState::as_str),
+            ["queued", "active"]
+        );
+    }
 }

--- a/src/observability/metrics/task.rs
+++ b/src/observability/metrics/task.rs
@@ -4,10 +4,10 @@ use std::time::{Duration, Instant};
 use opentelemetry::KeyValue;
 
 use crate::db::DbPool;
-use crate::db::traits::metrics::{MetricsBackend, TaskMetricsSnapshot};
+use crate::db::traits::metrics::{MetricsRefreshBackend, TaskGaugeSnapshot};
 use crate::models::{TaskKind, TaskStatus};
 
-use super::scrape::{RefreshOutcome, record_refresh_attempt};
+use super::scrape::{RefreshOutcome, RefreshSource, record_refresh_attempt};
 use super::{Metrics, current};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -126,11 +126,11 @@ pub(super) async fn refresh_task_gauges(metrics: &Metrics, pool: &DbPool) {
     }
 
     let refresh_started_at = Instant::now();
-    match pool.metrics_task_snapshot().await {
+    match pool.metrics_task_gauge_snapshot().await {
         Ok(snapshot) => {
             record_refresh_attempt(
                 metrics,
-                "tasks",
+                RefreshSource::Tasks,
                 refresh_started_at,
                 RefreshOutcome::Succeeded,
             );
@@ -138,7 +138,12 @@ pub(super) async fn refresh_task_gauges(metrics: &Metrics, pool: &DbPool) {
             store_task_snapshot(metrics, snapshot);
         }
         Err(_) => {
-            record_refresh_attempt(metrics, "tasks", refresh_started_at, RefreshOutcome::Failed);
+            record_refresh_attempt(
+                metrics,
+                RefreshSource::Tasks,
+                refresh_started_at,
+                RefreshOutcome::Failed,
+            );
             if let Some(snapshot) = stale_task_snapshot(metrics) {
                 record_task_snapshot(metrics, &snapshot);
             } else {
@@ -148,7 +153,7 @@ pub(super) async fn refresh_task_gauges(metrics: &Metrics, pool: &DbPool) {
     }
 }
 
-fn cached_task_snapshot(metrics: &Metrics) -> Option<TaskMetricsSnapshot> {
+fn cached_task_snapshot(metrics: &Metrics) -> Option<TaskGaugeSnapshot> {
     let now = Instant::now();
     metrics
         .scrape_cache
@@ -157,7 +162,7 @@ fn cached_task_snapshot(metrics: &Metrics) -> Option<TaskMetricsSnapshot> {
         .and_then(|cache| cache.tasks.fresh_value(now))
 }
 
-fn stale_task_snapshot(metrics: &Metrics) -> Option<TaskMetricsSnapshot> {
+fn stale_task_snapshot(metrics: &Metrics) -> Option<TaskGaugeSnapshot> {
     metrics
         .scrape_cache
         .lock()
@@ -165,13 +170,13 @@ fn stale_task_snapshot(metrics: &Metrics) -> Option<TaskMetricsSnapshot> {
         .and_then(|cache| cache.tasks.cached_value())
 }
 
-fn store_task_snapshot(metrics: &Metrics, snapshot: TaskMetricsSnapshot) {
+fn store_task_snapshot(metrics: &Metrics, snapshot: TaskGaugeSnapshot) {
     if let Ok(mut cache) = metrics.scrape_cache.lock() {
         cache.tasks.store(snapshot, Instant::now());
     }
 }
 
-fn record_task_snapshot(metrics: &Metrics, snapshot: &TaskMetricsSnapshot) {
+fn record_task_snapshot(metrics: &Metrics, snapshot: &TaskGaugeSnapshot) {
     let now = chrono::Utc::now().naive_utc();
     let mut counts = HashMap::new();
 

--- a/src/observability/metrics/timer.rs
+++ b/src/observability/metrics/timer.rs
@@ -1,0 +1,43 @@
+use std::time::{Duration, Instant};
+
+/// Shared lifecycle state for metric timers that record an explicit outcome.
+pub(super) struct OutcomeTimer {
+    started_at: Instant,
+    finished: bool,
+}
+
+impl OutcomeTimer {
+    pub(super) fn start() -> Self {
+        Self {
+            started_at: Instant::now(),
+            finished: false,
+        }
+    }
+
+    pub(super) fn elapsed(&self) -> Duration {
+        self.started_at.elapsed()
+    }
+
+    pub(super) fn finish(&mut self) -> Duration {
+        self.finished = true;
+        self.elapsed()
+    }
+
+    pub(super) fn unfinished_elapsed(&self) -> Option<Duration> {
+        (!self.finished).then(|| self.elapsed())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OutcomeTimer;
+
+    #[test]
+    fn finished_timer_is_not_reported_as_unfinished() {
+        let mut timer = OutcomeTimer::start();
+
+        timer.finish();
+
+        assert!(timer.unfinished_elapsed().is_none());
+    }
+}

--- a/src/tasks/execution.rs
+++ b/src/tasks/execution.rs
@@ -158,7 +158,7 @@ pub(super) async fn execute_import_task<C>(
 where
     C: BackendContext + ?Sized,
 {
-    let total_timer = metrics::import_phase_timer("total");
+    let total_timer = metrics::import_phase_timer(metrics::ImportMetricPhase::Total);
     let pool = backend.db_pool();
     let payload = task
         .request_payload
@@ -187,11 +187,11 @@ where
     );
 
     async {
-        let planning_timer = metrics::import_phase_timer("planning");
+        let planning_timer = metrics::import_phase_timer(metrics::ImportMetricPhase::Planning);
         let planning = plan_import(backend, user, scopes, &request)
             .instrument(info_span!("import_planning"))
             .await;
-        let planning_time = planning_timer.finish("success");
+        let planning_time = planning_timer.finish(metrics::ImportMetricOutcome::Success);
 
         info!(
             message = "Import planning finished",
@@ -237,7 +237,7 @@ where
             )
             .await?;
             metrics::import_items(failed_count, 0, failed_count);
-            total_timer.finish("failed");
+            total_timer.finish(metrics::ImportMetricOutcome::Failed);
             return Ok(());
         }
 
@@ -284,7 +284,7 @@ where
         )
         .await?;
 
-        let execution_timer = metrics::import_phase_timer("execution");
+        let execution_timer = metrics::import_phase_timer(metrics::ImportMetricPhase::Execution);
         if request.dry_run() {
             for failure in failures {
                 accumulator.push_failure(
@@ -338,7 +338,12 @@ where
         } else {
             TaskStatus::PartiallySucceeded
         };
-        let metric_outcome = status.as_str();
+        let metric_outcome = match status {
+            TaskStatus::Succeeded => metrics::ImportMetricOutcome::Success,
+            TaskStatus::Failed => metrics::ImportMetricOutcome::Failed,
+            TaskStatus::PartiallySucceeded => metrics::ImportMetricOutcome::PartiallySucceeded,
+            _ => unreachable!("import execution produced a non-terminal status"),
+        };
 
         let summary = format!(
             "Import finished with {} succeeded and {} failed items",

--- a/src/tasks/execution.rs
+++ b/src/tasks/execution.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use tracing::{Instrument, error, info, info_span, warn};
 
 use crate::db::traits::task::{TaskBackend, TaskStateUpdate};
@@ -160,6 +158,7 @@ pub(super) async fn execute_import_task<C>(
 where
     C: BackendContext + ?Sized,
 {
+    let total_timer = metrics::import_phase_timer("total");
     let pool = backend.db_pool();
     let payload = task
         .request_payload
@@ -188,13 +187,11 @@ where
     );
 
     async {
-        let total_start = Instant::now();
-        let planning_start = Instant::now();
+        let planning_timer = metrics::import_phase_timer("planning");
         let planning = plan_import(backend, user, scopes, &request)
             .instrument(info_span!("import_planning"))
             .await;
-        let planning_time = planning_start.elapsed();
-        metrics::import_phase_duration("planning", planning_time);
+        let planning_time = planning_timer.finish("success");
 
         info!(
             message = "Import planning finished",
@@ -224,7 +221,7 @@ where
                 validation_failures = failed_count,
                 atomicity = ?atomicity,
                 planning_time = ?planning_time,
-                total_time = ?total_start.elapsed()
+                total_time = ?total_timer.elapsed()
             );
             crate::db::traits::task::insert_import_results(pool, &results).await?;
             let summary = format!("Import validation failed for {failed_count} item(s)");
@@ -240,7 +237,7 @@ where
             )
             .await?;
             metrics::import_items(failed_count, 0, failed_count);
-            metrics::import_phase_duration("total", total_start.elapsed());
+            total_timer.finish("failed");
             return Ok(());
         }
 
@@ -287,7 +284,7 @@ where
         )
         .await?;
 
-        let execution_start = Instant::now();
+        let execution_timer = metrics::import_phase_timer("execution");
         if request.dry_run() {
             for failure in failures {
                 accumulator.push_failure(
@@ -341,14 +338,14 @@ where
         } else {
             TaskStatus::PartiallySucceeded
         };
+        let metric_outcome = status.as_str();
 
         let summary = format!(
             "Import finished with {} succeeded and {} failed items",
             accumulator.success, accumulator.failed
         );
 
-        let execution_time = execution_start.elapsed();
-        metrics::import_phase_duration("execution", execution_time);
+        let execution_time = execution_timer.finish(metric_outcome);
         info!(
             message = "Import execution finished",
             task_id = task.id,
@@ -356,7 +353,7 @@ where
             success_items = accumulator.success,
             failed_items = accumulator.failed,
             execution_time = ?execution_time,
-            total_time = ?total_start.elapsed()
+            total_time = ?total_timer.elapsed()
         );
 
         finalize_task(
@@ -379,7 +376,7 @@ where
             accumulator.success,
             accumulator.failed,
         );
-        metrics::import_phase_duration("total", total_start.elapsed());
+        total_timer.finish(metric_outcome);
 
         Ok(())
     }

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -721,18 +721,19 @@ async fn maybe_cleanup_expired_task_outputs(pool: &DbPool) -> Result<(), ApiErro
         return Ok(());
     };
 
-    metrics::export_output_cleanup_run();
+    metrics::task_output_cleanup_run("export");
     match purge_expired_export_outputs(pool).await {
-        Ok(deleted) => metrics::export_output_cleanup_deleted(deleted.len()),
+        Ok(deleted) => metrics::task_output_cleanup_deleted("export", deleted.len()),
         Err(error) => {
-            metrics::export_output_cleanup_failed();
+            metrics::task_output_cleanup_failed("export");
             return Err(error);
         }
     }
+    metrics::task_output_cleanup_run("backup");
     match purge_expired_backup_outputs(pool).await {
-        Ok(deleted) => metrics::export_output_cleanup_deleted(deleted.len()),
+        Ok(deleted) => metrics::task_output_cleanup_deleted("backup", deleted.len()),
         Err(error) => {
-            metrics::export_output_cleanup_failed();
+            metrics::task_output_cleanup_failed("backup");
             return Err(error);
         }
     }

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -721,19 +721,23 @@ async fn maybe_cleanup_expired_task_outputs(pool: &DbPool) -> Result<(), ApiErro
         return Ok(());
     };
 
-    metrics::task_output_cleanup_run("export");
+    metrics::task_output_cleanup_run(metrics::TaskOutputKind::Export);
     match purge_expired_export_outputs(pool).await {
-        Ok(deleted) => metrics::task_output_cleanup_deleted("export", deleted.len()),
+        Ok(deleted) => {
+            metrics::task_output_cleanup_deleted(metrics::TaskOutputKind::Export, deleted.len())
+        }
         Err(error) => {
-            metrics::task_output_cleanup_failed("export");
+            metrics::task_output_cleanup_failed(metrics::TaskOutputKind::Export);
             return Err(error);
         }
     }
-    metrics::task_output_cleanup_run("backup");
+    metrics::task_output_cleanup_run(metrics::TaskOutputKind::Backup);
     match purge_expired_backup_outputs(pool).await {
-        Ok(deleted) => metrics::task_output_cleanup_deleted("backup", deleted.len()),
+        Ok(deleted) => {
+            metrics::task_output_cleanup_deleted(metrics::TaskOutputKind::Backup, deleted.len())
+        }
         Err(error) => {
-            metrics::task_output_cleanup_failed("backup");
+            metrics::task_output_cleanup_failed(metrics::TaskOutputKind::Backup);
             return Err(error);
         }
     }

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -7,9 +7,10 @@ use diesel_async::pooled_connection::bb8::Pool;
 use rstest::rstest;
 use tokio::sync::Mutex;
 
+use crate::config::RuntimeRole;
 use crate::db::{DbConnection, DbPool};
 use crate::middlewares::TracingMiddleware;
-use crate::models::{TaskKind, TaskStatus};
+use crate::models::{ExportTemplateID, TaskKind, TaskStatus};
 use crate::observability::metrics;
 use crate::test_support::clear_metrics_scrape_cache;
 use crate::tests::{TestContext, test_context};
@@ -22,7 +23,7 @@ async fn metrics_endpoint_exports_prometheus_text(#[future(awt)] test_context: T
     let _lock = METRICS_TEST_LOCK.lock().await;
     let context = test_context;
     metrics::init().unwrap();
-    metrics::runtime_identity("test");
+    metrics::runtime_identity(RuntimeRole::Worker);
     clear_metrics_scrape_cache();
     let _in_flight = metrics::http_request_started_for_route("/test");
     metrics::http_request_finished("GET", "/test", 200, std::time::Duration::from_millis(1));
@@ -54,7 +55,7 @@ async fn metrics_endpoint_exports_prometheus_text(#[future(awt)] test_context: T
         "hubuum_db_operation_duration_seconds_bucket{caller=\"metrics_refresh\",operation=\"connection\",result=\"ok\""
     ));
     assert!(body.contains("hubuum_build_info{git_sha="));
-    assert!(body.contains("hubuum_runtime_info{role=\"test\"} 1"));
+    assert!(body.contains("hubuum_runtime_info{role=\"worker\"} 1"));
     assert!(body.contains("hubuum_process_start_time_seconds"));
     assert!(body.contains("hubuum_metrics_refresh_last_success_timestamp_seconds"));
 }
@@ -95,9 +96,15 @@ async fn metrics_endpoint_exports_representative_bounded_families() {
     metrics::export_completed("objects_in_class", "application/json");
     metrics::export_truncated("objects_in_class", "application/json");
     metrics::export_warnings("objects_in_class", "application/json", 2);
-    metrics::export_phase_timer("render", Some(42)).finish("success");
-    metrics::export_phase_timer("total", Some(42)).finish("success");
-    metrics::import_phase_duration("planning", Duration::from_millis(5));
+    let template_id = ExportTemplateID::new(42).unwrap();
+    metrics::export_phase_timer(metrics::ExportMetricPhase::Render, Some(template_id))
+        .finish(metrics::ExportMetricOutcome::Success);
+    metrics::export_phase_timer(metrics::ExportMetricPhase::Total, Some(template_id))
+        .finish(metrics::ExportMetricOutcome::Success);
+    metrics::import_phase_duration(
+        metrics::ImportMetricPhase::Planning,
+        Duration::from_millis(5),
+    );
     metrics::import_items(3, 2, 1);
     metrics::login_lockout("subnet");
     metrics::client_allowlist_rejected("disallowed_ip");

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -1,13 +1,14 @@
 use std::sync::LazyLock;
 use std::time::Duration;
 
-use actix_web::{App, http::StatusCode, test, web};
+use actix_web::{App, HttpResponse, http::StatusCode, test, web};
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::pooled_connection::bb8::Pool;
 use rstest::rstest;
 use tokio::sync::Mutex;
 
 use crate::db::{DbConnection, DbPool};
+use crate::middlewares::TracingMiddleware;
 use crate::models::{TaskKind, TaskStatus};
 use crate::observability::metrics;
 use crate::test_support::clear_metrics_scrape_cache;
@@ -21,8 +22,9 @@ async fn metrics_endpoint_exports_prometheus_text(#[future(awt)] test_context: T
     let _lock = METRICS_TEST_LOCK.lock().await;
     let context = test_context;
     metrics::init().unwrap();
+    metrics::runtime_identity("test");
     clear_metrics_scrape_cache();
-    metrics::http_request_started();
+    let _in_flight = metrics::http_request_started_for_route("/test");
     metrics::http_request_finished("GET", "/test", 200, std::time::Duration::from_millis(1));
 
     let app = test::init_service(
@@ -51,6 +53,10 @@ async fn metrics_endpoint_exports_prometheus_text(#[future(awt)] test_context: T
     assert!(body.contains(
         "hubuum_db_operation_duration_seconds_bucket{caller=\"metrics_refresh\",operation=\"connection\",result=\"ok\""
     ));
+    assert!(body.contains("hubuum_build_info{git_sha="));
+    assert!(body.contains("hubuum_runtime_info{role=\"test\"} 1"));
+    assert!(body.contains("hubuum_process_start_time_seconds"));
+    assert!(body.contains("hubuum_metrics_refresh_last_success_timestamp_seconds"));
 }
 
 #[actix_web::test]
@@ -89,13 +95,15 @@ async fn metrics_endpoint_exports_representative_bounded_families() {
     metrics::export_completed("objects_in_class", "application/json");
     metrics::export_truncated("objects_in_class", "application/json");
     metrics::export_warnings("objects_in_class", "application/json", 2);
-    metrics::export_template_observed(42, "inventory");
-    metrics::export_phase_duration("render", Duration::from_millis(12), Some(42));
+    metrics::export_phase_timer("render", Some(42)).finish("success");
+    metrics::export_phase_timer("total", Some(42)).finish("success");
     metrics::import_phase_duration("planning", Duration::from_millis(5));
     metrics::import_items(3, 2, 1);
     metrics::login_lockout("subnet");
     metrics::client_allowlist_rejected("disallowed_ip");
     metrics::remote_call_finished("GET", "none", "timeout", Duration::from_millis(10));
+    metrics::event_worker_wakeup("fanout", "poll");
+    metrics::task_worker_config(0, Duration::from_millis(200));
 
     let app = test::init_service(
         App::new()
@@ -110,8 +118,8 @@ async fn metrics_endpoint_exports_representative_bounded_families() {
 
     for metric_name in [
         "hubuum_export_completions_total",
+        "hubuum_export_duration_seconds",
         "hubuum_export_phase_duration_seconds",
-        "hubuum_export_template_info",
         "hubuum_export_truncations_total",
         "hubuum_export_warnings_total",
         "hubuum_import_phase_duration_seconds",
@@ -121,12 +129,19 @@ async fn metrics_endpoint_exports_representative_bounded_families() {
         "hubuum_login_lockouts_total",
         "hubuum_client_allowlist_rejections_total",
         "hubuum_remote_call_results_total",
+        "hubuum_event_worker_wakeups_total",
+        "hubuum_task_workers_configured",
+        "hubuum_task_poll_interval_seconds",
     ] {
         assert!(body.contains(metric_name), "missing metric: {metric_name}");
     }
     assert!(body.contains("template_id=\"42\""));
-    assert!(body.contains("template_name=\"inventory\""));
+    assert!(body.contains("phase=\"render\""));
+    assert!(body.contains("outcome=\"success\""));
     assert!(body.contains("outcome=\"timeout\""));
+    assert!(body.contains("hubuum_event_worker_wakeups_total{kind=\"poll\",worker=\"fanout\"}"));
+    assert!(body.contains("hubuum_task_workers_configured 0"));
+    assert!(body.contains("hubuum_task_poll_interval_seconds 0.2"));
 }
 
 #[actix_web::test]
@@ -186,7 +201,56 @@ async fn task_gauges_export_zero_for_bounded_kind_status_pairs(
             );
             assert!(body.contains(&line), "missing metrics line: {line}");
         }
+        for state in ["queued", "active"] {
+            let line = format!(
+                "hubuum_task_oldest_age_seconds{{kind=\"{}\",state=\"{state}\"}}",
+                kind.as_str(),
+            );
+            assert!(body.contains(&line), "missing metrics line: {line}");
+        }
     }
+}
+
+#[actix_web::test]
+async fn tracing_metrics_keep_stable_route_templates() {
+    let _lock = METRICS_TEST_LOCK.lock().await;
+    metrics::init().unwrap();
+    clear_metrics_scrape_cache();
+
+    async fn ok() -> HttpResponse {
+        HttpResponse::Ok().finish()
+    }
+
+    let app = test::init_service(
+        App::new()
+            .wrap(TracingMiddleware::new())
+            .app_data(web::Data::new(unreachable_pool()))
+            .route(
+                "/api/v1/classes/{class_id}/objects/{object_id}",
+                web::get().to(ok),
+            )
+            .route("/metrics", web::get().to(metrics::scrape)),
+    )
+    .await;
+    let response = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/v1/classes/42/objects/99")
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response =
+        test::call_service(&app, test::TestRequest::get().uri("/metrics").to_request()).await;
+    let body = test::read_body(response).await;
+    let body = std::str::from_utf8(&body).unwrap();
+
+    assert!(body.contains(
+        "hubuum_http_requests_total{method=\"GET\",route=\"/api/v1/classes/{class_id}/objects/{object_id}\",status_code=\"200\",status_family=\"2xx\"}"
+    ));
+    assert!(!body.contains("route=\"/api/v1/classes/42/objects/99\""));
+    assert!(body.contains("hubuum_http_requests_in_flight{route=\"/metrics\"} 1"));
 }
 
 fn unreachable_pool() -> DbPool {

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -88,40 +88,18 @@ async fn metrics_endpoint_is_best_effort_when_database_refresh_fails() {
 }
 
 #[actix_web::test]
-async fn metrics_endpoint_exports_representative_bounded_families() {
-    let _lock = METRICS_TEST_LOCK.lock().await;
-    metrics::init().unwrap();
-    clear_metrics_scrape_cache();
-
-    metrics::export_completed("objects_in_class", "application/json");
-    metrics::export_truncated("objects_in_class", "application/json");
-    metrics::export_warnings("objects_in_class", "application/json", 2);
-    let template_id = ExportTemplateID::new(42).unwrap();
-    metrics::export_phase_timer(metrics::ExportMetricPhase::Render, Some(template_id))
-        .finish(metrics::ExportMetricOutcome::Success);
-    metrics::export_phase_timer(metrics::ExportMetricPhase::Total, Some(template_id))
-        .finish(metrics::ExportMetricOutcome::Success);
-    metrics::import_phase_duration(
-        metrics::ImportMetricPhase::Planning,
-        Duration::from_millis(5),
-    );
-    metrics::import_items(3, 2, 1);
-    metrics::login_lockout("subnet");
-    metrics::client_allowlist_rejected("disallowed_ip");
-    metrics::remote_call_finished("GET", "none", "timeout", Duration::from_millis(10));
-    metrics::event_worker_wakeup("fanout", "poll");
-    metrics::task_worker_config(0, Duration::from_millis(200));
-
-    let app = test::init_service(
-        App::new()
-            .app_data(web::Data::new(unreachable_pool()))
-            .route("/metrics", web::get().to(metrics::scrape)),
-    )
+async fn export_metrics_use_bounded_phase_and_template_labels() {
+    let body = scrape_recorded_metrics(|| {
+        metrics::export_completed("objects_in_class", "application/json");
+        metrics::export_truncated("objects_in_class", "application/json");
+        metrics::export_warnings("objects_in_class", "application/json", 2);
+        let template_id = ExportTemplateID::new(42).unwrap();
+        metrics::export_phase_timer(metrics::ExportMetricPhase::Render, Some(template_id))
+            .finish(metrics::ExportMetricOutcome::Success);
+        metrics::export_phase_timer(metrics::ExportMetricPhase::Total, Some(template_id))
+            .finish(metrics::ExportMetricOutcome::Success);
+    })
     .await;
-    let response =
-        test::call_service(&app, test::TestRequest::get().uri("/metrics").to_request()).await;
-    let body = test::read_body(response).await;
-    let body = std::str::from_utf8(&body).unwrap();
 
     for metric_name in [
         "hubuum_export_completions_total",
@@ -129,47 +107,85 @@ async fn metrics_endpoint_exports_representative_bounded_families() {
         "hubuum_export_phase_duration_seconds",
         "hubuum_export_truncations_total",
         "hubuum_export_warnings_total",
-        "hubuum_import_phase_duration_seconds",
-        "hubuum_import_processed_items_total",
-        "hubuum_import_succeeded_items_total",
-        "hubuum_import_failed_items_total",
-        "hubuum_login_lockouts_total",
-        "hubuum_client_allowlist_rejections_total",
-        "hubuum_remote_call_results_total",
-        "hubuum_event_worker_wakeups_total",
-        "hubuum_task_workers_configured",
-        "hubuum_task_poll_interval_seconds",
     ] {
         assert!(body.contains(metric_name), "missing metric: {metric_name}");
     }
     assert!(body.contains("template_id=\"42\""));
     assert!(body.contains("phase=\"render\""));
     assert!(body.contains("outcome=\"success\""));
+}
+
+#[actix_web::test]
+async fn import_metrics_export_phase_and_item_families() {
+    let body = scrape_recorded_metrics(|| {
+        metrics::import_phase_duration("planning", Duration::from_millis(5));
+        metrics::import_items(3, 2, 1);
+    })
+    .await;
+
+    for metric_name in [
+        "hubuum_import_phase_duration_seconds",
+        "hubuum_import_processed_items_total",
+        "hubuum_import_succeeded_items_total",
+        "hubuum_import_failed_items_total",
+    ] {
+        assert!(body.contains(metric_name), "missing metric: {metric_name}");
+    }
+    assert!(body.contains("phase=\"planning\""));
+    assert!(body.contains("outcome=\"success\""));
+}
+
+#[actix_web::test]
+async fn login_lockout_metrics_export_the_scope() {
+    let body = scrape_recorded_metrics(|| metrics::login_lockout("subnet")).await;
+
+    assert!(body.contains("hubuum_login_lockouts_total{scope=\"subnet\"}"));
+}
+
+#[actix_web::test]
+async fn client_allowlist_metrics_export_the_rejection_reason() {
+    let body =
+        scrape_recorded_metrics(|| metrics::client_allowlist_rejected("disallowed_ip")).await;
+
+    assert!(body.contains("hubuum_client_allowlist_rejections_total{reason=\"disallowed_ip\"}"));
+}
+
+#[actix_web::test]
+async fn remote_call_metrics_export_the_terminal_outcome() {
+    let body = scrape_recorded_metrics(|| {
+        metrics::remote_call_finished("GET", "none", "timeout", Duration::from_millis(10));
+    })
+    .await;
+
+    assert!(body.contains("hubuum_remote_call_duration_seconds"));
+    assert!(body.contains("hubuum_remote_call_results_total"));
     assert!(body.contains("outcome=\"timeout\""));
+}
+
+#[actix_web::test]
+async fn event_worker_metrics_export_bounded_wakeup_labels() {
+    let body = scrape_recorded_metrics(|| metrics::event_worker_wakeup("fanout", "poll")).await;
+
     assert!(body.contains("hubuum_event_worker_wakeups_total{kind=\"poll\",worker=\"fanout\"}"));
+}
+
+#[actix_web::test]
+async fn task_worker_config_metrics_use_dimensionally_typed_families() {
+    let body =
+        scrape_recorded_metrics(|| metrics::task_worker_config(0, Duration::from_millis(200)))
+            .await;
+
     assert!(body.contains("hubuum_task_workers_configured 0"));
     assert!(body.contains("hubuum_task_poll_interval_seconds 0.2"));
 }
 
 #[actix_web::test]
 async fn task_queue_wait_uses_kind_only_labels() {
-    let _lock = METRICS_TEST_LOCK.lock().await;
-    metrics::init().unwrap();
-    clear_metrics_scrape_cache();
-
-    metrics::task_claimed("remote_call", Some(Duration::from_millis(25)));
-    metrics::task_completed("remote_call", "succeeded", Some(Duration::from_millis(5)));
-
-    let app = test::init_service(
-        App::new()
-            .app_data(web::Data::new(unreachable_pool()))
-            .route("/metrics", web::get().to(metrics::scrape)),
-    )
+    let body = scrape_recorded_metrics(|| {
+        metrics::task_claimed("remote_call", Some(Duration::from_millis(25)));
+        metrics::task_completed("remote_call", "succeeded", Some(Duration::from_millis(5)));
+    })
     .await;
-    let req = test::TestRequest::get().uri("/metrics").to_request();
-    let response = test::call_service(&app, req).await;
-    let body = test::read_body(response).await;
-    let body = std::str::from_utf8(&body).unwrap();
 
     assert!(body.contains("hubuum_task_queue_wait_duration_seconds_bucket{kind=\"remote_call\""));
     assert!(!body.contains("hubuum_task_queue_wait_duration_seconds_bucket{final_status="));
@@ -268,4 +284,22 @@ fn unreachable_pool() -> DbPool {
         .max_size(1)
         .connection_timeout(Duration::from_millis(5))
         .build_unchecked(manager)
+}
+
+async fn scrape_recorded_metrics(record: impl FnOnce()) -> String {
+    let _lock = METRICS_TEST_LOCK.lock().await;
+    metrics::init().unwrap();
+    clear_metrics_scrape_cache();
+    record();
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(unreachable_pool()))
+            .route("/metrics", web::get().to(metrics::scrape)),
+    )
+    .await;
+    let response =
+        test::call_service(&app, test::TestRequest::get().uri("/metrics").to_request()).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    String::from_utf8(test::read_body(response).await.to_vec()).unwrap()
 }

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -89,6 +89,8 @@ async fn metrics_endpoint_exports_representative_bounded_families() {
     metrics::export_completed("objects_in_class", "application/json");
     metrics::export_truncated("objects_in_class", "application/json");
     metrics::export_warnings("objects_in_class", "application/json", 2);
+    metrics::export_template_observed(42, "inventory");
+    metrics::export_phase_duration("render", Duration::from_millis(12), Some(42));
     metrics::import_phase_duration("planning", Duration::from_millis(5));
     metrics::import_items(3, 2, 1);
     metrics::login_lockout("subnet");
@@ -108,6 +110,8 @@ async fn metrics_endpoint_exports_representative_bounded_families() {
 
     for metric_name in [
         "hubuum_export_completions_total",
+        "hubuum_export_phase_duration_seconds",
+        "hubuum_export_template_info",
         "hubuum_export_truncations_total",
         "hubuum_export_warnings_total",
         "hubuum_import_phase_duration_seconds",
@@ -120,6 +124,8 @@ async fn metrics_endpoint_exports_representative_bounded_families() {
     ] {
         assert!(body.contains(metric_name), "missing metric: {metric_name}");
     }
+    assert!(body.contains("template_id=\"42\""));
+    assert!(body.contains("template_name=\"inventory\""));
     assert!(body.contains("outcome=\"timeout\""));
 }
 


### PR DESCRIPTION
## Summary

- configure explicit fractional-second histogram buckets for HTTP/database latency, outbound calls, and long-running background work
- add build, runtime-role, process-start, scrape-freshness, and route-aware in-flight metrics while preserving #181's bounded database `caller` contract
- expose an instrumented metrics-only listener from worker-role processes so Prometheus can scrape API and worker processes directly
- split mixed-unit configuration gauges into dimensionally typed metrics and make event wakeups a real counter
- report task backlog age per task kind and distinguish export/backup output cleanup
- expose aggregate export phase outcomes plus per-template total duration, backed by a resettable current template ID/name mapping
- record import/export error and timeout outcomes and persist export total/query/hydration/render timings in task details
- document per-process scraping, database-wide gauge aggregation, bucket interpretation, mean/p95 queries, template joins, alerts, and dashboard migration

## Why

OpenTelemetry's unit-agnostic default histogram boundaries started at 5 while Hubuum records duration observations as fractional seconds. Normal millisecond HTTP and database work therefore accumulated in the first useful `le="5"` bucket: `_sum / _count` could produce a mean, but the histogram could not produce useful latency percentiles.

The deployed public metrics URL also load-balanced between materially different processes. Process-local counters and pool gauges appeared to reset or disappear, worker-only activity was not directly scrapeable, and identical database-wide gauges could be accidentally summed across replicas. The existing output did not identify the scraped build or runtime role, expose refresh staleness, or show which stored export template was slow.

Several metric contracts were also misleading: millisecond configuration values were exported under untyped gauges, cumulative event wakeups were gauges, task age lacked task kind, output cleanup combined exports and backups under export-only names, and failed import/export phases could disappear from timing data.

## Behavior and impact

Durations remain fractional seconds. HTTP/database histograms cover 0.5 ms through 30 seconds, outbound calls cover 10 ms through 120 seconds, and queued/background work covers 10 ms through one hour. Full-second buckets are intentional for exceptional slow work; fast operations still retain millisecond precision.

API/all-role processes serve metrics on their normal listener. Worker-role processes serve only the configured metrics path on their configured listener when metrics are enabled. The worker listener uses the same allowlist, tracing, request metrics, and TLS configuration as applicable, while its supervisor exclusively owns signal-driven graceful shutdown. Prometheus should scrape every process through a stable target rather than a load-balanced public URL. Database-wide inventory, task, template, and event gauges should be aggregated with `max` or `avg`, not `sum`.

`hubuum_export_phase_duration_seconds` stays low-cardinality with `phase` and `outcome`. `hubuum_export_duration_seconds` carries `template_id` and `outcome` only for total export duration; ad-hoc exports use `template_id="none"`. `hubuum_export_template_info` reflects the current shared database and removes stale renamed/deleted template identities on refresh. Task IDs and raw resource paths remain excluded from labels.

Export task details add nullable `total_duration_ms`, `query_duration_ms`, `hydration_duration_ms`, and `render_duration_ms` fields while output remains available. There is no breaking HTTP API change.

## Breaking Prometheus contract

Dashboard and alert queries must be updated before deployment:

- replace `hubuum_task_worker_config` with `hubuum_task_workers_configured` and `hubuum_task_poll_interval_seconds`
- replace `hubuum_event_worker_config` with the typed worker-count, batch-size, poll-interval, and lock-timeout families
- replace `hubuum_event_worker_wakeups` with counter `hubuum_event_worker_wakeups_total`
- replace `hubuum_export_output_cleanup_*` with `hubuum_task_output_cleanup_*{kind}`
- account for new labels on HTTP in-flight, task-age, export-phase, and import-phase families
- use `hubuum_export_duration_seconds` for per-template total-duration joins

The `[Unreleased]` changelog and `docs/metrics.md` call out the migration explicitly.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- regenerated OpenAPI and verified byte parity with `docs/openapi.json`
- `git diff --check`