### PR TITLE
Refresh generated single-host configuration during updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Single-host updates now refresh generated Compose and Caddy configuration
+  before rolling application containers, while preserving existing `.env`
+  values and adding only newly introduced defaults.
 - Shared-host installations using direct routing now proxy `/metrics` to the
   backend instead of letting the request fall through to the frontend.
 - Reduced idle database pool checkouts by combining maintenance and claim

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -298,8 +298,9 @@ Use `--service-name NAME` to install the unit under a different name. Without `-
 
 The installer copies `install-single-host.sh`, `update-single-host.sh`,
 `single-host-rollout.sh`, `stop-single-host.sh`, and
-`uninstall-single-host.sh` into the install directory. A curl-based installer
-rerun refreshes all five management scripts before updating the deployment:
+`uninstall-single-host.sh` into the install directory. Before pulling or
+building application images, the updater refreshes those management scripts
+and regenerates `compose.yml` and `Caddyfile` from the current installer:
 
 ```bash
 cd /opt/hubuum
@@ -308,8 +309,10 @@ sudo ./update-single-host.sh
 
 For image-based installs, the update command pulls the latest configured
 images. For source-build installs, it fetches the source checkouts and rebuilds
-the local app images. On an established rolling installation, it then performs
-a rolling application update:
+the local app images. Existing `.env` values, including operator-added
+settings, are preserved; defaults introduced by a newer installer are appended
+only when their keys are missing. On an established rolling installation, it
+then performs a rolling application update:
 
 1. Stop the all-role primary gracefully while the API-only standby continues
    serving HTTP. This drains old-version workers before schema migration.
@@ -330,7 +333,8 @@ Valkey service without recreating an existing infrastructure container.
 Caddy, PostgreSQL, and Valkey remain running throughout this sequence. Newly
 pulled images for those infrastructure services are not activated by the
 rolling application update; schedule a maintenance window when those services
-themselves need replacement.
+themselves need replacement. A changed generated Caddyfile is applied by the
+normal Caddy reload in the rolling sequence.
 
 Pass `--auth-config /absolute/host/path.toml` to change the read-only external
 authentication file as part of the same update and rolling replacement.
@@ -345,6 +349,11 @@ readiness-aware Caddy configuration. The installer brings up the standby before
 replacing the existing primary. A subsequent `update-single-host.sh` refuses to
 fall back to a destructive restart when the installed Compose file lacks the
 rolling-update services.
+
+Installations whose updater predates automatic generated-configuration refresh
+must likewise re-run the current `install-single-host.sh` once. That one-time
+rerun installs the self-refreshing updater; later `update-single-host.sh` runs
+pick up Caddy, Compose, and management-script changes automatically.
 
 The live container contract test covers adoption from the published v0.0.1
 image: the old API remains online while the candidate applies all newer

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -54,6 +54,7 @@ Options:
   --stop                  Stop the installed stack and exit
   --uninstall             Stop the stack, remove systemd unit if present, and exit
   --purge                 With --uninstall, also remove compose volumes and install directory
+  --refresh-config        Refresh generated deployment files and management scripts without rolling
   --mode MODE             Install mode: all or backend. Default: all
   --dir PATH              Install directory. Default: /opt/hubuum
   --web FQDN              Public frontend hostname. Required in all mode
@@ -135,6 +136,7 @@ while [[ $# -gt 0 ]]; do
     --mode) MODE="$2"; ARG_SET+=" MODE"; shift 2 ;;
     --stop) ACTION="stop"; shift ;;
     --uninstall) ACTION="uninstall"; shift ;;
+    --refresh-config) ACTION="refresh-config"; shift ;;
     --purge) PURGE="true"; shift ;;
     --dir) INSTALL_DIR="$2"; shift 2 ;;
     --web) WEB_FQDN="$2"; ARG_SET+=" WEB_FQDN"; shift 2 ;;
@@ -158,8 +160,8 @@ while [[ $# -gt 0 ]]; do
     --systemd) INSTALL_SYSTEMD="true"; shift ;;
     --service-name) SERVICE_NAME="$2"; SERVICE_NAME_SET="true"; shift 2 ;;
     --no-systemd) INSTALL_SYSTEMD="false"; shift ;;
