### PR TITLE
Sanitize persisted restore errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   credential-bearing connection cache keys.
 - Failed restore status responses now retain only public-safe error messages;
   detailed database, connection, hashing, and internal failures remain in
-  server logs instead of being persisted for capability-authenticated clients.
+  server logs with the restore job identifier instead of being persisted for
+  capability-authenticated clients.
 
 ## [0.0.8] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   event-sink configuration and routing, full backup contents, restore
   capabilities and errors, login-limiter connection URLs, and
   credential-bearing connection cache keys.
+- Failed restore status responses now retain only public-safe error messages;
+  detailed database, connection, hashing, and internal failures remain in
+  server logs instead of being persisted for capability-authenticated clients.
 
 ## [0.0.8] - 2026-08-01
 

--- a/src/restores/mod.rs
+++ b/src/restores/mod.rs
@@ -583,8 +583,13 @@ async fn fail_restore_and_resume(
     job_id: i64,
     error: &ApiError,
 ) -> Result<(), ApiError> {
-    let stored_error = error.to_string();
+    tracing::error!(message = "Restore failed", error = %error);
+    let stored_error = restore_error_for_storage(error);
     fail_restore_and_resume_db(pool, job_id, &stored_error).await
+}
+
+fn restore_error_for_storage(error: &ApiError) -> String {
+    error.public_message().to_string()
 }
 
 pub async fn confirm_restore(
@@ -913,9 +918,11 @@ mod tests {
 
     use super::{
         MAX_PERSONAL_DEFINITIONS, MAX_SHARED_DEFINITIONS, RESTORE_RECONCILIATION_GRACE_SECONDS,
-        RestoreSettings, confirmation_is_stale, restore_capability_matches, sha256,
+        RestoreSettings, confirmation_is_stale, restore_error_for_storage,
+        restore_capability_matches, sha256,
         validate_computed_field_definitions,
     };
+    use crate::errors::ApiError;
     use crate::models::{BackupDocument, BackupManifest, BackupState, CURRENT_BACKUP_VERSION};
 
     fn computed_definition(class_id: i32, owner_id: Option<i32>, key: String) -> serde_json::Value {
@@ -1025,5 +1032,21 @@ mod tests {
                 .unwrap_err();
 
         assert!(error.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn restore_status_errors_do_not_expose_internal_details() {
+        for error in [
+            ApiError::InternalServerError("secret internal path".to_string()),
+            ApiError::DatabaseError("password=database-secret".to_string()),
+            ApiError::DbConnectionError("postgres://user:secret@db/app".to_string()),
+            ApiError::HashError("hash implementation detail".to_string()),
+        ] {
+            let stored = restore_error_for_storage(&error);
+
+            assert_eq!(stored, "An internal error occurred");
+            assert!(!stored.contains("secret"));
+            assert!(!stored.contains("implementation detail"));
+        }
     }
 }

--- a/src/restores/mod.rs
+++ b/src/restores/mod.rs
@@ -918,9 +918,8 @@ mod tests {
 
     use super::{
         MAX_PERSONAL_DEFINITIONS, MAX_SHARED_DEFINITIONS, RESTORE_RECONCILIATION_GRACE_SECONDS,
-        RestoreSettings, confirmation_is_stale, restore_error_for_storage,
-        restore_capability_matches, sha256,
-        validate_computed_field_definitions,
+        RestoreSettings, confirmation_is_stale, restore_capability_matches,
+        restore_error_for_storage, sha256, validate_computed_field_definitions,
     };
     use crate::errors::ApiError;
     use crate::models::{BackupDocument, BackupManifest, BackupState, CURRENT_BACKUP_VERSION};
@@ -1034,19 +1033,46 @@ mod tests {
         assert!(error.to_string().contains("duplicate"));
     }
 
-    #[test]
-    fn restore_status_errors_do_not_expose_internal_details() {
-        for error in [
-            ApiError::InternalServerError("secret internal path".to_string()),
-            ApiError::DatabaseError("password=database-secret".to_string()),
-            ApiError::DbConnectionError("postgres://user:secret@db/app".to_string()),
-            ApiError::HashError("hash implementation detail".to_string()),
-        ] {
-            let stored = restore_error_for_storage(&error);
+    #[rstest]
+    #[case::internal_server(
+        ApiError::InternalServerError("secret internal path".to_string()),
+        "secret internal path"
+    )]
+    #[case::database(
+        ApiError::DatabaseError("password=database-secret".to_string()),
+        "database-secret"
+    )]
+    #[case::connection(
+        ApiError::DbConnectionError("postgres://user:secret@db/app".to_string()),
+        "user:secret"
+    )]
+    #[case::hash(
+        ApiError::HashError("hash implementation detail".to_string()),
+        "implementation detail"
+    )]
+    fn restore_status_internal_errors_do_not_expose_details(
+        #[case] error: ApiError,
+        #[case] private_detail: &str,
+    ) {
+        let stored = restore_error_for_storage(&error);
 
-            assert_eq!(stored, "An internal error occurred");
-            assert!(!stored.contains("secret"));
-            assert!(!stored.contains("implementation detail"));
-        }
+        assert_eq!(stored, "An internal error occurred");
+        assert!(!stored.contains(private_detail));
+    }
+
+    #[rstest]
+    #[case::validation(
+        ApiError::ValidationError("Backup manifest is invalid".to_string()),
+        "Backup manifest is invalid"
+    )]
+    #[case::conflict(
+        ApiError::Conflict("Restore stage changed status concurrently".to_string()),
+        "Restore stage changed status concurrently"
+    )]
+    fn restore_status_preserves_public_safe_errors(
+        #[case] error: ApiError,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(restore_error_for_storage(&error), expected);
     }
 }

--- a/src/restores/mod.rs
+++ b/src/restores/mod.rs
@@ -583,7 +583,7 @@ async fn fail_restore_and_resume(
     job_id: i64,
     error: &ApiError,
 ) -> Result<(), ApiError> {
-    tracing::error!(message = "Restore failed", error = %error);
+    tracing::error!(message = "Restore failed", restore_job_id = job_id, error = %error);
     let stored_error = restore_error_for_storage(error);
     fail_restore_and_resume_db(pool, job_id, &stored_error).await
 }


### PR DESCRIPTION
## Summary

Sanitize errors persisted for restore-status responses. Public-safe validation and conflict messages remain available, while database, connection, hashing, and internal failures are reduced to a stable generic message.

Detailed failures continue to be logged on the server with the restore job identifier for operator diagnosis. Parameterized regressions cover each internal error class and preservation of public-safe validation and conflict messages.

## Rationale

Restore status is capability-authenticated, but its durable error field should not become a channel for internal database or infrastructure details. Persisted errors also survive longer than the originating request. Administrators still need a reliable identifier for correlating a sanitized status with its internal failure.

## Behavior and compatibility

Clients receive less detail for internal restore failures. Restore execution, public validation errors, and the status schema are unchanged. Internal failure logs include `restore_job_id`; restore capabilities are not logged. No migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
