### PR TITLE
Add object relation cardinality constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   classes, objects, class relations, and object relations without exposing
   timestamp mutation through standard resource endpoints. Unchanged import
   overwrites do not create redundant history revisions.
+- Added optional per-class-side object relation limits, allowing class
+  relations to enforce one-to-one, one-to-many, or bounded object
+  cardinalities.
 
 ## [0.0.6] - 2026-07-29
 

--- a/docs/import_api.md
+++ b/docs/import_api.md
@@ -307,6 +307,10 @@ Exactly one of `class_ref` or `class_key` must be set.
 | `from_class_key` | object | conditional | Use when the source class already exists. |
 | `to_class_ref` | string | conditional | Use when the target class is created in the same request. |
 | `to_class_key` | object | conditional | Use when the target class already exists. |
+| `forward_template_alias` | string | no | Template alias when traversing from the source class to the target class. |
+| `reverse_template_alias` | string | no | Template alias when traversing from the target class to the source class. |
+| `from_max_relations` | positive integer or null | no | Maximum relations allowed for each source-class object. Omit or use `null` for unlimited. |
+| `to_max_relations` | positive integer or null | no | Maximum relations allowed for each target-class object. Omit or use `null` for unlimited. |
 | `timestamps` | object | no | Import-only `created_at` and `updated_at` values. |
 
 Exactly one of `from_class_ref` or `from_class_key` must be set, and exactly one of `to_class_ref` or `to_class_key` must be set.
@@ -319,6 +323,7 @@ Example:
     {
       "ref": "rel:server-runs-on-rack",
       "from_class_ref": "class:server",
+      "from_max_relations": 1,
       "to_class_key": {
         "name": "rack",
         "collection_key": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -20988,6 +20988,17 @@
             "type": "integer",
             "format": "int32"
           },
+          "from_max_relations": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectRelationLimit",
+                "description": "Maximum relations allowed for each object in `from_hubuum_class_id`.\n`None` means unlimited."
+              }
+            ]
+          },
           "id": {
             "type": "integer",
             "format": "int32"
@@ -21001,6 +21012,17 @@
           "to_hubuum_class_id": {
             "type": "integer",
             "format": "int32"
+          },
+          "to_max_relations": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectRelationLimit",
+                "description": "Maximum relations allowed for each object in `to_hubuum_class_id`.\n`None` means unlimited."
+              }
+            ]
           },
           "updated_at": {
             "type": "string",
@@ -21416,6 +21438,16 @@
               "null"
             ]
           },
+          "from_max_relations": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectRelationLimit"
+              }
+            ]
+          },
           "ref": {
             "type": [
               "string",
@@ -21452,6 +21484,16 @@
             "type": [
               "string",
               "null"
+            ]
+          },
+          "to_max_relations": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectRelationLimit"
+              }
             ]
           }
         }
@@ -23268,6 +23310,17 @@
             "type": "integer",
             "format": "int32"
           },
+          "from_max_relations": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectRelationLimit",
+                "description": "Maximum relations allowed for each object in `from_hubuum_class_id`.\nOmit or set to `null` for unlimited."
+              }
+            ]
+          },
           "reverse_template_alias": {
             "type": [
               "string",
@@ -23277,13 +23330,26 @@
           "to_hubuum_class_id": {
             "type": "integer",
             "format": "int32"
+          },
+          "to_max_relations": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectRelationLimit",
+                "description": "Maximum relations allowed for each object in `to_hubuum_class_id`.\nOmit or set to `null` for unlimited."
+              }
+            ]
           }
         },
         "example": {
           "forward_template_alias": "rooms",
           "from_hubuum_class_id": 1,
+          "from_max_relations": 1,
           "reverse_template_alias": "hosts",
-          "to_hubuum_class_id": 2
+          "to_hubuum_class_id": 2,
+          "to_max_relations": null
         }
       },
       "NewHubuumClassRelationFromClass": {
@@ -23299,6 +23365,17 @@
               "null"
             ]
           },
+          "from_max_relations": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectRelationLimit",
+                "description": "Maximum relations allowed for each object in the class from the URL.\nOmit or set to `null` for unlimited."
+              }
+            ]
+          },
           "reverse_template_alias": {
             "type": [
               "string",
@@ -23308,12 +23385,25 @@
           "to_hubuum_class_id": {
             "type": "integer",
             "format": "int32"
+          },
+          "to_max_relations": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectRelationLimit",
+                "description": "Maximum relations allowed for each object in `to_hubuum_class_id`.\nOmit or set to `null` for unlimited."
+              }
+            ]
           }
         },
         "example": {
           "forward_template_alias": "rooms",
+          "from_max_relations": 1,
           "reverse_template_alias": "hosts",
-          "to_hubuum_class_id": 2
+          "to_hubuum_class_id": 2,
+          "to_max_relations": null
         }
       },
       "NewHubuumObject": {
@@ -23866,6 +23956,12 @@
             "type": "string"
           }
         }
+      },
+      "ObjectRelationLimit": {
+        "type": "integer",
+        "format": "int32",
+        "description": "Maximum number of object relations allowed for one object on one side of a class relation.",
+        "minimum": 1
       },
       "ObjectsByClass": {
         "type": "object",

--- a/docs/relationship_endpoints.md
+++ b/docs/relationship_endpoints.md
@@ -18,6 +18,28 @@ For filtering, sorting, and cursor pagination support, see:
 | Create | `POST` | `/api/v1/relations/classes` | Create a class relation |
 | Delete | `DELETE` | `/api/v1/relations/classes/{relation_id}` | Delete a class relation |
 
+Class relation create payloads accept `from_max_relations` and
+`to_max_relations`. Each is either a positive integer or `null`; `null` means
+unlimited. A limit applies independently to every object in the class on that
+side of the relation. For example, this allows each jack to relate to at most
+one room while allowing a room to contain any number of jacks:
+
+```json
+{
+  "from_hubuum_class_id": 10,
+  "to_hubuum_class_id": 20,
+  "forward_template_alias": "room",
+  "reverse_template_alias": "jacks",
+  "from_max_relations": 1,
+  "to_max_relations": null
+}
+```
+
+Class relations are stored in canonical class-ID order. If the supplied class
+IDs are reversed during creation, the aliases and limits are reversed with
+them, so each setting continues to apply to the class supplied on that side.
+Creating an object relation beyond either limit returns `409 Conflict`.
+
 ### Object relations
 
 | Operation | Method | Path | Description |

--- a/migrations/2026-07-30-000001_object_relation_cardinality/down.sql
+++ b/migrations/2026-07-30-000001_object_relation_cardinality/down.sql
@@ -1,0 +1,67 @@
+CREATE OR REPLACE FUNCTION enforce_class_relation_order()
+RETURNS TRIGGER AS $$
+DECLARE
+    temp INT;
+    temp_alias VARCHAR;
+BEGIN
+    IF NEW.from_hubuum_class_id > NEW.to_hubuum_class_id THEN
+        temp := NEW.from_hubuum_class_id;
+        NEW.from_hubuum_class_id := NEW.to_hubuum_class_id;
+        NEW.to_hubuum_class_id := temp;
+        temp_alias := NEW.forward_template_alias;
+        NEW.forward_template_alias := NEW.reverse_template_alias;
+        NEW.reverse_template_alias := temp_alias;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION validate_object_relation()
+RETURNS TRIGGER AS $$
+DECLARE
+    from_class_id INT;
+    to_class_id INT;
+    relation_from_class_id INT;
+    relation_to_class_id INT;
+BEGIN
+    IF NEW.from_hubuum_object_id = NEW.to_hubuum_object_id THEN
+        RAISE EXCEPTION 'Invalid object relation: objects cannot be related to themselves';
+    END IF;
+
+    SELECT hubuum_class_id
+    INTO from_class_id
+    FROM hubuumobject
+    WHERE id = NEW.from_hubuum_object_id;
+
+    SELECT hubuum_class_id
+    INTO to_class_id
+    FROM hubuumobject
+    WHERE id = NEW.to_hubuum_object_id;
+
+    IF from_class_id = to_class_id THEN
+        RAISE EXCEPTION 'Invalid object relation: objects cannot be related to the same classes';
+    END IF;
+
+    SELECT from_hubuum_class_id, to_hubuum_class_id
+    INTO relation_from_class_id, relation_to_class_id
+    FROM hubuumclass_relation
+    WHERE id = NEW.class_relation_id;
+
+    IF (from_class_id != relation_from_class_id OR to_class_id != relation_to_class_id) AND
+       (from_class_id != relation_to_class_id OR to_class_id != relation_from_class_id) THEN
+        RAISE EXCEPTION 'Invalid object relation: objects do not match the specified class relation';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+ALTER TABLE hubuumclass_relation
+    DROP CONSTRAINT hubuumclass_relation_from_max_relations_positive,
+    DROP CONSTRAINT hubuumclass_relation_to_max_relations_positive,
+    DROP COLUMN from_max_relations,
+    DROP COLUMN to_max_relations;
+
+ALTER TABLE hubuumclass_relation_history
+    DROP COLUMN from_max_relations,
+    DROP COLUMN to_max_relations;

--- a/migrations/2026-07-30-000001_object_relation_cardinality/up.sql
+++ b/migrations/2026-07-30-000001_object_relation_cardinality/up.sql
@@ -46,6 +46,10 @@ DECLARE
     relation_from_object_id INT;
     relation_to_object_id INT;
     current_relation_count BIGINT;
+    cardinality_constraint_name CONSTANT TEXT :=
+        'hubuumobject_relation_cardinality';
+    cardinality_error_template CONSTANT TEXT :=
+        'Object relation cardinality exceeded: object %s is limited to %s relations by class relation %s';
 BEGIN
     IF NEW.from_hubuum_object_id = NEW.to_hubuum_object_id THEN
         RAISE EXCEPTION 'Invalid object relation: objects cannot be related to themselves';
@@ -123,11 +127,15 @@ BEGIN
           );
 
         IF current_relation_count >= relation_from_max_relations THEN
-            RAISE EXCEPTION
-                'Object relation cardinality exceeded: object % is limited to % relations by class relation %',
-                relation_from_object_id,
-                relation_from_max_relations,
-                NEW.class_relation_id;
+            RAISE EXCEPTION USING
+                ERRCODE = '23514',
+                CONSTRAINT = cardinality_constraint_name,
+                MESSAGE = format(
+                    cardinality_error_template,
+                    relation_from_object_id,
+                    relation_from_max_relations,
+                    NEW.class_relation_id
+                );
         END IF;
     END IF;
 
@@ -143,11 +151,15 @@ BEGIN
           );
 
         IF current_relation_count >= relation_to_max_relations THEN
-            RAISE EXCEPTION
-                'Object relation cardinality exceeded: object % is limited to % relations by class relation %',
-                relation_to_object_id,
-                relation_to_max_relations,
-                NEW.class_relation_id;
+            RAISE EXCEPTION USING
+                ERRCODE = '23514',
+                CONSTRAINT = cardinality_constraint_name,
+                MESSAGE = format(
+                    cardinality_error_template,
+                    relation_to_object_id,
+                    relation_to_max_relations,
+                    NEW.class_relation_id
+                );
         END IF;
     END IF;
 