-    --script-base-url) SCRIPT_BASE_URL="${2%/}"; shift 2 ;;
-    --script-ref) SCRIPT_REF="$2"; shift 2 ;;
+    --script-base-url) SCRIPT_BASE_URL="${2%/}"; ARG_SET+=" SCRIPT_BASE_URL"; shift 2 ;;
+    --script-ref) SCRIPT_REF="$2"; ARG_SET+=" SCRIPT_BASE_URL"; shift 2 ;;
     --build-from-source) BUILD_FROM_SOURCE="true"; ARG_SET+=" BUILD_FROM_SOURCE"; shift ;;
     --no-pull) PULL="false"; shift ;;
     --recreate) RECREATE="true"; shift ;;
@@ -169,6 +171,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 ENV_FILE="$INSTALL_DIR/.env"
+
+generates_deployment_files() {
+  [[ "$ACTION" == "install" || "$ACTION" == "refresh-config" ]]
+}
+
+if [[ "$ACTION" == "refresh-config" && ! -f "$ENV_FILE" ]]; then
+  die "missing $ENV_FILE; run install-single-host.sh first"
+fi
 
 arg_was_set() {
   [[ " $ARG_SET " == *" $1 "* ]]
@@ -187,7 +197,7 @@ reuse_from_env() {
   printf -v "$var" '%s' "$val"
 }
 
-if [[ "$ACTION" == "install" && -f "$ENV_FILE" ]]; then
+if generates_deployment_files && [[ -f "$ENV_FILE" ]]; then
   reuse_from_env MODE INSTALL_MODE
   reuse_from_env WEB_FQDN WEB_FQDN
   reuse_from_env API_FQDN API_FQDN
@@ -206,6 +216,7 @@ if [[ "$ACTION" == "install" && -f "$ENV_FILE" ]]; then
   reuse_from_env BUILD_FROM_SOURCE BUILD_FROM_SOURCE
   reuse_from_env NETWORK_SUBNET HUBUUM_CLIENT_ALLOWLIST
   reuse_from_env AUTH_CONFIG_HOST_PATH HUBUUM_AUTH_CONFIG_HOST_PATH
+  reuse_from_env SCRIPT_BASE_URL MANAGEMENT_SCRIPT_BASE_URL
 fi
 
 [[ "$MODE" == "all" || "$MODE" == "backend" ]] || die "--mode must be all or backend"
@@ -221,25 +232,25 @@ fi
 if [[ -n "$SCRIPT_REF" ]]; then
   SCRIPT_BASE_URL="https://raw.githubusercontent.com/hubuum/hubuum/${SCRIPT_REF}/scripts"
 fi
-if [[ "$ACTION" == "install" && -z "$API_FQDN" ]]; then
+if generates_deployment_files && [[ -z "$API_FQDN" ]]; then
   usage
   exit 2
 fi
-if [[ "$ACTION" == "install" && -z "$LETSENCRYPT_EMAIL" ]]; then
+if generates_deployment_files && [[ -z "$LETSENCRYPT_EMAIL" ]]; then
   usage
   exit 2
 fi
-if [[ "$ACTION" == "install" && "$MODE" == "all" && -z "$WEB_FQDN" ]]; then
+if generates_deployment_files && [[ "$MODE" == "all" && -z "$WEB_FQDN" ]]; then
   usage
   exit 2
 fi
-if [[ "$ACTION" == "install" && "$MODE" == "all" && "$WEB_FQDN" == "$API_FQDN" && -z "$SHARED_HOST_ROUTING" ]]; then
+if generates_deployment_files && [[ "$MODE" == "all" && "$WEB_FQDN" == "$API_FQDN" && -z "$SHARED_HOST_ROUTING" ]]; then
   die "--shared-host-routing is required when --web and --api use the same hostname"
 fi
-if [[ "$ACTION" == "install" && "$MODE" == "all" && "$WEB_FQDN" != "$API_FQDN" && -n "$SHARED_HOST_ROUTING" ]]; then
+if generates_deployment_files && [[ "$MODE" == "all" && "$WEB_FQDN" != "$API_FQDN" && -n "$SHARED_HOST_ROUTING" ]]; then
   die "--shared-host-routing only applies when --web and --api use the same hostname"
 fi
-if [[ "$ACTION" == "install" && "$MODE" == "backend" && -n "$SHARED_HOST_ROUTING" ]]; then
+if generates_deployment_files && [[ "$MODE" == "backend" && -n "$SHARED_HOST_ROUTING" ]]; then
   die "--shared-host-routing only applies in all mode"
 fi
 if [[ "$EUID" -ne 0 ]]; then
@@ -352,7 +363,7 @@ if [[ "$ACTION" == "uninstall" ]]; then
 fi
 
 need_cmd openssl
-if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
+if [[ "$BUILD_FROM_SOURCE" == "true" && "$ACTION" != "refresh-config" ]]; then
   need_cmd git
 fi
 
@@ -431,7 +442,7 @@ clone_or_update() {
   fi
 }
 
-if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
+if [[ "$BUILD_FROM_SOURCE" == "true" && "$ACTION" != "refresh-config" ]]; then
   clone_or_update "$BACKEND_REPO" "$INSTALL_DIR/src/hubuum" "$BACKEND_REF"
   if [[ "$MODE" == "all" ]]; then
     clone_or_update "$FRONTEND_REPO" "$INSTALL_DIR/src/hubuum-frontend" "$FRONTEND_REF"
@@ -475,7 +486,7 @@ if [[ "$MODE" == "all" ]]; then
   LOGIN_RATE_LIMIT_BACKEND="valkey"
 fi
 
-{
+write_deployment_env() {
   printf 'INSTALL_MODE=%s\n' "$MODE"
   printf 'WEB_FQDN=%s\n' "$WEB_FQDN"
   printf 'API_FQDN=%s\n' "$API_FQDN"
@@ -484,6 +495,7 @@ fi
   printf 'BUILD_FROM_SOURCE=%s\n' "$BUILD_FROM_SOURCE"
   printf 'CONTAINER_ENGINE=%s\n' "$ENGINE_BIN"
   printf 'SYSTEMD_SERVICE_NAME=%s\n' "$SERVICE_NAME"
+  printf 'MANAGEMENT_SCRIPT_BASE_URL=%s\n' "$SCRIPT_BASE_URL"
   printf '\n'
   printf 'BACKEND_IMAGE=%s\n' "$BACKEND_IMAGE"
   printf 'FRONTEND_IMAGE=%s\n' "$FRONTEND_IMAGE"
@@ -526,7 +538,35 @@ fi
   printf 'SESSION_TTL_SECONDS=28800\n'
   printf 'SESSION_PREFIX=hubuum:sess:\n'
   printf 'NEXT_PUBLIC_APP_NAME=%s\n' "$(quote_env "Hubuum Console")"
-} > "$ENV_FILE"
+}
+
+merge_missing_env_values() {
+  local generated_env="$1"
+  local key
+  local line
+  local wrote_header="false"
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ "$line" == [A-Z0-9_]*=* ]] || continue
+    key="${line%%=*}"
+    if ! grep -q "^${key}=" "$ENV_FILE"; then
+      if [[ "$wrote_header" == "false" ]]; then
+        printf '\n# Defaults added by deployment configuration refresh\n' >> "$ENV_FILE"
+        wrote_header="true"
+      fi
+      printf '%s\n' "$line" >> "$ENV_FILE"
+    fi
+  done < "$generated_env"
+}
+
+if [[ "$ACTION" == "refresh-config" ]]; then
+  GENERATED_ENV_TEMP="$(mktemp "$INSTALL_DIR/.env.generated.XXXXXX")"
+  write_deployment_env > "$GENERATED_ENV_TEMP"
+  merge_missing_env_values "$GENERATED_ENV_TEMP"
+  rm -f "$GENERATED_ENV_TEMP"
+else
+  write_deployment_env > "$ENV_FILE"
+fi
 
 chmod 0600 "$ENV_FILE"
 
