### PR TITLE
Fix resource-scoped admin list visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Migrated deterministic benchmarks from IAI-Callgrind to Gungraun and updated
   the reusable benchmark workflow to its v2.3 migration bridge.
 
+### Fixed
+
+- Resource-scoped administrator tokens now list in-scope collections, classes,
+  objects, and relations without requiring duplicate collection permission
+  grants.
+
 ## [0.0.6] - 2026-07-29
 
 ### Added

--- a/src/db/traits/collection/permissions.rs
+++ b/src/db/traits/collection/permissions.rs
@@ -261,15 +261,14 @@ pub async fn user_can_on_any_from_backend<U: GroupAccessors + AuthzSubject>(
         return Ok(vec![]);
     }
 
-    // The admin "all collections" fast path applies only to unscoped tokens; a
-    // scoped admin token falls through to the scoped grant query below.
-    if scopes.is_none() && AuthzSubject::is_admin(&user_id, pool).await? {
-        return with_connection(pool, async |conn| {
-            crate::schema::collections::table
-                .load::<Collection>(conn)
-                .await
-        })
-        .await;
+    // The permission scope has already been checked above. Admins retain their
+    // collection authority, while the resource predicate still bounds results.
+    if AuthzSubject::is_admin(&user_id, pool).await? {
+        let mut query = collections.into_boxed();
+        if let Some(scope) = resource_scope_ids(scopes) {
+            query = query.filter(collection_scope_predicate(scope));
+        }
+        return with_connection(pool, async |conn| query.load::<Collection>(conn).await).await;
     }
 
     let base_query = {

--- a/src/db/traits/user/membership.rs
+++ b/src/db/traits/user/membership.rs
@@ -108,8 +108,9 @@ pub trait LoadPermittedCollections: GroupAccessors + AuthzSubject {
     ///
     /// * `scopes = None` — unscoped (admins get all collections via the fast path).
     /// * `scopes = Some(..)` — the requested permissions must be within scope.
-    ///   Admins retain their collection authority; callers apply the resource
-    ///   boundary to the classes, objects, or relations they load.
+    ///   Admins retain their collection authority. The downstream entity query
+    ///   applies the resource boundary because a class- or object-only scope may
+    ///   select a descendant without exposing its parent collection.
     async fn load_collections_with_permissions<'a, I>(
         &self,
         pool: &DbPool,
@@ -171,9 +172,10 @@ where
             return Ok(Vec::new());
         }
 
-        // The permission scope has already been checked above. Admins retain
-        // their collection authority; the downstream entity query applies the
-        // token's resource boundary.
+        // Do not filter this collection context by collection-only resource IDs:
+        // class- and object-scoped tokens still need their parent collection as
+        // query context. Every downstream entity query applies its own resource
+        // predicate before returning rows.
         if is_admin {
             return with_connection(pool, async |conn| {
                 collections

--- a/src/db/traits/user/membership.rs
+++ b/src/db/traits/user/membership.rs
@@ -103,13 +103,13 @@ where
 }
 
 pub trait LoadPermittedCollections: GroupAccessors + AuthzSubject {
-    /// Load all collections the subject has the given permissions on, intersected
-    /// with the token scope set.
+    /// Load the collections the subject has the given permissions on after
+    /// enforcing the token's permission scope.
     ///
     /// * `scopes = None` — unscoped (admins get all collections via the fast path).
-    /// * `scopes = Some(..)` — the requested permissions must be within scope; a
-    ///   scoped admin falls through to the per-collection permission query rather
-    ///   than the all-collections fast path.
+    /// * `scopes = Some(..)` — the requested permissions must be within scope.
+    ///   Admins retain their collection authority; callers apply the resource
+    ///   boundary to the classes, objects, or relations they load.
     async fn load_collections_with_permissions<'a, I>(
         &self,
         pool: &DbPool,
@@ -171,9 +171,10 @@ where
             return Ok(Vec::new());
         }
 
-        // Unscoped admins see everything; scoped admins fall through to the
-        // permission query so their token scope still bounds the listing.
-        if is_admin && scopes.is_none() {
+        // The permission scope has already been checked above. Admins retain
+        // their collection authority; the downstream entity query applies the
+        // token's resource boundary.
+        if is_admin {
             return with_connection(pool, async |conn| {
                 collections
                     .select(collections::all_columns())

--- a/src/db/traits/user/search.rs
+++ b/src/db/traits/user/search.rs
@@ -236,7 +236,6 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         if !scope_allows(scopes, &[Permissions::ReadCollection]) {
             return Ok(Vec::new());
         }
-        let is_admin = is_admin && scopes.is_none();
         use crate::schema::collection_closure::dsl::{
             ancestor_collection_id, collection_closure, descendant_collection_id,
         };
@@ -357,7 +356,6 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         if !scope_allows(scopes, &[Permissions::ReadCollection]) {
             return Ok(0);
         }
-        let is_admin = is_admin && scopes.is_none();
 
         let query_params = query_options.filters.clone();
         // Validate any `permissions` query filters. The requested value does not

--- a/src/db/traits/user/unified_search.rs
+++ b/src/db/traits/user/unified_search.rs
@@ -177,12 +177,9 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
         params: &UnifiedSearchSpec,
         scopes: Option<&TokenScope>,
     ) -> Result<Vec<Collection>, ApiError> {
-        let is_unscoped_admin = AuthzSubject::is_admin(self, pool).await? && scopes.is_none();
+        let is_admin = AuthzSubject::is_admin(self, pool).await?;
         self.search_unified_collections_from_backend_with_admin_status(
-            pool,
-            params,
-            scopes,
-            is_unscoped_admin,
+            pool, params, scopes, is_admin,
         )
         .await
     }
@@ -192,7 +189,7 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
         pool: &DbPool,
         params: &UnifiedSearchSpec,
         scopes: Option<&TokenScope>,
-        is_unscoped_admin: bool,
+        is_admin: bool,
     ) -> Result<Vec<Collection>, ApiError> {
         if !scope_allows(scopes, &[Permissions::ReadCollection]) {
             return Ok(Vec::new());
@@ -208,7 +205,7 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
         with_connection_async(pool.clone(), async move |conn| {
             sql_query(COLLECTION_SEARCH_SQL)
                 .bind::<Text, _>(query)
-                .bind::<Bool, _>(is_unscoped_admin)
+                .bind::<Bool, _>(is_admin)
                 .bind::<Integer, _>(principal_id)
                 .bind::<Bool, _>(scope_binds.unrestricted)
                 .bind::<Array<Integer>, _>(scope_binds.collection_ids)
@@ -229,14 +226,9 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
         params: &UnifiedSearchSpec,
         scopes: Option<&TokenScope>,
     ) -> Result<Vec<HubuumClassExpanded>, ApiError> {
-        let is_unscoped_admin = AuthzSubject::is_admin(self, pool).await? && scopes.is_none();
-        self.search_unified_classes_from_backend_with_admin_status(
-            pool,
-            params,
-            scopes,
-            is_unscoped_admin,
-        )
-        .await
+        let is_admin = AuthzSubject::is_admin(self, pool).await?;
+        self.search_unified_classes_from_backend_with_admin_status(pool, params, scopes, is_admin)
+            .await
     }
 
     async fn search_unified_classes_from_backend_with_admin_status(
@@ -244,7 +236,7 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
         pool: &DbPool,
         params: &UnifiedSearchSpec,
         scopes: Option<&TokenScope>,
-        is_unscoped_admin: bool,
+        is_admin: bool,
     ) -> Result<Vec<HubuumClassExpanded>, ApiError> {
         if !scope_allows(
             scopes,
@@ -264,7 +256,7 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
             sql_query(CLASS_SEARCH_SQL)
                 .bind::<Text, _>(query)
                 .bind::<Bool, _>(search_schema)
-                .bind::<Bool, _>(is_unscoped_admin)
+                .bind::<Bool, _>(is_admin)
                 .bind::<Integer, _>(principal_id)
                 .bind::<Bool, _>(scope_binds.unrestricted)
                 .bind::<Array<Integer>, _>(scope_binds.collection_ids)
@@ -309,14 +301,9 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
         params: &UnifiedSearchSpec,
         scopes: Option<&TokenScope>,
     ) -> Result<Vec<HubuumObject>, ApiError> {
-        let is_unscoped_admin = AuthzSubject::is_admin(self, pool).await? && scopes.is_none();
-        self.search_unified_objects_from_backend_with_admin_status(
-            pool,
-            params,
-            scopes,
-            is_unscoped_admin,
-        )
-        .await
+        let is_admin = AuthzSubject::is_admin(self, pool).await?;
+        self.search_unified_objects_from_backend_with_admin_status(pool, params, scopes, is_admin)
+            .await
     }
 
     async fn search_unified_objects_from_backend_with_admin_status(
@@ -324,7 +311,7 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
         pool: &DbPool,
         params: &UnifiedSearchSpec,
         scopes: Option<&TokenScope>,
-        is_unscoped_admin: bool,
+        is_admin: bool,
     ) -> Result<Vec<HubuumObject>, ApiError> {
         if !scope_allows(
             scopes,
@@ -344,7 +331,7 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
             sql_query(OBJECT_SEARCH_SQL)
                 .bind::<Text, _>(query)
                 .bind::<Bool, _>(search_data)
-                .bind::<Bool, _>(is_unscoped_admin)
+                .bind::<Bool, _>(is_admin)
                 .bind::<Integer, _>(principal_id)
                 .bind::<Bool, _>(scope_binds.unrestricted)
                 .bind::<Array<Integer>, _>(scope_binds.collection_ids)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -46,8 +46,8 @@ use crate::models::collection::{Collection, NewCollectionWithAssignee};
 use crate::models::group::{Group, NewGroup};
 use crate::models::user::{NewUser, User};
 use crate::models::{
-    HubuumClass, HubuumObject, NewHubuumClass, NewHubuumObject, PrincipalID,
-    PrincipalTokenCreateRequest, TokenScope,
+    HubuumClass, HubuumObject, NewHubuumClass, NewHubuumObject, Permissions, PrincipalID,
+    PrincipalTokenCreateRequest, TokenResourceScope, TokenScope,
 };
 
 use crate::utilities::auth::{generate_random_password, hash_password};
@@ -580,14 +580,39 @@ pub async fn create_test_service_account(
 }
 
 /// Mint a scoped token for a principal id; returns the raw token string.
-pub async fn scoped_token(
-    pool: &DbPool,
-    principal_id: i32,
-    permissions: &[crate::models::Permissions],
-) -> String {
+pub async fn scoped_token(pool: &DbPool, principal_id: i32, permissions: &[Permissions]) -> String {
     let scope = TokenScope::from_request_parts(Some(permissions.to_vec()), None)
         .expect("valid permission token scope")
         .expect("permission token scope is present");
+    scoped_principal_token(pool, principal_id, scope).await
+}
+
+/// Mint a token narrowed to the supplied collection, class, or object entries.
+pub async fn resource_scoped_token(
+    pool: &DbPool,
+    principal_id: i32,
+    resource_scopes: Vec<TokenResourceScope>,
+) -> String {
+    let scope = TokenScope::from_request_parts(None, Some(resource_scopes))
+        .expect("valid resource token scope")
+        .expect("resource token scope is present");
+    scoped_principal_token(pool, principal_id, scope).await
+}
+
+/// Mint a token narrowed by both permission and resource dimensions.
+pub async fn scoped_token_with_resources(
+    pool: &DbPool,
+    principal_id: i32,
+    permissions: &[Permissions],
+    resource_scopes: Vec<TokenResourceScope>,
+) -> String {
+    let scope = TokenScope::from_request_parts(Some(permissions.to_vec()), Some(resource_scopes))
+        .expect("valid combined token scope")
+        .expect("combined token scope is present");
+    scoped_principal_token(pool, principal_id, scope).await
+}
+
+async fn scoped_principal_token(pool: &DbPool, principal_id: i32, scope: TokenScope) -> String {
     PrincipalTokenCreateRequest::new(
         PrincipalID::new(principal_id).expect("valid persisted principal id"),
     )
@@ -595,25 +620,6 @@ pub async fn scoped_token(
     .create(pool, None)
     .await
     .expect("failed to mint scoped token")
-    .get_token()
-}
-
-/// Mint a token narrowed to the supplied collection, class, or object entries.
-pub async fn resource_scoped_token(
-    pool: &DbPool,
-    principal_id: i32,
-    resource_scopes: Vec<crate::models::TokenResourceScope>,
-) -> String {
-    let scope = crate::models::TokenScope::from_request_parts(None, Some(resource_scopes))
-        .expect("valid resource token scope")
-        .expect("resource token scope is present");
-    PrincipalTokenCreateRequest::new(
-        PrincipalID::new(principal_id).expect("valid persisted principal id"),
-    )
-    .scope(Some(scope))
-    .create(pool, None)
-    .await
-    .expect("failed to mint resource-scoped token")
     .get_token()
 }
 

--- a/tests/api_core_data_suite/search.rs
+++ b/tests/api_core_data_suite/search.rs
@@ -4,16 +4,53 @@ mod tests {
     use rstest::rstest;
 
     use crate::models::{
-        CollectionID, NewHubuumClass, NewHubuumObject, Permissions, PrincipalID,
-        PrincipalTokenCreateRequest, TokenResourceScope, TokenScope, UnifiedSearchResponse,
+        CollectionID, NewHubuumClass, NewHubuumObject, Permissions, TokenResourceScope,
+        UnifiedSearchResponse,
     };
     use crate::tests::api_operations::get_request;
     use crate::tests::asserts::assert_response_status;
-    use crate::tests::{TestContext, test_context};
+    use crate::tests::{CollectionFixture, TestContext, scoped_token_with_resources, test_context};
     use crate::traits::CanSave;
 
     const SEARCH_ENDPOINT: &str = "/api/v1/search";
     const SEARCH_STREAM_ENDPOINT: &str = "/api/v1/search/stream";
+
+    struct SearchResourceFixture {
+        class_id: i32,
+        object_id: i32,
+    }
+
+    async fn create_search_resources(
+        context: &TestContext,
+        collection: &CollectionFixture,
+        needle: &str,
+    ) -> SearchResourceFixture {
+        let class = NewHubuumClass {
+            name: format!("{needle}-class-{}", collection.collection.id),
+            collection_id: collection.collection.id,
+            json_schema: None,
+            validate_schema: Some(false),
+            description: format!("{needle} class"),
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let object = NewHubuumObject {
+            name: format!("{needle}-object-{}", collection.collection.id),
+            collection_id: collection.collection.id,
+            hubuum_class_id: class.id,
+            data: serde_json::json!({"tag": needle}),
+            description: format!("{needle} object"),
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+
+        SearchResourceFixture {
+            class_id: class.id,
+            object_id: object.id,
+        }
+    }
 
     #[rstest]
     #[actix_web::test]
@@ -233,27 +270,7 @@ mod tests {
             .unwrap();
 
         for collection in [&visible, &hidden] {
-            let class = NewHubuumClass {
-                name: format!("permneedle-class-{}", collection.collection.id),
-                collection_id: collection.collection.id,
-                json_schema: None,
-                validate_schema: Some(false),
-                description: "permneedle class".to_string(),
-            }
-            .save_without_events(&context.pool)
-            .await
-            .unwrap();
-
-            NewHubuumObject {
-                name: format!("permneedle-object-{}", collection.collection.id),
-                collection_id: collection.collection.id,
-                hubuum_class_id: class.id,
-                data: serde_json::json!({"tag": "permneedle"}),
-                description: "permneedle object".to_string(),
-            }
-            .save_without_events(&context.pool)
-            .await
-            .unwrap();
+            create_search_resources(&context, collection, "permneedle").await;
         }
 
         let resp = get_request(
@@ -308,54 +325,21 @@ mod tests {
             .collection_fixture(&format!("{needle}_hidden"))
             .await;
 
-        let mut visible_class = None;
-        let mut visible_object = None;
-        for collection in [&visible, &hidden] {
-            let class = NewHubuumClass {
-                name: format!("{needle}-class-{}", collection.collection.id),
-                collection_id: collection.collection.id,
-                json_schema: None,
-                validate_schema: Some(false),
-                description: format!("{needle} class"),
-            }
-            .save_without_events(&context.pool)
-            .await
-            .unwrap();
-            let object = NewHubuumObject {
-                name: format!("{needle}-object-{}", collection.collection.id),
-                collection_id: collection.collection.id,
-                hubuum_class_id: class.id,
-                data: serde_json::json!({"tag": &needle}),
-                description: format!("{needle} object"),
-            }
-            .save_without_events(&context.pool)
-            .await
-            .unwrap();
-            if collection.collection.id == visible.collection.id {
-                visible_class = Some(class);
-                visible_object = Some(object);
-            }
-        }
-
-        let scope = TokenScope::from_request_parts(
-            Some(vec![
+        let visible_resources = create_search_resources(&context, &visible, &needle).await;
+        create_search_resources(&context, &hidden, &needle).await;
+        let token = scoped_token_with_resources(
+            &context.pool,
+            context.admin_user.id,
+            &[
                 Permissions::ReadCollection,
                 Permissions::ReadClass,
                 Permissions::ReadObject,
-            ]),
-            Some(vec![TokenResourceScope::Collection(
+            ],
+            vec![TokenResourceScope::Collection(
                 CollectionID::new(visible.collection.id).unwrap(),
-            )]),
+            )],
         )
-        .unwrap()
-        .unwrap();
-        let token =
-            PrincipalTokenCreateRequest::new(PrincipalID::new(context.admin_user.id).unwrap())
-                .scope(Some(scope))
-                .create(&context.pool, None)
-                .await
-                .unwrap()
-                .get_token();
+        .await;
 
         let response = get_request(
             &context.pool,
@@ -382,7 +366,7 @@ mod tests {
                 .iter()
                 .map(|class| class.id)
                 .collect::<Vec<_>>(),
-            vec![visible_class.unwrap().id]
+            vec![visible_resources.class_id]
         );
         assert_eq!(
             search
@@ -391,7 +375,7 @@ mod tests {
                 .iter()
                 .map(|object| object.id)
                 .collect::<Vec<_>>(),
-            vec![visible_object.unwrap().id]
+            vec![visible_resources.object_id]
         );
 
         visible.cleanup().await.unwrap();

--- a/tests/api_core_data_suite/search.rs
+++ b/tests/api_core_data_suite/search.rs
@@ -3,7 +3,10 @@ mod tests {
     use actix_web::{http::StatusCode, test};
     use rstest::rstest;
 
-    use crate::models::{NewHubuumClass, NewHubuumObject, UnifiedSearchResponse};
+    use crate::models::{
+        CollectionID, NewHubuumClass, NewHubuumObject, Permissions, PrincipalID,
+        PrincipalTokenCreateRequest, TokenResourceScope, TokenScope, UnifiedSearchResponse,
+    };
     use crate::tests::api_operations::get_request;
     use crate::tests::asserts::assert_response_status;
     use crate::tests::{TestContext, test_context};
@@ -283,6 +286,112 @@ mod tests {
                 .objects
                 .iter()
                 .all(|object| object.collection_id == visible.collection.id)
+        );
+
+        visible.cleanup().await.unwrap();
+        hidden.cleanup().await.unwrap();
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn test_api_search_resource_scoped_admin_without_group_grants(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let needle = context.scoped_name("scopedadminsearch").replace('_', "");
+        let visible = context
+            .scope
+            .collection_fixture(&format!("{needle}_visible"))
+            .await;
+        let hidden = context
+            .scope
+            .collection_fixture(&format!("{needle}_hidden"))
+            .await;
+
+        let mut visible_class = None;
+        let mut visible_object = None;
+        for collection in [&visible, &hidden] {
+            let class = NewHubuumClass {
+                name: format!("{needle}-class-{}", collection.collection.id),
+                collection_id: collection.collection.id,
+                json_schema: None,
+                validate_schema: Some(false),
+                description: format!("{needle} class"),
+            }
+            .save_without_events(&context.pool)
+            .await
+            .unwrap();
+            let object = NewHubuumObject {
+                name: format!("{needle}-object-{}", collection.collection.id),
+                collection_id: collection.collection.id,
+                hubuum_class_id: class.id,
+                data: serde_json::json!({"tag": &needle}),
+                description: format!("{needle} object"),
+            }
+            .save_without_events(&context.pool)
+            .await
+            .unwrap();
+            if collection.collection.id == visible.collection.id {
+                visible_class = Some(class);
+                visible_object = Some(object);
+            }
+        }
+
+        let scope = TokenScope::from_request_parts(
+            Some(vec![
+                Permissions::ReadCollection,
+                Permissions::ReadClass,
+                Permissions::ReadObject,
+            ]),
+            Some(vec![TokenResourceScope::Collection(
+                CollectionID::new(visible.collection.id).unwrap(),
+            )]),
+        )
+        .unwrap()
+        .unwrap();
+        let token =
+            PrincipalTokenCreateRequest::new(PrincipalID::new(context.admin_user.id).unwrap())
+                .scope(Some(scope))
+                .create(&context.pool, None)
+                .await
+                .unwrap()
+                .get_token();
+
+        let response = get_request(
+            &context.pool,
+            &token,
+            &format!("{SEARCH_ENDPOINT}?q={needle}&kinds=collection,class,object"),
+        )
+        .await;
+        let response = assert_response_status(response, StatusCode::OK).await;
+        let search: UnifiedSearchResponse = test::read_body_json(response).await;
+
+        assert_eq!(
+            search
+                .results
+                .collections
+                .iter()
+                .map(|collection| collection.id)
+                .collect::<Vec<_>>(),
+            vec![visible.collection.id]
+        );
+        assert_eq!(
+            search
+                .results
+                .classes
+                .iter()
+                .map(|class| class.id)
+                .collect::<Vec<_>>(),
+            vec![visible_class.unwrap().id]
+        );
+        assert_eq!(
+            search
+                .results
+                .objects
+                .iter()
+                .map(|object| object.id)
+                .collect::<Vec<_>>(),
+            vec![visible_object.unwrap().id]
         );
 
         visible.cleanup().await.unwrap();

--- a/tests/api_identity_suite/service_accounts.rs
+++ b/tests/api_identity_suite/service_accounts.rs
@@ -37,12 +37,13 @@ mod tests {
     use crate::models::token::Token;
     use crate::models::user::{LoginUser, NewUser};
     use crate::models::{
-        CollectionID, GroupResponse, HubuumClassID, HubuumObject, HubuumObjectID,
-        HubuumObjectRelation, MAX_TOKEN_RESOURCE_SCOPES, NewHubuumClass, NewHubuumClassRelation,
-        NewHubuumObject, NewHubuumObjectRelation, NewServiceAccount, NewTaskRecord, Permissions,
-        PrincipalID, PrincipalMemberResponse, PrincipalTokenCreateRequest, PrincipalTokenMetadata,
-        ServiceAccount, ServiceAccountID, ServiceAccountResponse, TaskID, TaskKind, TaskRecord,
-        TaskStatus, TokenResourceScope, TokenScope,
+        CollectionID, GroupResponse, HubuumClassID, HubuumClassRelation, HubuumObject,
+        HubuumObjectID, HubuumObjectRelation, MAX_TOKEN_RESOURCE_SCOPES, NewHubuumClass,
+        NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, NewServiceAccount,
+        NewTaskRecord, Permissions, PrincipalID, PrincipalMemberResponse,
+        PrincipalTokenCreateRequest, PrincipalTokenMetadata, ServiceAccount, ServiceAccountID,
+        ServiceAccountResponse, TaskID, TaskKind, TaskRecord, TaskStatus, TokenResourceScope,
+        TokenScope,
     };
     use crate::pagination::TOTAL_COUNT_HEADER;
     use crate::test_support::{
@@ -52,7 +53,7 @@ mod tests {
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
     use crate::tests::asserts::{assert_response_status, header_value};
     use crate::tests::{
-        ClassFixture, TestContext, create_test_classes, create_test_group,
+        ClassFixture, TestContext, create_class_fixture, create_test_classes, create_test_group,
         create_test_service_account, create_test_user, ensure_admin_group, lock_test_mutex,
         resource_scoped_token, scoped_token, scoped_token_with_resources, service_account_token,
     };
@@ -97,6 +98,7 @@ mod tests {
     struct ScopedAdminListFixture {
         classes: ClassFixture,
         objects: Vec<HubuumObject>,
+        class_relation: HubuumClassRelation,
         object_relation: HubuumObjectRelation,
     }
 
@@ -123,7 +125,7 @@ mod tests {
             .scope
             .collection_fixture("scoped_admin_list_visibility")
             .await;
-        let classes = crate::tests::create_class_fixture(
+        let classes = create_class_fixture(
             &context.pool,
             collection,
             (0..2)
@@ -176,6 +178,7 @@ mod tests {
         ScopedAdminListFixture {
             classes,
             objects,
+            class_relation,
             object_relation,
         }
     }
@@ -1284,6 +1287,7 @@ mod tests {
         Classes,
         ObjectsByClassId,
         ObjectsByClassName,
+        ClassRelations,
         ObjectRelations,
     }
 
@@ -1316,8 +1320,8 @@ mod tests {
                 },
                 Self::ObjectsByClassName => ScopedAdminListRequest {
                     exact_endpoint: format!(
-                        "/api/v1/classes/{}/{}",
-                        fixture.classes[0].id, fixture.objects[0].id
+                        "/api/v1/classes/by-name/{}/objects/by-name/{}",
+                        fixture.classes[0].name, fixture.objects[0].name
                     ),
                     list_endpoint: format!(
                         "/api/v1/classes/by-name/{}/objects",
@@ -1325,10 +1329,21 @@ mod tests {
                     ),
                     expected_ids: vec![fixture.objects[0].id],
                 },
+                Self::ClassRelations => ScopedAdminListRequest {
+                    exact_endpoint: format!(
+                        "/api/v1/relations/classes/{}",
+                        fixture.class_relation.id
+                    ),
+                    list_endpoint: "/api/v1/relations/classes".to_string(),
+                    expected_ids: vec![fixture.class_relation.id],
+                },
                 Self::ObjectRelations => ScopedAdminListRequest {
                     exact_endpoint: format!(
-                        "/api/v1/relations/objects/{}",
-                        fixture.object_relation.id
+                        "/api/v1/classes/{}/{}/relations/{}/{}",
+                        fixture.classes[0].id,
+                        fixture.objects[0].id,
+                        fixture.classes[1].id,
+                        fixture.objects[1].id
                     ),
                     list_endpoint: "/api/v1/relations/objects".to_string(),
                     expected_ids: vec![fixture.object_relation.id],
@@ -1342,6 +1357,7 @@ mod tests {
     #[case::classes(ScopedAdminListTarget::Classes)]
     #[case::objects_by_class_id(ScopedAdminListTarget::ObjectsByClassId)]
     #[case::objects_by_class_name(ScopedAdminListTarget::ObjectsByClassName)]
+    #[case::class_relations(ScopedAdminListTarget::ClassRelations)]
     #[case::object_relations(ScopedAdminListTarget::ObjectRelations)]
     #[actix_web::test]
     async fn test_resource_scoped_admin_lists_in_scope_resources_without_group_grants(
@@ -1378,9 +1394,10 @@ mod tests {
         let request = target.request(&fixture);
 
         let exact = get_request(&context.pool, &token, &request.exact_endpoint).await;
-        assert_eq!(exact.status(), StatusCode::OK);
+        assert_response_status(exact, StatusCode::OK).await;
 
         let response = get_request(&context.pool, &token, &request.list_endpoint).await;
+        let response = assert_response_status(response, StatusCode::OK).await;
         let total = header_value(&response, TOTAL_COUNT_HEADER)
             .unwrap()
             .parse::<i64>()

--- a/tests/api_identity_suite/service_accounts.rs
+++ b/tests/api_identity_suite/service_accounts.rs
@@ -38,9 +38,9 @@ mod tests {
     use crate::models::user::{LoginUser, NewUser};
     use crate::models::{
         CollectionID, GroupResponse, HubuumClassID, HubuumObject, HubuumObjectID,
-        MAX_TOKEN_RESOURCE_SCOPES, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
-        NewHubuumObjectRelation, NewServiceAccount, NewTaskRecord, Permissions, PrincipalID,
-        PrincipalMemberResponse, PrincipalTokenCreateRequest, PrincipalTokenMetadata,
+        HubuumObjectRelation, MAX_TOKEN_RESOURCE_SCOPES, NewHubuumClass, NewHubuumClassRelation,
+        NewHubuumObject, NewHubuumObjectRelation, NewServiceAccount, NewTaskRecord, Permissions,
+        PrincipalID, PrincipalMemberResponse, PrincipalTokenCreateRequest, PrincipalTokenMetadata,
         ServiceAccount, ServiceAccountID, ServiceAccountResponse, TaskID, TaskKind, TaskRecord,
         TaskStatus, TokenResourceScope, TokenScope,
     };
@@ -54,7 +54,7 @@ mod tests {
     use crate::tests::{
         ClassFixture, TestContext, create_test_classes, create_test_group,
         create_test_service_account, create_test_user, ensure_admin_group, lock_test_mutex,
-        resource_scoped_token, scoped_token, service_account_token,
+        resource_scoped_token, scoped_token, scoped_token_with_resources, service_account_token,
     };
     use crate::traits::{CanSave, PermissionController};
     use crate::utilities::auth::generate_random_password;
@@ -92,6 +92,92 @@ mod tests {
             .await
             .unwrap();
         (classes, objects, sa)
+    }
+
+    struct ScopedAdminListFixture {
+        classes: ClassFixture,
+        objects: Vec<HubuumObject>,
+        object_relation: HubuumObjectRelation,
+    }
+
+    impl ScopedAdminListFixture {
+        fn collection_id(&self) -> i32 {
+            self.classes.collection.collection.id
+        }
+
+        fn token_resources(&self) -> Vec<TokenResourceScope> {
+            std::iter::once(TokenResourceScope::Collection(
+                CollectionID::new(self.collection_id()).unwrap(),
+            ))
+            .chain(
+                self.classes
+                    .iter()
+                    .map(|class| TokenResourceScope::Class(HubuumClassID::new(class.id).unwrap())),
+            )
+            .collect()
+        }
+    }
+
+    async fn scoped_admin_list_fixture(context: &TestContext) -> ScopedAdminListFixture {
+        let collection = context
+            .scope
+            .collection_fixture("scoped_admin_list_visibility")
+            .await;
+        let classes = crate::tests::create_class_fixture(
+            &context.pool,
+            collection,
+            (0..2)
+                .map(|index| NewHubuumClass {
+                    name: context.scoped_name(&format!("scoped_admin_class_{index}")),
+                    description: "scoped administrator list test".to_string(),
+                    collection_id: 0,
+                    json_schema: None,
+                    validate_schema: Some(false),
+                })
+                .collect(),
+        )
+        .await
+        .unwrap();
+        let mut objects = Vec::with_capacity(classes.len());
+        for (index, class) in classes.iter().enumerate() {
+            objects.push(
+                NewHubuumObject {
+                    name: context.scoped_name(&format!("scoped_admin_object_{index}")),
+                    collection_id: class.collection_id,
+                    hubuum_class_id: class.id,
+                    data: serde_json::json!({"index": index}),
+                    description: "scoped administrator list test".to_string(),
+                }
+                .save_without_events(&context.pool)
+                .await
+                .unwrap(),
+            );
+        }
+        let class_relation = NewHubuumClassRelation {
+            from_hubuum_class_id: classes[0].id,
+            to_hubuum_class_id: classes[1].id,
+            forward_template_alias: None,
+            reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let object_relation = NewHubuumObjectRelation {
+            from_hubuum_object_id: objects[0].id,
+            to_hubuum_object_id: objects[1].id,
+            class_relation_id: class_relation.id,
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+
+        ScopedAdminListFixture {
+            classes,
+            objects,
+            object_relation,
+        }
     }
 
     #[derive(QueryableByName)]
@@ -1201,78 +1287,74 @@ mod tests {
         ObjectRelations,
     }
 
+    struct ScopedAdminListRequest {
+        exact_endpoint: String,
+        list_endpoint: String,
+        expected_ids: Vec<i32>,
+    }
+
+    impl ScopedAdminListTarget {
+        fn request(self, fixture: &ScopedAdminListFixture) -> ScopedAdminListRequest {
+            match self {
+                Self::Collections => ScopedAdminListRequest {
+                    exact_endpoint: format!("{COLLECTIONS_ENDPOINT}/{}", fixture.collection_id()),
+                    list_endpoint: COLLECTIONS_ENDPOINT.to_string(),
+                    expected_ids: vec![fixture.collection_id()],
+                },
+                Self::Classes => ScopedAdminListRequest {
+                    exact_endpoint: format!("/api/v1/classes/{}", fixture.classes[0].id),
+                    list_endpoint: "/api/v1/classes".to_string(),
+                    expected_ids: fixture.classes.iter().map(|class| class.id).collect(),
+                },
+                Self::ObjectsByClassId => ScopedAdminListRequest {
+                    exact_endpoint: format!(
+                        "/api/v1/classes/{}/{}",
+                        fixture.classes[0].id, fixture.objects[0].id
+                    ),
+                    list_endpoint: format!("/api/v1/classes/{}/", fixture.classes[0].id),
+                    expected_ids: vec![fixture.objects[0].id],
+                },
+                Self::ObjectsByClassName => ScopedAdminListRequest {
+                    exact_endpoint: format!(
+                        "/api/v1/classes/{}/{}",
+                        fixture.classes[0].id, fixture.objects[0].id
+                    ),
+                    list_endpoint: format!(
+                        "/api/v1/classes/by-name/{}/objects",
+                        fixture.classes[0].name
+                    ),
+                    expected_ids: vec![fixture.objects[0].id],
+                },
+                Self::ObjectRelations => ScopedAdminListRequest {
+                    exact_endpoint: format!(
+                        "/api/v1/relations/objects/{}",
+                        fixture.object_relation.id
+                    ),
+                    list_endpoint: "/api/v1/relations/objects".to_string(),
+                    expected_ids: vec![fixture.object_relation.id],
+                },
+            }
+        }
+    }
+
     #[rstest]
-    #[case::collections(ScopedAdminListTarget::Collections, 1)]
-    #[case::classes(ScopedAdminListTarget::Classes, 2)]
-    #[case::objects_by_class_id(ScopedAdminListTarget::ObjectsByClassId, 1)]
-    #[case::objects_by_class_name(ScopedAdminListTarget::ObjectsByClassName, 1)]
-    #[case::object_relations(ScopedAdminListTarget::ObjectRelations, 1)]
+    #[case::collections(ScopedAdminListTarget::Collections)]
+    #[case::classes(ScopedAdminListTarget::Classes)]
+    #[case::objects_by_class_id(ScopedAdminListTarget::ObjectsByClassId)]
+    #[case::objects_by_class_name(ScopedAdminListTarget::ObjectsByClassName)]
+    #[case::object_relations(ScopedAdminListTarget::ObjectRelations)]
     #[actix_web::test]
     async fn test_resource_scoped_admin_lists_in_scope_resources_without_group_grants(
         #[case] target: ScopedAdminListTarget,
-        #[case] expected_total: i64,
     ) {
         let context = TestContext::new().await;
-        let collection = context
-            .scope
-            .collection_fixture("scoped_admin_list_visibility")
-            .await;
-        let classes = crate::tests::create_class_fixture(
-            &context.pool,
-            collection,
-            (0..2)
-                .map(|index| NewHubuumClass {
-                    name: context.scoped_name(&format!("scoped_admin_class_{index}")),
-                    description: "scoped administrator list test".to_string(),
-                    collection_id: 0,
-                    json_schema: None,
-                    validate_schema: Some(false),
-                })
-                .collect(),
-        )
-        .await
-        .unwrap();
-        let mut objects = Vec::new();
-        for (index, class) in classes.iter().enumerate() {
-            objects.push(
-                NewHubuumObject {
-                    name: context.scoped_name(&format!("scoped_admin_object_{index}")),
-                    collection_id: class.collection_id,
-                    hubuum_class_id: class.id,
-                    data: serde_json::json!({"index": index}),
-                    description: "scoped administrator list test".to_string(),
-                }
-                .save_without_events(&context.pool)
-                .await
-                .unwrap(),
-            );
-        }
-        let class_relation = NewHubuumClassRelation {
-            from_hubuum_class_id: classes[0].id,
-            to_hubuum_class_id: classes[1].id,
-            forward_template_alias: None,
-            reverse_template_alias: None,
-            from_max_relations: None,
-            to_max_relations: None,
-        }
-        .save_without_events(&context.pool)
-        .await
-        .unwrap();
-        let object_relation = NewHubuumObjectRelation {
-            from_hubuum_object_id: objects[0].id,
-            to_hubuum_object_id: objects[1].id,
-            class_relation_id: class_relation.id,
-        }
-        .save_without_events(&context.pool)
-        .await
-        .unwrap();
-
+        let fixture = scoped_admin_list_fixture(&context).await;
         let admin_group = ensure_admin_group(&context.pool).await;
         assert!(
             !group_can_on(
                 &context.pool,
                 admin_group.id,
-                classes.collection.collection.clone(),
+                fixture.classes.collection.collection.clone(),
                 Permissions::ReadCollection,
             )
             .await
@@ -1280,67 +1362,25 @@ mod tests {
             "the administrator group must not have an explicit collection grant"
         );
 
-        let scope = TokenScope::from_request_parts(
-            Some(vec![
+        let token = scoped_token_with_resources(
+            &context.pool,
+            context.admin_user.id,
+            &[
                 Permissions::ReadCollection,
                 Permissions::ReadClass,
                 Permissions::ReadObject,
                 Permissions::ReadClassRelation,
                 Permissions::ReadObjectRelation,
-            ]),
-            Some(vec![
-                TokenResourceScope::Collection(
-                    CollectionID::new(classes.collection.collection.id).unwrap(),
-                ),
-                TokenResourceScope::Class(HubuumClassID::new(classes[0].id).unwrap()),
-                TokenResourceScope::Class(HubuumClassID::new(classes[1].id).unwrap()),
-            ]),
+            ],
+            fixture.token_resources(),
         )
-        .unwrap()
-        .unwrap();
-        let token =
-            PrincipalTokenCreateRequest::new(PrincipalID::new(context.admin_user.id).unwrap())
-                .scope(Some(scope))
-                .create(&context.pool, None)
-                .await
-                .unwrap()
-                .get_token();
+        .await;
+        let request = target.request(&fixture);
 
-        let (exact_endpoint, list_endpoint, expected_ids) = match target {
-            ScopedAdminListTarget::Collections => (
-                format!(
-                    "{COLLECTIONS_ENDPOINT}/{}",
-                    classes.collection.collection.id
-                ),
-                COLLECTIONS_ENDPOINT.to_string(),
-                vec![classes.collection.collection.id],
-            ),
-            ScopedAdminListTarget::Classes => (
-                format!("/api/v1/classes/{}", classes[0].id),
-                "/api/v1/classes".to_string(),
-                classes.iter().map(|class| class.id).collect(),
-            ),
-            ScopedAdminListTarget::ObjectsByClassId => (
-                format!("/api/v1/classes/{}/{}", classes[0].id, objects[0].id),
-                format!("/api/v1/classes/{}/", classes[0].id),
-                vec![objects[0].id],
-            ),
-            ScopedAdminListTarget::ObjectsByClassName => (
-                format!("/api/v1/classes/{}/{}", classes[0].id, objects[0].id),
-                format!("/api/v1/classes/by-name/{}/objects", classes[0].name),
-                vec![objects[0].id],
-            ),
-            ScopedAdminListTarget::ObjectRelations => (
-                format!("/api/v1/relations/objects/{}", object_relation.id),
-                "/api/v1/relations/objects".to_string(),
-                vec![object_relation.id],
-            ),
-        };
-
-        let exact = get_request(&context.pool, &token, &exact_endpoint).await;
+        let exact = get_request(&context.pool, &token, &request.exact_endpoint).await;
         assert_eq!(exact.status(), StatusCode::OK);
 
-        let response = get_request(&context.pool, &token, &list_endpoint).await;
+        let response = get_request(&context.pool, &token, &request.list_endpoint).await;
         let total = header_value(&response, TOTAL_COUNT_HEADER)
             .unwrap()
             .parse::<i64>()
@@ -1350,10 +1390,11 @@ mod tests {
             .as_array()
             .unwrap()
             .iter()
-            .map(|resource| resource["id"].as_i64().unwrap() as i32)
+            .map(|resource| i32::try_from(resource["id"].as_i64().unwrap()).unwrap())
             .collect::<Vec<_>>();
+        let expected_total = i64::try_from(request.expected_ids.len()).unwrap();
 
-        assert_eq!((total, ids), (expected_total, expected_ids));
+        assert_eq!((total, ids), (expected_total, request.expected_ids));
     }
 
     #[derive(Clone, Copy)]

--- a/tests/api_identity_suite/service_accounts.rs
+++ b/tests/api_identity_suite/service_accounts.rs
@@ -32,13 +32,13 @@ mod tests {
     use crate::errors::ApiError;
     use crate::events::{Action, EntityType};
     use crate::models::Collection;
-    use crate::models::collection::user_can_on_any;
+    use crate::models::collection::{group_can_on, user_can_on_any};
     use crate::models::principal::{PrincipalKind, load_principal_by_id};
     use crate::models::token::Token;
     use crate::models::user::{LoginUser, NewUser};
     use crate::models::{
         CollectionID, GroupResponse, HubuumClassID, HubuumObject, HubuumObjectID,
-        MAX_TOKEN_RESOURCE_SCOPES, NewHubuumClassRelation, NewHubuumObject,
+        MAX_TOKEN_RESOURCE_SCOPES, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
         NewHubuumObjectRelation, NewServiceAccount, NewTaskRecord, Permissions, PrincipalID,
         PrincipalMemberResponse, PrincipalTokenCreateRequest, PrincipalTokenMetadata,
         ServiceAccount, ServiceAccountID, ServiceAccountResponse, TaskID, TaskKind, TaskRecord,
@@ -1190,6 +1190,170 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!((total, ids), (1, vec![i64::from(objects[0].id)]));
+    }
+
+    #[derive(Clone, Copy)]
+    enum ScopedAdminListTarget {
+        Collections,
+        Classes,
+        ObjectsByClassId,
+        ObjectsByClassName,
+        ObjectRelations,
+    }
+
+    #[rstest]
+    #[case::collections(ScopedAdminListTarget::Collections, 1)]
+    #[case::classes(ScopedAdminListTarget::Classes, 2)]
+    #[case::objects_by_class_id(ScopedAdminListTarget::ObjectsByClassId, 1)]
+    #[case::objects_by_class_name(ScopedAdminListTarget::ObjectsByClassName, 1)]
+    #[case::object_relations(ScopedAdminListTarget::ObjectRelations, 1)]
+    #[actix_web::test]
+    async fn test_resource_scoped_admin_lists_in_scope_resources_without_group_grants(
+        #[case] target: ScopedAdminListTarget,
+        #[case] expected_total: i64,
+    ) {
+        let context = TestContext::new().await;
+        let collection = context
+            .scope
+            .collection_fixture("scoped_admin_list_visibility")
+            .await;
+        let classes = crate::tests::create_class_fixture(
+            &context.pool,
+            collection,
+            (0..2)
+                .map(|index| NewHubuumClass {
+                    name: context.scoped_name(&format!("scoped_admin_class_{index}")),
+                    description: "scoped administrator list test".to_string(),
+                    collection_id: 0,
+                    json_schema: None,
+                    validate_schema: Some(false),
+                })
+                .collect(),
+        )
+        .await
+        .unwrap();
+        let mut objects = Vec::new();
+        for (index, class) in classes.iter().enumerate() {
+            objects.push(
+                NewHubuumObject {
+                    name: context.scoped_name(&format!("scoped_admin_object_{index}")),
+                    collection_id: class.collection_id,
+                    hubuum_class_id: class.id,
+                    data: serde_json::json!({"index": index}),
+                    description: "scoped administrator list test".to_string(),
+                }
+                .save_without_events(&context.pool)
+                .await
+                .unwrap(),
+            );
+        }
+        let class_relation = NewHubuumClassRelation {
+            from_hubuum_class_id: classes[0].id,
+            to_hubuum_class_id: classes[1].id,
+            forward_template_alias: None,
+            reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let object_relation = NewHubuumObjectRelation {
+            from_hubuum_object_id: objects[0].id,
+            to_hubuum_object_id: objects[1].id,
+            class_relation_id: class_relation.id,
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+
+        let admin_group = ensure_admin_group(&context.pool).await;
+        assert!(
+            !group_can_on(
+                &context.pool,
+                admin_group.id,
+                classes.collection.collection.clone(),
+                Permissions::ReadCollection,
+            )
+            .await
+            .unwrap(),
+            "the administrator group must not have an explicit collection grant"
+        );
+
+        let scope = TokenScope::from_request_parts(
+            Some(vec![
+                Permissions::ReadCollection,
+                Permissions::ReadClass,
+                Permissions::ReadObject,
+                Permissions::ReadClassRelation,
+                Permissions::ReadObjectRelation,
+            ]),
+            Some(vec![
+                TokenResourceScope::Collection(
+                    CollectionID::new(classes.collection.collection.id).unwrap(),
+                ),
+                TokenResourceScope::Class(HubuumClassID::new(classes[0].id).unwrap()),
+                TokenResourceScope::Class(HubuumClassID::new(classes[1].id).unwrap()),
+            ]),
+        )
+        .unwrap()
+        .unwrap();
+        let token =
+            PrincipalTokenCreateRequest::new(PrincipalID::new(context.admin_user.id).unwrap())
+                .scope(Some(scope))
+                .create(&context.pool, None)
+                .await
+                .unwrap()
+                .get_token();
+
+        let (exact_endpoint, list_endpoint, expected_ids) = match target {
+            ScopedAdminListTarget::Collections => (
+                format!(
+                    "{COLLECTIONS_ENDPOINT}/{}",
+                    classes.collection.collection.id
+                ),
+                COLLECTIONS_ENDPOINT.to_string(),
+                vec![classes.collection.collection.id],
+            ),
+            ScopedAdminListTarget::Classes => (
+                format!("/api/v1/classes/{}", classes[0].id),
+                "/api/v1/classes".to_string(),
+                classes.iter().map(|class| class.id).collect(),
+            ),
+            ScopedAdminListTarget::ObjectsByClassId => (
+                format!("/api/v1/classes/{}/{}", classes[0].id, objects[0].id),
+                format!("/api/v1/classes/{}/", classes[0].id),
+                vec![objects[0].id],
+            ),
+            ScopedAdminListTarget::ObjectsByClassName => (
+                format!("/api/v1/classes/{}/{}", classes[0].id, objects[0].id),
+                format!("/api/v1/classes/by-name/{}/objects", classes[0].name),
+                vec![objects[0].id],
+            ),
+            ScopedAdminListTarget::ObjectRelations => (
+                format!("/api/v1/relations/objects/{}", object_relation.id),
+                "/api/v1/relations/objects".to_string(),
+                vec![object_relation.id],
+            ),
+        };
+
+        let exact = get_request(&context.pool, &token, &exact_endpoint).await;
+        assert_eq!(exact.status(), StatusCode::OK);
+
+        let response = get_request(&context.pool, &token, &list_endpoint).await;
+        let total = header_value(&response, TOTAL_COUNT_HEADER)
+            .unwrap()
+            .parse::<i64>()
+            .unwrap();
+        let body: serde_json::Value = test::read_body_json(response).await;
+        let ids = body
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|resource| resource["id"].as_i64().unwrap() as i32)
+            .collect::<Vec<_>>();
+
+        assert_eq!((total, ids), (expected_total, expected_ids));
     }
 
     #[derive(Clone, Copy)]


### PR DESCRIPTION
## Summary

- preserve administrator authority in list and unified-search queries after token permission-scope validation
- continue applying resource-scope predicates to collections, classes, objects, and both relation endpoints
- add regression coverage for collection, class, object, class-relation, object-relation, and unified-search visibility without duplicate admin-group grants
- centralize combined permission/resource token setup and use typed fixtures to keep the regression matrix maintainable
- align exact-read preconditions with the corresponding by-name and nested relation list routes
- document the fix in the Unreleased changelog

## Root cause

Exact-resource authorization checked the token's permission and resource boundaries before applying the administrator bypass. Several list paths instead disabled that bypass whenever a token was scoped, then required ordinary collection permission rows. That made a scoped administrator's exact reads succeed while the corresponding lists returned an empty page.

## Behavior

Resource-scoped administrator tokens now retain the principal's administrator authority, but only after the requested permissions pass the token-scope check. Parent collections remain internal query context for class- and object-scoped tokens, while SQL resource predicates still restrict returned rows to the token boundary. Non-administrator group-grant behavior is unchanged.

Breaking changes: none.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`

Fixes #189