### PR TITLE
Type permission target IDs at API boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking (Rust API):** permission-controller group parameters and
+  permission-backend collection and group parameters now use validated
+  `CollectionID` and `GroupID` values instead of raw integers. Downstream
+  callers and backend implementations must construct the newtypes at their
+  input boundaries and update their method signatures.
+
 ## [0.0.8] - 2026-08-01
 
 ### Fixed

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -774,11 +774,7 @@ async fn read_resolved_class_permissions(
         (permissions, total_count)
     } else {
         pool.permission_backend()
-            .groups_with_permissions_on(
-                target_collection_id.id(),
-                &class_permissions,
-                &search_params,
-            )
+            .groups_with_permissions_on(target_collection_id, &class_permissions, &search_params)
             .await?
     };
 

--- a/src/api/v1/handlers/collections.rs
+++ b/src/api/v1/handlers/collections.rs
@@ -448,7 +448,7 @@ pub async fn get_collection_permissions(
         .await?
     } else {
         pool.permission_backend()
-            .groups_with_permissions_on(collection.id, &[], &search_params)
+            .groups_with_permissions_on(*collection_id, &[], &search_params)
             .await?
     };
     ApiResponse::paginated(permissions, total_count, &params)
@@ -500,7 +500,7 @@ pub async fn get_collection_group_permissions(
         collection_model::group_on(&pool, collection.id, group_id.id()).await?
     } else {
         pool.permission_backend()
-            .group_permission_on(collection.id, group_id.id())
+            .group_permission_on(collection_id, group_id)
             .await?
             .ok_or_else(|| ApiError::NotFound("Permission record not found".to_string()))?
     };
