### PR TITLE
Migrate Rust PR Bench workflow to v3

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   benchmarks:
     name: Self-contained benchmarks
-    uses: terjekv/github-action-iai-callgrind/.github/workflows/rust-pr-bench.yml@v2.3
+    uses: terjekv/github-action-iai-callgrind/.github/workflows/rust-pr-bench.yml@v3
     secrets: inherit
     with:
       backend: all


### PR DESCRIPTION
## Summary

- Update the reusable Rust PR Bench workflow from the v2.3 migration bridge to v3.
- Preserve the existing Gungraun, Criterion, autodiscovery, moved-benchmark detection, and regression-threshold configuration.

## Rationale

Hubuum already completed the IAI-Callgrind-to-Gungraun dependency and input migration through the v2.3 bridge. Rust PR Bench v3 makes Gungraun the canonical backend while retaining history and legacy comment compatibility, so the remaining consumer migration is the workflow reference update.

Existing `*_callgrind` benchmark target names remain unchanged to preserve base/head metric pairing and benchmark history.

## Impact

This changes benchmark CI tooling only. Production behavior and the public API are unchanged.

## Changelog

No changelog entry is warranted because this is an internal CI workflow update with no user-facing Hubuum impact.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
