### PR TITLE
Reject credentials embedded in LDAP URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   stop deserializing or depending on this field. The persistence-only
   `EventDelivery` model no longer implements Serde or OpenAPI schema traits,
   and its claim token is crate-private.
+- **Breaking:** LDAP provider URLs now reject embedded user information. Move
+  service credentials into `bind_dn` and `bind_password`; configuration debug
+  output now shows only the LDAP URL scheme, host, and port.
 - Local password changes and administrative password resets now atomically
   revoke all active bearer tokens for the affected user.
 - Redacted embedded URL credentials and common secret-header spellings from

--- a/crates/hubuum-auth-ldap/src/lib.rs
+++ b/crates/hubuum-auth-ldap/src/lib.rs
@@ -543,18 +543,29 @@ mod tests {
         assert!(matches!(&error, AuthProviderError::Config(_)));
     }
 
-    #[test]
-    fn ldap_url_with_embedded_credentials_is_rejected() {
-        let error = LdapIdentityProvider::new(ldap_config(
-            "ldaps://service-account:embedded-secret@directory.example",
-        ))
-        .err()
-        .unwrap();
-
+    fn assert_embedded_credentials_rejected(url: &str) {
+        let error = LdapIdentityProvider::new(ldap_config(url)).err().unwrap();
         assert_eq!(
             error.to_string(),
             "provider configuration error: ldap url must not contain embedded credentials; configure bind_dn and bind_password instead"
         );
+    }
+
+    #[test]
+    fn ldap_url_with_embedded_username_and_password_is_rejected() {
+        assert_embedded_credentials_rejected(
+            "ldaps://service-account:embedded-secret@directory.example",
+        );
+    }
+
+    #[test]
+    fn ldap_url_with_embedded_username_is_rejected() {
+        assert_embedded_credentials_rejected("ldaps://service-account@directory.example");
+    }
+
+    #[test]
+    fn ldap_url_with_embedded_password_is_rejected() {
+        assert_embedded_credentials_rejected("ldaps://:embedded-secret@directory.example");
     }
 
     #[test]

--- a/crates/hubuum-auth-ldap/src/lib.rs
+++ b/crates/hubuum-auth-ldap/src/lib.rs
@@ -40,11 +40,28 @@ pub struct LdapScopeConfig {
     pub group_rules: Vec<GroupMappingRuleConfig>,
 }
 
+struct LdapUrlDebug<'a>(&'a str);
+
+impl fmt::Debug for LdapUrlDebug<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Ok(url) = Url::parse(self.0) else {
+            return formatter.write_str("<invalid LDAP URL>");
+        };
+
+        formatter
+            .debug_struct("LdapUrl")
+            .field("scheme", &url.scheme())
+            .field("host", &url.host_str())
+            .field("port", &url.port_or_known_default())
+            .finish()
+    }
+}
+
 impl fmt::Debug for LdapScopeConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("LdapScopeConfig")
             .field("scope", &self.scope)
-            .field("url", &self.url)
+            .field("url", &LdapUrlDebug(&self.url))
             .field("bind_dn", &self.bind_dn)
             .field(
                 "bind_password",
@@ -116,6 +133,12 @@ impl LdapIdentityProvider {
         if parsed_url.host_str().is_none() {
             return Err(AuthProviderError::Config(
                 "ldap url must include a host".to_string(),
+            ));
+        }
+        if !parsed_url.username().is_empty() || parsed_url.password().is_some() {
+            return Err(AuthProviderError::Config(
+                "ldap url must not contain embedded credentials; configure bind_dn and bind_password instead"
+                    .to_string(),
             ));
         }
         let starttls = match parsed_url.scheme() {
@@ -518,6 +541,47 @@ mod tests {
             .err()
             .unwrap();
         assert!(matches!(&error, AuthProviderError::Config(_)));
+    }
+
+    #[test]
+    fn ldap_url_with_embedded_credentials_is_rejected() {
+        let error = LdapIdentityProvider::new(ldap_config(
+            "ldaps://service-account:embedded-secret@directory.example",
+        ))
+        .err()
+        .unwrap();
+
+        assert_eq!(
+            error.to_string(),
+            "provider configuration error: ldap url must not contain embedded credentials; configure bind_dn and bind_password instead"
+        );
+    }
+
+    #[test]
+    fn ldap_config_debug_redacts_url_details_and_bind_password() {
+        let config = LdapScopeConfig {
+            bind_dn: Some("cn=service,dc=example,dc=org".to_string()),
+            bind_password: Some("bind-password-secret".to_string()),
+            ..ldap_config(
+                "ldaps://service-account:url-password-secret@directory.example:1636/dc=private?token=query-secret#fragment-secret",
+            )
+        };
+
+        let debug = format!("{config:?}");
+
+        assert!(debug.contains("directory.example"));
+        assert!(debug.contains("1636"));
+        assert!(debug.contains("<redacted>"));
+        for secret in [
+            "service-account",
+            "url-password-secret",
+            "dc=private",
+            "query-secret",
+            "fragment-secret",
+            "bind-password-secret",
+        ] {
+            assert!(!debug.contains(secret));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reject LDAP provider URLs containing embedded user information and redact configured LDAP URL details from debug output.

Require service credentials to use the dedicated `bind_dn` and `bind_password` fields, while debug formatting retains only scheme, host, and port.

## Rationale

Credentials embedded in URLs are easily copied into diagnostics and can conflict with the explicit bind credential model. Rejecting them establishes one auditable credential path and reduces accidental disclosure.

## Behavior and compatibility

This is a breaking configuration change for deployments with URL userinfo. Move those credentials to `bind_dn` and `bind_password`. Normal LDAP URLs are unchanged; no database migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
