### PR TITLE
Redact credential-bearing debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Response debug logs no longer include custom HTTP header values, preventing
   pagination cursors and future secret-bearing headers from leaking into logs.
 - Redacted passwords, raw logout bearer tokens, stored token digests, task
-  request payloads, idempotency keys, task lease tokens, and credential-bearing
-  event-sink connection keys from debug output.
+  request payloads, idempotency keys, task lease tokens, event-sink delivery
+  fields, and credential-bearing event-sink connection keys from debug output.
 
 ## [0.0.8] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Response debug logs no longer include custom HTTP header values, preventing
   pagination cursors and future secret-bearing headers from leaking into logs.
 - Redacted passwords, raw logout bearer tokens, stored token digests, task
-  request payloads, idempotency keys, task lease tokens, event-sink delivery
-  fields, and credential-bearing event-sink connection keys from debug output.
+  request payloads, idempotency keys, task lease tokens, outbound HTTP headers
+  and response previews, event-sink delivery fields, and credential-bearing
+  event-sink connection keys from debug output.
 
 ## [0.0.8] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Response debug logs no longer include custom HTTP header values, preventing
   pagination cursors and future secret-bearing headers from leaking into logs.
 - Redacted passwords, raw logout bearer tokens, stored token digests, task
-  request payloads, idempotency keys, and task lease tokens from debug output.
+  request payloads, idempotency keys, task lease tokens, and credential-bearing
+  event-sink connection keys from debug output.
 
 ## [0.0.8] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   missing stages from capability mismatches without recording the capability.
 - Response debug logs no longer include custom HTTP header values, preventing
   pagination cursors and future secret-bearing headers from leaking into logs.
-- Redacted passwords, stored token digests, task request payloads,
-  idempotency keys, and task lease tokens from model debug output.
+- Redacted passwords, raw logout bearer tokens, stored token digests, task
+  request payloads, idempotency keys, and task lease tokens from debug output.
 
 ## [0.0.8] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   lease data, worker claim tokens, audit-event payloads, outbound HTTP headers,
   URLs and response previews, remote-target configuration and results,
   event-sink configuration and routing, full backup contents, restore
-  capabilities and errors, and credential-bearing connection cache keys.
+  capabilities and errors, login-limiter connection URLs, and
+  credential-bearing connection cache keys.
 
 ## [0.0.8] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   missing stages from capability mismatches without recording the capability.
 - Response debug logs no longer include custom HTTP header values, preventing
   pagination cursors and future secret-bearing headers from leaking into logs.
+- Redacted passwords, stored token digests, task request payloads,
+  idempotency keys, and task lease tokens from model debug output.
 
 ## [0.0.8] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   missing stages from capability mismatches without recording the capability.
 - Response debug logs no longer include custom HTTP header values, preventing
   pagination cursors and future secret-bearing headers from leaking into logs.
-- Redacted passwords, raw logout bearer tokens, stored token digests, task
-  request payloads, idempotency keys, task lease tokens, outbound HTTP headers
-  and response previews, event-sink delivery fields, and credential-bearing
-  event-sink connection keys from debug output.
+- Debug formatting now redacts authentication credentials, including raw
+  logout bearer tokens and stored token digests, along with task request and
+  lease data, worker claim tokens, audit-event payloads, outbound HTTP headers,
+  URLs and response previews, remote-target configuration and results,
+  event-sink configuration and routing, full backup contents, restore
+  capabilities and errors, and credential-bearing connection cache keys.
 
 ## [0.0.8] - 2026-08-01
 

