### PR TITLE
Redact response header values from logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Restore-status capability checks no longer disclose whether a restore stage
   ID exists when the supplied capability is invalid. Server logs distinguish
   missing stages from capability mismatches without recording the capability.
+- Response debug logs no longer include custom HTTP header values, preventing
+  pagination cursors and future secret-bearing headers from leaking into logs.
 
 ## [0.0.8] - 2026-08-01
 

--- a/src/api/response.rs
+++ b/src/api/response.rs
@@ -259,3 +259,44 @@ impl ResponseLocation {
         &self.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logger::{HubuumLoggingFormat, test_support::JsonLogWriter};
+    use actix_web::test as actix_test;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    #[test]
+    fn response_header_debug_log_omits_the_value() {
+        let header_name = "x-sensitive-response-data";
+        let header_value = "secret-pagination-cursor";
+        let writer = JsonLogWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(writer.clone())
+                .event_format(HubuumLoggingFormat),
+        );
+        let request = actix_test::TestRequest::default().to_http_request();
+
+        let response = tracing::subscriber::with_default(subscriber, || {
+            ApiResponse::new_with_headers(
+                (),
+                StatusCode::OK,
+                HashMap::from([(header_name.to_string(), header_value.to_string())]),
+            )
+            .respond_to(&request)
+        });
+
+        assert_eq!(
+            response.headers().get(header_name),
+            Some(&HeaderValue::from_static(header_value))
+        );
+
+        let logs = writer.raw_output();
+        assert!(logs.contains("Adding response header"));
+        assert!(logs.contains(header_name));
+        assert!(!logs.contains(header_value));
+    }
+}

--- a/src/api/response.rs
+++ b/src/api/response.rs
@@ -227,7 +227,7 @@ fn insert_headers(
 ) {
     if let Some(headers) = headers {
         for (key, value) in headers {
-            debug!(message = "Adding response header", key = key, value = value);
+            debug!(message = "Adding response header", key = key);
             response_builder.insert_header((key, value));
         }
     }


### PR DESCRIPTION
## Summary

Stop including custom response-header values in debug logs while retaining the header name needed to understand response construction.

Add a regression test that verifies the header remains in the HTTP response while its value is absent from captured debug output.

## Rationale

Pagination cursors are already emitted through response headers, and future headers may carry other sensitive values. Logging those values unnecessarily duplicates bearer-like material into log retention systems.

## Behavior and compatibility

Response construction and header contents are unchanged. Debug logs now contain the header name only. No API, dependency, or migration changes are required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