@@ -912,6 +952,11 @@ networks:
 EOF
 
 cd "$INSTALL_DIR"
+
+if [[ "$ACTION" == "refresh-config" ]]; then
+  echo "Refreshed Hubuum deployment files and management scripts."
+  exit 0
+fi
 
 if [[ "$PULL" == "true" ]]; then
   PULL_SERVICES=(caddy)

--- a/scripts/test-install-script-refresh.sh
+++ b/scripts/test-install-script-refresh.sh
@@ -70,4 +70,62 @@ for script_name in "${management_scripts[@]}"; do
   [[ -x "$INSTALL_DIR/$script_name" ]]
 done
 
+merge_function_source="$(
+  sed -n '/^merge_missing_env_values() {$/,/^}$/p' \
+    "$REPOSITORY_ROOT/scripts/install-single-host.sh"
+)"
+[[ -n "$merge_function_source" ]]
+eval "$merge_function_source"
+
+ENV_FILE="$INSTALL_DIR/.env"
+GENERATED_ENV="$TEST_ROOT/generated.env"
+cat > "$ENV_FILE" <<'EOF'
+INSTALL_MODE=all
+HUBUUM_LOG_LEVEL=debug
+OPERATOR_CUSTOM_SETTING=preserved
+EOF
+cat > "$GENERATED_ENV" <<'EOF'
+INSTALL_MODE=backend
+HUBUUM_LOG_LEVEL=info
+MANAGEMENT_SCRIPT_BASE_URL=https://example.invalid/scripts
+NEW_GENERATED_DEFAULT=present
+EOF
+
+merge_missing_env_values "$GENERATED_ENV"
+
+[[ "$(grep -c '^INSTALL_MODE=' "$ENV_FILE")" -eq 1 ]]
+[[ "$(grep -c '^HUBUUM_LOG_LEVEL=' "$ENV_FILE")" -eq 1 ]]
+grep -qx 'INSTALL_MODE=all' "$ENV_FILE"
+grep -qx 'HUBUUM_LOG_LEVEL=debug' "$ENV_FILE"
+grep -qx 'OPERATOR_CUSTOM_SETTING=preserved' "$ENV_FILE"
+grep -qx 'MANAGEMENT_SCRIPT_BASE_URL=https://example.invalid/scripts' "$ENV_FILE"
+grep -qx 'NEW_GENERATED_DEFAULT=present' "$ENV_FILE"
+
+refresh_function_source="$(
+  sed -n '/^refresh_deployment_files() {$/,/^}$/p' \
+    "$REPOSITORY_ROOT/scripts/update-single-host.sh"
+)"
+[[ -n "$refresh_function_source" ]]
+eval "$refresh_function_source"
+
+BASH_LOG="$TEST_ROOT/bash.log"
+BUILD_FROM_SOURCE="false"
+ENGINE_BIN="docker"
+MANAGEMENT_SCRIPT_BASE_URL="$SCRIPT_BASE_URL"
+bash() {
+  if [[ "${1:-}" == "-n" ]]; then
+    return 0
+  fi
+  printf '%s\n' "$*" >> "$BASH_LOG"
+}
+
+refresh_deployment_files
+
+grep -q -- "--refresh-config --dir $INSTALL_DIR --engine docker" "$BASH_LOG"
+grep -q -- "--script-base-url $SCRIPT_BASE_URL" "$BASH_LOG"
+if find "$INSTALL_DIR" -maxdepth 1 -name '.install-single-host.*' | grep -q .; then
+  echo "temporary refreshed installer was not removed" >&2
+  exit 1
+fi
+
 echo "Management script refresh test passed"

