### PR TITLE
Bound event sink connection cache growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Concurrent first deliveries to the same AMQP, email, or Valkey endpoint now
   share one connection initializer instead of opening duplicate connections
   and discarding all but one.
+- Event-sink connection caches now retain at most 64 recently used endpoint
+  configurations, bounding stale connections and credential-resolved URI keys
+  after sink configuration or secret rotation.
 
 ## [0.0.8] - 2026-08-01
 

--- a/crates/hubuum-event-sinks-common/src/lib.rs
+++ b/crates/hubuum-event-sinks-common/src/lib.rs
@@ -1,7 +1,9 @@
+use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::future::Future;
 use std::hash::Hash;
-use std::sync::Arc;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Weak};
 
 use serde::de::DeserializeOwned;
 use serde_json::Value;
@@ -39,6 +41,7 @@ impl From<EventSinkSecretError> for SinkError {
 }
 
 pub const DEFAULT_MAX_ENVELOPE_BYTES: usize = 1_000_000;
+pub const DEFAULT_URI_CONNECTION_POOL_CAPACITY: usize = 64;
 
 pub fn serialize_envelope_to_string(
     envelope: &EventEnvelope,
@@ -179,7 +182,14 @@ fn uri_userinfo(uri: &str) -> Option<&str> {
 }
 
 pub struct UriConnectionPool<K, V> {
-    entries: Mutex<std::collections::HashMap<K, Arc<OnceCell<V>>>>,
+    capacity: NonZeroUsize,
+    state: Mutex<UriConnectionPoolState<K, V>>,
+}
+
+#[derive(Debug)]
+struct UriConnectionPoolState<K, V> {
+    entries: HashMap<K, Arc<OnceCell<V>>>,
+    recency: VecDeque<K>,
 }
 
 impl<K, V> fmt::Debug for UriConnectionPool<K, V> {
@@ -190,8 +200,21 @@ impl<K, V> fmt::Debug for UriConnectionPool<K, V> {
 
 impl<K, V> Default for UriConnectionPool<K, V> {
     fn default() -> Self {
+        Self::new(
+            NonZeroUsize::new(DEFAULT_URI_CONNECTION_POOL_CAPACITY)
+                .expect("the default URI connection pool capacity is non-zero"),
+        )
+    }
+}
+
+impl<K, V> UriConnectionPool<K, V> {
+    pub fn new(capacity: NonZeroUsize) -> Self {
         Self {
-            entries: Mutex::new(std::collections::HashMap::new()),
+            capacity,
+            state: Mutex::new(UriConnectionPoolState {
+                entries: HashMap::new(),
+                recency: VecDeque::new(),
+            }),
         }
     }
 }
@@ -207,30 +230,84 @@ where
         Fut: Future<Output = Result<V, SinkError>>,
     {
         let entry = {
-            let mut entries = self.entries.lock().await;
-            entries
-                .entry(key.clone())
-                .or_insert_with(|| Arc::new(OnceCell::new()))
-                .clone()
+            let mut state = self.state.lock().await;
+            if let Some(entry) = state.entries.get(&key).cloned() {
+                state.touch(&key);
+                entry
+            } else {
+                state.evict_idle_to(self.capacity.get() - 1);
+                let entry = Arc::new(OnceCell::new());
+                state.entries.insert(key.clone(), Arc::clone(&entry));
+                state.recency.push_back(key.clone());
+                entry
+            }
         };
 
+        let entry_identity = Arc::downgrade(&entry);
         let result = entry.get_or_try_init(|| create(key.clone())).await.cloned();
+        drop(entry);
+
+        let mut state = self.state.lock().await;
         if result.is_err() {
-            let mut entries = self.entries.lock().await;
-            let remove_failed_entry = entries.get(&key).is_some_and(|current| {
-                Arc::ptr_eq(current, &entry)
-                    && current.get().is_none()
-                    && Arc::strong_count(current) == 2
-            });
-            if remove_failed_entry {
-                entries.remove(&key);
-            }
+            state.remove_failed(&key, &entry_identity);
         }
+        state.evict_idle_to(self.capacity.get());
         result
     }
 
     pub async fn remove(&self, key: &K) {
-        self.entries.lock().await.remove(key);
+        self.state.lock().await.remove(key);
+    }
+}
+
+impl<K, V> UriConnectionPoolState<K, V>
+where
+    K: Eq + Hash + Clone,
+{
+    fn touch(&mut self, key: &K) {
+        self.remove_recency(key);
+        self.recency.push_back(key.clone());
+    }
+
+    fn evict_idle_to(&mut self, maximum_entries: usize) {
+        let mut candidates = self.recency.len();
+        while self.entries.len() > maximum_entries && candidates > 0 {
+            candidates -= 1;
+            let Some(key) = self.recency.pop_front() else {
+                break;
+            };
+            let is_idle = self
+                .entries
+                .get(&key)
+                .is_some_and(|entry| Arc::strong_count(entry) == 1);
+            if is_idle {
+                self.entries.remove(&key);
+            } else {
+                self.recency.push_back(key);
+            }
+        }
+    }
+
+    fn remove_failed(&mut self, key: &K, expected: &Weak<OnceCell<V>>) {
+        let remove_failed_entry = self.entries.get(key).is_some_and(|current| {
+            Weak::ptr_eq(&Arc::downgrade(current), expected)
+                && current.get().is_none()
+                && Arc::strong_count(current) == 1
+        });
+        if remove_failed_entry {
+            self.remove(key);
+        }
+    }
+
+    fn remove(&mut self, key: &K) {
+        self.entries.remove(key);
+        self.remove_recency(key);
+    }
+
+    fn remove_recency(&mut self, key: &K) {
+        if let Some(position) = self.recency.iter().position(|candidate| candidate == key) {
+            self.recency.remove(position);
+        }
     }
 }
 
@@ -264,6 +341,6 @@ mod tests {
         );
 
         assert_eq!(result.unwrap_err().to_string(), "initialization failed");
-        assert!(block_on(pool.entries.lock()).is_empty());
+        assert!(block_on(pool.state.lock()).entries.is_empty());
     }
 }

