### PR TITLE
Migrate benchmarks to Gungraun with Rust PR Bench v2.3

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   benchmarks:
     name: Self-contained benchmarks
-    uses: terjekv/github-action-iai-callgrind/.github/workflows/rust-pr-bench.yml@v2
+    uses: terjekv/github-action-iai-callgrind/.github/workflows/rust-pr-bench.yml@v2.3
     secrets: inherit
     with:
       backend: all
@@ -18,7 +18,7 @@ jobs:
       auto_detect_moved_benchmarks: true
       criterion_statistic: median
       criterion_cli_args: "--noplot --sample-size 40 --measurement-time 4"
-      regression_threshold_pct_iai_callgrind: 3
+      regression_threshold_pct_gungraun: 3
       regression_threshold_pct_criterion: 50
       fail_on_regression: true
       feature_sets_json: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   relations to enforce one-to-one, one-to-many, or bounded object
   cardinalities.
 
+### Changed
+
+- Migrated deterministic benchmarks from IAI-Callgrind to Gungraun and updated
+  the reusable benchmark workflow to its v2.3 migration bridge.
+
 ## [0.0.6] - 2026-07-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,12 +654,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
+name = "bincode-next"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "1d6626829353ae29293be5c86f42de5f0468bc758af074b0c7d08f07e538ccbc"
 dependencies = [
+ "pastey",
+ "rapidhash",
  "serde",
+ "unty-next",
 ]
 
 [[package]]
@@ -1449,6 +1452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
+name = "either-or-both"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6717164c227120ba9ddf3e2b32305fc0122741d3ee41a54968eae7573ee01933"
+dependencies = [
+ "indexmap",
+ "serde",
+]
+
+[[package]]
 name = "email-encoding"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +1821,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