--- a/scripts/update-single-host.sh
+++ b/scripts/update-single-host.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_DIR="/opt/hubuum"
 ENGINE="auto"
 SERVICE_NAME=""
 USE_SYSTEMD="true"
 AUTH_CONFIG_HOST_PATH=""
+DEFAULT_MANAGEMENT_SCRIPT_BASE_URL="https://raw.githubusercontent.com/hubuum/hubuum/main/scripts"
 
 usage() {
   cat <<'EOF'
@@ -104,24 +104,17 @@ fi
 ENV_FILE="$INSTALL_DIR/.env"
 [[ -f "$ENV_FILE" ]] || die "missing $ENV_FILE; run install-single-host.sh first"
 [[ -f "$INSTALL_DIR/compose.yml" ]] || die "missing $INSTALL_DIR/compose.yml; run install-single-host.sh first"
-[[ -f "$SCRIPT_DIR/single-host-rollout.sh" ]] || die "missing $SCRIPT_DIR/single-host-rollout.sh; re-run install-single-host.sh first"
-grep -q '^  hubuum-api-standby:' "$INSTALL_DIR/compose.yml" || die "installed compose.yml does not support rolling updates; re-run install-single-host.sh first"
-
 if [[ -n "$AUTH_CONFIG_HOST_PATH" ]]; then
-  grep -q 'HUBUUM_AUTH_CONFIG_PATH' "$INSTALL_DIR/compose.yml" || die "installed compose.yml does not support auth configuration; re-run install-single-host.sh first"
   AUTH_CONFIG_HOST_PATH="$(absolute_config_path "$AUTH_CONFIG_HOST_PATH")"
   set_env_value HUBUUM_AUTH_CONFIG_HOST_PATH "$AUTH_CONFIG_HOST_PATH"
-fi
-
-if grep -q 'HUBUUM_AUTH_CONFIG_PATH' "$INSTALL_DIR/compose.yml"; then
-  AUTH_CONFIG_HOST_PATH="$(read_env_value HUBUUM_AUTH_CONFIG_HOST_PATH || true)"
-  [[ -n "$AUTH_CONFIG_HOST_PATH" ]] || die "HUBUUM_AUTH_CONFIG_HOST_PATH is missing from $ENV_FILE"
-  absolute_config_path "$AUTH_CONFIG_HOST_PATH" >/dev/null
 fi
 
 BUILD_FROM_SOURCE="$(read_env_value BUILD_FROM_SOURCE || printf 'false')"
 INSTALL_MODE="$(read_env_value INSTALL_MODE || printf 'all')"
 DATABASE_MANAGED="$(read_env_value DATABASE_MANAGED || printf 'true')"
+MANAGEMENT_SCRIPT_BASE_URL="$(
+  read_env_value MANAGEMENT_SCRIPT_BASE_URL || printf '%s' "$DEFAULT_MANAGEMENT_SCRIPT_BASE_URL"
+)"
 if [[ -z "$SERVICE_NAME" ]]; then
   SERVICE_NAME="$(read_env_value SYSTEMD_SERVICE_NAME || printf 'hubuum')"
 fi
