### PR TITLE
Bound login credential inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   certificate and 1 MiB key limits; malformed rustls certificate entries are
   rejected instead of skipped. Before upgrading, replace non-regular TLS files,
   reduce oversized PEM material, and correct malformed certificate entries.
+- **Breaking (HTTP API):** Login identity scopes and names are now limited to
+  255 characters, and login passwords to 4096 characters. Clients must keep
+  those fields within the new limits before upgrading. Oversized requests are
+  rejected before rate-limit state or password workers are used, bounding
+  unauthenticated limiter-key memory and password-processing work.
 - **Breaking (HTTP and Rust API):** Event-delivery API responses no longer
   expose the internal `claim_token` worker lease capability. API clients must
   stop deserializing or depending on this field. The persistence-only

--- a/docs/auth_model.md
+++ b/docs/auth_model.md
@@ -440,6 +440,9 @@ IAM/credential-management surfaces.
   password and receive a generic `401`. Failed attempts are rate-limited by
   `name` + client IP (see [login_rate_limiting.md](login_rate_limiting.md)). A
   successful response returns the raw token and its authoritative `expires_at`.
+  Login `identity_scope` and `name` values are limited to 255 Unicode characters,
+  and passwords to 4096. Larger fields are rejected before rate-limit
+  bookkeeping, directory/database lookup, or password verification.
 - `GET /api/v0/auth/validate` and current-token logout use `Authenticated`, so a
   valid scoped service-account token validates as valid.
 - All-token logout / revoke-all are unscoped human/IAM management operations.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -45,6 +45,16 @@
               }
             }
           },
+          "400": {
+            "description": "Login fields exceed their supported lengths",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -22916,13 +22926,16 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "maxLength": 255
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 255
           },
           "password": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 4096
           }
         },
         "example": {

--- a/src/api/handlers/auth.rs
+++ b/src/api/handlers/auth.rs
@@ -61,6 +61,7 @@ pub async fn get_auth_providers() -> Result<impl Responder, ApiError> {
     request_body = LoginUser,
     responses(
         (status = 200, description = "Token and authoritative expiry issued", body = LoginResponse),
+        (status = 400, description = "Login fields exceed their supported lengths", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
         (status = 429, description = "Too many login attempts", body = ApiErrorResponse),
         (status = 500, description = "Internal server error", body = ApiErrorResponse)
@@ -73,6 +74,7 @@ pub async fn login(
     req_input: web::Json<LoginUser>,
 ) -> Result<impl Responder, ApiError> {
     let login = req_input.into_inner();
+    login.validate()?;
     let identity_scope = login
         .identity_scope
         .clone()

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -1059,6 +1059,10 @@ fn capitalize(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::user::{
+        MAX_LOGIN_IDENTITY_SCOPE_CHARACTERS, MAX_LOGIN_NAME_CHARACTERS,
+        MAX_LOGIN_PASSWORD_CHARACTERS,
+    };
     use actix_web::{
         App,
         http::{Method, StatusCode},
@@ -1290,6 +1294,25 @@ mod tests {
                 )),
                 Some(&Value::from(1)),
                 "restore job path should document its positive-ID invariant"
+            );
+        }
+    }
+
+    #[test]
+    fn login_schema_documents_credential_length_limits() {
+        let json = openapi_json();
+
+        for (field, maximum) in [
+            ("identity_scope", MAX_LOGIN_IDENTITY_SCOPE_CHARACTERS),
+            ("name", MAX_LOGIN_NAME_CHARACTERS),
+            ("password", MAX_LOGIN_PASSWORD_CHARACTERS),
+        ] {
+            assert_eq!(
+                json.pointer(&format!(
+                    "/components/schemas/LoginUser/properties/{field}/maxLength"
+                )),
+                Some(&Value::from(maximum)),
+                "LoginUser.{field} should document its enforced length limit"
             );
         }
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -316,6 +316,7 @@ impl AuthProviderBackend for LdapAuthProvider {
 }
 
 pub async fn login(pool: &DbPool, login: LoginUser) -> Result<User, ApiError> {
+    login.validate()?;
     let scope = login
         .identity_scope
         .as_deref()

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -22,6 +22,10 @@ use crate::traits::{
 
 use tracing::{debug, error, warn};
 
+pub const MAX_LOGIN_IDENTITY_SCOPE_CHARACTERS: usize = 255;
+pub const MAX_LOGIN_NAME_CHARACTERS: usize = 255;
+pub const MAX_LOGIN_PASSWORD_CHARACTERS: usize = 4096;
+
 /// A human user. The id is the principal id; the login/display name lives on
 /// `principals.name`, not here.
 #[derive(Serialize, Deserialize, Queryable, Selectable, Insertable, PartialEq, Clone, ToSchema)]
@@ -590,18 +594,32 @@ impl UserID {
 #[derive(Deserialize, Serialize, ToSchema)]
 #[schema(example = login_user_example)]
 pub struct LoginUser {
+    #[schema(max_length = 255)]
     pub identity_scope: Option<String>,
+    #[schema(max_length = 255)]
     pub name: String,
+    #[schema(max_length = 4096)]
     pub password: String,
 }
 
 impl LoginUser {
+    pub fn validate(&self) -> Result<(), ApiError> {
+        validate_login_field_length(
+            "identity_scope",
+            self.identity_scope.as_deref().unwrap_or_default(),
+            MAX_LOGIN_IDENTITY_SCOPE_CHARACTERS,
+        )?;
+        validate_login_field_length("name", &self.name, MAX_LOGIN_NAME_CHARACTERS)?;
+        validate_login_field_length("password", &self.password, MAX_LOGIN_PASSWORD_CHARACTERS)
+    }
+
     /// Check if the user exists and the plaintext password in the struct
     /// matches the hashed password in the database.
     pub async fn login<C>(self, backend: &C) -> Result<User, ApiError>
     where
         C: BackendContext + ?Sized,
     {
+        self.validate()?;
         // We deliberately map "not found" to a generic auth failure (401) rather
         // than 404 so we do not leak which names exist. Service-account
         // principals have no users row, so they naturally cannot log in here.
@@ -657,6 +675,19 @@ impl LoginUser {
             }
         }
     }
+}
+
+fn validate_login_field_length(
+    field: &str,
+    value: &str,
+    maximum_characters: usize,
+) -> Result<(), ApiError> {
+    if value.chars().nth(maximum_characters).is_some() {
+        return Err(ApiError::BadRequest(format!(
+            "{field} must be at most {maximum_characters} characters"
+        )));
+    }
+    Ok(())
 }
 
 pub fn auth_failure() -> ApiError {
@@ -734,5 +765,52 @@ mod tests {
 
         assert!(output.contains(REDACTED_DEBUG_VALUE));
         assert!(!output.contains(password));
+    }
+
+    #[rstest::rstest]
+    #[case::identity_scope(
+        Some("s".repeat(MAX_LOGIN_IDENTITY_SCOPE_CHARACTERS + 1)),
+        "alice".to_string(),
+        "password".to_string(),
+        "identity_scope"
+    )]
+    #[case::name(
+        None,
+        "a".repeat(MAX_LOGIN_NAME_CHARACTERS + 1),
+        "password".to_string(),
+        "name"
+    )]
+    #[case::password(
+        None,
+        "alice".to_string(),
+        "p".repeat(MAX_LOGIN_PASSWORD_CHARACTERS + 1),
+        "password"
+    )]
+    fn oversized_login_fields_are_rejected(
+        #[case] identity_scope: Option<String>,
+        #[case] name: String,
+        #[case] password: String,
+        #[case] field: &str,
+    ) {
+        let error = LoginUser {
+            identity_scope,
+            name,
+            password,
+        }
+        .validate()
+        .unwrap_err();
+
+        assert!(matches!(error, ApiError::BadRequest(message) if message.contains(field)));
+    }
+
+    #[test]
+    fn login_fields_accept_their_documented_character_limits() {
+        let login = LoginUser {
+            identity_scope: Some("s".repeat(MAX_LOGIN_IDENTITY_SCOPE_CHARACTERS)),
+            name: "a".repeat(MAX_LOGIN_NAME_CHARACTERS),
+            password: "p".repeat(MAX_LOGIN_PASSWORD_CHARACTERS),
+        };
+
+        login.validate().unwrap();
     }
 }

