### PR TITLE
Improve runtime metric diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   can be identified and counter resets can be correlated with restarts.
 - Linux, macOS, and Windows scrape targets now expose standard Prometheus
   process metrics for CPU, resident and virtual memory, file descriptors or
-  handles, and process start time.
+  handles, and process start time, with process refresh health included in the
+  existing scrape-refresh diagnostics.
 - Worker-only processes now expose their own metrics-only HTTP listener at the
   configured bind address, port, and path, allowing Prometheus to scrape task
   and event workers directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Database-backed template identity no longer retains deleted or renamed
   templates in a process, and import and export phase timings record error
   outcomes.
+- Process descriptor-pressure metrics now use the live macOS soft limit and
+  report the incomparable Windows handle limit as unavailable. Principal
+  cleanup cancellations now persist their terminal timestamps.
 
 ## [0.0.5] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   transactional PostgreSQL notifications.
 - Added build, runtime-role, and process-start metrics so every scrape target
   can be identified and counter resets can be correlated with restarts.
+- Linux, macOS, and Windows scrape targets now expose standard Prometheus
+  process metrics for CPU, resident and virtual memory, file descriptors or
+  handles, and process start time.
 - Worker-only processes now expose their own metrics-only HTTP listener at the
   configured bind address, port, and path, allowing Prometheus to scrape task
   and event workers directly.
 - Added scrape-refresh duration and freshness metrics, route-labelled in-flight
   requests, and per-task-kind oldest queued and active ages.
