### PR TITLE
Encapsulate event sink workspace APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `Clone`; pagination borrows or moves rows and accepts non-clone domain types.
 - External identity refresh removes stale group memberships with one set-based
   database write instead of issuing one delete per stale membership.
+- **Breaking (Rust API):** Encapsulated event-sink delivery and webhook settings
+  fields. Workspace-crate consumers must use `SinkDelivery` accessors and the
+  validating `WebhookSinkSettings` constructor and configuration methods.
 
 ### Security
 

--- a/crates/hubuum-event-sink-amqp/src/lib.rs
+++ b/crates/hubuum-event-sink-amqp/src/lib.rs
@@ -54,7 +54,7 @@ impl AmqpSink {
         delivery: SinkDelivery<'_>,
     ) -> Result<(), SinkError> {
         let config = parse_config(&delivery)?;
-        let uri = resolve_event_sink_secret_uri(&config.uri, delivery.secret_ref, "AMQP")?;
+        let uri = resolve_event_sink_secret_uri(&config.uri, delivery.secret_ref(), "AMQP")?;
         require_tls_uri_scheme(&uri, "AMQP", &["amqps"])?;
         let channel = self.channel(&uri).await?;
 

--- a/crates/hubuum-event-sink-email/src/lib.rs
+++ b/crates/hubuum-event-sink-email/src/lib.rs
@@ -85,7 +85,7 @@ impl EmailSink {
     ) -> Result<(), SinkError> {
         let config = parse_config(&delivery)?;
         let routing = parse_routing(&delivery)?;
-        let uri = resolve_event_sink_secret_uri(&config.uri, delivery.secret_ref, "email")?;
+        let uri = resolve_event_sink_secret_uri(&config.uri, delivery.secret_ref(), "email")?;
         require_tls_uri_scheme(&uri, "email", &["smtps"])?;
         let rendered = render_email(envelope, &config)?;
         let message = build_message(&config, &routing, rendered)?;

--- a/crates/hubuum-event-sink-valkey/src/lib.rs
+++ b/crates/hubuum-event-sink-valkey/src/lib.rs
@@ -81,7 +81,7 @@ impl ValkeySink {
     ) -> Result<(), SinkError> {
         let config = parse_config(&delivery)?;
         let routing = parse_routing(&delivery)?;
-        let uri = resolve_event_sink_secret_uri(&config.uri, delivery.secret_ref, "Valkey")?;
+        let uri = resolve_event_sink_secret_uri(&config.uri, delivery.secret_ref(), "Valkey")?;
         require_tls_uri_scheme(&uri, "Valkey", &["rediss"])?;
         let client = self.client(&uri).await?;
         let entry = stream_entry(envelope, routing, config)?;

--- a/crates/hubuum-event-sink-webhook/src/lib.rs
+++ b/crates/hubuum-event-sink-webhook/src/lib.rs
@@ -30,12 +30,61 @@ impl WebhookSink {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WebhookSinkSettings {
-    pub max_timeout_ms: u64,
-    pub max_response_bytes: usize,
-    pub max_request_bytes: usize,
-    pub allow_private_targets: bool,
-    pub dangerous_accept_invalid_certs: bool,
-    pub dangerous_allow_localhost: bool,
+    max_timeout_ms: u64,
+    max_response_bytes: usize,
+    max_request_bytes: usize,
+    allow_private_targets: bool,
+    dangerous_accept_invalid_certs: bool,
+    dangerous_allow_localhost: bool,
+}
+
+impl WebhookSinkSettings {
+    pub fn new(max_timeout_ms: u64, max_response_bytes: usize) -> Result<Self, SinkError> {
+        if max_timeout_ms == 0 {
+            return Err(SinkError::new(
+                "Webhook maximum timeout must be greater than zero",
+            ));
+        }
+        if max_response_bytes == 0 {
+            return Err(SinkError::new(
+                "Webhook maximum response size must be greater than zero",
+            ));
+        }
+
+        Ok(Self {
+            max_timeout_ms,
+            max_response_bytes,
+            max_request_bytes: max_response_bytes,
+            allow_private_targets: false,
+            dangerous_accept_invalid_certs: false,
+            dangerous_allow_localhost: false,
+        })
+    }
+
+    pub fn with_max_request_bytes(mut self, max_request_bytes: usize) -> Result<Self, SinkError> {
+        if max_request_bytes == 0 {
+            return Err(SinkError::new(
+                "Webhook maximum request size must be greater than zero",
+            ));
+        }
+        self.max_request_bytes = max_request_bytes;
+        Ok(self)
+    }
+
+    pub fn allow_private_targets(mut self, allow_private_targets: bool) -> Self {
+        self.allow_private_targets = allow_private_targets;
+        self
+    }
+
+    pub fn dangerous_accept_invalid_certs(mut self, dangerous_accept_invalid_certs: bool) -> Self {
+        self.dangerous_accept_invalid_certs = dangerous_accept_invalid_certs;
+        self
+    }
+
+    pub fn dangerous_allow_localhost(mut self, dangerous_allow_localhost: bool) -> Self {
+        self.dangerous_allow_localhost = dangerous_allow_localhost;
+        self
+    }
 }
 
 #[derive(Deserialize)]
@@ -82,7 +131,7 @@ async fn deliver_webhook(
 
     let config: WebhookConfig = parse_sink_config(&delivery, "webhook")?;
 
-    let mut headers = webhook_headers(&config, delivery.secret_ref)?;
+    let mut headers = webhook_headers(&config, delivery.secret_ref())?;
     headers
         .insert("content-type", "application/json")
         .map_err(sink_error)?;
@@ -257,14 +306,43 @@ mod tests {
     }
 
     fn settings() -> WebhookSinkSettings {
-        WebhookSinkSettings {
-            max_timeout_ms: 30_000,
-            max_response_bytes: 1_000_000,
-            max_request_bytes: 1_000_000,
-            allow_private_targets: false,
-            dangerous_accept_invalid_certs: true,
-            dangerous_allow_localhost: true,
-        }
+        WebhookSinkSettings::new(30_000, 1_000_000)
+            .unwrap()
+            .dangerous_accept_invalid_certs(true)
+            .dangerous_allow_localhost(true)
+    }
+
+    #[test]
+    fn webhook_sink_settings_reject_zero_timeout() {
+        let error = WebhookSinkSettings::new(0, 1_000_000).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Webhook maximum timeout must be greater than zero"
+        );
+    }
+
+    #[test]
+    fn webhook_sink_settings_reject_zero_response_limit() {
+        let error = WebhookSinkSettings::new(30_000, 0).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Webhook maximum response size must be greater than zero"
+        );
+    }
+
+    #[test]
+    fn webhook_sink_settings_reject_zero_request_limit() {
+        let error = WebhookSinkSettings::new(30_000, 1_000_000)
+            .unwrap()
+            .with_max_request_bytes(0)
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Webhook maximum request size must be greater than zero"
+        );
     }
 
     fn delivery(url: String) -> (serde_json::Value, serde_json::Value) {

--- a/crates/hubuum-event-sinks-common/src/lib.rs
+++ b/crates/hubuum-event-sinks-common/src/lib.rs
@@ -78,9 +78,9 @@ pub fn ensure_payload_within_limit(
 
 #[derive(Clone, Copy)]
 pub struct SinkDelivery<'a> {
-    pub config: &'a Value,
-    pub routing: &'a Value,
-    pub secret_ref: Option<&'a str>,
+    config: &'a Value,
+    routing: &'a Value,
+    secret_ref: Option<&'a str>,
 }
 
 impl fmt::Debug for SinkDelivery<'_> {
@@ -97,13 +97,25 @@ impl<'a> SinkDelivery<'a> {
             secret_ref,
         }
     }
+
+    pub fn config(&self) -> &'a Value {
+        self.config
+    }
+
+    pub fn routing(&self) -> &'a Value {
+        self.routing
+    }
+
+    pub fn secret_ref(&self) -> Option<&'a str> {
+        self.secret_ref
+    }
 }
 
 pub fn parse_sink_config<T: DeserializeOwned>(
     delivery: &SinkDelivery<'_>,
     sink_label: &str,
 ) -> Result<T, SinkError> {
-    serde_json::from_value(delivery.config.clone())
+    serde_json::from_value(delivery.config().clone())
         .map_err(|error| SinkError::new(format!("Invalid {sink_label} config: {error}")))
 }
 