--- a/crates/hubuum-event-sink-amqp/src/lib.rs
+++ b/crates/hubuum-event-sink-amqp/src/lib.rs
@@ -25,7 +25,7 @@ impl fmt::Debug for AmqpSink {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct AmqpConfig {
     uri: String,
     exchange: String,
@@ -39,6 +39,12 @@ struct AmqpConfig {
     mandatory: bool,
     #[serde(default)]
     max_payload_bytes: Option<usize>,
+}
+
+impl fmt::Debug for AmqpConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("AmqpConfig").finish_non_exhaustive()
+    }
 }
 
 impl AmqpSink {
@@ -184,6 +190,25 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+
+    #[test]
+    fn parsed_amqp_debug_omits_connection_configuration() {
+        let config = AmqpConfig {
+            uri: "amqps://user:connection-secret@example.invalid/%2f".to_string(),
+            exchange: "private-exchange".to_string(),
+            exchange_type: "topic".to_string(),
+            declare_exchange: true,
+            durable: true,
+            mandatory: false,
+            max_payload_bytes: Some(1024),
+        };
+
+        let debug = format!("{config:?}");
+
+        assert_eq!(debug, "AmqpConfig { .. }");
+        assert!(!debug.contains("connection-secret"));
+        assert!(!debug.contains("private-exchange"));
+    }
     fn envelope() -> EventEnvelope {
         EventEnvelope {
             id: 42,

--- a/crates/hubuum-event-sink-email/src/lib.rs
+++ b/crates/hubuum-event-sink-email/src/lib.rs
@@ -24,7 +24,7 @@ impl fmt::Debug for EmailSink {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct EmailConfig {
     uri: String,
     from: String,
@@ -38,7 +38,15 @@ struct EmailConfig {
     max_payload_bytes: Option<usize>,
 }
 
-#[derive(Debug, Deserialize)]
+impl fmt::Debug for EmailConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EmailConfig")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Deserialize)]
 struct EmailRouting {
     #[serde(default, alias = "to")]
     recipients: Vec<String>,
@@ -48,10 +56,25 @@ struct EmailRouting {
     bcc: Vec<String>,
 }
 
-#[derive(Debug)]
+impl fmt::Debug for EmailRouting {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EmailRouting")
+            .finish_non_exhaustive()
+    }
+}
+
 struct RenderedEmail {
     subject: String,
     body: String,
+}
+
+impl fmt::Debug for RenderedEmail {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RenderedEmail")
+            .finish_non_exhaustive()
+    }
 }
 
 impl EmailSink {
@@ -264,6 +287,38 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+
+    #[test]
+    fn parsed_email_debug_omits_configuration_routing_and_content() {
+        let config = EmailConfig {
+            uri: "smtps://user:connection-secret@example.invalid".to_string(),
+            from: "sender@example.invalid".to_string(),
+            reply_to: None,
+            subject_template: "subject-template-secret".to_string(),
+            body_template: "body-template-secret".to_string(),
+            max_payload_bytes: Some(1024),
+        };
+        let routing = EmailRouting {
+            recipients: vec!["recipient@example.invalid".to_string()],
+            cc: Vec::new(),
+            bcc: vec!["hidden@example.invalid".to_string()],
+        };
+        let rendered = RenderedEmail {
+            subject: "rendered-subject-secret".to_string(),
+            body: "rendered-body-secret".to_string(),
+        };
+
+        let config_debug = format!("{config:?}");
+        let routing_debug = format!("{routing:?}");
+        let rendered_debug = format!("{rendered:?}");
+
+        assert_eq!(config_debug, "EmailConfig { .. }");
+        assert_eq!(routing_debug, "EmailRouting { .. }");
+        assert_eq!(rendered_debug, "RenderedEmail { .. }");
+        assert!(!config_debug.contains("connection-secret"));
+        assert!(!routing_debug.contains("hidden@example.invalid"));
+        assert!(!rendered_debug.contains("rendered-body-secret"));
+    }
     fn envelope() -> EventEnvelope {
         EventEnvelope {
             id: 42,

--- a/crates/hubuum-event-sink-valkey/src/lib.rs
+++ b/crates/hubuum-event-sink-valkey/src/lib.rs
@@ -23,7 +23,7 @@ impl fmt::Debug for ValkeySink {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct ValkeyConfig {
     uri: String,
     #[serde(default)]
@@ -36,18 +36,41 @@ struct ValkeyConfig {
     io_timeout_ms: Option<u64>,
 }
 
-#[derive(Debug, Deserialize)]
+impl fmt::Debug for ValkeyConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ValkeyConfig")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Deserialize)]
 struct ValkeyRouting {
     stream: String,
 }
 
-#[derive(Debug)]
+impl fmt::Debug for ValkeyRouting {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ValkeyRouting")
+            .finish_non_exhaustive()
+    }
+}
+
 struct StreamEntry {
     stream: String,
     max_len: Option<usize>,
     approximate_trim: bool,
     io_timeout: Duration,
     fields: Vec<(&'static str, String)>,
+}
+
+impl fmt::Debug for StreamEntry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StreamEntry")
+            .finish_non_exhaustive()
+    }
 }
 
 impl ValkeySink {
@@ -197,6 +220,38 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+
+    #[test]
+    fn parsed_valkey_debug_omits_connection_routing_and_payload_fields() {
+        let config = ValkeyConfig {
+            uri: "rediss://user:connection-secret@example.invalid/0".to_string(),
+            max_len: Some(100),
+            approximate_trim: true,
+            max_payload_bytes: Some(1024),
+            io_timeout_ms: Some(2000),
+        };
+        let routing = ValkeyRouting {
+            stream: "private-stream".to_string(),
+        };
+        let entry = StreamEntry {
+            stream: "private-stream".to_string(),
+            max_len: Some(100),
+            approximate_trim: true,
+            io_timeout: Duration::from_secs(2),
+            fields: vec![("event", "payload-secret".to_string())],
+        };
+
+        let config_debug = format!("{config:?}");
+        let routing_debug = format!("{routing:?}");
+        let entry_debug = format!("{entry:?}");
+
+        assert_eq!(config_debug, "ValkeyConfig { .. }");
+        assert_eq!(routing_debug, "ValkeyRouting { .. }");
+        assert_eq!(entry_debug, "StreamEntry { .. }");
+        assert!(!config_debug.contains("connection-secret"));
+        assert!(!routing_debug.contains("private-stream"));
+        assert!(!entry_debug.contains("payload-secret"));
+    }
     fn envelope() -> EventEnvelope {
         EventEnvelope {
             id: 42,

--- a/crates/hubuum-event-sink-webhook/src/lib.rs
+++ b/crates/hubuum-event-sink-webhook/src/lib.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
 use hubuum_event_sinks_common::{
     EventEnvelope, SinkDelivery, SinkError, ensure_payload_within_limit, parse_sink_config,
@@ -38,12 +38,20 @@ pub struct WebhookSinkSettings {
     pub dangerous_allow_localhost: bool,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct WebhookRouting {
     url: String,
 }
 
-#[derive(Debug, Default, Deserialize)]
+impl fmt::Debug for WebhookRouting {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WebhookRouting")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Default, Deserialize)]
 struct WebhookConfig {
     #[serde(default)]
     timeout_ms: Option<u64>,
@@ -53,6 +61,14 @@ struct WebhookConfig {
     max_request_bytes: Option<usize>,
     #[serde(default)]
     headers: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+impl fmt::Debug for WebhookConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WebhookConfig")
+            .finish_non_exhaustive()
+    }
 }
 
 async fn deliver_webhook(
@@ -178,6 +194,29 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+
+    #[test]
+    fn parsed_webhook_debug_omits_routing_and_header_values() {
+        let routing = WebhookRouting {
+            url: "https://example.invalid/hook?token=routing-secret".to_string(),
+        };
+        let config = WebhookConfig {
+            headers: Some(serde_json::Map::from_iter([(
+                "authorization".to_string(),
+                serde_json::Value::String("header-secret".to_string()),
+            )])),
+            ..WebhookConfig::default()
+        };
+
+        let routing_debug = format!("{routing:?}");
+        let config_debug = format!("{config:?}");
+
+        assert_eq!(routing_debug, "WebhookRouting { .. }");
+        assert_eq!(config_debug, "WebhookConfig { .. }");
+        assert!(!routing_debug.contains("routing-secret"));
+        assert!(!config_debug.contains("header-secret"));
+    }
+
     const LOCALHOST_CERT_DER_B64: &str = "MIIDHzCCAgegAwIBAgIUT7YypqM2YgvdrXLHby8OFyeNEEIwDQYJKoZIhvcNAQELBQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDYyMzA0MDEyMloXDTI2MDYyNDA0MDEyMlowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAn3A378veyRzeP7MSS/S61EPpE+v9Z+fGlFC4qB8SOUHvO1D6+QZrqcKkUJZb/HKnQyDydMNMBJfjswid5l18ogPVFmfGInGp50T3ceH8i1DAnN1Bj6g6h/QgKe64elkYDukaoHkqLGiQ7Nwsllm8UqwdgFa+B1hYD6uoYAcd/4gv5ClxOx6bkwganvWas+PXyHEEdYW7YBRAyPrJHIInWjck5k5UJPn5Vy551ptGpurvUqf2M7VcmnxjHAldTnc9br+chIvLtyulWg8pBAdFwu+4ZM0jWQpTRhVi5lWB+q7mmI8Da4izV0/K2a1bDnSN6j4rmAzEknok0fMoGXzWjQIDAQABo2kwZzAdBgNVHQ4EFgQUDp9XEjhqPBb8Ef0vyJXXDqLjcDwwHwYDVR0jBBgwFoAUDp9XEjhqPBb8Ef0vyJXXDqLjcDwwDwYDVR0TAQH/BAUwAwEB/zAUBgNVHREEDTALgglsb2NhbGhvc3QwDQYJKoZIhvcNAQELBQADggEBAJFxe1GtT9g/PI0Ht912WKwCJc8Oj0U49zUK8TRe9VZHMaJriozeS+4P6I6RhmMR4RV2bPtvjQjzv9ZCHoGoiPUupHd+PUGn8oyezDWoGLuwlPE0dQyn3OAdV1no6q/HI6PFThHTd2o/cLl3nfyIu56sCRLiwrMg6xH3UZ6VJ4qjtxTuyYloMNrb09Uyo7G1Qpw7qfiOB8whyJcjC8Gx1H1JTmF/h/CU2u79yAcVIRA4N6zJLAdtsseUjyTb5CAagmvZ6wZBqB+XNCwXzV09+56zt5fFtopF7mBgQcE21wtlzoKKLUyivc5FzgOHPv3YDJiooYyFXcOOobY1B0k8ih8=";
     const LOCALHOST_KEY_DER_B64: &str = "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCfcDfvy97JHN4/sxJL9LrUQ+kT6/1n58aUULioHxI5Qe87UPr5BmupwqRQllv8cqdDIPJ0w0wEl+OzCJ3mXXyiA9UWZ8YicannRPdx4fyLUMCc3UGPqDqH9CAp7rh6WRgO6RqgeSosaJDs3CyWWbxSrB2AVr4HWFgPq6hgBx3/iC/kKXE7HpuTCBqe9Zqz49fIcQR1hbtgFEDI+skcgidaNyTmTlQk+flXLnnWm0am6u9Sp/YztVyafGMcCV1Odz1uv5yEi8u3K6VaDykEB0XC77hkzSNZClNGFWLmVYH6ruaYjwNriLNXT8rZrVsOdI3qPiuYDMSSeiTR8ygZfNaNAgMBAAECggEAAQH66ebA1Y9whamibqggtQiyrd6HAohCnR1CEhpOWCcaXPbuAtJNkUapRSf72gAAND4v3j2ikL1S+P9Yxhc7lBclbMoV+3uxk5+qFYVxzNlzsz1RoLUMs0IkCtEt6L/UyIaLDjLGUCavrIAKuxNKlM0/EOOgCcyljFuUUAIKIwOcOKv7rG/t7GC+wZMTT3oyICgihwsN7D527BTKRlk6zcSCj38B21drfgLAMreGRt8NGcByhzo3BuazRkYyEw8SP9LCEbDQKwWGR2xJtxwnSHcrvYvSklhDAB3EP29URstGUxapRg4re25e3MRVIjVdYtCeGt8Ie71UZgO/lgwYAQKBgQDPL192FKjTUwqfhjICpXYiNbbseXw7dvvNfLOZvuE20zPTkwwEWkpF2dxQX44RfYS625jzj9GHRijKwL6HlV89i+pNw+N2OWLUdWkkeMVqqknSPgJavZ4O3WKpk+cSgVm0VgaxNfvwoNi+TnLQblP6YFoXMG/luY3wYg0CviHzAQKBgQDFAPGIU/G6SYAnD5SJcojUXKzH3ivvciBYuLJt4FGUlfym9fnkQNbGNJAL4c3otPTcR/r0br2JIrxod5/w4c93Q4EKmXEwMdW26npxDR8uO/caSvFGZweikqxIj0Im5UlGV3cuanFb+u0jZWjCjFxMO2sWGRMdwrgQm+GyG7z/jQKBgA+vxIiKM+YcKXe+j1bH9FPOwVTSNefCsHn0cRy46RBfmVLxlT1XILx9LEMhmP4WBNCpA8GdJ/4X/8qqIULeumFMkKbmp/gxjBwN77IFOt1Cm2hBraf1J1x0wp2YRyyNgp82zDbqoXKsmvx9sA+76rvQQ8Hxtucrz2Vd5yJIBwYBAoGAaLd7q8+TKkZvjFPHzNfIy7kHTqZWDE1JzF9A2Q7nzmd7iPQvBJlCkNDX0LkSTqQBlCXey5chwIdqRs1vgwdE1ExZh1zQwaF7zGMO+pDTBixxyNQVNCsH7+6vDVK5AxvVu0I6471IzG+xJaN98AvT8+GRpollk+gxFwMFETuVVvECgYAJ8qBnL/YnusNmORCdItqG6adl+0H4ohikxNurIP8cBRjKGJ6XSC2Qs3BmljiqL9aLluKTcbhOBKlH6iq63vA8KxF7JjVBj2NXClDh6MO6hr/4gWTi7VMpC3CWT80IijoMAth37y+MImdaJhG2kut+XcT14KFakVJM1JCbe0Ygdw==";
 

--- a/crates/hubuum-event-sinks-common/src/lib.rs
+++ b/crates/hubuum-event-sinks-common/src/lib.rs
@@ -159,9 +159,14 @@ fn uri_userinfo(uri: &str) -> Option<&str> {
     (!userinfo.is_empty() && !host.is_empty()).then_some(userinfo)
 }
 
-#[derive(Debug)]
 pub struct UriConnectionPool<K, V> {
     entries: Mutex<std::collections::HashMap<K, V>>,
+}
+
+impl<K, V> fmt::Debug for UriConnectionPool<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UriConnectionPool").finish_non_exhaustive()
+    }
 }
 
 impl<K, V> Default for UriConnectionPool<K, V> {

--- a/crates/hubuum-event-sinks-common/src/lib.rs
+++ b/crates/hubuum-event-sinks-common/src/lib.rs
@@ -76,11 +76,17 @@ pub fn ensure_payload_within_limit(
     Ok(())
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct SinkDelivery<'a> {
     pub config: &'a Value,
     pub routing: &'a Value,
     pub secret_ref: Option<&'a str>,
+}
+
+impl fmt::Debug for SinkDelivery<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SinkDelivery").finish_non_exhaustive()
+    }
 }
 
 impl<'a> SinkDelivery<'a> {

--- a/crates/hubuum-events-core/src/lib.rs
+++ b/crates/hubuum-events-core/src/lib.rs
@@ -415,7 +415,7 @@ pub fn valid_actions(entity_type: EntityType) -> &'static [Action] {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(ToSchema))]
 pub struct EventEnvelope {
     pub id: i64,
@@ -436,6 +436,32 @@ pub struct EventEnvelope {
     pub after: Option<serde_json::Value>,
     pub metadata: serde_json::Value,
     pub schema_version: i32,
+}
+
+impl fmt::Debug for EventEnvelope {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EventEnvelope")
+            .field("id", &self.id)
+            .field("event_id", &self.event_id)
+            .field("occurred_at", &self.occurred_at)
+            .field("entity_type", &self.entity_type)
+            .field("entity_id", &self.entity_id)
+            .field("entity_name", &self.entity_name)
+            .field("collection_id", &self.collection_id)
+            .field("action", &self.action)
+            .field("actor_user_id", &self.actor_user_id)
+            .field("actor_kind", &self.actor_kind)
+            .field("provenance", &self.provenance)
+            .field("request_id", &self.request_id)
+            .field("correlation_id", &self.correlation_id)
+            .field("summary", &self.summary)
+            .field("before", &self.before.as_ref().map(|_| "<redacted>"))
+            .field("after", &self.after.as_ref().map(|_| "<redacted>"))
+            .field("metadata", &"<redacted>")
+            .field("schema_version", &self.schema_version)
+            .finish()
+    }
 }
 
 impl EventEnvelope {
@@ -993,5 +1019,20 @@ mod tests {
             metadata: serde_json::json!({"related_collection_ids": [20, "21"]}),
             schema_version: 1,
         }
+    }
+
+    #[test]
+    fn event_envelope_debug_redacts_payload_snapshots() {
+        let mut event = envelope();
+        event.before = Some(serde_json::json!({"token": "before-secret"}));
+        event.after = Some(serde_json::json!({"token": "after-secret"}));
+        event.metadata = serde_json::json!({"token": "metadata-secret"});
+
+        let debug = format!("{event:?}");
+
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("before-secret"));
+        assert!(!debug.contains("after-secret"));
+        assert!(!debug.contains("metadata-secret"));
     }
 }

--- a/crates/hubuum-outbound-http/src/lib.rs
+++ b/crates/hubuum-outbound-http/src/lib.rs
@@ -307,9 +307,23 @@ fn transport_controls_header(name: &HeaderName) -> bool {
     )
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct OutboundHeaders {
     inner: HeaderMap,
+}
+
+impl fmt::Debug for OutboundHeaders {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let names = self
+            .inner
+            .keys()
+            .map(HeaderName::as_str)
+            .collect::<Vec<_>>();
+        formatter
+            .debug_struct("OutboundHeaders")
+            .field("names", &names)
+            .finish()
+    }
 }
 
 impl OutboundHeaders {
@@ -394,7 +408,6 @@ impl OutboundRequest {
     }
 }
 
-#[derive(Debug)]
 pub struct OutboundResponse {
     status_code: u16,
     status_display: String,
@@ -403,6 +416,21 @@ pub struct OutboundResponse {
     body_preview: String,
     duration_ms: i32,
     url: String,
+}
+
+impl fmt::Debug for OutboundResponse {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OutboundResponse")
+            .field("status_code", &self.status_code)
+            .field("status_display", &self.status_display)
+            .field("success", &self.success)
+            .field("headers", &"[REDACTED]")
+            .field("body_preview", &"[REDACTED]")
+            .field("duration_ms", &self.duration_ms)
+            .field("url", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl OutboundResponse {
@@ -686,6 +714,41 @@ mod tests {
             OutboundHttpError::Request.to_string(),
             "outbound call failed"
         );
+    }
+
+    #[test]
+    fn outbound_headers_debug_omits_header_values() {
+        let raw_authorization = "Bearer outbound-secret";
+        let mut headers = OutboundHeaders::new();
+        headers.insert("authorization", raw_authorization).unwrap();
+        headers.insert("x-request-id", "request-1").unwrap();
+
+        let debug = format!("{headers:?}");
+
+        assert!(debug.contains("authorization"));
+        assert!(debug.contains("x-request-id"));
+        assert!(!debug.contains(raw_authorization));
+    }
+
+    #[test]
+    fn outbound_response_debug_omits_payload_headers_and_url() {
+        let response = OutboundResponse {
+            status_code: 200,
+            status_display: "200 OK".to_string(),
+            success: true,
+            headers: serde_json::json!({"set-cookie": "response-header-secret"}),
+            body_preview: "response-body-secret".to_string(),
+            duration_ms: 12,
+            url: "https://example.invalid/hook?token=url-secret".to_string(),
+        };
+
+        let debug = format!("{response:?}");
+
+        assert!(debug.contains("status_code: 200"));
+        assert!(debug.contains("duration_ms: 12"));
+        assert!(!debug.contains("response-header-secret"));
+        assert!(!debug.contains("response-body-secret"));
+        assert!(!debug.contains("url-secret"));
     }
 
     #[test]

--- a/crates/hubuum-outbound-http/src/lib.rs
+++ b/crates/hubuum-outbound-http/src/lib.rs
@@ -122,11 +122,22 @@ impl OutboundMethod {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct OutboundUrlParts {
     url: Url,
     host: String,
     port: u16,
+}
+
+impl fmt::Debug for OutboundUrlParts {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OutboundUrlParts")
+            .field("url", &"[REDACTED]")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .finish()
+    }
 }
 
 impl OutboundUrlParts {
@@ -669,6 +680,17 @@ mod tests {
             validate_outbound_url("https://example.com@127.0.0.1/hook"),
             Err(OutboundHttpError::EmbeddedCredentials)
         ));
+    }
+
+    #[test]
+    fn outbound_url_debug_omits_query_credentials() {
+        let parts = validate_outbound_url("https://example.com/hook?api_key=query-secret").unwrap();
+
+        let debug = format!("{parts:?}");
+
+        assert!(debug.contains("example.com"));
+        assert!(debug.contains("port: 443"));
+        assert!(!debug.contains("query-secret"));
     }
 
     #[test]

--- a/crates/hubuum-task-core/src/lib.rs
+++ b/crates/hubuum-task-core/src/lib.rs
@@ -14,8 +14,17 @@ use std::str::FromStr;
 pub const MAX_IDEMPOTENCY_KEY_BYTES: usize = 255;
 
 /// A non-empty, storage-safe task idempotency key.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct IdempotencyKey(String);
+
+impl fmt::Debug for IdempotencyKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("IdempotencyKey")
+            .field(&"[REDACTED]")
+            .finish()
+    }
+}
 
 impl IdempotencyKey {
     pub fn new(value: impl Into<String>) -> Result<Self, IdempotencyKeyError> {
@@ -92,6 +101,17 @@ mod tests {
         let key = IdempotencyKey::new("x".repeat(MAX_IDEMPOTENCY_KEY_BYTES)).unwrap();
 
         assert_eq!(key.as_str().len(), MAX_IDEMPOTENCY_KEY_BYTES);
+    }
+
+    #[test]
+    fn debug_redacts_the_key_value() {
+        let raw_key = "customer-supplied-idempotency-secret";
+        let key = IdempotencyKey::new(raw_key).unwrap();
+
+        let debug = format!("{key:?}");
+
+        assert_eq!(debug, "IdempotencyKey(\"[REDACTED]\")");
+        assert!(!debug.contains(raw_key));
     }
 
     #[test]

--- a/src/api/handlers/auth.rs
+++ b/src/api/handlers/auth.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::api::openapi::{ApiErrorResponse, LoginResponse, MessageResponse};
 use crate::api::response::ApiResponse;
 use crate::db::DbPool;
@@ -6,16 +8,25 @@ use crate::extractors::{AdminAccess, Authenticated, ManagementAccess};
 use crate::middlewares::rate_limit::{
     LoginAttemptOutcome, begin_login_attempt, client_ip_for_request, finish_login_attempt,
 };
-use crate::models::{LOCAL_IDENTITY_SCOPE, LoginUser, Token, UserID};
+use crate::models::{LOCAL_IDENTITY_SCOPE, LoginUser, REDACTED_DEBUG_VALUE, Token, UserID};
 use crate::observability::metrics;
 use actix_web::{HttpRequest, Responder, get, post, web};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
 pub struct LogoutTokenRequest {
     pub token: String,
+}
+
+impl fmt::Debug for LogoutTokenRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LogoutTokenRequest")
+            .field("token", &REDACTED_DEBUG_VALUE)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -302,4 +313,23 @@ pub async fn validate_token(user_access: Authenticated) -> Result<impl Responder
     );
 
     Ok(ApiResponse::message("Token is valid."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logout_token_request_debug_redacts_raw_bearer_token() {
+        let raw_token = "raw-logout-bearer-token";
+        let debug = format!(
+            "{:?}",
+            LogoutTokenRequest {
+                token: raw_token.to_string(),
+            }
+        );
+
+        assert!(!debug.contains(raw_token));
+        assert!(debug.contains(REDACTED_DEBUG_VALUE));
+    }
 }

--- a/src/db/traits/restore.rs
+++ b/src/db/traits/restore.rs
@@ -92,7 +92,7 @@ const HISTORY_SEQUENCE_TABLES: &[&str] = &[
 
 const DATABASE_UTC_NOW_SQL: &str = "clock_timestamp() AT TIME ZONE 'UTC'";
 
-#[derive(Debug, Queryable, Selectable)]
+#[derive(Queryable, Selectable)]
 #[diesel(table_name = crate::schema::restore_jobs)]
 pub(crate) struct RestoreJobStatusRecord {
     pub(crate) id: i64,

--- a/src/events/model.rs
+++ b/src/events/model.rs
@@ -11,11 +11,13 @@ use crate::db::prelude::*;
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::errors::ApiError;
 use crate::models::search::{FilterField, SortParam};
+use crate::models::{REDACTED_DEBUG_VALUE, redacted_debug_option};
 use crate::pagination::{
     CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
 };
@@ -146,7 +148,7 @@ impl From<EventId> for Uuid {
 }
 
 /// A committed event row — the read model for the audit log (#74) and delivery.
-#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
+#[derive(Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name = events)]
 pub struct Event {
     pub id: i64,
@@ -173,7 +175,40 @@ pub struct Event {
     pub task_id: Option<i32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+impl fmt::Debug for Event {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Event")
+            .field("id", &self.id)
+            .field("event_id", &self.event_id)
+            .field("occurred_at", &self.occurred_at)
+            .field("entity_type", &self.entity_type)
+            .field("entity_id", &self.entity_id)
+            .field("entity_name", &self.entity_name)
+            .field("collection_id", &self.collection_id)
+            .field("action", &self.action)
+            .field("actor_user_id", &self.actor_user_id)
+            .field("actor_kind", &self.actor_kind)
+            .field("request_id", &self.request_id)
+            .field("correlation_id", &self.correlation_id)
+            .field("summary", &self.summary)
+            .field("before", &redacted_debug_option(&self.before))
+            .field("after", &redacted_debug_option(&self.after))
+            .field("metadata", &REDACTED_DEBUG_VALUE)
+            .field("schema_version", &self.schema_version)
+            .field("dispatched_at", &self.dispatched_at)
+            .field("fanout_locked_until", &self.fanout_locked_until)
+            .field(
+                "fanout_claim_token",
+                &redacted_debug_option(&self.fanout_claim_token),
+            )
+            .field("initiator_user_id", &self.initiator_user_id)
+            .field("task_id", &self.task_id)
+            .finish()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct EventResponse {
     pub id: i64,
     pub event_id: Uuid,
@@ -193,6 +228,32 @@ pub struct EventResponse {
     pub after: Option<serde_json::Value>,
     pub metadata: serde_json::Value,
     pub schema_version: i32,
+}
+
+impl fmt::Debug for EventResponse {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EventResponse")
+            .field("id", &self.id)
+            .field("event_id", &self.event_id)
+            .field("occurred_at", &self.occurred_at)
+            .field("entity_type", &self.entity_type)
+            .field("entity_id", &self.entity_id)
+            .field("entity_name", &self.entity_name)
+            .field("collection_id", &self.collection_id)
+            .field("action", &self.action)
+            .field("actor_user_id", &self.actor_user_id)
+            .field("actor_kind", &self.actor_kind)
+            .field("provenance", &self.provenance)
+            .field("request_id", &self.request_id)
+            .field("correlation_id", &self.correlation_id)
+            .field("summary", &self.summary)
+            .field("before", &redacted_debug_option(&self.before))
+            .field("after", &redacted_debug_option(&self.after))
+            .field("metadata", &REDACTED_DEBUG_VALUE)
+            .field("schema_version", &self.schema_version)
+            .finish()
+    }
 }
 
 impl Event {
@@ -322,7 +383,7 @@ impl CursorSqlMapping for EventResponse {
 /// snapshot fields are added with the `with_*` builders. Columns owned by the
 /// database (`id`, `occurred_at`, `dispatched_at`, fan-out claim fields) are
 /// intentionally absent so the row uses their defaults on insert.
-#[derive(Debug, Insertable)]
+#[derive(Insertable)]
 #[diesel(table_name = events)]
 pub struct NewEvent {
     event_id: Uuid,
@@ -342,6 +403,31 @@ pub struct NewEvent {
     after: Option<serde_json::Value>,
     metadata: serde_json::Value,
     schema_version: i32,
+}
+
+impl fmt::Debug for NewEvent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NewEvent")
+            .field("event_id", &self.event_id)
+            .field("entity_type", &self.entity_type)
+            .field("entity_id", &self.entity_id)
+            .field("entity_name", &self.entity_name)
+            .field("collection_id", &self.collection_id)
+            .field("action", &self.action)
+            .field("actor_user_id", &self.actor_user_id)
+            .field("actor_kind", &self.actor_kind)
+            .field("initiator_user_id", &self.initiator_user_id)
+            .field("task_id", &self.task_id)
+            .field("request_id", &self.request_id)
+            .field("correlation_id", &self.correlation_id)
+            .field("summary", &self.summary)
+            .field("before", &redacted_debug_option(&self.before))
+            .field("after", &redacted_debug_option(&self.after))
+            .field("metadata", &REDACTED_DEBUG_VALUE)
+            .field("schema_version", &self.schema_version)
+            .finish()
+    }
 }
 
 impl NewEvent {
@@ -490,5 +576,74 @@ impl NewEvent {
     /// The caller-provided correlation id, if any.
     pub fn correlation_id(&self) -> Option<&str> {
         self.correlation_id.as_deref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn timestamp() -> NaiveDateTime {
+        chrono::DateTime::from_timestamp(1_700_000_000, 0)
+            .unwrap()
+            .naive_utc()
+    }
+
+    #[test]
+    fn new_event_debug_redacts_payload_snapshots() {
+        let event = NewEvent::new(
+            EntityType::Collection,
+            Action::Created,
+            ActorKind::User,
+            "created",
+        )
+        .unwrap()
+        .with_before(serde_json::json!({"token": "before-secret"}))
+        .with_after(serde_json::json!({"token": "after-secret"}))
+        .with_metadata(serde_json::json!({"token": "metadata-secret"}));
+
+        let debug = format!("{event:?}");
+
+        assert!(debug.contains(REDACTED_DEBUG_VALUE));
+        assert!(!debug.contains("before-secret"));
+        assert!(!debug.contains("after-secret"));
+        assert!(!debug.contains("metadata-secret"));
+    }
+
+    #[test]
+    fn stored_event_debug_redacts_payloads_and_fanout_claim_token() {
+        let claim_token = Uuid::parse_str("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").unwrap();
+        let event = Event {
+            id: 1,
+            event_id: Uuid::new_v4(),
+            occurred_at: timestamp(),
+            entity_type: EntityType::Collection.as_str().to_string(),
+            entity_id: Some(2),
+            entity_name: Some("collection".to_string()),
+            collection_id: Some(2),
+            action: Action::Created.as_str().to_string(),
+            actor_user_id: Some(3),
+            actor_kind: ActorKind::User.as_str().to_string(),
+            request_id: None,
+            correlation_id: None,
+            summary: "created".to_string(),
+            before: Some(serde_json::json!({"token": "stored-before-secret"})),
+            after: Some(serde_json::json!({"token": "stored-after-secret"})),
+            metadata: serde_json::json!({"token": "stored-metadata-secret"}),
+            schema_version: 1,
+            dispatched_at: None,
+            fanout_locked_until: Some(timestamp()),
+            fanout_claim_token: Some(claim_token),
+            initiator_user_id: Some(3),
+            task_id: None,
+        };
+
+        let debug = format!("{event:?}");
+
+        assert!(debug.contains(REDACTED_DEBUG_VALUE));
+        assert!(!debug.contains("stored-before-secret"));
+        assert!(!debug.contains("stored-after-secret"));
+        assert!(!debug.contains("stored-metadata-secret"));
+        assert!(!debug.contains(&claim_token.to_string()));
     }
 }

--- a/src/events/sink.rs
+++ b/src/events/sink.rs
@@ -206,6 +206,7 @@ impl Sink for hubuum_event_sink_valkey::ValkeySink {
 #[cfg(test)]
 mod tests {
     use futures::FutureExt;
+    use hubuum_event_sinks_common::UriConnectionPool;
     use uuid::Uuid;
 
     use super::*;
@@ -280,6 +281,22 @@ mod tests {
             .deliver(&envelope, &subscription, &sink)
             .await
             .unwrap();
+    }
+
+    #[actix_rt::test]
+    async fn uri_connection_pool_debug_omits_credential_bearing_keys() {
+        let pool = UriConnectionPool::<String, String>::default();
+        pool.get_or_try_insert_with(
+            "rediss://user:secret@example.invalid/0".to_string(),
+            |_| async { Ok("client with secret state".to_string()) },
+        )
+        .await
+        .unwrap();
+
+        let debug = format!("{pool:?}");
+        assert_eq!(debug, "UriConnectionPool { .. }");
+        assert!(!debug.contains("secret"));
+        assert!(!debug.contains("example.invalid"));
     }
 
     #[cfg(any(feature = "amqp", feature = "email", feature = "valkey"))]

--- a/src/events/sink.rs
+++ b/src/events/sink.rs
@@ -299,6 +299,23 @@ mod tests {
         assert!(!debug.contains("example.invalid"));
     }
 
+    #[test]
+    fn sink_delivery_debug_omits_config_routing_and_secret_reference() {
+        let config = serde_json::json!({
+            "headers": {"authorization": "Bearer config-secret"}
+        });
+        let routing = serde_json::json!({
+            "url": "https://user:routing-secret@example.invalid/events"
+        });
+        let delivery = SinkDelivery::new(&config, &routing, Some("secret-reference"));
+
+        let debug = format!("{delivery:?}");
+        assert_eq!(debug, "SinkDelivery { .. }");
+        assert!(!debug.contains("config-secret"));
+        assert!(!debug.contains("routing-secret"));
+        assert!(!debug.contains("secret-reference"));
+    }
+
     #[cfg(any(feature = "amqp", feature = "email", feature = "valkey"))]
     #[test]
     fn tls_scheme_validator_rejects_cleartext_uris() {

--- a/src/middlewares/rate_limit.rs
+++ b/src/middlewares/rate_limit.rs
@@ -4,8 +4,10 @@ use ipnet::{Ipv4Net, Ipv6Net};
 use crate::config::{LoginRateLimitConfig, login_rate_limit_config};
 use crate::errors::ApiError;
 use crate::middlewares::client_allowlist::{ProxyTrust, extract_client_ip_from_http_request};
+use crate::models::REDACTED_DEBUG_VALUE;
 
 use std::collections::{HashMap, VecDeque};
+use std::fmt;
 use std::net::IpAddr;
 #[cfg(feature = "login-rate-limit-valkey")]
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -117,7 +119,7 @@ pub struct LoginRateLimitStoreSettings {
     backend: LoginRateLimitStoreBackend,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 enum LoginRateLimitStoreBackend {
     Memory,
     #[cfg(feature = "login-rate-limit-valkey")]
@@ -126,6 +128,23 @@ enum LoginRateLimitStoreBackend {
         prefix: String,
         io_timeout: Duration,
     },
+}
+
+impl fmt::Debug for LoginRateLimitStoreBackend {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Memory => formatter.write_str("Memory"),
+            #[cfg(feature = "login-rate-limit-valkey")]
+            Self::Valkey {
+                prefix, io_timeout, ..
+            } => formatter
+                .debug_struct("Valkey")
+                .field("url", &REDACTED_DEBUG_VALUE)
+                .field("prefix", prefix)
+                .field("io_timeout", io_timeout)
+                .finish(),
+        }
+    }
 }
 
 impl LoginRateLimitStoreSettings {
@@ -768,6 +787,26 @@ mod tests {
     use super::*;
     use rstest::rstest;
     use std::net::Ipv4Addr;
+
+    #[cfg(feature = "login-rate-limit-valkey")]
+    #[test]
+    fn valkey_store_settings_debug_redacts_connection_url() {
+        let settings = LoginRateLimitStoreSettings::valkey(
+            "redis://limiter-user:limiter-secret@valkey.example/7",
+            "hubuum-login",
+            Duration::from_secs(2),
+        )
+        .unwrap();
+
+        let debug = format!("{settings:?}");
+
+        assert!(debug.contains(REDACTED_DEBUG_VALUE));
+        assert!(debug.contains("hubuum-login"));
+        assert!(debug.contains("2s"));
+        assert!(!debug.contains("limiter-user"));
+        assert!(!debug.contains("limiter-secret"));
+        assert!(!debug.contains("valkey.example"));
+    }
 
     #[rstest]
     #[case("u:local/alice|192.0.2.1", "principal_ip")]

--- a/src/models/backup.rs
+++ b/src/models/backup.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fmt;
 use std::str::FromStr;
 
 use chrono::NaiveDateTime;
@@ -8,6 +9,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::errors::ApiError;
+use crate::models::{REDACTED_DEBUG_VALUE, redacted_debug_option};
 use crate::schema::{backup_task_outputs, restore_jobs, server_instances};
 
 use super::principal::Principal;
@@ -167,20 +169,46 @@ pub struct BackupManifest {
 /// Privileged, restore-only table snapshots. In backup version 3, each section
 /// name and row shape corresponds to the PostgreSQL table restored from it.
 /// These are versioned disaster-recovery internals, not portable import data.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema, Default)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, ToSchema, Default)]
 pub struct BackupHistory {
     #[schema(value_type = Object)]
     pub sections: BTreeMap<String, Vec<serde_json::Value>>,
 }
 
+impl fmt::Debug for BackupHistory {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BackupHistory")
+            .field("section_count", &self.sections.len())
+            .field(
+                "row_count",
+                &self.sections.values().map(Vec::len).sum::<usize>(),
+            )
+            .finish()
+    }
+}
+
 /// Exact logical rows used by the destructive full-system restore path.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema, Default)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, ToSchema, Default)]
 pub struct BackupState {
     #[schema(value_type = Object)]
     pub sections: BTreeMap<String, Vec<serde_json::Value>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+impl fmt::Debug for BackupState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BackupState")
+            .field("section_count", &self.sections.len())
+            .field(
+                "row_count",
+                &self.sections.values().map(Vec::len).sum::<usize>(),
+            )
+            .finish()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct BackupDocument {
     pub backup_version: i32,
@@ -189,6 +217,20 @@ pub struct BackupDocument {
     pub state: BackupState,
     pub history: Option<BackupHistory>,
     pub manifest: BackupManifest,
+}
+
+impl fmt::Debug for BackupDocument {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BackupDocument")
+            .field("backup_version", &self.backup_version)
+            .field("created_at", &self.created_at)
+            .field("source_version", &self.source_version)
+            .field("state", &self.state)
+            .field("history", &self.history)
+            .field("manifest", &self.manifest)
+            .finish()
+    }
 }
 
 impl BackupDocument {
@@ -368,7 +410,7 @@ pub struct RestoreValidationSummary {
     pub total_items: i64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct RestoreStageResponse {
     pub id: i64,
     pub status: RestoreJobStatus,
@@ -391,12 +433,53 @@ pub struct RestoreStageResponse {
     pub restore_capability: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+impl fmt::Debug for RestoreStageResponse {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoreStageResponse")
+            .field("id", &self.id)
+            .field("status", &self.status)
+            .field("requested_by", &self.requested_by)
+            .field(
+                "requested_by_identity_scope",
+                &self.requested_by_identity_scope,
+            )
+            .field("requested_by_name", &self.requested_by_name)
+            .field("sha256", &self.sha256)
+            .field("byte_size", &self.byte_size)
+            .field("expires_at", &self.expires_at)
+            .field("error", &redacted_debug_option(&self.error))
+            .field("confirmed_at", &self.confirmed_at)
+            .field("started_at", &self.started_at)
+            .field("finished_at", &self.finished_at)
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .field("validation", &self.validation)
+            .field(
+                "restore_capability",
+                &redacted_debug_option(&self.restore_capability),
+            )
+            .finish()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RestoreConfirmRequest {
     pub restore_capability: String,
     pub sha256: String,
     pub confirmation: String,
+}
+
+impl fmt::Debug for RestoreConfirmRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoreConfirmRequest")
+            .field("restore_capability", &REDACTED_DEBUG_VALUE)
+            .field("sha256", &self.sha256)
+            .field("confirmation", &self.confirmation)
+            .finish()
+    }
 }
 
 pub const RESTORE_CONFIRMATION_PHRASE: &str = "REPLACE ALL HUBUUM DATA";
@@ -409,4 +492,85 @@ pub struct ServerInstanceRecord {
     pub drained: bool,
     pub last_heartbeat_at: NaiveDateTime,
     pub started_at: NaiveDateTime,
+}
+
+#[cfg(test)]
+mod sensitive_debug_tests {
+    use super::*;
+
+    fn timestamp() -> NaiveDateTime {
+        chrono::DateTime::from_timestamp(1_700_000_000, 0)
+            .unwrap()
+            .naive_utc()
+    }
+
+    #[test]
+    fn backup_debug_reports_shape_without_snapshot_rows() {
+        let document = BackupDocument {
+            backup_version: CURRENT_BACKUP_VERSION,
+            created_at: timestamp(),
+            source_version: "test".to_string(),
+            state: BackupState {
+                sections: BTreeMap::from([(
+                    "users".to_string(),
+                    vec![serde_json::json!({"password": "backup-state-secret"})],
+                )]),
+            },
+            history: Some(BackupHistory {
+                sections: BTreeMap::from([(
+                    "remote_call_results".to_string(),
+                    vec![serde_json::json!({"body": "backup-history-secret"})],
+                )]),
+            }),
+            manifest: BackupManifest::default(),
+        };
+
+        let debug = format!("{document:?}");
+
+        assert!(debug.contains("section_count: 1"));
+        assert!(debug.contains("row_count: 1"));
+        assert!(!debug.contains("backup-state-secret"));
+        assert!(!debug.contains("backup-history-secret"));
+    }
+
+    #[test]
+    fn restore_debug_redacts_capabilities_and_persisted_errors() {
+        let response = RestoreStageResponse {
+            id: 1,
+            status: RestoreJobStatus::Validated,
+            requested_by: Some(2),
+            requested_by_identity_scope: "local".to_string(),
+            requested_by_name: "admin".to_string(),
+            sha256: "document-sha".to_string(),
+            byte_size: 42,
+            expires_at: timestamp(),
+            error: Some("restore-internal-secret".to_string()),
+            confirmed_at: None,
+            started_at: None,
+            finished_at: None,
+            created_at: timestamp(),
+            updated_at: timestamp(),
+            validation: RestoreValidationSummary {
+                backup_version: CURRENT_BACKUP_VERSION,
+                source_version: "test".to_string(),
+                includes_history: true,
+                total_items: 1,
+            },
+            restore_capability: Some("restore-capability-secret".to_string()),
+        };
+        let confirmation = RestoreConfirmRequest {
+            restore_capability: "confirm-capability-secret".to_string(),
+            sha256: "document-sha".to_string(),
+            confirmation: RESTORE_CONFIRMATION_PHRASE.to_string(),
+        };
+
+        let response_debug = format!("{response:?}");
+        let confirmation_debug = format!("{confirmation:?}");
+
+        assert!(response_debug.contains(REDACTED_DEBUG_VALUE));
+        assert!(!response_debug.contains("restore-internal-secret"));
+        assert!(!response_debug.contains("restore-capability-secret"));
+        assert!(confirmation_debug.contains(REDACTED_DEBUG_VALUE));
+        assert!(!confirmation_debug.contains("confirm-capability-secret"));
+    }
 }

--- a/src/models/event_delivery.rs
+++ b/src/models/event_delivery.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 use crate::db::prelude::*;
 use chrono::NaiveDateTime;
@@ -7,6 +7,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::errors::ApiError;
+use crate::models::redacted_debug_option;
 use crate::models::search::{FilterField, SortParam};
 use crate::pagination::{
     CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
@@ -81,7 +82,7 @@ impl FromStr for EventDeliveryStatus {
     }
 }
 
-#[derive(Debug, Clone, Queryable, Selectable, PartialEq, Eq)]
+#[derive(Clone, Queryable, Selectable, PartialEq, Eq)]
 #[diesel(table_name = event_deliveries)]
 pub struct EventDelivery {
     pub id: i64,
@@ -95,6 +96,25 @@ pub struct EventDelivery {
     pub(crate) claim_token: Option<Uuid>,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
+}
+
+impl fmt::Debug for EventDelivery {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EventDelivery")
+            .field("id", &self.id)
+            .field("event_id", &self.event_id)
+            .field("subscription_id", &self.subscription_id)
+            .field("status", &self.status)
+            .field("attempts", &self.attempts)
+            .field("next_attempt_at", &self.next_attempt_at)
+            .field("last_error", &redacted_debug_option(&self.last_error))
+            .field("locked_until", &self.locked_until)
+            .field("claim_token", &redacted_debug_option(&self.claim_token))
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
@@ -302,6 +322,7 @@ impl CursorSqlMapping for EventDelivery {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::REDACTED_DEBUG_VALUE;
 
     #[test]
     fn event_delivery_response_omits_internal_claim_token() {
@@ -327,5 +348,32 @@ mod tests {
 
         assert!(serialized.get("claim_token").is_none());
         assert!(!serialized.to_string().contains(&claim_token.to_string()));
+    }
+
+    #[test]
+    fn event_delivery_debug_redacts_claim_token_and_error() {
+        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0)
+            .unwrap()
+            .naive_utc();
+        let claim_token = Uuid::parse_str("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").unwrap();
+        let delivery = EventDelivery {
+            id: 1,
+            event_id: 2,
+            subscription_id: 3,
+            status: EventDeliveryStatus::InFlight.as_str().to_string(),
+            attempts: 1,
+            next_attempt_at: timestamp,
+            last_error: Some("delivery-error-secret".to_string()),
+            locked_until: Some(timestamp),
+            claim_token: Some(claim_token),
+            created_at: timestamp,
+            updated_at: timestamp,
+        };
+
+        let debug = format!("{delivery:?}");
+
+        assert!(debug.contains(REDACTED_DEBUG_VALUE));
+        assert!(!debug.contains("delivery-error-secret"));
+        assert!(!debug.contains(&claim_token.to_string()));
     }
 }

--- a/src/models/event_subscription.rs
+++ b/src/models/event_subscription.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 use crate::db::prelude::*;
 use chrono::NaiveDateTime;
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize, Serializer};
 use utoipa::ToSchema;
 
 use crate::errors::ApiError;
-use crate::models::CollectionID;
 use crate::models::search::{FilterField, SortParam};
+use crate::models::{CollectionID, REDACTED_DEBUG_VALUE};
 use crate::pagination::{
     CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
 };
@@ -75,7 +75,35 @@ impl FromStr for EventSinkKind {
     }
 }
 
-#[derive(Debug, Clone, Queryable, Selectable)]
+macro_rules! impl_redacted_event_sink_debug {
+    ($target:ty, $($field:ident),+ $(,)?) => {
+        impl fmt::Debug for $target {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let mut debug = formatter.debug_struct(stringify!($target));
+                $(debug.field(stringify!($field), &self.$field);)+
+                debug
+                    .field("configuration", &REDACTED_DEBUG_VALUE)
+                    .finish()
+            }
+        }
+    };
+}
+
+macro_rules! impl_redacted_event_subscription_debug {
+    ($target:ty, $($field:ident),+ $(,)?) => {
+        impl fmt::Debug for $target {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let mut debug = formatter.debug_struct(stringify!($target));
+                $(debug.field(stringify!($field), &self.$field);)+
+                debug
+                    .field("routing", &REDACTED_DEBUG_VALUE)
+                    .finish()
+            }
+        }
+    };
+}
+
+#[derive(Clone, Queryable, Selectable)]
 #[diesel(table_name = event_sinks)]
 pub(crate) struct EventSinkRow {
     pub id: i32,
@@ -88,7 +116,17 @@ pub(crate) struct EventSinkRow {
     pub updated_at: NaiveDateTime,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+impl_redacted_event_sink_debug!(
+    EventSinkRow,
+    id,
+    name,
+    kind,
+    enabled,
+    created_at,
+    updated_at,
+);
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct EventSink {
     pub id: i32,
     pub name: String,
@@ -101,7 +139,9 @@ pub struct EventSink {
     pub updated_at: NaiveDateTime,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+impl_redacted_event_sink_debug!(EventSink, id, name, kind, enabled, created_at, updated_at,);
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct NewEventSink {
     pub name: String,
     pub kind: EventSinkKind,
@@ -112,7 +152,9 @@ pub struct NewEventSink {
     pub enabled: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+impl_redacted_event_sink_debug!(NewEventSink, name, kind, enabled);
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct UpdateEventSink {
     pub name: Option<String>,
     pub kind: Option<EventSinkKind>,
@@ -127,7 +169,9 @@ pub struct UpdateEventSink {
     pub enabled: Option<bool>,
 }
 
-#[derive(Debug, Clone, Insertable)]
+impl_redacted_event_sink_debug!(UpdateEventSink, name, kind, enabled);
+
+#[derive(Clone, Insertable)]
 #[diesel(table_name = event_sinks)]
 pub(crate) struct NewEventSinkRow {
     pub name: String,
@@ -137,7 +181,9 @@ pub(crate) struct NewEventSinkRow {
     pub enabled: bool,
 }
 
-#[derive(Debug, Clone, AsChangeset)]
+impl_redacted_event_sink_debug!(NewEventSinkRow, name, kind, enabled);
+
+#[derive(Clone, AsChangeset)]
 #[diesel(table_name = event_sinks)]
 pub(crate) struct UpdateEventSinkRow {
     pub name: Option<String>,
@@ -146,6 +192,8 @@ pub(crate) struct UpdateEventSinkRow {
     pub secret_ref: Option<Option<String>>,
     pub enabled: Option<bool>,
 }
+
+impl_redacted_event_sink_debug!(UpdateEventSinkRow, name, kind, enabled);
 
 impl UpdateEventSinkRow {
     pub(crate) fn has_changes(&self, current: &EventSinkRow) -> bool {
@@ -168,7 +216,7 @@ impl UpdateEventSinkRow {
     }
 }
 
-#[derive(Debug, Clone, Queryable, Selectable)]
+#[derive(Clone, Queryable, Selectable)]
 #[diesel(table_name = event_subscriptions)]
 pub(crate) struct EventSubscriptionRow {
     pub id: i32,
@@ -185,7 +233,22 @@ pub(crate) struct EventSubscriptionRow {
     pub updated_at: NaiveDateTime,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+impl_redacted_event_subscription_debug!(
+    EventSubscriptionRow,
+    id,
+    collection_id,
+    sink_id,
+    name,
+    description,
+    entity_types,
+    actions,
+    filter,
+    enabled,
+    created_at,
+    updated_at,
+);
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct EventSubscription {
     pub id: i32,
     pub collection_id: i32,
@@ -203,7 +266,22 @@ pub struct EventSubscription {
     pub updated_at: NaiveDateTime,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+impl_redacted_event_subscription_debug!(
+    EventSubscription,
+    id,
+    collection_id,
+    sink_id,
+    name,
+    description,
+    entity_types,
+    actions,
+    filter,
+    enabled,
+    created_at,
+    updated_at,
+);
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct NewEventSubscription {
     pub sink_id: EventSinkID,
     pub name: String,
@@ -219,7 +297,18 @@ pub struct NewEventSubscription {
     pub enabled: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+impl_redacted_event_subscription_debug!(
+    NewEventSubscription,
+    sink_id,
+    name,
+    description,
+    entity_types,
+    actions,
+    filter,
+    enabled,
+);
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct UpdateEventSubscription {
     pub sink_id: Option<EventSinkID>,
     pub name: Option<String>,
@@ -231,7 +320,18 @@ pub struct UpdateEventSubscription {
     pub enabled: Option<bool>,
 }
 
-#[derive(Debug, Clone, Insertable)]
+impl_redacted_event_subscription_debug!(
+    UpdateEventSubscription,
+    sink_id,
+    name,
+    description,
+    entity_types,
+    actions,
+    filter,
+    enabled,
+);
+
+#[derive(Clone, Insertable)]
 #[diesel(table_name = event_subscriptions)]
 pub(crate) struct NewEventSubscriptionRow {
     pub collection_id: i32,
@@ -245,7 +345,19 @@ pub(crate) struct NewEventSubscriptionRow {
     pub enabled: bool,
 }
 
-#[derive(Debug, Clone, AsChangeset)]
+impl_redacted_event_subscription_debug!(
+    NewEventSubscriptionRow,
+    collection_id,
+    sink_id,
+    name,
+    description,
+    entity_types,
+    actions,
+    filter,
+    enabled,
+);
+
+#[derive(Clone, AsChangeset)]
 #[diesel(table_name = event_subscriptions)]
 pub(crate) struct UpdateEventSubscriptionRow {
     pub sink_id: Option<i32>,
@@ -257,6 +369,17 @@ pub(crate) struct UpdateEventSubscriptionRow {
     pub routing: Option<serde_json::Value>,
     pub enabled: Option<bool>,
 }
+
+impl_redacted_event_subscription_debug!(
+    UpdateEventSubscriptionRow,
+    sink_id,
+    name,
+    description,
+    entity_types,
+    actions,
+    filter,
+    enabled,
+);
 
 impl UpdateEventSubscriptionRow {
     pub(crate) fn has_changes(&self, current: &EventSubscriptionRow) -> bool {
@@ -855,5 +978,87 @@ mod tests {
         );
         assert!(!serialized.to_string().contains(credential));
         assert!(!serialized.to_string().contains(api_key));
+    }
+
+    fn timestamp() -> NaiveDateTime {
+        chrono::DateTime::from_timestamp(1_700_000_000, 0)
+            .unwrap()
+            .naive_utc()
+    }
+
+    fn assert_omits(debug: &str, secrets: &[&str]) {
+        assert!(debug.contains(REDACTED_DEBUG_VALUE));
+        for secret in secrets {
+            assert!(!debug.contains(secret));
+        }
+    }
+
+    #[test]
+    fn event_sink_debug_redacts_request_and_persisted_configuration() {
+        let request = NewEventSink {
+            name: "webhook".to_string(),
+            kind: EventSinkKind::Webhook,
+            config: serde_json::json!({
+                "headers": {"authorization": "request-config-secret"}
+            }),
+            secret_ref: Some("request-secret-reference".to_string()),
+            enabled: true,
+        };
+        let row = EventSinkRow {
+            id: 1,
+            name: "webhook".to_string(),
+            kind: "webhook".to_string(),
+            config: serde_json::json!({
+                "headers": {"authorization": "stored-config-secret"}
+            }),
+            secret_ref: Some("stored-secret-reference".to_string()),
+            enabled: true,
+            created_at: timestamp(),
+            updated_at: timestamp(),
+        };
+
+        assert_omits(
+            &format!("{request:?}"),
+            &["request-config-secret", "request-secret-reference"],
+        );
+        assert_omits(
+            &format!("{row:?}"),
+            &["stored-config-secret", "stored-secret-reference"],
+        );
+    }
+
+    #[test]
+    fn event_subscription_debug_redacts_request_and_persisted_routing() {
+        let request = NewEventSubscription {
+            sink_id: EventSinkID::new(1).unwrap(),
+            name: "subscription".to_string(),
+            description: String::new(),
+            entity_types: vec!["object".to_string()],
+            actions: vec!["updated".to_string()],
+            filter: EventSubscriptionFilter::default(),
+            routing: serde_json::json!({
+                "url": "https://example.invalid/hook?key=request-routing-secret"
+            }),
+            enabled: true,
+        };
+        let row = EventSubscriptionRow {
+            id: 2,
+            collection_id: 3,
+            sink_id: 1,
+            name: "subscription".to_string(),
+            description: String::new(),
+            entity_types: serde_json::json!(["object"]),
+            actions: serde_json::json!(["updated"]),
+            filter: serde_json::json!({}),
+            routing: serde_json::json!({
+                "url": "https://example.invalid/hook?key=stored-routing-secret"
+            }),
+            enabled: true,
+            created_at: timestamp(),
+            updated_at: timestamp(),
+        };
+
+        assert_omits(&format!("{request:?}"), &["request-routing-secret"]);
+        assert_omits(&format!("{row:?}"), &["stored-routing-secret"]);
     }
 }

--- a/src/models/import.rs
+++ b/src/models/import.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use chrono::NaiveDateTime;
 use hubuum_events_core::EventSubscriptionFilter;
 use serde::{Deserialize, Serialize};
@@ -13,7 +15,7 @@ use crate::models::remote_target::validate_target_parts;
 use crate::models::{
     EventSinkKind, ExportContentType, ExportInclude, ExportLimits, ExportMissingDataPolicy,
     ExportRelationContext, ExportScopeKind, ExportTemplateKind, ObjectRelationLimit, Permissions,
-    RemoteAuthConfig, RemoteHttpMethod, RemoteTargetSubjectType,
+    RemoteAuthConfig, RemoteHttpMethod, RemoteTargetSubjectType, redacted_debug_option,
 };
 
 pub const CURRENT_IMPORT_VERSION: i32 = 1;
@@ -186,7 +188,7 @@ pub struct ImportGroupInput {
     pub timestamps: Option<RestoreTimestamps>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ImportPrincipalSubtype {
     Human {
@@ -204,6 +206,43 @@ pub enum ImportPrincipalSubtype {
         created_by_key: Option<PrincipalKey>,
         disabled_at: Option<NaiveDateTime>,
     },
+}
+
+impl fmt::Debug for ImportPrincipalSubtype {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Human {
+                password,
+                password_hash,
+                proper_name,
+                email,
+                anonymized_at,
+            } => formatter
+                .debug_struct("Human")
+                .field("password", &redacted_debug_option(password))
+                .field("password_hash", &redacted_debug_option(password_hash))
+                .field("proper_name", proper_name)
+                .field("email", email)
+                .field("anonymized_at", anonymized_at)
+                .finish(),
+            Self::ServiceAccount {
+                description,
+                owner_group_ref,
+                owner_group_key,
+                created_by_ref,
+                created_by_key,
+                disabled_at,
+            } => formatter
+                .debug_struct("ServiceAccount")
+                .field("description", description)
+                .field("owner_group_ref", owner_group_ref)
+                .field("owner_group_key", owner_group_key)
+                .field("created_by_ref", created_by_ref)
+                .field("created_by_key", created_by_key)
+                .field("disabled_at", disabled_at)
+                .finish(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
@@ -746,8 +785,8 @@ mod tests {
         RestoreTimestamps, validate_optional_selector, validate_required_selector,
     };
     use crate::models::{
-        CollectionKey, EventSinkKind, ExportContentType, ExportTemplateKind, RemoteAuthConfig,
-        RemoteHttpMethod, RemoteTargetSubjectType,
+        CollectionKey, EventSinkKind, ExportContentType, ExportTemplateKind, REDACTED_DEBUG_VALUE,
+        RemoteAuthConfig, RemoteHttpMethod, RemoteTargetSubjectType,
     };
 
     #[test]
@@ -815,6 +854,26 @@ mod tests {
                 .is_ok(),
             expected_valid
         );
+    }
+
+    #[rstest]
+    #[case::plaintext(Some("import-password"), None, "import-password")]
+    #[case::hash(
+        None,
+        Some("$argon2id$imported-password-hash"),
+        "$argon2id$imported-password-hash"
+    )]
+    fn imported_human_debug_redacts_credentials(
+        #[case] password: Option<&str>,
+        #[case] password_hash: Option<&str>,
+        #[case] credential: &str,
+    ) {
+        let principal = human_principal(password, password_hash);
+
+        let output = format!("{principal:?}");
+
+        assert!(output.contains(REDACTED_DEBUG_VALUE));
+        assert!(!output.contains(credential));
     }
 
     #[rstest]

--- a/src/models/import.rs
+++ b/src/models/import.rs
@@ -444,7 +444,7 @@ impl ImportExportTemplateInput {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct ImportRemoteTargetInput {
     #[serde(rename = "ref")]
     pub ref_: Option<String>,
@@ -465,6 +465,27 @@ pub struct ImportRemoteTargetInput {
     pub timeout_ms: i32,
     pub enabled: bool,
     pub timestamps: Option<RestoreTimestamps>,
+}
+
+impl fmt::Debug for ImportRemoteTargetInput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ImportRemoteTargetInput")
+            .field("ref_", &self.ref_)
+            .field("collection_ref", &self.collection_ref)
+            .field("collection_key", &self.collection_key)
+            .field("class_ref", &self.class_ref)
+            .field("class_key", &self.class_key)
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .field("method", &self.method)
+            .field("configuration", &REDACTED_DEBUG_VALUE)
+            .field("allowed_subject_types", &self.allowed_subject_types)
+            .field("timeout_ms", &self.timeout_ms)
+            .field("enabled", &self.enabled)
+            .field("timestamps", &self.timestamps)
+            .finish()
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
@@ -535,7 +556,7 @@ impl fmt::Debug for ImportEventSubscriptionInput {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, ToSchema)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Default, ToSchema)]
 pub struct ImportGraph {
     #[serde(default)]
     pub identity_scopes: Vec<ImportIdentityScopeInput>,
@@ -565,6 +586,29 @@ pub struct ImportGraph {
     pub event_sinks: Vec<ImportEventSinkInput>,
     #[serde(default)]
     pub event_subscriptions: Vec<ImportEventSubscriptionInput>,
+}
+
+impl fmt::Debug for ImportGraph {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ImportGraph")
+            .field("identity_scopes", &self.identity_scopes.len())
+            .field("groups", &self.groups.len())
+            .field("principals", &self.principals.len())
+            .field("group_memberships", &self.group_memberships.len())
+            .field("collections", &self.collections.len())
+            .field("classes", &self.classes.len())
+            .field("objects", &self.objects.len())
+            .field("class_relations", &self.class_relations.len())
+            .field("object_relations", &self.object_relations.len())
+            .field("collection_permissions", &self.collection_permissions.len())
+            .field("export_templates", &self.export_templates.len())
+            .field("remote_targets", &self.remote_targets.len())
+            .field("event_sinks", &self.event_sinks.len())
+            .field("event_subscriptions", &self.event_subscriptions.len())
+            .field("contents", &REDACTED_DEBUG_VALUE)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
@@ -1138,8 +1182,31 @@ mod tests {
     }
 
     #[test]
-    fn import_debug_redacts_event_sink_configuration_and_routing() {
-        let request = request_with_graph(ImportGraph {
+    fn import_debug_redacts_graph_and_integration_configuration() {
+        let graph = ImportGraph {
+            remote_targets: vec![ImportRemoteTargetInput {
+                ref_: Some("target:1".to_string()),
+                collection_ref: Some("collection:1".to_string()),
+                collection_key: None,
+                class_ref: None,
+                class_key: None,
+                name: "remote-target".to_string(),
+                description: String::new(),
+                method: RemoteHttpMethod::Post,
+                url_template: "https://example.invalid/hook?key=import-target-url-secret"
+                    .to_string(),
+                headers_template: serde_json::json!({
+                    "authorization": "import-target-header-secret"
+                }),
+                body_template: Some("import-target-body-secret".to_string()),
+                auth_config: RemoteAuthConfig::BearerSecret {
+                    secret: "import-target-auth-secret".to_string(),
+                },
+                allowed_subject_types: vec![RemoteTargetSubjectType::Collection],
+                timeout_ms: 1_000,
+                enabled: true,
+                timestamps: None,
+            }],
             event_sinks: vec![ImportEventSinkInput {
                 ref_: Some("sink:1".to_string()),
                 name: "webhook".to_string(),
@@ -1169,13 +1236,26 @@ mod tests {
                 timestamps: None,
             }],
             ..ImportGraph::default()
-        });
+        };
+
+        let target_debug = format!("{:?}", graph.remote_targets[0]);
+        let sink_debug = format!("{:?}", graph.event_sinks[0]);
+        let subscription_debug = format!("{:?}", graph.event_subscriptions[0]);
+        let request = request_with_graph(graph);
 
         let debug = format!("{request:?}");
 
         assert!(debug.contains(REDACTED_DEBUG_VALUE));
-        assert!(!debug.contains("import-config-secret"));
-        assert!(!debug.contains("import-secret-reference"));
-        assert!(!debug.contains("import-routing-secret"));
+        assert!(debug.contains("remote_targets: 1"));
+        for output in [target_debug, sink_debug, subscription_debug, debug] {
+            assert!(output.contains(REDACTED_DEBUG_VALUE));
+            assert!(!output.contains("import-config-secret"));
+            assert!(!output.contains("import-secret-reference"));
+            assert!(!output.contains("import-routing-secret"));
+            assert!(!output.contains("import-target-url-secret"));
+            assert!(!output.contains("import-target-header-secret"));
+            assert!(!output.contains("import-target-body-secret"));
+            assert!(!output.contains("import-target-auth-secret"));
+        }
     }
 }

--- a/src/models/import.rs
+++ b/src/models/import.rs
@@ -15,7 +15,8 @@ use crate::models::remote_target::validate_target_parts;
 use crate::models::{
     EventSinkKind, ExportContentType, ExportInclude, ExportLimits, ExportMissingDataPolicy,
     ExportRelationContext, ExportScopeKind, ExportTemplateKind, ObjectRelationLimit, Permissions,
-    RemoteAuthConfig, RemoteHttpMethod, RemoteTargetSubjectType, redacted_debug_option,
+    REDACTED_DEBUG_VALUE, RemoteAuthConfig, RemoteHttpMethod, RemoteTargetSubjectType,
+    redacted_debug_option,
 };
 
 pub const CURRENT_IMPORT_VERSION: i32 = 1;
@@ -466,7 +467,7 @@ pub struct ImportRemoteTargetInput {
     pub timestamps: Option<RestoreTimestamps>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct ImportEventSinkInput {
     #[serde(rename = "ref")]
     pub ref_: Option<String>,
@@ -479,7 +480,21 @@ pub struct ImportEventSinkInput {
     pub timestamps: Option<RestoreTimestamps>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+impl fmt::Debug for ImportEventSinkInput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ImportEventSinkInput")
+            .field("ref_", &self.ref_)
+            .field("name", &self.name)
+            .field("kind", &self.kind)
+            .field("configuration", &REDACTED_DEBUG_VALUE)
+            .field("enabled", &self.enabled)
+            .field("timestamps", &self.timestamps)
+            .finish()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct ImportEventSubscriptionInput {
     #[serde(rename = "ref")]
     pub ref_: Option<String>,
@@ -497,6 +512,27 @@ pub struct ImportEventSubscriptionInput {
     pub routing: serde_json::Value,
     pub enabled: bool,
     pub timestamps: Option<RestoreTimestamps>,
+}
+
+impl fmt::Debug for ImportEventSubscriptionInput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ImportEventSubscriptionInput")
+            .field("ref_", &self.ref_)
+            .field("collection_ref", &self.collection_ref)
+            .field("collection_key", &self.collection_key)
+            .field("sink_ref", &self.sink_ref)
+            .field("sink_key", &self.sink_key)
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .field("entity_types", &self.entity_types)
+            .field("actions", &self.actions)
+            .field("filter", &self.filter)
+            .field("routing", &REDACTED_DEBUG_VALUE)
+            .field("enabled", &self.enabled)
+            .field("timestamps", &self.timestamps)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, ToSchema)]
@@ -780,9 +816,10 @@ mod tests {
 
     use super::{
         IdentityScopeKey, ImportAtomicity, ImportCollisionPolicy, ImportEventSinkInput,
-        ImportExportTemplateInput, ImportGraph, ImportMode, ImportPermissionPolicy,
-        ImportPrincipalInput, ImportPrincipalSubtype, ImportRemoteTargetInput, ImportRequest,
-        RestoreTimestamps, validate_optional_selector, validate_required_selector,
+        ImportEventSubscriptionInput, ImportExportTemplateInput, ImportGraph, ImportMode,
+        ImportPermissionPolicy, ImportPrincipalInput, ImportPrincipalSubtype,
+        ImportRemoteTargetInput, ImportRequest, RestoreTimestamps, validate_optional_selector,
+        validate_required_selector,
     };
     use crate::models::{
         CollectionKey, EventSinkKind, ExportContentType, ExportTemplateKind, REDACTED_DEBUG_VALUE,
@@ -1098,5 +1135,47 @@ mod tests {
         });
 
         assert!(request.validate().is_err());
+    }
+
+    #[test]
+    fn import_debug_redacts_event_sink_configuration_and_routing() {
+        let request = request_with_graph(ImportGraph {
+            event_sinks: vec![ImportEventSinkInput {
+                ref_: Some("sink:1".to_string()),
+                name: "webhook".to_string(),
+                kind: EventSinkKind::Webhook,
+                config: serde_json::json!({
+                    "headers": {"authorization": "import-config-secret"}
+                }),
+                secret_ref: Some("import-secret-reference".to_string()),
+                enabled: true,
+                timestamps: None,
+            }],
+            event_subscriptions: vec![ImportEventSubscriptionInput {
+                ref_: Some("subscription:1".to_string()),
+                collection_ref: Some("collection:1".to_string()),
+                collection_key: None,
+                sink_ref: Some("sink:1".to_string()),
+                sink_key: None,
+                name: "subscription".to_string(),
+                description: String::new(),
+                entity_types: vec!["object".to_string()],
+                actions: vec!["updated".to_string()],
+                filter: serde_json::json!({}),
+                routing: serde_json::json!({
+                    "url": "https://example.invalid/hook?key=import-routing-secret"
+                }),
+                enabled: true,
+                timestamps: None,
+            }],
+            ..ImportGraph::default()
+        });
+
+        let debug = format!("{request:?}");
+
+        assert!(debug.contains(REDACTED_DEBUG_VALUE));
+        assert!(!debug.contains("import-config-secret"));
+        assert!(!debug.contains("import-secret-reference"));
+        assert!(!debug.contains("import-routing-secret"));
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,4 +1,11 @@
 #![allow(ambiguous_glob_reexports)] // We have several test modules, should be fine
+
+pub(crate) const REDACTED_DEBUG_VALUE: &str = "<redacted>";
+
+pub(crate) fn redacted_debug_option<T>(value: &Option<T>) -> Option<&'static str> {
+    value.as_ref().map(|_| REDACTED_DEBUG_VALUE)
+}
+
 pub mod backup;
 pub mod class;
 pub mod collection;

--- a/src/models/remote_target.rs
+++ b/src/models/remote_target.rs
@@ -1,5 +1,5 @@
 use crate::models::token_scope::TokenScope;
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 use crate::db::prelude::*;
 use chrono::NaiveDateTime;
@@ -17,7 +17,7 @@ use crate::errors::ApiError;
 use crate::models::search::{FilterField, SortParam};
 use crate::models::{
     Collection, CollectionID, HubuumClassID, HubuumClassRelationID, HubuumObjectID,
-    HubuumObjectRelationID, Permissions,
+    HubuumObjectRelationID, Permissions, REDACTED_DEBUG_VALUE, redacted_debug_option,
 };
 use crate::pagination::{
     CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
@@ -106,7 +106,7 @@ impl FromStr for RemoteHttpMethod {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum RemoteAuthConfig {
     #[default]
@@ -124,7 +124,60 @@ pub enum RemoteAuthConfig {
     },
 }
 
-#[derive(Debug, Clone, Queryable, Selectable)]
+impl fmt::Debug for RemoteAuthConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::None => formatter.write_str("None"),
+            Self::BearerSecret { .. } => formatter
+                .debug_struct("BearerSecret")
+                .field("secret", &REDACTED_DEBUG_VALUE)
+                .finish(),
+            Self::BasicSecret { username, .. } => formatter
+                .debug_struct("BasicSecret")
+                .field("username", username)
+                .field("secret", &REDACTED_DEBUG_VALUE)
+                .finish(),
+            Self::ApiKeySecret { header, .. } => formatter
+                .debug_struct("ApiKeySecret")
+                .field("header", header)
+                .field("secret", &REDACTED_DEBUG_VALUE)
+                .finish(),
+        }
+    }
+}
+
+macro_rules! impl_redacted_remote_target_debug {
+    ($target:ty, $($field:ident),+ $(,)?) => {
+        impl fmt::Debug for $target {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let mut debug = formatter.debug_struct(stringify!($target));
+                $(debug.field(stringify!($field), &self.$field);)+
+                debug
+                    .field("configuration", &REDACTED_DEBUG_VALUE)
+                    .finish()
+            }
+        }
+    };
+}
+
+macro_rules! impl_redacted_remote_call_result_debug {
+    ($target:ty, $($field:ident),+ $(,)?) => {
+        impl fmt::Debug for $target {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let mut debug = formatter.debug_struct(stringify!($target));
+                $(debug.field(stringify!($field), &self.$field);)+
+                debug
+                    .field("rendered_url", &REDACTED_DEBUG_VALUE)
+                    .field("response_headers", &REDACTED_DEBUG_VALUE)
+                    .field("response_body_preview", &REDACTED_DEBUG_VALUE)
+                    .field("error", &redacted_debug_option(&self.error))
+                    .finish()
+            }
+        }
+    };
+}
+
+#[derive(Clone, Queryable, Selectable)]
 #[diesel(table_name = remote_targets)]
 pub(crate) struct RemoteTargetRow {
     pub id: i32,
@@ -143,6 +196,21 @@ pub(crate) struct RemoteTargetRow {
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
 }
+
+impl_redacted_remote_target_debug!(
+    RemoteTargetRow,
+    id,
+    collection_id,
+    class_id,
+    name,
+    description,
+    method,
+    allowed_subject_types,
+    timeout_ms,
+    enabled,
+    created_at,
+    updated_at,
+);
 
 impl RemoteTargetRow {
     pub(crate) fn audit_snapshot(&self) -> serde_json::Value {
@@ -166,7 +234,7 @@ impl RemoteTargetRow {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct RemoteTarget {
     pub id: i32,
     pub collection_id: i32,
@@ -185,7 +253,22 @@ pub struct RemoteTarget {
     pub updated_at: NaiveDateTime,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+impl_redacted_remote_target_debug!(
+    RemoteTarget,
+    id,
+    collection_id,
+    class_id,
+    name,
+    description,
+    method,
+    allowed_subject_types,
+    timeout_ms,
+    enabled,
+    created_at,
+    updated_at,
+);
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct NewRemoteTarget {
     pub collection_id: CollectionID,
     pub class_id: Option<HubuumClassID>,
@@ -205,7 +288,19 @@ pub struct NewRemoteTarget {
     pub enabled: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+impl_redacted_remote_target_debug!(
+    NewRemoteTarget,
+    collection_id,
+    class_id,
+    name,
+    description,
+    method,
+    allowed_subject_types,
+    timeout_ms,
+    enabled,
+);
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct UpdateRemoteTarget {
     pub collection_id: Option<CollectionID>,
     #[serde(
@@ -233,7 +328,19 @@ pub struct UpdateRemoteTarget {
     pub enabled: Option<bool>,
 }
 
-#[derive(Debug, Clone, Insertable)]
+impl_redacted_remote_target_debug!(
+    UpdateRemoteTarget,
+    collection_id,
+    class_id,
+    name,
+    description,
+    method,
+    allowed_subject_types,
+    timeout_ms,
+    enabled,
+);
+
+#[derive(Clone, Insertable)]
 #[diesel(table_name = remote_targets)]
 pub(crate) struct NewRemoteTargetRow {
     pub collection_id: i32,
@@ -250,7 +357,19 @@ pub(crate) struct NewRemoteTargetRow {
     pub enabled: bool,
 }
 
-#[derive(Debug, Clone, AsChangeset)]
+impl_redacted_remote_target_debug!(
+    NewRemoteTargetRow,
+    collection_id,
+    class_id,
+    name,
+    description,
+    method,
+    allowed_subject_types,
+    timeout_ms,
+    enabled,
+);
+
+#[derive(Clone, AsChangeset)]
 #[diesel(table_name = remote_targets)]
 pub(crate) struct UpdateRemoteTargetRow {
     pub collection_id: Option<i32>,
@@ -266,6 +385,18 @@ pub(crate) struct UpdateRemoteTargetRow {
     pub timeout_ms: Option<i32>,
     pub enabled: Option<bool>,
 }
+
+impl_redacted_remote_target_debug!(
+    UpdateRemoteTargetRow,
+    collection_id,
+    class_id,
+    name,
+    description,
+    method,
+    allowed_subject_types,
+    timeout_ms,
+    enabled,
+);
 
 impl UpdateRemoteTargetRow {
     pub(crate) fn has_changes(&self, current: &RemoteTargetRow) -> bool {
@@ -323,9 +454,18 @@ pub struct RemoteTargetInvokeRequest {
     pub body_override: RemoteInvocationBodyOverride,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, ToSchema)]
+#[derive(Clone, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(transparent)]
 pub struct RemoteInvocationParameters(serde_json::Value);
+
+impl fmt::Debug for RemoteInvocationParameters {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("RemoteInvocationParameters")
+            .field(&REDACTED_DEBUG_VALUE)
+            .finish()
+    }
+}
 
 impl RemoteInvocationParameters {
     pub fn new(value: serde_json::Value) -> Result<Self, ApiError> {
@@ -359,9 +499,18 @@ impl<'de> Deserialize<'de> for RemoteInvocationParameters {
     }
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, ToSchema)]
+#[derive(Clone, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(transparent)]
 pub struct RemoteInvocationBodyOverride(serde_json::Value);
+
+impl fmt::Debug for RemoteInvocationBodyOverride {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("RemoteInvocationBodyOverride")
+            .field(&REDACTED_DEBUG_VALUE)
+            .finish()
+    }
+}
 
 impl RemoteInvocationBodyOverride {
     pub fn new(value: serde_json::Value) -> Result<Self, ApiError> {
@@ -454,9 +603,17 @@ pub struct ResolvedRemoteInvocationSubject {
     pub context: RemoteTemplateContext,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RemoteTemplateContext {
     value: serde_json::Value,
+}
+
+impl fmt::Debug for RemoteTemplateContext {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RemoteTemplateContext")
+            .finish_non_exhaustive()
+    }
 }
 
 impl RemoteTemplateContext {
@@ -487,7 +644,7 @@ impl RemoteTemplateContext {
     }
 }
 
-#[derive(Debug, Clone, Queryable, Selectable, Serialize, Deserialize, PartialEq, ToSchema)]
+#[derive(Clone, Queryable, Selectable, Serialize, Deserialize, PartialEq, ToSchema)]
 #[diesel(table_name = remote_call_results)]
 pub struct RemoteCallResult {
     pub id: i32,
@@ -506,7 +663,21 @@ pub struct RemoteCallResult {
     pub created_at: NaiveDateTime,
 }
 
-#[derive(Debug, Clone, Insertable)]
+impl_redacted_remote_call_result_debug!(
+    RemoteCallResult,
+    id,
+    task_id,
+    target_id,
+    subject_type,
+    subject_id,
+    method,
+    response_status,
+    duration_ms,
+    success,
+    created_at,
+);
+
+#[derive(Clone, Insertable)]
 #[diesel(table_name = remote_call_results)]
 pub struct NewRemoteCallResult {
     pub task_id: i32,
@@ -522,6 +693,18 @@ pub struct NewRemoteCallResult {
     pub success: bool,
     pub error: Option<String>,
 }
+
+impl_redacted_remote_call_result_debug!(
+    NewRemoteCallResult,
+    task_id,
+    target_id,
+    subject_type,
+    subject_id,
+    method,
+    response_status,
+    duration_ms,
+    success,
+);
 
 impl TryFrom<RemoteTargetRow> for RemoteTarget {
     type Error = ApiError;
@@ -1274,9 +1457,125 @@ mod tests {
                 .contains("controlled by the HTTP transport")
         );
     }
+
+    #[test]
+    fn remote_auth_debug_redacts_secret_references() {
+        let cases = [
+            RemoteAuthConfig::BearerSecret {
+                secret: "bearer-secret-reference".to_string(),
+            },
+            RemoteAuthConfig::BasicSecret {
+                username: "integration-user".to_string(),
+                secret: "basic-secret-reference".to_string(),
+            },
+            RemoteAuthConfig::ApiKeySecret {
+                header: "x-api-key".to_string(),
+                secret: "api-key-secret-reference".to_string(),
+            },
+        ];
+
+        for auth in cases {
+            let debug = format!("{auth:?}");
+
+            assert!(debug.contains(REDACTED_DEBUG_VALUE));
+            assert!(!debug.contains("secret-reference"));
+        }
+    }
+
+    #[test]
+    fn remote_target_debug_redacts_all_outbound_configuration() {
+        let target = NewRemoteTarget {
+            collection_id: CollectionID::new(1).unwrap(),
+            class_id: None,
+            name: "inventory-hook".to_string(),
+            description: "Inventory integration".to_string(),
+            method: RemoteHttpMethod::Post,
+            url_template: "https://example.invalid/hook?key=url-secret".to_string(),
+            headers_template: serde_json::json!({"authorization": "header-secret"}),
+            body_template: Some("body-secret".to_string()),
+            auth_config: RemoteAuthConfig::BearerSecret {
+                secret: "auth-secret-reference".to_string(),
+            },
+            allowed_subject_types: vec![RemoteTargetSubjectType::Object],
+            timeout_ms: 1_000,
+            enabled: true,
+        };
+
+        let debug = format!("{target:?}");
+
+        assert!(debug.contains("inventory-hook"));
+        assert!(debug.contains(REDACTED_DEBUG_VALUE));
+        for secret in [
+            "url-secret",
+            "header-secret",
+            "body-secret",
+            "auth-secret-reference",
+        ] {
+            assert!(!debug.contains(secret));
+        }
+    }
+
+    #[test]
+    fn remote_invocation_debug_redacts_parameters_body_and_context() {
+        let payload = StoredRemoteCallTaskPayload {
+            target_id: RemoteTargetID::new(1).unwrap(),
+            subject: RemoteInvocationSubject::Collection {
+                collection_id: CollectionID::new(2).unwrap(),
+            },
+            parameters: RemoteInvocationParameters::new(serde_json::json!({
+                "token": "parameter-secret"
+            }))
+            .unwrap(),
+            body_override: RemoteInvocationBodyOverride::new(serde_json::json!({
+                "password": "body-override-secret"
+            }))
+            .unwrap(),
+        };
+        let context = RemoteTemplateContext::new(serde_json::json!({
+            "private": "context-secret"
+        }))
+        .unwrap();
+
+        let payload_debug = format!("{payload:?}");
+        let context_debug = format!("{context:?}");
+
+        assert!(payload_debug.contains(REDACTED_DEBUG_VALUE));
+        assert!(!payload_debug.contains("parameter-secret"));
+        assert!(!payload_debug.contains("body-override-secret"));
+        assert!(!context_debug.contains("context-secret"));
+    }
+
+    #[test]
+    fn remote_call_result_debug_redacts_url_headers_and_body() {
+        let result = NewRemoteCallResult {
+            task_id: 1,
+            target_id: Some(2),
+            subject_type: "object".to_string(),
+            subject_id: 3,
+            method: "post".to_string(),
+            rendered_url: "https://example.invalid/hook?key=result-url-secret".to_string(),
+            response_status: Some(200),
+            response_headers: Some(serde_json::json!({
+                "set-cookie": "result-header-secret"
+            })),
+            response_body_preview: Some("result-body-secret".to_string()),
+            duration_ms: 12,
+            success: true,
+            error: Some("result-error-secret".to_string()),
+        };
+
+        let debug = format!("{result:?}");
+
+        assert!(debug.contains("response_status: Some(200)"));
+        assert!(debug.contains(REDACTED_DEBUG_VALUE));
+        assert!(!debug.contains("result-url-secret"));
+        assert!(!debug.contains("result-header-secret"));
+        assert!(!debug.contains("result-body-secret"));
+        assert!(!debug.contains("result-error-secret"));
+    }
 }
 
-#[derive(serde::Serialize, diesel::Queryable, Clone, Debug, ToSchema)]
+#[derive(serde::Serialize, diesel::Queryable, Clone, ToSchema)]
 #[diesel(table_name = crate::schema::remote_targets_history)]
 pub struct RemoteTargetHistory {
     pub id: i32,
@@ -1303,5 +1602,28 @@ pub struct RemoteTargetHistory {
     pub initiator_user_id: Option<i32>,
     pub task_id: Option<i32>,
 }
+
+impl_redacted_remote_target_debug!(
+    RemoteTargetHistory,
+    id,
+    collection_id,
+    class_id,
+    name,
+    description,
+    method,
+    allowed_subject_types,
+    timeout_ms,
+    enabled,
+    created_at,
+    updated_at,
+    op,
+    valid_from,
+    valid_to,
+    actor_id,
+    history_id,
+    actor_kind,
+    initiator_user_id,
+    task_id,
+);
 
 crate::impl_history_pagination!(RemoteTargetHistory, "remote_targets_history");

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::db::prelude::*;
 use async_trait::async_trait;
 use chrono::NaiveDateTime;
@@ -8,9 +10,9 @@ use crate::db::DbPool;
 use crate::db::traits::task::TaskBackend;
 use crate::errors::ApiError;
 use crate::events::{Event, MutationProvenance, PrincipalNames, Provenance, StoredProvenance};
-use crate::models::BackupOutputLookup;
 use crate::models::principal::PrincipalID;
 use crate::models::search::{FilterField, SortParam};
+use crate::models::{BackupOutputLookup, redacted_debug_option};
 use crate::permissions::{AuthzTarget, ResourceAttrs, ResourceKind, ResourceRef};
 use crate::schema::{backup_task_outputs, export_task_outputs, import_task_results, tasks};
 use crate::traits::SelfAccessors;
@@ -212,7 +214,7 @@ crate::int_id_newtype! {
     noun = "task id";
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
+#[derive(Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name = tasks)]
 pub struct TaskRecord {
     pub id: i32,
@@ -245,6 +247,46 @@ pub struct TaskRecord {
     pub initiator_user_id: Option<i32>,
 }
 
+impl fmt::Debug for TaskRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TaskRecord")
+            .field("id", &self.id)
+            .field("kind", &self.kind)
+            .field("status", &self.status)
+            .field("submitted_by", &self.submitted_by)
+            .field(
+                "idempotency_key",
+                &redacted_debug_option(&self.idempotency_key),
+            )
+            .field("request_hash", &self.request_hash)
+            .field(
+                "request_payload",
+                &redacted_debug_option(&self.request_payload),
+            )
+            .field("summary", &self.summary)
+            .field("total_items", &self.total_items)
+            .field("processed_items", &self.processed_items)
+            .field("success_items", &self.success_items)
+            .field("failed_items", &self.failed_items)
+            .field("submitted_token_id", &self.submitted_token_id)
+            .field("submitted_token_scoped", &self.submitted_token_scoped)
+            .field("submitted_token_scopes", &self.submitted_token_scopes)
+            .field("request_redacted_at", &self.request_redacted_at)
+            .field("started_at", &self.started_at)
+            .field("finished_at", &self.finished_at)
+            .field("deleted_at", &self.deleted_at)
+            .field("deleted_by", &self.deleted_by)
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .field("lease_token", &redacted_debug_option(&self.lease_token))
+            .field("lease_expires_at", &self.lease_expires_at)
+            .field("attempt_count", &self.attempt_count)
+            .field("initiator_user_id", &self.initiator_user_id)
+            .finish()
+    }
+}
+
 impl TaskRecord {
     pub(crate) fn worker_provenance(&self) -> MutationProvenance {
         MutationProvenance::worker(self.initiator_user_id, self.id)
@@ -259,7 +301,7 @@ impl TaskRecord {
     }
 }
 
-#[derive(Debug, Insertable)]
+#[derive(Insertable)]
 #[diesel(table_name = tasks)]
 pub struct NewTaskRecord {
     pub kind: String,
@@ -282,6 +324,37 @@ pub struct NewTaskRecord {
     pub request_redacted_at: Option<NaiveDateTime>,
     pub started_at: Option<NaiveDateTime>,
     pub finished_at: Option<NaiveDateTime>,
+}
+
+impl fmt::Debug for NewTaskRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NewTaskRecord")
+            .field("kind", &self.kind)
+            .field("status", &self.status)
+            .field("submitted_by", &self.submitted_by)
+            .field(
+                "idempotency_key",
+                &redacted_debug_option(&self.idempotency_key),
+            )
+            .field("request_hash", &self.request_hash)
+            .field(
+                "request_payload",
+                &redacted_debug_option(&self.request_payload),
+            )
+            .field("summary", &self.summary)
+            .field("total_items", &self.total_items)
+            .field("processed_items", &self.processed_items)
+            .field("success_items", &self.success_items)
+            .field("failed_items", &self.failed_items)
+            .field("submitted_token_id", &self.submitted_token_id)
+            .field("submitted_token_scoped", &self.submitted_token_scoped)
+            .field("submitted_token_scopes", &self.submitted_token_scopes)
+            .field("request_redacted_at", &self.request_redacted_at)
+            .field("started_at", &self.started_at)
+            .field("finished_at", &self.finished_at)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -969,11 +1042,86 @@ impl AuthzTarget for TaskID {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::REDACTED_DEBUG_VALUE;
 
     fn test_timestamp() -> NaiveDateTime {
         chrono::DateTime::from_timestamp(1_700_000_000, 0)
             .unwrap()
             .naive_utc()
+    }
+
+    #[test]
+    fn task_record_debug_redacts_sensitive_execution_fields() {
+        let idempotency_key = "idempotency-secret";
+        let payload_secret = "task-payload-secret";
+        let lease_token = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let timestamp = test_timestamp();
+        let task = TaskRecord {
+            id: 7,
+            kind: TaskKind::Import.as_str().to_string(),
+            status: TaskStatus::Running.as_str().to_string(),
+            submitted_by: Some(1),
+            idempotency_key: Some(idempotency_key.to_string()),
+            request_hash: Some("request-hash".to_string()),
+            request_payload: Some(serde_json::json!({"password": payload_secret})),
+            summary: None,
+            total_items: 1,
+            processed_items: 0,
+            success_items: 0,
+            failed_items: 0,
+            submitted_token_id: Some(2),
+            submitted_token_scoped: true,
+            submitted_token_scopes: serde_json::json!([]),
+            request_redacted_at: None,
+            started_at: Some(timestamp),
+            finished_at: None,
+            deleted_at: None,
+            deleted_by: None,
+            created_at: timestamp,
+            updated_at: timestamp,
+            lease_token: Some(uuid::Uuid::parse_str(lease_token).unwrap()),
+            lease_expires_at: Some(timestamp),
+            attempt_count: 1,
+            initiator_user_id: Some(1),
+        };
+
+        let output = format!("{task:?}");
+
+        assert!(output.contains(REDACTED_DEBUG_VALUE));
+        assert!(!output.contains(idempotency_key));
+        assert!(!output.contains(payload_secret));
+        assert!(!output.contains(lease_token));
+    }
+
+    #[test]
+    fn new_task_record_debug_redacts_sensitive_request_fields() {
+        let idempotency_key = "idempotency-secret";
+        let payload_secret = "task-payload-secret";
+        let task = NewTaskRecord {
+            kind: TaskKind::Import.as_str().to_string(),
+            status: TaskStatus::Queued.as_str().to_string(),
+            submitted_by: Some(1),
+            idempotency_key: Some(idempotency_key.to_string()),
+            request_hash: Some("request-hash".to_string()),
+            request_payload: Some(serde_json::json!({"password": payload_secret})),
+            summary: None,
+            total_items: 1,
+            processed_items: 0,
+            success_items: 0,
+            failed_items: 0,
+            submitted_token_id: Some(2),
+            submitted_token_scoped: true,
+            submitted_token_scopes: serde_json::json!([]),
+            request_redacted_at: None,
+            started_at: None,
+            finished_at: None,
+        };
+
+        let output = format!("{task:?}");
+
+        assert!(output.contains(REDACTED_DEBUG_VALUE));
+        assert!(!output.contains(idempotency_key));
+        assert!(!output.contains(payload_secret));
     }
 
     #[test]

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use chrono::NaiveDateTime;
 
 use crate::db::prelude::*;
@@ -11,7 +13,9 @@ use crate::db::traits::user::DeleteTokenRecord;
 use crate::errors::ApiError;
 use crate::events::EventContext;
 use crate::models::search::{FilterField, SortParam};
-use crate::models::{PrincipalID, TokenLifetime, TokenScope, TokenScopeDetails};
+use crate::models::{
+    PrincipalID, REDACTED_DEBUG_VALUE, TokenLifetime, TokenScope, TokenScopeDetails,
+};
 use crate::schema::tokens;
 use crate::traits::{
     BackendContext, CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
@@ -19,7 +23,7 @@ use crate::traits::{
 
 /// A persisted bearer token, keyed to a principal, with a full lifecycle. The
 /// `token` field stores the HMAC hash, never the raw value.
-#[derive(Serialize, Deserialize, Queryable, Insertable, Selectable, Clone, Debug, ToSchema)]
+#[derive(Serialize, Deserialize, Queryable, Insertable, Selectable, Clone, ToSchema)]
 #[diesel(table_name = tokens)]
 pub struct PrincipalToken {
     pub id: i32,
@@ -33,6 +37,25 @@ pub struct PrincipalToken {
     pub revoked_at: Option<NaiveDateTime>,
     pub permission_scoped: bool,
     pub resource_scoped: bool,
+}
+
+impl fmt::Debug for PrincipalToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PrincipalToken")
+            .field("id", &self.id)
+            .field("token", &REDACTED_DEBUG_VALUE)
+            .field("principal_id", &self.principal_id)
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .field("issued", &self.issued)
+            .field("expires_at", &self.expires_at)
+            .field("last_used_at", &self.last_used_at)
+            .field("revoked_at", &self.revoked_at)
+            .field("permission_scoped", &self.permission_scoped)
+            .field("resource_scoped", &self.resource_scoped)
+            .finish()
+    }
 }
 
 crate::int_id_newtype! {
@@ -487,5 +510,35 @@ impl CursorSqlMapping for PrincipalToken {
                 )));
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn principal_token_debug_redacts_stored_digest() {
+        let token_digest = "keyed-token-digest";
+        let token = PrincipalToken {
+            id: 1,
+            token: token_digest.to_string(),
+            principal_id: 2,
+            name: Some("automation".to_string()),
+            description: None,
+            issued: chrono::DateTime::from_timestamp(1_700_000_000, 0)
+                .unwrap()
+                .naive_utc(),
+            expires_at: None,
+            last_used_at: None,
+            revoked_at: None,
+            permission_scoped: false,
+            resource_scoped: false,
+        };
+
+        let output = format!("{token:?}");
+
+        assert!(output.contains(REDACTED_DEBUG_VALUE));
+        assert!(!output.contains(token_digest));
     }
 }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -1,13 +1,15 @@
+use std::fmt;
+
 use crate::db::prelude::*;
 use crate::db::traits::user::{
     AnonymizeUserRecord, CreateUserRecord, DeleteUserRecord, OwnedUserTokenRecord,
     SetUserPasswordRecord, UpdateUserRecord,
 };
 use crate::events::EventContext;
-use crate::models::PrincipalID;
 use crate::models::identity::LOCAL_IDENTITY_SCOPE;
 use crate::models::principal::load_principal_by_id;
 use crate::models::token::{IssuedToken, PrincipalToken, PrincipalTokenCreateRequest, Token};
+use crate::models::{PrincipalID, REDACTED_DEBUG_VALUE, redacted_debug_option};
 use crate::schema::users;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -22,9 +24,7 @@ use tracing::{debug, error, warn};
 
 /// A human user. The id is the principal id; the login/display name lives on
 /// `principals.name`, not here.
-#[derive(
-    Serialize, Deserialize, Queryable, Selectable, Insertable, PartialEq, Debug, Clone, ToSchema,
-)]
+#[derive(Serialize, Deserialize, Queryable, Selectable, Insertable, PartialEq, Clone, ToSchema)]
 #[diesel(table_name = users)]
 pub struct User {
     pub id: i32,
@@ -37,6 +37,22 @@ pub struct User {
     pub created_at: chrono::NaiveDateTime,
     pub updated_at: chrono::NaiveDateTime,
     pub anonymized_at: Option<chrono::NaiveDateTime>,
+}
+
+impl fmt::Debug for User {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("User")
+            .field("id", &self.id)
+            .field("kind", &self.kind)
+            .field("password", &redacted_debug_option(&self.password))
+            .field("proper_name", &self.proper_name)
+            .field("email", &self.email)
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .field("anonymized_at", &self.anonymized_at)
+            .finish()
+    }
 }
 
 /// Public representation of a user, including the name resolved from the
@@ -471,7 +487,7 @@ impl UpdateUser {
 /// Struct to create a new user.
 ///
 /// The password is expected to be plaintext. `name` is the principal name.
-#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 #[schema(example = new_user_example)]
 pub struct NewUser {
     pub identity_scope: Option<String>,
@@ -479,6 +495,19 @@ pub struct NewUser {
     pub password: String,
     pub proper_name: Option<String>,
     pub email: Option<String>,
+}
+
+impl fmt::Debug for NewUser {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NewUser")
+            .field("identity_scope", &self.identity_scope)
+            .field("name", &self.name)
+            .field("password", &REDACTED_DEBUG_VALUE)
+            .field("proper_name", &self.proper_name)
+            .field("email", &self.email)
+            .finish()
+    }
 }
 
 impl NewUser {
@@ -653,5 +682,53 @@ fn login_user_example() -> LoginUser {
         identity_scope: None,
         name: "alice".to_string(),
         password: "correct-horse-battery-staple".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_timestamp() -> chrono::NaiveDateTime {
+        chrono::DateTime::from_timestamp(1_700_000_000, 0)
+            .unwrap()
+            .naive_utc()
+    }
+
+    #[test]
+    fn user_debug_redacts_stored_password_hash() {
+        let password_hash = "$argon2id$stored-password-hash";
+        let user = User {
+            id: 1,
+            kind: "human".to_string(),
+            password: Some(password_hash.to_string()),
+            proper_name: Some("Alice".to_string()),
+            email: Some("alice@example.com".to_string()),
+            created_at: test_timestamp(),
+            updated_at: test_timestamp(),
+            anonymized_at: None,
+        };
+
+        let output = format!("{user:?}");
+
+        assert!(output.contains(REDACTED_DEBUG_VALUE));
+        assert!(!output.contains(password_hash));
+    }
+
+    #[test]
+    fn new_user_debug_redacts_plaintext_password() {
+        let password = "correct-horse-battery-staple";
+        let user = NewUser {
+            identity_scope: None,
+            name: "alice".to_string(),
+            password: password.to_string(),
+            proper_name: Some("Alice".to_string()),
+            email: Some("alice@example.com".to_string()),
+        };
+
+        let output = format!("{user:?}");
+
+        assert!(output.contains(REDACTED_DEBUG_VALUE));
+        assert!(!output.contains(password));
     }
 }

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -434,7 +434,6 @@ async fn process_one_task_with_settings(
                 warn!(
                     message = "Task failure finalization stopped because its worker lease was lost",
                     task_id = task.id,
-                    claim_token = ?task.lease_token,
                 );
             }
         }
@@ -526,7 +525,6 @@ fn start_task_lease_heartbeat(
     let task_id = task.id;
     Some(spawn_task_lease_monitor(
         task_id,
-        claim_token,
         settings,
         initial_confirmed_expiry,
         move || {
@@ -544,7 +542,6 @@ fn start_task_lease_heartbeat(
 
 fn spawn_task_lease_monitor<F, Fut>(
     task_id: i32,
-    claim_token: uuid::Uuid,
     settings: TaskWorkerSettings,
     initial_confirmed_expiry: TokioInstant,
     renew: F,
@@ -561,7 +558,6 @@ where
     let handle = TASK_LEASE_RUNTIME.spawn(async move {
         let lost = monitor_task_lease(
             task_id,
-            claim_token,
             settings,
             initial_confirmed_expiry,
             renew,
@@ -581,7 +577,6 @@ where
 
 async fn monitor_task_lease<F, Fut>(
     task_id: i32,
-    claim_token: uuid::Uuid,
     settings: TaskWorkerSettings,
     mut confirmed_expiry: TokioInstant,
     mut renew: F,
@@ -600,7 +595,6 @@ where
                 warn!(
                     message = "Task lease renewal deadline expired",
                     task_id,
-                    claim_token = %claim_token,
                 );
                 return true;
             }
@@ -614,7 +608,6 @@ where
                         warn!(
                             message = "Task lease renewal did not complete before the lease expired",
                             task_id,
-                            claim_token = %claim_token,
                         );
                         return true;
                     }
@@ -631,7 +624,6 @@ where
                         warn!(
                             message = "Task lease is no longer owned by this worker",
                             task_id,
-                            claim_token = %claim_token,
                         );
                         return true;
                     }
@@ -639,7 +631,6 @@ where
                         warn!(
                             message = "Failed to renew task worker lease",
                             task_id,
-                            claim_token = %claim_token,
                             error = %error,
                         );
                     }
@@ -930,6 +921,16 @@ mod lease_heartbeat_tests {
 
     use super::*;
 
+    #[test]
+    fn lease_diagnostics_do_not_log_claim_tokens() {
+        let source = include_str!("worker.rs");
+        let direct_token_field = ["claim_", "token = %"].concat();
+        let optional_token_field = ["claim_", "token = ?task.lease_token"].concat();
+
+        assert!(!source.contains(&direct_token_field));
+        assert!(!source.contains(&optional_token_field));
+    }
+
     fn new_single_connection_execution_pool() -> DbPool {
         let config = get_config().expect("test requires database configuration");
         let settings = DatabasePoolSettings::builder(config.database_url.clone())
@@ -958,7 +959,6 @@ mod lease_heartbeat_tests {
         actix_rt::System::new().block_on(async move {
             let heartbeat = spawn_task_lease_monitor(
                 1,
-                uuid::Uuid::new_v4(),
                 settings,
                 TokioInstant::now() + settings.lease_duration,
                 move || {
@@ -992,7 +992,6 @@ mod lease_heartbeat_tests {
         actix_rt::System::new().block_on(async move {
             let mut heartbeat = spawn_task_lease_monitor(
                 1,
-                uuid::Uuid::new_v4(),
                 settings,
                 TokioInstant::now() + settings.lease_duration,
                 || async {
@@ -1072,7 +1071,6 @@ mod lease_heartbeat_tests {
             Duration::from_millis(250),
             monitor_task_lease(
                 1,
-                uuid::Uuid::new_v4(),
                 settings,
                 confirmed_expiry,
                 || {


### PR DESCRIPTION
## Summary

Replace broad derived `Debug` output across credential-bearing domain and integration types with explicit, redacted implementations.

Cover authentication credentials, password hashes, bearer-token digests, task requests and leases, worker claim tokens, event payloads and sink configuration, outbound URLs, headers and previews, remote-target configuration and results, backup snapshots, restore capabilities and errors, login-limiter connection URLs, and connection-cache keys.

Also redact parsed AMQP, email, Valkey, and webhook configuration, routing, rendered content, and delivery payload structures. Imported task graphs now expose only per-section counts in debug output, with their complete contents redacted.

## Rationale

Derived debug formatting recursively prints fields that were never intended for logs. These types cross error, tracing, test, and operational boundaries, so one incidental `{:?}` can expose stored credentials or complete request payloads.

## Behavior and compatibility

Runtime behavior and public serialization are unchanged. Debug output retains safe identifiers and structural context while omitting secret values. This is an internal diagnostics hardening change with no migration or OpenAPI change.

## Verification

- `source .env && ./run_tests.sh`
- `cargo test -p hubuum-event-sink-amqp -p hubuum-event-sink-email -p hubuum-event-sink-valkey -p hubuum-event-sink-webhook`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