--- a/tests/api_identity_suite/auth.rs
+++ b/tests/api_identity_suite/auth.rs
@@ -4,7 +4,7 @@ mod tests {
     use crate::db::traits::ActiveTokens;
     use crate::db::{init_pool, with_connection};
     use crate::middlewares::ProxyTrust;
-    use crate::models::user::LoginUser;
+    use crate::models::user::{LoginUser, MAX_LOGIN_NAME_CHARACTERS};
     use crate::test_support::{
         LOGIN_RATE_LIMIT_TEST_LOCK, integration_test_config,
         reset_login_rate_limit as reset_login_rate_limit_for_tests,
@@ -274,6 +274,37 @@ mod tests {
             "{:?}",
             test::read_body(resp).await
         );
+    }
+
+    #[actix_web::test]
+    async fn oversized_login_name_is_rejected() {
+        let _guard = lock_auth_test_state().await;
+        reset_login_rate_limit_for_tests().await;
+        let config = integration_test_config().unwrap();
+        let pool = init_pool(&config.database_url, config.db_pool_size);
+        let app = test::init_service(
+            App::new()
+                .wrap(actix_web::middleware::from_fn(
+                    crate::middlewares::actor_context,
+                ))
+                .app_data(Data::new(pool.clone()))
+                .app_data(crate::tests::app_context(&pool))
+                .configure(api::config),
+        )
+        .await;
+        let login = LoginUser {
+            identity_scope: None,
+            name: "a".repeat(MAX_LOGIN_NAME_CHARACTERS + 1),
+            password: "password".to_string(),
+        };
+
+        let response = test::TestRequest::post()
+            .uri(LOGIN_ENDPOINT)
+            .set_json(&login)
+            .send_request(&app)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[actix_web::test]


### PR DESCRIPTION
## Summary

Bound unauthenticated login inputs before they touch rate-limit state or password workers: identity scope and name are limited to 255 characters, and passwords to 4096 characters.

Document the limits in the request schema, authentication model, and generated OpenAPI, with boundary and over-limit regressions.

## Rationale

Unbounded attacker-controlled identifiers can grow limiter keys, while unbounded passwords can consume avoidable allocation and password-processing work before authentication fails.

## Behavior and compatibility

**Breaking (HTTP API):** Oversized fields now return a bad-request response. Clients must keep identity scopes and names within 255 characters and passwords within 4096 characters before upgrading. Inputs at the documented limits continue to work. OpenAPI was regenerated; no database migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- OpenAPI regenerated with `cargo run --quiet --bin hubuum-openapi > docs/openapi.json`
