### PR TITLE
Prepare v0.0.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.0.8] - 2026-08-01
+
+### Fixed
+
+- Resource-scoped administrator tokens now list in-scope collections, classes,
+  objects, and relations without requiring duplicate collection permission
+  grants.
+
 ## [0.0.7] - 2026-07-31
 
 ### Added
@@ -23,12 +31,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Migrated deterministic benchmarks from IAI-Callgrind to Gungraun and updated
   the reusable benchmark workflow to its v2.3 migration bridge.
-
-### Fixed
-
-- Resource-scoped administrator tokens now list in-scope collections, classes,
-  objects, and relations without requiring duplicate collection permission
-  grants.
 
 ## [0.0.6] - 2026-07-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2068,7 +2068,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hubuum"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hubuum"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 description = "Flexible asset management REST service."
 license = "MIT"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.0.7"
+    "version": "0.0.8"
   },
   "servers": [
     {

--- a/tests/api_identity_suite/service_accounts.rs
+++ b/tests/api_identity_suite/service_accounts.rs
@@ -482,7 +482,6 @@ mod tests {
         let group = create_test_group(&context.pool).await;
         let sa = create_test_service_account(&context.pool, &group, None).await;
         let lifetime_hours = integration_test_config().unwrap().token_lifetime_hours;
-        let earliest = chrono::Utc::now().naive_utc() + chrono::Duration::hours(lifetime_hours);
 
         let response = post_request(
             &context.pool,
@@ -496,7 +495,6 @@ mod tests {
         let raw_token = body["token"].as_str().unwrap();
         let returned_expiry =
             serde_json::from_value::<chrono::NaiveDateTime>(body["expires_at"].clone()).unwrap();
-        let latest = chrono::Utc::now().naive_utc() + chrono::Duration::hours(lifetime_hours);
 
         let (persisted_issued, persisted_expiry) = with_connection(&context.pool, async |conn| {
             tokens
@@ -508,8 +506,6 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(returned_expiry >= earliest);
-        assert!(returned_expiry <= latest);
         assert_eq!(persisted_expiry, Some(returned_expiry));
         assert_eq!(
             returned_expiry,


### PR DESCRIPTION
## Summary

- Bump Hubuum from 0.0.7 to 0.0.8 and regenerate the committed OpenAPI version.
- Refresh the lockfile to the latest compatible `clap` and `clap_builder` patch releases.
- Move the resource-scoped administrator visibility fix into the v0.0.8 release notes, where it first ships.
- Make the default token-expiry integration test compare database-derived timestamps instead of assuming the application host and PostgreSQL clocks are identical.

## Impact

Hubuum v0.0.8 fixes listing of in-scope collections, classes, objects, and relations for resource-scoped administrator tokens without requiring duplicate collection permission grants.

Breaking changes: none.

## Root cause

The administrator visibility fix landed after the v0.0.7 tag, although its changelog entry was initially placed under v0.0.7. Release verification also exposed a timing-sensitive test that bounded a PostgreSQL-derived timestamp using the application host clock; small cross-host clock differences could fail the parallel suite even though the persisted expiry invariant was correct.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `./scripts/check-version-bump.sh`
- `./scripts/check-release-readiness.sh v0.0.8`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`
