### PR TITLE
Prepare v0.0.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.0.6] - 2026-07-29
+
 ### Added
 
 - Database acquisition, failure, operation-duration, and operation-error metrics

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,13 +1407,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1450,11 +1450,11 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "email-encoding"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
+checksum = "420b9da095f052ea597503e39073b5b3c522f7db933fbac202d91d24492693fd"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.0",
  "memchr",
 ]
 
@@ -1494,11 +1494,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2018,7 +2017,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hubuum"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -2079,7 +2078,7 @@ dependencies = [
  "tokio-postgres",
  "tokio-postgres-rustls",
  "tokio-rustls",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-serde",
  "tracing-subscriber",
@@ -2648,9 +2647,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.1"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc9116a0f75b7336e55eb2a2a0ddef86c37cadf02924a571751aa123d5a0290"
+checksum = "f8a77951c56b6a0af03c22af6953d6ffcfba9403c765578921f3f1089b999db6"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2677,18 +2676,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.1"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628a1f02bda4651d9a6088ee6386a92f0ee96255b0c99e9dfe1be91bf83bd838"
+checksum = "a4c2e64f341a1d6a15d2daa3c967e48921cf15b9c7f23a9899e8b63c7f7c4199"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.1"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d94a372f8d81d070fd405065c6b1168d8248d1d6adad073ac708de254698c6"
+checksum = "94e097778f3e9c6a33862077dbf07aca0360d0b18d2a7abc323da132df49ee83"
 dependencies = [
  "ahash",
  "bytecount",
@@ -3841,9 +3840,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.1"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978badf4419c9d0e1bc6e7466e99277f829d768257670c46d88121ca75e34bf7"
+checksum = "b772e96f8eb6badd4eb10fbc08b8a98244c09b4af37e72e8fa612c854604b870"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -4851,9 +4850,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4896,9 +4895,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hubuum"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 description = "Flexible asset management REST service."
 license = "MIT"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.0.5"
+    "version": "0.0.6"
   },
   "servers": [
     {


### PR DESCRIPTION
## Summary

Prepare Hubuum v0.0.6 by bumping the package and generated OpenAPI versions, rolling the complete Unreleased changelog into the dated v0.0.6 section, and refreshing the lockfile to compatible patch releases.

## Release impact

This release substantially improves runtime observability and distributed-worker efficiency. It adds bounded database caller labels, notification-driven task wakeups, workload-specific histogram buckets, stable per-process scrape targets, process and build identity metrics, task backlog and terminal-recency metrics, and richer import/export timing diagnostics.

It also fixes stale generated single-host deployment configuration during updates, direct shared-host metrics routing, redundant idle database work, duplicate direct-routing health checks, API-only worker-count reporting, restore drain-barrier sampling, one-connection worker notification listeners, and stale template metric identities.

## Breaking changes and upgrade actions

- **Database metric label contract:** database acquisition, failure, duration, and operation-error series now include a bounded `caller` label. Update recording rules and exact label-set matches that assume the previous unlabeled series.
- **Prometheus metric contract:** configuration and cleanup metrics use dimensionally typed names, event wakeups are a counter, and HTTP in-flight, task-age, export-phase, and import-phase families have new bounded labels. Dashboard and alert owners must migrate the renamed families and changed label sets documented in `docs/metrics.md` before deploying v0.0.6.

## Dependency refresh

The lockfile refresh includes compatible patch updates for displaydoc, email-encoding, event-listener, the jsonschema 0.49 family, referencing, and the TOML 1.1 family.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- OpenAPI regeneration byte parity
- `./scripts/check-version-bump.sh`
- `./scripts/check-release-readiness.sh v0.0.6`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`

The required dual-TLS production Docker build completed all dependency and source compilation and reached the final fat-LTO application link. Docker Desktop then killed `rustc` with `cannot allocate memory`; the pull-request container-build check remains the authoritative Linux release-link gate.