--- a/src/events/sink.rs
+++ b/src/events/sink.rs
@@ -202,6 +202,7 @@ impl Sink for hubuum_event_sink_valkey::ValkeySink {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
@@ -368,6 +369,83 @@ mod tests {
         assert_eq!(second, Ok(42));
         assert_eq!(cached, Ok(42));
         assert_eq!(initializations.load(Ordering::SeqCst), 2);
+    }
+
+    #[actix_rt::test]
+    async fn uri_connection_pool_evicts_the_least_recently_used_key_at_capacity() {
+        let pool = UriConnectionPool::<String, usize>::new(NonZeroUsize::new(2).unwrap());
+
+        pool.get_or_try_insert_with("old".to_string(), |_| async { Ok(1) })
+            .await
+            .unwrap();
+        pool.get_or_try_insert_with("recent".to_string(), |_| async { Ok(2) })
+            .await
+            .unwrap();
+        pool.get_or_try_insert_with("old".to_string(), |_| async { Ok(10) })
+            .await
+            .unwrap();
+        pool.get_or_try_insert_with("new".to_string(), |_| async { Ok(3) })
+            .await
+            .unwrap();
+
+        let old = pool
+            .get_or_try_insert_with("old".to_string(), |_| async { Ok(10) })
+            .await;
+        let recent = pool
+            .get_or_try_insert_with("recent".to_string(), |_| async { Ok(20) })
+            .await;
+
+        assert_eq!(old, Ok(1));
+        assert_eq!(recent, Ok(20));
+    }
+
+    #[actix_rt::test]
+    async fn uri_connection_pool_does_not_evict_an_initializer_in_flight() {
+        let pool = UriConnectionPool::<String, usize>::new(NonZeroUsize::new(1).unwrap());
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let initializations = Arc::new(AtomicUsize::new(0));
+
+        let first = pool.get_or_try_insert_with("shared".to_string(), {
+            let started = Arc::clone(&started);
+            let release = Arc::clone(&release);
+            let initializations = Arc::clone(&initializations);
+            move |_| async move {
+                initializations.fetch_add(1, Ordering::SeqCst);
+                started.notify_one();
+                release.notified().await;
+                Ok(1)
+            }
+        });
+        let overlap = async {
+            started.notified().await;
+            pool.get_or_try_insert_with("other".to_string(), |_| async { Ok(2) })
+                .await
+                .unwrap();
+
+            let shared = pool.get_or_try_insert_with("shared".to_string(), {
+                let initializations = Arc::clone(&initializations);
+                move |_| async move {
+                    initializations.fetch_add(1, Ordering::SeqCst);
+                    Ok(99)
+                }
+            });
+            tokio::pin!(shared);
+            tokio::select! {
+                unexpected = &mut shared => {
+                    panic!("in-flight initializer was evicted: {unexpected:?}");
+                }
+                () = tokio::time::sleep(Duration::from_millis(25)) => {}
+            }
+            release.notify_one();
+            shared.await
+        };
+
+        let (first, shared) = tokio::join!(first, overlap);
+
+        assert_eq!(first, Ok(1));
+        assert_eq!(shared, Ok(1));
+        assert_eq!(initializations.load(Ordering::SeqCst), 1);
     }
 
     #[cfg(any(feature = "amqp", feature = "email", feature = "valkey"))]


### PR DESCRIPTION
## Summary

Bound each event-sink connection cache to 64 recently used endpoint configurations and evict the least recently used key when the cache reaches capacity.

Preserve the singleflight initialization behavior while updating recency on hits and removing failed initializers cleanly.

## Rationale

Sink reconfiguration and secret rotation can continually produce new credential-resolved connection keys. An unbounded process-lifetime cache retains stale connections and sensitive URI keys indefinitely.

## Dependencies

This PR is stacked on **Singleflight event sink connections** and targets `agent/singleflight-event-sink-connections`. Merge that dependency first, then retarget this PR to `main` if GitHub does not do so automatically.

## Behavior and compatibility

At most 64 connection keys are retained per pool. Evicted destinations reconnect on their next delivery. No API or database migration changes are required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
