### PR TITLE
Type restore job identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `i32` values. Downstream update adapters must declare the associated type,
   and callers must construct the matching ID before invoking `update` or
   `update_without_events`.
+- **Breaking (Rust API):** restore confirmation and status functions now
+  accept a validated `RestoreJobID` instead of a raw `i64`. Downstream callers
+  must construct `RestoreJobID` at their input boundary. Versioned restore
+  paths reject non-positive stage IDs at the request boundary.
 
 ### Security
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -16391,7 +16391,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "minimum": 1
             }
           }
         ],
@@ -16498,7 +16499,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "minimum": 1
             }
           }
         ],

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -1277,6 +1277,24 @@ mod tests {
     }
 
     #[test]
+    fn restore_job_paths_document_positive_ids() {
+        let json = openapi_json();
+
+        for (path, method) in [
+            ("~1api~1v1~1restores~1{restore_id}~1confirm", "post"),
+            ("~1api~1v1~1restores~1{restore_id}~1status", "get"),
+        ] {
+            assert_eq!(
+                json.pointer(&format!(
+                    "/paths/{path}/{method}/parameters/0/schema/minimum"
+                )),
+                Some(&Value::from(1)),
+                "restore job path should document its positive-ID invariant"
+            );
+        }
+    }
+
+    #[test]
     fn export_scope_ids_document_positive_minimum() {
         let json = openapi_json();
 

--- a/src/api/v1/handlers/restores.rs
+++ b/src/api/v1/handlers/restores.rs
@@ -9,7 +9,7 @@ use crate::errors::ApiError;
 use crate::extractors::AdminAccess;
 use crate::models::principal::load_principal_by_id;
 use crate::models::{
-    BackupDocument, RestoreConfirmRequest, RestoreInitiator, RestoreStageRequest,
+    BackupDocument, RestoreConfirmRequest, RestoreInitiator, RestoreJobID, RestoreStageRequest,
     RestoreStageResponse,
 };
 use crate::restores::{
@@ -72,7 +72,7 @@ pub async fn create_restore_stage(
     path = "/api/v1/restores/{restore_id}/confirm",
     tag = "restores",
     security(("bearer_auth" = [])),
-    params(("restore_id" = i64, Path, description = "Restore stage ID")),
+    params(("restore_id" = i64, Path, description = "Restore stage ID", minimum = 1)),
     request_body = RestoreConfirmRequest,
     responses(
         (status = 200, description = "Restore completed", body = RestoreStageResponse,
@@ -89,7 +89,7 @@ pub async fn create_restore_stage(
 pub async fn confirm_restore_stage(
     pool: web::Data<DbPool>,
     _admin: AdminAccess,
-    restore_id: web::Path<i64>,
+    restore_id: web::Path<RestoreJobID>,
     confirmation: web::Json<RestoreConfirmRequest>,
 ) -> Result<impl Responder, ApiError> {
     let response = confirm_restore(&pool, restore_id.into_inner(), &confirmation).await?;
@@ -101,7 +101,7 @@ pub async fn confirm_restore_stage(
     path = "/api/v1/restores/{restore_id}/status",
     tag = "restores",
     security(("restore_capability" = [])),
-    params(("restore_id" = i64, Path, description = "Restore stage ID")),
+    params(("restore_id" = i64, Path, description = "Restore stage ID", minimum = 1)),
     responses(
         (status = 200, description = "Restore status", body = RestoreStageResponse,
             headers(("Cache-Control" = String, description = "Always no-store for restore metadata"))
@@ -113,7 +113,7 @@ pub async fn confirm_restore_stage(
 #[get("/{restore_id}/status")]
 pub async fn get_restore_status(
     pool: web::Data<DbPool>,
-    restore_id: web::Path<i64>,
+    restore_id: web::Path<RestoreJobID>,
     request: HttpRequest,
 ) -> Result<HttpResponse, ApiError> {
     let capability = request

--- a/src/bin/admin.rs
+++ b/src/bin/admin.rs
@@ -26,7 +26,7 @@ use hubuum::errors::{ApiError, EXIT_CODE_CONFIG_ERROR, fatal_error};
 use hubuum::logger;
 use hubuum::models::{
     BackupRequest, ExportTaskOutputRecord, ExportTemplate, RESTORE_CONFIRMATION_PHRASE,
-    RestoreConfirmRequest, RestoreInitiator, RestoreStageRequest, User,
+    RestoreConfirmRequest, RestoreInitiator, RestoreJobID, RestoreStageRequest, User,
 };
 use hubuum::restores::{RestoreSettings, confirm_restore, stage_restore};
 use hubuum::schema::export_task_outputs::dsl::export_task_outputs;
@@ -411,7 +411,7 @@ async fn restore_database(
     })?;
     let restored = confirm_restore(
         &pool,
-        staged.id,
+        RestoreJobID::new(staged.id)?,
         &RestoreConfirmRequest {
             restore_capability: capability,
             sha256: staged.sha256,

--- a/src/models/backup.rs
+++ b/src/models/backup.rs
@@ -249,7 +249,7 @@ impl BackupDocument {
 mod tests {
     use rstest::rstest;
 
-    use super::{BackupRequest, RestoreInitiator, RestoreStageRequest};
+    use super::{BackupRequest, RestoreInitiator, RestoreJobID, RestoreStageRequest};
 
     #[test]
     fn backup_requests_include_history_by_default() {
@@ -286,6 +286,13 @@ mod tests {
 
         assert!(RestoreStageRequest::new(initiator, Vec::new()).is_err());
     }
+
+    #[test]
+    fn restore_job_id_rejects_non_positive_values_at_deserialization() {
+        assert_eq!(RestoreJobID::new(1).unwrap().id(), 1);
+        assert!(serde_json::from_str::<RestoreJobID>("0").is_err());
+        assert!(serde_json::from_str::<RestoreJobID>("-1").is_err());
+    }
 }
 
 #[derive(Queryable, Selectable)]
@@ -308,6 +315,36 @@ pub struct NewBackupTaskOutputRecord {
     pub byte_size: i64,
     pub sha256: String,
     pub output_expires_at: NaiveDateTime,
+}
+
+/// Identifier wrapper for a staged restore job.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
+#[schema(value_type = i64)]
+pub struct RestoreJobID(i64);
+
+impl RestoreJobID {
+    pub fn new(id: i64) -> Result<Self, ApiError> {
+        if id <= 0 {
+            return Err(ApiError::BadRequest(format!(
+                "Invalid restore job id '{id}': must be a positive integer"
+            )));
+        }
+        Ok(Self(id))
+    }
+
+    pub fn id(self) -> i64 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for RestoreJobID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let id = <i64 as Deserialize>::deserialize(deserializer)?;
+        Self::new(id).map_err(serde::de::Error::custom)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/restores/mod.rs
+++ b/src/restores/mod.rs
@@ -30,8 +30,8 @@ use crate::models::retention::FutureRetention;
 use crate::models::{
     BackupDocument, COMPUTED_FIELD_VISIBILITY_PERSONAL, COMPUTED_FIELD_VISIBILITY_SHARED,
     ComputedFieldDefinitionRequest, ComputedResultType, MaintenanceState, NewRestoreJobRecord,
-    RESTORE_CONFIRMATION_PHRASE, RestoreConfirmRequest, RestoreJobRecord, RestoreJobStatus,
-    RestoreStageRequest, RestoreStageResponse, RestoreValidationSummary,
+    RESTORE_CONFIRMATION_PHRASE, RestoreConfirmRequest, RestoreJobID, RestoreJobRecord,
+    RestoreJobStatus, RestoreStageRequest, RestoreStageResponse, RestoreValidationSummary,
 };
 
 static RESTORE_COORDINATOR: Once = Once::new();
@@ -500,16 +500,19 @@ pub async fn stage_restore(
     })
 }
 
-pub async fn load_restore_job(pool: &DbPool, job_id: i64) -> Result<RestoreJobRecord, ApiError> {
-    load_restore_job_db(pool, job_id).await
+pub async fn load_restore_job(
+    pool: &DbPool,
+    job_id: RestoreJobID,
+) -> Result<RestoreJobRecord, ApiError> {
+    load_restore_job_db(pool, job_id.id()).await
 }
 
 pub async fn restore_status(
     pool: &DbPool,
-    job_id: i64,
+    job_id: RestoreJobID,
     capability: &str,
 ) -> Result<RestoreStageResponse, ApiError> {
-    let job = match load_restore_status_job_db(pool, job_id).await {
+    let job = match load_restore_status_job_db(pool, job_id.id()).await {
         Ok(job) => Some(job),
         Err(ApiError::NotFound(_)) => None,
         Err(error) => return Err(error),
@@ -521,7 +524,7 @@ pub async fn restore_status(
     let Some(job) = job else {
         tracing::warn!(
             message = "Restore capability rejected",
-            restore_job_id = job_id,
+            restore_job_id = job_id.id(),
             reason = "restore stage not found"
         );
         return Err(invalid_restore_capability());
@@ -529,7 +532,7 @@ pub async fn restore_status(
     if !capability_valid {
         tracing::warn!(
             message = "Restore capability rejected",
-            restore_job_id = job_id,
+            restore_job_id = job_id.id(),
             reason = "capability mismatch"
         );
         return Err(invalid_restore_capability());
@@ -600,7 +603,7 @@ fn restore_error_for_storage(error: &ApiError) -> String {
 
 pub async fn confirm_restore(
     pool: &DbPool,
-    job_id: i64,
+    job_id: RestoreJobID,
     confirmation: &RestoreConfirmRequest,
 ) -> Result<RestoreStageResponse, ApiError> {
     let job = match load_restore_job(pool, job_id).await {
@@ -615,7 +618,7 @@ pub async fn confirm_restore(
     let Some(job) = job else {
         tracing::warn!(
             message = "Restore capability rejected",
-            restore_job_id = job_id,
+            restore_job_id = job_id.id(),
             reason = "restore stage not found"
         );
         return Err(invalid_restore_capability());
@@ -623,7 +626,7 @@ pub async fn confirm_restore(
     if !capability_valid {
         tracing::warn!(
             message = "Restore capability rejected",
-            restore_job_id = job_id,
+            restore_job_id = job_id.id(),
             reason = "capability mismatch"
         );
         return Err(invalid_restore_capability());
@@ -725,7 +728,7 @@ async fn reconcile_interrupted_restore_from_snapshot(
         resume_maintenance_without_job_db(pool).await?;
         return Err(error);
     };
-    let job = match load_restore_job(pool, job_id).await {
+    let job = match load_restore_job_db(pool, job_id).await {
         Ok(job) => job,
         Err(error) => {
             fail_restore_and_resume(pool, job_id, &error).await?;

--- a/tests/restore_roundtrip.rs
+++ b/tests/restore_roundtrip.rs
@@ -10,8 +10,8 @@ use hubuum::db::{
 use hubuum::events::{Action, ActorKind, EntityType, MutationProvenance, NewEvent, emit_event};
 use hubuum::models::{
     BackupRequest, NewHubuumClass, NewHubuumClassRelation, NewTaskRecord, ObjectRelationLimit,
-    RESTORE_CONFIRMATION_PHRASE, RestoreConfirmRequest, RestoreInitiator, RestoreJobStatus,
-    RestoreStageRequest, TaskKind, TaskStatus,
+    RESTORE_CONFIRMATION_PHRASE, RestoreConfirmRequest, RestoreInitiator, RestoreJobID,
+    RestoreJobStatus, RestoreStageRequest, TaskKind, TaskStatus,
 };
 use hubuum::restores::{
     RestoreSettings, confirm_restore, maintenance_state, reconcile_interrupted_restore,
@@ -334,7 +334,7 @@ async fn interrupted_restore_is_reconciled_after_the_drain_transition() {
         .expect("stage confirmation-path restore");
     let completed = confirm_restore(
         &pool,
-        confirmed_stage.id,
+        RestoreJobID::new(confirmed_stage.id).expect("positive staged restore id"),
         &RestoreConfirmRequest {
             restore_capability: confirmed_stage
                 .restore_capability


### PR DESCRIPTION
## Summary

Add a validated `RestoreJobID` newtype and use it across restore confirmation, status, admin, model, and persistence paths.

Deserialize versioned route parameters directly into the newtype so non-positive identifiers are rejected before restore lookup or capability processing.

## Rationale

Restore stage IDs are domain identifiers with a positive-value invariant. Carrying raw `i64` values spreads validation and weakens type safety around capability-authenticated operations.

## Behavior and compatibility

**Breaking (HTTP and Rust API):** restore function callers must construct `RestoreJobID` instead of passing raw `i64` values, and HTTP clients must use positive restore IDs. Versioned paths reject zero or negative IDs at the request boundary. OpenAPI was regenerated; no migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- OpenAPI regenerated with `cargo run --quiet --bin hubuum-openapi > docs/openapi.json`