--- a/migrations/2026-07-30-000001_object_relation_cardinality/up.sql
+++ b/migrations/2026-07-30-000001_object_relation_cardinality/up.sql
@@ -65,8 +65,8 @@ BEGIN
         RAISE EXCEPTION 'Invalid object relation: objects cannot be related to the same classes';
     END IF;
 
-    -- The row lock serializes relation creation for this class relation. Without
-    -- it, two concurrent inserts could both observe a count below the limit.
+    -- Keep the class relation definition stable while this trigger runs without
+    -- serializing concurrent object relation inserts.
     SELECT
         from_hubuum_class_id,
         to_hubuum_class_id,
@@ -79,7 +79,7 @@ BEGIN
         relation_to_max_relations
     FROM hubuumclass_relation
     WHERE id = NEW.class_relation_id
-    FOR UPDATE;
+    FOR SHARE;
 
     IF (from_class_id != relation_from_class_id OR to_class_id != relation_to_class_id) AND
        (from_class_id != relation_to_class_id OR to_class_id != relation_from_class_id) THEN
@@ -92,6 +92,23 @@ BEGIN
     ELSE
         relation_from_object_id := NEW.to_hubuum_object_id;
         relation_to_object_id := NEW.from_hubuum_object_id;
+    END IF;
+
+    -- Serialize only inserts that compete for the same bounded object. Locking
+    -- in object-ID order prevents deadlocks when both sides are bounded.
+    IF relation_from_max_relations IS NOT NULL OR
+       relation_to_max_relations IS NOT NULL THEN
+        PERFORM id
+        FROM hubuumobject
+        WHERE (
+            relation_from_max_relations IS NOT NULL
+            AND id = relation_from_object_id
+        ) OR (
+            relation_to_max_relations IS NOT NULL
+            AND id = relation_to_object_id
+        )
+        ORDER BY id
+        FOR UPDATE;
     END IF;
 
     IF relation_from_max_relations IS NOT NULL THEN

--- a/migrations/2026-07-30-000001_object_relation_cardinality/up.sql
+++ b/migrations/2026-07-30-000001_object_relation_cardinality/up.sql
@@ -1,0 +1,139 @@
+ALTER TABLE hubuumclass_relation
+    ADD COLUMN from_max_relations INT NULL,
+    ADD COLUMN to_max_relations INT NULL,
+    ADD CONSTRAINT hubuumclass_relation_from_max_relations_positive
+        CHECK (from_max_relations IS NULL OR from_max_relations > 0),
+    ADD CONSTRAINT hubuumclass_relation_to_max_relations_positive
+        CHECK (to_max_relations IS NULL OR to_max_relations > 0);
+
+ALTER TABLE hubuumclass_relation_history
+    ADD COLUMN from_max_relations INT NULL,
+    ADD COLUMN to_max_relations INT NULL;
+
+CREATE OR REPLACE FUNCTION enforce_class_relation_order()
+RETURNS TRIGGER AS $$
+DECLARE
+    temp INT;
+    temp_alias VARCHAR;
+    temp_limit INT;
+BEGIN
+    IF NEW.from_hubuum_class_id > NEW.to_hubuum_class_id THEN
+        temp := NEW.from_hubuum_class_id;
+        NEW.from_hubuum_class_id := NEW.to_hubuum_class_id;
+        NEW.to_hubuum_class_id := temp;
+
+        temp_alias := NEW.forward_template_alias;
+        NEW.forward_template_alias := NEW.reverse_template_alias;
+        NEW.reverse_template_alias := temp_alias;
+
+        temp_limit := NEW.from_max_relations;
+        NEW.from_max_relations := NEW.to_max_relations;
+        NEW.to_max_relations := temp_limit;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION validate_object_relation()
+RETURNS TRIGGER AS $$
+DECLARE
+    from_class_id INT;
+    to_class_id INT;
+    relation_from_class_id INT;
+    relation_to_class_id INT;
+    relation_from_max_relations INT;
+    relation_to_max_relations INT;
+    relation_from_object_id INT;
+    relation_to_object_id INT;
+    current_relation_count BIGINT;
+BEGIN
+    IF NEW.from_hubuum_object_id = NEW.to_hubuum_object_id THEN
+        RAISE EXCEPTION 'Invalid object relation: objects cannot be related to themselves';
+    END IF;
+
+    SELECT hubuum_class_id
+    INTO from_class_id
+    FROM hubuumobject
+    WHERE id = NEW.from_hubuum_object_id;
+
+    SELECT hubuum_class_id
+    INTO to_class_id
+    FROM hubuumobject
+    WHERE id = NEW.to_hubuum_object_id;
+
+    IF from_class_id = to_class_id THEN
+        RAISE EXCEPTION 'Invalid object relation: objects cannot be related to the same classes';
+    END IF;
+
+    -- The row lock serializes relation creation for this class relation. Without
+    -- it, two concurrent inserts could both observe a count below the limit.
+    SELECT
+        from_hubuum_class_id,
+        to_hubuum_class_id,
+        from_max_relations,
+        to_max_relations
+    INTO
+        relation_from_class_id,
+        relation_to_class_id,
+        relation_from_max_relations,
+        relation_to_max_relations
+    FROM hubuumclass_relation
+    WHERE id = NEW.class_relation_id
+    FOR UPDATE;
+
+    IF (from_class_id != relation_from_class_id OR to_class_id != relation_to_class_id) AND
+       (from_class_id != relation_to_class_id OR to_class_id != relation_from_class_id) THEN
+        RAISE EXCEPTION 'Invalid object relation: objects do not match the specified class relation';
+    END IF;
+
+    IF from_class_id = relation_from_class_id THEN
+        relation_from_object_id := NEW.from_hubuum_object_id;
+        relation_to_object_id := NEW.to_hubuum_object_id;
+    ELSE
+        relation_from_object_id := NEW.to_hubuum_object_id;
+        relation_to_object_id := NEW.from_hubuum_object_id;
+    END IF;
+
+    IF relation_from_max_relations IS NOT NULL THEN
+        SELECT COUNT(*)
+        INTO current_relation_count
+        FROM hubuumobject_relation
+        WHERE class_relation_id = NEW.class_relation_id
+          AND id != NEW.id
+          AND (
+              from_hubuum_object_id = relation_from_object_id
+              OR to_hubuum_object_id = relation_from_object_id
+          );
+
+        IF current_relation_count >= relation_from_max_relations THEN
+            RAISE EXCEPTION
+                'Object relation cardinality exceeded: object % is limited to % relations by class relation %',
+                relation_from_object_id,
+                relation_from_max_relations,
+                NEW.class_relation_id;
+        END IF;
+    END IF;
+
+    IF relation_to_max_relations IS NOT NULL THEN
+        SELECT COUNT(*)
+        INTO current_relation_count
+        FROM hubuumobject_relation
+        WHERE class_relation_id = NEW.class_relation_id
+          AND id != NEW.id
+          AND (
+              from_hubuum_object_id = relation_to_object_id
+              OR to_hubuum_object_id = relation_to_object_id
+          );
+
+        IF current_relation_count >= relation_to_max_relations THEN
+            RAISE EXCEPTION
+                'Object relation cardinality exceeded: object % is limited to % relations by class relation %',
+                relation_to_object_id,
+                relation_to_max_relations,
+                NEW.class_relation_id;
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -1281,6 +1281,47 @@ mod tests {
     }
 
     #[test]