@@ -111,7 +123,7 @@ pub fn parse_sink_routing<T: DeserializeOwned>(
     delivery: &SinkDelivery<'_>,
     sink_label: &str,
 ) -> Result<T, SinkError> {
-    serde_json::from_value(delivery.routing.clone())
+    serde_json::from_value(delivery.routing().clone())
         .map_err(|error| SinkError::new(format!("Invalid {sink_label} routing: {error}")))
 }
 

--- a/src/events/sink.rs
+++ b/src/events/sink.rs
@@ -130,14 +130,11 @@ fn webhook_settings() -> WebhookSinkSettings {
             DEFAULT_REMOTE_CALL_MAX_RESPONSE_BYTES,
             DEFAULT_REMOTE_CALL_ALLOW_PRIVATE_TARGETS,
         ));
-    WebhookSinkSettings {
-        max_timeout_ms,
-        max_response_bytes,
-        max_request_bytes: max_response_bytes,
-        allow_private_targets,
-        dangerous_accept_invalid_certs: cfg!(test),
-        dangerous_allow_localhost: cfg!(test),
-    }
+    WebhookSinkSettings::new(max_timeout_ms, max_response_bytes)
+        .expect("remote call limits are validated before event sinks are initialized")
+        .allow_private_targets(allow_private_targets)
+        .dangerous_accept_invalid_certs(cfg!(test))
+        .dangerous_allow_localhost(cfg!(test))
 }
 
 impl Sink for hubuum_event_sink_webhook::WebhookSink {


### PR DESCRIPTION
## Summary

Encapsulate event-sink workspace APIs by making delivery and webhook setting fields private, adding focused accessors, and introducing validating webhook construction and configuration methods.

Update the AMQP, email, Valkey, webhook, and server integration points to use the smaller explicit interface.

## Rationale

Public field bags let callers bypass invariants such as non-zero timeouts and request or response limits, and they couple workspace consumers to representation details.

## Behavior and compatibility

This is a breaking Rust API change for workspace-crate consumers. Callers must use `SinkDelivery` accessors and the `WebhookSinkSettings` validating API. Valid runtime configuration behaves as before; no database migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
