### PR TITLE
Type IAM update identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   Downstream callers must migrate to the builder and stop invoking the private
   helpers. Operators must correct zero, inconsistent, or unrepresentable
   worker-duration values before upgrading; those values now fail startup.
+- **Breaking (Rust API):** `UpdateUser::save`,
+  `UpdateUser::save_without_events`, `UpdateGroup::save`, and
+  `UpdateGroup::save_without_events` now accept validated `UserID` or
+  `GroupID` values instead of raw `i32` identifiers. Library callers must
+  construct the matching ID newtype before invoking these domain update
+  methods.
 
 ### Security
 

--- a/src/api/v1/handlers/groups.rs
+++ b/src/api/v1/handlers/groups.rs
@@ -161,6 +161,7 @@ pub async fn update_group(
     requestor: AdminAccess,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
+    let group_id = group_id.into_inner();
     let target_id = group_id.id();
 
     debug!(
@@ -172,7 +173,7 @@ pub async fn update_group(
     let event_context = requestor.event_context(&req);
     let updated = updated_group
         .into_inner()
-        .save(target_id, &pool, Some(&event_context))
+        .save(group_id, &pool, Some(&event_context))
         .await?;
     Ok(ApiResponse::new(
         updated.to_response(&pool).await?,

--- a/src/api/v1/handlers/users.rs
+++ b/src/api/v1/handlers/users.rs
@@ -163,7 +163,7 @@ pub async fn update_user(
     let event_context = requestor.event_context(&req);
     let user = updated_user
         .into_inner()
-        .save(target_id, &pool, Some(&event_context))
+        .save(user_id, &pool, Some(&event_context))
         .await?;
     Ok(ApiResponse::new(
         user.to_response(&pool).await?,

--- a/src/db/traits/user/auth.rs
+++ b/src/db/traits/user/auth.rs
@@ -672,6 +672,7 @@ impl LoadUserRecord for UserID {
 mod tests {
     use super::*;
     use crate::db::traits::Status;
+    use crate::models::user::UserID;
     use crate::tests::{TestScope, create_user_with_params};
 
     async fn user_with_tokens(scope: &TestScope, label: &str) -> (User, Vec<Token>) {
@@ -724,7 +725,7 @@ mod tests {
             proper_name: None,
             email: None,
         }
-        .save(user.id, &scope.pool, Some(&context))
+        .save(UserID::new(user.id).unwrap(), &scope.pool, Some(&context))
         .await
         .unwrap();
 
@@ -743,7 +744,7 @@ mod tests {
             proper_name: Some("Updated Name".to_string()),
             email: None,
         }
-        .save(user.id, &scope.pool, Some(&context))
+        .save(UserID::new(user.id).unwrap(), &scope.pool, Some(&context))
         .await
         .unwrap();
 

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -48,7 +48,7 @@ use crate::models::{
     NewExportTemplate, NewHubuumClassRelation, NewHubuumObjectRelation, NewRemoteTargetRow,
     NewUser, ObjectRelationLimit, Permissions, PermissionsList, PrincipalID, PrincipalToken,
     PrincipalTokenCreateRequest, RemoteTargetID, Token, TokenID, UpdateExportTemplate,
-    UpdateRemoteTargetRow, UpdateUser,
+    UpdateRemoteTargetRow, UpdateUser, UserID,
 };
 use crate::schema::events::dsl::events;
 use crate::tests::{
@@ -1585,14 +1585,14 @@ async fn group_writes_emit_lifecycle_events_in_transaction() {
     let updated = UpdateGroup {
         groupname: Some(scope.scoped_name("event_group_after")),
     }
-    .save(group.id, &scope.pool, Some(&context))
+    .save(GroupID::new(group.id).unwrap(), &scope.pool, Some(&context))
     .await
     .unwrap();
 
     let unchanged = UpdateGroup {
         groupname: Some(updated.groupname.clone()),
     }
-    .save(group.id, &scope.pool, Some(&context))
+    .save(GroupID::new(group.id).unwrap(), &scope.pool, Some(&context))
     .await
     .unwrap();
     assert_eq!(unchanged.updated_at, updated.updated_at);
@@ -1721,7 +1721,7 @@ async fn user_writes_emit_lifecycle_events_without_password_material() {
         proper_name: Some("After User".to_string()),
         email: Some("after@example.invalid".to_string()),
     }
-    .save(user.id, &scope.pool, Some(&context))
+    .save(UserID::new(user.id).unwrap(), &scope.pool, Some(&context))
     .await
     .unwrap();
 
@@ -1730,7 +1730,7 @@ async fn user_writes_emit_lifecycle_events_without_password_material() {
         proper_name: Some("After User".to_string()),
         email: Some("after@example.invalid".to_string()),
     }
-    .save(user.id, &scope.pool, Some(&context))
+    .save(UserID::new(user.id).unwrap(), &scope.pool, Some(&context))
     .await
     .unwrap();
     assert_eq!(unchanged.updated_at, updated.updated_at);

--- a/src/models/group.rs
+++ b/src/models/group.rs
@@ -397,26 +397,26 @@ impl UpdateGroup {
     /// change.
     pub async fn save_without_events<C>(
         &self,
-        group_id: i32,
+        group_id: GroupID,
         backend: &C,
     ) -> Result<Group, ApiError>
     where
         C: BackendContext + ?Sized,
     {
-        self.update_group_record_without_events(group_id, backend.db_pool())
+        self.update_group_record_without_events(group_id.id(), backend.db_pool())
             .await
     }
 
     pub async fn save<C>(
         &self,
-        group_id: i32,
+        group_id: GroupID,
         backend: &C,
         context: Option<&EventContext>,
     ) -> Result<Group, ApiError>
     where
         C: BackendContext + ?Sized,
     {
-        self.update_group_record(group_id, backend.db_pool(), context)
+        self.update_group_record(group_id.id(), backend.db_pool(), context)
             .await
     }
 }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -458,19 +458,23 @@ impl UpdateUser {
     /// fixture construction, cleanup, and event-system tests. Normal application
     /// code should use [`UpdateUser::save`] so event subscribers observe the
     /// change.
-    pub async fn save_without_events<C>(self, user_id: i32, backend: &C) -> Result<User, ApiError>
+    pub async fn save_without_events<C>(
+        self,
+        user_id: UserID,
+        backend: &C,
+    ) -> Result<User, ApiError>
     where
         C: BackendContext + ?Sized,
     {
         let hashed = self.hash_password().await?;
         hashed
-            .update_user_record_without_events(user_id, backend.db_pool())
+            .update_user_record_without_events(user_id.id(), backend.db_pool())
             .await
     }
 
     pub async fn save<C>(
         self,
-        user_id: i32,
+        user_id: UserID,
         backend: &C,
         context: Option<&EventContext>,
     ) -> Result<User, ApiError>
@@ -479,7 +483,7 @@ impl UpdateUser {
     {
         let hashed = self.hash_password().await?;
         hashed
-            .update_user_record(user_id, backend.db_pool(), context)
+            .update_user_record(user_id.id(), backend.db_pool(), context)
             .await
     }
 }


### PR DESCRIPTION
## Summary

Require validated `UserID` and `GroupID` newtypes for user and group domain update methods, including event-producing and event-free save paths.

Update handlers, models, and tests so raw route integers are converted once at the boundary and remain typed through persistence.

## Rationale

Raw `i32` identifiers weaken domain boundaries and allow user and group IDs to be mixed accidentally. Associated methods should express the identifier they accept in their signatures.

## Behavior and compatibility

**Breaking (Rust API):** `UpdateUser` and `UpdateGroup` save methods now require their validated identifier newtypes. Downstream library callers must construct `UserID` or `GroupID` at their input boundary before invoking these methods. HTTP behavior and database storage are unchanged; no migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