+- Added database-wide last-terminal task timestamps by kind and status so
+  retained task outcome counts can be distinguished from recent failures.
 - Export metrics now expose aggregate phase outcomes and a per-template total
   duration histogram. A resettable database snapshot maps template IDs to
   current names, while export task details persist total, query, hydration, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,6 +2054,7 @@ dependencies = [
  "ipnet",
  "json-patch",
  "jsonschema",
+ "libc",
  "lru",
  "minijinja",
  "openssl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,6 +2073,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "sysinfo",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
@@ -3018,6 +3019,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3117,6 +3127,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4513,6 +4533,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5399,6 +5433,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5409,6 +5464,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5438,6 +5504,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -5500,6 +5576,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 percent-encoding = "2"
 rustls = { version = "0.23", features = ["aws-lc-rs", "ring"] }
 prometheus = "0.14"
+sysinfo = { version = "0.39.6", default-features = false, features = ["system"] }
 openssl = { version = "0.10.80", optional = true }
 lru = "0.18.0"
 # treetop-client is currently consumed from git at version 0.0.1. Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,9 @@ lru = "0.18.0"
 treetop-client = { git = "https://github.com/terjekv/treetop-client", optional = true }
 toml = "1.1"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 criterion = "0.8.2"
 iai-callgrind = "0.16.1"

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -34,6 +34,19 @@ Use these metrics to identify a target:
 - `hubuum_runtime_info{role}`
 - `hubuum_process_start_time_seconds`
 
+Check the target mix before interpreting process-local worker metrics:
+
+```promql
+count by (role) (hubuum_runtime_info)
+```
+
+An API-only target reports `hubuum_runtime_info{role="api"}` and zero configured
+task and event workers. It can still expose database-wide task and template
+gauges, but export, import, remote-call, task-execution, and worker-loop
+counters and histograms are produced by worker-enabled targets. If those
+families are absent from an API scrape, verify that Prometheus has a separate
+worker target before treating the absence as no activity.
+
 Inventory, task backlog, export-template identity, and event-queue gauges are
 database-wide snapshots. Every replica connected to the same database reports
 the same logical values. Aggregate those series with `max` or `avg`, not `sum`,
@@ -121,6 +134,20 @@ Classic Prometheus histograms do not expose exact minimum or maximum
 observations. `histogram_quantile` estimates percentiles from bucket boundaries
 and remains aggregatable across processes.
 
+Readiness probes commonly dominate request counts. Exclude probes and the
+scrape endpoint when calculating application traffic or an overall application
+latency:
+
+```promql
+sum by (route) (
+  rate(
+    hubuum_http_requests_total{
+      route!~"/(healthz|readyz|metrics)"
+    }[5m]
+  )
+)
+```
+
 Counter and histogram series appear only after a process observes a matching
 event. Seeing only `/readyz` means that target handled readiness probes but not
 application requests; it does not mean other routes are filtered out.
@@ -154,6 +181,12 @@ max by (template_id, template_name) (
 | `hubuum_build_info` | `version`, `git_sha` | Build identity for the scraped process |
 | `hubuum_runtime_info` | `role` | Runtime role for the scraped process |
 | `hubuum_process_start_time_seconds` | none | Unix timestamp when the process initialized metrics |
+| `process_cpu_seconds_total` | none | Process user and system CPU time |
+| `process_open_fds` | none | Process open file descriptors or handles |
+| `process_max_fds` | none | Process file-descriptor or handle limit |
+| `process_resident_memory_bytes` | none | Process resident memory |
+| `process_virtual_memory_bytes` | none | Process virtual memory |
+| `process_start_time_seconds` | none | Operating-system process start time |
 | `hubuum_http_requests_total` | `method`, `route`, `status_code`, `status_family` | HTTP requests by stable route template or coarse route group |
 | `hubuum_http_request_duration_seconds` | `method`, `route`, `status_family` | HTTP request duration histogram |
 | `hubuum_http_requests_in_flight` | `route` | Requests currently being handled by stable route |
@@ -174,6 +207,29 @@ The bounded database `caller` values are `event_delivery`, `event_fanout`,
 `request_maintenance`, `restore_coordinator`, `task_lease`, `task_worker`,
 `token_retention`, and `unattributed`.
 
+The standard unprefixed `process_*` families are available on Linux, macOS, and
+Windows. The names intentionally match the Prometheus ecosystem so existing
+process dashboards and alerts can be reused. File-descriptor or handle gauges
+remain zero if the operating system cannot return that information. Prefer
+resident memory for cross-platform pressure alerts: virtual address-space size
+is especially large and not directly comparable on macOS.
+`process_start_time_seconds` is the operating system's process start, while
+`hubuum_process_start_time_seconds` records when Hubuum initialized metrics.
+
+Useful starting queries include:
+
+```promql
+rate(process_cpu_seconds_total[5m])
+```
+
+```promql
+process_resident_memory_bytes
+```
+
+```promql
+process_open_fds / process_max_fds
+```
+
 ### Tasks, Exports, Imports, And Remote Calls
 
 | Metric | Labels | Description |
@@ -188,6 +244,7 @@ The bounded database `caller` values are `event_delivery`, `event_fanout`,
 | `hubuum_task_poll_interval_seconds` | none | Configured task-worker poll interval |
 | `hubuum_tasks` | `kind`, `status` | Current database-wide task counts |
 | `hubuum_task_oldest_age_seconds` | `kind`, `state` | Oldest queued and active task age per task kind |
+| `hubuum_task_last_terminal_timestamp_seconds` | `kind`, `status` | Most recent finish time for each task kind and terminal status; zero means none is retained |
 | `hubuum_task_output_cleanup_runs_total` | `kind` | Stored output cleanup runs for export or backup artifacts |
 | `hubuum_task_output_cleanup_failures_total` | `kind` | Stored output cleanup failures |
 | `hubuum_task_output_cleanup_deleted_total` | `kind` | Stored outputs deleted by cleanup |
@@ -242,12 +299,15 @@ These thresholds are deployment starting points, not universal defaults:
 | Signal | Suggested alert |
 | --- | --- |
 | Missing target | `up == 0`, grouped by expected API and worker target |
+| Missing worker telemetry | Queued tasks with `sum(hubuum_task_workers_configured) == 0`, or no expected `worker`/`all` role target |
 | Counter reset | Unexpected `resets(hubuum_http_requests_total[15m])`, correlated with process start time |
+| Process resource pressure | CPU, resident memory, or open-FD/handle ratio above the target's established baseline |
 | Stale snapshots | Current time minus `hubuum_metrics_refresh_last_success_timestamp_seconds` exceeds the cache and scrape tolerance |
 | DB acquisition failures | Any sustained non-zero `hubuum_db_connection_acquire_failures_total` rate |
 | DB pool pressure | Checked-out divided by configured connections above `0.8` for several minutes |
 | HTTP 5xx rate | `5xx` status family above the normal route-specific baseline |
 | Task queue age | Oldest queued task age above the expected latency for that task kind |
+| Recent task failure | `time() - max by (kind) (hubuum_task_last_terminal_timestamp_seconds{status="failed"})` below the alert window |
 | Task worker errors | Sustained non-zero worker iteration `outcome="error"` rate |
 | Task lease recovery | Any unexpected `hubuum_task_lease_recoveries_total` increase |
 | Export or import failures | Failure or timeout outcomes above the task-kind baseline |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -206,6 +206,9 @@ max by (template_id, template_name) (
 | `hubuum_metrics_refresh_failures_total` | `source` | Best-effort refresh failures |
 | `hubuum_metrics_refresh_skipped_total` | `source`, `reason` | Refreshes skipped because another scrape was already refreshing |
 
+The bounded refresh `source` values are `database`, `events`, `inventory`,
+`login_limiter`, `process`, and `tasks`.
+
 The bounded database `caller` values are `event_delivery`, `event_fanout`,
 `event_retention`, `http_request`, `metrics_refresh`, `readiness`,
 `request_maintenance`, `restore_coordinator`, `task_lease`, `task_worker`,

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -136,7 +136,11 @@ and remains aggregatable across processes.
 
 Readiness probes commonly dominate request counts. Exclude probes and the
 scrape endpoint when calculating application traffic or an overall application
-latency:
+latency. The example uses the default scrape route, `/metrics`. If
+`HUBUUM_METRICS_PATH` is customized, replace `/metrics` in the matcher with the
+exact configured path; for example, use
+`route!~"/(healthz|readyz)|/internal/metrics"` for `/internal/metrics`.
+Prometheus regex matchers are fully anchored:
 
 ```promql
 sum by (route) (
@@ -183,7 +187,7 @@ max by (template_id, template_name) (
 | `hubuum_process_start_time_seconds` | none | Unix timestamp when the process initialized metrics |
 | `process_cpu_seconds_total` | none | Process user and system CPU time |
 | `process_open_fds` | none | Process open file descriptors or handles |
-| `process_max_fds` | none | Process file-descriptor or handle limit |
+| `process_max_fds` | none | Comparable process file-descriptor limit; zero when unavailable |
 | `process_resident_memory_bytes` | none | Process resident memory |
 | `process_virtual_memory_bytes` | none | Process virtual memory |
 | `process_start_time_seconds` | none | Operating-system process start time |
@@ -210,9 +214,11 @@ The bounded database `caller` values are `event_delivery`, `event_fanout`,
 The standard unprefixed `process_*` families are available on Linux, macOS, and
 Windows. The names intentionally match the Prometheus ecosystem so existing
 process dashboards and alerts can be reused. File-descriptor or handle gauges
-remain zero if the operating system cannot return that information. Prefer
-resident memory for cross-platform pressure alerts: virtual address-space size
-is especially large and not directly comparable on macOS.
+remain zero if the operating system cannot return that information. On Windows,
+`process_open_fds` counts kernel handles and `process_max_fds` is zero because
+Windows has no comparable fixed per-process handle limit. Prefer resident memory
+for cross-platform pressure alerts: virtual address-space size is especially
+large and not directly comparable on macOS.
 `process_start_time_seconds` is the operating system's process start, while
 `hubuum_process_start_time_seconds` records when Hubuum initialized metrics.
 
@@ -227,7 +233,9 @@ process_resident_memory_bytes
 ```
 
 ```promql
-process_open_fds / process_max_fds
+(process_open_fds / process_max_fds)
+and
+(process_max_fds > 0)
 ```
 
 ### Tasks, Exports, Imports, And Remote Calls

--- a/src/api/v1/handlers/service_accounts.rs
+++ b/src/api/v1/handlers/service_accounts.rs
@@ -6,9 +6,8 @@ use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
 use crate::db::DbPool;
 use crate::db::traits::service_account::{
-    DisableServiceAccount, SaveServiceAccount, cancel_pending_tasks_for_principal,
-    count_manageable_service_accounts, is_human_owner_group_member,
-    revoke_all_tokens_for_principal, search_manageable_service_accounts,
+    DisableServiceAccount, SaveServiceAccount, count_manageable_service_accounts,
+    is_human_owner_group_member, search_manageable_service_accounts,
 };
 use crate::errors::ApiError;
 use crate::extractors::{AccessEventContext, ManagementAccess};
@@ -256,9 +255,6 @@ pub async fn disable_service_account(
 
     let event_context = requestor.event_context(&req);
     let disabled = id.disable(&pool, &event_context).await?;
-    // Immediately soft-revoke its tokens and cancel its pending work.
-    revoke_all_tokens_for_principal(&pool, id.id()).await?;
-    cancel_pending_tasks_for_principal(&pool, id.id()).await?;
 
     debug!(
         message = "Service account disabled",

--- a/src/db/traits/computed_field.rs
+++ b/src/db/traits/computed_field.rs
@@ -12,7 +12,8 @@ use tracing::{info, warn};
 use crate::db::prelude::*;
 use crate::db::traits::search::{JsonSqlPredicate, dynamic_sql_predicate};
 use crate::db::traits::task::{
-    TaskBackend, TaskStateUpdate, emit_internal_task_event, insert_internal_queued_task,
+    QueuedTaskCancellation, TaskBackend, TaskStateUpdate, cancel_queued_tasks_conn,
+    insert_internal_queued_task,
 };
 use crate::db::{DbConnection, DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
@@ -27,7 +28,7 @@ use crate::models::{
     ComputedFieldErrorResponse, ComputedFieldMutationResponse, ComputedObjectScopesResponse,
     ComputedResultType, ComputedScopeResponse, HubuumClass, HubuumObject,
     HubuumObjectComputedResponse, NewObjectComputedData, NewTaskEventRecord, ObjectComputedData,
-    SharedComputedScopeResponse, TaskKind, TaskRecord, TaskResultCounts, TaskStatus,
+    PrincipalID, SharedComputedScopeResponse, TaskKind, TaskRecord, TaskResultCounts, TaskStatus,
     ValidatedComputedFieldPatch,
 };
 use crate::pagination::{CursorSqlField, CursorSqlMapping, CursorSqlType};
@@ -329,34 +330,21 @@ async fn cancel_queued_reindex_tasks(
     target_class_id: i32,
     actor_id: Option<i32>,
 ) -> Result<(), ApiError> {
-    let cancelled = diesel::sql_query(
-        "UPDATE tasks SET status='cancelled', summary='Superseded by a newer computed-field rebuild', \
-         finished_at=(clock_timestamp() AT TIME ZONE 'UTC'), request_payload=NULL, \
-         request_redacted_at=(clock_timestamp() AT TIME ZONE 'UTC'), \
-         updated_at=(clock_timestamp() AT TIME ZONE 'UTC') \
+    let queued = diesel::sql_query(
+        "SELECT id FROM tasks \
          WHERE kind='reindex' AND status='queued' \
            AND request_payload->>'type'='computed_fields' \
-           AND request_payload->>'class_id'=$1 \
-         RETURNING id",
+           AND request_payload->>'class_id'=$1",
     )
     .bind::<Text, _>(target_class_id.to_string())
     .load::<ReturnedTaskId>(conn)
     .await?;
-
-    for task in cancelled {
-        emit_internal_task_event(
-            conn,
-            &NewTaskEventRecord {
-                task_id: task.id,
-                event_type: TaskStatus::Cancelled.as_str().to_string(),
-                message: "Computed-field rebuild superseded".to_string(),
-                data: None,
-            },
-            actor_id,
-            TaskKind::Reindex,
-        )
-        .await?;
-    }
+    let task_ids = queued.into_iter().map(|task| task.id).collect::<Vec<_>>();
+    let actor = actor_id.map(PrincipalID::new).transpose()?;
+    let cancellation = QueuedTaskCancellation::new("Superseded by a newer computed-field rebuild")
+        .with_event_message("Computed-field rebuild superseded")
+        .with_actor(actor);
+    cancel_queued_tasks_conn(conn, &task_ids, &cancellation).await?;
     Ok(())
 }
 

--- a/src/db/traits/computed_field/rebuild.rs
+++ b/src/db/traits/computed_field/rebuild.rs
@@ -15,11 +15,7 @@ pub async fn request_class_rebuild(
             use crate::schema::tasks::dsl::{id, request_payload, status, tasks};
             let active = tasks
                 .filter(id.eq(task_id_value))
-                .filter(status.eq_any([
-                    TaskStatus::Queued.as_str(),
-                    TaskStatus::Validating.as_str(),
-                    TaskStatus::Running.as_str(),
-                ]))
+                .filter(status.eq_any(TaskStatus::NON_TERMINAL.map(TaskStatus::as_str)))
                 .select(request_payload)
                 .first::<Option<serde_json::Value>>(conn)
                 .await

--- a/src/db/traits/metrics.rs
+++ b/src/db/traits/metrics.rs
@@ -72,17 +72,17 @@ pub(crate) struct TaskGaugeAge {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct TaskGaugeLastFinished {
+pub(crate) struct TaskGaugeLastTerminal {
     pub(crate) kind: TaskKind,
     pub(crate) status: TaskStatus,
-    pub(crate) timestamp: Option<NaiveDateTime>,
+    pub(crate) finished_at: Option<NaiveDateTime>,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct TaskGaugeSnapshot {
     pub(crate) counts: Vec<TaskGaugeCount>,
     pub(crate) ages: Vec<TaskGaugeAge>,
-    pub(crate) last_finished: Vec<TaskGaugeLastFinished>,
+    pub(crate) last_terminal: Vec<TaskGaugeLastTerminal>,
 }
 
 #[derive(Debug, Clone)]
@@ -126,10 +126,7 @@ where
                 .get_result::<Option<NaiveDateTime>>(conn)
                 .await?;
             let oldest_active_at = tasks::table
-                .filter(tasks::status.eq_any([
-                    TaskStatus::Validating.as_str(),
-                    TaskStatus::Running.as_str(),
-                ]))
+                .filter(tasks::status.eq_any(TaskStatus::ACTIVE.map(TaskStatus::as_str)))
                 .select(min(tasks::started_at))
                 .get_result::<Option<NaiveDateTime>>(conn)
                 .await?;
@@ -194,26 +191,23 @@ where
                 .load::<(String, Option<NaiveDateTime>)>(conn)
                 .await?;
             let oldest_active = tasks::table
-                .filter(tasks::status.eq_any([
-                    TaskStatus::Validating.as_str(),
-                    TaskStatus::Running.as_str(),
-                ]))
+                .filter(tasks::status.eq_any(TaskStatus::ACTIVE.map(TaskStatus::as_str)))
                 .group_by(tasks::kind)
                 .select((tasks::kind, min(tasks::started_at)))
                 .load::<(String, Option<NaiveDateTime>)>(conn)
                 .await?;
-            let last_finished = tasks::table
+            let last_terminal = tasks::table
                 .filter(tasks::status.eq_any(TaskStatus::TERMINAL.map(TaskStatus::as_str)))
                 .group_by((tasks::kind, tasks::status))
                 .select((tasks::kind, tasks::status, max(tasks::finished_at)))
                 .load::<(String, String, Option<NaiveDateTime>)>(conn)
                 .await?
                 .into_iter()
-                .map(|(kind, status, timestamp)| {
-                    Ok(TaskGaugeLastFinished {
+                .map(|(kind, status, finished_at)| {
+                    Ok(TaskGaugeLastTerminal {
                         kind: TaskKind::from_db(&kind)?,
                         status: TaskStatus::from_db(&status)?,
-                        timestamp,
+                        finished_at,
                     })
                 })
                 .collect::<Result<Vec<_>, ApiError>>()?;
@@ -247,7 +241,7 @@ where
             Ok::<_, ApiError>(TaskGaugeSnapshot {
                 counts,
                 ages,
-                last_finished,
+                last_terminal,
             })
         })
         .await

--- a/src/db/traits/metrics.rs
+++ b/src/db/traits/metrics.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use chrono::NaiveDateTime;
-use diesel::dsl::{count_star, min};
+use diesel::dsl::{count_star, max, min};
 use diesel::sql_types::BigInt;
 
 use crate::db::prelude::*;
@@ -72,9 +72,17 @@ pub(crate) struct TaskGaugeAge {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct TaskGaugeLastFinished {
+    pub(crate) kind: TaskKind,
+    pub(crate) status: TaskStatus,
+    pub(crate) timestamp: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct TaskGaugeSnapshot {
     pub(crate) counts: Vec<TaskGaugeCount>,
     pub(crate) ages: Vec<TaskGaugeAge>,
+    pub(crate) last_finished: Vec<TaskGaugeLastFinished>,
 }
 
 #[derive(Debug, Clone)]
@@ -194,6 +202,21 @@ where
                 .select((tasks::kind, min(tasks::started_at)))
                 .load::<(String, Option<NaiveDateTime>)>(conn)
                 .await?;
+            let last_finished = tasks::table
+                .filter(tasks::status.eq_any(TaskStatus::TERMINAL.map(TaskStatus::as_str)))
+                .group_by((tasks::kind, tasks::status))
+                .select((tasks::kind, tasks::status, max(tasks::finished_at)))
+                .load::<(String, String, Option<NaiveDateTime>)>(conn)
+                .await?
+                .into_iter()
+                .map(|(kind, status, timestamp)| {
+                    Ok(TaskGaugeLastFinished {
+                        kind: TaskKind::from_db(&kind)?,
+                        status: TaskStatus::from_db(&status)?,
+                        timestamp,
+                    })
+                })
+                .collect::<Result<Vec<_>, ApiError>>()?;
 
             let mut ages_by_kind = HashMap::new();
             for (kind, timestamp) in oldest_queued {
@@ -221,7 +244,11 @@ where
                 })
                 .collect();
 
-            Ok::<_, ApiError>(TaskGaugeSnapshot { counts, ages })
+            Ok::<_, ApiError>(TaskGaugeSnapshot {
+                counts,
+                ages,
+                last_finished,
+            })
         })
         .await
     }

--- a/src/db/traits/service_account.rs
+++ b/src/db/traits/service_account.rs
@@ -3,15 +3,16 @@ use serde_json::json;
 use crate::db::prelude::*;
 use crate::db::traits::identity::identity_scope_by_name;
 use crate::db::traits::principal::InsertPrincipalRecord;
+use crate::db::traits::task::{QueuedTaskCancellation, cancel_queued_tasks_conn};
 use crate::db::{DbConnection, DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
 use crate::models::identity::LOCAL_IDENTITY_SCOPE;
-use crate::models::principal::{NewPrincipal, Principal, PrincipalKind};
+use crate::models::principal::{NewPrincipal, Principal, PrincipalID, PrincipalKind};
 use crate::models::search::{FilterField, QueryOptions};
 use crate::models::{
     NewServiceAccount, ServiceAccount, ServiceAccountID, ServiceAccountWithName, TaskKind,
-    TaskStatus, UpdateServiceAccount,
+    TaskRecord, TaskStatus, UpdateServiceAccount,
 };
 use crate::schema::service_accounts;
 use crate::traits::accessors::InstanceAdapter;
@@ -264,45 +265,70 @@ async fn disable_service_account<C>(
 where
     C: BackendContext + ?Sized,
 {
-    use crate::schema::service_accounts::dsl::{disabled_at, id, service_accounts as sa_table};
     let sa_id = account_id.id();
-    with_transaction(
-        backend.db_pool(),
-        async |conn| -> Result<ServiceAccount, ApiError> {
-            let before = sa_table
-                .filter(id.eq(sa_id))
-                .for_update()
-                .first::<ServiceAccount>(conn)
-                .await?;
-            if before.disabled_at.is_some() {
-                return Ok(before);
-            }
-            let disabled = diesel::update(sa_table.filter(id.eq(sa_id)))
-                .set(disabled_at.eq(diesel::dsl::now))
-                .get_result::<ServiceAccount>(conn)
-                .await?;
-            if let Some(event_context) = event_context {
-                let name = load_principal_name_by_id(conn, disabled.id).await?;
-                let event = NewEvent::new(
-                    EntityType::ServiceAccount,
-                    Action::Disabled,
-                    event_context.actor_kind(),
-                    format!("Service account '{name}' disabled"),
-                )?
-                .with_context(event_context)
-                .with_entity_id(disabled.id)
-                .with_entity_name(&name)
-                .with_before(service_account_snapshot(&before, &name))
-                .with_after(service_account_snapshot(&disabled, &name))
-                .with_metadata(json!({
-                    "owner_group_id": disabled.owner_group_id,
-                }));
-                emit_event(conn, &event).await?;
-            }
-            Ok(disabled)
-        },
+    let (disabled, cancelled_tasks) = with_transaction(backend.db_pool(), async |conn| {
+        disable_service_account_conn(conn, sa_id, event_context).await
+    })
+    .await?;
+
+    record_cancelled_task_metrics(&cancelled_tasks);
+    Ok(disabled)
+}
+
+async fn disable_service_account_conn(
+    conn: &mut DbConnection,
+    service_account_id: i32,
+    event_context: Option<&EventContext>,
+) -> Result<(ServiceAccount, Vec<TaskRecord>), ApiError> {
+    use crate::schema::service_accounts::dsl::{disabled_at, id, service_accounts as sa_table};
+
+    let before = sa_table
+        .filter(id.eq(service_account_id))
+        .for_update()
+        .first::<ServiceAccount>(conn)
+        .await?;
+    let disabled = if before.disabled_at.is_some() {
+        before
+    } else {
+        let disabled = diesel::update(sa_table.filter(id.eq(service_account_id)))
+            .set(disabled_at.eq(diesel::dsl::now))
+            .get_result::<ServiceAccount>(conn)
+            .await?;
+        if let Some(event_context) = event_context {
+            let name = load_principal_name_by_id(conn, disabled.id).await?;
+            let event = NewEvent::new(
+                EntityType::ServiceAccount,
+                Action::Disabled,
+                event_context.actor_kind(),
+                format!("Service account '{name}' disabled"),
+            )?
+            .with_context(event_context)
+            .with_entity_id(disabled.id)
+            .with_entity_name(&name)
+            .with_before(service_account_snapshot(&before, &name))
+            .with_after(service_account_snapshot(&disabled, &name))
+            .with_metadata(json!({
+                "owner_group_id": disabled.owner_group_id,
+            }));
+            emit_event(conn, &event).await?;
+        }
+        disabled
+    };
+
+    revoke_all_tokens_for_principal_conn(conn, service_account_id).await?;
+    let actor = event_context
+        .and_then(EventContext::actor_user_id)
+        .map(PrincipalID::new)
+        .transpose()?;
+    let cancelled_tasks = cancel_pending_tasks_for_principal_conn(
+        conn,
+        service_account_id,
+        actor,
+        event_context.is_some(),
     )
-    .await
+    .await?;
+
+    Ok((disabled, cancelled_tasks))
 }
 
 async fn delete_service_account(
@@ -421,64 +447,70 @@ pub async fn revoke_all_tokens_for_principal(
     pool: &DbPool,
     principal_id_value: i32,
 ) -> Result<usize, ApiError> {
-    use crate::schema::tokens::dsl::{principal_id, revoked_at, tokens};
     with_connection(pool, async |conn| {
-        diesel::update(
-            tokens
-                .filter(principal_id.eq(principal_id_value))
-                .filter(revoked_at.is_null()),
-        )
-        .set(revoked_at.eq(diesel::dsl::now))
-        .execute(conn)
-        .await
+        revoke_all_tokens_for_principal_conn(conn, principal_id_value).await
     })
     .await
+}
+
+async fn revoke_all_tokens_for_principal_conn(
+    conn: &mut DbConnection,
+    principal_id_value: i32,
+) -> Result<usize, ApiError> {
+    use crate::schema::tokens::dsl::{principal_id, revoked_at, tokens};
+    Ok(diesel::update(
+        tokens
+            .filter(principal_id.eq(principal_id_value))
+            .filter(revoked_at.is_null()),
+    )
+    .set(revoked_at.eq(diesel::dsl::now))
+    .execute(conn)
+    .await?)
 }
 
 pub async fn cancel_pending_tasks_for_principal(
     pool: &DbPool,
     principal_id_value: i32,
 ) -> Result<usize, ApiError> {
-    let cancelled_kinds = with_connection(pool, async |conn| {
-        cancel_pending_tasks_for_principal_conn(conn, principal_id_value).await
+    let cancelled_tasks = with_transaction(pool, async |conn| {
+        cancel_pending_tasks_for_principal_conn(conn, principal_id_value, None, true).await
     })
     .await?;
 
-    for task_kind in &cancelled_kinds {
-        crate::observability::metrics::task_completed(
-            task_kind,
-            TaskStatus::Cancelled.as_str(),
-            None,
-        );
-    }
-
-    Ok(cancelled_kinds.len())
+    record_cancelled_task_metrics(&cancelled_tasks);
+    Ok(cancelled_tasks.len())
 }
 
 async fn cancel_pending_tasks_for_principal_conn(
     conn: &mut DbConnection,
     principal_id_value: i32,
-) -> Result<Vec<String>, ApiError> {
-    use crate::schema::tasks::dsl::{finished_at, kind, status, submitted_by, tasks, updated_at};
-    use diesel::dsl::sql;
-    use diesel::sql_types::{Nullable, Timestamp};
+    actor: Option<PrincipalID>,
+    emit_events: bool,
+) -> Result<Vec<TaskRecord>, ApiError> {
+    use crate::schema::tasks::dsl::{id, kind, status, submitted_by, tasks};
 
-    const DATABASE_UTC_NOW_SQL: &str = "clock_timestamp() AT TIME ZONE 'UTC'";
+    let task_ids = tasks
+        .filter(submitted_by.eq(principal_id_value))
+        .filter(status.eq(TaskStatus::Queued.as_str()))
+        .filter(kind.ne(TaskKind::Reindex.as_str()))
+        .select(id)
+        .load::<i32>(conn)
+        .await?;
+    let cancellation =
+        QueuedTaskCancellation::new("Task cancelled because its submitting principal was disabled")
+            .with_actor(actor)
+            .with_event_emission(emit_events);
+    cancel_queued_tasks_conn(conn, &task_ids, &cancellation).await
+}
 
-    Ok(diesel::update(
-        tasks
-            .filter(submitted_by.eq(principal_id_value))
-            .filter(status.eq(TaskStatus::Queued.as_str()))
-            .filter(kind.ne(TaskKind::Reindex.as_str())),
-    )
-    .set((
-        status.eq(TaskStatus::Cancelled.as_str()),
-        finished_at.eq(sql::<Nullable<Timestamp>>(DATABASE_UTC_NOW_SQL)),
-        updated_at.eq(sql::<Timestamp>(DATABASE_UTC_NOW_SQL)),
-    ))
-    .returning(kind)
-    .get_results::<String>(conn)
-    .await?)
+fn record_cancelled_task_metrics(cancelled_tasks: &[TaskRecord]) {
+    for task in cancelled_tasks {
+        crate::observability::metrics::task_completed(
+            &task.kind,
+            TaskStatus::Cancelled.as_str(),
+            None,
+        );
+    }
 }
 
 pub async fn service_accounts_owned_by_group(
@@ -636,8 +668,33 @@ where
 mod tests {
     use super::*;
     use crate::models::{NewTaskRecord, TaskRecord};
-    use crate::schema::tasks;
-    use crate::tests::{TestContext, create_test_user};
+    use crate::schema::{tasks, tokens};
+    use crate::tests::{
+        TestContext, create_test_group, create_test_service_account, create_test_user,
+        service_account_token,
+    };
+
+    fn queued_export_task(submitter_id: i32, idempotency_key: String) -> NewTaskRecord {
+        NewTaskRecord {
+            kind: TaskKind::Export.as_str().to_string(),
+            status: TaskStatus::Queued.as_str().to_string(),
+            submitted_by: Some(submitter_id),
+            idempotency_key: Some(idempotency_key),
+            request_hash: None,
+            request_payload: Some(serde_json::json!({"secret": "redact-me"})),
+            summary: None,
+            total_items: 0,
+            processed_items: 0,
+            success_items: 0,
+            failed_items: 0,
+            submitted_token_id: None,
+            submitted_token_scoped: false,
+            submitted_token_scopes: serde_json::json!([]),
+            request_redacted_at: None,
+            started_at: None,
+            finished_at: None,
+        }
+    }
 
     #[tokio::test]
     async fn cancelling_pending_tasks_records_a_terminal_timestamp() {
@@ -648,30 +705,17 @@ mod tests {
             &context.pool,
             async |conn| -> Result<TaskRecord, ApiError> {
                 let task = diesel::insert_into(tasks::table)
-                    .values(NewTaskRecord {
-                        kind: TaskKind::Export.as_str().to_string(),
-                        status: TaskStatus::Queued.as_str().to_string(),
-                        submitted_by: Some(submitter_id),
-                        idempotency_key: Some(context.scoped_name("cancel-terminal-timestamp")),
-                        request_hash: None,
-                        request_payload: None,
-                        summary: None,
-                        total_items: 0,
-                        processed_items: 0,
-                        success_items: 0,
-                        failed_items: 0,
-                        submitted_token_id: None,
-                        submitted_token_scoped: false,
-                        submitted_token_scopes: serde_json::json!([]),
-                        request_redacted_at: None,
-                        started_at: None,
-                        finished_at: None,
-                    })
+                    .values(queued_export_task(
+                        submitter_id,
+                        context.scoped_name("cancel-terminal-timestamp"),
+                    ))
                     .get_result::<TaskRecord>(conn)
                     .await?;
 
-                let cancelled = cancel_pending_tasks_for_principal_conn(conn, submitter_id).await?;
-                assert_eq!(cancelled, vec![TaskKind::Export.as_str().to_string()]);
+                let cancelled =
+                    cancel_pending_tasks_for_principal_conn(conn, submitter_id, None, true).await?;
+                assert_eq!(cancelled.len(), 1);
+                assert_eq!(cancelled[0].kind, TaskKind::Export.as_str());
 
                 Ok(tasks::table.find(task.id).first::<TaskRecord>(conn).await?)
             },
@@ -681,6 +725,51 @@ mod tests {
 
         assert_eq!(cancelled_task.status, TaskStatus::Cancelled.as_str());
         assert!(cancelled_task.finished_at.is_some());
+        assert!(cancelled_task.request_payload.is_none());
+        assert!(cancelled_task.request_redacted_at.is_some());
         assert!(cancelled_task.updated_at >= cancelled_task.created_at);
+    }
+
+    #[tokio::test]
+    async fn disabling_service_account_atomically_revokes_tokens_and_cancels_tasks() {
+        let context = TestContext::new().await;
+        let owner_group = create_test_group(&context.pool).await;
+        let service_account = create_test_service_account(&context.pool, &owner_group, None).await;
+        let _token = service_account_token(&context.pool, &service_account, None, None).await;
+
+        let cancelled_task = with_transaction(
+            &context.pool,
+            async |conn| -> Result<TaskRecord, ApiError> {
+                let task = diesel::insert_into(tasks::table)
+                    .values(queued_export_task(
+                        service_account.id,
+                        context.scoped_name("atomic-disable"),
+                    ))
+                    .get_result::<TaskRecord>(conn)
+                    .await?;
+
+                let (disabled, cancelled) =
+                    disable_service_account_conn(conn, service_account.id, None).await?;
+                assert!(disabled.disabled_at.is_some());
+                assert_eq!(cancelled.len(), 1);
+                assert_eq!(cancelled[0].id, task.id);
+
+                let revoked_at = tokens::table
+                    .filter(tokens::principal_id.eq(service_account.id))
+                    .select(tokens::revoked_at)
+                    .first::<Option<chrono::NaiveDateTime>>(conn)
+                    .await?;
+                assert!(revoked_at.is_some());
+
+                Ok(tasks::table.find(task.id).first::<TaskRecord>(conn).await?)
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(cancelled_task.status, TaskStatus::Cancelled.as_str());
+        assert!(cancelled_task.finished_at.is_some());
+        assert!(cancelled_task.request_payload.is_none());
+        assert!(cancelled_task.request_redacted_at.is_some());
     }
 }

--- a/src/db/traits/service_account.rs
+++ b/src/db/traits/service_account.rs
@@ -439,18 +439,8 @@ pub async fn cancel_pending_tasks_for_principal(
     pool: &DbPool,
     principal_id_value: i32,
 ) -> Result<usize, ApiError> {
-    use crate::schema::tasks::dsl::{kind, status, submitted_by, tasks};
     let cancelled_kinds = with_connection(pool, async |conn| {
-        diesel::update(
-            tasks
-                .filter(submitted_by.eq(principal_id_value))
-                .filter(status.eq(TaskStatus::Queued.as_str()))
-                .filter(kind.ne(TaskKind::Reindex.as_str())),
-        )
-        .set(status.eq(TaskStatus::Cancelled.as_str()))
-        .returning(kind)
-        .get_results::<String>(conn)
-        .await
+        cancel_pending_tasks_for_principal_conn(conn, principal_id_value).await
     })
     .await?;
 
@@ -463,6 +453,32 @@ pub async fn cancel_pending_tasks_for_principal(
     }
 
     Ok(cancelled_kinds.len())
+}
+
+async fn cancel_pending_tasks_for_principal_conn(
+    conn: &mut DbConnection,
+    principal_id_value: i32,
+) -> Result<Vec<String>, ApiError> {
+    use crate::schema::tasks::dsl::{finished_at, kind, status, submitted_by, tasks, updated_at};
+    use diesel::dsl::sql;
+    use diesel::sql_types::{Nullable, Timestamp};
+
+    const DATABASE_UTC_NOW_SQL: &str = "clock_timestamp() AT TIME ZONE 'UTC'";
+
+    Ok(diesel::update(
+        tasks
+            .filter(submitted_by.eq(principal_id_value))
+            .filter(status.eq(TaskStatus::Queued.as_str()))
+            .filter(kind.ne(TaskKind::Reindex.as_str())),
+    )
+    .set((
+        status.eq(TaskStatus::Cancelled.as_str()),
+        finished_at.eq(sql::<Nullable<Timestamp>>(DATABASE_UTC_NOW_SQL)),
+        updated_at.eq(sql::<Timestamp>(DATABASE_UTC_NOW_SQL)),
+    ))
+    .returning(kind)
+    .get_results::<String>(conn)
+    .await?)
 }
 
 pub async fn service_accounts_owned_by_group(
@@ -614,4 +630,57 @@ where
         base_query.count().get_result::<i64>(conn).await
     })
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{NewTaskRecord, TaskRecord};
+    use crate::schema::tasks;
+    use crate::tests::{TestContext, create_test_user};
+
+    #[tokio::test]
+    async fn cancelling_pending_tasks_records_a_terminal_timestamp() {
+        let context = TestContext::new().await;
+        let submitter_id = create_test_user(&context.pool).await.id;
+
+        let cancelled_task = with_transaction(
+            &context.pool,
+            async |conn| -> Result<TaskRecord, ApiError> {
+                let task = diesel::insert_into(tasks::table)
+                    .values(NewTaskRecord {
+                        kind: TaskKind::Export.as_str().to_string(),
+                        status: TaskStatus::Queued.as_str().to_string(),
+                        submitted_by: Some(submitter_id),
+                        idempotency_key: Some(context.scoped_name("cancel-terminal-timestamp")),
+                        request_hash: None,
+                        request_payload: None,
+                        summary: None,
+                        total_items: 0,
+                        processed_items: 0,
+                        success_items: 0,
+                        failed_items: 0,
+                        submitted_token_id: None,
+                        submitted_token_scoped: false,
+                        submitted_token_scopes: serde_json::json!([]),
+                        request_redacted_at: None,
+                        started_at: None,
+                        finished_at: None,
+                    })
+                    .get_result::<TaskRecord>(conn)
+                    .await?;
+
+                let cancelled = cancel_pending_tasks_for_principal_conn(conn, submitter_id).await?;
+                assert_eq!(cancelled, vec![TaskKind::Export.as_str().to_string()]);
+
+                Ok(tasks::table.find(task.id).first::<TaskRecord>(conn).await?)
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(cancelled_task.status, TaskStatus::Cancelled.as_str());
+        assert!(cancelled_task.finished_at.is_some());
+        assert!(cancelled_task.updated_at >= cancelled_task.created_at);
+    }
 }

--- a/src/db/traits/task.rs
+++ b/src/db/traits/task.rs
@@ -202,6 +202,105 @@ async fn database_now(
         .map_err(ApiError::from)
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct QueuedTaskCancellation {
+    summary: String,
+    event_message: String,
+    actor: Option<PrincipalID>,
+    emit_event: bool,
+}
+
+impl QueuedTaskCancellation {
+    pub(crate) fn new(summary: impl Into<String>) -> Self {
+        let summary = summary.into();
+        Self {
+            event_message: summary.clone(),
+            summary,
+            actor: None,
+            emit_event: true,
+        }
+    }
+
+    pub(crate) fn with_event_message(mut self, message: impl Into<String>) -> Self {
+        self.event_message = message.into();
+        self
+    }
+
+    pub(crate) fn with_actor(mut self, actor: Option<PrincipalID>) -> Self {
+        self.actor = actor;
+        self
+    }
+
+    pub(crate) fn with_event_emission(mut self, emit_event: bool) -> Self {
+        self.emit_event = emit_event;
+        self
+    }
+}
+
+/// Apply the complete queued-to-cancelled persistence transition.
+///
+/// Callers must invoke this inside a transaction when cancellation is part of a
+/// larger mutation. The status predicate protects tasks claimed after their ids
+/// were selected, while the shared transition keeps terminal timestamps,
+/// request redaction, leases, and lifecycle events consistent.
+pub(crate) async fn cancel_queued_tasks_conn(
+    conn: &mut crate::db::DbConnection,
+    task_ids: &[i32],
+    cancellation: &QueuedTaskCancellation,
+) -> Result<Vec<TaskRecord>, ApiError> {
+    use crate::schema::tasks::dsl::{
+        finished_at, id, lease_expires_at, lease_token, request_payload, request_redacted_at,
+        status, summary, tasks, updated_at,
+    };
+
+    if task_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let terminal_at = database_now(conn).await?;
+    let cancelled = diesel::update(
+        tasks
+            .filter(id.eq_any(task_ids))
+            .filter(status.eq(TaskStatus::Queued.as_str())),
+    )
+    .set((
+        status.eq(TaskStatus::Cancelled.as_str()),
+        summary.eq(Some(cancellation.summary.clone())),
+        finished_at.eq(Some(terminal_at)),
+        request_payload.eq::<Option<serde_json::Value>>(None),
+        request_redacted_at.eq(Some(terminal_at)),
+        lease_token.eq::<Option<Uuid>>(None),
+        lease_expires_at.eq::<Option<NaiveDateTime>>(None),
+        updated_at.eq(terminal_at),
+    ))
+    .get_results::<TaskRecord>(conn)
+    .await?;
+
+    if cancellation.emit_event {
+        for task in &cancelled {
+            let provenance = if let Some(actor) = cancellation.actor {
+                task.user_provenance(actor)
+            } else {
+                task.system_provenance()
+            };
+            emit_task_lifecycle_event(
+                conn,
+                task,
+                &NewTaskEventRecord {
+                    task_id: task.id,
+                    event_type: TaskStatus::Cancelled.as_str().to_string(),
+                    message: cancellation.event_message.clone(),
+                    data: None,
+                },
+                &provenance,
+            )
+            .await?;
+        }
+    }
+
+    Ok(cancelled)
+}
+
 /// Anything that can name a task for a backend query: a [`TaskID`] from a request path or an
 /// already-loaded [`TaskRecord`] (and references to either). The required `task_id` resolves the
 /// raw id at the persistence boundary so it never leaks into the domain.
@@ -1155,27 +1254,6 @@ async fn emit_task_lifecycle_event(
         .map_err(ApiError::from)
 }
 
-pub(crate) async fn emit_internal_task_event(
-    conn: &mut crate::db::DbConnection,
-    event: &NewTaskEventRecord,
-    actor_user_id: Option<i32>,
-    task_kind: TaskKind,
-) -> Result<Event, ApiError> {
-    use crate::schema::tasks::dsl::{id, tasks};
-
-    let task = tasks
-        .filter(id.eq(event.task_id))
-        .first::<TaskRecord>(conn)
-        .await?;
-    let provenance = if let Some(actor_user_id) = actor_user_id {
-        task.user_provenance(PrincipalID::new(actor_user_id)?)
-    } else {
-        task.system_provenance()
-    };
-    debug_assert_eq!(task.kind, task_kind.as_str());
-    emit_task_lifecycle_event(conn, &task, event, &provenance).await
-}
-
 impl NewTaskEventRecord {
     /// Append this event to its task's history and return the persisted event.
     pub async fn append(self, pool: &DbPool) -> Result<TaskEventRecord, ApiError> {
@@ -1334,10 +1412,7 @@ pub async fn renew_task_lease(
 ) -> Result<bool, ApiError> {
     use crate::schema::tasks::dsl::{id, lease_expires_at, lease_token, status, tasks, updated_at};
 
-    let active_statuses = [
-        TaskStatus::Validating.as_str(),
-        TaskStatus::Running.as_str(),
-    ];
+    let active_statuses = TaskStatus::ACTIVE.map(TaskStatus::as_str);
     let updated = with_connection(pool, async |conn| -> Result<usize, ApiError> {
         let lease_milliseconds = lease_duration_milliseconds(lease_duration);
         diesel::update(
@@ -1420,10 +1495,7 @@ async fn recover_expired_task_leases_matching(
         request_payload, request_redacted_at, status, success_items, summary, tasks, updated_at,
     };
 
-    let active_statuses = [
-        TaskStatus::Validating.as_str(),
-        TaskStatus::Running.as_str(),
-    ];
+    let active_statuses = TaskStatus::ACTIVE.map(TaskStatus::as_str);
     let recovered = with_transaction(pool, async |conn| -> Result<Vec<TaskRecord>, ApiError> {
         let now = database_now(conn).await?;
         let stale_tasks = if let Some(task_id_filter) = task_id_filter {
@@ -1755,11 +1827,7 @@ async fn count_active_tasks_for_user_in_transaction(
 ) -> Result<i64, ApiError> {
     use crate::schema::tasks::dsl::{deleted_at, kind, status, submitted_by, tasks};
 
-    let active_statuses = [
-        TaskStatus::Queued.as_str(),
-        TaskStatus::Validating.as_str(),
-        TaskStatus::Running.as_str(),
-    ];
+    let active_statuses = TaskStatus::NON_TERMINAL.map(TaskStatus::as_str);
 
     tasks
         .filter(kind.eq(task_kind.as_str()))

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -85,6 +85,13 @@ impl TaskStatus {
         Self::Cancelled,
     ];
 
+    pub const TERMINAL: [Self; 4] = [
+        Self::Succeeded,
+        Self::Failed,
+        Self::PartiallySucceeded,
+        Self::Cancelled,
+    ];
+
     pub fn as_str(self) -> &'static str {
         match self {
             TaskStatus::Queued => "queued",
@@ -977,6 +984,14 @@ mod tests {
     #[test]
     fn task_result_counts_reject_processed_overflow() {
         assert!(TaskResultCounts::from_outcomes(i32::MAX, 1).is_err());
+    }
+
+    #[test]
+    fn terminal_task_statuses_are_stable() {
+        assert_eq!(
+            TaskStatus::TERMINAL.map(TaskStatus::as_str),
+            ["succeeded", "failed", "partially_succeeded", "cancelled"]
+        );
     }
 
     #[test]

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -85,12 +85,22 @@ impl TaskStatus {
         Self::Cancelled,
     ];
 
+    pub const ACTIVE: [Self; 2] = [Self::Validating, Self::Running];
+    pub const NON_TERMINAL: [Self; 3] = [Self::Queued, Self::Validating, Self::Running];
+
     pub const TERMINAL: [Self; 4] = [
         Self::Succeeded,
         Self::Failed,
         Self::PartiallySucceeded,
         Self::Cancelled,
     ];
+
+    pub const fn is_terminal(self) -> bool {
+        match self {
+            Self::Queued | Self::Validating | Self::Running => false,
+            Self::Succeeded | Self::Failed | Self::PartiallySucceeded | Self::Cancelled => true,
+        }
+    }
 
     pub fn as_str(self) -> &'static str {
         match self {
@@ -991,6 +1001,22 @@ mod tests {
         assert_eq!(
             TaskStatus::TERMINAL.map(TaskStatus::as_str),
             ["succeeded", "failed", "partially_succeeded", "cancelled"]
+        );
+        assert_eq!(
+            TaskStatus::ALL.map(TaskStatus::is_terminal),
+            [false, false, false, true, true, true, true]
+        );
+    }
+
+    #[test]
+    fn active_task_statuses_are_stable() {
+        assert_eq!(
+            TaskStatus::ACTIVE.map(TaskStatus::as_str),
+            ["validating", "running"]
+        );
+        assert_eq!(
+            TaskStatus::NON_TERMINAL.map(TaskStatus::as_str),
+            ["queued", "validating", "running"]
         );
     }
 

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -7,6 +7,7 @@ mod http;
 mod import;
 mod inventory;
 mod login;
+mod process;
 mod registry;
 mod remote_call;
 mod scrape;
@@ -23,6 +24,7 @@ use prometheus::{IntGaugeVec, Registry};
 use crate::errors::ApiError;
 
 use self::cache::ScrapeCache;
+use self::process::ProcessMetrics;
 
 pub use self::computed_field::{
     computed_evaluation, computed_live_fallback, computed_read_repair, computed_rebuild_batch,
@@ -85,6 +87,7 @@ struct Metrics {
     build_info: Gauge<u64>,
     runtime_info: Gauge<u64>,
     process_start_time: Gauge<f64>,
+    process_metrics: ProcessMetrics,
     http_requests: Counter<u64>,
     http_request_duration: Histogram<f64>,
     http_in_flight: UpDownCounter<i64>,
@@ -105,6 +108,7 @@ struct Metrics {
     task_poll_interval: Gauge<f64>,
     task_counts: Gauge<i64>,
     task_oldest_age: Gauge<f64>,
+    task_last_terminal_timestamp: Gauge<f64>,
     computed_evaluations: Counter<u64>,
     computed_evaluator_errors: Counter<u64>,
     computed_live_fallbacks: Counter<u64>,

--- a/src/observability/metrics/process.rs
+++ b/src/observability/metrics/process.rs
@@ -93,10 +93,10 @@ impl ProcessMetrics {
         Ok(metrics)
     }
 
-    pub(super) fn refresh(&self) {
-        if let Ok(mut state) = self.state.lock() {
-            self.refresh_state(&mut state);
-        }
+    pub(super) fn refresh(&self) -> bool {
+        self.state
+            .lock()
+            .is_ok_and(|mut state| self.refresh_state(&mut state))
     }
 
     fn refresh_required(&self) -> Result<(), ApiError> {
@@ -237,7 +237,7 @@ mod tests {
     fn supported_platform_exports_process_metrics() {
         let registry = Registry::new();
         let metrics = ProcessMetrics::new(&registry).unwrap();
-        metrics.refresh();
+        assert!(metrics.refresh());
 
         let mut encoded = Vec::new();
         TextEncoder::new()

--- a/src/observability/metrics/process.rs
+++ b/src/observability/metrics/process.rs
@@ -1,0 +1,245 @@
+use std::sync::Mutex;
+
+use prometheus::{Counter, IntGauge, Registry, core::Collector};
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, get_current_pid};
+
+use crate::errors::ApiError;
+
+const PROCESS_CPU_SECONDS: &str = "process_cpu_seconds_total";
+const PROCESS_OPEN_FDS: &str = "process_open_fds";
+const PROCESS_MAX_FDS: &str = "process_max_fds";
+const PROCESS_RESIDENT_MEMORY: &str = "process_resident_memory_bytes";
+const PROCESS_VIRTUAL_MEMORY: &str = "process_virtual_memory_bytes";
+const PROCESS_START_TIME: &str = "process_start_time_seconds";
+
+struct ProcessState {
+    system: System,
+    pid: Pid,
+    last_cpu_millis: u64,
+}
+
+struct ProcessSnapshot {
+    cpu_millis: u64,
+    open_files: Option<usize>,
+    open_files_limit: Option<usize>,
+    resident_memory_bytes: u64,
+    virtual_memory_bytes: u64,
+    start_time_seconds: u64,
+}
+
+pub(super) struct ProcessMetrics {
+    state: Mutex<ProcessState>,
+    cpu_seconds: Counter,
+    open_fds: IntGauge,
+    max_fds: IntGauge,
+    resident_memory_bytes: IntGauge,
+    virtual_memory_bytes: IntGauge,
+    start_time_seconds: IntGauge,
+}
+
+impl ProcessMetrics {
+    pub(super) fn new(registry: &Registry) -> Result<Self, ApiError> {
+        let cpu_seconds = create_and_register_counter(
+            registry,
+            PROCESS_CPU_SECONDS,
+            "Total user and system CPU time spent in seconds",
+        )?;
+        let open_fds = create_and_register_gauge(
+            registry,
+            PROCESS_OPEN_FDS,
+            "Number of open file descriptors or handles",
+        )?;
+        let max_fds = create_and_register_gauge(
+            registry,
+            PROCESS_MAX_FDS,
+            "Maximum number of open file descriptors or handles",
+        )?;
+        let resident_memory_bytes = create_and_register_gauge(
+            registry,
+            PROCESS_RESIDENT_MEMORY,
+            "Resident memory size in bytes",
+        )?;
+        let virtual_memory_bytes = create_and_register_gauge(
+            registry,
+            PROCESS_VIRTUAL_MEMORY,
+            "Virtual memory size in bytes",
+        )?;
+        let start_time_seconds = create_and_register_gauge(
+            registry,
+            PROCESS_START_TIME,
+            "Start time of the process since the Unix epoch in seconds",
+        )?;
+
+        let pid = get_current_pid().map_err(|error| {
+            ApiError::InternalServerError(format!(
+                "Failed to identify the current process for metrics: {error}"
+            ))
+        })?;
+        let metrics = Self {
+            state: Mutex::new(ProcessState {
+                system: System::new(),
+                pid,
+                last_cpu_millis: 0,
+            }),
+            cpu_seconds,
+            open_fds,
+            max_fds,
+            resident_memory_bytes,
+            virtual_memory_bytes,
+            start_time_seconds,
+        };
+        metrics.refresh_required()?;
+
+        Ok(metrics)
+    }
+
+    pub(super) fn refresh(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            self.refresh_state(&mut state);
+        }
+    }
+
+    fn refresh_required(&self) -> Result<(), ApiError> {
+        let mut state = self.state.lock().map_err(|_| {
+            ApiError::InternalServerError("Failed to initialize process metrics state".to_string())
+        })?;
+        if self.refresh_state(&mut state) {
+            Ok(())
+        } else {
+            Err(ApiError::InternalServerError(
+                "Failed to read current process metrics".to_string(),
+            ))
+        }
+    }
+
+    fn refresh_state(&self, state: &mut ProcessState) -> bool {
+        let pids = [state.pid];
+        state.system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&pids),
+            false,
+            ProcessRefreshKind::nothing()
+                .without_tasks()
+                .with_cpu()
+                .with_memory(),
+        );
+        let Some(snapshot) = state.system.process(state.pid).map(ProcessSnapshot::from) else {
+            return false;
+        };
+
+        if snapshot.cpu_millis >= state.last_cpu_millis {
+            self.cpu_seconds
+                .inc_by(snapshot.cpu_millis.saturating_sub(state.last_cpu_millis) as f64 / 1000.0);
+            state.last_cpu_millis = snapshot.cpu_millis;
+        }
+        self.open_fds
+            .set(saturating_i64(snapshot.open_files.unwrap_or_default()));
+        self.max_fds.set(saturating_i64(
+            snapshot.open_files_limit.unwrap_or_default(),
+        ));
+        self.resident_memory_bytes
+            .set(saturating_i64(snapshot.resident_memory_bytes));
+        self.virtual_memory_bytes
+            .set(saturating_i64(snapshot.virtual_memory_bytes));
+        self.start_time_seconds
+            .set(saturating_i64(snapshot.start_time_seconds));
+
+        true
+    }
+}
+
+impl From<&sysinfo::Process> for ProcessSnapshot {
+    fn from(process: &sysinfo::Process) -> Self {
+        Self {
+            cpu_millis: process.accumulated_cpu_time(),
+            open_files: process.open_files(),
+            open_files_limit: process.open_files_limit(),
+            resident_memory_bytes: process.memory(),
+            virtual_memory_bytes: process.virtual_memory(),
+            start_time_seconds: process.start_time(),
+        }
+    }
+}
+
+fn create_and_register_counter(
+    registry: &Registry,
+    name: &str,
+    help: &str,
+) -> Result<Counter, ApiError> {
+    let metric = Counter::new(name, help).map_err(|error| metric_creation_error(name, error))?;
+    register_metric(registry, metric.clone(), name)?;
+    Ok(metric)
+}
+
+fn create_and_register_gauge(
+    registry: &Registry,
+    name: &str,
+    help: &str,
+) -> Result<IntGauge, ApiError> {
+    let metric = IntGauge::new(name, help).map_err(|error| metric_creation_error(name, error))?;
+    register_metric(registry, metric.clone(), name)?;
+    Ok(metric)
+}
+
+fn register_metric<C>(registry: &Registry, metric: C, name: &str) -> Result<(), ApiError>
+where
+    C: Collector + 'static,
+{
+    registry.register(Box::new(metric)).map_err(|error| {
+        ApiError::InternalServerError(format!("Failed to register {name} metric: {error}"))
+    })
+}
+
+fn metric_creation_error(name: &str, error: prometheus::Error) -> ApiError {
+    ApiError::InternalServerError(format!("Failed to create {name} metric: {error}"))
+}
+
+fn saturating_i64<T>(value: T) -> i64
+where
+    T: TryInto<i64>,
+{
+    value.try_into().unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus::{Encoder, TextEncoder};
+
+    use super::*;
+
+    #[test]
+    fn supported_platform_exports_process_metrics() {
+        let registry = Registry::new();
+        let metrics = ProcessMetrics::new(&registry).unwrap();
+        metrics.refresh();
+
+        let mut encoded = Vec::new();
+        TextEncoder::new()
+            .encode(&registry.gather(), &mut encoded)
+            .unwrap();
+        let body = String::from_utf8(encoded).unwrap();
+
+        for metric_name in [
+            PROCESS_CPU_SECONDS,
+            PROCESS_MAX_FDS,
+            PROCESS_OPEN_FDS,
+            PROCESS_RESIDENT_MEMORY,
+            PROCESS_START_TIME,
+            PROCESS_VIRTUAL_MEMORY,
+        ] {
+            assert!(
+                body.contains(metric_name),
+                "missing process metric: {metric_name}"
+            );
+        }
+        assert!(metrics.open_fds.get() > 0);
+        assert!(metrics.max_fds.get() >= metrics.open_fds.get());
+        assert!(metrics.resident_memory_bytes.get() > 0);
+        assert!(metrics.virtual_memory_bytes.get() > 0);
+        assert!(metrics.start_time_seconds.get() > 0);
+    }
+
+    #[test]
+    fn large_unsigned_values_saturate_at_signed_metric_limit() {
+        assert_eq!(saturating_i64(u64::MAX), i64::MAX);
+    }
+}

--- a/src/observability/metrics/process.rs
+++ b/src/observability/metrics/process.rs
@@ -152,12 +152,39 @@ impl From<&sysinfo::Process> for ProcessSnapshot {
         Self {
             cpu_millis: process.accumulated_cpu_time(),
             open_files: process.open_files(),
-            open_files_limit: process.open_files_limit(),
+            open_files_limit: process_open_files_limit(process),
             resident_memory_bytes: process.memory(),
             virtual_memory_bytes: process.virtual_memory(),
             start_time_seconds: process.start_time(),
         }
     }
+}
+
+#[cfg(target_os = "macos")]
+fn process_open_files_limit(_process: &sysinfo::Process) -> Option<usize> {
+    let mut limits = std::mem::MaybeUninit::<libc::rlimit>::uninit();
+    // SAFETY: `limits` points to writable storage for the `rlimit` value that
+    // `getrlimit` initializes on success.
+    let result = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, limits.as_mut_ptr()) };
+    if result != 0 {
+        return None;
+    }
+
+    // SAFETY: A successful `getrlimit` call initialized `limits`.
+    let soft_limit = unsafe { limits.assume_init() }.rlim_cur;
+    soft_limit.try_into().ok()
+}
+
+#[cfg(target_os = "windows")]
+fn process_open_files_limit(_process: &sysinfo::Process) -> Option<usize> {
+    // `open_files` is the process's kernel handle count on Windows. Windows has
+    // no fixed per-process handle limit comparable to that count.
+    None
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn process_open_files_limit(process: &sysinfo::Process) -> Option<usize> {
+    process.open_files_limit()
 }
 
 fn create_and_register_counter(
@@ -232,7 +259,10 @@ mod tests {
             );
         }
         assert!(metrics.open_fds.get() > 0);
-        assert!(metrics.max_fds.get() >= metrics.open_fds.get());
+        #[cfg(target_os = "windows")]
+        assert_eq!(metrics.max_fds.get(), 0);
+        #[cfg(not(target_os = "windows"))]
+        assert!(metrics.max_fds.get() > 0);
         assert!(metrics.resident_memory_bytes.get() > 0);
         assert!(metrics.virtual_memory_bytes.get() > 0);
         assert!(metrics.start_time_seconds.get() > 0);

--- a/src/observability/metrics/registry.rs
+++ b/src/observability/metrics/registry.rs
@@ -11,6 +11,7 @@ use crate::errors::ApiError;
 use crate::logger;
 
 use super::cache::ScrapeCache;
+use super::process::ProcessMetrics;
 use super::{METRICS, Metrics};
 
 const LATENCY_BUCKETS_SECONDS: &[f64] = &[
@@ -97,6 +98,7 @@ pub fn init() -> Result<(), ApiError> {
     }
 
     let registry = Registry::new();
+    let process_metrics = ProcessMetrics::new(&registry)?;
     let provider = build_provider(&registry)?;
     let meter = provider.meter("hubuum");
     let export_template_info = IntGaugeVec::new(
@@ -135,6 +137,7 @@ pub fn init() -> Result<(), ApiError> {
             .with_description("Unix timestamp when this Hubuum process initialized metrics")
             .with_unit("s")
             .build(),
+        process_metrics,
         http_requests: meter
             .u64_counter("hubuum_http_requests")
             .with_description("HTTP requests handled")
@@ -220,6 +223,11 @@ pub fn init() -> Result<(), ApiError> {
         task_oldest_age: meter
             .f64_gauge("hubuum_task_oldest_age")
             .with_description("Oldest queued or active task age")
+            .with_unit("s")
+            .build(),
+        task_last_terminal_timestamp: meter
+            .f64_gauge("hubuum_task_last_terminal_timestamp")
+            .with_description("Unix timestamp of the most recently finished task")
             .with_unit("s")
             .build(),
         computed_evaluations: meter

--- a/src/observability/metrics/scrape.rs
+++ b/src/observability/metrics/scrape.rs
@@ -22,6 +22,7 @@ pub(super) enum RefreshSource {
     Events,
     Inventory,
     LoginLimiter,
+    Process,
     Tasks,
 }
 
@@ -32,6 +33,7 @@ impl RefreshSource {
             Self::Events => "events",
             Self::Inventory => "inventory",
             Self::LoginLimiter => "login_limiter",
+            Self::Process => "process",
             Self::Tasks => "tasks",
         }
     }
@@ -39,7 +41,18 @@ impl RefreshSource {
 
 pub async fn scrape(pool: web::Data<DbPool>) -> Result<impl Responder, ApiError> {
     let metrics = get()?;
-    metrics.process_metrics.refresh();
+    let process_refresh_started_at = Instant::now();
+    let process_refresh_outcome = if metrics.process_metrics.refresh() {
+        RefreshOutcome::Succeeded
+    } else {
+        RefreshOutcome::Failed
+    };
+    record_refresh_attempt(
+        metrics,
+        RefreshSource::Process,
+        process_refresh_started_at,
+        process_refresh_outcome,
+    );
     with_db_call_site(
         DbCallSite::MetricsRefresh,
         refresh_scrape_gauges(metrics, &pool),
@@ -114,10 +127,18 @@ mod tests {
                 RefreshSource::Events,
                 RefreshSource::Inventory,
                 RefreshSource::LoginLimiter,
+                RefreshSource::Process,
                 RefreshSource::Tasks,
             ]
             .map(RefreshSource::as_str),
-            ["database", "events", "inventory", "login_limiter", "tasks",]
+            [
+                "database",
+                "events",
+                "inventory",
+                "login_limiter",
+                "process",
+                "tasks",
+            ]
         );
     }
 }

--- a/src/observability/metrics/scrape.rs
+++ b/src/observability/metrics/scrape.rs
@@ -39,6 +39,7 @@ impl RefreshSource {
 
 pub async fn scrape(pool: web::Data<DbPool>) -> Result<impl Responder, ApiError> {
     let metrics = get()?;
+    metrics.process_metrics.refresh();
     with_db_call_site(
         DbCallSite::MetricsRefresh,
         refresh_scrape_gauges(metrics, &pool),

--- a/src/observability/metrics/task.rs
+++ b/src/observability/metrics/task.rs
@@ -179,13 +179,13 @@ fn store_task_snapshot(metrics: &Metrics, snapshot: TaskGaugeSnapshot) {
 fn record_task_snapshot(metrics: &Metrics, snapshot: &TaskGaugeSnapshot) {
     let now = chrono::Utc::now().naive_utc();
     let mut counts = HashMap::new();
-    let mut last_finished = HashMap::new();
+    let mut last_terminal = HashMap::new();
 
     for row in &snapshot.counts {
         counts.insert((row.kind, row.status), row.count);
     }
-    for row in &snapshot.last_finished {
-        last_finished.insert((row.kind, row.status), row.timestamp);
+    for row in &snapshot.last_terminal {
+        last_terminal.insert((row.kind, row.status), row.finished_at);
     }
 
     for kind in TaskKind::ALL {
@@ -198,12 +198,7 @@ fn record_task_snapshot(metrics: &Metrics, snapshot: &TaskGaugeSnapshot) {
                 metrics,
                 kind,
                 status,
-                last_finished
-                    .get(&(kind, status))
-                    .copied()
-                    .flatten()
-                    .map(timestamp_seconds)
-                    .unwrap_or(0.0),
+                terminal_timestamp_seconds(last_terminal.get(&(kind, status)).copied().flatten()),
             );
         }
     }
@@ -272,8 +267,10 @@ fn record_last_terminal_timestamp(
     );
 }
 
-fn timestamp_seconds(timestamp: chrono::NaiveDateTime) -> f64 {
-    timestamp.and_utc().timestamp_millis() as f64 / 1000.0
+fn terminal_timestamp_seconds(timestamp: Option<chrono::NaiveDateTime>) -> f64 {
+    timestamp
+        .map(|timestamp| timestamp.and_utc().timestamp_millis() as f64 / 1000.0)
+        .unwrap_or(0.0)
 }
 
 fn age_seconds(
@@ -287,7 +284,7 @@ fn age_seconds(
 mod tests {
     use chrono::NaiveDate;
 
-    use super::{TaskAgeState, TaskOutputKind, timestamp_seconds};
+    use super::{TaskAgeState, TaskOutputKind, terminal_timestamp_seconds};
 
     #[test]
     fn task_output_kinds_have_stable_bounded_labels() {
@@ -312,6 +309,13 @@ mod tests {
             .and_hms_milli_opt(12, 34, 56, 789)
             .unwrap();
 
-        assert!((timestamp_seconds(timestamp) - 1_785_242_096.789).abs() < f64::EPSILON);
+        assert!(
+            (terminal_timestamp_seconds(Some(timestamp)) - 1_785_242_096.789).abs() < f64::EPSILON
+        );
+    }
+
+    #[test]
+    fn missing_terminal_timestamp_exports_zero() {
+        assert_eq!(terminal_timestamp_seconds(None), 0.0);
     }
 }

--- a/src/observability/metrics/task.rs
+++ b/src/observability/metrics/task.rs
@@ -179,15 +179,32 @@ fn store_task_snapshot(metrics: &Metrics, snapshot: TaskGaugeSnapshot) {
 fn record_task_snapshot(metrics: &Metrics, snapshot: &TaskGaugeSnapshot) {
     let now = chrono::Utc::now().naive_utc();
     let mut counts = HashMap::new();
+    let mut last_finished = HashMap::new();
 
     for row in &snapshot.counts {
         counts.insert((row.kind, row.status), row.count);
+    }
+    for row in &snapshot.last_finished {
+        last_finished.insert((row.kind, row.status), row.timestamp);
     }
 
     for kind in TaskKind::ALL {
         for status in TaskStatus::ALL {
             let count = counts.get(&(kind, status)).copied().unwrap_or(0);
             record_task_count(metrics, kind, status, count);
+        }
+        for status in TaskStatus::TERMINAL {
+            record_last_terminal_timestamp(
+                metrics,
+                kind,
+                status,
+                last_finished
+                    .get(&(kind, status))
+                    .copied()
+                    .flatten()
+                    .map(timestamp_seconds)
+                    .unwrap_or(0.0),
+            );
         }
     }
 
@@ -211,6 +228,9 @@ fn record_empty_task_snapshot(metrics: &Metrics) {
     for kind in TaskKind::ALL {
         for status in TaskStatus::ALL {
             record_task_count(metrics, kind, status, 0);
+        }
+        for status in TaskStatus::TERMINAL {
+            record_last_terminal_timestamp(metrics, kind, status, 0.0);
         }
         record_task_age(metrics, kind, TaskAgeState::Queued, 0.0);
         record_task_age(metrics, kind, TaskAgeState::Active, 0.0);
@@ -237,6 +257,25 @@ fn record_task_age(metrics: &Metrics, kind: TaskKind, state: TaskAgeState, age: 
     );
 }
 
+fn record_last_terminal_timestamp(
+    metrics: &Metrics,
+    kind: TaskKind,
+    status: TaskStatus,
+    timestamp: f64,
+) {
+    metrics.task_last_terminal_timestamp.record(
+        timestamp,
+        &[
+            KeyValue::new("kind", kind.as_str()),
+            KeyValue::new("status", status.as_str()),
+        ],
+    );
+}
+
+fn timestamp_seconds(timestamp: chrono::NaiveDateTime) -> f64 {
+    timestamp.and_utc().timestamp_millis() as f64 / 1000.0
+}
+
 fn age_seconds(
     timestamp: Option<chrono::NaiveDateTime>,
     now: chrono::NaiveDateTime,
@@ -246,7 +285,9 @@ fn age_seconds(
 
 #[cfg(test)]
 mod tests {
-    use super::{TaskAgeState, TaskOutputKind};
+    use chrono::NaiveDate;
+
+    use super::{TaskAgeState, TaskOutputKind, timestamp_seconds};
 
     #[test]
     fn task_output_kinds_have_stable_bounded_labels() {
@@ -262,5 +303,15 @@ mod tests {
             [TaskAgeState::Queued, TaskAgeState::Active].map(TaskAgeState::as_str),
             ["queued", "active"]
         );
+    }
+
+    #[test]
+    fn terminal_timestamp_preserves_millisecond_precision_in_seconds() {
+        let timestamp = NaiveDate::from_ymd_opt(2026, 7, 28)
+            .unwrap()
+            .and_hms_milli_opt(12, 34, 56, 789)
+            .unwrap();
+
+        assert!((timestamp_seconds(timestamp) - 1_785_242_096.789).abs() < f64::EPSILON);
     }
 }

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -58,6 +58,23 @@ async fn metrics_endpoint_exports_prometheus_text(#[future(awt)] test_context: T
     assert!(body.contains("hubuum_runtime_info{role=\"worker\"} 1"));
     assert!(body.contains("hubuum_process_start_time_seconds"));
     assert!(body.contains("hubuum_metrics_refresh_last_success_timestamp_seconds"));
+    assert!(body.contains(
+        "hubuum_task_last_terminal_timestamp_seconds{kind=\"export\",status=\"failed\"}"
+    ));
+
+    for metric_name in [
+        "process_cpu_seconds_total",
+        "process_max_fds",
+        "process_open_fds",
+        "process_resident_memory_bytes",
+        "process_start_time_seconds",
+        "process_virtual_memory_bytes",
+    ] {
+        assert!(
+            body.contains(metric_name),
+            "missing process metric: {metric_name}"
+        );
+    }
 }
 
 #[actix_web::test]

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -2,16 +2,20 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 use actix_web::{App, HttpResponse, http::StatusCode, test, web};
+use chrono::{NaiveDate, NaiveDateTime};
+use diesel::{ExpressionMethods, QueryDsl};
+use diesel_async::RunQueryDsl;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::pooled_connection::bb8::Pool;
 use rstest::rstest;
 use tokio::sync::Mutex;
 
 use crate::config::RuntimeRole;
-use crate::db::{DbConnection, DbPool};
+use crate::db::{DbConnection, DbPool, with_connection};
 use crate::middlewares::TracingMiddleware;
-use crate::models::{ExportTemplateID, TaskKind, TaskStatus};
+use crate::models::{ExportTemplateID, NewTaskRecord, TaskKind, TaskStatus};
 use crate::observability::metrics;
+use crate::schema::tasks;
 use crate::test_support::clear_metrics_scrape_cache;
 use crate::tests::{TestContext, test_context};
 
@@ -58,6 +62,9 @@ async fn metrics_endpoint_exports_prometheus_text(#[future(awt)] test_context: T
     assert!(body.contains("hubuum_runtime_info{role=\"worker\"} 1"));
     assert!(body.contains("hubuum_process_start_time_seconds"));
     assert!(body.contains("hubuum_metrics_refresh_last_success_timestamp_seconds"));
+    assert!(
+        body.contains("hubuum_metrics_refresh_last_success_timestamp_seconds{source=\"process\"}")
+    );
     assert!(body.contains(
         "hubuum_task_last_terminal_timestamp_seconds{kind=\"export\",status=\"failed\"}"
     ));
@@ -251,6 +258,75 @@ async fn task_gauges_export_zero_for_bounded_kind_status_pairs(
     }
 }
 
+#[rstest]
+#[actix_web::test]
+async fn task_terminal_gauge_exports_latest_finished_timestamp(
+    #[future(awt)] test_context: TestContext,
+) {
+    let _lock = METRICS_TEST_LOCK.lock().await;
+    let context = test_context;
+    metrics::init().unwrap();
+    clear_metrics_scrape_cache();
+
+    let older = NaiveDate::from_ymd_opt(9998, 1, 1)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap();
+    let latest = NaiveDate::from_ymd_opt(9998, 1, 2)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap();
+    let records = [
+        terminal_task_record(&context, "older", older),
+        terminal_task_record(&context, "latest", latest),
+    ];
+    let task_ids = with_connection(&context.pool, async |conn| {
+        diesel::insert_into(tasks::table)
+            .values(&records)
+            .returning(tasks::id)
+            .get_results::<i32>(conn)
+            .await
+    })
+    .await
+    .unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .app_data(context.pool.clone())
+            .route("/metrics", web::get().to(metrics::scrape)),
+    )
+    .await;
+    let response =
+        test::call_service(&app, test::TestRequest::get().uri("/metrics").to_request()).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+
+    with_connection(&context.pool, async |conn| {
+        diesel::delete(tasks::table.filter(tasks::id.eq_any(task_ids)))
+            .execute(conn)
+            .await
+    })
+    .await
+    .unwrap();
+    clear_metrics_scrape_cache();
+
+    let metric = body
+        .lines()
+        .find(|line| {
+            line.starts_with(
+                "hubuum_task_last_terminal_timestamp_seconds{kind=\"backup\",status=\"failed\"}",
+            )
+        })
+        .expect("missing backup/failed terminal timestamp metric");
+    let exported = metric
+        .split_whitespace()
+        .nth(1)
+        .expect("metric value")
+        .parse::<f64>()
+        .expect("numeric metric value");
+    assert_eq!(exported, latest.and_utc().timestamp() as f64);
+}
+
 #[actix_web::test]
 async fn tracing_metrics_keep_stable_route_templates() {
     let _lock = METRICS_TEST_LOCK.lock().await;
@@ -291,6 +367,32 @@ async fn tracing_metrics_keep_stable_route_templates() {
     ));
     assert!(!body.contains("route=\"/api/v1/classes/42/objects/99\""));
     assert!(body.contains("hubuum_http_requests_in_flight{route=\"/metrics\"} 1"));
+}
+
+fn terminal_task_record(
+    context: &TestContext,
+    label: &str,
+    finished_at: NaiveDateTime,
+) -> NewTaskRecord {
+    NewTaskRecord {
+        kind: TaskKind::Backup.as_str().to_string(),
+        status: TaskStatus::Failed.as_str().to_string(),
+        submitted_by: Some(context.admin_user.id),
+        idempotency_key: Some(context.scoped_name(&format!("terminal-metric-{label}"))),
+        request_hash: None,
+        request_payload: None,
+        summary: Some("terminal metric fixture".to_string()),
+        total_items: 1,
+        processed_items: 1,
+        success_items: 0,
+        failed_items: 1,
+        submitted_token_id: None,
+        submitted_token_scoped: false,
+        submitted_token_scopes: serde_json::json!([]),
+        request_redacted_at: Some(finished_at),
+        started_at: Some(finished_at),
+        finished_at: Some(finished_at),
+    }
 }
 
 fn unreachable_pool() -> DbPool {


### PR DESCRIPTION
## Summary

- expose standard cross-platform Prometheus process metrics for CPU time, resident and virtual memory, process start time, and open file-descriptor/handle usage
- expose `hubuum_task_last_terminal_timestamp_seconds{kind,status}` so retained task outcome counts can be distinguished from recent failures
- document how to identify API-only versus worker-enabled scrape targets, exclude readiness/scrape traffic, interpret process metrics, and alert on recent task failures
- update the Unreleased changelog

## Rationale

A review of the production scrape after real API and task activity showed that the expanded metrics are materially useful: stable application routes, fractional-second latency buckets, bounded database callers, inventory, task counts, template identities, and snapshot freshness are all visible.

The review also exposed three remaining diagnostic gaps:

1. The public scrape is an API-role target with no configured workers. Worker-local export/task histograms are therefore correctly absent, but this was easy to misinterpret as missing instrumentation. The guide now makes the scrape-target requirement explicit.
2. Readiness probes dominate the observed HTTP request volume, so a naïve aggregate mostly describes probe latency. The guide now provides an application-traffic query that excludes health, readiness, and the configured metrics route.
3. A retained failed-task count does not say whether the failure happened seconds ago or months ago. The new terminal timestamp gauge makes recency alerts possible without log inspection.

Process-local CPU, memory, and descriptor/handle pressure were also unavailable. The new collector publishes conventional unprefixed `process_*` metric names so standard Prometheus dashboards can consume them.

## Review fixes

- read the live macOS `RLIMIT_NOFILE` soft limit instead of sysinfo's fixed value
- export `process_max_fds` as zero on Windows because the reported open count is a kernel-handle count without a comparable fixed per-process limit
- centralize queued-task cancellation so terminal timestamps, request redaction, lease cleanup, summaries, and lifecycle events remain consistent
- make service-account disablement, token revocation, and pending-task cancellation one database transaction
- test the exported latest terminal timestamp value and zero fallback instead of checking only that the metric family exists
- report process collector refresh success and failure through the existing bounded refresh diagnostics
- consolidate active, non-terminal, and terminal task status classifications and align internal last-terminal naming with the metric contract
- tell operators to substitute the exact configured `HUBUUM_METRICS_PATH` in application-traffic queries and guard descriptor ratios when no comparable limit exists

## Behavior notes

- Existing per-template export timing remains worker-local. Operators must scrape each worker-enabled process to see it.
- `hubuum_task_last_terminal_timestamp_seconds` is database-wide and emits all bounded task-kind/terminal-status combinations; zero means no matching retained task.
- Queued tasks cancelled during principal or computed-field cleanup now use the same terminal persistence invariants, including request-payload redaction.
- `process_start_time_seconds` is the operating-system process start, while `hubuum_process_start_time_seconds` remains the time Hubuum initialized metrics.
- On Windows, `process_open_fds` represents kernel handles and `process_max_fds` is zero because no comparable fixed handle limit exists.
- This adds metric families only; there is no HTTP API or schema breaking change.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- process collector integration exercised successfully on macOS
- the required dual-TLS Alpine production build compiled dependencies and application code through the final release link, but Docker Desktop killed the fat-LTO server link twice after exhausting its 7.65 GiB allocation, including a serialized one-job retry; the PR container-build check remains the authoritative Linux release-link gate