@@ -608,11 +608,11 @@ pub async fn grant_collection_group_permissions(
     if pool.permission_backend().supports_mutation() {
         let event_context = requestor.event_context(&req);
         collection
-            .grant(&pool, group_id.id(), permissions, Some(&event_context))
+            .grant(&pool, group_id, permissions, Some(&event_context))
             .await?;
     } else {
         pool.permission_backend()
-            .apply_permissions(collection.id, group_id.id(), permissions, false)
+            .apply_permissions(collection_id, group_id, permissions, false)
             .await?;
     }
 
@@ -676,11 +676,11 @@ pub async fn replace_collection_group_permissions(
     if pool.permission_backend().supports_mutation() {
         let event_context = requestor.event_context(&req);
         collection
-            .set_permissions(&pool, group_id.id(), permissions, Some(&event_context))
+            .set_permissions(&pool, group_id, permissions, Some(&event_context))
             .await?;
     } else {
         pool.permission_backend()
-            .apply_permissions(collection.id, group_id.id(), permissions, true)
+            .apply_permissions(collection_id, group_id, permissions, true)
             .await?;
     }
 
@@ -731,11 +731,11 @@ pub async fn revoke_collection_group_permissions(
     if pool.permission_backend().supports_mutation() {
         let event_context = requestor.event_context(&req);
         collection
-            .revoke_all(&pool, group_id.id(), Some(&event_context))
+            .revoke_all(&pool, group_id, Some(&event_context))
             .await?;
     } else {
         pool.permission_backend()
-            .revoke_all(collection.id, group_id.id())
+            .revoke_all(collection_id, group_id)
             .await?;
     }
 
@@ -789,7 +789,7 @@ pub async fn get_collection_group_permission(
         group_can_on(&pool, group_id.id(), collection, permission).await?
     } else {
         pool.permission_backend()
-            .group_permission_on(collection.id, group_id.id())
+            .group_permission_on(collection_id, group_id)
             .await?
             .is_some_and(|row| row.granted().contains(&permission))
     };
@@ -847,11 +847,11 @@ pub async fn grant_collection_group_permission(
     if pool.permission_backend().supports_mutation() {
         let event_context = requestor.event_context(&req);
         collection
-            .grant(&pool, group_id.id(), permissions, Some(&event_context))
+            .grant(&pool, group_id, permissions, Some(&event_context))
             .await?;
     } else {
         pool.permission_backend()
-            .apply_permissions(collection.id, group_id.id(), permissions, false)
+            .apply_permissions(collection_id, group_id, permissions, false)
             .await?;
     }
 
@@ -905,11 +905,11 @@ pub async fn revoke_collection_group_permission(
     if pool.permission_backend().supports_mutation() {
         let event_context = requestor.event_context(&req);
         collection
-            .revoke(&pool, group_id.id(), permissions, Some(&event_context))
+            .revoke(&pool, group_id, permissions, Some(&event_context))
             .await?;
     } else {
         pool.permission_backend()
-            .revoke_permissions(collection.id, group_id.id(), permissions)
+            .revoke_permissions(collection_id, group_id, permissions)
             .await?;
     }
 
@@ -1075,7 +1075,7 @@ pub async fn get_collection_groups_with_permission(
     } else {
         let (permissions, total_count) = pool
             .permission_backend()
-            .groups_with_permissions_on(collection.id, &[permission], &search_params)
+            .groups_with_permissions_on(collection_id, &[permission], &search_params)
             .await?;
         (
             permissions.into_iter().map(|row| row.group).collect(),

--- a/src/db/traits/permissions.rs
+++ b/src/db/traits/permissions.rs
@@ -6,7 +6,8 @@ use crate::db::{DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
 use crate::models::{
-    NewPermission, Permission, PermissionFilter, Permissions, PermissionsList, UpdatePermission,
+    GroupID, NewPermission, Permission, PermissionFilter, Permissions, PermissionsList,
+    UpdatePermission,
 };
 use crate::traits::CollectionAccessors;
 
@@ -340,13 +341,14 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
     async fn apply_permissions_from_backend_without_events(
         &self,
         pool: &DbPool,
-        group_id_for_grant: i32,
+        group_id_for_grant: GroupID,
         permission_list: PermissionsList<Permissions>,
         replace_existing: bool,
     ) -> Result<Permission, ApiError> {
         use crate::schema::permissions::dsl::*;
 
         let target_collection_id = self.collection_id(pool).await?.id();
+        let group_id_for_grant = group_id_for_grant.id();
 
         with_transaction(pool, async |conn| -> Result<Permission, ApiError> {
             let existing_entry = permissions
@@ -572,7 +574,7 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
     async fn apply_permissions_from_backend(
         &self,
         pool: &DbPool,
-        group_id_for_grant: i32,
+        group_id_for_grant: GroupID,
         permission_list: PermissionsList<Permissions>,
         replace_existing: bool,
         context: Option<&EventContext>,
@@ -591,6 +593,7 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
         use crate::schema::permissions::dsl::*;
 
         let target_collection_id = self.collection_id(pool).await?.id();
+        let group_id_for_grant = group_id_for_grant.id();
         let requested = permission_list.iter().copied().collect::<Vec<_>>();
 
         with_transaction(pool, async |conn| -> Result<Permission, ApiError> {
@@ -659,12 +662,13 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
     async fn revoke_permissions_from_backend_without_events(
         &self,
         pool: &DbPool,
-        group_id_for_revoke: i32,
+        group_id_for_revoke: GroupID,
         permission_list: PermissionsList<Permissions>,
     ) -> Result<Permission, ApiError> {
         use crate::schema::permissions::dsl::*;
 
         let target_collection_id = self.collection_id(pool).await?.id();
+        let group_id_for_revoke = group_id_for_revoke.id();
 
         with_transaction(pool, async |conn| -> Result<Permission, ApiError> {
             let before = permissions
@@ -790,7 +794,7 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
     async fn revoke_permissions_from_backend(
         &self,
         pool: &DbPool,
-        group_id_for_revoke: i32,
+        group_id_for_revoke: GroupID,
         permission_list: PermissionsList<Permissions>,
         context: Option<&EventContext>,
     ) -> Result<Permission, ApiError> {
@@ -807,6 +811,7 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
         use crate::schema::permissions::dsl::*;
 
         let target_collection_id = self.collection_id(pool).await?.id();
+        let group_id_for_revoke = group_id_for_revoke.id();
         let requested = permission_list.iter().copied().collect::<Vec<_>>();
 
         with_transaction(pool, async |conn| -> Result<Permission, ApiError> {
@@ -851,11 +856,12 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
     async fn revoke_all_from_backend_without_events(
         &self,
         pool: &DbPool,
-        group_id_for_revoke: i32,
+        group_id_for_revoke: GroupID,
     ) -> Result<(), ApiError> {
         use crate::schema::permissions::dsl::*;
 
         let collection_id_for_revoke = self.collection_id(pool).await?.id();
+        let group_id_for_revoke = group_id_for_revoke.id();
         with_connection(pool, async |conn| {
             diesel::delete(permissions)
                 .filter(collection_id.eq(collection_id_for_revoke))
@@ -871,7 +877,7 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
     async fn revoke_all_from_backend(
         &self,
         pool: &DbPool,
-        group_id_for_revoke: i32,
+        group_id_for_revoke: GroupID,
         context: Option<&EventContext>,
     ) -> Result<(), ApiError> {
         let Some(context) = context else {
@@ -883,6 +889,7 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
         use crate::schema::permissions::dsl::*;
 
         let collection_id_for_revoke = self.collection_id(pool).await?.id();
+        let group_id_for_revoke = group_id_for_revoke.id();
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
             let before = permissions
                 .filter(collection_id.eq(collection_id_for_revoke))

--- a/src/db/traits/user/mod.rs
+++ b/src/db/traits/user/mod.rs
@@ -40,7 +40,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    use crate::models::{Permissions as P, PermissionsList as PL};
+    use crate::models::{GroupID, Permissions as P, PermissionsList as PL};
     use crate::tests::{TestScope, create_test_group, create_user_with_params};
     use crate::traits::AuthzSubject;
     use crate::traits::PermissionController;
@@ -124,7 +124,7 @@ mod tests {
             .collection
             .grant_without_events(
                 &pool,
-                groups[0].id,
+                GroupID::new(groups[0].id).unwrap(),
                 PL::new(vec![P::CreateClass, P::ReadClass]),
             )
             .await
@@ -133,7 +133,7 @@ mod tests {
             .collection
             .grant_without_events(
                 &pool,
-                groups[0].id,
+                GroupID::new(groups[0].id).unwrap(),
                 PL::new(vec![P::CreateClass, P::DeleteClass]),
             )
             .await
@@ -143,7 +143,7 @@ mod tests {
             .collection
             .grant_without_events(
                 &pool,
-                groups[1].id,
+                GroupID::new(groups[1].id).unwrap(),
                 PL::new(vec![P::CreateObject, P::ReadObject]),
             )
             .await
@@ -152,7 +152,7 @@ mod tests {
             .collection
             .grant_without_events(
                 &pool,
-                groups[1].id,
+                GroupID::new(groups[1].id).unwrap(),
                 PL::new(vec![P::CreateObject, P::DeleteObject]),
             )
             .await

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -1860,7 +1860,7 @@ async fn permission_writes_emit_granted_revoked_events() {
         .collection
         .grant(
             &scope.pool,
-            group.id,
+            GroupID::new(group.id).unwrap(),
             PermissionsList::new([Permissions::ReadCollection, Permissions::CreateClass]),
             Some(&context),
         )
@@ -1871,7 +1871,7 @@ async fn permission_writes_emit_granted_revoked_events() {
         .collection
         .grant(
             &scope.pool,
-            group.id,
+            GroupID::new(group.id).unwrap(),
             PermissionsList::new([Permissions::ReadCollection, Permissions::CreateClass]),
             Some(&context),
         )
@@ -1882,7 +1882,7 @@ async fn permission_writes_emit_granted_revoked_events() {
         .collection
         .apply_permissions(
             &scope.pool,
-            group.id,
+            GroupID::new(group.id).unwrap(),
             PermissionsList::new([Permissions::ReadCollection, Permissions::CreateClass]),
             true,
             Some(&context),
@@ -1894,7 +1894,7 @@ async fn permission_writes_emit_granted_revoked_events() {
         .collection
         .revoke(
             &scope.pool,
-            group.id,
+            GroupID::new(group.id).unwrap(),
             PermissionsList::new([Permissions::CreateClass]),
             Some(&context),
         )
@@ -1905,7 +1905,7 @@ async fn permission_writes_emit_granted_revoked_events() {
         .collection
         .revoke(
             &scope.pool,
-            group.id,
+            GroupID::new(group.id).unwrap(),
             PermissionsList::new([Permissions::CreateClass]),
             Some(&context),
         )
@@ -1914,12 +1914,12 @@ async fn permission_writes_emit_granted_revoked_events() {
 
     fixture
         .collection
-        .revoke_all(&scope.pool, group.id, Some(&context))
+        .revoke_all(&scope.pool, GroupID::new(group.id).unwrap(), Some(&context))
         .await
         .unwrap();
     fixture
         .collection
-        .revoke_all(&scope.pool, group.id, Some(&context))
+        .revoke_all(&scope.pool, GroupID::new(group.id).unwrap(), Some(&context))
         .await
         .unwrap();
 

--- a/src/middlewares/tracing.rs
+++ b/src/middlewares/tracing.rs
@@ -9,6 +9,8 @@ use actix_web::{
     http::header::{HeaderName, HeaderValue},
 };
 use futures_util::future::{self, LocalBoxFuture, Ready};
+#[cfg(feature = "integration-test-support")]
+use tracing::{Dispatch, instrument::WithSubscriber};
 use tracing::{Instrument, Level, Span, debug, error, field, info, span, warn};
 use uuid::Uuid;
 
@@ -65,6 +67,8 @@ fn elapsed_millis(start_time: Instant) -> u64 {
 #[derive(Clone)]
 pub struct TracingMiddleware {
     proxy_trust: ProxyTrust,
+    #[cfg(feature = "integration-test-support")]
+    capture_dispatch: Option<Dispatch>,
 }
 
 impl Default for TracingMiddleware {
@@ -77,11 +81,25 @@ impl TracingMiddleware {
     pub fn new() -> Self {
         Self {
             proxy_trust: ProxyTrust::peer_only(),
+            #[cfg(feature = "integration-test-support")]
+            capture_dispatch: None,
         }
     }
 
     pub fn new_with_trust(proxy_trust: ProxyTrust) -> Self {
-        Self { proxy_trust }
+        Self {
+            proxy_trust,
+            #[cfg(feature = "integration-test-support")]
+            capture_dispatch: None,
+        }
+    }
+
+    #[cfg(feature = "integration-test-support")]
+    pub(crate) fn new_with_capture_dispatch(capture_dispatch: Dispatch) -> Self {
+        Self {
+            proxy_trust: ProxyTrust::peer_only(),
+            capture_dispatch: Some(capture_dispatch),
+        }
     }
 }
 
@@ -101,6 +119,8 @@ where
         future::ready(Ok(TracingMiddlewareService {
             service,
             proxy_trust: self.proxy_trust.clone(),
+            #[cfg(feature = "integration-test-support")]
+            capture_dispatch: self.capture_dispatch.clone(),
         }))
     }
 }
@@ -108,6 +128,8 @@ where
 pub struct TracingMiddlewareService<S> {
     service: S,
     proxy_trust: ProxyTrust,
+    #[cfg(feature = "integration-test-support")]
+    capture_dispatch: Option<Dispatch>,
 }
 
 impl<S, B> Service<ServiceRequest> for TracingMiddlewareService<S>
@@ -124,6 +146,13 @@ where
     }
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
+        #[cfg(feature = "integration-test-support")]
+        let capture_dispatch = self.capture_dispatch.clone();
+        #[cfg(feature = "integration-test-support")]
+        let capture_guard = capture_dispatch
+            .as_ref()
+            .map(tracing::dispatcher::set_default);
+
         let request_id = Uuid::new_v4();
         let request_id_s = request_id.to_string();
 
@@ -168,7 +197,7 @@ where
         let in_flight_guard = metrics::http_request_started_for_route(&route);
         let fut = span.in_scope(|| self.service.call(req));
 
-        Box::pin(
+        let future = Box::pin(
             async move {
                 let _in_flight_guard = in_flight_guard;
                 let mut res = match fut.await {
@@ -277,7 +306,17 @@ where
                 Ok(res)
             }
             .instrument(span),
-        )
+        );
+
+        #[cfg(feature = "integration-test-support")]
+        {
+            drop(capture_guard);
+            if let Some(capture_dispatch) = capture_dispatch {
+                return Box::pin(future.with_subscriber(capture_dispatch));
+            }
+        }
+
+        future
     }
 }
 

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -503,7 +503,7 @@ mod tests {
     use super::*;
     use crate::db::DbPool;
     use crate::db::traits::UserPermissions;
-    use crate::models::group::NewGroup;
+    use crate::models::group::{GroupID, NewGroup};
     use crate::models::permissions::PermissionsList;
     use crate::tests::{TestScope, create_test_user, generate_all_subsets};
     use crate::traits::{CanDelete, CanSave, PermissionController};
@@ -519,7 +519,7 @@ mod tests {
         for group in groups {
             collection
                 .clone()
-                .grant_without_events(pool, group.id, permissions.clone())
+                .grant_without_events(pool, GroupID::new(group.id).unwrap(), permissions.clone())
                 .await
                 .unwrap();
 
@@ -588,7 +588,7 @@ mod tests {
             .collection
             .set_permissions_without_events(
                 &pool,
-                parent.owner_group.id,
+                GroupID::new(parent.owner_group.id).unwrap(),
                 PermissionsList::new([Permissions::ReadCollection]),
             )
             .await
@@ -596,7 +596,7 @@ mod tests {
         child
             .set_permissions_without_events(
                 &pool,
-                child_group.id,
+                GroupID::new(child_group.id).unwrap(),
                 PermissionsList::new([Permissions::UpdateCollection]),
             )
             .await
@@ -772,7 +772,11 @@ mod tests {
         // This should return an ApiError::NotFound
         let result = collection
             .collection
-            .grant_one(&pool, 99999999, Permissions::ReadCollection)
+            .grant_one(
+                &pool,
+                GroupID::new(99_999_999).unwrap(),
+                Permissions::ReadCollection,
+            )
             .await;
 
         assert!(result.is_err());
@@ -906,7 +910,11 @@ mod tests {
             // Grant this subset of permissions
             collection
                 .collection
-                .grant_without_events(&pool, group_id, PermissionsList::new(subset.clone()))
+                .grant_without_events(
+                    &pool,
+                    GroupID::new(group_id).unwrap(),
+                    PermissionsList::new(subset.clone()),
+                )
                 .await
                 .unwrap();
 
@@ -973,14 +981,22 @@ mod tests {
             // Grant all permissions
             collection
                 .collection
-                .grant_without_events(&pool, group_id, PermissionsList::new(permissions.clone()))
+                .grant_without_events(
+                    &pool,
+                    GroupID::new(group_id).unwrap(),
+                    PermissionsList::new(permissions.clone()),
+                )
                 .await
                 .unwrap();
 
             // Revoke this subset of permissions
             collection
                 .collection
-                .revoke_without_events(&pool, group_id, PermissionsList::new(subset.clone()))
+                .revoke_without_events(
+                    &pool,
+                    GroupID::new(group_id).unwrap(),
+                    PermissionsList::new(subset.clone()),
+                )
                 .await
                 .unwrap();
 
@@ -1025,7 +1041,7 @@ mod tests {
 
         collection
             .collection
-            .grant_one(&pool, group_id, NP::ReadCollection)
+            .grant_one(&pool, GroupID::new(group_id).unwrap(), NP::ReadCollection)
             .await
             .unwrap();
 
@@ -1059,7 +1075,7 @@ mod tests {
 
         collection
             .collection
-            .grant_one(&pool, group_id, NP::UpdateCollection)
+            .grant_one(&pool, GroupID::new(group_id).unwrap(), NP::UpdateCollection)
             .await
             .unwrap();
 
@@ -1088,7 +1104,7 @@ mod tests {
 
         collection
             .collection
-            .revoke_one(&pool, group_id, NP::UpdateCollection)
+            .revoke_one(&pool, GroupID::new(group_id).unwrap(), NP::UpdateCollection)
             .await
             .unwrap();
 
@@ -1146,7 +1162,7 @@ mod tests {
             .collection
             .set_permissions_without_events(
                 &pool,
-                group_id,
+                GroupID::new(group_id).unwrap(),
                 PermissionsList::new([Permissions::ReadTemplate, Permissions::UpdateTemplate]),
             )
             .await
@@ -1195,7 +1211,11 @@ mod tests {
 
         collection
             .collection
-            .grant_one(&pool, group_id, Permissions::CreateTemplate)
+            .grant_one(
+                &pool,
+                GroupID::new(group_id).unwrap(),
+                Permissions::CreateTemplate,
+            )
             .await
             .unwrap();
 
@@ -1212,7 +1232,11 @@ mod tests {
 
         collection
             .collection
-            .revoke_one(&pool, group_id, Permissions::UpdateTemplate)
+            .revoke_one(
+                &pool,
+                GroupID::new(group_id).unwrap(),
+                Permissions::UpdateTemplate,
+            )
             .await
             .unwrap();
 
@@ -1272,12 +1296,20 @@ mod tests {
 
         collection
             .collection
-            .grant_one(&pool, delegate_group.id, Permissions::DelegateCollection)
+            .grant_one(
+                &pool,
+                GroupID::new(delegate_group.id).unwrap(),
+                Permissions::DelegateCollection,
+            )
             .await
             .unwrap();
         collection
             .collection
-            .grant_one(&pool, non_delegate_group.id, Permissions::ReadCollection)
+            .grant_one(
+                &pool,
+                GroupID::new(non_delegate_group.id).unwrap(),
+                Permissions::ReadCollection,
+            )
             .await
             .unwrap();
 

--- a/src/models/traits/user.rs
+++ b/src/models/traits/user.rs
@@ -538,7 +538,7 @@ mod test {
         class
             .grant_without_events(
                 &context.pool,
-                test_group_1.id,
+                GroupID::new(test_group_1.id).unwrap(),
                 PermissionsList::new([
                     Permissions::ReadClass,
                     Permissions::UpdateClass,
@@ -602,7 +602,11 @@ mod test {
         assert_not_contains!(&classlist, &class);
 
         collection_fixture
-            .grant_one(&context.pool, test_group_2.id, Permissions::ReadCollection)
+            .grant_one(
+                &context.pool,
+                GroupID::new(test_group_2.id).unwrap(),
+                Permissions::ReadCollection,
+            )
             .await
             .unwrap();
 
@@ -633,7 +637,11 @@ mod test {
         assert_contains!(&classlist, &class);
 
         class
-            .grant_one(&context.pool, test_group_2.id, Permissions::ReadClass)
+            .grant_one(
+                &context.pool,
+                GroupID::new(test_group_2.id).unwrap(),
+                Permissions::ReadClass,
+            )
             .await
             .unwrap();
 
@@ -648,7 +656,11 @@ mod test {
         assert_contains!(&classlist, &class);
 
         class
-            .revoke_one(&context.pool, test_group_2.id, Permissions::ReadClass)
+            .revoke_one(
+                &context.pool,
+                GroupID::new(test_group_2.id).unwrap(),
+                Permissions::ReadClass,
+            )
             .await
             .unwrap();
 
@@ -673,7 +685,7 @@ mod test {
         assert_contains!(&collection_list, &collection_fixture);
 
         collection_fixture
-            .revoke_all_without_events(&context.pool, test_group_2.id)
+            .revoke_all_without_events(&context.pool, GroupID::new(test_group_2.id).unwrap())
             .await
             .unwrap();
 

--- a/src/permissions/backend.rs
+++ b/src/permissions/backend.rs
@@ -2,7 +2,9 @@ use async_trait::async_trait;
 
 use crate::errors::ApiError;
 use crate::models::search::QueryOptions;
-use crate::models::{Collection, GroupPermission, Permission, Permissions, PermissionsList};
+use crate::models::{
+    Collection, CollectionID, GroupID, GroupPermission, Permission, Permissions, PermissionsList,
+};
 
 use super::types::{
     AuthorizationResult, PermissionDecision, PermissionRequest, PrincipalRef, ResourceRef,
@@ -116,7 +118,7 @@ pub trait PermissionBackend: Send + Sync {
     /// Returns `(rows, total_count)` so handlers can populate `X-Total-Count`.
     async fn groups_with_permissions_on(
         &self,
-        collection_id: i32,
+        collection_id: CollectionID,
         permissions_filter: &[Permissions],
         page: &QueryOptions,
     ) -> Result<(Vec<GroupPermission>, i64), ApiError>;
@@ -125,16 +127,16 @@ pub trait PermissionBackend: Send + Sync {
     /// In Treetop mode `id` / `created_at` / `updated_at` are synthetic.
     async fn group_permission_on(
         &self,
-        collection_id: i32,
-        group_id: i32,
+        collection_id: CollectionID,
+        group_id: GroupID,
     ) -> Result<Option<Permission>, ApiError>;
 
     /// Apply (grant or replace) a set of permissions to a group on a collection.
     /// Treetop returns `ApiError::NotImplemented`.
     async fn apply_permissions(
         &self,
-        collection_id: i32,
-        group_id: i32,
+        collection_id: CollectionID,
+        group_id: GroupID,
         list: PermissionsList<Permissions>,
         replace_existing: bool,
     ) -> Result<Permission, ApiError>;
@@ -143,14 +145,18 @@ pub trait PermissionBackend: Send + Sync {
     /// Treetop returns `ApiError::NotImplemented`.
     async fn revoke_permissions(
         &self,
-        collection_id: i32,
-        group_id: i32,
+        collection_id: CollectionID,
+        group_id: GroupID,
         list: PermissionsList<Permissions>,
     ) -> Result<Permission, ApiError>;
 
     /// Revoke all permissions of a group on a collection.
     /// Treetop returns `ApiError::NotImplemented`.
-    async fn revoke_all(&self, collection_id: i32, group_id: i32) -> Result<(), ApiError>;
+    async fn revoke_all(
+        &self,
+        collection_id: CollectionID,
+        group_id: GroupID,
+    ) -> Result<(), ApiError>;
 
     /// Whether mutations are supported. Handlers can early-reject before
     /// calling the mutation methods if they want a cleaner error path.

--- a/src/permissions/local/mod.rs
+++ b/src/permissions/local/mod.rs
@@ -9,7 +9,7 @@ use crate::db::{DbPool, with_connection};
 use crate::errors::ApiError;
 use crate::models::search::QueryOptions;
 use crate::models::{
-    Collection, CollectionID, GroupPermission, Permission, Permissions, PermissionsList,
+    Collection, CollectionID, GroupID, GroupPermission, Permission, Permissions, PermissionsList,
     PrincipalID,
 };
 use crate::traits::{AuthzSubject, PermissionController};
@@ -239,15 +239,14 @@ impl PermissionBackend for LocalPermissionBackend {
 
     async fn groups_with_permissions_on(
         &self,
-        collection_id: i32,
+        collection_id: CollectionID,
         permissions_filter: &[Permissions],
         page: &QueryOptions,
     ) -> Result<(Vec<GroupPermission>, i64), ApiError> {
         let start = Instant::now();
-        let collection = CollectionID::new(collection_id)?;
         let (rows, total) = collection_backend::groups_on_paginated_with_total_count_from_backend(
             &self.pool,
-            collection,
+            collection_id,
             permissions_filter.to_vec(),
             page,
         )
@@ -264,18 +263,21 @@ impl PermissionBackend for LocalPermissionBackend {
 
     async fn group_permission_on(
         &self,
-        collection_id: i32,
-        group_id: i32,
+        collection_id: CollectionID,
+        group_id: GroupID,
     ) -> Result<Option<Permission>, ApiError> {
         let start = Instant::now();
-        let result =
-            match collection_backend::group_on_from_backend(&self.pool, collection_id, group_id)
-                .await
-            {
-                Ok(permission) => Ok(Some(permission)),
-                Err(ApiError::NotFound(_)) => Ok(None),
-                Err(error) => Err(error),
-            };
+        let result = match collection_backend::group_on_from_backend(
+            &self.pool,
+            collection_id.id(),
+            group_id.id(),
+        )
+        .await
+        {
+            Ok(permission) => Ok(Some(permission)),
+            Err(ApiError::NotFound(_)) => Ok(None),
+            Err(error) => Err(error),
+        };
         let result_count = result
             .as_ref()
             .map(|row| row.is_some() as usize)
@@ -292,31 +294,31 @@ impl PermissionBackend for LocalPermissionBackend {
 
     async fn apply_permissions(
         &self,
-        collection_id: i32,
-        group_id: i32,
+        collection_id: CollectionID,
+        group_id: GroupID,
         list: PermissionsList<Permissions>,
         replace_existing: bool,
     ) -> Result<Permission, ApiError> {
-        CollectionID::new(collection_id)?
+        collection_id
             .apply_permissions(&self.pool, group_id, list, replace_existing, None)
             .await
     }
 
     async fn revoke_permissions(
         &self,
-        collection_id: i32,
-        group_id: i32,
+        collection_id: CollectionID,
+        group_id: GroupID,
         list: PermissionsList<Permissions>,
     ) -> Result<Permission, ApiError> {
-        CollectionID::new(collection_id)?
-            .revoke(&self.pool, group_id, list, None)
-            .await
+        collection_id.revoke(&self.pool, group_id, list, None).await
     }
 
-    async fn revoke_all(&self, collection_id: i32, group_id: i32) -> Result<(), ApiError> {
-        CollectionID::new(collection_id)?
-            .revoke_all(&self.pool, group_id, None)
-            .await
+    async fn revoke_all(
+        &self,
+        collection_id: CollectionID,
+        group_id: GroupID,
+    ) -> Result<(), ApiError> {
+        collection_id.revoke_all(&self.pool, group_id, None).await
     }
 
     fn supports_mutation(&self) -> bool {

--- a/src/permissions/test_support/mock_treetop.rs
+++ b/src/permissions/test_support/mock_treetop.rs
@@ -7,7 +7,10 @@ use chrono::DateTime;
 
 use crate::errors::ApiError;
 use crate::models::search::{QueryOptions, QueryParamsExt};
-use crate::models::{Collection, Group, GroupPermission, Permission, Permissions, PermissionsList};
+use crate::models::{
+    Collection, CollectionID, Group, GroupID, GroupPermission, Permission, Permissions,
+    PermissionsList,
+};
 use crate::pagination::{known_count_or_skipped, paginate_in_memory};
 
 use super::super::backend::PermissionBackend;
@@ -446,10 +449,11 @@ impl PermissionBackend for MockTreetopBackend {
 
     async fn groups_with_permissions_on(
         &self,
-        collection_id: i32,
+        collection_id: CollectionID,
         permissions_filter: &[Permissions],
         page: &QueryOptions,
     ) -> Result<(Vec<GroupPermission>, i64), ApiError> {
+        let collection_id = collection_id.id();
         let groups_opt = self.group_candidates.lock().unwrap().clone();
         let all_groups = match groups_opt {
             Some(g) => g,
@@ -516,9 +520,11 @@ impl PermissionBackend for MockTreetopBackend {
 
     async fn group_permission_on(
         &self,
-        collection_id: i32,
-        group_id: i32,
+        collection_id: CollectionID,
+        group_id: GroupID,
     ) -> Result<Option<Permission>, ApiError> {
+        let collection_id = collection_id.id();
+        let group_id = group_id.id();
         let principal = PrincipalRef::new(0, vec![group_id]);
         let requests: Vec<PermissionRequest> = Permissions::all()
             .iter()
@@ -545,8 +551,8 @@ impl PermissionBackend for MockTreetopBackend {
 
     async fn apply_permissions(
         &self,
-        _collection_id: i32,
-        _group_id: i32,
+        _collection_id: CollectionID,
+        _group_id: GroupID,
         _list: PermissionsList<Permissions>,
         _replace_existing: bool,
     ) -> Result<Permission, ApiError> {
@@ -558,8 +564,8 @@ impl PermissionBackend for MockTreetopBackend {
 
     async fn revoke_permissions(
         &self,
-        _collection_id: i32,
-        _group_id: i32,
+        _collection_id: CollectionID,
+        _group_id: GroupID,
         _list: PermissionsList<Permissions>,
     ) -> Result<Permission, ApiError> {
         Err(ApiError::NotImplemented(
@@ -568,7 +574,11 @@ impl PermissionBackend for MockTreetopBackend {
         ))
     }
 
-    async fn revoke_all(&self, _collection_id: i32, _group_id: i32) -> Result<(), ApiError> {
+    async fn revoke_all(
+        &self,
+        _collection_id: CollectionID,
+        _group_id: GroupID,
+    ) -> Result<(), ApiError> {
         Err(ApiError::NotImplemented(
             "permission mutations are managed out-of-band when using a treetop-style backend"
                 .to_string(),

--- a/src/permissions/treetop/mod.rs
+++ b/src/permissions/treetop/mod.rs
@@ -11,7 +11,10 @@ use crate::config::AppConfig;
 use crate::db::{DbPool, with_connection};
 use crate::errors::ApiError;
 use crate::models::search::{FilterField, QueryOptions, QueryParamsExt};
-use crate::models::{Collection, Group, GroupPermission, Permission, Permissions, PermissionsList};
+use crate::models::{
+    Collection, CollectionID, Group, GroupID, GroupPermission, Permission, Permissions,
+    PermissionsList,
+};
 use crate::pagination::{known_count_or_skipped, paginate_in_memory};
 use crate::schema::collections;
 
@@ -392,7 +395,7 @@ impl PermissionBackend for TreetopPermissionBackend {
 
     async fn groups_with_permissions_on(
         &self,
-        collection_id: i32,
+        collection_id: CollectionID,
         permissions_filter: &[Permissions],
         page: &QueryOptions,
     ) -> Result<(Vec<GroupPermission>, i64), ApiError> {
@@ -402,6 +405,7 @@ impl PermissionBackend for TreetopPermissionBackend {
         use crate::{date_search, numeric_search, string_search};
 
         let start = Instant::now();
+        let collection_id = collection_id.id();
 
         let mut group_query = groups_dsl.into_boxed();
         for param in &page.filters {
@@ -500,10 +504,12 @@ impl PermissionBackend for TreetopPermissionBackend {
 
     async fn group_permission_on(
         &self,
-        collection_id: i32,
-        group_id: i32,
+        collection_id: CollectionID,
+        group_id: GroupID,
     ) -> Result<Option<Permission>, ApiError> {
         let start = Instant::now();
+        let collection_id = collection_id.id();
+        let group_id = group_id.id();
         let principal = PrincipalRef::new(0, vec![group_id]);
         let checks = Permissions::all()
             .iter()
@@ -538,8 +544,8 @@ impl PermissionBackend for TreetopPermissionBackend {
 
     async fn apply_permissions(
         &self,
-        _collection_id: i32,
-        _group_id: i32,
+        _collection_id: CollectionID,
+        _group_id: GroupID,
         _list: PermissionsList<Permissions>,
         _replace_existing: bool,
     ) -> Result<Permission, ApiError> {
@@ -551,8 +557,8 @@ impl PermissionBackend for TreetopPermissionBackend {
 
     async fn revoke_permissions(
         &self,
-        _collection_id: i32,
-        _group_id: i32,
+        _collection_id: CollectionID,
+        _group_id: GroupID,
         _list: PermissionsList<Permissions>,
     ) -> Result<Permission, ApiError> {
         Err(ApiError::NotImplemented(
@@ -561,7 +567,11 @@ impl PermissionBackend for TreetopPermissionBackend {
         ))
     }
 
-    async fn revoke_all(&self, _collection_id: i32, _group_id: i32) -> Result<(), ApiError> {
+    async fn revoke_all(
+        &self,
+        _collection_id: CollectionID,
+        _group_id: GroupID,
+    ) -> Result<(), ApiError> {
         Err(ApiError::NotImplemented(
             "permission mutations are managed out-of-band when using the treetop backend"
                 .to_string(),

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -5,6 +5,8 @@
 //! process-global reset and capture facilities.
 
 use hubuum_auth_core::AuthenticatedExternalUser;
+use tracing::Dispatch;
+use tracing_subscriber::layer::SubscriberExt;
 
 use crate::auth::ConfiguredLdapScope;
 use crate::db::DbPool;
@@ -15,6 +17,20 @@ use crate::models::{CollectionID, NewEventSink, NewEventSubscription, TaskKind};
 
 pub use crate::logger::test_support::JsonLogWriter;
 pub use crate::middlewares::rate_limit::LOGIN_RATE_LIMIT_TEST_LOCK;
+
+pub fn tracing_middleware_with_log_capture()
+-> (crate::middlewares::TracingMiddleware, JsonLogWriter) {
+    let writer = JsonLogWriter::default();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .json()
+            .with_writer(writer.clone())
+            .event_format(crate::logger::HubuumLoggingFormat),
+    );
+    let middleware =
+        crate::middlewares::TracingMiddleware::new_with_capture_dispatch(Dispatch::new(subscriber));
+    (middleware, writer)
+}
 
 #[cfg(not(test))]
 pub fn integration_test_config() -> Result<&'static crate::config::AppConfig, ApiError> {

--- a/src/tests/permissions/auth_target.rs
+++ b/src/tests/permissions/auth_target.rs
@@ -12,8 +12,8 @@ use actix_web::test as actix_test;
 use serde_json::json;
 
 use crate::models::{
-    NewHubuumClass, NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, Permissions,
-    PermissionsList,
+    CollectionID, GroupID, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
+    NewHubuumObjectRelation, Permissions, PermissionsList,
 };
 use crate::permissions::{
     AuthzTarget, LocalPermissionBackend, PermissionBackend, PermissionDecision, PermissionRequest,
@@ -427,8 +427,8 @@ async fn local_backend_relation_and_check_denies_partial_permission() {
     // Grant ReadClassRelation on collection_a only.
     backend
         .apply_permissions(
-            fixture_a.collection.id,
-            group.id,
+            CollectionID::new(fixture_a.collection.id).unwrap(),
+            GroupID::new(group.id).unwrap(),
             PermissionsList::new(vec![Permissions::ReadClassRelation]),
             false,
         )
@@ -449,8 +449,8 @@ async fn local_backend_relation_and_check_denies_partial_permission() {
     // Grant ReadClassRelation on collection_b too.
     backend
         .apply_permissions(
-            fixture_b.collection.id,
-            group.id,
+            CollectionID::new(fixture_b.collection.id).unwrap(),
+            GroupID::new(group.id).unwrap(),
             PermissionsList::new(vec![Permissions::ReadClassRelation]),
             false,
         )

--- a/src/tests/permissions/backend_trait.rs
+++ b/src/tests/permissions/backend_trait.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use actix_web::test as actix_test;
 
-use crate::models::{Permissions, PermissionsList};
+use crate::models::{CollectionID, GroupID, Permissions, PermissionsList};
 use crate::permissions::local::LocalPermissionBackend;
 use crate::permissions::{
     PermissionBackend, PermissionDecision, PermissionRequest, PrincipalRef, ResourceRef,
@@ -68,8 +68,8 @@ async fn local_backend_grants_then_authorizes_collection_read() {
     // Grant ReadCollection on this collection to our group.
     backend
         .apply_permissions(
-            collection_id,
-            group.id,
+            CollectionID::new(collection_id).unwrap(),
+            GroupID::new(group.id).unwrap(),
             PermissionsList::new(vec![Permissions::ReadCollection]),
             false,
         )
@@ -123,8 +123,8 @@ async fn local_backend_authorize_many_returns_per_request_decisions() {
 
     backend
         .apply_permissions(
-            granted_ns.collection.id,
-            group.id,
+            CollectionID::new(granted_ns.collection.id).unwrap(),
+            GroupID::new(group.id).unwrap(),
             PermissionsList::new(vec![Permissions::ReadCollection]),
             false,
         )

--- a/src/tests/permissions/exporter_round_trip.rs
+++ b/src/tests/permissions/exporter_round_trip.rs
@@ -17,7 +17,7 @@ mod tests {
 
     use actix_web::test as actix_test;
 
-    use crate::models::{Permissions, PermissionsList};
+    use crate::models::{CollectionID, GroupID, Permissions, PermissionsList};
     use crate::permissions::backend::PermissionBackend;
     use crate::permissions::export::export_cedar_to;
     use crate::permissions::local::LocalPermissionBackend;
@@ -63,8 +63,8 @@ mod tests {
         // Grants via the production path so the SQL row shape is correct.
         local
             .apply_permissions(
-                ns_one.collection.id,
-                g_alpha.id,
+                CollectionID::new(ns_one.collection.id).unwrap(),
+                GroupID::new(g_alpha.id).unwrap(),
                 PermissionsList::new(vec![Permissions::ReadCollection, Permissions::ReadClass]),
                 false,
             )
@@ -72,8 +72,8 @@ mod tests {
             .expect("grant alpha on one");
         local
             .apply_permissions(
-                ns_two.collection.id,
-                g_alpha.id,
+                CollectionID::new(ns_two.collection.id).unwrap(),
+                GroupID::new(g_alpha.id).unwrap(),
                 PermissionsList::new(vec![Permissions::ReadObject]),
                 false,
             )
@@ -81,8 +81,8 @@ mod tests {
             .expect("grant alpha on two");
         local
             .apply_permissions(
-                ns_one.collection.id,
-                g_beta.id,
+                CollectionID::new(ns_one.collection.id).unwrap(),
+                GroupID::new(g_beta.id).unwrap(),
                 PermissionsList::new(vec![Permissions::DelegateCollection]),
                 false,
             )
@@ -201,8 +201,8 @@ mod tests {
 
         local
             .apply_permissions(
-                ns_rel.collection.id,
-                g_rel.id,
+                CollectionID::new(ns_rel.collection.id).unwrap(),
+                GroupID::new(g_rel.id).unwrap(),
                 PermissionsList::new(vec![Permissions::ReadClassRelation]),
                 false,
             )

--- a/src/tests/permissions/live_treetop_parity.rs
+++ b/src/tests/permissions/live_treetop_parity.rs
@@ -18,7 +18,7 @@ use actix_web::test as actix_test;
 
 use crate::config::{PermissionBackendKind, get_config};
 use crate::errors::ApiError;
-use crate::models::Permissions;
+use crate::models::{CollectionID, GroupID, Permissions};
 use crate::permissions::backend::PermissionBackend;
 use crate::permissions::treetop::TreetopPermissionBackend;
 use crate::permissions::types::{PermissionDecision, PermissionRequest, PrincipalRef, ResourceRef};
@@ -182,7 +182,10 @@ async fn live_group_permission_on_returns_grant_grid_for_known_group() {
     seed_collection_if_missing(TEST_NAMESPACE_ID).await;
 
     let perm = backend
-        .group_permission_on(TEST_NAMESPACE_ID, TEST_NORMAL_GROUP_ID)
+        .group_permission_on(
+            CollectionID::new(TEST_NAMESPACE_ID).unwrap(),
+            GroupID::new(TEST_NORMAL_GROUP_ID).unwrap(),
+        )
         .await
         .expect("group_permission_on failed");
 

--- a/src/tests/permissions/mock_treetop.rs
+++ b/src/tests/permissions/mock_treetop.rs
@@ -6,7 +6,7 @@ use actix_web::test as actix_test;
 
 use crate::errors::ApiError;
 use crate::models::search::parse_query_parameter;
-use crate::models::{GroupPermission, Permissions};
+use crate::models::{CollectionID, GroupID, GroupPermission, Permissions};
 use crate::pagination::{finalize_page, prepare_db_pagination};
 use crate::permissions::backend::PermissionBackend;
 use crate::permissions::test_support::{MockAllowRule, MockTreetopBackend};
@@ -130,8 +130,8 @@ async fn mock_mutation_methods_return_not_implemented() {
 
     let result = backend
         .apply_permissions(
-            7,
-            100,
+            CollectionID::new(7).unwrap(),
+            GroupID::new(100).unwrap(),
             PermissionsList::new(vec![Permissions::ReadCollection]),
             false,
         )
@@ -140,14 +140,16 @@ async fn mock_mutation_methods_return_not_implemented() {
 
     let result = backend
         .revoke_permissions(
-            7,
-            100,
+            CollectionID::new(7).unwrap(),
+            GroupID::new(100).unwrap(),
             PermissionsList::new(vec![Permissions::ReadCollection]),
         )
         .await;
     assert!(matches!(result, Err(ApiError::NotImplemented(_))));
 
-    let result = backend.revoke_all(7, 100).await;
+    let result = backend
+        .revoke_all(CollectionID::new(7).unwrap(), GroupID::new(100).unwrap())
+        .await;
     assert!(matches!(result, Err(ApiError::NotImplemented(_))));
 
     assert!(!backend.supports_mutation());
@@ -226,7 +228,10 @@ async fn mock_group_permission_on_synthesizes_row_from_rules() {
         },
     });
 
-    let row = backend.group_permission_on(7, 100).await.unwrap();
+    let row = backend
+        .group_permission_on(CollectionID::new(7).unwrap(), GroupID::new(100).unwrap())
+        .await
+        .unwrap();
     assert!(
         row.is_some(),
         "should synthesize a row when at least one perm is Allow"
@@ -249,7 +254,10 @@ async fn mock_group_permission_on_synthesizes_row_from_rules() {
     assert_eq!(row.group_id, 100);
 
     // No rules for group 200 → None.
-    let none = backend.group_permission_on(7, 200).await.unwrap();
+    let none = backend
+        .group_permission_on(CollectionID::new(7).unwrap(), GroupID::new(200).unwrap())
+        .await
+        .unwrap();
     assert!(
         none.is_none(),
         "no permissions → None (mirrors Local 'no row exists')"
@@ -355,7 +363,7 @@ async fn mock_groups_with_permissions_on_filters_and_paginates() {
         include_total: true,
     };
     let (results, count) = backend
-        .groups_with_permissions_on(7, &[], &page)
+        .groups_with_permissions_on(CollectionID::new(7).unwrap(), &[], &page)
         .await
         .unwrap();
     assert_eq!(count, 2, "group 100 and 200 have permissions");
@@ -366,7 +374,7 @@ async fn mock_groups_with_permissions_on_filters_and_paginates() {
     // Non-empty filter: only groups with ALL filter permissions.
     let (results, count) = backend
         .groups_with_permissions_on(
-            7,
+            CollectionID::new(7).unwrap(),
             &[Permissions::ReadCollection, Permissions::CreateClass],
             &page,
         )
@@ -385,7 +393,7 @@ async fn mock_groups_with_permissions_on_filters_and_paginates() {
         include_total: true,
     };
     let (results, count) = backend
-        .groups_with_permissions_on(7, &[], &page_limited)
+        .groups_with_permissions_on(CollectionID::new(7).unwrap(), &[], &page_limited)
         .await
         .unwrap();
     assert_eq!(count, 2, "total count is 2 even though limit is 1");
@@ -395,7 +403,7 @@ async fn mock_groups_with_permissions_on_filters_and_paginates() {
     let first_request = parse_query_parameter("sort=groupname.desc&limit=1").unwrap();
     let first_prepared = prepare_db_pagination::<GroupPermission>(&first_request).unwrap();
     let (first_rows, _) = backend
-        .groups_with_permissions_on(7, &[], &first_prepared)
+        .groups_with_permissions_on(CollectionID::new(7).unwrap(), &[], &first_prepared)
         .await
         .unwrap();
     let first_page = finalize_page(first_rows, &first_request).unwrap();
@@ -405,7 +413,7 @@ async fn mock_groups_with_permissions_on_filters_and_paginates() {
     second_request.cursor = first_page.next_cursor;
     let second_prepared = prepare_db_pagination::<GroupPermission>(&second_request).unwrap();
     let (second_rows, _) = backend
-        .groups_with_permissions_on(7, &[], &second_prepared)
+        .groups_with_permissions_on(CollectionID::new(7).unwrap(), &[], &second_prepared)
         .await
         .unwrap();
     let second_page = finalize_page(second_rows, &second_request).unwrap();

--- a/src/tests/permissions/visibility.rs
+++ b/src/tests/permissions/visibility.rs
@@ -13,7 +13,9 @@ use async_trait::async_trait;
 
 use crate::errors::ApiError;
 use crate::models::search::QueryOptions;
-use crate::models::{Collection, GroupPermission, Permission, Permissions, PermissionsList};
+use crate::models::{
+    Collection, CollectionID, GroupID, GroupPermission, Permission, Permissions, PermissionsList,
+};
 use crate::permissions::backend::PermissionBackend;
 use crate::permissions::local::LocalPermissionBackend;
 use crate::permissions::types::{
@@ -78,7 +80,7 @@ impl PermissionBackend for ForceSlowPath {
 
     async fn groups_with_permissions_on(
         &self,
-        collection_id: i32,
+        collection_id: CollectionID,
         permissions_filter: &[Permissions],
         page: &QueryOptions,
     ) -> Result<(Vec<GroupPermission>, i64), ApiError> {
@@ -89,8 +91,8 @@ impl PermissionBackend for ForceSlowPath {
 
     async fn group_permission_on(
         &self,
-        collection_id: i32,
-        group_id: i32,
+        collection_id: CollectionID,
+        group_id: GroupID,
     ) -> Result<Option<Permission>, ApiError> {
         self.inner
             .group_permission_on(collection_id, group_id)
@@ -99,8 +101,8 @@ impl PermissionBackend for ForceSlowPath {
 
     async fn apply_permissions(
         &self,
-        collection_id: i32,
-        group_id: i32,
+        collection_id: CollectionID,
+        group_id: GroupID,
         list: PermissionsList<Permissions>,
         replace_existing: bool,
     ) -> Result<Permission, ApiError> {
@@ -111,8 +113,8 @@ impl PermissionBackend for ForceSlowPath {
 
     async fn revoke_permissions(
         &self,
-        collection_id: i32,
-        group_id: i32,
+        collection_id: CollectionID,
+        group_id: GroupID,
         list: PermissionsList<Permissions>,
     ) -> Result<Permission, ApiError> {
         self.inner
@@ -120,7 +122,11 @@ impl PermissionBackend for ForceSlowPath {
             .await
     }
 
-    async fn revoke_all(&self, collection_id: i32, group_id: i32) -> Result<(), ApiError> {
+    async fn revoke_all(
+        &self,
+        collection_id: CollectionID,
+        group_id: GroupID,
+    ) -> Result<(), ApiError> {
         self.inner.revoke_all(collection_id, group_id).await
     }
 
@@ -178,8 +184,8 @@ async fn paginate_authorized_filters_pages_correctly_under_slow_path() {
 
     backend
         .apply_permissions(
-            ns_a.collection.id,
-            group.id,
+            CollectionID::new(ns_a.collection.id).unwrap(),
+            GroupID::new(group.id).unwrap(),
             PermissionsList::new(vec![Permissions::ReadCollection]),
             false,
         )
@@ -187,8 +193,8 @@ async fn paginate_authorized_filters_pages_correctly_under_slow_path() {
         .expect("grant on a");
     backend
         .apply_permissions(
-            ns_c.collection.id,
-            group.id,
+            CollectionID::new(ns_c.collection.id).unwrap(),
+            GroupID::new(group.id).unwrap(),
             PermissionsList::new(vec![Permissions::ReadCollection]),
             false,
         )

--- a/src/traits/permissions.rs
+++ b/src/traits/permissions.rs
@@ -5,7 +5,7 @@ use crate::db::traits::authz::AuthzSubject;
 use crate::db::traits::permissions::PermissionControllerBackend;
 use crate::errors::ApiError;
 use crate::events::EventContext;
-use crate::models::{Permission, Permissions, PermissionsList};
+use crate::models::{GroupID, Permission, Permissions, PermissionsList};
 
 use super::{BackendContext, CollectionAccessors};
 
@@ -98,7 +98,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     async fn grant_without_events<C>(
         &self,
         backend: &C,
-        group_id_for_grant: i32,
+        group_id_for_grant: GroupID,
         permission_list: PermissionsList<Permissions>,
     ) -> Result<Permission, ApiError>
     where
@@ -111,7 +111,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     async fn grant<C>(
         &self,
         backend: &C,
-        group_id_for_grant: i32,
+        group_id_for_grant: GroupID,
         permission_list: PermissionsList<Permissions>,
         context: Option<&EventContext>,
     ) -> Result<Permission, ApiError>
@@ -136,7 +136,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     async fn apply_permissions_without_events<C>(
         &self,
         backend: &C,
-        group_id_for_grant: i32,
+        group_id_for_grant: GroupID,
         permission_list: PermissionsList<Permissions>,
         replace_existing: bool,
     ) -> Result<Permission, ApiError>
@@ -155,7 +155,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     async fn apply_permissions<C>(
         &self,
         backend: &C,
-        group_id_for_grant: i32,
+        group_id_for_grant: GroupID,
         permission_list: PermissionsList<Permissions>,
         replace_existing: bool,
         context: Option<&EventContext>,
@@ -201,7 +201,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     async fn revoke_without_events<C>(
         &self,
         backend: &C,
-        group_id_for_revoke: i32,
+        group_id_for_revoke: GroupID,
         permission_list: PermissionsList<Permissions>,
     ) -> Result<Permission, ApiError>
     where
@@ -218,7 +218,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     async fn revoke<C>(
         &self,
         backend: &C,
-        group_id_for_revoke: i32,
+        group_id_for_revoke: GroupID,
         permission_list: PermissionsList<Permissions>,
         context: Option<&EventContext>,
     ) -> Result<Permission, ApiError>
@@ -258,7 +258,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     async fn grant_one<C>(
         &self,
         backend: &C,
-        group_identifier: i32,
+        group_identifier: GroupID,
         permission: Permissions,
     ) -> Result<Permission, ApiError>
     where
@@ -295,7 +295,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     async fn revoke_one<C>(
         &self,
         backend: &C,
-        group_identifier: i32,
+        group_identifier: GroupID,
         permission: Permissions,
     ) -> Result<Permission, ApiError>
     where
@@ -337,7 +337,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     async fn set_permissions_without_events<C>(
         &self,
         backend: &C,
-        group_identifier: i32,
+        group_identifier: GroupID,
         permission_list: PermissionsList<Permissions>,
     ) -> Result<Permission, ApiError>
     where
@@ -350,7 +350,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     async fn set_permissions<C>(
         &self,
         backend: &C,
-        group_identifier: i32,
+        group_identifier: GroupID,
         permission_list: PermissionsList<Permissions>,
         context: Option<&EventContext>,
     ) -> Result<Permission, ApiError>
@@ -385,7 +385,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     async fn revoke_all_without_events<C>(
         &self,
         backend: &C,
-        group_id_for_revoke: i32,
+        group_id_for_revoke: GroupID,
     ) -> Result<(), ApiError>
     where
         C: BackendContext + ?Sized,
@@ -397,7 +397,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     async fn revoke_all<C>(
         &self,
         backend: &C,
-        group_id_for_revoke: i32,
+        group_id_for_revoke: GroupID,
         context: Option<&EventContext>,
     ) -> Result<(), ApiError>
     where

--- a/tests/api_core_data_suite/classes.rs
+++ b/tests/api_core_data_suite/classes.rs
@@ -8,7 +8,7 @@ pub mod tests {
     use crate::events::EventContext;
     use crate::models::traits::{ResolveClassTarget, UpdateResolvedClass};
     use crate::models::{
-        ClassSelector, HubuumClassExpanded, HubuumClassID, NewHubuumClass, Permissions,
+        ClassSelector, GroupID, HubuumClassExpanded, HubuumClassID, NewHubuumClass, Permissions,
         PermissionsList, UpdateHubuumClass,
     };
     use crate::traits::{CanSave, PermissionController, SelfAccessors};
@@ -501,7 +501,7 @@ pub mod tests {
             .collection
             .grant_without_events(
                 &context.pool,
-                group.id,
+                GroupID::new(group.id).unwrap(),
                 PermissionsList::new([Permissions::UpdateClass]),
             )
             .await
@@ -534,7 +534,7 @@ pub mod tests {
             .collection
             .grant_without_events(
                 &context.pool,
-                group.id,
+                GroupID::new(group.id).unwrap(),
                 PermissionsList::new([Permissions::CreateClass]),
             )
             .await

--- a/tests/api_core_data_suite/collections.rs
+++ b/tests/api_core_data_suite/collections.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::models::{
-        Collection, GroupPermission, GroupResponse, NewCollectionWithAssignee, NewGroup,
+        Collection, GroupID, GroupPermission, GroupResponse, NewCollectionWithAssignee, NewGroup,
         Permission, Permissions, UpdateCollection,
     };
 
@@ -542,7 +542,7 @@ mod tests {
         let np_read = Permissions::ReadCollection;
         collection_fixture
             .collection
-            .grant_one(&context.pool, test_group.id, np_read)
+            .grant_one(&context.pool, GroupID::new(test_group.id).unwrap(), np_read)
             .await
             .unwrap();
 
@@ -560,7 +560,11 @@ mod tests {
         let np_update = Permissions::UpdateCollection;
         collection_fixture
             .collection
-            .grant_one(&context.pool, test_group.id, np_update)
+            .grant_one(
+                &context.pool,
+                GroupID::new(test_group.id).unwrap(),
+                np_update,
+            )
             .await
             .unwrap();
 
@@ -591,7 +595,11 @@ mod tests {
         let np_delegate = Permissions::DelegateCollection;
         collection_fixture
             .collection
-            .grant_one(&context.pool, test_group.id, np_delegate)
+            .grant_one(
+                &context.pool,
+                GroupID::new(test_group.id).unwrap(),
+                np_delegate,
+            )
             .await
             .unwrap();
 
@@ -662,12 +670,20 @@ mod tests {
 
         collection_fixture
             .collection
-            .grant_one(&context.pool, group_one.id, Permissions::ReadCollection)
+            .grant_one(
+                &context.pool,
+                GroupID::new(group_one.id).unwrap(),
+                Permissions::ReadCollection,
+            )
             .await
             .unwrap();
         collection_fixture
             .collection
-            .grant_one(&context.pool, group_two.id, Permissions::ReadCollection)
+            .grant_one(
+                &context.pool,
+                GroupID::new(group_two.id).unwrap(),
+                Permissions::ReadCollection,
+            )
             .await
             .unwrap();
 
@@ -770,7 +786,11 @@ mod tests {
         for group in [&group_one, &group_two, &group_three] {
             collection_fixture
                 .collection
-                .grant_one(&context.pool, group.id, Permissions::ReadCollection)
+                .grant_one(
+                    &context.pool,
+                    GroupID::new(group.id).unwrap(),
+                    Permissions::ReadCollection,
+                )
                 .await
                 .unwrap();
         }

--- a/tests/api_core_data_suite/computed_fields.rs
+++ b/tests/api_core_data_suite/computed_fields.rs
@@ -15,7 +15,7 @@ mod tests {
     use crate::events::EventContext;
     use crate::models::search::parse_query_parameter;
     use crate::models::{
-        ComputedFieldDefinitionRequest, HubuumClassID, NewHubuumClass, NewHubuumObject,
+        ComputedFieldDefinitionRequest, GroupID, HubuumClassID, NewHubuumClass, NewHubuumObject,
         Permissions, TaskID, TaskStatus,
     };
     use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER, finalize_page};
@@ -438,7 +438,7 @@ mod tests {
             fixture
                 .collection
                 .collection
-                .grant_one(&context.pool, group.id, *permission)
+                .grant_one(&context.pool, GroupID::new(group.id).unwrap(), *permission)
                 .await
                 .unwrap();
         }

--- a/tests/api_core_data_suite/computed_fields/tests/definitions.rs
+++ b/tests/api_core_data_suite/computed_fields/tests/definitions.rs
@@ -353,7 +353,11 @@ async fn service_accounts_cannot_manage_or_receive_personal_fields(
         fixture
             .collection
             .collection
-            .grant_one(&test_context.pool, group.id, permission)
+            .grant_one(
+                &test_context.pool,
+                GroupID::new(group.id).unwrap(),
+                permission,
+            )
             .await
             .unwrap();
     }

--- a/tests/api_core_data_suite/object_aggregates/mod.rs
+++ b/tests/api_core_data_suite/object_aggregates/mod.rs
@@ -10,9 +10,9 @@ use crate::db::traits::computed_field::{
 };
 use crate::events::EventContext;
 use crate::models::{
-    ComputedFieldDefinitionPatch, ComputedFieldDefinitionRequest, HubuumObject, HubuumObjectID,
-    MAX_OBJECT_AGGREGATE_CURSOR_LENGTH, NewHubuumClass, NewHubuumObject, Permissions,
-    ServiceAccountID, TaskID, TokenResourceScope, UpdateHubuumObject,
+    ComputedFieldDefinitionPatch, ComputedFieldDefinitionRequest, GroupID, HubuumObject,
+    HubuumObjectID, MAX_OBJECT_AGGREGATE_CURSOR_LENGTH, NewHubuumClass, NewHubuumObject,
+    Permissions, ServiceAccountID, TaskID, TokenResourceScope, UpdateHubuumObject,
 };
 use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER};
 use crate::permissions::test_support::mock_treetop::{MockAllowRule, MockTreetopBackend};
@@ -225,7 +225,7 @@ async fn grant_normal_user_read_access(
         fixture
             .collection
             .collection
-            .grant_one(&context.pool, group.id, permission)
+            .grant_one(&context.pool, GroupID::new(group.id).unwrap(), permission)
             .await
             .unwrap();
     }

--- a/tests/api_core_data_suite/relations.rs
+++ b/tests/api_core_data_suite/relations.rs
@@ -9,7 +9,7 @@ mod tests {
     use crate::db::{DbPool, with_transaction};
     use crate::errors::ApiError;
     use crate::models::{
-        CollectionID, HubuumClass, HubuumClassRelation, HubuumClassWithPath, HubuumObject,
+        CollectionID, GroupID, HubuumClass, HubuumClassRelation, HubuumClassWithPath, HubuumObject,
         HubuumObjectRelation, HubuumObjectWithPath, NewHubuumClass, NewHubuumClassRelation,
         NewHubuumClassRelationFromClass, NewHubuumObject, NewHubuumObjectRelation,
         ObjectRelationLimit, Permissions, RelatedClassGraph, RelatedObjectGraph,
@@ -1120,7 +1120,11 @@ mod tests {
 
         // Grant permissions to the group (and indirectly to the user).
         collection
-            .grant_one(&context.pool, group.id, Permissions::ReadClassRelation)
+            .grant_one(
+                &context.pool,
+                GroupID::new(group.id).unwrap(),
+                Permissions::ReadClassRelation,
+            )
             .await
             .unwrap();
 
@@ -2200,7 +2204,11 @@ mod tests {
             .await
             .unwrap();
         collection
-            .grant_one(&context.pool, group.id, Permissions::ReadObject)
+            .grant_one(
+                &context.pool,
+                GroupID::new(group.id).unwrap(),
+                Permissions::ReadObject,
+            )
             .await
             .unwrap();
 
@@ -2317,11 +2325,19 @@ mod tests {
             .await
             .unwrap();
         visible_collection
-            .grant_one(&context.pool, group.id, Permissions::ReadObject)
+            .grant_one(
+                &context.pool,
+                GroupID::new(group.id).unwrap(),
+                Permissions::ReadObject,
+            )
             .await
             .unwrap();
         visible_collection
-            .grant_one(&context.pool, group.id, Permissions::ReadObjectRelation)
+            .grant_one(
+                &context.pool,
+                GroupID::new(group.id).unwrap(),
+                Permissions::ReadObjectRelation,
+            )
             .await
             .unwrap();
 

--- a/tests/api_identity_suite/service_accounts.rs
+++ b/tests/api_identity_suite/service_accounts.rs
@@ -37,7 +37,7 @@ mod tests {
     use crate::models::token::Token;
     use crate::models::user::{LoginUser, NewUser};
     use crate::models::{
-        CollectionID, GroupResponse, HubuumClassID, HubuumClassRelation, HubuumObject,
+        CollectionID, GroupID, GroupResponse, HubuumClassID, HubuumClassRelation, HubuumObject,
         HubuumObjectID, HubuumObjectRelation, MAX_TOKEN_RESOURCE_SCOPES, NewHubuumClass,
         NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, NewServiceAccount,
         NewTaskRecord, Permissions, PrincipalID, PrincipalMemberResponse,
@@ -2557,7 +2557,11 @@ mod tests {
         let group = create_test_group(pool).await;
         fixture
             .collection
-            .grant_one(pool, group.id, Permissions::ReadTemplate)
+            .grant_one(
+                pool,
+                GroupID::new(group.id).unwrap(),
+                Permissions::ReadTemplate,
+            )
             .await
             .unwrap();
         let sa = create_test_service_account(pool, &group, None).await;
@@ -2584,7 +2588,11 @@ mod tests {
         let group = create_test_group(pool).await;
         for collection in [&included.collection, &excluded.collection] {
             collection
-                .grant_one(pool, group.id, Permissions::ReadTemplate)
+                .grant_one(
+                    pool,
+                    GroupID::new(group.id).unwrap(),
+                    Permissions::ReadTemplate,
+                )
                 .await
                 .unwrap();
         }
@@ -2654,7 +2662,7 @@ mod tests {
         let group = create_test_group(pool).await;
         fixture
             .collection
-            .grant_one(pool, group.id, granted)
+            .grant_one(pool, GroupID::new(group.id).unwrap(), granted)
             .await
             .unwrap();
         let sa = create_test_service_account(pool, &group, None).await;

--- a/tests/api_jobs_suite/export_templates.rs
+++ b/tests/api_jobs_suite/export_templates.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use crate::models::{
         Collection, ExportContentType, ExportLimits, ExportMissingDataPolicy, ExportScopeKind,
-        ExportTemplate, ExportTemplateKind, NewCollectionWithAssignee, NewExportTemplate,
+        ExportTemplate, ExportTemplateKind, GroupID, NewCollectionWithAssignee, NewExportTemplate,
         NewHubuumClass, Permissions, PermissionsList, UpdateExportTemplate,
     };
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
@@ -409,7 +409,7 @@ mod tests {
         source_collection
             .grant_without_events(
                 &pool,
-                test_group.id,
+                GroupID::new(test_group.id).unwrap(),
                 PermissionsList::new([Permissions::UpdateTemplate]),
             )
             .await
@@ -435,7 +435,7 @@ mod tests {
         target_collection
             .grant_without_events(
                 &pool,
-                test_group.id,
+                GroupID::new(test_group.id).unwrap(),
                 PermissionsList::new([Permissions::CreateTemplate]),
             )
             .await
@@ -578,7 +578,7 @@ mod tests {
         target_collection
             .grant_without_events(
                 &pool,
-                test_group.id,
+                GroupID::new(test_group.id).unwrap(),
                 PermissionsList::new([Permissions::CreateTemplate]),
             )
             .await
@@ -641,7 +641,7 @@ mod tests {
         visible_collection
             .grant_without_events(
                 &pool,
-                test_group.id,
+                GroupID::new(test_group.id).unwrap(),
                 PermissionsList::new([Permissions::ReadTemplate]),
             )
             .await
@@ -688,7 +688,7 @@ mod tests {
         collection
             .revoke_without_events(
                 &pool,
-                admin_group.id,
+                GroupID::new(admin_group.id).unwrap(),
                 PermissionsList::new([
                     Permissions::ReadTemplate,
                     Permissions::CreateTemplate,
@@ -1093,7 +1093,7 @@ mod tests {
         collection
             .grant_without_events(
                 &pool,
-                test_group.id,
+                GroupID::new(test_group.id).unwrap(),
                 PermissionsList::new([Permissions::ReadTemplate]),
             )
             .await
@@ -1120,7 +1120,7 @@ mod tests {
         collection
             .grant_without_events(
                 &pool,
-                test_group.id,
+                GroupID::new(test_group.id).unwrap(),
                 PermissionsList::new([Permissions::UpdateTemplate]),
             )
             .await
@@ -1164,7 +1164,7 @@ mod tests {
         collection
             .grant_without_events(
                 &pool,
-                test_group.id,
+                GroupID::new(test_group.id).unwrap(),
                 PermissionsList::new([Permissions::ReadTemplate, Permissions::UpdateTemplate]),
             )
             .await
@@ -1182,7 +1182,7 @@ mod tests {
         collection
             .grant_without_events(
                 &pool,
-                test_group.id,
+                GroupID::new(test_group.id).unwrap(),
                 PermissionsList::new([Permissions::DeleteTemplate]),
             )
             .await

--- a/tests/api_jobs_suite/remote_targets.rs
+++ b/tests/api_jobs_suite/remote_targets.rs
@@ -22,7 +22,7 @@ mod tests {
 
     use crate::db::with_connection;
     use crate::models::{
-        HubuumClassRelation, HubuumObjectRelation, NewHubuumClass, NewHubuumClassRelation,
+        GroupID, HubuumClassRelation, HubuumObjectRelation, NewHubuumClass, NewHubuumClassRelation,
         NewHubuumObject, NewHubuumObjectRelation, Permissions, PermissionsList, RemoteCallResult,
         RemoteTarget, TaskResponse, TaskStatus,
     };
@@ -469,7 +469,7 @@ mod tests {
         collection
             .grant_without_events(
                 &context.pool,
-                group.id,
+                GroupID::new(group.id).unwrap(),
                 PermissionsList::new([Permissions::CreateRemoteTarget]),
             )
             .await
@@ -639,7 +639,7 @@ mod tests {
         source_collection
             .grant_without_events(
                 &context.pool,
-                group.id,
+                GroupID::new(group.id).unwrap(),
                 PermissionsList::new([Permissions::UpdateRemoteTarget]),
             )
             .await
@@ -664,7 +664,7 @@ mod tests {
             .collection
             .grant_without_events(
                 &context.pool,
-                group.id,
+                GroupID::new(group.id).unwrap(),
                 PermissionsList::new([Permissions::CreateRemoteTarget]),
             )
             .await
@@ -1110,7 +1110,7 @@ mod tests {
         collection
             .grant_without_events(
                 &context.pool,
-                group.id,
+                GroupID::new(group.id).unwrap(),
                 PermissionsList::new([Permissions::ReadObject]),
             )
             .await
@@ -1216,7 +1216,7 @@ mod tests {
         from_collection
             .grant_without_events(
                 &context.pool,
-                group.id,
+                GroupID::new(group.id).unwrap(),
                 PermissionsList::new([
                     Permissions::ReadObjectRelation,
                     Permissions::ExecuteRemoteTarget,
@@ -1240,7 +1240,11 @@ mod tests {
             .await
             .unwrap();
         to_collection
-            .grant_one(&context.pool, group.id, Permissions::ReadObjectRelation)
+            .grant_one(
+                &context.pool,
+                GroupID::new(group.id).unwrap(),
+                Permissions::ReadObjectRelation,
+            )
             .await
             .unwrap();
 

--- a/tests/api_platform_suite/events.rs
+++ b/tests/api_platform_suite/events.rs
@@ -6,7 +6,7 @@ mod tests {
 
     use crate::db::with_connection;
     use crate::events::{Action, ActorKind, EntityType, EventResponse, NewEvent, emit_event};
-    use crate::models::{NewHubuumClass, NewHubuumObject, Permissions, PermissionsList};
+    use crate::models::{GroupID, NewHubuumClass, NewHubuumObject, Permissions, PermissionsList};
     use crate::tests::TestContext;
     use crate::tests::api_operations::get_request;
     use crate::tests::asserts::{assert_response_status, header_value};
@@ -58,7 +58,7 @@ mod tests {
             .collection
             .grant_without_events(
                 &context.pool,
-                group.id,
+                GroupID::new(group.id).unwrap(),
                 PermissionsList::new([Permissions::ReadAudit]),
             )
             .await
@@ -100,7 +100,7 @@ mod tests {
             .collection
             .grant_without_events(
                 &context.pool,
-                group.id,
+                GroupID::new(group.id).unwrap(),
                 PermissionsList::new([Permissions::ReadAudit]),
             )
             .await
@@ -172,7 +172,7 @@ mod tests {
             .collection
             .grant_without_events(
                 &context.pool,
-                group.id,
+                GroupID::new(group.id).unwrap(),
                 PermissionsList::new([Permissions::ReadAudit]),
             )
             .await
@@ -244,7 +244,7 @@ mod tests {
         related_collection
             .grant_without_events(
                 &context.pool,
-                group.id,
+                GroupID::new(group.id).unwrap(),
                 PermissionsList::new([Permissions::ReadAudit]),
             )
             .await

--- a/tests/api_platform_suite/request_and_correlation.rs
+++ b/tests/api_platform_suite/request_and_correlation.rs
@@ -9,6 +9,7 @@ mod tests {
     };
     use serde_json::json;
     use std::{future::Future, str::FromStr};
+    use tokio::sync::Mutex;
 
     use crate::config::ClientAllowlist;
     use crate::events::RequestProvenance;
@@ -22,6 +23,7 @@ mod tests {
     use crate::tests::{TestContext, test_context};
 
     const ENDPOINT: &str = "/api/v1/classes/";
+    static REQUEST_LOG_CAPTURE_LOCK: Mutex<()> = Mutex::const_new(());
 
     #[rstest]
     #[case::with_correlation_id(Some("test-correlation-id"), true)]
@@ -109,6 +111,10 @@ mod tests {
     where
         F: Future<Output = T>,
     {
+        // Subscriber registration updates tracing's process-wide callsite interest cache.
+        // Keep capture subscribers alive one at a time so parallel request-log tests cannot
+        // invalidate another request's capture while its authenticated DB work is in flight.
+        let _capture_guard = REQUEST_LOG_CAPTURE_LOCK.lock().await;
         let (tracing_middleware, writer) = tracing_middleware_with_log_capture();
         let output = run(tracing_middleware).await;
         (output, writer)

--- a/tests/api_platform_suite/request_and_correlation.rs
+++ b/tests/api_platform_suite/request_and_correlation.rs
@@ -9,22 +9,19 @@ mod tests {
     };
     use serde_json::json;
     use std::{future::Future, str::FromStr};
-    use tokio::sync::Mutex;
-    use tracing::instrument::WithSubscriber;
-    use tracing_subscriber::layer::SubscriberExt;
 
     use crate::config::ClientAllowlist;
     use crate::events::RequestProvenance;
-    use crate::logger::HubuumLoggingFormat;
     use crate::middlewares::actor_context;
     use crate::middlewares::{ClientAllowlistMiddleware, TracingMiddleware};
-    use crate::test_support::{JsonLogWriter, record_principal_on_current_span};
+    use crate::test_support::{
+        JsonLogWriter, record_principal_on_current_span, tracing_middleware_with_log_capture,
+    };
     use crate::tests::api_operations::get_request_with_correlation;
     use crate::tests::asserts::assert_response_status;
     use crate::tests::{TestContext, test_context};
 
     const ENDPOINT: &str = "/api/v1/classes/";
-    static REQUEST_LOG_CAPTURE_LOCK: Mutex<()> = Mutex::const_new(());
 
     #[rstest]
     #[case::with_correlation_id(Some("test-correlation-id"), true)]
@@ -106,19 +103,14 @@ mod tests {
         assert_eq!(body["correlation_id"], "context-correlation");
     }
 
-    async fn capture_request_logs<T>(future: impl Future<Output = T>) -> (T, JsonLogWriter) {
-        // These tests install distinct task-local tracing subscribers around nested Actix
-        // middleware futures. Keep capture windows from overlapping: parallel capture has
-        // intermittently dropped the final middleware event on CI.
-        let _capture_guard = REQUEST_LOG_CAPTURE_LOCK.lock().await;
-        let writer = JsonLogWriter::default();
-        let subscriber = tracing_subscriber::registry().with(
-            tracing_subscriber::fmt::layer()
-                .json()
-                .with_writer(writer.clone())
-                .event_format(HubuumLoggingFormat),
-        );
-        let output = future.with_subscriber(subscriber).await;
+    async fn capture_request_logs<T, F>(
+        run: impl FnOnce(TracingMiddleware) -> F,
+    ) -> (T, JsonLogWriter)
+    where
+        F: Future<Output = T>,
+    {
+        let (tracing_middleware, writer) = tracing_middleware_with_log_capture();
+        let output = run(tracing_middleware).await;
         (output, writer)
     }
 
@@ -153,10 +145,10 @@ mod tests {
         #[case] expected_status: StatusCode,
         #[case] expected_severity: &str,
     ) {
-        let (resp, writer) = capture_request_logs(async {
+        let (resp, writer) = capture_request_logs(|tracing_middleware| async move {
             let app = test::init_service(
                 App::new()
-                    .wrap(TracingMiddleware::new())
+                    .wrap(tracing_middleware)
                     .route("/ok", web::get().to(ok_handler))
                     .route("/bad-request", web::get().to(bad_request_handler))
                     .route("/server-error", web::get().to(server_error_handler)),
@@ -191,10 +183,10 @@ mod tests {
     #[case::readiness("/readyz")]
     #[actix_web::test]
     async fn tracing_middleware_logs_successful_probes_at_debug(#[case] path: &str) {
-        let (resp, writer) = capture_request_logs(async {
+        let (resp, writer) = capture_request_logs(|tracing_middleware| async move {
             let app = test::init_service(
                 App::new()
-                    .wrap(TracingMiddleware::new())
+                    .wrap(tracing_middleware)
                     .route("/healthz", web::get().to(ok_handler))
                     .route("/readyz", web::get().to(ok_handler)),
             )
@@ -216,10 +208,10 @@ mod tests {
 
     #[actix_web::test]
     async fn tracing_middleware_keeps_failed_readiness_probes_at_error() {
-        let (resp, writer) = capture_request_logs(async {
+        let (resp, writer) = capture_request_logs(|tracing_middleware| async move {
             let app = test::init_service(
                 App::new()
-                    .wrap(TracingMiddleware::new())
+                    .wrap(tracing_middleware)
                     .route("/readyz", web::get().to(service_unavailable_handler)),
             )
             .await;
@@ -243,10 +235,10 @@ mod tests {
 
     #[actix_web::test]
     async fn tracing_middleware_includes_recorded_principal_on_request_logs() {
-        let (resp, writer) = capture_request_logs(async {
+        let (resp, writer) = capture_request_logs(|tracing_middleware| async move {
             let app = test::init_service(
                 App::new()
-                    .wrap(TracingMiddleware::new())
+                    .wrap(tracing_middleware)
                     .route("/principal", web::get().to(principal_handler)),
             )
             .await;
@@ -270,11 +262,12 @@ mod tests {
     #[actix_web::test]
     async fn production_middleware_stack_records_authenticated_principal_on_request_logs() {
         let test_context = TestContext::new().await;
-        let (resp, writer) = capture_request_logs(async {
+        let expected_principal_id = test_context.admin_user.id;
+        let (resp, writer) = capture_request_logs(|tracing_middleware| async move {
             let app = test::init_service(
                 App::new()
                     .wrap(actix_web::middleware::from_fn(actor_context))
-                    .wrap(TracingMiddleware::new())
+                    .wrap(tracing_middleware)
                     .app_data(test_context.pool.clone())
                     .app_data(crate::tests::app_context(&test_context.pool))
                     .route("/principal", web::get().to(ok_handler)),
@@ -298,19 +291,19 @@ mod tests {
             .iter()
             .find(|event| event["message"] == "request complete")
             .expect("request completion log");
-        assert_eq!(event["principal_id"], test_context.admin_user.id);
+        assert_eq!(event["principal_id"], expected_principal_id);
     }
 
     #[actix_web::test]
     async fn production_middleware_stack_traces_allowlist_rejections() {
-        let (resp, writer) = capture_request_logs(async {
+        let (resp, writer) = capture_request_logs(|tracing_middleware| async move {
             let app = test::init_service(
                 App::new()
                     .wrap(actix_web::middleware::from_fn(actor_context))
                     .wrap(ClientAllowlistMiddleware::new(
                         ClientAllowlist::from_str("10.0.0.0/24").expect("allowlist"),
                     ))
-                    .wrap(TracingMiddleware::new())
+                    .wrap(tracing_middleware)
                     .route("/denied", web::get().to(ok_handler)),
             )
             .await;


### PR DESCRIPTION
## Summary

Replace raw integer group and collection identifiers at permission-controller and permission-backend boundaries with validated `GroupID` and `CollectionID` newtypes.

Carry those types through local, Treetop, mock, model, handler, and test implementations so identifier validity is established at the boundary rather than repeatedly assumed downstream.

## Rationale

Permission targets are security-sensitive domain values. Raw integers allow invalid or accidentally swapped identifiers to travel through authorization code without compiler help.

## Behavior and compatibility

This is a breaking Rust API change for downstream permission backends and callers: signatures now require the matching ID newtype. HTTP behavior and database storage are unchanged, and no migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