@@ -160,6 +153,39 @@ update_source_checkout() {
   git -C "$dest" pull --ff-only || true
 }
 
+refresh_deployment_files() {
+  local installer
+  local installer_temp=""
+
+  if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
+    installer="$INSTALL_DIR/src/hubuum/scripts/install-single-host.sh"
+    [[ -f "$installer" ]] || die "updated source checkout does not contain scripts/install-single-host.sh"
+  else
+    command -v curl >/dev/null 2>&1 || die "curl is required to refresh generated deployment files"
+    installer_temp="$(mktemp "$INSTALL_DIR/.install-single-host.XXXXXX")"
+    if ! curl -fsSL "${MANAGEMENT_SCRIPT_BASE_URL}/install-single-host.sh" -o "$installer_temp"; then
+      rm -f "$installer_temp"
+      die "could not refresh install-single-host.sh from $MANAGEMENT_SCRIPT_BASE_URL"
+    fi
+    installer="$installer_temp"
+  fi
+
+  if ! bash -n "$installer"; then
+    [[ -z "$installer_temp" ]] || rm -f "$installer_temp"
+    die "refreshed install-single-host.sh failed shell syntax validation"
+  fi
+
+  if ! bash "$installer" \
+    --refresh-config \
+    --dir "$INSTALL_DIR" \
+    --engine "$ENGINE_BIN" \
+    --script-base-url "$MANAGEMENT_SCRIPT_BASE_URL"; then
+    [[ -z "$installer_temp" ]] || rm -f "$installer_temp"
+    die "could not refresh generated deployment files"
+  fi
+  [[ -z "$installer_temp" ]] || rm -f "$installer_temp"
+}
+
 detect_engine
 ENGINE_PATH="$(command -v "$ENGINE_BIN")"
 if [[ "$ENGINE_BIN" == "podman" ]]; then
@@ -175,7 +201,19 @@ if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
   if [[ "$INSTALL_MODE" == "all" ]]; then
     update_source_checkout "$INSTALL_DIR/src/hubuum-frontend"
   fi
+fi
 
+refresh_deployment_files
+
+[[ -f "$INSTALL_DIR/single-host-rollout.sh" ]] || die "configuration refresh did not install single-host-rollout.sh"
+grep -q '^  hubuum-api-standby:' "$INSTALL_DIR/compose.yml" || die "refreshed compose.yml does not support rolling updates"
+if grep -q 'HUBUUM_AUTH_CONFIG_PATH' "$INSTALL_DIR/compose.yml"; then
+  AUTH_CONFIG_HOST_PATH="$(read_env_value HUBUUM_AUTH_CONFIG_HOST_PATH || true)"
+  [[ -n "$AUTH_CONFIG_HOST_PATH" ]] || die "HUBUUM_AUTH_CONFIG_HOST_PATH is missing from $ENV_FILE"
+  absolute_config_path "$AUTH_CONFIG_HOST_PATH" >/dev/null
+fi
+
+if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
   PULL_SERVICES=(caddy)
   [[ "$DATABASE_MANAGED" == "true" ]] && PULL_SERVICES+=(postgres)
   [[ "$INSTALL_MODE" == "all" ]] && PULL_SERVICES+=(valkey)
