### PR TITLE
Type generic update identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `GroupID` values instead of raw `i32` identifiers. Library callers must
   construct the matching ID newtype before invoking these domain update
   methods.
+- **Breaking Rust API:** `CanUpdate` and its adapter now declare an associated
+  `Identifier` type. Built-in collection, class, object, export-template, and
+  service-account updates require their validated ID newtypes instead of raw
+  `i32` values. Downstream update adapters must declare the associated type,
+  and callers must construct the matching ID before invoking `update` or
+  `update_without_events`.
 
 ### Security
 

--- a/src/api/v1/handlers/collections.rs
+++ b/src/api/v1/handlers/collections.rs
@@ -198,6 +198,7 @@ pub async fn update_collection(
     update_data: web::Json<UpdateCollection>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
+    let collection_id = collection_id.into_inner();
     debug!(
         message = "Collection update requested",
         requestor = requestor.principal.name,
@@ -217,7 +218,7 @@ pub async fn update_collection(
     let event_context = requestor.event_context(&req);
     let updated_collection = update_data
         .into_inner()
-        .update(&pool, collection.id, &event_context)
+        .update(&pool, collection_id, &event_context)
         .await?;
     Ok(ApiResponse::accepted(updated_collection))
 }

--- a/src/api/v1/handlers/export_templates.rs
+++ b/src/api/v1/handlers/export_templates.rs
@@ -339,7 +339,7 @@ pub async fn patch_template(
     }
 
     let event_context = requestor.event_context(&req);
-    let updated = update.update(&pool, existing.id, &event_context).await?;
+    let updated = update.update(&pool, template_id, &event_context).await?;
 
     Ok(ApiResponse::new(updated, StatusCode::OK))
 }

--- a/src/api/v1/handlers/service_accounts.rs
+++ b/src/api/v1/handlers/service_accounts.rs
@@ -222,7 +222,7 @@ pub async fn update_service_account(
     }
 
     let event_context = requestor.event_context(&req);
-    let updated = update.update(&pool, id.id(), &event_context).await?;
+    let updated = update.update(&pool, id, &event_context).await?;
     Ok(ApiResponse::new(
         response_for(&pool, &updated).await?,
         StatusCode::OK,

--- a/src/db/traits/service_account.rs
+++ b/src/db/traits/service_account.rs
@@ -143,22 +143,24 @@ where
 
 impl UpdateAdapter for UpdateServiceAccount {
     type Output = ServiceAccount;
+    type Identifier = ServiceAccountID;
 
     async fn update_adapter_without_events(
         &self,
         pool: &DbPool,
-        service_account_id: i32,
+        service_account_id: ServiceAccountID,
     ) -> Result<ServiceAccount, ApiError> {
-        update_service_account_record(self, pool, service_account_id, None).await
+        update_service_account_record(self, pool, service_account_id.id(), None).await
     }
 
     async fn update_adapter(
         &self,
         pool: &DbPool,
-        service_account_id: i32,
+        service_account_id: ServiceAccountID,
         event_context: &EventContext,
     ) -> Result<ServiceAccount, ApiError> {
-        update_service_account_record(self, pool, service_account_id, Some(event_context)).await
+        update_service_account_record(self, pool, service_account_id.id(), Some(event_context))
+            .await
     }
 }
 

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -44,11 +44,11 @@ use crate::models::token::revoke_token_by_id_for_principal;
 use crate::models::{
     CollectionID, EventDelivery, EventDeliveryID, EventDeliveryStatus, EventSink as EventSinkModel,
     EventSinkID, EventSinkKind, EventSubscription, ExportContentType, ExportTemplateID,
-    ExportTemplateKind, GroupID, HubuumClassRelationID, NewEventSink, NewEventSubscription,
-    NewExportTemplate, NewHubuumClassRelation, NewHubuumObjectRelation, NewRemoteTargetRow,
-    NewUser, ObjectRelationLimit, Permissions, PermissionsList, PrincipalID, PrincipalToken,
-    PrincipalTokenCreateRequest, RemoteTargetID, Token, TokenID, UpdateExportTemplate,
-    UpdateRemoteTargetRow, UpdateUser, UserID,
+    ExportTemplateKind, GroupID, HubuumClassID, HubuumClassRelationID, HubuumObjectID,
+    NewEventSink, NewEventSubscription, NewExportTemplate, NewHubuumClassRelation,
+    NewHubuumObjectRelation, NewRemoteTargetRow, NewUser, ObjectRelationLimit, Permissions,
+    PermissionsList, PrincipalID, PrincipalToken, PrincipalTokenCreateRequest, RemoteTargetID,
+    Token, TokenID, UpdateExportTemplate, UpdateRemoteTargetRow, UpdateUser, UserID,
 };
 use crate::schema::events::dsl::events;
 use crate::tests::{
@@ -1137,7 +1137,11 @@ async fn collection_writes_emit_lifecycle_events_in_transaction() {
         name: Some(collection_name.clone()),
         description: Some("after".to_string()),
     }
-    .update(&scope.pool, collection.id, &context)
+    .update(
+        &scope.pool,
+        CollectionID::new(collection.id).unwrap(),
+        &context,
+    )
     .await
     .unwrap();
 
@@ -1145,7 +1149,11 @@ async fn collection_writes_emit_lifecycle_events_in_transaction() {
         name: Some(collection_name.clone()),
         description: Some("after".to_string()),
     }
-    .update(&scope.pool, collection.id, &context)
+    .update(
+        &scope.pool,
+        CollectionID::new(collection.id).unwrap(),
+        &context,
+    )
     .await
     .unwrap();
     assert_eq!(unchanged.updated_at, updated.updated_at);
@@ -1226,7 +1234,7 @@ async fn class_writes_emit_lifecycle_events_in_transaction() {
         validate_schema: Some(false),
         description: Some("after".to_string()),
     }
-    .update(&scope.pool, class.id, &context)
+    .update(&scope.pool, HubuumClassID::new(class.id).unwrap(), &context)
     .await
     .unwrap();
 
@@ -1240,7 +1248,7 @@ async fn class_writes_emit_lifecycle_events_in_transaction() {
         validate_schema: Some(false),
         description: Some("after".to_string()),
     }
-    .update(&scope.pool, class.id, &context)
+    .update(&scope.pool, HubuumClassID::new(class.id).unwrap(), &context)
     .await
     .unwrap();
     assert_eq!(unchanged.updated_at, updated.updated_at);
@@ -1307,7 +1315,11 @@ async fn object_writes_emit_lifecycle_events_in_transaction() {
         data: Some(serde_json::json!({"state": "after"})),
         description: Some("after".to_string()),
     }
-    .update(&scope.pool, object.id, &context)
+    .update(
+        &scope.pool,
+        HubuumObjectID::new(object.id).unwrap(),
+        &context,
+    )
     .await
     .unwrap();
 
@@ -1318,7 +1330,11 @@ async fn object_writes_emit_lifecycle_events_in_transaction() {
         data: Some(serde_json::json!({"state": "after"})),
         description: Some("after".to_string()),
     }
-    .update(&scope.pool, object.id, &context)
+    .update(
+        &scope.pool,
+        HubuumObjectID::new(object.id).unwrap(),
+        &context,
+    )
     .await
     .unwrap();
     assert_eq!(unchanged.updated_at, updated.updated_at);
@@ -2005,7 +2021,11 @@ async fn export_template_writes_emit_lifecycle_events() {
         default_missing_data_policy: None,
         default_limits: None,
     }
-    .update(&scope.pool, template.id, &context)
+    .update(
+        &scope.pool,
+        ExportTemplateID::new(template.id).unwrap(),
+        &context,
+    )
     .await
     .unwrap();
 
@@ -2023,7 +2043,11 @@ async fn export_template_writes_emit_lifecycle_events() {
         default_missing_data_policy: None,
         default_limits: None,
     }
-    .update(&scope.pool, template.id, &context)
+    .update(
+        &scope.pool,
+        ExportTemplateID::new(template.id).unwrap(),
+        &context,
+    )
     .await
     .unwrap();
 

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -355,7 +355,10 @@ pub mod tests {
             description: None,
         };
 
-        let updated_class = update.update_without_events(&pool, class.id).await.unwrap();
+        let updated_class = update
+            .update_without_events(&pool, HubuumClassID::new(class.id).unwrap())
+            .await
+            .unwrap();
 
         assert_eq!(updated_class.id, class.id);
         assert_eq!(updated_class.name, "test update 2");

--- a/src/models/export_template.rs
+++ b/src/models/export_template.rs
@@ -599,22 +599,23 @@ impl NewExportTemplate {
 
 impl UpdateAdapter for UpdateExportTemplate {
     type Output = ExportTemplate;
+    type Identifier = ExportTemplateID;
 
     async fn update_adapter_without_events(
         &self,
         pool: &DbPool,
-        entry_id: i32,
+        entry_id: ExportTemplateID,
     ) -> Result<ExportTemplate, ApiError> {
-        apply_export_template_update(pool, entry_id, self.clone(), None).await
+        apply_export_template_update(pool, entry_id.id(), self.clone(), None).await
     }
 
     async fn update_adapter(
         &self,
         pool: &DbPool,
-        entry_id: i32,
+        entry_id: ExportTemplateID,
         context: &EventContext,
     ) -> Result<ExportTemplate, ApiError> {
-        apply_export_template_update(pool, entry_id, self.clone(), Some(context)).await
+        apply_export_template_update(pool, entry_id.id(), self.clone(), Some(context)).await
     }
 }
 

--- a/src/models/traits/class.rs
+++ b/src/models/traits/class.rs
@@ -106,7 +106,9 @@ impl SaveAdapter for HubuumClass {
             description: Some(self.description.clone()),
         };
 
-        update.update_without_events(pool, self.id).await
+        update
+            .update_without_events(pool, HubuumClassID::new(self.id)?)
+            .await
     }
 
     async fn save_adapter(
@@ -158,23 +160,24 @@ impl SaveAdapter for NewHubuumClass {
 
 impl UpdateAdapter for UpdateHubuumClass {
     type Output = HubuumClass;
+    type Identifier = HubuumClassID;
 
     async fn update_adapter_without_events(
         &self,
         pool: &DbPool,
-        class_id: i32,
+        class_id: HubuumClassID,
     ) -> Result<HubuumClass, ApiError> {
-        self.update_class_record_without_events(pool, class_id)
+        self.update_class_record_without_events(pool, class_id.id())
             .await
     }
 
     async fn update_adapter(
         &self,
         pool: &DbPool,
-        class_id: i32,
+        class_id: HubuumClassID,
         context: &EventContext,
     ) -> Result<HubuumClass, ApiError> {
-        self.update_class_record(pool, class_id, Some(context))
+        self.update_class_record(pool, class_id.id(), Some(context))
             .await
     }
 }

--- a/src/models/traits/collection.rs
+++ b/src/models/traits/collection.rs
@@ -26,7 +26,7 @@ impl SaveAdapter for Collection {
             description: Some(self.description.clone()),
         };
         updated_collection
-            .update_without_events(pool, self.id)
+            .update_without_events(pool, CollectionID::new(self.id)?)
             .await
     }
 
@@ -67,23 +67,24 @@ impl DeleteAdapter for CollectionID {
 
 impl UpdateAdapter for UpdateCollection {
     type Output = Collection;
+    type Identifier = CollectionID;
 
     async fn update_adapter_without_events(
         &self,
         pool: &DbPool,
-        target_collection_id: i32,
+        target_collection_id: CollectionID,
     ) -> Result<Self::Output, ApiError> {
-        self.update_collection_record_without_events(pool, target_collection_id)
+        self.update_collection_record_without_events(pool, target_collection_id.id())
             .await
     }
 
     async fn update_adapter(
         &self,
         pool: &DbPool,
-        target_collection_id: i32,
+        target_collection_id: CollectionID,
         context: &EventContext,
     ) -> Result<Self::Output, ApiError> {
-        self.update_collection_record(pool, target_collection_id, Some(context))
+        self.update_collection_record(pool, target_collection_id.id(), Some(context))
             .await
     }
 }

--- a/src/models/traits/object.rs
+++ b/src/models/traits/object.rs
@@ -160,23 +160,24 @@ impl SaveAdapter for NewHubuumObject {
 
 impl UpdateAdapter for UpdateHubuumObject {
     type Output = HubuumObject;
+    type Identifier = HubuumObjectID;
 
     async fn update_adapter_without_events(
         &self,
         pool: &DbPool,
-        object_id: i32,
+        object_id: HubuumObjectID,
     ) -> Result<Self::Output, ApiError> {
-        self.update_object_record_without_events(pool, object_id)
+        self.update_object_record_without_events(pool, object_id.id())
             .await
     }
 
     async fn update_adapter(
         &self,
         pool: &DbPool,
-        object_id: i32,
+        object_id: HubuumObjectID,
         context: &EventContext,
     ) -> Result<Self::Output, ApiError> {
-        self.update_object_record(pool, object_id, Some(context))
+        self.update_object_record(pool, object_id.id(), Some(context))
             .await
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -843,6 +843,7 @@ pub fn generate_all_subsets<T: Clone>(items: &[T]) -> Vec<Vec<T>> {
 mod test {
 
     use super::*;
+    use crate::models::CollectionID;
     use crate::{models::collection::UpdateCollection, traits::CanUpdate};
 
     #[actix_rt::test]
@@ -859,7 +860,7 @@ mod test {
         };
 
         let updated_collection = update
-            .update_without_events(&pool, collection.collection.id)
+            .update_without_events(&pool, CollectionID::new(collection.collection.id).unwrap())
             .await
             .unwrap();
         let new_created_at = updated_collection.created_at;

--- a/src/tests/storage_performance.rs
+++ b/src/tests/storage_performance.rs
@@ -347,9 +347,12 @@ async fn collection_no_op_update_does_not_write_or_emit_an_event() {
         description: Some(fixture.collection.description.clone()),
     };
 
-    let (updated, queries) =
-        capture_queries(update.update(&scope.pool, fixture.collection.id, &EventContext::system()))
-            .await;
+    let (updated, queries) = capture_queries(update.update(
+        &scope.pool,
+        CollectionID::new(fixture.collection.id).unwrap(),
+        &EventContext::system(),
+    ))
+    .await;
     assert_eq!(
         updated.expect("no-op update should return current row"),
         fixture.collection
@@ -507,9 +510,12 @@ async fn changed_collection_update_writes_once_and_emits_one_event() {
         description: Some("changed query budget description".to_string()),
     };
 
-    let (updated, queries) =
-        capture_queries(update.update(&scope.pool, fixture.collection.id, &EventContext::system()))
-            .await;
+    let (updated, queries) = capture_queries(update.update(
+        &scope.pool,
+        CollectionID::new(fixture.collection.id).unwrap(),
+        &EventContext::system(),
+    ))
+    .await;
     assert_eq!(
         updated.expect("changed update should succeed").description,
         "changed query budget description"
@@ -619,7 +625,10 @@ async fn collection_history_query_count_is_constant_with_page_size() {
                 name: None,
                 description: Some(format!("query budget history version {version}")),
             }
-            .update_without_events(&scope.pool, fixture.collection.id),
+            .update_without_events(
+                &scope.pool,
+                CollectionID::new(fixture.collection.id).unwrap(),
+            ),
         )
         .await
         .expect("history-generating update should succeed");

--- a/src/tests/temporal/mod.rs
+++ b/src/tests/temporal/mod.rs
@@ -1,6 +1,6 @@
 use crate::db::prelude::*;
 use crate::db::with_connection;
-use crate::models::{NewHubuumClass, UpdateHubuumClass};
+use crate::models::{HubuumClassID, NewHubuumClass, UpdateHubuumClass};
 use crate::tests::TestScope;
 use crate::traits::{CanSave, CanUpdate};
 use chrono::{DateTime, Utc};
@@ -279,7 +279,7 @@ async fn unchanged_domain_update_is_noop() {
         validate_schema: Some(class.validate_schema),
         description: Some(class.description.clone()),
     }
-    .update_without_events(&pool, class.id)
+    .update_without_events(&pool, HubuumClassID::new(class.id).unwrap())
     .await
     .unwrap();
 

--- a/src/traits/crud.rs
+++ b/src/traits/crud.rs
@@ -49,6 +49,8 @@ pub trait CanSave {
 /// returned after the update completes.
 pub trait CanUpdate {
     type Output;
+    /// Validated identifier for the persisted model updated by this request.
+    type Identifier;
     /// Update without emitting domain events.
     ///
     /// Intended only for internal infrastructure paths such as bootstrap/setup,
@@ -57,7 +59,7 @@ pub trait CanUpdate {
     async fn update_without_events<C>(
         &self,
         backend: &C,
-        entry_id: i32,
+        entry_id: Self::Identifier,
     ) -> Result<Self::Output, ApiError>
     where
         C: BackendContext + ?Sized;
@@ -65,7 +67,7 @@ pub trait CanUpdate {
     async fn update<C>(
         &self,
         backend: &C,
-        entry_id: i32,
+        entry_id: Self::Identifier,
         context: &EventContext,
     ) -> Result<Self::Output, ApiError>
     where
@@ -139,17 +141,18 @@ where
 #[doc(hidden)]
 pub trait UpdateAdapter {
     type Output;
+    type Identifier;
 
     async fn update_adapter_without_events(
         &self,
         pool: &DbPool,
-        entry_id: i32,
+        entry_id: Self::Identifier,
     ) -> Result<Self::Output, ApiError>;
 
     async fn update_adapter(
         &self,
         pool: &DbPool,
-        entry_id: i32,
+        entry_id: Self::Identifier,
         _context: &EventContext,
     ) -> Result<Self::Output, ApiError> {
         self.update_adapter_without_events(pool, entry_id).await
@@ -161,11 +164,12 @@ where
     T: UpdateAdapter,
 {
     type Output = T::Output;
+    type Identifier = T::Identifier;
 
     async fn update_without_events<C>(
         &self,
         backend: &C,
-        entry_id: i32,
+        entry_id: Self::Identifier,
     ) -> Result<Self::Output, ApiError>
     where
         C: BackendContext + ?Sized,
@@ -177,7 +181,7 @@ where
     async fn update<C>(
         &self,
         backend: &C,
-        entry_id: i32,
+        entry_id: Self::Identifier,
         context: &EventContext,
     ) -> Result<Self::Output, ApiError>
     where

--- a/tests/api_core_data_suite/classes.rs
+++ b/tests/api_core_data_suite/classes.rs
@@ -802,7 +802,11 @@ pub mod tests {
             validate_schema: None,
             description: Some("v2".to_string()),
         }
-        .update(&context.pool, created.id, &event_context)
+        .update(
+            &context.pool,
+            HubuumClassID::new(created.id).unwrap(),
+            &event_context,
+        )
         .await
         .unwrap();
 
@@ -879,7 +883,11 @@ pub mod tests {
             validate_schema: None,
             description: None,
         }
-        .update(&context.pool, class.id, &event_context)
+        .update(
+            &context.pool,
+            HubuumClassID::new(class.id).unwrap(),
+            &event_context,
+        )
         .await
         .unwrap();
 
@@ -958,7 +966,11 @@ pub mod tests {
             validate_schema: None,
             description: None,
         }
-        .update(&context.pool, class.id, &event_context)
+        .update(
+            &context.pool,
+            HubuumClassID::new(class.id).unwrap(),
+            &event_context,
+        )
         .await
         .unwrap();
 
@@ -1090,7 +1102,11 @@ pub mod tests {
             validate_schema: None,
             description: Some("v2".to_string()),
         }
-        .update(&context.pool, created.id, &event_context)
+        .update(
+            &context.pool,
+            HubuumClassID::new(created.id).unwrap(),
+            &event_context,
+        )
         .await
         .unwrap();
 
@@ -1101,7 +1117,11 @@ pub mod tests {
             validate_schema: None,
             description: Some("v3".to_string()),
         }
-        .update(&context.pool, created.id, &event_context)
+        .update(
+            &context.pool,
+            HubuumClassID::new(created.id).unwrap(),
+            &event_context,
+        )
         .await
         .unwrap();
 

--- a/tests/api_core_data_suite/collections.rs
+++ b/tests/api_core_data_suite/collections.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
     use crate::models::{
-        Collection, GroupID, GroupPermission, GroupResponse, NewCollectionWithAssignee, NewGroup,
-        Permission, Permissions, UpdateCollection,
+        Collection, CollectionID, GroupID, GroupPermission, GroupResponse,
+        NewCollectionWithAssignee, NewGroup, Permission, Permissions, UpdateCollection,
     };
 
     use crate::pagination::{
@@ -1081,7 +1081,11 @@ mod tests {
             name: None,
             description: Some("v2".to_string()),
         }
-        .update(&context.pool, created.id, &event_context)
+        .update(
+            &context.pool,
+            CollectionID::new(created.id).unwrap(),
+            &event_context,
+        )
         .await
         .unwrap();
 

--- a/tests/api_core_data_suite/object_aggregates/external_authorization.rs
+++ b/tests/api_core_data_suite/object_aggregates/external_authorization.rs
@@ -151,7 +151,7 @@ async fn non_pushdown_aggregation_preserves_large_internal_sums(
             data: Some(serde_json::from_str(r#"{"amount":9e308}"#).unwrap()),
             description: None,
         }
-        .update_without_events(&test_context.pool, object.id)
+        .update_without_events(&test_context.pool, HubuumObjectID::new(object.id).unwrap())
         .await
         .unwrap();
     }
@@ -414,7 +414,7 @@ async fn non_pushdown_grouping_uses_the_authorized_object_snapshot(
             data: None,
             description: None,
         }
-        .update_without_events(&pool, authorized_object.id)
+        .update_without_events(&pool, HubuumObjectID::new(authorized_object.id).unwrap())
         .await
         .unwrap();
     });

--- a/tests/api_core_data_suite/objects.rs
+++ b/tests/api_core_data_suite/objects.rs
@@ -10,8 +10,8 @@ mod tests {
     use crate::events::EventContext;
     use crate::models::traits::{CreateObjectInResolvedClass, ResolveClassTarget};
     use crate::models::{
-        ClassSelector, HubuumClassID, HubuumObject, NewHubuumClass, NewHubuumObject,
-        UpdateHubuumObject,
+        ClassSelector, HubuumClassID, HubuumObject, HubuumObjectID, NewHubuumClass,
+        NewHubuumObject, UpdateHubuumObject,
     };
     use crate::traits::{CanDelete, CanSave};
     use actix_web::{http::StatusCode, test};
@@ -1688,7 +1688,11 @@ mod tests {
             data: None,
             description: Some("v2".to_string()),
         }
-        .update(&context.pool, created.id, &event_context)
+        .update(
+            &context.pool,
+            HubuumObjectID::new(created.id).unwrap(),
+            &event_context,
+        )
         .await
         .unwrap();
 

--- a/tests/api_jobs_suite/export_templates.rs
+++ b/tests/api_jobs_suite/export_templates.rs
@@ -4,8 +4,8 @@ mod tests {
 
     use crate::models::{
         Collection, ExportContentType, ExportLimits, ExportMissingDataPolicy, ExportScopeKind,
-        ExportTemplate, ExportTemplateKind, GroupID, NewCollectionWithAssignee, NewExportTemplate,
-        NewHubuumClass, Permissions, PermissionsList, UpdateExportTemplate,
+        ExportTemplate, ExportTemplateID, ExportTemplateKind, GroupID, NewCollectionWithAssignee,
+        NewExportTemplate, NewHubuumClass, Permissions, PermissionsList, UpdateExportTemplate,
     };
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
     use crate::tests::asserts::{assert_paginated_collection_total_count, assert_response_status};
@@ -1244,7 +1244,11 @@ mod tests {
             default_missing_data_policy: None,
             default_limits: None,
         }
-        .update(&pool, created.id, &event_context)
+        .update(
+            &pool,
+            ExportTemplateID::new(created.id).unwrap(),
+            &event_context,
+        )
         .await
         .unwrap();
 

--- a/tests/api_jobs_suite/exports.rs
+++ b/tests/api_jobs_suite/exports.rs
@@ -11,11 +11,12 @@ mod tests {
     use crate::db::traits::task::{TaskBackend, TaskStateUpdate, purge_expired_export_outputs};
     use crate::models::{
         CollectionID, ExportContentType, ExportJsonResponse, ExportRelationContext, ExportRequest,
-        ExportScope, ExportScopeKind, ExportTemplate, ExportTemplateKind, HubuumClass,
-        HubuumClassRelation, HubuumObjectRelation, NewExportTaskOutputRecord, NewExportTemplate,
-        NewHubuumClass, NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation,
-        NewTaskEventRecord, NewTaskRecord, Permissions, TaskEventResponse, TaskID, TaskKind,
-        TaskResponse, TaskResultCounts, TaskStatus, TokenResourceScope, UpdateExportTemplate,
+        ExportScope, ExportScopeKind, ExportTemplate, ExportTemplateID, ExportTemplateKind,
+        HubuumClass, HubuumClassRelation, HubuumObjectRelation, NewExportTaskOutputRecord,
+        NewExportTemplate, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
+        NewHubuumObjectRelation, NewTaskEventRecord, NewTaskRecord, Permissions, TaskEventResponse,
+        TaskID, TaskKind, TaskResponse, TaskResultCounts, TaskStatus, TokenResourceScope,
+        UpdateExportTemplate,
     };
     use crate::tests::api_operations::{get_request, post_request_with_headers};
     use crate::tests::asserts::{assert_response_status, header_value};
@@ -606,7 +607,7 @@ mod tests {
             template: Some("changed output".to_string()),
             ..empty_update_template_payload()
         }
-        .update_without_events(&context.pool, template_id)
+        .update_without_events(&context.pool, ExportTemplateID::new(template_id).unwrap())
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary

Give `CanUpdate` an associated `Identifier` type and use validated collection, class, object, export-template, and service-account ID newtypes throughout generic update adapters.

Convert raw request identifiers at handler boundaries and preserve their domain type through model and persistence calls.

## Rationale

A generic update trait accepting raw `i32` values discards the compiler's ability to distinguish unrelated resources. The associated type makes each implementation's identifier contract explicit.

## Behavior and compatibility

This is a breaking Rust API change. Downstream `CanUpdate` implementations must declare `Identifier`, and callers must pass that type. HTTP behavior and database storage are unchanged; no migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
