### PR TITLE
Make permission lists explicit and canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - **Breaking (Rust API):** Encapsulated event-sink delivery and webhook settings
   fields. Workspace-crate consumers must use `SinkDelivery` accessors and the
   validating `WebhookSinkSettings` constructor and configuration methods.
+- **Breaking (Rust API):** `PermissionsList` is now a permission-specific,
+  non-generic domain type that canonicalizes duplicate values. Rust callers
+  should replace `PermissionsList<Permissions>` with `PermissionsList`.
 
 ### Security
 

--- a/src/api/v1/handlers/collections.rs
+++ b/src/api/v1/handlers/collections.rs
@@ -666,7 +666,7 @@ pub async fn replace_collection_group_permissions(
         collection
     );
 
-    if permissions.iter().next().is_none() {
+    if permissions.is_empty() {
         return Err(ApiError::BadRequest(
             "Permissions list cannot be empty for replace operation, use DELETE endpoint instead"
                 .to_string(),

--- a/src/db/traits/permissions.rs
+++ b/src/db/traits/permissions.rs
@@ -76,7 +76,7 @@ fn permission_event(
 }
 
 fn update_permission_for_grant(
-    permission_list: &PermissionsList<Permissions>,
+    permission_list: &PermissionsList,
     replace_existing: bool,
 ) -> UpdatePermission {
     let mut update_perm = if replace_existing {
@@ -172,7 +172,7 @@ fn update_permission_for_grant(
 
 fn grant_changes_permission(
     current: &Permission,
-    requested: &PermissionsList<Permissions>,
+    requested: &PermissionsList,
     replace_existing: bool,
 ) -> bool {
     let granted = current.granted();
@@ -187,19 +187,14 @@ fn grant_changes_permission(
     }
 }
 
-fn revoke_changes_permission(
-    current: &Permission,
-    requested: &PermissionsList<Permissions>,
-) -> bool {
+fn revoke_changes_permission(current: &Permission, requested: &PermissionsList) -> bool {
     let granted = current.granted();
     requested
         .iter()
         .any(|permission| granted.contains(permission))
 }
 
-fn update_permission_for_revoke(
-    permission_list: &PermissionsList<Permissions>,
-) -> UpdatePermission {
+fn update_permission_for_revoke(permission_list: &PermissionsList) -> UpdatePermission {
     let mut update_perm = UpdatePermission::default();
     for permission in permission_list {
         match permission {
@@ -258,7 +253,7 @@ fn update_permission_for_revoke(
 pub(crate) fn new_permission_from_list(
     target_collection_id: i32,
     gid: i32,
-    permission_list: &PermissionsList<Permissions>,
+    permission_list: &PermissionsList,
 ) -> NewPermission {
     NewPermission {
         collection_id: target_collection_id,
@@ -342,7 +337,7 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
         &self,
         pool: &DbPool,
         group_id_for_grant: GroupID,
-        permission_list: PermissionsList<Permissions>,
+        permission_list: PermissionsList,
         replace_existing: bool,
     ) -> Result<Permission, ApiError> {
         use crate::schema::permissions::dsl::*;
@@ -575,7 +570,7 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
         &self,
         pool: &DbPool,
         group_id_for_grant: GroupID,
-        permission_list: PermissionsList<Permissions>,
+        permission_list: PermissionsList,
         replace_existing: bool,
         context: Option<&EventContext>,
     ) -> Result<Permission, ApiError> {
@@ -663,7 +658,7 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
         &self,
         pool: &DbPool,
         group_id_for_revoke: GroupID,
-        permission_list: PermissionsList<Permissions>,
+        permission_list: PermissionsList,
     ) -> Result<Permission, ApiError> {
         use crate::schema::permissions::dsl::*;
 
@@ -795,7 +790,7 @@ pub trait PermissionControllerBackend: Serialize + CollectionAccessors {
         &self,
         pool: &DbPool,
         group_id_for_revoke: GroupID,
-        permission_list: PermissionsList<Permissions>,
+        permission_list: PermissionsList,
         context: Option<&EventContext>,
     ) -> Result<Permission, ApiError> {
         let Some(context) = context else {

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -305,10 +305,7 @@ impl<T> AuthorizationCandidates<T> {
         )
     }
 
-    fn permission_requests(
-        &self,
-        permissions: &PermissionsList<Permissions>,
-    ) -> Vec<PermissionRequest> {
+    fn permission_requests(&self, permissions: &PermissionsList) -> Vec<PermissionRequest> {
         self.0
             .iter()
             .map(|(_, resource)| PermissionRequest {
@@ -342,7 +339,7 @@ impl<T> AuthorizationCandidates<T> {
 fn query_permissions(
     query: &QueryOptions,
     required: &[Permissions],
-) -> Result<PermissionsList<Permissions>, ApiError> {
+) -> Result<PermissionsList, ApiError> {
     let mut permissions = query.filters.permissions()?;
     permissions.ensure_contains(required);
     Ok(permissions)
@@ -512,7 +509,7 @@ where
         &self,
         candidates: Vec<T>,
         resources: Vec<ResourceRef>,
-        permissions: PermissionsList<Permissions>,
+        permissions: PermissionsList,
     ) -> Result<Vec<T>, ApiError> {
         let candidates = AuthorizationCandidates::new(candidates, resources)?;
         if !scope_allows(self.scopes, permissions.as_slice()) {
@@ -542,7 +539,7 @@ where
         &self,
         candidates: Vec<T>,
         resources: Vec<ResourceRef>,
-        permissions: PermissionsList<Permissions>,
+        permissions: PermissionsList,
         query: &QueryOptions,
     ) -> Result<Vec<T>, ApiError>
     where
@@ -557,8 +554,8 @@ where
     async fn authorized_object_graph(
         &self,
         paths: &[Vec<i32>],
-        object_permissions: PermissionsList<Permissions>,
-        relation_permissions: PermissionsList<Permissions>,
+        object_permissions: PermissionsList,
+        relation_permissions: PermissionsList,
     ) -> Result<AuthorizedObjectGraph, ApiError> {
         let mut object_ids = paths
             .iter()
@@ -916,7 +913,7 @@ where
     async fn object_relations_between_ids_with_permissions(
         &self,
         object_ids: &[i32],
-        permissions: PermissionsList<Permissions>,
+        permissions: PermissionsList,
     ) -> Result<Vec<HubuumObjectRelation>, ApiError> {
         if let Some(is_admin) = self.authorization.local_is_admin() {
             return self

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -512,7 +512,7 @@ mod tests {
         pool: &DbPool,
         collection: &Collection,
         groups: &[Group],
-        permissions: PermissionsList<Permissions>,
+        permissions: PermissionsList,
     ) {
         let collection = collection.clone();
 
@@ -808,7 +808,7 @@ mod tests {
         let collection = scope.collection_fixture("test_list_groups").await;
 
         type NP = Permissions;
-        type PL = PermissionsList<Permissions>;
+        type PL = PermissionsList;
 
         // Note: Slicing is *NOT* inclusive, so this will assign to groups 0, 1, and 2
         assign_to_groups(

--- a/src/models/permissions.rs
+++ b/src/models/permissions.rs
@@ -1,7 +1,7 @@
 use crate::db::prelude::*;
 use std::{fmt, fmt::Display, slice};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use utoipa::ToSchema;
 
 use crate::{errors::ApiError, schema::permissions};
@@ -238,45 +238,63 @@ impl Display for Permissions {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct PermissionsList<T: Serialize + PartialEq + Clone>(Vec<T>);
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct PermissionsList(Vec<Permissions>);
 
-impl<T: Serialize + PartialEq + Clone> PermissionsList<T> {
-    // Constructor that accepts a generic IntoIterator so we can create a PermissionsList from any
-    // collection of items that can be converted into an iterator.
-    pub fn new<I: IntoIterator<Item = T>>(items: I) -> Self {
-        PermissionsList(items.into_iter().collect())
+impl PermissionsList {
+    /// Build a permission set, preserving the first occurrence of each value.
+    pub fn new<I: IntoIterator<Item = Permissions>>(items: I) -> Self {
+        let mut permissions = Vec::new();
+        for permission in items {
+            if !permissions.contains(&permission) {
+                permissions.push(permission);
+            }
+        }
+        Self(permissions)
     }
 
     pub fn from_query_params(
         query_params: Vec<ParsedQueryParam>,
-    ) -> Result<PermissionsList<Permissions>, ApiError> {
+    ) -> Result<PermissionsList, ApiError> {
         use crate::models::search::QueryParamsExt;
         query_params.permissions()
     }
 
-    pub fn contains(&self, item: &T) -> bool {
+    pub fn contains(&self, item: &Permissions) -> bool {
         self.0.contains(item)
     }
 
-    pub fn ensure_contains(&mut self, items: &[T]) {
+    pub fn ensure_contains(&mut self, items: &[Permissions]) {
         for item in items {
             if !self.contains(item) {
-                self.0.push(item.clone());
+                self.0.push(*item);
             }
         }
     }
-    // Method to get an iterator over references to the items in the Vec<T>
-    pub fn iter(&self) -> slice::Iter<'_, T> {
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn iter(&self) -> slice::Iter<'_, Permissions> {
         self.0.iter()
     }
 
-    pub fn as_slice(&self) -> &[T] {
+    pub fn as_slice(&self) -> &[Permissions] {
         &self.0
     }
 }
 
-impl<T: Serialize + PartialEq + Clone + Display> Display for PermissionsList<T> {
+impl<'de> Deserialize<'de> for PermissionsList {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Vec::<Permissions>::deserialize(deserializer).map(Self::new)
+    }
+}
+
+impl Display for PermissionsList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let formatted = self
             .0
@@ -288,9 +306,9 @@ impl<T: Serialize + PartialEq + Clone + Display> Display for PermissionsList<T> 
     }
 }
 
-impl<'a, T: Serialize + PartialEq + Clone> IntoIterator for &'a PermissionsList<T> {
-    type Item = &'a T;
-    type IntoIter = slice::Iter<'a, T>;
+impl<'a> IntoIterator for &'a PermissionsList {
+    type Item = &'a Permissions;
+    type IntoIter = slice::Iter<'a, Permissions>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -544,7 +562,7 @@ pub struct UpdatePermission {
 mod tests {
     use crate::db::prelude::*;
 
-    use super::{PermissionFilter, Permissions};
+    use super::{PermissionFilter, Permissions, PermissionsList};
     use crate::schema::permissions::dsl::permissions;
 
     #[test]
@@ -560,6 +578,32 @@ mod tests {
             assert_eq!(Permissions::from_string(name).unwrap(), permission);
             assert_eq!(permission.to_string(), name);
         }
+    }
+
+    #[test]
+    fn permission_list_constructor_preserves_first_occurrences() {
+        let permission_list = PermissionsList::new([
+            Permissions::ReadCollection,
+            Permissions::UpdateCollection,
+            Permissions::ReadCollection,
+        ]);
+
+        assert_eq!(
+            permission_list.as_slice(),
+            &[Permissions::ReadCollection, Permissions::UpdateCollection]
+        );
+    }
+
+    #[test]
+    fn permission_list_deserialization_canonicalizes_duplicates() {
+        let permission_list: PermissionsList =
+            serde_json::from_str(r#"["ReadCollection","UpdateCollection","ReadCollection"]"#)
+                .unwrap();
+
+        assert_eq!(
+            permission_list.as_slice(),
+            &[Permissions::ReadCollection, Permissions::UpdateCollection]
+        );
     }
 
     #[test]

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -1,7 +1,6 @@
 use chrono::NaiveDateTime;
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::net::IpAddr;
 use std::str::FromStr;
 use tracing::debug;
@@ -787,7 +786,7 @@ pub trait QueryParamsExt {
     /// ### Returns    
     ///
     /// * A PermissionsList of Permissions or ApiError::BadRequest if the permissions are invalid
-    fn permissions(&self) -> Result<PermissionsList<Permissions>, ApiError>;
+    fn permissions(&self) -> Result<PermissionsList, ApiError>;
 
     /// ## Get a list of all JSON Schema elements in a list of parsed query parameters
     ///
@@ -859,13 +858,12 @@ impl QueryParamsExt for Vec<ParsedQueryParam> {
     /// Note that the list is not sorted and duplicates are removed.
     ///
     /// If any value is not a valid permission, return an ApiError::BadRequest.
-    fn permissions(&self) -> Result<PermissionsList<Permissions>, ApiError> {
-        let mut unique_permissions = HashSet::new();
-        for param in self.iter().filter(|p| p.is_permission()) {
-            let permission = param.value_as_permission()?;
-            unique_permissions.insert(permission);
-        }
-        Ok(PermissionsList::new(unique_permissions))
+    fn permissions(&self) -> Result<PermissionsList, ApiError> {
+        self.iter()
+            .filter(|param| param.is_permission())
+            .map(ParsedQueryParam::value_as_permission)
+            .collect::<Result<Vec<_>, _>>()
+            .map(PermissionsList::new)
     }
     /// ## Get a list of all JSON schema entries in a list of parsed query parameters
     ///

--- a/src/permissions/backend.rs
+++ b/src/permissions/backend.rs
@@ -137,7 +137,7 @@ pub trait PermissionBackend: Send + Sync {
         &self,
         collection_id: CollectionID,
         group_id: GroupID,
-        list: PermissionsList<Permissions>,
+        list: PermissionsList,
         replace_existing: bool,
     ) -> Result<Permission, ApiError>;
 
@@ -147,7 +147,7 @@ pub trait PermissionBackend: Send + Sync {
         &self,
         collection_id: CollectionID,
         group_id: GroupID,
-        list: PermissionsList<Permissions>,
+        list: PermissionsList,
     ) -> Result<Permission, ApiError>;
 
     /// Revoke all permissions of a group on a collection.

--- a/src/permissions/local/mod.rs
+++ b/src/permissions/local/mod.rs
@@ -296,7 +296,7 @@ impl PermissionBackend for LocalPermissionBackend {
         &self,
         collection_id: CollectionID,
         group_id: GroupID,
-        list: PermissionsList<Permissions>,
+        list: PermissionsList,
         replace_existing: bool,
     ) -> Result<Permission, ApiError> {
         collection_id
@@ -308,7 +308,7 @@ impl PermissionBackend for LocalPermissionBackend {
         &self,
         collection_id: CollectionID,
         group_id: GroupID,
-        list: PermissionsList<Permissions>,
+        list: PermissionsList,
     ) -> Result<Permission, ApiError> {
         collection_id.revoke(&self.pool, group_id, list, None).await
     }

--- a/src/permissions/local/queries.rs
+++ b/src/permissions/local/queries.rs
@@ -126,7 +126,7 @@ pub(crate) async fn apply_permissions_query(
     pool: &DbPool,
     collection_id_param: i32,
     group_id_for_grant: i32,
-    permission_list: PermissionsList<Permissions>,
+    permission_list: PermissionsList,
     replace_existing: bool,
 ) -> Result<Permission, ApiError> {
     use crate::schema::permissions::dsl::*;
@@ -305,7 +305,7 @@ pub(crate) async fn revoke_permissions_query(
     pool: &DbPool,
     collection_id_param: i32,
     group_id_for_revoke: i32,
-    permission_list: PermissionsList<Permissions>,
+    permission_list: PermissionsList,
 ) -> Result<Permission, ApiError> {
     use crate::schema::permissions::dsl::*;
 

--- a/src/permissions/test_support/mock_treetop.rs
+++ b/src/permissions/test_support/mock_treetop.rs
@@ -553,7 +553,7 @@ impl PermissionBackend for MockTreetopBackend {
         &self,
         _collection_id: CollectionID,
         _group_id: GroupID,
-        _list: PermissionsList<Permissions>,
+        _list: PermissionsList,
         _replace_existing: bool,
     ) -> Result<Permission, ApiError> {
         Err(ApiError::NotImplemented(
@@ -566,7 +566,7 @@ impl PermissionBackend for MockTreetopBackend {
         &self,
         _collection_id: CollectionID,
         _group_id: GroupID,
-        _list: PermissionsList<Permissions>,
+        _list: PermissionsList,
     ) -> Result<Permission, ApiError> {
         Err(ApiError::NotImplemented(
             "permission mutations are managed out-of-band when using a treetop-style backend"

--- a/src/permissions/treetop/mod.rs
+++ b/src/permissions/treetop/mod.rs
@@ -546,7 +546,7 @@ impl PermissionBackend for TreetopPermissionBackend {
         &self,
         _collection_id: CollectionID,
         _group_id: GroupID,
-        _list: PermissionsList<Permissions>,
+        _list: PermissionsList,
         _replace_existing: bool,
     ) -> Result<Permission, ApiError> {
         Err(ApiError::NotImplemented(
@@ -559,7 +559,7 @@ impl PermissionBackend for TreetopPermissionBackend {
         &self,
         _collection_id: CollectionID,
         _group_id: GroupID,
-        _list: PermissionsList<Permissions>,
+        _list: PermissionsList,
     ) -> Result<Permission, ApiError> {
         Err(ApiError::NotImplemented(
             "permission mutations are managed out-of-band when using the treetop backend"

--- a/src/tests/permissions/visibility.rs
+++ b/src/tests/permissions/visibility.rs
@@ -103,7 +103,7 @@ impl PermissionBackend for ForceSlowPath {
         &self,
         collection_id: CollectionID,
         group_id: GroupID,
-        list: PermissionsList<Permissions>,
+        list: PermissionsList,
         replace_existing: bool,
     ) -> Result<Permission, ApiError> {
         self.inner
@@ -115,7 +115,7 @@ impl PermissionBackend for ForceSlowPath {
         &self,
         collection_id: CollectionID,
         group_id: GroupID,
-        list: PermissionsList<Permissions>,
+        list: PermissionsList,
     ) -> Result<Permission, ApiError> {
         self.inner
             .revoke_permissions(collection_id, group_id, list)

--- a/src/traits/permissions.rs
+++ b/src/traits/permissions.rs
@@ -99,7 +99,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
         &self,
         backend: &C,
         group_id_for_grant: GroupID,
-        permission_list: PermissionsList<Permissions>,
+        permission_list: PermissionsList,
     ) -> Result<Permission, ApiError>
     where
         C: BackendContext + ?Sized,
@@ -112,7 +112,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
         &self,
         backend: &C,
         group_id_for_grant: GroupID,
-        permission_list: PermissionsList<Permissions>,
+        permission_list: PermissionsList,
         context: Option<&EventContext>,
     ) -> Result<Permission, ApiError>
     where
@@ -137,7 +137,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
         &self,
         backend: &C,
         group_id_for_grant: GroupID,
-        permission_list: PermissionsList<Permissions>,
+        permission_list: PermissionsList,
         replace_existing: bool,
     ) -> Result<Permission, ApiError>
     where
@@ -156,7 +156,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
         &self,
         backend: &C,
         group_id_for_grant: GroupID,
-        permission_list: PermissionsList<Permissions>,
+        permission_list: PermissionsList,
         replace_existing: bool,
         context: Option<&EventContext>,
     ) -> Result<Permission, ApiError>
@@ -202,7 +202,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
         &self,
         backend: &C,
         group_id_for_revoke: GroupID,
-        permission_list: PermissionsList<Permissions>,
+        permission_list: PermissionsList,
     ) -> Result<Permission, ApiError>
     where
         C: BackendContext + ?Sized,
@@ -219,7 +219,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
         &self,
         backend: &C,
         group_id_for_revoke: GroupID,
-        permission_list: PermissionsList<Permissions>,
+        permission_list: PermissionsList,
         context: Option<&EventContext>,
     ) -> Result<Permission, ApiError>
     where
@@ -338,7 +338,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
         &self,
         backend: &C,
         group_identifier: GroupID,
-        permission_list: PermissionsList<Permissions>,
+        permission_list: PermissionsList,
     ) -> Result<Permission, ApiError>
     where
         C: BackendContext + ?Sized,
@@ -351,7 +351,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
         &self,
         backend: &C,
         group_identifier: GroupID,
-        permission_list: PermissionsList<Permissions>,
+        permission_list: PermissionsList,
         context: Option<&EventContext>,
     ) -> Result<Permission, ApiError>
     where


### PR DESCRIPTION
## Summary

Replace the generic permission-list wrapper with an explicit `PermissionsList` domain type that canonicalizes duplicate permissions while preserving first-occurrence order.

Apply canonicalization in constructors and deserialization, then simplify local and external permission request generation and revocation logic around the invariant.

## Rationale

Duplicate permission values cause redundant authorization work and make equality, update, and revoke behavior depend on caller input shape. The invariant belongs at the domain boundary.

## Behavior and compatibility

This is a breaking Rust API change: callers must replace `PermissionsList<Permissions>` with `PermissionsList`. Duplicate values are now silently canonicalized. HTTP semantics and database storage are unchanged; no migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