+    fn object_relation_limits_document_positive_nullable_fields() {
+        let json = openapi_json();
+        assert_eq!(
+            json.pointer("/components/schemas/ObjectRelationLimit/minimum"),
+            Some(&Value::from(1)),
+            "ObjectRelationLimit should document its positive-value invariant"
+        );
+
+        for schema_name in [
+            "HubuumClassRelation",
+            "ImportClassRelationInput",
+            "NewHubuumClassRelation",
+            "NewHubuumClassRelationFromClass",
+        ] {
+            for field in ["from_max_relations", "to_max_relations"] {
+                let variants = json
+                    .pointer(&format!(
+                        "/components/schemas/{schema_name}/properties/{field}/oneOf"
+                    ))
+                    .and_then(Value::as_array)
+                    .unwrap_or_else(|| {
+                        panic!("{schema_name}.{field} should be a nullable limit schema")
+                    });
+                assert!(
+                    variants.iter().any(|variant| {
+                        variant.get("type").and_then(Value::as_str) == Some("null")
+                    }),
+                    "{schema_name}.{field} should allow null for unlimited relations"
+                );
+                assert!(
+                    variants.iter().any(|variant| {
+                        variant.get("$ref").and_then(Value::as_str)
+                            == Some("#/components/schemas/ObjectRelationLimit")
+                    }),
+                    "{schema_name}.{field} should reference ObjectRelationLimit"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn object_data_json_patch_media_type_limits_and_statuses_are_documented() {
         let json = openapi_json();
         let operation_pointers = [

--- a/src/api/v1/handlers/classes/class_related.rs
+++ b/src/api/v1/handlers/classes/class_related.rs
@@ -129,6 +129,8 @@ async fn create_class_relation(
         to_hubuum_class_id: partial_relation.to_hubuum_class_id,
         forward_template_alias: partial_relation.forward_template_alias.clone(),
         reverse_template_alias: partial_relation.reverse_template_alias.clone(),
+        from_max_relations: partial_relation.from_max_relations,
+        to_max_relations: partial_relation.to_max_relations,
     };
 
     let resource = relation.to_resource_ref(&pool).await?;

--- a/src/api/v1/handlers/classes/class_related.rs
+++ b/src/api/v1/handlers/classes/class_related.rs
@@ -111,8 +111,6 @@ async fn create_class_relation(
     relation_data: web::Json<NewHubuumClassRelationFromClass>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    use crate::models::NewHubuumClassRelation;
-
     let user = &requestor.principal;
     let class_id = class_id.into_inner();
     let partial_relation = relation_data.into_inner();
@@ -124,14 +122,7 @@ async fn create_class_relation(
         to_class = partial_relation.to_hubuum_class_id,
     );
 
-    let relation = NewHubuumClassRelation {
-        from_hubuum_class_id: class_id.id(),
-        to_hubuum_class_id: partial_relation.to_hubuum_class_id,
-        forward_template_alias: partial_relation.forward_template_alias.clone(),
-        reverse_template_alias: partial_relation.reverse_template_alias.clone(),
-        from_max_relations: partial_relation.from_max_relations,
-        to_max_relations: partial_relation.to_max_relations,
-    };
+    let relation = partial_relation.into_relation(class_id);
 
     let resource = relation.to_resource_ref(&pool).await?;
     authorize_resources(

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -100,7 +100,7 @@ impl DbCallSite {
 /// Latest migration required by this binary. The test below keeps this value
 /// synchronized with the migration directory so readiness cannot silently lag
 /// behind a newly added schema change.
-pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260729000001";
+pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260730000001";
 
 #[derive(diesel::QueryableByName)]
 struct DatabaseSchemaReadiness {

--- a/src/db/traits/relations.rs
+++ b/src/db/traits/relations.rs
@@ -185,6 +185,8 @@ fn class_relation_snapshot(relation: &HubuumClassRelation) -> serde_json::Value 
         "to_hubuum_class_id": relation.to_hubuum_class_id,
         "forward_template_alias": relation.forward_template_alias,
         "reverse_template_alias": relation.reverse_template_alias,
+        "from_max_relations": relation.from_max_relations,
+        "to_max_relations": relation.to_max_relations,
         "created_at": relation.created_at,
         "updated_at": relation.updated_at,
     })
@@ -1082,6 +1084,10 @@ impl SaveClassRelationRecord for NewHubuumClassRelation {
                 &mut normalized.forward_template_alias,
                 &mut normalized.reverse_template_alias,
             );
+            std::mem::swap(
+                &mut normalized.from_max_relations,
+                &mut normalized.to_max_relations,
+            );
         }
 
         with_connection(pool, async |conn| {
@@ -1125,6 +1131,10 @@ impl SaveClassRelationRecord for NewHubuumClassRelation {
             std::mem::swap(
                 &mut normalized.forward_template_alias,
                 &mut normalized.reverse_template_alias,
+            );
+            std::mem::swap(
+                &mut normalized.from_max_relations,
+                &mut normalized.to_max_relations,
             );
         }
 

--- a/src/db/traits/relations.rs
+++ b/src/db/traits/relations.rs
@@ -16,7 +16,6 @@ use crate::models::{
     user_can_on_any,
 };
 use crate::permissions::{ResourceAttrs, ResourceKind, ResourceRef};
-use crate::utilities::aliases::normalize_template_alias;
 use crate::{
     apply_query_options, bind_transitive_filter_params, date_search, numeric_search, string_search,
     trace_query,
@@ -1063,32 +1062,7 @@ impl SaveClassRelationRecord for NewHubuumClassRelation {
     ) -> Result<HubuumClassRelation, ApiError> {
         use crate::schema::hubuumclass_relation::dsl::hubuumclass_relation;
 
-        if self.from_hubuum_class_id == self.to_hubuum_class_id {
-            return Err(ApiError::BadRequest(
-                "from_hubuum_class_id and to_hubuum_class_id cannot be the same".to_string(),
-            ));
-        }
-
-        let mut normalized = self.clone();
-        normalized.forward_template_alias =
-            normalize_template_alias_option(&normalized.forward_template_alias)?;
-        normalized.reverse_template_alias =
-            normalize_template_alias_option(&normalized.reverse_template_alias)?;
-
-        if normalized.from_hubuum_class_id > normalized.to_hubuum_class_id {
-            std::mem::swap(
-                &mut normalized.from_hubuum_class_id,
-                &mut normalized.to_hubuum_class_id,
-            );
-            std::mem::swap(
-                &mut normalized.forward_template_alias,
-                &mut normalized.reverse_template_alias,
-            );
-            std::mem::swap(
-                &mut normalized.from_max_relations,
-                &mut normalized.to_max_relations,
-            );
-        }
+        let normalized = self.clone().normalized()?;
 
         with_connection(pool, async |conn| {
             diesel::insert_into(hubuumclass_relation)
@@ -1111,32 +1085,7 @@ impl SaveClassRelationRecord for NewHubuumClassRelation {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id};
         use crate::schema::hubuumclass_relation::dsl::hubuumclass_relation;
 
-        if self.from_hubuum_class_id == self.to_hubuum_class_id {
-            return Err(ApiError::BadRequest(
-                "from_hubuum_class_id and to_hubuum_class_id cannot be the same".to_string(),
-            ));
-        }
-
-        let mut normalized = self.clone();
-        normalized.forward_template_alias =
-            normalize_template_alias_option(&normalized.forward_template_alias)?;
-        normalized.reverse_template_alias =
-            normalize_template_alias_option(&normalized.reverse_template_alias)?;
-
-        if normalized.from_hubuum_class_id > normalized.to_hubuum_class_id {
-            std::mem::swap(
-                &mut normalized.from_hubuum_class_id,
-                &mut normalized.to_hubuum_class_id,
-            );
-            std::mem::swap(
-                &mut normalized.forward_template_alias,
-                &mut normalized.reverse_template_alias,
-            );
-            std::mem::swap(
-                &mut normalized.from_max_relations,
-                &mut normalized.to_max_relations,
-            );
-        }
+        let normalized = self.clone().normalized()?;
 
         with_transaction(
             pool,
@@ -1172,10 +1121,6 @@ impl SaveClassRelationRecord for NewHubuumClassRelation {
         )
         .await
     }
-}
-
-fn normalize_template_alias_option(alias: &Option<String>) -> Result<Option<String>, ApiError> {
-    alias.as_deref().map(normalize_template_alias).transpose()
 }
 
 pub trait LoadObjectRelationRecord {

--- a/src/db/traits/task_import.rs
+++ b/src/db/traits/task_import.rs
@@ -15,6 +15,7 @@ use crate::models::{
     NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, NewPermission, Permission,
     Permissions, PermissionsList, Principal, RestoreTimestamps, ServiceAccount, UpdateCollection,
     UpdateHubuumClass, UpdateHubuumObject, UpdatePermission, User,
+    ObjectRelationLimit,
 };
 use crate::utilities::aliases::normalize_template_alias;
 
@@ -1468,6 +1469,8 @@ pub async fn create_class_relation_db(
     right: i32,
     forward_template_alias: Option<String>,
     reverse_template_alias: Option<String>,
+    from_max_relations: Option<ObjectRelationLimit>,
+    to_max_relations: Option<ObjectRelationLimit>,
     timestamps: Option<&RestoreTimestamps>,
 ) -> Result<HubuumClassRelation, ApiError> {
     use crate::schema::hubuumclass_relation::dsl::{created_at, hubuumclass_relation, updated_at};
@@ -1488,6 +1491,16 @@ pub async fn create_class_relation_db(
             reverse_template_alias
         } else {
             forward_template_alias
+        },
+        from_max_relations: if left <= right {
+            from_max_relations
+        } else {
+            to_max_relations
+        },
+        to_max_relations: if left <= right {
+            to_max_relations
+        } else {
+            from_max_relations
         },
     };
 

--- a/src/db/traits/task_import.rs
+++ b/src/db/traits/task_import.rs
@@ -15,9 +15,7 @@ use crate::models::{
     NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, NewPermission, Permission,
     Permissions, PermissionsList, Principal, RestoreTimestamps, ServiceAccount, UpdateCollection,
     UpdateHubuumClass, UpdateHubuumObject, UpdatePermission, User,
-    ObjectRelationLimit,
 };
-use crate::utilities::aliases::normalize_template_alias;
 
 pub async fn lookup_collections_by_name(
     pool: &DbPool,
@@ -1465,44 +1463,11 @@ pub async fn upsert_event_subscription_db(
 
 pub async fn create_class_relation_db(
     conn: &mut crate::db::DbConnection,
-    left: i32,
-    right: i32,
-    forward_template_alias: Option<String>,
-    reverse_template_alias: Option<String>,
-    from_max_relations: Option<ObjectRelationLimit>,
-    to_max_relations: Option<ObjectRelationLimit>,
+    new_relation: NewHubuumClassRelation,
     timestamps: Option<&RestoreTimestamps>,
 ) -> Result<HubuumClassRelation, ApiError> {
     use crate::schema::hubuumclass_relation::dsl::{created_at, hubuumclass_relation, updated_at};
-    let pair = normalize_pair(left, right);
-    let forward_template_alias =
-        normalize_template_alias_option(forward_template_alias.as_deref())?;
-    let reverse_template_alias =
-        normalize_template_alias_option(reverse_template_alias.as_deref())?;
-    let new_relation = NewHubuumClassRelation {
-        from_hubuum_class_id: pair.0,
-        to_hubuum_class_id: pair.1,
-        forward_template_alias: if left <= right {
-            forward_template_alias.clone()
-        } else {
-            reverse_template_alias.clone()
-        },
-        reverse_template_alias: if left <= right {
-            reverse_template_alias
-        } else {
-            forward_template_alias
-        },
-        from_max_relations: if left <= right {
-            from_max_relations
-        } else {
-            to_max_relations
-        },
-        to_max_relations: if left <= right {
-            to_max_relations
-        } else {
-            from_max_relations
-        },
-    };
+    let new_relation = new_relation.normalized()?;
 
     match timestamps {
         Some(timestamps) => diesel::insert_into(hubuumclass_relation)
@@ -1559,10 +1524,6 @@ pub async fn update_class_relation_timestamps_db(
         .map_err(ApiError::from)
     })
     .await
-}
-
-fn normalize_template_alias_option(alias: Option<&str>) -> Result<Option<String>, ApiError> {
-    alias.map(normalize_template_alias).transpose()
 }
 
 pub async fn create_object_relation_db(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,6 +15,7 @@ use crate::observability::metrics;
 const PUBLIC_INTERNAL_ERROR: &str = "An internal error occurred";
 const PUBLIC_SERVICE_UNAVAILABLE: &str = "Service temporarily unavailable";
 const PUBLIC_PERMISSION_BACKEND_UNAVAILABLE: &str = "Permission backend temporarily unavailable";
+const OBJECT_RELATION_CARDINALITY_CONSTRAINT: &str = "hubuumobject_relation_cardinality";
 
 // Exit codes for startup/initialization failures.
 // These help shell scripts and orchestration systems determine the failure mode.
@@ -316,7 +317,12 @@ impl From<DieselError> for ApiError {
                 debug!(message = message, error = ?e);
                 ApiError::NotFound(message)
             }
-            DieselError::DatabaseError(DatabaseErrorKind::CheckViolation, _) => {
+            DieselError::DatabaseError(DatabaseErrorKind::CheckViolation, ref info) => {
+                if info.constraint_name() == Some(OBJECT_RELATION_CARDINALITY_CONSTRAINT) {
+                    let message = info.message().to_string();
+                    debug!(message = message, error = ?e);
+                    return ApiError::Conflict(message);
+                }
                 let message = "Check constraint not met".to_string();
                 debug!(message = message, error = ?e);
                 ApiError::BadRequest(message)
@@ -326,10 +332,6 @@ impl From<DieselError> for ApiError {
                 if message.starts_with("Invalid object relation:") {
                     debug!(message = message, error = ?e);
                     return ApiError::BadRequest(message.to_string());
-                }
-                if message.starts_with("Object relation cardinality exceeded:") {
-                    debug!(message = message, error = ?e);
-                    return ApiError::Conflict(message.to_string());
                 }
                 error!(message = "Database error", error = ?e);
                 ApiError::DatabaseError(e.to_string())

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -327,6 +327,10 @@ impl From<DieselError> for ApiError {
                     debug!(message = message, error = ?e);
                     return ApiError::BadRequest(message.to_string());
                 }
+                if message.starts_with("Object relation cardinality exceeded:") {
+                    debug!(message = message, error = ?e);
+                    return ApiError::Conflict(message.to_string());
+                }
                 error!(message = "Database error", error = ?e);
                 ApiError::DatabaseError(e.to_string())
             }

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -46,7 +46,7 @@ use crate::models::{
     EventSinkID, EventSinkKind, EventSubscription, ExportContentType, ExportTemplateID,
     ExportTemplateKind, GroupID, HubuumClassRelationID, NewEventSink, NewEventSubscription,
     NewExportTemplate, NewHubuumClassRelation, NewHubuumObjectRelation, NewRemoteTargetRow,
-    NewUser, Permissions, PermissionsList, PrincipalID, PrincipalToken,
+    NewUser, ObjectRelationLimit, Permissions, PermissionsList, PrincipalID, PrincipalToken,
     PrincipalTokenCreateRequest, RemoteTargetID, Token, TokenID, UpdateExportTemplate,
     UpdateRemoteTargetRow, UpdateUser,
 };
@@ -1396,6 +1396,8 @@ async fn class_relation_writes_emit_lifecycle_events_in_transaction() {
         to_hubuum_class_id: class_b.id,
         forward_template_alias: Some("children".to_string()),
         reverse_template_alias: Some("parents".to_string()),
+        from_max_relations: Some(ObjectRelationLimit::new(1).unwrap()),
+        to_max_relations: None,
     }
     .save(&scope.pool, &context)
     .await
@@ -1432,6 +1434,10 @@ async fn class_relation_writes_emit_lifecycle_events_in_transaction() {
         rows[0].after.as_ref().unwrap()["forward_template_alias"],
         "children"
     );
+    assert_eq!(
+        rows[0].after.as_ref().unwrap()["from_max_relations"],
+        serde_json::json!(1)
+    );
 
     assert_eq!(rows[1].action, "deleted");
     assert_eq!(
@@ -1441,6 +1447,10 @@ async fn class_relation_writes_emit_lifecycle_events_in_transaction() {
     assert_eq!(
         rows[1].before.as_ref().unwrap()["reverse_template_alias"],
         "parents"
+    );
+    assert_eq!(
+        rows[1].before.as_ref().unwrap()["from_max_relations"],
+        serde_json::json!(1)
     );
     assert!(rows[1].after.is_none());
 
@@ -1484,6 +1494,8 @@ async fn object_relation_writes_emit_lifecycle_events_in_transaction() {
         to_hubuum_class_id: class_b.id,
         forward_template_alias: None,
         reverse_template_alias: None,
+        from_max_relations: None,
+        to_max_relations: None,
     }
     .save_without_events(&scope.pool)
     .await

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -3049,6 +3049,8 @@ mod tests {
             to_hubuum_class_id: hidden_adjacent_class.id,
             forward_template_alias: Some("secret_alias".to_string()),
             reverse_template_alias: Some("secret_reverse_alias".to_string()),
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(&context.pool)
         .await
@@ -3135,6 +3137,8 @@ mod tests {
             to_hubuum_class_id: intermediate_class.id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(&context.pool)
         .await
@@ -3443,6 +3447,8 @@ mod tests {
             to_hubuum_class_id: room_class.id,
             forward_template_alias: Some("rooms".to_string()),
             reverse_template_alias: Some("hosts".to_string()),
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(&scope.pool)
         .await

--- a/src/models/import.rs
+++ b/src/models/import.rs
@@ -12,8 +12,8 @@ use crate::models::export_template::{
 use crate::models::remote_target::validate_target_parts;
 use crate::models::{
     EventSinkKind, ExportContentType, ExportInclude, ExportLimits, ExportMissingDataPolicy,
-    ExportRelationContext, ExportScopeKind, ExportTemplateKind, Permissions, RemoteAuthConfig,
-    RemoteHttpMethod, RemoteTargetSubjectType,
+    ExportRelationContext, ExportScopeKind, ExportTemplateKind, ObjectRelationLimit, Permissions,
+    RemoteAuthConfig, RemoteHttpMethod, RemoteTargetSubjectType,
 };
 
 pub const CURRENT_IMPORT_VERSION: i32 = 1;
@@ -326,6 +326,8 @@ pub struct ImportClassRelationInput {
     pub to_class_key: Option<ClassKey>,
     pub forward_template_alias: Option<String>,
     pub reverse_template_alias: Option<String>,
+    pub from_max_relations: Option<ObjectRelationLimit>,
+    pub to_max_relations: Option<ObjectRelationLimit>,
     pub timestamps: Option<RestoreTimestamps>,
 }
 

--- a/src/models/relation.rs
+++ b/src/models/relation.rs
@@ -16,6 +16,7 @@ use crate::errors::ApiError;
 use crate::models::{HubuumClassID, HubuumClassWithPath, HubuumObjectID, HubuumObjectWithPath};
 use crate::permissions::{AuthzTarget, ResourceAttrs, ResourceKind, ResourceRef};
 use crate::traits::SelfAccessors;
+use crate::utilities::aliases::normalize_template_alias;
 use crate::{schema::hubuumclass_relation, schema::hubuumobject_relation};
 
 crate::int_id_newtype! {
@@ -133,6 +134,59 @@ pub struct NewHubuumClassRelationFromClass {
     /// Maximum relations allowed for each object in `to_hubuum_class_id`.
     /// Omit or set to `null` for unlimited.
     pub to_max_relations: Option<ObjectRelationLimit>,
+}
+
+impl NewHubuumClassRelation {
+    /// Validate and normalize a class relation before persistence.
+    ///
+    /// Class IDs are stored in ascending order. Directional aliases and limits
+    /// move with their corresponding class when the supplied order is reversed.
+    pub(crate) fn normalized(mut self) -> Result<Self, ApiError> {
+        if self.from_hubuum_class_id == self.to_hubuum_class_id {
+            return Err(ApiError::BadRequest(
+                "from_hubuum_class_id and to_hubuum_class_id cannot be the same".to_string(),
+            ));
+        }
+
+        self.forward_template_alias = self
+            .forward_template_alias
+            .as_deref()
+            .map(normalize_template_alias)
+            .transpose()?;
+        self.reverse_template_alias = self
+            .reverse_template_alias
+            .as_deref()
+            .map(normalize_template_alias)
+            .transpose()?;
+
+        if self.from_hubuum_class_id > self.to_hubuum_class_id {
+            std::mem::swap(&mut self.from_hubuum_class_id, &mut self.to_hubuum_class_id);
+            std::mem::swap(
+                &mut self.forward_template_alias,
+                &mut self.reverse_template_alias,
+            );
+            std::mem::swap(&mut self.from_max_relations, &mut self.to_max_relations);
+        }
+
+        Ok(self)
+    }
+}
+
+impl NewHubuumClassRelationFromClass {
+    /// Complete a class-scoped relation request with the class from the route.
+    pub(crate) fn into_relation(
+        self,
+        from_hubuum_class_id: HubuumClassID,
+    ) -> NewHubuumClassRelation {
+        NewHubuumClassRelation {
+            from_hubuum_class_id: from_hubuum_class_id.id(),
+            to_hubuum_class_id: self.to_hubuum_class_id,
+            forward_template_alias: self.forward_template_alias,
+            reverse_template_alias: self.reverse_template_alias,
+            from_max_relations: self.from_max_relations,
+            to_max_relations: self.to_max_relations,
+        }
+    }
 }
 
 crate::int_id_newtype! {
@@ -536,6 +590,39 @@ pub mod tests {
     use crate::models::{HubuumClass, HubuumObject};
     use crate::tests::{TestContext, TestScope, test_context};
     use crate::traits::{CanDelete, CanSave, SelfAccessors};
+
+    #[test]
+    fn class_relation_normalization_keeps_directional_settings_with_their_classes() {
+        let normalized = NewHubuumClassRelation {
+            from_hubuum_class_id: 20,
+            to_hubuum_class_id: 10,
+            forward_template_alias: Some("Jack Room".to_string()),
+            reverse_template_alias: Some("Room Jacks".to_string()),
+            from_max_relations: Some(ObjectRelationLimit::new(1).unwrap()),
+            to_max_relations: Some(ObjectRelationLimit::new(2).unwrap()),
+        }
+        .normalized()
+        .expect("class relation should normalize");
+
+        assert_eq!(normalized.from_hubuum_class_id, 10);
+        assert_eq!(normalized.to_hubuum_class_id, 20);
+        assert_eq!(
+            normalized.forward_template_alias.as_deref(),
+            Some("room_jacks")
+        );
+        assert_eq!(
+            normalized.reverse_template_alias.as_deref(),
+            Some("jack_room")
+        );
+        assert_eq!(
+            normalized.from_max_relations,
+            Some(ObjectRelationLimit::new(2).unwrap())
+        );
+        assert_eq!(
+            normalized.to_max_relations,
+            Some(ObjectRelationLimit::new(1).unwrap())
+        );
+    }
 
     pub async fn create_collection_and_classes(
         suffix: &str,

--- a/src/models/relation.rs
+++ b/src/models/relation.rs
@@ -1,9 +1,15 @@
 use crate::db::prelude::*;
 use async_trait::async_trait;
+use diesel::deserialize::{self, FromSql, FromSqlRow};
+use diesel::expression::AsExpression;
+use diesel::pg::{Pg, PgValue};
+use diesel::serialize::{self, Output, ToSql};
 use diesel::sql_types::{Array, Bool, Integer, Jsonb, Nullable, Text, Timestamp};
 
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+use utoipa::openapi::schema::{Schema, Type};
+use utoipa::openapi::{KnownFormat, ObjectBuilder, RefOr, SchemaFormat};
 
 use crate::db::DbPool;
 use crate::errors::ApiError;
@@ -18,6 +24,67 @@ crate::int_id_newtype! {
     noun = "class relation id";
 }
 
+/// Maximum number of object relations allowed for one object on one side of a
+/// class relation.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, AsExpression, FromSqlRow)]
+#[diesel(sql_type = Integer)]
+pub struct ObjectRelationLimit(i32);
+
+impl ObjectRelationLimit {
+    /// Create a positive object-relation limit.
+    pub fn new(value: i32) -> Result<Self, ApiError> {
+        if value <= 0 {
+            return Err(ApiError::BadRequest(format!(
+                "Invalid object relation limit '{value}': must be a positive integer"
+            )));
+        }
+        Ok(Self(value))
+    }
+
+    /// Return the underlying positive limit.
+    pub fn value(self) -> i32 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for ObjectRelationLimit {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = i32::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+impl FromSql<Integer, Pg> for ObjectRelationLimit {
+    fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
+        let value = i32::from_sql(value)?;
+        Self::new(value).map_err(|error| error.to_string().into())
+    }
+}
+
+impl ToSql<Integer, Pg> for ObjectRelationLimit {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+        <i32 as ToSql<Integer, Pg>>::to_sql(&self.0, out)
+    }
+}
+
+impl utoipa::PartialSchema for ObjectRelationLimit {
+    fn schema() -> RefOr<Schema> {
+        ObjectBuilder::new()
+            .schema_type(Type::Integer)
+            .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32)))
+            .minimum(Some(1))
+            .description(Some(
+                "Maximum number of object relations allowed for one object on one side of a class relation.",
+            ))
+            .into()
+    }
+}
+
+impl ToSchema for ObjectRelationLimit {}
+
 #[derive(Debug, Serialize, Deserialize, Queryable, Clone, PartialEq, Eq, ToSchema)]
 #[diesel(table_name = hubuumclass_relation)]
 pub struct HubuumClassRelation {
@@ -28,6 +95,12 @@ pub struct HubuumClassRelation {
     pub reverse_template_alias: Option<String>,
     pub created_at: chrono::NaiveDateTime,
     pub updated_at: chrono::NaiveDateTime,
+    /// Maximum relations allowed for each object in `from_hubuum_class_id`.
+    /// `None` means unlimited.
+    pub from_max_relations: Option<ObjectRelationLimit>,
+    /// Maximum relations allowed for each object in `to_hubuum_class_id`.
+    /// `None` means unlimited.
+    pub to_max_relations: Option<ObjectRelationLimit>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable, ToSchema)]
@@ -38,6 +111,12 @@ pub struct NewHubuumClassRelation {
     pub to_hubuum_class_id: i32,
     pub forward_template_alias: Option<String>,
     pub reverse_template_alias: Option<String>,
+    /// Maximum relations allowed for each object in `from_hubuum_class_id`.
+    /// Omit or set to `null` for unlimited.
+    pub from_max_relations: Option<ObjectRelationLimit>,
+    /// Maximum relations allowed for each object in `to_hubuum_class_id`.
+    /// Omit or set to `null` for unlimited.
+    pub to_max_relations: Option<ObjectRelationLimit>,
 }
 
 /// To create new relations between classes from within a class
@@ -48,6 +127,12 @@ pub struct NewHubuumClassRelationFromClass {
     pub to_hubuum_class_id: i32,
     pub forward_template_alias: Option<String>,
     pub reverse_template_alias: Option<String>,
+    /// Maximum relations allowed for each object in the class from the URL.
+    /// Omit or set to `null` for unlimited.
+    pub from_max_relations: Option<ObjectRelationLimit>,
+    /// Maximum relations allowed for each object in `to_hubuum_class_id`.
+    /// Omit or set to `null` for unlimited.
+    pub to_max_relations: Option<ObjectRelationLimit>,
 }
 
 crate::int_id_newtype! {
@@ -293,6 +378,8 @@ fn new_hubuum_class_relation_example() -> NewHubuumClassRelation {
         to_hubuum_class_id: 2,
         forward_template_alias: Some("rooms".to_string()),
         reverse_template_alias: Some("hosts".to_string()),
+        from_max_relations: Some(ObjectRelationLimit::new(1).expect("valid example limit")),
+        to_max_relations: None,
     }
 }
 
@@ -301,6 +388,8 @@ fn new_hubuum_class_relation_from_class_example() -> NewHubuumClassRelationFromC
         to_hubuum_class_id: 2,
         forward_template_alias: Some("rooms".to_string()),
         reverse_template_alias: Some("hosts".to_string()),
+        from_max_relations: Some(ObjectRelationLimit::new(1).expect("valid example limit")),
+        to_max_relations: None,
     }
 }
 
@@ -500,6 +589,8 @@ pub mod tests {
             to_hubuum_class_id: class2.id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         };
 
         let relation = relation.save_without_events(pool).await.unwrap();
@@ -512,6 +603,8 @@ pub mod tests {
                 to_hubuum_class_id: class1.id,
                 forward_template_alias: None,
                 reverse_template_alias: None,
+                from_max_relations: None,
+                to_max_relations: None,
             }
         } else {
             NewHubuumClassRelation {
@@ -519,6 +612,8 @@ pub mod tests {
                 to_hubuum_class_id: class2.id,
                 forward_template_alias: None,
                 reverse_template_alias: None,
+                from_max_relations: None,
+                to_max_relations: None,
             }
         };
 
@@ -574,6 +669,8 @@ pub mod tests {
             to_hubuum_class_id: class1.id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         };
 
         match relation.save_without_events(&pool).await {
@@ -602,6 +699,8 @@ pub mod tests {
             to_hubuum_class_id: class1.id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         };
         match old_relation.save_without_events(&pool).await {
             Err(ApiError::Conflict(_)) => {}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -324,6 +324,8 @@ diesel::table! {
         reverse_template_alias -> Nullable<Varchar>,
         created_at -> Timestamp,
         updated_at -> Timestamp,
+        from_max_relations -> Nullable<Int4>,
+        to_max_relations -> Nullable<Int4>,
     }
 }
 
@@ -344,6 +346,8 @@ diesel::table! {
         actor_kind -> Nullable<Text>,
         initiator_user_id -> Nullable<Int4>,
         task_id -> Nullable<Int4>,
+        from_max_relations -> Nullable<Int4>,
+        to_max_relations -> Nullable<Int4>,
     }
 }
 

--- a/src/tasks/execution.rs
+++ b/src/tasks/execution.rs
@@ -7,8 +7,8 @@ use crate::models::{
     Collection, EventSinkKey, GroupKey, HubuumClass, HubuumObject, IdentityScopeKey,
     ImportAtomicity, ImportClassRelationInput, ImportCollisionPolicy, ImportExportTemplateInput,
     ImportMode, ImportObjectRelationInput, ImportPermissionPolicy, ImportPrincipalSubtype,
-    ImportRequest, NewTaskEventRecord, PrincipalKey, TaskRecord, TaskResultCounts, TaskStatus,
-    TokenScope,
+    ImportRequest, NewHubuumClassRelation, NewTaskEventRecord, PrincipalKey, TaskRecord,
+    TaskResultCounts, TaskStatus, TokenScope,
 };
 use crate::observability::metrics;
 use crate::traits::BackendContext;
@@ -730,12 +730,14 @@ pub(super) async fn execute_planned_item(
                 resolve_class_relation_runtime(conn, runtime, input).await?;
             create_class_relation_db(
                 conn,
-                from_class.id,
-                to_class.id,
-                input.forward_template_alias.clone(),
-                input.reverse_template_alias.clone(),
-                input.from_max_relations,
-                input.to_max_relations,
+                NewHubuumClassRelation {
+                    from_hubuum_class_id: from_class.id,
+                    to_hubuum_class_id: to_class.id,
+                    forward_template_alias: input.forward_template_alias.clone(),
+                    reverse_template_alias: input.reverse_template_alias.clone(),
+                    from_max_relations: input.from_max_relations,
+                    to_max_relations: input.to_max_relations,
+                },
                 input.timestamps.as_ref(),
             )
             .await?;

--- a/src/tasks/execution.rs
+++ b/src/tasks/execution.rs
@@ -734,6 +734,8 @@ pub(super) async fn execute_planned_item(
                 to_class.id,
                 input.forward_template_alias.clone(),
                 input.reverse_template_alias.clone(),
+                input.from_max_relations,
+                input.to_max_relations,
                 input.timestamps.as_ref(),
             )
             .await?;

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -278,6 +278,8 @@ async fn relation_timestamp_overwrite_requires_update_permission(
         to_hubuum_class_id: classes[1].id,
         forward_template_alias: None,
         reverse_template_alias: None,
+        from_max_relations: None,
+        to_max_relations: None,
     }
     .save_without_events(&context.pool)
     .await
@@ -343,6 +345,8 @@ async fn relation_timestamp_overwrite_requires_update_permission(
                 to_class_key: Some(class_key(1)),
                 forward_template_alias: None,
                 reverse_template_alias: None,
+                from_max_relations: None,
+                to_max_relations: None,
                 timestamps: Some(timestamps),
             });
         }
@@ -660,10 +664,14 @@ async fn unchanged_core_import_overwrite_returns_current_row_without_history(
         }
         let class_relation = create_class_relation_db(
             conn,
-            classes[0].id,
-            classes[1].id,
-            None,
-            None,
+            NewHubuumClassRelation {
+                from_hubuum_class_id: classes[0].id,
+                to_hubuum_class_id: classes[1].id,
+                forward_template_alias: None,
+                reverse_template_alias: None,
+                from_max_relations: None,
+                to_max_relations: None,
+            },
             Some(&timestamps),
         )
         .await?;
@@ -808,8 +816,19 @@ async fn core_imports_without_timestamps_use_database_transaction_time() {
             classes.push(class);
             objects.push(object);
         }
-        let class_relation =
-            create_class_relation_db(conn, classes[0].id, classes[1].id, None, None, None).await?;
+        let class_relation = create_class_relation_db(
+            conn,
+            NewHubuumClassRelation {
+                from_hubuum_class_id: classes[0].id,
+                to_hubuum_class_id: classes[1].id,
+                forward_template_alias: None,
+                reverse_template_alias: None,
+                from_max_relations: None,
+                to_max_relations: None,
+            },
+            None,
+        )
+        .await?;
         let object_relation =
             create_object_relation_db(conn, &objects[0], &objects[1], None).await?;
         let actual = [

--- a/src/tests/permissions/auth_target.rs
+++ b/src/tests/permissions/auth_target.rs
@@ -152,6 +152,8 @@ async fn class_relation_cross_collection_populates_from_to_collections() {
         to_hubuum_class_id: class_b.id,
         forward_template_alias: None,
         reverse_template_alias: None,
+        from_max_relations: None,
+        to_max_relations: None,
     }
     .save_without_events(&pool)
     .await
@@ -218,6 +220,8 @@ async fn class_relation_same_collection_populates_collection_id() {
         to_hubuum_class_id: class_b.id,
         forward_template_alias: None,
         reverse_template_alias: None,
+        from_max_relations: None,
+        to_max_relations: None,
     }
     .save_without_events(&pool)
     .await
@@ -277,6 +281,8 @@ async fn object_relation_cross_collection_populates_all_fields() {
         to_hubuum_class_id: class_b.id,
         forward_template_alias: None,
         reverse_template_alias: None,
+        from_max_relations: None,
+        to_max_relations: None,
     }
     .save_without_events(&pool)
     .await
@@ -394,6 +400,8 @@ async fn local_backend_relation_and_check_denies_partial_permission() {
         to_hubuum_class_id: class_b.id,
         forward_template_alias: None,
         reverse_template_alias: None,
+        from_max_relations: None,
+        to_max_relations: None,
     }
     .save_without_events(&pool)
     .await

--- a/src/tests/search/classrelations.rs
+++ b/src/tests/search/classrelations.rs
@@ -49,6 +49,8 @@ mod test {
             to_hubuum_class_id: classes[1].id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(pool)
         .await
@@ -59,6 +61,8 @@ mod test {
             to_hubuum_class_id: classes[2].id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(pool)
         .await

--- a/src/tests/storage_performance.rs
+++ b/src/tests/storage_performance.rs
@@ -556,6 +556,8 @@ async fn object_relation_create_has_a_fixed_query_and_checkout_budget() {
         to_hubuum_class_id: class_two.id,
         forward_template_alias: Some("seconds".to_string()),
         reverse_template_alias: Some("firsts".to_string()),
+        from_max_relations: None,
+        to_max_relations: None,
     }
     .save_without_events(&scope.pool)
     .await

--- a/src/utilities/aliases.rs
+++ b/src/utilities/aliases.rs
@@ -1,8 +1,7 @@
 //! Shared normalization for export template aliases.
 //!
-//! Relation creation (`db::traits::relations`) and import processing
-//! (`db::traits::task_import`) both validate and canonicalize user-supplied template aliases the
-//! same way, so the rule lives here once.
+//! Class relation requests and import processing both validate user-supplied
+//! template aliases the same way, so the rule lives here once.
 
 use crate::errors::ApiError;
 

--- a/tests/api_core_data_suite/querying.rs
+++ b/tests/api_core_data_suite/querying.rs
@@ -189,6 +189,8 @@ mod tests {
             to_hubuum_class_id: classes[1].id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(&context.pool)
         .await
@@ -198,6 +200,8 @@ mod tests {
             to_hubuum_class_id: classes[2].id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(&context.pool)
         .await

--- a/tests/api_core_data_suite/relations.rs
+++ b/tests/api_core_data_suite/relations.rs
@@ -4,11 +4,12 @@ mod tests {
     use rstest::rstest;
 
     use crate::db::DbPool;
+    use crate::errors::ApiError;
     use crate::models::{
         CollectionID, HubuumClass, HubuumClassRelation, HubuumClassWithPath, HubuumObject,
         HubuumObjectRelation, HubuumObjectWithPath, NewHubuumClass, NewHubuumClassRelation,
-        NewHubuumClassRelationFromClass, NewHubuumObject, NewHubuumObjectRelation, Permissions,
-        RelatedClassGraph, RelatedObjectGraph,
+        NewHubuumClassRelationFromClass, NewHubuumObject, NewHubuumObjectRelation,
+        ObjectRelationLimit, Permissions, RelatedClassGraph, RelatedObjectGraph,
     };
     use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER};
     use crate::traits::{CanSave, PermissionController, SelfAccessors};
@@ -65,6 +66,8 @@ mod tests {
             to_hubuum_class_id: to_class.id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         };
 
         relation.save_without_events(pool).await.unwrap()
@@ -704,6 +707,8 @@ mod tests {
             to_hubuum_class_id: classes[1].id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         };
 
         let endpoint = format!("/api/v1/classes/{}/relations/", classes[0].id);
@@ -740,11 +745,15 @@ mod tests {
             to_hubuum_class_id: classes[1].id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         };
         let reverse_content = NewHubuumClassRelationFromClass {
             to_hubuum_class_id: classes[0].id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         };
 
         let forward_endpoint = format!("/api/v1/classes/{}/relations/", classes[0].id);
@@ -778,6 +787,199 @@ mod tests {
         let resp = assert_response_status(resp, StatusCode::OK).await;
         let relation_response_from_global: HubuumClassRelation = test::read_body_json(resp).await;
         assert_eq!(relation_response, relation_response_from_global);
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_class_relation_limits_follow_classes_when_relation_order_is_normalized(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "class_relation_limits_normalized_order").await;
+        let content = NewHubuumClassRelation {
+            from_hubuum_class_id: classes[1].id,
+            to_hubuum_class_id: classes[0].id,
+            forward_template_alias: None,
+            reverse_template_alias: None,
+            from_max_relations: Some(ObjectRelationLimit::new(1).unwrap()),
+            to_max_relations: Some(ObjectRelationLimit::new(2).unwrap()),
+        };
+
+        let resp = post_request(
+            &context.pool,
+            &context.admin_token,
+            CLASS_RELATIONS_ENDPOINT,
+            &content,
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::CREATED).await;
+        let relation: HubuumClassRelation = test::read_body_json(resp).await;
+
+        assert_eq!(relation.from_hubuum_class_id, classes[0].id);
+        assert_eq!(relation.to_hubuum_class_id, classes[1].id);
+        assert_eq!(
+            relation.from_max_relations,
+            Some(ObjectRelationLimit::new(2).unwrap())
+        );
+        assert_eq!(
+            relation.to_max_relations,
+            Some(ObjectRelationLimit::new(1).unwrap())
+        );
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_object_relation_limit_rejects_an_extra_relation_for_the_same_object(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "object_relation_limit").await;
+        let relation = NewHubuumClassRelation {
+            from_hubuum_class_id: classes[0].id,
+            to_hubuum_class_id: classes[1].id,
+            forward_template_alias: None,
+            reverse_template_alias: None,
+            from_max_relations: Some(ObjectRelationLimit::new(1).unwrap()),
+            to_max_relations: None,
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let objects = create_objects_in_classes(&context.pool, &classes).await;
+        let second_target = NewHubuumObject {
+            hubuum_class_id: classes[1].id,
+            collection_id: classes[1].collection_id,
+            name: format!("second_object_in_{}", classes[1].name),
+            description: "Second relation target".to_string(),
+            data: serde_json::json!({}),
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let first_relation = NewHubuumObjectRelation {
+            from_hubuum_object_id: objects[0].id,
+            to_hubuum_object_id: objects[1].id,
+            class_relation_id: relation.id,
+        };
+        let extra_relation = NewHubuumObjectRelation {
+            from_hubuum_object_id: objects[0].id,
+            to_hubuum_object_id: second_target.id,
+            class_relation_id: relation.id,
+        };
+
+        let resp = post_request(
+            &context.pool,
+            &context.admin_token,
+            OBJECT_RELATIONS_ENDPOINT,
+            &first_relation,
+        )
+        .await;
+        let _ = assert_response_status(resp, StatusCode::CREATED).await;
+
+        let resp = post_request(
+            &context.pool,
+            &context.admin_token,
+            OBJECT_RELATIONS_ENDPOINT,
+            &extra_relation,
+        )
+        .await;
+        let resp = assert_response_status(resp, StatusCode::CONFLICT).await;
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert!(
+            body["message"]
+                .as_str()
+                .is_some_and(|message| message.starts_with(
+                    "Object relation cardinality exceeded:"
+                ))
+        );
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_object_relation_limit_serializes_concurrent_creates(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "object_relation_limit_concurrent").await;
+        let relation = NewHubuumClassRelation {
+            from_hubuum_class_id: classes[0].id,
+            to_hubuum_class_id: classes[1].id,
+            forward_template_alias: None,
+            reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: Some(ObjectRelationLimit::new(1).unwrap()),
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let objects = create_objects_in_classes(&context.pool, &classes).await;
+        let second_source = NewHubuumObject {
+            hubuum_class_id: classes[0].id,
+            collection_id: classes[0].collection_id,
+            name: format!("second_object_in_{}", classes[0].name),
+            description: "Second relation source".to_string(),
+            data: serde_json::json!({}),
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let first_relation = NewHubuumObjectRelation {
+            from_hubuum_object_id: objects[0].id,
+            to_hubuum_object_id: objects[1].id,
+            class_relation_id: relation.id,
+        };
+        let competing_relation = NewHubuumObjectRelation {
+            from_hubuum_object_id: second_source.id,
+            to_hubuum_object_id: objects[1].id,
+            class_relation_id: relation.id,
+        };
+
+        let (first_result, competing_result) = tokio::join!(
+            first_relation.save_without_events(&context.pool),
+            competing_relation.save_without_events(&context.pool)
+        );
+        let results = [first_result, competing_result];
+
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert!(results.iter().any(|result| {
+            matches!(
+                result,
+                Err(ApiError::Conflict(message))
+                    if message.starts_with("Object relation cardinality exceeded:")
+            )
+        }));
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_class_relation_limit_must_be_positive(#[future(awt)] test_context: TestContext) {
+        let context = test_context;
+        let classes = create_test_classes(&context, "class_relation_limit_positive").await;
+        let content = serde_json::json!({
+            "from_hubuum_class_id": classes[0].id,
+            "to_hubuum_class_id": classes[1].id,
+            "forward_template_alias": null,
+            "reverse_template_alias": null,
+            "from_max_relations": 0,
+            "to_max_relations": null
+        });
+
+        let resp = post_request(
+            &context.pool,
+            &context.admin_token,
+            CLASS_RELATIONS_ENDPOINT,
+            &content,
+        )
+        .await;
+        let _ = assert_response_status(resp, StatusCode::BAD_REQUEST).await;
 
         cleanup(&classes).await;
     }

--- a/tests/api_core_data_suite/relations.rs
+++ b/tests/api_core_data_suite/relations.rs
@@ -1,9 +1,12 @@
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use crate::db::prelude::*;
     use actix_web::{http::StatusCode, test};
     use rstest::rstest;
 
-    use crate::db::DbPool;
+    use crate::db::{DbPool, with_transaction};
     use crate::errors::ApiError;
     use crate::models::{
         CollectionID, HubuumClass, HubuumClassRelation, HubuumClassWithPath, HubuumObject,
@@ -954,6 +957,109 @@ mod tests {
                     if message.starts_with("Object relation cardinality exceeded:")
             )
         }));
+
+        cleanup(&classes).await;
+    }
+
+    #[rstest]
+    #[case::unlimited(false)]
+    #[case::bounded_objects(true)]
+    #[actix_web::test]
+    async fn test_object_relation_limit_does_not_serialize_unrelated_creates(
+        #[case] bounded: bool,
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let case_name = if bounded { "bounded" } else { "unlimited" };
+        let classes = create_test_classes(
+            &context,
+            &format!("unrelated_object_relations_concurrent_{case_name}"),
+        )
+        .await;
+        let relation = NewHubuumClassRelation {
+            from_hubuum_class_id: classes[0].id,
+            to_hubuum_class_id: classes[1].id,
+            forward_template_alias: None,
+            reverse_template_alias: None,
+            from_max_relations: bounded
+                .then(|| ObjectRelationLimit::new(1).expect("valid test limit")),
+            to_max_relations: None,
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let objects = create_objects_in_classes(&context.pool, &classes).await;
+        let second_source = NewHubuumObject {
+            hubuum_class_id: classes[0].id,
+            collection_id: classes[0].collection_id,
+            name: format!("second_object_in_{}", classes[0].name),
+            description: "Independent relation source".to_string(),
+            data: serde_json::json!({}),
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let second_target = NewHubuumObject {
+            hubuum_class_id: classes[1].id,
+            collection_id: classes[1].collection_id,
+            name: format!("second_object_in_{}", classes[1].name),
+            description: "Independent relation target".to_string(),
+            data: serde_json::json!({}),
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let held_relation = NewHubuumObjectRelation {
+            from_hubuum_object_id: objects[0].id,
+            to_hubuum_object_id: objects[1].id,
+            class_relation_id: relation.id,
+        };
+        let independent_relation = NewHubuumObjectRelation {
+            from_hubuum_object_id: second_source.id,
+            to_hubuum_object_id: second_target.id,
+            class_relation_id: relation.id,
+        };
+        let (inserted_tx, inserted_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let insert_pool = context.pool.clone();
+
+        let held_insert = actix_web::rt::spawn(async move {
+            with_transaction(&insert_pool, async move |conn| -> Result<(), ApiError> {
+                use crate::schema::hubuumobject_relation;
+
+                diesel::insert_into(hubuumobject_relation::table)
+                    .values(&held_relation)
+                    .execute(conn)
+                    .await?;
+                inserted_tx
+                    .send(())
+                    .expect("held insert should still be running");
+                release_rx
+                    .await
+                    .expect("test should release the held insert");
+                Ok(())
+            })
+            .await
+        });
+
+        inserted_rx
+            .await
+            .expect("held object relation insert ended unexpectedly");
+        let independent_result = tokio::time::timeout(
+            Duration::from_secs(5),
+            independent_relation.save_without_events(&context.pool),
+        )
+        .await;
+        release_tx
+            .send(())
+            .expect("held insert should wait for release");
+        held_insert
+            .await
+            .expect("held insert task should complete")
+            .expect("held insert transaction should commit");
+        independent_result
+            .expect("an unrelated object relation insert must not wait for the held transaction")
+            .expect("independent object relation should be created");
 
         cleanup(&classes).await;
     }

--- a/tests/api_core_data_suite/relations.rs
+++ b/tests/api_core_data_suite/relations.rs
@@ -201,6 +201,23 @@ mod tests {
         objects
     }
 
+    async fn create_relation_test_object(
+        pool: &DbPool,
+        class: &HubuumClass,
+        label: &str,
+    ) -> HubuumObject {
+        NewHubuumObject {
+            hubuum_class_id: class.id,
+            collection_id: class.collection_id,
+            name: format!("{label}_in_{}", class.name),
+            description: format!("{label} in {}", class.description),
+            data: serde_json::json!({}),
+        }
+        .save_without_events(pool)
+        .await
+        .expect("relation test object should be created")
+    }
+
     #[rstest]
     #[actix_web::test]
     async fn test_get_class_relations_list(#[future(awt)] test_context: TestContext) {
@@ -804,8 +821,8 @@ mod tests {
         let content = NewHubuumClassRelation {
             from_hubuum_class_id: classes[1].id,
             to_hubuum_class_id: classes[0].id,
-            forward_template_alias: None,
-            reverse_template_alias: None,
+            forward_template_alias: Some("Jack Room".to_string()),
+            reverse_template_alias: Some("Room Jacks".to_string()),
             from_max_relations: Some(ObjectRelationLimit::new(1).unwrap()),
             to_max_relations: Some(ObjectRelationLimit::new(2).unwrap()),
         };
@@ -822,6 +839,14 @@ mod tests {
 
         assert_eq!(relation.from_hubuum_class_id, classes[0].id);
         assert_eq!(relation.to_hubuum_class_id, classes[1].id);
+        assert_eq!(
+            relation.forward_template_alias.as_deref(),
+            Some("room_jacks")
+        );
+        assert_eq!(
+            relation.reverse_template_alias.as_deref(),
+            Some("jack_room")
+        );
         assert_eq!(
             relation.from_max_relations,
             Some(ObjectRelationLimit::new(2).unwrap())
@@ -853,16 +878,8 @@ mod tests {
         .await
         .unwrap();
         let objects = create_objects_in_classes(&context.pool, &classes).await;
-        let second_target = NewHubuumObject {
-            hubuum_class_id: classes[1].id,
-            collection_id: classes[1].collection_id,
-            name: format!("second_object_in_{}", classes[1].name),
-            description: "Second relation target".to_string(),
-            data: serde_json::json!({}),
-        }
-        .save_without_events(&context.pool)
-        .await
-        .unwrap();
+        let second_target =
+            create_relation_test_object(&context.pool, &classes[1], "second_relation_target").await;
         let first_relation = NewHubuumObjectRelation {
             from_hubuum_object_id: objects[0].id,
             to_hubuum_object_id: objects[1].id,
@@ -922,16 +939,8 @@ mod tests {
         .await
         .unwrap();
         let objects = create_objects_in_classes(&context.pool, &classes).await;
-        let second_source = NewHubuumObject {
-            hubuum_class_id: classes[0].id,
-            collection_id: classes[0].collection_id,
-            name: format!("second_object_in_{}", classes[0].name),
-            description: "Second relation source".to_string(),
-            data: serde_json::json!({}),
-        }
-        .save_without_events(&context.pool)
-        .await
-        .unwrap();
+        let second_source =
+            create_relation_test_object(&context.pool, &classes[0], "second_relation_source").await;
         let first_relation = NewHubuumObjectRelation {
             from_hubuum_object_id: objects[0].id,
             to_hubuum_object_id: objects[1].id,
@@ -989,26 +998,12 @@ mod tests {
         .await
         .unwrap();
         let objects = create_objects_in_classes(&context.pool, &classes).await;
-        let second_source = NewHubuumObject {
-            hubuum_class_id: classes[0].id,
-            collection_id: classes[0].collection_id,
-            name: format!("second_object_in_{}", classes[0].name),
-            description: "Independent relation source".to_string(),
-            data: serde_json::json!({}),
-        }
-        .save_without_events(&context.pool)
-        .await
-        .unwrap();
-        let second_target = NewHubuumObject {
-            hubuum_class_id: classes[1].id,
-            collection_id: classes[1].collection_id,
-            name: format!("second_object_in_{}", classes[1].name),
-            description: "Independent relation target".to_string(),
-            data: serde_json::json!({}),
-        }
-        .save_without_events(&context.pool)
-        .await
-        .unwrap();
+        let second_source =
+            create_relation_test_object(&context.pool, &classes[0], "independent_relation_source")
+                .await;
+        let second_target =
+            create_relation_test_object(&context.pool, &classes[1], "independent_relation_target")
+                .await;
         let held_relation = NewHubuumObjectRelation {
             from_hubuum_object_id: objects[0].id,
             to_hubuum_object_id: objects[1].id,

--- a/tests/api_identity_suite/service_accounts.rs
+++ b/tests/api_identity_suite/service_accounts.rs
@@ -1259,6 +1259,8 @@ mod tests {
             to_hubuum_class_id: classes[1].id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(&context.pool)
         .await
@@ -1378,6 +1380,8 @@ mod tests {
             to_hubuum_class_id: classes[1].id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         };
         let class_relation = if matches!(
             (kind, operation),

--- a/tests/api_jobs_suite/exports.rs
+++ b/tests/api_jobs_suite/exports.rs
@@ -292,6 +292,8 @@ mod tests {
             to_hubuum_class_id: to_class_id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(pool)
         .await
@@ -1494,6 +1496,8 @@ mod tests {
             to_hubuum_class_id: room_class.id,
             forward_template_alias: Some("rooms".to_string()),
             reverse_template_alias: Some("hosts".to_string()),
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(&context.pool)
         .await
@@ -1503,6 +1507,8 @@ mod tests {
             to_hubuum_class_id: person_class.id,
             forward_template_alias: Some("persons".to_string()),
             reverse_template_alias: Some("rooms".to_string()),
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(&context.pool)
         .await
@@ -1645,6 +1651,8 @@ mod tests {
             to_hubuum_class_id: room_class.id,
             forward_template_alias: Some("rooms".to_string()),
             reverse_template_alias: Some("hosts".to_string()),
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(&context.pool)
         .await
@@ -1654,6 +1662,8 @@ mod tests {
             to_hubuum_class_id: person_class.id,
             forward_template_alias: Some("persons".to_string()),
             reverse_template_alias: Some("rooms".to_string()),
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(&context.pool)
         .await
@@ -2150,6 +2160,8 @@ mod tests {
             to_hubuum_class_id: room_class.id,
             forward_template_alias: Some("rooms".to_string()),
             reverse_template_alias: Some("hosts".to_string()),
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(&context.pool)
         .await
@@ -2365,6 +2377,8 @@ mod tests {
             to_hubuum_class_id: room_class.id,
             forward_template_alias: Some("rooms".to_string()),
             reverse_template_alias: Some("hosts".to_string()),
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(&context.pool)
         .await

--- a/tests/api_jobs_suite/imports.rs
+++ b/tests/api_jobs_suite/imports.rs
@@ -19,13 +19,18 @@ mod tests {
         ImportPrincipalInput, ImportPrincipalSubtype, ImportRequest, ImportTaskResultResponse,
         NewTaskRecord, Permissions, RestoreTimestamps, TaskEventResponse, TaskKind, TaskResponse,
         TaskStatus,
+        ObjectRelationLimit,
     };
     use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER};
     use crate::schema::collections::dsl::{
         collections, description as collection_description, id as collection_id_field,
     };
     use crate::schema::hubuumclass::dsl::{
-        collection_id as class_collection_id, hubuumclass, name as class_name,
+        collection_id as class_collection_id, hubuumclass, id as class_id, name as class_name,
+    };
+    use crate::schema::hubuumclass_relation::dsl::{
+        from_hubuum_class_id, from_max_relations, hubuumclass_relation, to_hubuum_class_id,
+        to_max_relations,
     };
     use crate::schema::hubuumclass_relation::dsl as class_relation;
     use crate::schema::hubuumobject::dsl as object;
@@ -429,6 +434,101 @@ mod tests {
                 vec![(expected.created_at(), expected.updated_at()); 7]
             );
         }
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn class_relation_import_preserves_object_relation_limits(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let jack_name = context.scoped_name("import_cardinality_jack");
+        let room_name = context.scoped_name("import_cardinality_room");
+        let body = ImportRequest {
+            version: CURRENT_IMPORT_VERSION,
+            dry_run: Some(false),
+            mode: Some(ImportMode {
+                atomicity: Some(ImportAtomicity::Strict),
+                collision_policy: Some(ImportCollisionPolicy::Abort),
+                permission_policy: Some(ImportPermissionPolicy::Abort),
+            }),
+            graph: ImportGraph {
+                collections: vec![ImportCollectionInput {
+                    ref_: Some("collection:cardinality".to_string()),
+                    name: context.scoped_name("import_cardinality"),
+                    description: "Relation cardinality import".to_string(),
+                    parent_collection_ref: None,
+                    parent_collection_key: None,
+                }],
+                classes: vec![
+                    ImportClassInput {
+                        ref_: Some("class:jack".to_string()),
+                        name: jack_name.clone(),
+                        description: "Jack".to_string(),
+                        json_schema: None,
+                        validate_schema: Some(false),
+                        collection_ref: Some("collection:cardinality".to_string()),
+                        collection_key: None,
+                    },
+                    ImportClassInput {
+                        ref_: Some("class:room".to_string()),
+                        name: room_name.clone(),
+                        description: "Room".to_string(),
+                        json_schema: None,
+                        validate_schema: Some(false),
+                        collection_ref: Some("collection:cardinality".to_string()),
+                        collection_key: None,
+                    },
+                ],
+                class_relations: vec![ImportClassRelationInput {
+                    ref_: Some("relation:jack-room".to_string()),
+                    from_class_ref: Some("class:jack".to_string()),
+                    from_class_key: None,
+                    to_class_ref: Some("class:room".to_string()),
+                    to_class_key: None,
+                    forward_template_alias: Some("room".to_string()),
+                    reverse_template_alias: Some("jacks".to_string()),
+                    from_max_relations: Some(ObjectRelationLimit::new(1).unwrap()),
+                    to_max_relations: None,
+                }],
+                ..ImportGraph::default()
+            },
+        };
+
+        let response = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            IMPORTS_ENDPOINT,
+            &body,
+            Vec::new(),
+        )
+        .await;
+        let response = assert_response_status(response, StatusCode::ACCEPTED).await;
+        let task: TaskResponse = test::read_body_json(response).await;
+        let completed = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+        assert_eq!(completed.progress.success_items, 4);
+
+        let limits = with_connection(&context.pool, async |conn| {
+            let jack_id = hubuumclass
+                .filter(class_name.eq(jack_name))
+                .select(class_id)
+                .first::<i32>(conn)
+                .await?;
+            let room_id = hubuumclass
+                .filter(class_name.eq(room_name))
+                .select(class_id)
+                .first::<i32>(conn)
+                .await?;
+            hubuumclass_relation
+                .filter(from_hubuum_class_id.eq(jack_id.min(room_id)))
+                .filter(to_hubuum_class_id.eq(jack_id.max(room_id)))
+                .select((from_max_relations, to_max_relations))
+                .first::<(Option<i32>, Option<i32>)>(conn)
+                .await
+        })
+        .await
+        .unwrap();
+        assert_eq!(limits, (Some(1), None));
     }
 
     #[rstest]

--- a/tests/api_jobs_suite/imports.rs
+++ b/tests/api_jobs_suite/imports.rs
@@ -11,15 +11,14 @@ mod tests {
 
     use crate::db::{DbPool, with_connection};
     use crate::models::{
-        CURRENT_IMPORT_VERSION, CollectionKey, GroupKey, IdentityScopeKey, ImportAtomicity,
-        ImportClassInput, ImportClassRelationInput, ImportCollectionInput,
+        CURRENT_IMPORT_VERSION, CollectionKey, GroupKey, HubuumClassRelation, IdentityScopeKey,
+        ImportAtomicity, ImportClassInput, ImportClassRelationInput, ImportCollectionInput,
         ImportCollectionPermissionInput, ImportCollisionPolicy, ImportEventSubscriptionInput,
         ImportGraph, ImportGroupInput, ImportGroupMembershipInput, ImportIdentityScopeInput,
         ImportMode, ImportObjectInput, ImportObjectRelationInput, ImportPermissionPolicy,
         ImportPrincipalInput, ImportPrincipalSubtype, ImportRequest, ImportTaskResultResponse,
-        NewTaskRecord, Permissions, RestoreTimestamps, TaskEventResponse, TaskKind, TaskResponse,
-        TaskStatus,
-        ObjectRelationLimit,
+        NewTaskRecord, ObjectRelationLimit, Permissions, RestoreTimestamps, TaskEventResponse,
+        TaskKind, TaskResponse, TaskStatus,
     };
     use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER};
     use crate::schema::collections::dsl::{
@@ -28,11 +27,10 @@ mod tests {
     use crate::schema::hubuumclass::dsl::{
         collection_id as class_collection_id, hubuumclass, id as class_id, name as class_name,
     };
-    use crate::schema::hubuumclass_relation::dsl::{
-        from_hubuum_class_id, from_max_relations, hubuumclass_relation, to_hubuum_class_id,
-        to_max_relations,
-    };
     use crate::schema::hubuumclass_relation::dsl as class_relation;
+    use crate::schema::hubuumclass_relation::dsl::{
+        from_hubuum_class_id, hubuumclass_relation, to_hubuum_class_id,
+    };
     use crate::schema::hubuumobject::dsl as object;
     use crate::schema::hubuumobject_relation::dsl as object_relation;
     use crate::schema::tasks::dsl::{
@@ -508,7 +506,7 @@ mod tests {
         let completed = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
         assert_eq!(completed.progress.success_items, 4);
 
-        let limits = with_connection(&context.pool, async |conn| {
+        let (jack_id, room_id, relation) = with_connection(&context.pool, async |conn| {
             let jack_id = hubuumclass
                 .filter(class_name.eq(jack_name))
                 .select(class_id)
@@ -519,16 +517,25 @@ mod tests {
                 .select(class_id)
                 .first::<i32>(conn)
                 .await?;
-            hubuumclass_relation
+            let relation = hubuumclass_relation
                 .filter(from_hubuum_class_id.eq(jack_id.min(room_id)))
                 .filter(to_hubuum_class_id.eq(jack_id.max(room_id)))
-                .select((from_max_relations, to_max_relations))
-                .first::<(Option<i32>, Option<i32>)>(conn)
-                .await
+                .first::<HubuumClassRelation>(conn)
+                .await?;
+            Ok::<_, diesel::result::Error>((jack_id, room_id, relation))
         })
         .await
         .unwrap();
-        assert_eq!(limits, (Some(1), None));
+        let (jack_limit, room_limit) = if relation.from_hubuum_class_id == jack_id {
+            assert_eq!(relation.to_hubuum_class_id, room_id);
+            (relation.from_max_relations, relation.to_max_relations)
+        } else {
+            assert_eq!(relation.from_hubuum_class_id, room_id);
+            assert_eq!(relation.to_hubuum_class_id, jack_id);
+            (relation.to_max_relations, relation.from_max_relations)
+        };
+        assert_eq!(jack_limit, Some(ObjectRelationLimit::new(1).unwrap()));
+        assert_eq!(room_limit, None);
     }
 
     #[rstest]

--- a/tests/api_jobs_suite/imports.rs
+++ b/tests/api_jobs_suite/imports.rs
@@ -135,6 +135,8 @@ mod tests {
                     to_class_key: None,
                     forward_template_alias: None,
                     reverse_template_alias: None,
+                    from_max_relations: None,
+                    to_max_relations: None,
                     timestamps: Some(timestamps.clone()),
                 }],
                 object_relations: vec![ImportObjectRelationInput {
@@ -457,6 +459,7 @@ mod tests {
                     description: "Relation cardinality import".to_string(),
                     parent_collection_ref: None,
                     parent_collection_key: None,
+                    timestamps: None,
                 }],
                 classes: vec![
                     ImportClassInput {
@@ -467,6 +470,7 @@ mod tests {
                         validate_schema: Some(false),
                         collection_ref: Some("collection:cardinality".to_string()),
                         collection_key: None,
+                        timestamps: None,
                     },
                     ImportClassInput {
                         ref_: Some("class:room".to_string()),
@@ -476,6 +480,7 @@ mod tests {
                         validate_schema: Some(false),
                         collection_ref: Some("collection:cardinality".to_string()),
                         collection_key: None,
+                        timestamps: None,
                     },
                 ],
                 class_relations: vec![ImportClassRelationInput {
@@ -488,6 +493,7 @@ mod tests {
                     reverse_template_alias: Some("jacks".to_string()),
                     from_max_relations: Some(ObjectRelationLimit::new(1).unwrap()),
                     to_max_relations: None,
+                    timestamps: None,
                 }],
                 ..ImportGraph::default()
             },

--- a/tests/api_jobs_suite/remote_targets.rs
+++ b/tests/api_jobs_suite/remote_targets.rs
@@ -202,6 +202,8 @@ mod tests {
             to_hubuum_class_id: to_class_id,
             forward_template_alias: None,
             reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
         }
         .save_without_events(&context.pool)
         .await

--- a/tests/restore_roundtrip.rs
+++ b/tests/restore_roundtrip.rs
@@ -9,7 +9,7 @@ use hubuum::db::{
 };
 use hubuum::events::{Action, ActorKind, EntityType, MutationProvenance, NewEvent, emit_event};
 use hubuum::models::{
-    BackupRequest, NewHubuumClass, NewHubuumClassRelation, NewTaskRecord,
+    BackupRequest, NewHubuumClass, NewHubuumClassRelation, NewTaskRecord, ObjectRelationLimit,
     RESTORE_CONFIRMATION_PHRASE, RestoreConfirmRequest, RestoreInitiator, RestoreJobStatus,
     RestoreStageRequest, TaskKind, TaskStatus,
 };
@@ -74,6 +74,8 @@ async fn interrupted_restore_is_reconciled_after_the_drain_transition() {
         to_hubuum_class_id: second_class.id,
         forward_template_alias: None,
         reverse_template_alias: None,
+        from_max_relations: Some(ObjectRelationLimit::new(1).unwrap()),
+        to_max_relations: None,
     }
     .save_without_events(&pool)
     .await
@@ -292,8 +294,12 @@ async fn interrupted_restore_is_reconciled_after_the_drain_transition() {
     let (relation_exists, reachability_exists) = with_connection(&pool, async |conn| {
         let relation_exists = hubuumclass_relation::table
             .filter(hubuumclass_relation::id.eq(class_relation.id))
-            .select(hubuumclass_relation::id)
-            .first::<i32>(conn)
+            .select((
+                hubuumclass_relation::id,
+                hubuumclass_relation::from_max_relations,
+                hubuumclass_relation::to_max_relations,
+            ))
+            .first::<(i32, Option<i32>, Option<i32>)>(conn)
             .await
             .optional()?;
         let reachability_exists = hubuumclass_reachability::table
@@ -313,7 +319,11 @@ async fn interrupted_restore_is_reconciled_after_the_drain_transition() {
             reachability_exists,
             maintenance_state(&pool).await.unwrap(),
         ),
-        (Some(class_relation.id), Some(1), "normal".to_string())
+        (
+            Some((class_relation.id, Some(1), None)),
+            Some(1),
+            "normal".to_string(),
+        )
     );
 
     let initiator = RestoreInitiator::new(None, "test", "restore-confirmation")


### PR DESCRIPTION
## Summary

Add optional directional cardinality constraints to class relations so each object on either side can be limited to a positive number of object relations. This supports one-to-one, one-to-many, and bounded relation models, including the Jack/Room case where each Jack belongs to at most one Room.

## Behavior

- Adds nullable `from_max_relations` and `to_max_relations` fields to class relations; `null` remains unlimited.
- Validates limits as positive integers at the API boundary and with database constraints.
- Preserves side-specific limits when class relation IDs are canonicalized.
- Enforces limits in PostgreSQL while keeping the class-relation definition under a compatible shared lock and serializing only inserts that compete for the same bounded object.
- Allows unlimited relations and unrelated bounded objects to be inserted concurrently.
- Returns `409 Conflict` when an object relation would exceed a configured limit.
- Preserves limits through imports, exports/backups, restores, and audit snapshots.

## Documentation

- Regenerates `docs/openapi.json` with both nullable fields, their descriptions, and a minimum value of 1.
- Documents the API behavior and a Jack/Room example in `docs/relationship_endpoints.md`.
- Documents import fields and an example in `docs/import_api.md`.
- Adds an `[Unreleased]` changelog entry.

## Database migration

Adds the two nullable limit columns and positive-value constraints, updates temporal history, and replaces the relation normalization and object-relation validation trigger functions. Existing class relations remain unlimited, so no user migration action is required beyond applying the database migration.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `cargo run --quiet --bin hubuum-openapi > docs/openapi.json`
- `git diff --check`

No breaking changes.