### PR TITLE
Sanitize integration transport errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Redacted embedded URL credentials and common secret-header spellings from
   event sink configuration and subscription routing responses and audit
   snapshots.
+- **Breaking (Rust API):** `OutboundHttpError::ResponseRead` and
+  `OutboundHttpError::Request` no longer carry low-level error strings, keeping
+  endpoint details out of integration diagnostics and persisted event-delivery
+  failures. Downstream matches and constructors must remove the former string
+  payloads. Credential-resolved AMQP, email, and Valkey connection failures are
+  likewise reported without transport-library detail.
 
 ## [0.0.8] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Redacted embedded URL credentials and common secret-header spellings from
   event sink configuration and subscription routing responses and audit
   snapshots.
-- **Breaking (Rust API):** `OutboundHttpError::ResponseRead` and
-  `OutboundHttpError::Request` no longer carry low-level error strings, keeping
-  endpoint details out of integration diagnostics and persisted event-delivery
-  failures. Downstream matches and constructors must remove the former string
-  payloads. Credential-resolved AMQP, email, and Valkey connection failures are
-  likewise reported without transport-library detail. The underlying failures
-  remain available to administrators in contextual server logs.
+- **Breaking (Rust API):** `OutboundHttpError::ClientBuild`,
+  `OutboundHttpError::ResponseRead`, and `OutboundHttpError::Request` no longer
+  carry low-level error strings, keeping endpoint details out of integration
+  diagnostics and persisted event-delivery failures. Downstream matches and
+  constructors must remove the former string payloads. Credential-resolved
+  AMQP, email, and Valkey transport failures are likewise reported without
+  transport-library detail. The underlying failures remain available to
+  administrators in contextual server logs.
 
 ## [0.0.8] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   endpoint details out of integration diagnostics and persisted event-delivery
   failures. Downstream matches and constructors must remove the former string
   payloads. Credential-resolved AMQP, email, and Valkey connection failures are
-  likewise reported without transport-library detail.
+  likewise reported without transport-library detail. The underlying failures
+  remain available to administrators in contextual server logs.
 
 ## [0.0.8] - 2026-08-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,6 +2198,7 @@ dependencies = [
  "lettre",
  "serde",
  "serde_json",
+ "tracing",
  "uuid",
 ]
 
@@ -2213,6 +2214,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -2264,6 +2266,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/hubuum-event-sink-amqp/src/lib.rs
+++ b/crates/hubuum-event-sink-amqp/src/lib.rs
@@ -118,7 +118,7 @@ impl AmqpSink {
                 Connection::connect(&uri, ConnectionProperties::default().enable_auto_recover())
                     .await
                     .map(Arc::new)
-                    .map_err(|error| SinkError::new(format!("AMQP connection failed: {error}")))
+                    .map_err(|_| SinkError::new("AMQP connection failed"))
             })
             .await?;
 

--- a/crates/hubuum-event-sink-amqp/src/lib.rs
+++ b/crates/hubuum-event-sink-amqp/src/lib.rs
@@ -118,7 +118,13 @@ impl AmqpSink {
                 Connection::connect(&uri, ConnectionProperties::default().enable_auto_recover())
                     .await
                     .map(Arc::new)
-                    .map_err(|_| SinkError::new("AMQP connection failed"))
+                    .map_err(|error| {
+                        warn!(
+                            message = "AMQP connection failed",
+                            error = %error,
+                        );
+                        SinkError::new("AMQP connection failed")
+                    })
             })
             .await?;
 

