### PR TITLE
Singleflight event sink connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Export, backup, and staged-restore retention horizons now reject durations or
   expiry timestamps outside the supported range instead of panicking during
   startup or artifact creation.
+- Concurrent first deliveries to the same AMQP, email, or Valkey endpoint now
+  share one connection initializer instead of opening duplicate connections
+  and discarding all but one.
 
 ## [0.0.8] - 2026-08-01
 

--- a/crates/hubuum-event-sinks-common/src/lib.rs
+++ b/crates/hubuum-event-sinks-common/src/lib.rs
@@ -1,10 +1,11 @@
 use std::fmt;
 use std::future::Future;
 use std::hash::Hash;
+use std::sync::Arc;
 
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, OnceCell};
 
 pub use hubuum_events_core::{
     EventEnvelope, EventSinkSecretError, resolve_event_sink_secret, resolve_event_sink_secret_uri,
@@ -178,7 +179,7 @@ fn uri_userinfo(uri: &str) -> Option<&str> {
 }
 
 pub struct UriConnectionPool<K, V> {
-    entries: Mutex<std::collections::HashMap<K, V>>,
+    entries: Mutex<std::collections::HashMap<K, Arc<OnceCell<V>>>>,
 }
 
 impl<K, V> fmt::Debug for UriConnectionPool<K, V> {
@@ -205,25 +206,64 @@ where
         F: FnOnce(K) -> Fut,
         Fut: Future<Output = Result<V, SinkError>>,
     {
-        {
-            let entries = self.entries.lock().await;
-            if let Some(value) = entries.get(&key) {
-                return Ok(value.clone());
+        let entry = {
+            let mut entries = self.entries.lock().await;
+            entries
+                .entry(key.clone())
+                .or_insert_with(|| Arc::new(OnceCell::new()))
+                .clone()
+        };
+
+        let result = entry.get_or_try_init(|| create(key.clone())).await.cloned();
+        if result.is_err() {
+            let mut entries = self.entries.lock().await;
+            let remove_failed_entry = entries.get(&key).is_some_and(|current| {
+                Arc::ptr_eq(current, &entry)
+                    && current.get().is_none()
+                    && Arc::strong_count(current) == 2
+            });
+            if remove_failed_entry {
+                entries.remove(&key);
             }
         }
-
-        let created = create(key.clone()).await?;
-
-        let mut entries = self.entries.lock().await;
-        if let Some(value) = entries.get(&key) {
-            Ok(value.clone())
-        } else {
-            entries.insert(key, created.clone());
-            Ok(created)
-        }
+        result
     }
 
     pub async fn remove(&self, key: &K) {
         self.entries.lock().await.remove(key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::task::{Context, Poll, Waker};
+
+    use super::{SinkError, UriConnectionPool};
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        let mut context = Context::from_waker(Waker::noop());
+        let mut future = std::pin::pin!(future);
+
+        loop {
+            match future.as_mut().poll(&mut context) {
+                Poll::Ready(output) => return output,
+                Poll::Pending => std::thread::yield_now(),
+            }
+        }
+    }
+
+    #[test]
+    fn failed_initializer_is_removed_from_the_pool() {
+        let pool = UriConnectionPool::<String, usize>::default();
+
+        let result = block_on(
+            pool.get_or_try_insert_with("failed-uri".to_string(), |_| async move {
+                Err(SinkError::new("initialization failed"))
+            }),
+        );
+
+        assert_eq!(result.unwrap_err().to_string(), "initialization failed");
+        assert!(block_on(pool.entries.lock()).is_empty());
     }
 }

--- a/src/events/sink.rs
+++ b/src/events/sink.rs
@@ -202,7 +202,12 @@ impl Sink for hubuum_event_sink_valkey::ValkeySink {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
     use futures::FutureExt;
+    use futures::future::join_all;
     use hubuum_event_sinks_common::UriConnectionPool;
     use uuid::Uuid;
 
@@ -311,6 +316,58 @@ mod tests {
         assert!(!debug.contains("config-secret"));
         assert!(!debug.contains("routing-secret"));
         assert!(!debug.contains("secret-reference"));
+    }
+
+    #[actix_rt::test]
+    async fn uri_connection_pool_initializes_each_key_once_under_concurrency() {
+        let pool = UriConnectionPool::<String, usize>::default();
+        let initializations = Arc::new(AtomicUsize::new(0));
+
+        let results = join_all((0..16).map(|_| {
+            let initializations = Arc::clone(&initializations);
+            pool.get_or_try_insert_with("shared-uri".to_string(), move |_| async move {
+                initializations.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(25)).await;
+                Ok(42)
+            })
+        }))
+        .await;
+
+        assert!(results.into_iter().all(|result| result == Ok(42)));
+        assert_eq!(initializations.load(Ordering::SeqCst), 1);
+    }
+
+    #[actix_rt::test]
+    async fn uri_connection_pool_retries_a_failed_initializer() {
+        let pool = UriConnectionPool::<String, usize>::default();
+        let initializations = Arc::new(AtomicUsize::new(0));
+
+        let first = pool
+            .get_or_try_insert_with("retry-uri".to_string(), {
+                let initializations = Arc::clone(&initializations);
+                move |_| async move {
+                    initializations.fetch_add(1, Ordering::SeqCst);
+                    Err(SinkError::new("initialization failed"))
+                }
+            })
+            .await;
+        let second = pool
+            .get_or_try_insert_with("retry-uri".to_string(), {
+                let initializations = Arc::clone(&initializations);
+                move |_| async move {
+                    initializations.fetch_add(1, Ordering::SeqCst);
+                    Ok(42)
+                }
+            })
+            .await;
+        let cached = pool
+            .get_or_try_insert_with("retry-uri".to_string(), |_| async move { Ok(99) })
+            .await;
+
+        assert_eq!(first.unwrap_err().to_string(), "initialization failed");
+        assert_eq!(second, Ok(42));
+        assert_eq!(cached, Ok(42));
+        assert_eq!(initializations.load(Ordering::SeqCst), 2);
     }
 
     #[cfg(any(feature = "amqp", feature = "email", feature = "valkey"))]


### PR DESCRIPTION
## Summary

Make event-sink connection initialization singleflight per connection key. Concurrent first deliveries to the same AMQP, email, or Valkey destination now await one initializer and reuse its result.

Failed initialization is removed from the pool so a later delivery can retry instead of retaining a failed cell.

## Rationale

The previous check-then-connect path allowed bursts of deliveries to open duplicate connections and discard all but one. That wastes sockets, authentication work, and remote service capacity precisely during startup or reconfiguration spikes.

## Behavior and compatibility

Connection semantics are unchanged for successful callers. Concurrency now performs one initialization per key, and failures remain retryable. No API or database migration changes are required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