@@ -186,7 +224,7 @@ else
 fi
 
 # shellcheck source=scripts/single-host-rollout.sh
-source "$SCRIPT_DIR/single-host-rollout.sh"
+source "$INSTALL_DIR/single-host-rollout.sh"
 hubuum_rollout
 
 if [[ "$USE_SYSTEMD" == "true" && -d /run/systemd/system && "$(command -v systemctl || true)" ]] && systemctl cat "${SERVICE_NAME}.service" >/dev/null 2>&1; then

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -572,16 +572,29 @@ fn single_host_installer_preserves_the_bind_mounted_caddyfile_inode() {
 #[test]
 fn single_host_updater_never_tears_down_the_stack() {
     let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let updater = fs::read_to_string(repository.join("scripts/update-single-host.sh"))
-        .expect("single-host updater should be readable");
-    let rollout = fs::read_to_string(repository.join("scripts/single-host-rollout.sh"))
+    let updater = read_repository_text("scripts/update-single-host.sh");
+    let rollout_helper = fs::read_to_string(repository.join("scripts/single-host-rollout.sh"))
         .expect("single-host rollout helper should be readable");
+    let refresh = updater
+        .find("refresh_deployment_files\n")
+        .expect("single-host updater should refresh generated deployment files");
+    let pull = updater[refresh..]
+        .find("\"${COMPOSE_CMD[@]}\" pull")
+        .map(|offset| refresh + offset)
+        .expect("single-host updater should pull images after refreshing configuration");
+    let rollout = updater[pull..]
+        .find("hubuum_rollout")
+        .map(|offset| pull + offset)
+        .expect("single-host updater should roll services after refreshing configuration");
 
-    assert!(updater.contains("hubuum_rollout"));
+    assert!(refresh < pull);
+    assert!(pull < rollout);
+    assert!(updater.contains("--refresh-config"));
+    assert!(updater.contains("source \"$INSTALL_DIR/single-host-rollout.sh\""));
     assert!(updater.contains("export PODMAN_COMPOSE_WARNING_LOGS=false"));
     assert!(!updater.contains("systemctl restart"));
     assert!(!updater.contains("down --remove-orphans"));
-    assert!(!rollout.contains("down --remove-orphans"));
+    assert!(!rollout_helper.contains("down --remove-orphans"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- refresh the installed management scripts, generated `compose.yml`, and generated `Caddyfile` before a single-host update pulls or builds application images
- preserve every existing operator-controlled `.env` value while appending defaults that newer installers introduce
- source the freshly installed rollout helper so the normal rolling sequence reloads changed Caddy configuration
- add regression coverage for environment merging, updater refresh arguments, temporary installer cleanup, and refresh/pull/rollout ordering
- document the one-time adoption step for installations with an older updater

## Rationale

The single-host updater previously refreshed application images but continued using the generated Compose and Caddy files from the original installation. Consequently, routing and health-check changes could be present in the deployed application image while the running host retained stale proxy configuration. This was visible after the metrics polling improvements landed: the application behavior changed, but the host still lacked the new standby metrics route and retained the old readiness-probe pattern.

The updater must obtain the current installer before rolling containers because that installer owns the generated deployment contract. Configuration refresh is deliberately separate from application rollout: it does not clone sources, pull images, build images, start services, or stop services. Existing `.env` keys remain authoritative so updates cannot silently replace operator settings.

## Behavior notes

For image installations, the updater downloads the installer from the persisted management-script base URL. For source installations, it first updates the checkout and then uses that checkout's installer. The refreshed deployment is validated for rolling-update and authentication support before images are pulled or built.

The regular rolling helper reloads Caddy after the generated file changes, so the updated routing becomes active without replacing the Caddy container. Installations whose updater predates this behavior need to run the current installer once; subsequent updater runs self-refresh their deployment files.

This change is not breaking. The user-visible fix is recorded under `[Unreleased]` in `CHANGELOG.md`.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `bash -n scripts/install-single-host.sh scripts/update-single-host.sh scripts/test-install-script-refresh.sh`
- `bash scripts/test-install-script-refresh.sh`
- `bash scripts/test-single-host-rollout.sh`
- `cargo test --bin hubuum-server single_host_updater_never_tears_down_the_stack --locked`