### PR TITLE
Hide restore stage existence from invalid capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   transport-library detail. The underlying failures remain available to
   administrators in contextual server logs.
 - Restore-status capability checks no longer disclose whether a restore stage
-  ID exists when the supplied capability is invalid.
+  ID exists when the supplied capability is invalid. Server logs distinguish
+  missing stages from capability mismatches without recording the capability.
 
 ## [0.0.8] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   AMQP, email, and Valkey transport failures are likewise reported without
   transport-library detail. The underlying failures remain available to
   administrators in contextual server logs.
+- Restore-status capability checks no longer disclose whether a restore stage
+  ID exists when the supplied capability is invalid.
 
 ## [0.0.8] - 2026-08-01
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -16532,17 +16532,7 @@
             }
           },
           "403": {
-            "description": "Capability rejected",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Restore stage not found",
+            "description": "Capability rejected or restore stage unavailable",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/api/v1/handlers/restores.rs
+++ b/src/api/v1/handlers/restores.rs
@@ -107,8 +107,7 @@ pub async fn confirm_restore_stage(
             headers(("Cache-Control" = String, description = "Always no-store for restore metadata"))
         ),
         (status = 400, description = "Restore capability header is missing", body = ApiErrorResponse),
-        (status = 403, description = "Capability rejected", body = ApiErrorResponse),
-        (status = 404, description = "Restore stage not found", body = ApiErrorResponse)
+        (status = 403, description = "Capability rejected or restore stage unavailable", body = ApiErrorResponse)
     )
 )]
 #[get("/{restore_id}/status")]

