### PR TITLE
Bound common query complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   those fields within the new limits before upgrading. Oversized requests are
   rejected before rate-limit state or password workers are used, bounding
   unauthenticated limiter-key memory and password-processing work.
+- **Breaking (HTTP API):** Common resource queries now reject more than 128
+  parameters, 64 filters, or 8 distinct sort fields before building database
+  queries. Duplicate sort fields and ambiguous repeated history `at` parameters
+  are also rejected. Clients must keep queries within those limits and send one
+  value for each sort field and history `at` parameter before upgrading. This
+  bounds query-parser allocation and quadratic cursor-predicate growth.
 - **Breaking (HTTP and Rust API):** Event-delivery API responses no longer
   expose the internal `claim_token` worker lease capability. API clients must
   stop deserializing or depending on this field. The persistence-only

--- a/crates/hubuum-query/src/lib.rs
+++ b/crates/hubuum-query/src/lib.rs
@@ -17,6 +17,17 @@ use std::str::FromStr;
 /// limits.
 pub const MAX_INTEGER_FILTER_VALUES: usize = 1_024;
 
+/// Maximum number of top-level `key=value` components accepted by the common
+/// query parser.
+pub const MAX_QUERY_PARAMETERS: usize = 128;
+
+/// Maximum number of resource filters accepted by one parsed query.
+pub const MAX_QUERY_FILTERS: usize = 64;
+
+/// Maximum number of requested sort fields. Cursor predicate construction is
+/// quadratic in this value, so keep it deliberately small and explicit.
+pub const MAX_QUERY_SORT_FIELDS: usize = 8;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum QueryError {
     BadRequest(String),
@@ -82,13 +93,22 @@ fn parse_query_parameter_with_options(
         ));
     }
 