+name = "gungraun"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9300d38d30facf6870c15bc9e243edcc47e5ddc270c9d2c1ae824a00b1faea79"
+dependencies = [
+ "bincode-next",
+ "derive_more",
+ "gungraun-macros",
+ "gungraun-runner",
+]
+
+[[package]]
+name = "gungraun-macros"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f3214bae6cfd6739f4f29edb262bae439c6393a7b7b12c4eeb96417c2e50df"
+dependencies = [
+ "derive_more",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "gungraun-runner"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c68c92812da579a2510a2cc702d5aa3251992b9662d4a98502ca46e0cbe16e"
+dependencies = [
+ "either-or-both",
+ "serde",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,6 +2086,7 @@ dependencies = [
  "diesel_migrations",
  "futures",
  "futures-util",
+ "gungraun",
  "hmac 0.13.0",
  "hubuum-auth-core",
  "hubuum-auth-ldap",
@@ -2049,7 +2101,6 @@ dependencies = [
  "hubuum-query",
  "hubuum-task-core",
  "hubuum-templates",
- "iai-callgrind",
  "ipnet",
  "json-patch",
  "jsonschema",
@@ -2220,7 +2271,7 @@ name = "hubuum-query"
 version = "0.0.1"
 dependencies = [
  "chrono",
- "iai-callgrind",
+ "gungraun",
  "percent-encoding",
  "serde_json",
 ]
@@ -2234,7 +2285,7 @@ name = "hubuum-templates"
 version = "0.0.1"
 dependencies = [
  "chrono",
- "iai-callgrind",
+ "gungraun",
  "minijinja",
  "serde_json",
 ]
@@ -2304,42 +2355,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iai-callgrind"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e4910d3a9137442723dfb772c32dc10674c4181ca078d2fd227cd5dce9db0"
-dependencies = [
- "bincode",
- "derive_more",
- "iai-callgrind-macros",
- "iai-callgrind-runner",
-]
-
-[[package]]
-name = "iai-callgrind-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d03775318d3f9f01b39ac6612b01464006dc397a654a89dd57df2fd34fb68c3"
-dependencies = [
- "derive_more",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "iai-callgrind-runner"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74c9743c00c3bca4aaffc69c87cae56837796cd362438daf354a3f785788c68"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3348,6 +3363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3576,25 +3597,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "be5bfc63c4dc85083c9daaf7112d0261701d4058677c3bff7f2afc44e30ef3e1"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "dd0d42490f6b7b143eef32b9e3522e42bf25dadc02c69ed72236f80adb949b5c"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3749,6 +3770,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -5110,6 +5140,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16062d030850f35054e37746427b9febb74a2f24c9c6dd6fa2d0c13c5f53221e"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ libc = "0.2"
 
 [dev-dependencies]
 criterion = "0.8.2"
-iai-callgrind = "0.16.1"
+gungraun = "0.19.4"
 regex = "1"
 rstest = "0.26"
 tokio-rustls = "0.26"

--- a/benches/json_sql_filters_callgrind.rs
+++ b/benches/json_sql_filters_callgrind.rs
@@ -1,5 +1,5 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use hubuum::models::search::{ParsedQueryParam, ParsedQueryParamExt, SearchOperator};
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 
 fn json_filter_fixtures() -> [ParsedQueryParam; 4] {

--- a/benches/object_validation_geo_callgrind.rs
+++ b/benches/object_validation_geo_callgrind.rs
@@ -1,6 +1,6 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use hubuum::models::NewHubuumObject;
 use hubuum::traits::ValidateAgainstSchema;
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 use std::sync::LazyLock;
 use tokio::runtime::Runtime;

--- a/benches/object_validation_nested_callgrind.rs
+++ b/benches/object_validation_nested_callgrind.rs
@@ -1,6 +1,6 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use hubuum::models::NewHubuumObject;
 use hubuum::traits::ValidateAgainstSchema;
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 use std::sync::LazyLock;
 use tokio::runtime::Runtime;

--- a/benches/permissions_parsing_callgrind.rs
+++ b/benches/permissions_parsing_callgrind.rs
@@ -1,5 +1,5 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use hubuum::models::Permissions;
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 
 // Permission strings span the full match arm and exercise both early- and

--- a/benches/request_hash_callgrind.rs
+++ b/benches/request_hash_callgrind.rs
@@ -1,5 +1,5 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use hubuum::tasks::request_hash;
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 use std::sync::LazyLock;
 

--- a/benches/token_storage_hash_callgrind.rs
+++ b/benches/token_storage_hash_callgrind.rs
@@ -1,5 +1,5 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use hubuum::models::Token;
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 
 // Token storage hashing (HMAC-SHA256 + hex encoding) runs on every

--- a/benches/unified_search_cursor_callgrind.rs
+++ b/benches/unified_search_cursor_callgrind.rs
@@ -1,5 +1,5 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use hubuum::models::{UnifiedSearchCursorToken, decode_cursor, encode_cursor};
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 
 // Pagination cursor round-trip: serde serialization + base64url encode, then

--- a/benches/unified_search_query_parsing_callgrind.rs
+++ b/benches/unified_search_query_parsing_callgrind.rs
@@ -1,6 +1,6 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use hubuum::models::parse_unified_search_query_with_limits;
 use hubuum::pagination::PageLimits;
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 
 // Unified-search query parsing: percent-decoding, kind-set parsing, boolean and

--- a/crates/hubuum-query/Cargo.toml
+++ b/crates/hubuum-query/Cargo.toml
@@ -12,7 +12,7 @@ percent-encoding = "2"
 serde_json = "1"
 
 [dev-dependencies]
-iai-callgrind = "0.16.1"
+gungraun = "0.19.4"
 
 [[bench]]
 name = "parse_query_parameter_callgrind"

--- a/crates/hubuum-query/benches/jsonb_type_inference_callgrind.rs
+++ b/crates/hubuum-query/benches/jsonb_type_inference_callgrind.rs
@@ -1,5 +1,5 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use hubuum_query::{Operator, get_jsonb_field_type_from_value_and_operator};
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 
 const CASES: [(&str, Operator); 7] = [

--- a/crates/hubuum-query/benches/parse_integer_list_callgrind.rs
+++ b/crates/hubuum-query/benches/parse_integer_list_callgrind.rs
@@ -1,5 +1,5 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use hubuum_query::parse_integer_list;
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 
 #[library_benchmark]

--- a/crates/hubuum-query/benches/parse_query_parameter_callgrind.rs
+++ b/crates/hubuum-query/benches/parse_query_parameter_callgrind.rs
@@ -1,5 +1,5 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use hubuum_query::parse_query_parameter;
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 
 const COMPLEX_QUERY: &str = concat!(

--- a/crates/hubuum-query/benches/search_operator_parsing_callgrind.rs
+++ b/crates/hubuum-query/benches/search_operator_parsing_callgrind.rs
@@ -1,5 +1,5 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use hubuum_query::SearchOperator;
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 
 const OPERATORS: [&str; 12] = [

--- a/crates/hubuum-templates/Cargo.toml
+++ b/crates/hubuum-templates/Cargo.toml
@@ -12,7 +12,7 @@ minijinja = { version = "2", features = ["fuel"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 
 [dev-dependencies]
-iai-callgrind = "0.16.1"
+gungraun = "0.19.4"
 
 [[bench]]
 name = "size_limited_writer_callgrind"

--- a/crates/hubuum-templates/benches/size_limited_writer_callgrind.rs
+++ b/crates/hubuum-templates/benches/size_limited_writer_callgrind.rs
@@ -1,5 +1,5 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use hubuum_templates::SizeLimitedWriter;
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use std::hint::black_box;
 use std::io::Write;
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -125,7 +125,12 @@ database benchmarks live in nested benchmark directories with explicit Cargo
 paths so they remain in their dedicated jobs without disabling autodiscovery.
 The container-build tests enforce this separation.
 
-`iai-callgrind` requires `valgrind` to be installed locally.
+Gungraun requires `valgrind` and the matching benchmark runner to be installed
+locally:
+
+```bash
+cargo install --locked --version 0.19.4 gungraun-runner
+```
 
 The PostgreSQL storage benchmark is opt-in and requires an empty, migrated,
 disposable benchmark database. Fixture creation, cleanup, and warmup happen
@@ -194,7 +199,8 @@ query nondeterministically to the next operation.
 
 - The self-contained benchmark job runs both backends in one combined
   `backend: all` job, so PRs get a single consolidated benchmark export.
-- `iai-callgrind` remains the practical gating signal with a low regression threshold.
+- Gungraun's Callgrind measurements remain the practical gating signal with a
+  low regression threshold.
 - Criterion still runs in the same combined job, but uses a very high regression threshold so it exports timing changes without acting as a meaningful gate.
 - A separate PostgreSQL job runs storage Criterion benchmarks against
   isolated base and pull-request databases. It warns above a 10% median change

--- a/docs/development.md
+++ b/docs/development.md
@@ -104,12 +104,13 @@ Benchmarking runs in a separate GitHub workflow, `.github/workflows/benchmarks.y
 The benchmark targets are split one benchmark binary per file so CI can fan them out independently:
 
 ```bash
-cargo bench --bench parse_query_parameter_callgrind
-cargo bench --bench parse_integer_list_callgrind
+cargo bench -p hubuum-query --bench parse_query_parameter_callgrind
+cargo bench -p hubuum-query --bench parse_integer_list_callgrind
 cargo bench --bench json_sql_filters_callgrind
-cargo bench --bench search_operator_parsing_callgrind
+cargo bench -p hubuum-query --bench search_operator_parsing_callgrind
 cargo bench --bench permissions_parsing_callgrind
-cargo bench --bench jsonb_type_inference_callgrind
+cargo bench -p hubuum-query --bench jsonb_type_inference_callgrind
+cargo bench -p hubuum-templates --bench size_limited_writer_callgrind
 cargo bench --bench token_storage_hash_callgrind
 cargo bench --bench request_hash_callgrind
 cargo bench --bench unified_search_query_parsing_callgrind


### PR DESCRIPTION
## Summary

- replace the IAI-Callgrind 0.16.1 development dependencies and benchmark imports with Gungraun 0.19.4
- pin the reusable benchmark workflow to v2.3 and use its preferred Gungraun regression-threshold input
- document the matching local Gungraun runner and record the migration in the changelog
- qualify workspace-member benchmark commands and document the previously omitted templates benchmark

## Rationale

IAI-Callgrind has been renamed to Gungraun. Rust PR Bench v2.3 provides the migration bridge needed here: it installs the exact runner requested by each revision and normalizes `target/iai` and `target/gungraun` metrics, so the existing IAI-Callgrind base can be compared with the Gungraun head.

The existing `*_callgrind` benchmark target filenames are intentionally retained. Stable target names preserve base/head metric pairing and PR benchmark history while the dependency changes underneath them.

## Impact

This changes benchmark tooling only; production behavior and the public API are unchanged. Local benchmark runs now require `gungraun-runner` 0.19.4 in addition to Valgrind.

There are no breaking changes for Hubuum users. The developer-facing migration is included under `[Unreleased]` in `CHANGELOG.md`.

## Verification

- `cargo check --workspace --benches --locked`
- `cargo clippy --all-targets -- -D warnings`
- `source .env && ./run_tests.sh`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `actionlint .github/workflows/benchmarks.yml`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`

A pre-rebase full-suite run hit a statement timeout in `test_related_object_graph`; the test passed immediately in isolation and the complete suite passed on rerun. After rebasing onto the current `main`, the complete suite passed again without failures.
