### PR TITLE
Stabilize request log capture tests

### DIFF
--- a/tests/api_platform_suite/request_and_correlation.rs
+++ b/tests/api_platform_suite/request_and_correlation.rs
@@ -9,6 +9,7 @@ mod tests {
     };
     use serde_json::json;
     use std::{future::Future, str::FromStr};
+    use tokio::sync::Mutex;
     use tracing::instrument::WithSubscriber;
     use tracing_subscriber::layer::SubscriberExt;
 
@@ -23,6 +24,7 @@ mod tests {
     use crate::tests::{TestContext, test_context};
 
     const ENDPOINT: &str = "/api/v1/classes/";
+    static REQUEST_LOG_CAPTURE_LOCK: Mutex<()> = Mutex::const_new(());
 
     #[rstest]
     #[case::with_correlation_id(Some("test-correlation-id"), true)]
@@ -105,6 +107,10 @@ mod tests {
     }
 
     async fn capture_request_logs<T>(future: impl Future<Output = T>) -> (T, JsonLogWriter) {
+        // These tests install distinct task-local tracing subscribers around nested Actix
+        // middleware futures. Keep capture windows from overlapping: parallel capture has
+        // intermittently dropped the final middleware event on CI.
+        let _capture_guard = REQUEST_LOG_CAPTURE_LOCK.lock().await;
         let writer = JsonLogWriter::default();
         let subscriber = tracing_subscriber::registry().with(
             tracing_subscriber::fmt::layer()


### PR DESCRIPTION
## Summary

- Serialize request-log capture windows in the API platform test harness.
- Keep each task-local tracing subscriber active without overlapping sibling captures.

## Impact

This changes test-only code. Runtime behavior and public APIs are unchanged.

## Root cause

Parallel request-log tests installed distinct task-local tracing subscribers while Actix polled nested middleware futures. On CI, the final request-completion event could intermittently be missed by one test writer even though the middleware completed normally. The failure appeared in two sibling assertions on different architectures.

## Changelog

No changelog entry: this is an internal test-harness stabilization with no user-facing behavior change.

## Verification

- source .env && ./run_tests.sh
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- 20 repeated parallel middleware-focused runs against fresh migrated databases