-    for (key, value) in decode_query_parameter_pairs(qs)? {
-        if passthrough_keys.contains(key.as_str()) {
-            passthrough.entry(key).or_default().push(value);
+    for (index, chunk) in qs.split('&').enumerate() {
+        if index >= MAX_QUERY_PARAMETERS {
+            return Err(QueryError::BadRequest(format!(
+                "query accepts at most {MAX_QUERY_PARAMETERS} parameters"
+            )));
+        }
+        let (key, value) = decode_query_parameter_pair(chunk)?;
+        if passthrough_keys.contains(key.as_ref()) {
+            passthrough
+                .entry(key.into_owned())
+                .or_default()
+                .push(value.into_owned());
             continue;
         }
 
-        match key.as_str() {
+        match key.as_ref() {
             "limit" => {
                 if limit.is_some() {
                     return Err(QueryError::BadRequest("duplicate limit".into()));
@@ -102,7 +122,7 @@ fn parse_query_parameter_with_options(
                 if cursor.is_some() {
                     return Err(QueryError::BadRequest("duplicate cursor".into()));
                 }
-                cursor = Some(value);
+                cursor = Some(value.into_owned());
             }
             "include_total" => {
                 if include_total.is_some() {
@@ -112,10 +132,36 @@ fn parse_query_parameter_with_options(
             }
             "sort" | "order_by" => {
                 for piece in value.split(',') {
-                    sort.push(parse_sort_param(piece)?);
+                    if sort.len() >= MAX_QUERY_SORT_FIELDS {
+                        return Err(QueryError::BadRequest(format!(
+                            "query accepts at most {MAX_QUERY_SORT_FIELDS} sort fields"
+                        )));
+                    }
+                    let parsed = parse_sort_param(piece)?;
+                    if sort
+                        .iter()
+                        .any(|existing: &SortParam| existing.field == parsed.field)
+                    {
+                        return Err(QueryError::BadRequest(format!(
+                            "duplicate sort field '{}'",
+                            parsed.field
+                        )));
+                    }
+                    sort.push(parsed);
                 }
             }
-            _ => filters.push(parse_single_filter(&key, &value, allow_computed_filters)?),
+            _ => {
+                if filters.len() >= MAX_QUERY_FILTERS {
+                    return Err(QueryError::BadRequest(format!(
+                        "query accepts at most {MAX_QUERY_FILTERS} filters"
+                    )));
+                }
+                filters.push(parse_single_filter(
+                    key.as_ref(),
+                    value.as_ref(),
+                    allow_computed_filters,
+                )?);
+            }
         }
     }
 
@@ -1299,6 +1345,112 @@ mod tests {
         assert_eq!(parsed.sort.len(), 2);
         assert!(parsed.sort[0].descending);
         assert!(!parsed.sort[1].descending);
+    }
+
+    #[test]
+    fn common_parser_rejects_more_than_the_parameter_limit() {
+        let query = std::iter::repeat_n("local=value", MAX_QUERY_PARAMETERS + 1)
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let error = parse_query_parameter_with_passthrough(&query, &["local"]).unwrap_err();
+
+        assert_eq!(
+            error,
+            QueryError::BadRequest(format!(
+                "query accepts at most {MAX_QUERY_PARAMETERS} parameters"
+            ))
+        );
+    }
+
+    #[test]
+    fn common_parser_accepts_the_parameter_limit() {
+        let query = std::iter::repeat_n("local=value", MAX_QUERY_PARAMETERS)
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let (_, passthrough) = parse_query_parameter_with_passthrough(&query, &["local"]).unwrap();
+
+        assert_eq!(passthrough["local"].len(), MAX_QUERY_PARAMETERS);
+    }
+
+    #[test]
+    fn common_parser_rejects_more_than_the_filter_limit() {
+        let query = std::iter::repeat_n("name__contains=value", MAX_QUERY_FILTERS + 1)
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let error = parse_query_parameter(&query).unwrap_err();
+
+        assert_eq!(
+            error,
+            QueryError::BadRequest(format!("query accepts at most {MAX_QUERY_FILTERS} filters"))
+        );
+    }
+
+    #[test]
+    fn common_parser_accepts_the_filter_limit() {
+        let query = std::iter::repeat_n("name__contains=value", MAX_QUERY_FILTERS)
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let parsed = parse_query_parameter(&query).unwrap();
+
+        assert_eq!(parsed.filters.len(), MAX_QUERY_FILTERS);
+    }
+
+    #[test]
+    fn common_parser_rejects_more_than_the_sort_limit() {
+        let fields = [
+            "id",
+            "name",
+            "description",
+            "created_at",
+            "updated_at",
+            "collection_id",
+            "class_id",
+            "username",
+            "proper_name",
+        ];
+        assert_eq!(fields.len(), MAX_QUERY_SORT_FIELDS + 1);
+
+        let error = parse_query_parameter(&format!("sort={}", fields.join(","))).unwrap_err();
+
+        assert_eq!(
+            error,
+            QueryError::BadRequest(format!(
+                "query accepts at most {MAX_QUERY_SORT_FIELDS} sort fields"
+            ))
+        );
+    }
+
+    #[test]
+    fn common_parser_accepts_the_sort_limit() {
+        let fields = [
+            "id",
+            "name",
+            "description",
+            "created_at",
+            "updated_at",
+            "collection_id",
+            "class_id",
+            "username",
+        ];
+        assert_eq!(fields.len(), MAX_QUERY_SORT_FIELDS);
+
+        let parsed = parse_query_parameter(&format!("sort={}", fields.join(","))).unwrap();
+
+        assert_eq!(parsed.sort.len(), MAX_QUERY_SORT_FIELDS);
+    }
+
+    #[test]
+    fn common_parser_rejects_duplicate_sort_fields() {
+        let error = parse_query_parameter("sort=id.asc,-id").unwrap_err();
+
+        assert_eq!(
+            error,
+            QueryError::BadRequest("duplicate sort field 'id'".to_string())
+        );
     }
 
     #[test]

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -14,6 +14,7 @@ Query parameters are passed as standard query string parameters:
 - `field__operator=value` applies an explicit operator
 - filters are combined with `AND`
 - repeated `sort` fields are expressed as a comma-separated list
+- one common resource query may contain at most 128 parameters and 64 filters
 
 Example:
 
@@ -99,6 +100,8 @@ Supported forms:
 Notes:
 
 - Sort support is endpoint-specific.
+- A query may request at most eight distinct sort fields. Repeating the same
+  field, including with a different direction, is rejected.
 - Cursor pagination requires a stable sort, so Hubuum appends a deterministic tie-breaker automatically.
 - If you omit `sort`, each endpoint uses its own default stable sort.
 - Some relation endpoints support sorting on contextual fields like `from_*`, `to_*`, `depth`, and `path`.

--- a/src/api/v1/handlers/history.rs
+++ b/src/api/v1/handlers/history.rs
@@ -174,10 +174,14 @@ where
 pub fn parse_as_of(query_string: &str) -> Result<DateTime<Utc>, ApiError> {
     let (_opts, passthrough) =
         crate::models::search::parse_query_parameter_with_passthrough(query_string, &["at"])?;
-    let at = passthrough
+    let at_values = passthrough
         .get("at")
-        .and_then(|values| values.as_slice().first())
         .ok_or_else(|| ApiError::BadRequest("missing required 'at' parameter".into()))?;
+    let [at] = at_values.as_slice() else {
+        return Err(ApiError::BadRequest(
+            "at may be supplied exactly once".to_string(),
+        ));
+    };
     DateTime::parse_from_rfc3339(at)
         .map(|dt| dt.with_timezone(&Utc))
         .map_err(|_| ApiError::BadRequest(format!("invalid rfc3339 timestamp: {at}")))
@@ -284,6 +288,16 @@ mod tests {
         assert!(matches!(
             parse_as_of("at=not-a-date"),
             Err(ApiError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn parse_as_of_rejects_duplicate_timestamps() {
+        let error = parse_as_of("at=2026-01-02T03:04:05Z&at=2026-01-03T03:04:05Z").unwrap_err();
+
+        assert!(matches!(
+            error,
+            ApiError::BadRequest(message) if message == "at may be supplied exactly once"
         ));
     }
 


### PR DESCRIPTION
## Summary

Bound common resource queries to 128 parameters, 64 filters, and 8 distinct sort fields before building database queries.

Reject duplicate sort fields and ambiguous repeated history `at` parameters, and document the effective query contract.

## Rationale

Unbounded query parsing allocates attacker-controlled structures, while each additional sort field expands cursor predicates quadratically. Duplicate control parameters also create ambiguous behavior that callers should resolve explicitly.

## Behavior and compatibility

**Breaking (HTTP API):** Queries beyond the limits, with duplicate sort fields, or with repeated history timestamps now return bad requests. Clients must keep queries within 128 parameters, 64 filters, and 8 distinct sort fields, and send one value for each sort field and history `at` parameter before upgrading. Ordinary queries are unchanged. No migration or schema change is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