--- a/src/restores/mod.rs
+++ b/src/restores/mod.rs
@@ -495,10 +495,22 @@ pub async fn restore_status(
     capability: &str,
 ) -> Result<RestoreStageResponse, ApiError> {
     let job = match load_restore_status_job_db(pool, job_id).await {
-        Err(ApiError::NotFound(_)) => return Err(invalid_restore_capability()),
+        Err(ApiError::NotFound(_)) => {
+            tracing::warn!(
+                message = "Restore capability rejected",
+                restore_job_id = job_id,
+                reason = "restore stage not found"
+            );
+            return Err(invalid_restore_capability());
+        }
         result => result?,
     };
     if !capability_matches(&job.capability_hash, capability) {
+        tracing::warn!(
+            message = "Restore capability rejected",
+            restore_job_id = job_id,
+            reason = "capability mismatch"
+        );
         return Err(invalid_restore_capability());
     }
     let status = job.status.parse::<RestoreJobStatus>()?;

--- a/src/restores/mod.rs
+++ b/src/restores/mod.rs
@@ -117,6 +117,10 @@ fn capability_matches(capability_hash: &str, capability: &str) -> bool {
             == 0
 }
 
+fn invalid_restore_capability() -> ApiError {
+    ApiError::Forbidden("Restore capability is invalid".to_string())
+}
+
 fn validation_summary(document: &BackupDocument) -> Result<RestoreValidationSummary, ApiError> {
     document.validate_version()?;
     for required in BACKUP_STATE_SECTIONS {
@@ -490,11 +494,12 @@ pub async fn restore_status(
     job_id: i64,
     capability: &str,
 ) -> Result<RestoreStageResponse, ApiError> {
-    let job = load_restore_status_job_db(pool, job_id).await?;
+    let job = match load_restore_status_job_db(pool, job_id).await {
+        Err(ApiError::NotFound(_)) => return Err(invalid_restore_capability()),
+        result => result?,
+    };
     if !capability_matches(&job.capability_hash, capability) {
-        return Err(ApiError::Forbidden(
-            "Restore capability is invalid".to_string(),
-        ));
+        return Err(invalid_restore_capability());
     }
     let status = job.status.parse::<RestoreJobStatus>()?;
     let validation = serde_json::from_value(job.validation_summary.clone())?;

--- a/src/restores/mod.rs
+++ b/src/restores/mod.rs
@@ -37,6 +37,8 @@ static RESTORE_COORDINATOR: Once = Once::new();
 static ACTIVE_MAINTENANCE_WORK: AtomicUsize = AtomicUsize::new(0);
 const RESTORE_DRAIN_TIMEOUT_SECONDS: u64 = 30;
 const RESTORE_STAGE_EXPIRY_INTERVAL_SECONDS: u64 = 60;
+const MISSING_RESTORE_CAPABILITY_HASH: &str =
+    "0000000000000000000000000000000000000000000000000000000000000000";
 // Keep this longer than the bounded drain so normal confirmations enter the
 // advisory-lock-protected restore transaction before recovery is eligible.
 const RESTORE_RECONCILIATION_GRACE_SECONDS: i64 = 60;
@@ -115,6 +117,13 @@ fn capability_matches(capability_hash: &str, capability: &str) -> bool {
                 difference | (left ^ right)
             })
             == 0
+}
+
+fn restore_capability_matches(capability_hash: Option<&str>, capability: &str) -> bool {
+    capability_matches(
+        capability_hash.unwrap_or(MISSING_RESTORE_CAPABILITY_HASH),
+        capability,
+    )
 }
 
 fn invalid_restore_capability() -> ApiError {
@@ -495,17 +504,23 @@ pub async fn restore_status(
     capability: &str,
 ) -> Result<RestoreStageResponse, ApiError> {
     let job = match load_restore_status_job_db(pool, job_id).await {
-        Err(ApiError::NotFound(_)) => {
-            tracing::warn!(
-                message = "Restore capability rejected",
-                restore_job_id = job_id,
-                reason = "restore stage not found"
-            );
-            return Err(invalid_restore_capability());
-        }
-        result => result?,
+        Ok(job) => Some(job),
+        Err(ApiError::NotFound(_)) => None,
+        Err(error) => return Err(error),
     };
-    if !capability_matches(&job.capability_hash, capability) {
+    let capability_valid = restore_capability_matches(
+        job.as_ref().map(|job| job.capability_hash.as_str()),
+        capability,
+    );
+    let Some(job) = job else {
+        tracing::warn!(
+            message = "Restore capability rejected",
+            restore_job_id = job_id,
+            reason = "restore stage not found"
+        );
+        return Err(invalid_restore_capability());
+    };
+    if !capability_valid {
         tracing::warn!(
             message = "Restore capability rejected",
             restore_job_id = job_id,
@@ -577,11 +592,30 @@ pub async fn confirm_restore(
     job_id: i64,
     confirmation: &RestoreConfirmRequest,
 ) -> Result<RestoreStageResponse, ApiError> {
-    let job = load_restore_job(pool, job_id).await?;
-    if !capability_matches(&job.capability_hash, &confirmation.restore_capability) {
-        return Err(ApiError::Forbidden(
-            "Restore capability is invalid".to_string(),
-        ));
+    let job = match load_restore_job(pool, job_id).await {
+        Ok(job) => Some(job),
+        Err(ApiError::NotFound(_)) => None,
+        Err(error) => return Err(error),
+    };
+    let capability_valid = restore_capability_matches(
+        job.as_ref().map(|job| job.capability_hash.as_str()),
+        &confirmation.restore_capability,
+    );
+    let Some(job) = job else {
+        tracing::warn!(
+            message = "Restore capability rejected",
+            restore_job_id = job_id,
+            reason = "restore stage not found"
+        );
+        return Err(invalid_restore_capability());
+    };
+    if !capability_valid {
+        tracing::warn!(
+            message = "Restore capability rejected",
+            restore_job_id = job_id,
+            reason = "capability mismatch"
+        );
+        return Err(invalid_restore_capability());
     }
     if confirmation.sha256 != job.sha256 {
         return Err(ApiError::Conflict(
@@ -879,7 +913,8 @@ mod tests {
 
     use super::{
         MAX_PERSONAL_DEFINITIONS, MAX_SHARED_DEFINITIONS, RESTORE_RECONCILIATION_GRACE_SECONDS,
-        RestoreSettings, confirmation_is_stale, validate_computed_field_definitions,
+        RestoreSettings, confirmation_is_stale, restore_capability_matches, sha256,
+        validate_computed_field_definitions,
     };
     use crate::models::{BackupDocument, BackupManifest, BackupState, CURRENT_BACKUP_VERSION};
 
@@ -923,6 +958,23 @@ mod tests {
         #[case] upload_bytes: usize,
     ) {
         assert!(RestoreSettings::new(retention_minutes, upload_bytes).is_err());
+    }
+
+    #[rstest]
+    #[case::exact_match(Some("expected-capability"), "expected-capability", true)]
+    #[case::mismatch(Some("expected-capability"), "different-capability", false)]
+    #[case::missing_stage(None, "expected-capability", false)]
+    fn restore_capability_validation_handles_present_and_missing_stages(
+        #[case] stored_capability: Option<&str>,
+        #[case] supplied_capability: &str,
+        #[case] expected: bool,
+    ) {
+        let stored_hash = stored_capability.map(|capability| sha256(capability.as_bytes()));
+
+        assert_eq!(
+            restore_capability_matches(stored_hash.as_deref(), supplied_capability),
+            expected
+        );
     }
 
     #[rstest]

--- a/tests/api_jobs_suite/restores.rs
+++ b/tests/api_jobs_suite/restores.rs
@@ -224,6 +224,63 @@ mod tests {
     }
 
     #[rstest]
+    #[case::existing_stage(true)]
+    #[case::missing_stage(false)]
+    #[actix_web::test]
+    async fn invalid_confirmation_capability_does_not_disclose_stage_existence(
+        #[future(awt)] test_context: TestContext,
+        #[case] stage_exists: bool,
+    ) {
+        let context = test_context;
+        let staged = if stage_exists {
+            let response = post_request(
+                &context.pool,
+                &context.admin_token,
+                "/api/v1/restores",
+                &minimally_valid_full_backup_document(),
+            )
+            .await;
+            let response = assert_response_status(response, StatusCode::CREATED).await;
+            Some(test::read_body_json::<RestoreStageResponse, _>(response).await)
+        } else {
+            None
+        };
+        let restore_id = staged.as_ref().map(|stage| stage.id).unwrap_or(i64::MAX);
+
+        let response = post_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/restores/{restore_id}/confirm"),
+            &RestoreConfirmRequest {
+                restore_capability: "invalid-restore-capability".to_string(),
+                sha256: "irrelevant-sha256".to_string(),
+                confirmation: RESTORE_CONFIRMATION_PHRASE.to_string(),
+            },
+        )
+        .await;
+        let response = assert_response_status(response, StatusCode::FORBIDDEN).await;
+        let body = test::read_body_json::<serde_json::Value, _>(response).await;
+
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "error": "Forbidden",
+                "message": "Restore capability is invalid"
+            })
+        );
+
+        if let Some(staged) = staged {
+            with_connection(&context.pool, async |conn| {
+                diesel::delete(restore_jobs.filter(id.eq(staged.id)))
+                    .execute(conn)
+                    .await
+            })
+            .await
+            .unwrap();
+        }
+    }
+
+    #[rstest]
     #[case::local_identity_scope(MissingRestoreSeed::LocalIdentityScope)]
     #[case::root_collection(MissingRestoreSeed::RootCollection)]
     #[case::root_closure(MissingRestoreSeed::RootClosure)]

--- a/tests/api_jobs_suite/restores.rs
+++ b/tests/api_jobs_suite/restores.rs
@@ -167,6 +167,63 @@ mod tests {
     }
 
     #[rstest]
+    #[case::existing_stage(true)]
+    #[case::missing_stage(false)]
+    #[actix_web::test]
+    async fn invalid_restore_capability_does_not_disclose_stage_existence(
+        #[future(awt)] test_context: TestContext,
+        #[case] stage_exists: bool,
+    ) {
+        let context = test_context;
+        let restore_id = if stage_exists {
+            let response = post_request(
+                &context.pool,
+                &context.admin_token,
+                "/api/v1/restores",
+                &minimally_valid_full_backup_document(),
+            )
+            .await;
+            let response = assert_response_status(response, StatusCode::CREATED).await;
+            test::read_body_json::<RestoreStageResponse, _>(response)
+                .await
+                .id
+        } else {
+            i64::MAX
+        };
+
+        let response = get_request_with_headers(
+            &context.pool,
+            "",
+            &format!("/api/v1/restores/{restore_id}/status"),
+            vec![(
+                actix_web::http::header::HeaderName::from_static("x-hubuum-restore-capability"),
+                "invalid-restore-capability".to_string(),
+            )],
+        )
+        .await;
+        let response = assert_response_status(response, StatusCode::FORBIDDEN).await;
+        let body = test::read_body_json::<serde_json::Value, _>(response).await;
+
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "error": "Forbidden",
+                "message": "Restore capability is invalid"
+            })
+        );
+
+        if stage_exists {
+            with_connection(&context.pool, async |conn| {
+                diesel::delete(restore_jobs.filter(id.eq(restore_id)))
+                    .execute(conn)
+                    .await
+            })
+            .await
+            .unwrap();
+        }
+    }
+
+    #[rstest]
     #[case::local_identity_scope(MissingRestoreSeed::LocalIdentityScope)]
     #[case::root_collection(MissingRestoreSeed::RootCollection)]
     #[case::root_closure(MissingRestoreSeed::RootClosure)]


### PR DESCRIPTION
## Summary

Make restore confirmation and status capability failures indistinguishable for existing and nonexistent stage identifiers.

Return one stable invalid-capability response without disclosing whether the requested restore stage exists, and update the documented API responses and regression coverage. Structured server logs retain the safe diagnostic distinction between a missing stage and a capability mismatch.

## Rationale

Different errors for an invalid capability on present and absent resources create an existence oracle. Capability-authenticated endpoints should authenticate the capability without revealing resource presence on failure. Administrators still need to distinguish the rejection cause when diagnosing a request.

## Behavior and compatibility

Invalid capabilities now receive the same response regardless of stage existence. Server logs include the requested restore job ID and a bounded rejection reason, but never the supplied capability or its hash. Valid restore flows are unchanged. OpenAPI was regenerated; no migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- OpenAPI regenerated with `cargo run --quiet --bin hubuum-openapi > docs/openapi.json`
