### PR TITLE
Fix portable release checksums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -662,7 +662,9 @@ jobs:
           done
           archive_name="hubuum-${{ matrix.platform.os_name }}-all-features-${GITHUB_REF_NAME}.tar.gz"
           tar czvf "dist/${archive_name}" -C dist/bin hubuum-server hubuum-admin
-          shasum -a 256 "dist/${archive_name}" > "dist/${archive_name}.sha256"
+          cd dist
+          shasum -a 256 "${archive_name}" > "${archive_name}.sha256"
+          shasum -a 256 -c "${archive_name}.sha256"
       - name: Upload release artifact
         uses: actions/upload-artifact@v7
         with:
@@ -754,7 +756,16 @@ jobs:
           $archive_name = "hubuum-${{ matrix.platform.os_name }}-full-release-${env:GITHUB_REF_NAME}.zip"
           Compress-Archive -Path "target/${{ matrix.platform.target }}/release/hubuum-server.exe", "target/${{ matrix.platform.target }}/release/hubuum-admin.exe" -DestinationPath "dist/$archive_name"
           $hash = (Get-FileHash "dist/$archive_name" -Algorithm SHA256).Hash.ToLower()
-          "$hash  $archive_name" | Out-File -FilePath "dist/$archive_name.sha256" -Encoding ascii
+          # Keep checksum files portable: UTF-8 without a BOM and an explicit LF.
+          $checksum = "$hash  $archive_name`n"
+          [System.IO.File]::WriteAllText(
+            "dist/$archive_name.sha256",
+            $checksum,
+            [System.Text.UTF8Encoding]::new($false)
+          )
+          if ([System.IO.File]::ReadAllText("dist/$archive_name.sha256") -cne $checksum) {
+            throw "Checksum file was not written exactly as expected"
+          }
       
       - name: Upload release artifact
         uses: actions/upload-artifact@v7
@@ -859,7 +870,9 @@ jobs:
           done
           archive_name="hubuum-${{ matrix.platform.os_name }}-${{ matrix.feature.ext }}-main.tar.gz"
           tar czvf "dist/${archive_name}" -C dist/bin hubuum-server hubuum-admin
-          shasum -a 256 "dist/${archive_name}" > "dist/${archive_name}.sha256"
+          cd dist
+          shasum -a 256 "${archive_name}" > "${archive_name}.sha256"
+          shasum -a 256 -c "${archive_name}.sha256"
       - name: Upload main artifact
         uses: actions/upload-artifact@v7
         with:
@@ -944,7 +957,9 @@ jobs:
           mkdir -p dist
           archive_name="hubuum-${{ matrix.platform.os_name }}-${{ matrix.feature.ext }}-main.tar.gz"
           tar czvf "dist/${archive_name}" -C "target/${{ matrix.platform.target }}/release" hubuum-server hubuum-admin
-          shasum -a 256 "dist/${archive_name}" > "dist/${archive_name}.sha256"
+          cd dist
+          shasum -a 256 "${archive_name}" > "${archive_name}.sha256"
+          shasum -a 256 -c "${archive_name}.sha256"
       - name: Package main archive (Windows)
         if: contains(matrix.platform.os_name, 'windows')
         shell: pwsh
@@ -953,7 +968,16 @@ jobs:
           $archive_name = "hubuum-${{ matrix.platform.os_name }}-${{ matrix.feature.ext }}-main.zip"
           Compress-Archive -Path "target/${{ matrix.platform.target }}/release/hubuum-server.exe", "target/${{ matrix.platform.target }}/release/hubuum-admin.exe" -DestinationPath "dist/$archive_name"
           $hash = (Get-FileHash "dist/$archive_name" -Algorithm SHA256).Hash.ToLower()
-          "$hash  $archive_name" | Out-File -FilePath "dist/$archive_name.sha256" -Encoding ascii
+          # Keep checksum files portable: UTF-8 without a BOM and an explicit LF.
+          $checksum = "$hash  $archive_name`n"
+          [System.IO.File]::WriteAllText(
+            "dist/$archive_name.sha256",
+            $checksum,
+            [System.Text.UTF8Encoding]::new($false)
+          )
+          if ([System.IO.File]::ReadAllText("dist/$archive_name.sha256") -cne $checksum) {
+            throw "Checksum file was not written exactly as expected"
+          }
       - name: Upload main artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary

Generate portable checksum files for tagged releases and `main-latest` artifacts.

Unix packaging now computes checksums from inside `dist`, so each checksum entry contains only the downloadable archive name. Windows packaging writes UTF-8 without a BOM and uses an explicit LF, making the files directly consumable by both `sha256sum -c` and `shasum -c`.

The Unix packaging steps also verify each generated checksum immediately.

## Release remediation

Consumer-side verification of v0.0.7 exposed the existing path and line-ending defects after publication. The three malformed v0.0.7 checksum assets were normalized and replaced without changing the tag or binary archives; all four published checksums now validate against their downloaded archives.

## Changelog

This is an internal release-tooling correction with no user-facing Hubuum behavior change, so no product changelog entry is warranted.

## Verification

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `source .env && ./run_tests.sh`
- Downloaded all v0.0.7 release assets and validated every published checksum with `shasum -a 256 -c`