--- a/crates/hubuum-event-sink-amqp/src/lib.rs
+++ b/crates/hubuum-event-sink-amqp/src/lib.rs
@@ -55,7 +55,7 @@ impl AmqpSink {
         channel
             .confirm_select(ConfirmSelectOptions::default())
             .await
-            .map_err(|error| SinkError::new(format!("AMQP confirm setup failed: {error}")))?;
+            .map_err(|error| amqp_transport_error("AMQP confirm setup failed", error))?;
 
         if config.declare_exchange {
             channel
@@ -69,9 +69,7 @@ impl AmqpSink {
                     FieldTable::default(),
                 )
                 .await
-                .map_err(|error| {
-                    SinkError::new(format!("AMQP exchange declaration failed: {error}"))
-                })?;
+                .map_err(|error| amqp_transport_error("AMQP exchange declaration failed", error))?;
         }
 
         let payload = serialize_envelope_to_vec(
@@ -95,11 +93,9 @@ impl AmqpSink {
                 properties,
             )
             .await
-            .map_err(|error| SinkError::new(format!("AMQP publish failed: {error}")))?
+            .map_err(|error| amqp_transport_error("AMQP publish failed", error))?
             .await
-            .map_err(|error| {
-                SinkError::new(format!("AMQP publish confirmation failed: {error}"))
-            })?;
+            .map_err(|error| amqp_transport_error("AMQP publish confirmation failed", error))?;
 
         match confirmation {
             Confirmation::Ack(None) | Confirmation::NotRequested => Ok(()),
@@ -118,30 +114,28 @@ impl AmqpSink {
                 Connection::connect(&uri, ConnectionProperties::default().enable_auto_recover())
                     .await
                     .map(Arc::new)
-                    .map_err(|error| {
-                        warn!(
-                            message = "AMQP connection failed",
-                            error = %error,
-                        );
-                        SinkError::new("AMQP connection failed")
-                    })
+                    .map_err(|error| amqp_transport_error("AMQP connection failed", error))
             })
             .await?;
 
         match connection.create_channel().await {
             Ok(channel) => Ok(channel),
             Err(error) => {
-                warn!(
-                    message = "Dropping failed AMQP connection from sink pool",
-                    error = %error
-                );
+                let error = amqp_transport_error("AMQP channel creation failed", error);
                 self.connections.remove(&key).await;
-                Err(SinkError::new(format!(
-                    "AMQP channel creation failed: {error}"
-                )))
+                Err(error)
             }
         }
     }
+}
+
+fn amqp_transport_error(operation: &'static str, error: impl fmt::Display) -> SinkError {
+    warn!(
+        message = "AMQP transport operation failed",
+        operation,
+        error = %error,
+    );
+    SinkError::new(operation)
 }
 
 fn parse_config(delivery: &SinkDelivery<'_>) -> Result<AmqpConfig, SinkError> {
@@ -237,6 +231,16 @@ mod tests {
     #[test]
     fn routing_key_uses_entity_type_and_action() {
         assert_eq!(routing_key(&envelope()), "collection.created");
+    }
+
+    #[test]
+    fn transport_errors_cannot_reach_delivery_results() {
+        let error = amqp_transport_error(
+            "AMQP publish failed",
+            "transport failure for amqps://user:secret@example.internal",
+        );
+
+        assert_eq!(error.to_string(), "AMQP publish failed");
     }
 
     #[test]

--- a/crates/hubuum-event-sink-email/Cargo.toml
+++ b/crates/hubuum-event-sink-email/Cargo.toml
@@ -20,6 +20,7 @@ lettre = { version = "0.11.22", default-features = false, features = [
 ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tracing = "0.1"
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/hubuum-event-sink-email/src/lib.rs
+++ b/crates/hubuum-event-sink-email/src/lib.rs
@@ -11,6 +11,7 @@ use lettre::message::Mailbox;
 use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
 use serde::Deserialize;
 use serde_json::{Map, Value};
+use tracing::warn;
 
 #[derive(Default)]
 pub struct EmailSink {
@@ -70,7 +71,13 @@ impl EmailSink {
             .await?
             .send(message)
             .await
-            .map_err(|_| SinkError::new("Email SMTP delivery failed"))?;
+            .map_err(|error| {
+                warn!(
+                    message = "Email SMTP delivery failed",
+                    error = %error,
+                );
+                SinkError::new("Email SMTP delivery failed")
+            })?;
         Ok(())
     }
 
@@ -78,7 +85,13 @@ impl EmailSink {
         self.transports
             .get_or_try_insert_with(uri.to_string(), |uri| async move {
                 AsyncSmtpTransport::<Tokio1Executor>::from_url(&uri)
-                    .map_err(|_| SinkError::new("Invalid email config"))
+                    .map_err(|error| {
+                        warn!(
+                            message = "Invalid email transport configuration",
+                            error = %error,
+                        );
+                        SinkError::new("Invalid email config")
+                    })
                     .map(|builder| builder.build())
             })
             .await

--- a/crates/hubuum-event-sink-email/src/lib.rs
+++ b/crates/hubuum-event-sink-email/src/lib.rs
@@ -70,7 +70,7 @@ impl EmailSink {
             .await?
             .send(message)
             .await
-            .map_err(|error| SinkError::new(format!("Email SMTP delivery failed: {error}")))?;
+            .map_err(|_| SinkError::new("Email SMTP delivery failed"))?;
         Ok(())
     }
 
@@ -78,7 +78,7 @@ impl EmailSink {
         self.transports
             .get_or_try_insert_with(uri.to_string(), |uri| async move {
                 AsyncSmtpTransport::<Tokio1Executor>::from_url(&uri)
-                    .map_err(|error| SinkError::new(format!("Invalid email config: {error}")))
+                    .map_err(|_| SinkError::new("Invalid email config"))
                     .map(|builder| builder.build())
             })
             .await

--- a/crates/hubuum-event-sink-valkey/Cargo.toml
+++ b/crates/hubuum-event-sink-valkey/Cargo.toml
@@ -14,6 +14,7 @@ redis = { version = "1.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt"] }
+tracing = "0.1"
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/hubuum-event-sink-valkey/src/lib.rs
+++ b/crates/hubuum-event-sink-valkey/src/lib.rs
@@ -70,8 +70,7 @@ impl ValkeySink {
     async fn client(&self, uri: &str) -> Result<Client, SinkError> {
         self.clients
             .get_or_try_insert_with(uri.to_string(), |uri| async move {
-                Client::open(uri)
-                    .map_err(|error| SinkError::new(format!("Invalid Valkey config: {error}")))
+                Client::open(uri).map_err(|_| SinkError::new("Invalid Valkey config"))
             })
             .await
     }
@@ -80,7 +79,7 @@ impl ValkeySink {
 fn publish_stream_entry(client: Client, entry: StreamEntry) -> Result<(), SinkError> {
     let mut connection = client
         .get_connection_with_timeout(entry.io_timeout)
-        .map_err(|error| SinkError::new(format!("Valkey connection failed: {error}")))?;
+        .map_err(|_| SinkError::new("Valkey connection failed"))?;
     connection
         .set_read_timeout(Some(entry.io_timeout))
         .map_err(|error| SinkError::new(format!("Valkey read timeout setup failed: {error}")))?;

--- a/crates/hubuum-event-sink-valkey/src/lib.rs
+++ b/crates/hubuum-event-sink-valkey/src/lib.rs
@@ -8,6 +8,7 @@ use hubuum_event_sinks_common::{
 };
 use redis::Client;
 use serde::Deserialize;
+use tracing::warn;
 
 const DEFAULT_VALKEY_IO_TIMEOUT_MS: u64 = 25_000;
 
@@ -70,7 +71,13 @@ impl ValkeySink {
     async fn client(&self, uri: &str) -> Result<Client, SinkError> {
         self.clients
             .get_or_try_insert_with(uri.to_string(), |uri| async move {
-                Client::open(uri).map_err(|_| SinkError::new("Invalid Valkey config"))
+                Client::open(uri).map_err(|error| {
+                    warn!(
+                        message = "Invalid Valkey transport configuration",
+                        error = %error,
+                    );
+                    SinkError::new("Invalid Valkey config")
+                })
             })
             .await
     }
@@ -79,7 +86,13 @@ impl ValkeySink {
 fn publish_stream_entry(client: Client, entry: StreamEntry) -> Result<(), SinkError> {
     let mut connection = client
         .get_connection_with_timeout(entry.io_timeout)
-        .map_err(|_| SinkError::new("Valkey connection failed"))?;
+        .map_err(|error| {
+            warn!(
+                message = "Valkey connection failed",
+                error = %error,
+            );
+            SinkError::new("Valkey connection failed")
+        })?;
     connection
         .set_read_timeout(Some(entry.io_timeout))
         .map_err(|error| SinkError::new(format!("Valkey read timeout setup failed: {error}")))?;

--- a/crates/hubuum-event-sink-valkey/src/lib.rs
+++ b/crates/hubuum-event-sink-valkey/src/lib.rs
@@ -65,19 +65,14 @@ impl ValkeySink {
 
         tokio::task::spawn_blocking(move || publish_stream_entry(client, entry))
             .await
-            .map_err(|error| SinkError::new(format!("Valkey delivery task failed: {error}")))?
+            .map_err(|error| valkey_transport_error("Valkey delivery task failed", error))?
     }
 
     async fn client(&self, uri: &str) -> Result<Client, SinkError> {
         self.clients
             .get_or_try_insert_with(uri.to_string(), |uri| async move {
-                Client::open(uri).map_err(|error| {
-                    warn!(
-                        message = "Invalid Valkey transport configuration",
-                        error = %error,
-                    );
-                    SinkError::new("Invalid Valkey config")
-                })
+                Client::open(uri)
+                    .map_err(|error| valkey_transport_error("Invalid Valkey config", error))
             })
             .await
     }
@@ -86,24 +81,27 @@ impl ValkeySink {
 fn publish_stream_entry(client: Client, entry: StreamEntry) -> Result<(), SinkError> {
     let mut connection = client
         .get_connection_with_timeout(entry.io_timeout)
-        .map_err(|error| {
-            warn!(
-                message = "Valkey connection failed",
-                error = %error,
-            );
-            SinkError::new("Valkey connection failed")
-        })?;
+        .map_err(|error| valkey_transport_error("Valkey connection failed", error))?;
     connection
         .set_read_timeout(Some(entry.io_timeout))
-        .map_err(|error| SinkError::new(format!("Valkey read timeout setup failed: {error}")))?;
+        .map_err(|error| valkey_transport_error("Valkey read timeout setup failed", error))?;
     connection
         .set_write_timeout(Some(entry.io_timeout))
-        .map_err(|error| SinkError::new(format!("Valkey write timeout setup failed: {error}")))?;
+        .map_err(|error| valkey_transport_error("Valkey write timeout setup failed", error))?;
     let command = xadd_command(&entry);
     let _: String = command
         .query(&mut connection)
-        .map_err(|error| SinkError::new(format!("Valkey XADD failed: {error}")))?;
+        .map_err(|error| valkey_transport_error("Valkey XADD failed", error))?;
     Ok(())
+}
+
+fn valkey_transport_error(operation: &'static str, error: impl fmt::Display) -> SinkError {
+    warn!(
+        message = "Valkey transport operation failed",
+        operation,
+        error = %error,
+    );
+    SinkError::new(operation)
 }
 
 fn parse_config(delivery: &SinkDelivery<'_>) -> Result<ValkeyConfig, SinkError> {
@@ -279,6 +277,16 @@ mod tests {
             error.to_string(),
             "Invalid Valkey config: uri credentials must use {secret} with secret_ref"
         );
+    }
+
+    #[test]
+    fn transport_errors_cannot_reach_delivery_results() {
+        let error = valkey_transport_error(
+            "Valkey XADD failed",
+            "transport failure for rediss://user:secret@example.internal",
+        );
+
+        assert_eq!(error.to_string(), "Valkey XADD failed");
     }
 
     #[test]

--- a/crates/hubuum-outbound-http/Cargo.toml
+++ b/crates/hubuum-outbound-http/Cargo.toml
@@ -11,3 +11,4 @@ ipnet = "2.12"
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 serde_json = "1"
 tokio = { version = "1", features = ["net"] }
+tracing = "0.1"

--- a/crates/hubuum-outbound-http/src/lib.rs
+++ b/crates/hubuum-outbound-http/src/lib.rs
@@ -54,10 +54,10 @@ pub enum OutboundHttpError {
     EmptyDnsResolution { host: String },
     DisallowedAddress { host: String, address: IpAddr },
     ClientBuild(String),
-    ResponseRead(String),
+    ResponseRead,
     Timeout,
     Connect,
-    Request(String),
+    Request,
     InvalidHeaderName { name: String },
     TransportControlledHeader { name: String },
     InvalidHeaderValue { name: String },
@@ -82,10 +82,10 @@ impl fmt::Display for OutboundHttpError {
                 "outbound host '{host}' resolves to a disallowed address ({address})"
             ),
             Self::ClientBuild(error) => write!(f, "HTTP client error: {error}"),
-            Self::ResponseRead(error) => write!(f, "failed reading outbound response: {error}"),
+            Self::ResponseRead => write!(f, "failed reading outbound response"),
             Self::Timeout => write!(f, "outbound call timed out"),
             Self::Connect => write!(f, "outbound connection failed"),
-            Self::Request(error) => write!(f, "outbound call failed: {error}"),
+            Self::Request => write!(f, "outbound call failed"),
             Self::InvalidHeaderName { name } => write!(f, "invalid outbound header name: {name}"),
             Self::TransportControlledHeader { name } => {
                 write!(
@@ -535,7 +535,7 @@ async fn read_capped_body(
         match response
             .chunk()
             .await
-            .map_err(|error| OutboundHttpError::ResponseRead(error.to_string()))?
+            .map_err(|_| OutboundHttpError::ResponseRead)?
         {
             Some(chunk) => {
                 let remaining = limit - buffer.len();
@@ -584,7 +584,7 @@ fn map_reqwest_error(error: reqwest::Error) -> OutboundHttpError {
     } else if error.is_connect() {
         OutboundHttpError::Connect
     } else {
-        OutboundHttpError::Request(error.to_string())
+        OutboundHttpError::Request
     }
 }
 
@@ -655,6 +655,18 @@ mod tests {
         let json = headers_to_json(&headers);
         assert_eq!(json["set-cookie"], "[redacted]");
         assert_eq!(json["x-request-id"], "abc");
+    }
+
+    #[test]
+    fn transport_errors_cannot_embed_endpoint_details() {
+        assert_eq!(
+            OutboundHttpError::ResponseRead.to_string(),
+            "failed reading outbound response"
+        );
+        assert_eq!(
+            OutboundHttpError::Request.to_string(),
+            "outbound call failed"
+        );
     }
 
     #[test]

--- a/crates/hubuum-outbound-http/src/lib.rs
+++ b/crates/hubuum-outbound-http/src/lib.rs
@@ -54,7 +54,7 @@ pub enum OutboundHttpError {
     DnsResolution { host: String },
     EmptyDnsResolution { host: String },
     DisallowedAddress { host: String, address: IpAddr },
-    ClientBuild(String),
+    ClientBuild,
     ResponseRead,
     Timeout,
     Connect,
@@ -82,7 +82,7 @@ impl fmt::Display for OutboundHttpError {
                 f,
                 "outbound host '{host}' resolves to a disallowed address ({address})"
             ),
-            Self::ClientBuild(error) => write!(f, "HTTP client error: {error}"),
+            Self::ClientBuild => write!(f, "HTTP client initialization failed"),
             Self::ResponseRead => write!(f, "failed reading outbound response"),
             Self::Timeout => write!(f, "outbound call timed out"),
             Self::Connect => write!(f, "outbound connection failed"),
@@ -492,7 +492,7 @@ fn cached_client(
     let now = CLIENT_CACHE_CLOCK.fetch_add(1, Ordering::Relaxed);
     let mut cache = CLIENT_CACHE
         .lock()
-        .map_err(|_| OutboundHttpError::ClientBuild("client cache lock poisoned".to_string()))?;
+        .map_err(|_| OutboundHttpError::ClientBuild)?;
 
     if let Some(entry) = cache.get_mut(&key) {
         entry.last_used = now;
@@ -505,9 +505,13 @@ fn cached_client(
     if accept_invalid_certs {
         builder = builder.danger_accept_invalid_certs(true);
     }
-    let client = builder
-        .build()
-        .map_err(|error| OutboundHttpError::ClientBuild(error.to_string()))?;
+    let client = builder.build().map_err(|error| {
+        warn!(
+            message = "Failed building outbound HTTP client",
+            error = %error.without_url(),
+        );
+        OutboundHttpError::ClientBuild
+    })?;
 
     if cache.len() >= MAX_CACHED_CLIENTS
         && let Some(stalest) = cache
@@ -670,6 +674,10 @@ mod tests {
 
     #[test]
     fn transport_errors_cannot_embed_endpoint_details() {
+        assert_eq!(
+            OutboundHttpError::ClientBuild.to_string(),
+            "HTTP client initialization failed"
+        );
         assert_eq!(
             OutboundHttpError::ResponseRead.to_string(),
             "failed reading outbound response"

--- a/crates/hubuum-outbound-http/src/lib.rs
+++ b/crates/hubuum-outbound-http/src/lib.rs
@@ -24,6 +24,7 @@ use std::time::{Duration, Instant};
 use ipnet::IpNet;
 use reqwest::Url;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use tracing::warn;
 
 const MAX_CACHED_CLIENTS: usize = 128;
 
@@ -532,11 +533,13 @@ async fn read_capped_body(
 ) -> Result<String, OutboundHttpError> {
     let mut buffer: Vec<u8> = Vec::new();
     while buffer.len() < limit {
-        match response
-            .chunk()
-            .await
-            .map_err(|_| OutboundHttpError::ResponseRead)?
-        {
+        match response.chunk().await.map_err(|error| {
+            warn!(
+                message = "Failed reading outbound HTTP response",
+                error = %error.without_url(),
+            );
+            OutboundHttpError::ResponseRead
+        })? {
             Some(chunk) => {
                 let remaining = limit - buffer.len();
                 let take = remaining.min(chunk.len());
@@ -579,9 +582,17 @@ fn headers_to_json(headers: &HeaderMap) -> serde_json::Value {
 }
 
 fn map_reqwest_error(error: reqwest::Error) -> OutboundHttpError {
-    if error.is_timeout() {
+    let is_timeout = error.is_timeout();
+    let is_connect = error.is_connect();
+    warn!(
+        message = "Outbound HTTP request failed",
+        error = %error.without_url(),
+        is_timeout,
+        is_connect,
+    );
+    if is_timeout {
         OutboundHttpError::Timeout
-    } else if error.is_connect() {
+    } else if is_connect {
         OutboundHttpError::Connect
     } else {
         OutboundHttpError::Request

--- a/src/events/delivery.rs
+++ b/src/events/delivery.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use actix_rt::time::sleep;
 use futures_util::StreamExt;
 use tokio::sync::Notify;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::config::{
     DEFAULT_EVENT_DELIVERY_BATCH_SIZE, DEFAULT_EVENT_DELIVERY_LOCK_TIMEOUT_MS,
@@ -215,6 +215,15 @@ async fn process_claimed_event_delivery_with_names(
             mark_event_delivery_succeeded(pool, delivery.id, claim_token).await?;
         }
         Err(error) => {
+            warn!(
+                message = "Event sink delivery failed",
+                event_delivery_id = delivery.id,
+                event_id = %envelope.event_id,
+                event_sink_id = sink.id,
+                event_subscription_id = subscription.id,
+                sink_kind = sink.kind.as_str(),
+                error = %error,
+            );
             mark_event_delivery_failed(pool, &delivery, settings, &error.to_string()).await?;
         }
     }

--- a/src/tasks/remote_call.rs
+++ b/src/tasks/remote_call.rs
@@ -324,9 +324,9 @@ fn remote_error_outcome(error: &OutboundHttpError) -> &'static str {
         OutboundHttpError::DnsResolution { .. }
         | OutboundHttpError::EmptyDnsResolution { .. }
         | OutboundHttpError::ClientBuild(_)
-        | OutboundHttpError::ResponseRead(_)
+        | OutboundHttpError::ResponseRead
         | OutboundHttpError::Connect
-        | OutboundHttpError::Request(_) => "failure",
+        | OutboundHttpError::Request => "failure",
     }
 }
 
@@ -518,12 +518,10 @@ fn outbound_error_to_api_message(error: OutboundHttpError) -> String {
             format!("Remote target host '{host}' resolves to a disallowed address ({address})")
         }
         OutboundHttpError::ClientBuild(error) => format!("HTTP client error: {error}"),
-        OutboundHttpError::ResponseRead(error) => {
-            format!("Failed reading remote response: {error}")
-        }
+        OutboundHttpError::ResponseRead => "Failed reading remote response".to_string(),
         OutboundHttpError::Timeout => "Remote call timed out".to_string(),
         OutboundHttpError::Connect => "Remote connection failed".to_string(),
-        OutboundHttpError::Request(error) => format!("Remote call failed: {error}"),
+        OutboundHttpError::Request => "Remote call failed".to_string(),
         OutboundHttpError::InvalidHeaderName { name } => format!("Invalid header name: {name}"),
         OutboundHttpError::TransportControlledHeader { name } => {
             format!("Header is controlled by the HTTP transport: {name}")
@@ -538,8 +536,8 @@ fn outbound_error_to_api_error(error: OutboundHttpError) -> ApiError {
     let internal = matches!(
         &error,
         OutboundHttpError::ClientBuild(_)
-            | OutboundHttpError::ResponseRead(_)
-            | OutboundHttpError::Request(_)
+            | OutboundHttpError::ResponseRead
+            | OutboundHttpError::Request
     );
     let message = outbound_error_to_api_message(error);
     if internal {
@@ -606,9 +604,9 @@ mod tests {
         "failure"
     )]
     #[case(OutboundHttpError::ClientBuild("client".to_string()), "failure")]
-    #[case(OutboundHttpError::ResponseRead("body".to_string()), "failure")]
+    #[case(OutboundHttpError::ResponseRead, "failure")]
     #[case(OutboundHttpError::Connect, "failure")]
-    #[case(OutboundHttpError::Request("request".to_string()), "failure")]
+    #[case(OutboundHttpError::Request, "failure")]
     fn remote_errors_use_lossless_metric_outcomes(
         #[case] error: OutboundHttpError,
         #[case] expected: &'static str,
@@ -645,9 +643,7 @@ mod tests {
 
     #[test]
     fn internal_outbound_errors_are_sanitized_for_storage() {
-        let error = outbound_error_to_api_error(OutboundHttpError::ResponseRead(
-            "transport failure for https://example.com/secret".to_string(),
-        ));
+        let error = outbound_error_to_api_error(OutboundHttpError::ResponseRead);
 
         assert!(matches!(error, ApiError::InternalServerError(_)));
         assert_eq!(

--- a/src/tasks/remote_call.rs
+++ b/src/tasks/remote_call.rs
@@ -265,6 +265,16 @@ async fn record_remote_call_failure(
     error: OutboundHttpError,
 ) -> Result<RemoteExecutionOutcome, ApiError> {
     let metric_outcome = remote_error_outcome(&error);
+    warn!(
+        message = "Remote target call failed",
+        task_id = context.task_id,
+        target_id = context.target_id,
+        subject_type = context.subject_type,
+        subject_id = context.subject_id,
+        method = context.method,
+        outcome = metric_outcome,
+        error = %error,
+    );
     let api_error = outbound_error_to_api_error(error);
     let message = crate::tasks::helpers::sanitize_error_for_storage(&api_error);
     metrics::remote_call_finished(

--- a/src/tasks/remote_call.rs
+++ b/src/tasks/remote_call.rs
@@ -333,7 +333,7 @@ fn remote_error_outcome(error: &OutboundHttpError) -> &'static str {
         | OutboundHttpError::InvalidHeaderValue { .. } => "validation_rejected",
         OutboundHttpError::DnsResolution { .. }
         | OutboundHttpError::EmptyDnsResolution { .. }
-        | OutboundHttpError::ClientBuild(_)
+        | OutboundHttpError::ClientBuild
         | OutboundHttpError::ResponseRead
         | OutboundHttpError::Connect
         | OutboundHttpError::Request => "failure",
@@ -527,7 +527,7 @@ fn outbound_error_to_api_message(error: OutboundHttpError) -> String {
         OutboundHttpError::DisallowedAddress { host, address } => {
             format!("Remote target host '{host}' resolves to a disallowed address ({address})")
         }
-        OutboundHttpError::ClientBuild(error) => format!("HTTP client error: {error}"),
+        OutboundHttpError::ClientBuild => "HTTP client initialization failed".to_string(),
         OutboundHttpError::ResponseRead => "Failed reading remote response".to_string(),
         OutboundHttpError::Timeout => "Remote call timed out".to_string(),
         OutboundHttpError::Connect => "Remote connection failed".to_string(),
@@ -545,7 +545,7 @@ fn outbound_error_to_api_message(error: OutboundHttpError) -> String {
 fn outbound_error_to_api_error(error: OutboundHttpError) -> ApiError {
     let internal = matches!(
         &error,
-        OutboundHttpError::ClientBuild(_)
+        OutboundHttpError::ClientBuild
             | OutboundHttpError::ResponseRead
             | OutboundHttpError::Request
     );
@@ -613,7 +613,7 @@ mod tests {
         },
         "failure"
     )]
-    #[case(OutboundHttpError::ClientBuild("client".to_string()), "failure")]
+    #[case(OutboundHttpError::ClientBuild, "failure")]
     #[case(OutboundHttpError::ResponseRead, "failure")]
     #[case(OutboundHttpError::Connect, "failure")]
     #[case(OutboundHttpError::Request, "failure")]


### PR DESCRIPTION
## Summary

Remove low-level transport strings from outbound HTTP, AMQP, email, and Valkey errors that can reach integration diagnostics or persisted event-delivery failures.

Retain stable error categories while keeping resolved endpoints, connection strings, and library-specific details out of externally observable failure text. Log underlying failures at their sanitization boundaries and add delivery or task identifiers where sanitized failures are persisted. HTTP request errors have their URLs removed before logging.

## Rationale

Transport libraries may embed credential-bearing URLs, host details, or response metadata in their display output. Persisting or returning those strings broadens the exposure of integration secrets and internal topology. Administrators still need contextual server-side diagnostics for failures whose externally visible text is deliberately reduced.

## Behavior and compatibility

This is a breaking Rust API change: `OutboundHttpError::ClientBuild`, `OutboundHttpError::ResponseRead`, and `OutboundHttpError::Request` no longer carry string payloads, and downstream matches or constructors must be updated. Runtime failures remain categorized, but expose less detail. Structured server logs retain safe diagnostic causes and correlation identifiers; configured secrets and HTTP request URLs are not logged by this change. No migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`
