### PR TITLE
Type creation assignee group identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   paths reject non-positive stage IDs at the request boundary.
 - **Breaking (Rust API):** `NewCollectionWithAssignee::group_id` and
   `NewServiceAccount::owner_group_id` now use the validated `GroupID` newtype.
-  Collection and service-account creation reject non-positive group IDs at the
-  request boundary.
+  Library callers must construct `GroupID` values for those fields. Collection
+  and service-account creation reject non-positive group IDs at the request
+  boundary.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   accept a validated `RestoreJobID` instead of a raw `i64`. Downstream callers
   must construct `RestoreJobID` at their input boundary. Versioned restore
   paths reject non-positive stage IDs at the request boundary.
+- **Breaking (Rust API):** `NewCollectionWithAssignee::group_id` and
+  `NewServiceAccount::owner_group_id` now use the validated `GroupID` newtype.
+  Collection and service-account creation reject non-positive group IDs at the
+  request boundary.
 
 ### Security
 

--- a/benches/postgres/storage_postgres_criterion.rs
+++ b/benches/postgres/storage_postgres_criterion.rs
@@ -6,7 +6,8 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use hubuum::db::{DbPool, ensure_database_schema_ready, init_pool_with_statement_timeout};
 use hubuum::events::EventContext;
 use hubuum::models::{
-    Collection, CollectionID, Group, NewCollectionWithAssignee, NewGroup, collection_ancestors,
+    Collection, CollectionID, Group, GroupID, NewCollectionWithAssignee, NewGroup,
+    collection_ancestors,
 };
 use hubuum::traits::{CanDelete, CanSave, CollectionAccessors};
 use tokio::runtime::{Builder, Runtime};
@@ -62,7 +63,8 @@ impl StorageFixture {
                 NewCollectionWithAssignee {
                     name: unique_name("storage-bench-collection"),
                     description: "PostgreSQL storage point-read benchmark".to_string(),
-                    group_id: owner_group.id,
+                    group_id: GroupID::new(owner_group.id)
+                        .expect("persisted owner group id should be positive"),
                     parent_collection_id: None,
                 }
                 .save_without_events(&pool),
@@ -77,7 +79,8 @@ impl StorageFixture {
                     NewCollectionWithAssignee {
                         name: unique_name(&format!("storage-bench-depth-{depth}")),
                         description: format!("PostgreSQL storage ancestor level {depth}"),
-                        group_id: owner_group.id,
+                        group_id: GroupID::new(owner_group.id)
+                            .expect("persisted owner group id should be positive"),
                         parent_collection_id: Some(
                             CollectionID::new(parent_id).expect("valid parent id"),
                         ),
@@ -170,7 +173,8 @@ fn benchmark_postgres_storage(c: &mut Criterion) {
                 let command = NewCollectionWithAssignee {
                     name: unique_name("storage-bench-create"),
                     description: "PostgreSQL storage create benchmark".to_string(),
-                    group_id: fixture.owner_group.id,
+                    group_id: GroupID::new(fixture.owner_group.id)
+                        .expect("persisted owner group id should be positive"),
                     parent_collection_id: Some(point_read_id),
                 };
                 let started = Instant::now();

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -23028,7 +23028,8 @@
           },
           "group_id": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "minimum": 1
           },
           "name": {
             "type": "string"
@@ -23584,7 +23585,8 @@
           },
           "owner_group_id": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "minimum": 1
           }
         },
         "example": {

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -1310,6 +1310,22 @@ mod tests {
     }
 
     #[test]
+    fn creation_assignee_group_ids_document_positive_minimum() {
+        let json = openapi_json();
+
+        for pointer in [
+            "/components/schemas/NewCollectionWithAssignee/properties/group_id/minimum",
+            "/components/schemas/NewServiceAccount/properties/owner_group_id/minimum",
+        ] {
+            assert_eq!(
+                json.pointer(pointer),
+                Some(&Value::from(1)),
+                "creation assignee group id should document its positive-ID invariant"
+            );
+        }
+    }
+
+    #[test]
     fn object_relation_limits_document_positive_nullable_fields() {
         let json = openapi_json();
         assert_eq!(

--- a/src/api/v1/handlers/service_accounts.rs
+++ b/src/api/v1/handlers/service_accounts.rs
@@ -82,7 +82,8 @@ pub async fn create_service_account(
     // Create authz: admin may create for any group; a non-admin human may create
     // only for a group they already belong to.
     if !requestor.user.is_admin(&pool).await?
-        && !is_human_owner_group_member(&pool, requestor.user.id, new_sa.owner_group_id).await?
+        && !is_human_owner_group_member(&pool, requestor.user.id, new_sa.owner_group_id.id())
+            .await?
     {
         return Err(ApiError::Forbidden(
             "May only create a service account owned by a group you belong to".to_string(),
@@ -93,7 +94,7 @@ pub async fn create_service_account(
         message = "Service account create requested",
         requestor = requestor.user.id,
         name = new_sa.name.as_str(),
-        owner_group_id = new_sa.owner_group_id
+        owner_group_id = new_sa.owner_group_id.id()
     );
 
     let event_context = requestor.event_context(&req);

--- a/src/db/traits/collection/records.rs
+++ b/src/db/traits/collection/records.rs
@@ -485,7 +485,7 @@ impl SaveCollectionWithAssigneeRecord for NewCollectionWithAssignee {
         };
 
         new_collection
-            .save_collection_for_group_record_without_events(pool, self.group_id)
+            .save_collection_for_group_record_without_events(pool, self.group_id.id())
             .await
     }
 
@@ -501,7 +501,7 @@ impl SaveCollectionWithAssigneeRecord for NewCollectionWithAssignee {
         };
 
         new_collection
-            .save_collection_for_group_record(pool, self.group_id, context)
+            .save_collection_for_group_record(pool, self.group_id.id(), context)
             .await
     }
 }

--- a/src/db/traits/service_account.rs
+++ b/src/db/traits/service_account.rs
@@ -77,7 +77,7 @@ where
 {
     let name = account.name.clone();
     let description = account.description.clone().unwrap_or_default();
-    let owner_group_id = account.owner_group_id;
+    let owner_group_id = account.owner_group_id.id();
     let scope_name = account
         .identity_scope
         .as_deref()

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -1126,7 +1126,7 @@ async fn collection_writes_emit_lifecycle_events_in_transaction() {
     let collection = NewCollectionWithAssignee {
         name: collection_name.clone(),
         description: "before".to_string(),
-        group_id: fixture.owner_group.id,
+        group_id: GroupID::new(fixture.owner_group.id).unwrap(),
         parent_collection_id: None,
     }
     .save(&scope.pool, &context)

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -9,7 +9,7 @@ use crate::db::DbPool;
 use crate::db::traits::authz::AuthzSubject;
 use crate::db::traits::collection as collection_backend;
 use crate::errors::ApiError;
-use crate::models::group::Group;
+use crate::models::group::{Group, GroupID};
 use crate::models::output::{EffectiveGroupPermission, GroupPermission};
 use crate::models::search::QueryOptions;
 use crate::models::traits::GroupAccessors;
@@ -75,7 +75,8 @@ impl UpdateCollection {
 pub struct NewCollectionWithAssignee {
     pub name: String,
     pub description: String,
-    pub group_id: i32,
+    #[schema(value_type = i32, minimum = 1)]
+    pub group_id: GroupID,
     pub parent_collection_id: Option<CollectionID>,
 }
 
@@ -107,7 +108,7 @@ fn new_collection_with_assignee_example() -> NewCollectionWithAssignee {
     NewCollectionWithAssignee {
         name: "global-assets".to_string(),
         description: "Shared assets and metadata".to_string(),
-        group_id: 1,
+        group_id: GroupID::new(1).expect("valid example group id"),
         parent_collection_id: None,
     }
 }
@@ -566,7 +567,7 @@ mod tests {
         let child = NewCollectionWithAssignee {
             name: scope.scoped_name("inherited_child"),
             description: "Child collection".to_string(),
-            group_id: child_group.id,
+            group_id: GroupID::new(child_group.id).unwrap(),
             parent_collection_id: Some(CollectionID::new(parent.collection.id).unwrap()),
         }
         .save_without_events(&pool)
@@ -674,7 +675,7 @@ mod tests {
         let child = NewCollectionWithAssignee {
             name: scope.scoped_name("move_child"),
             description: "Child collection".to_string(),
-            group_id: child_group.id,
+            group_id: GroupID::new(child_group.id).unwrap(),
             parent_collection_id: Some(CollectionID::new(parent.collection.id).unwrap()),
         }
         .save_without_events(&pool)
@@ -692,7 +693,7 @@ mod tests {
         let grandchild = NewCollectionWithAssignee {
             name: scope.scoped_name("move_grandchild"),
             description: "Grandchild collection".to_string(),
-            group_id: grandchild_group.id,
+            group_id: GroupID::new(grandchild_group.id).unwrap(),
             parent_collection_id: Some(CollectionID::new(child.id).unwrap()),
         }
         .save_without_events(&pool)

--- a/src/models/service_account.rs
+++ b/src/models/service_account.rs
@@ -4,6 +4,7 @@ use utoipa::ToSchema;
 
 use crate::db::DbPool;
 use crate::errors::ApiError;
+use crate::models::GroupID;
 use crate::models::search::{FilterField, SortParam};
 use crate::schema::service_accounts;
 use crate::traits::accessors::{IdAccessor, InstanceAdapter};
@@ -190,7 +191,8 @@ pub struct NewServiceAccount {
     pub name: String,
     #[serde(default)]
     pub description: Option<String>,
-    pub owner_group_id: i32,
+    #[schema(value_type = i32, minimum = 1)]
+    pub owner_group_id: GroupID,
 }
 
 /// Mutable fields on a service account.
@@ -229,6 +231,6 @@ fn new_service_account_example() -> NewServiceAccount {
         identity_scope: None,
         name: "dns-sync".to_string(),
         description: Some("Production DNS importer".to_string()),
-        owner_group_id: 1,
+        owner_group_id: GroupID::new(1).expect("valid example owner group id"),
     }
 }

--- a/src/models/traits/collection.rs
+++ b/src/models/traits/collection.rs
@@ -187,7 +187,7 @@ impl NewCollection {
     {
         self.save_collection_for_group_record_without_events(
             backend.db_pool(),
-            collection_with_assignee.group_id,
+            collection_with_assignee.group_id.id(),
         )
         .await
     }

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -36,7 +36,7 @@ use crate::db::{capture_queries, with_connection, with_transaction};
 use crate::errors::ApiError;
 use crate::models::{
     CURRENT_IMPORT_VERSION, ClassKey, CollectionID, CollectionKey, ExportContentType,
-    ExportScopeKind, ExportTemplateKind, ImportAtomicity, ImportClassInput,
+    ExportScopeKind, ExportTemplateKind, GroupID, ImportAtomicity, ImportClassInput,
     ImportClassRelationInput, ImportCollectionInput, ImportCollisionPolicy,
     ImportExportTemplateInput, ImportGraph, ImportGroupMembershipInput, ImportIdentityScopeInput,
     ImportMembershipSourceInput, ImportMode, ImportObjectInput, ImportObjectRelationInput,
@@ -2065,7 +2065,7 @@ async fn test_resolve_collection_planning_rejects_ambiguous_bare_name() {
     ((NewCollectionWithAssignee {
         name: child_name.clone(),
         description: "first ambiguous child".to_string(),
-        group_id: parent_one.owner_group.id,
+        group_id: GroupID::new(parent_one.owner_group.id).unwrap(),
         parent_collection_id: Some(CollectionID::new(parent_one.collection.id).unwrap()),
     })
     .save_without_events(&context.pool))
@@ -2074,7 +2074,7 @@ async fn test_resolve_collection_planning_rejects_ambiguous_bare_name() {
     ((NewCollectionWithAssignee {
         name: child_name.clone(),
         description: "second ambiguous child".to_string(),
-        group_id: parent_two.owner_group.id,
+        group_id: GroupID::new(parent_two.owner_group.id).unwrap(),
         parent_collection_id: Some(CollectionID::new(parent_two.collection.id).unwrap()),
     })
     .save_without_events(&context.pool))
@@ -2108,7 +2108,7 @@ async fn test_resolve_collection_planning_uses_path_to_disambiguate_name() {
     ((NewCollectionWithAssignee {
         name: child_name.clone(),
         description: "first path child".to_string(),
-        group_id: parent_one.owner_group.id,
+        group_id: GroupID::new(parent_one.owner_group.id).unwrap(),
         parent_collection_id: Some(CollectionID::new(parent_one.collection.id).unwrap()),
     })
     .save_without_events(&context.pool))
@@ -2117,7 +2117,7 @@ async fn test_resolve_collection_planning_uses_path_to_disambiguate_name() {
     let target_child = ((NewCollectionWithAssignee {
         name: child_name.clone(),
         description: "second path child".to_string(),
-        group_id: parent_two.owner_group.id,
+        group_id: GroupID::new(parent_two.owner_group.id).unwrap(),
         parent_collection_id: Some(CollectionID::new(parent_two.collection.id).unwrap()),
     })
     .save_without_events(&context.pool))

--- a/src/tests/id_newtypes.rs
+++ b/src/tests/id_newtypes.rs
@@ -7,7 +7,7 @@
 use crate::errors::ApiError;
 use crate::models::{
     CollectionID, ExportTemplateID, GroupID, HubuumClassID, HubuumClassRelationID, HubuumObjectID,
-    HubuumObjectRelationID, TaskID, TokenID, UserID,
+    HubuumObjectRelationID, NewCollectionWithAssignee, NewServiceAccount, TaskID, TokenID, UserID,
 };
 
 macro_rules! assert_id_newtype_validates {
@@ -49,4 +49,27 @@ fn all_id_newtypes_reject_invalid_ids() {
         TaskID,
         TokenID,
     );
+}
+
+#[test]
+fn new_collection_assignee_rejects_a_non_positive_group_id() {
+    let request = serde_json::json!({
+        "name": "assets",
+        "description": "Assets",
+        "group_id": 0,
+        "parent_collection_id": null
+    });
+
+    assert!(serde_json::from_value::<NewCollectionWithAssignee>(request).is_err());
+}
+
+#[test]
+fn new_service_account_owner_rejects_a_non_positive_group_id() {
+    let request = serde_json::json!({
+        "name": "dns-sync",
+        "description": "DNS automation",
+        "owner_group_id": 0
+    });
+
+    assert!(serde_json::from_value::<NewServiceAccount>(request).is_err());
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -572,7 +572,8 @@ pub async fn create_test_service_account(
         identity_scope: None,
         name,
         description: Some("test service account".to_string()),
-        owner_group_id: owner_group.id,
+        owner_group_id: crate::models::GroupID::new(owner_group.id)
+            .expect("persisted owner group id should be positive"),
     }
     .save_without_events(pool, created_by)
     .await
@@ -810,7 +811,7 @@ async fn create_collection_for_group(
     NewCollectionWithAssignee {
         name: collection_name.to_string(),
         description: "Test collection".to_string(),
-        group_id,
+        group_id: crate::models::GroupID::new(group_id)?,
         parent_collection_id: None,
     }
     .save_without_events(pool)

--- a/src/tests/storage_performance.rs
+++ b/src/tests/storage_performance.rs
@@ -18,7 +18,7 @@ use crate::events::EventContext;
 use crate::models::collection::effective_group_on;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
-    CollectionID, NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation,
+    CollectionID, GroupID, NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation,
     NewHubuumObject, NewHubuumObjectRelation, UpdateCollection, UserID, collection_ancestors,
 };
 use crate::tests::{TestScope, ensure_admin_user};
@@ -200,7 +200,7 @@ async fn collection_ancestor_query_count_is_constant_with_depth() {
         let collection = NewCollectionWithAssignee {
             name: scope.scoped_name(&format!("query_budget_ancestor_{depth}")),
             description: format!("query budget ancestor level {depth}"),
-            group_id: root_fixture.owner_group.id,
+            group_id: GroupID::new(root_fixture.owner_group.id).unwrap(),
             parent_collection_id: Some(
                 CollectionID::new(parent.id).expect("valid parent collection id"),
             ),
@@ -250,7 +250,7 @@ async fn collection_ancestor_plan_has_bounded_logical_work_at_representative_sca
         let collection = NewCollectionWithAssignee {
             name: scope.scoped_name(&format!("query_plan_ancestor_{depth}")),
             description: format!("query plan ancestor level {depth}"),
-            group_id: fixture.owner_group.id,
+            group_id: GroupID::new(fixture.owner_group.id).unwrap(),
             parent_collection_id: Some(
                 CollectionID::new(parent_id).expect("valid parent collection id"),
             ),
@@ -308,7 +308,7 @@ async fn collection_create_with_event_has_a_fixed_query_budget() {
     let command = NewCollectionWithAssignee {
         name: scope.scoped_name("query_budget_create_child"),
         description: "query budget create child".to_string(),
-        group_id: parent.owner_group.id,
+        group_id: GroupID::new(parent.owner_group.id).unwrap(),
         parent_collection_id: Some(
             CollectionID::new(parent.collection.id).expect("valid parent collection id"),
         ),
@@ -449,7 +449,7 @@ async fn effective_permission_query_count_is_constant_with_collection_depth() {
         let collection = NewCollectionWithAssignee {
             name: scope.scoped_name(&format!("query_budget_permission_depth_{depth}")),
             description: format!("query budget permission depth {depth}"),
-            group_id: root.owner_group.id,
+            group_id: GroupID::new(root.owner_group.id).unwrap(),
             parent_collection_id: Some(
                 CollectionID::new(parent.id).expect("valid parent collection id"),
             ),

--- a/tests/api_core_data_suite/collections.rs
+++ b/tests/api_core_data_suite/collections.rs
@@ -119,7 +119,7 @@ mod tests {
         let content = NewCollectionWithAssignee {
             name: "test_collection_create".to_string(),
             description: "test collection create description".to_string(),
-            group_id: admin_group.id,
+            group_id: GroupID::new(admin_group.id).unwrap(),
             parent_collection_id: None,
         };
 
@@ -198,6 +198,29 @@ mod tests {
         let _ = assert_response_status(resp, http::StatusCode::NOT_FOUND).await;
     }
 
+    #[rstest]
+    #[actix_web::test]
+    async fn collection_creation_rejects_a_non_positive_assignee_group_id(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let request = serde_json::json!({
+            "name": context.scoped_name("invalid_assignee"),
+            "description": "invalid assignee",
+            "group_id": 0
+        });
+
+        let response = post_request(
+            &context.pool,
+            &context.admin_token,
+            COLLECTION_ENDPOINT,
+            &request,
+        )
+        .await;
+
+        assert_response_status(response, http::StatusCode::BAD_REQUEST).await;
+    }
+
     // Invalid collection ids are refused during path extraction (`CollectionID`'s validating
     // `Deserialize` plus the `PathConfig` error handler), so the request is rejected at the edge
     // with a `400` rather than surfacing as a confusing lookup miss further in. Covers
@@ -274,7 +297,7 @@ mod tests {
         let content = NewCollectionWithAssignee {
             name: "test_collection_permissions".to_string(),
             description: "test collection permissions description".to_string(),
-            group_id: admin_group.id,
+            group_id: GroupID::new(admin_group.id).unwrap(),
             parent_collection_id: None,
         };
 

--- a/tests/api_core_data_suite/querying.rs
+++ b/tests/api_core_data_suite/querying.rs
@@ -8,7 +8,7 @@ mod tests {
     use crate::db::with_connection;
     use crate::models::search::{DataType, SearchOperator};
     use crate::models::{
-        Collection, HubuumClass, HubuumClassExpanded, HubuumObject, HubuumObjectWithPath,
+        Collection, GroupID, HubuumClass, HubuumClassExpanded, HubuumObject, HubuumObjectWithPath,
         NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
         NewHubuumObjectRelation,
     };
@@ -612,7 +612,7 @@ mod tests {
         let collection_z = NewCollectionWithAssignee {
             name: "querying_sort_description_collection_z".to_string(),
             description: "querying-sort-description-z".to_string(),
-            group_id: admin_group.id,
+            group_id: GroupID::new(admin_group.id).unwrap(),
             parent_collection_id: None,
         }
         .save_without_events(&context.pool)
@@ -621,7 +621,7 @@ mod tests {
         let collection_a = NewCollectionWithAssignee {
             name: "querying_sort_description_collection_a".to_string(),
             description: "querying-sort-description-a".to_string(),
-            group_id: admin_group.id,
+            group_id: GroupID::new(admin_group.id).unwrap(),
             parent_collection_id: None,
         }
         .save_without_events(&context.pool)
@@ -630,7 +630,7 @@ mod tests {
         let collection_m = NewCollectionWithAssignee {
             name: "querying_sort_description_collection_m".to_string(),
             description: "querying-sort-description-m".to_string(),
-            group_id: admin_group.id,
+            group_id: GroupID::new(admin_group.id).unwrap(),
             parent_collection_id: None,
         }
         .save_without_events(&context.pool)
@@ -805,7 +805,7 @@ mod tests {
         let collection_z = NewCollectionWithAssignee {
             name: "descending_sort_z".to_string(),
             description: "z-description".to_string(),
-            group_id: admin_group.id,
+            group_id: GroupID::new(admin_group.id).unwrap(),
             parent_collection_id: None,
         }
         .save_without_events(&context.pool)
@@ -814,7 +814,7 @@ mod tests {
         let collection_a = NewCollectionWithAssignee {
             name: "descending_sort_a".to_string(),
             description: "a-description".to_string(),
-            group_id: admin_group.id,
+            group_id: GroupID::new(admin_group.id).unwrap(),
             parent_collection_id: None,
         }
         .save_without_events(&context.pool)
@@ -823,7 +823,7 @@ mod tests {
         let collection_m = NewCollectionWithAssignee {
             name: "descending_sort_m".to_string(),
             description: "m-description".to_string(),
-            group_id: admin_group.id,
+            group_id: GroupID::new(admin_group.id).unwrap(),
             parent_collection_id: None,
         }
         .save_without_events(&context.pool)

--- a/tests/api_identity_suite/service_accounts.rs
+++ b/tests/api_identity_suite/service_accounts.rs
@@ -285,7 +285,7 @@ mod tests {
                 identity_scope: None,
                 name,
                 description: None,
-                owner_group_id: group.id,
+                owner_group_id: GroupID::new(group.id).unwrap(),
             }
             .save_without_events(pool, None)
             .await
@@ -2865,6 +2865,26 @@ mod tests {
 
     const SERVICE_ACCOUNTS_ENDPOINT: &str = "/api/v1/iam/service-accounts";
 
+    #[actix_web::test]
+    async fn service_account_creation_rejects_a_non_positive_owner_group_id() {
+        let context = TestContext::new().await;
+        let request = serde_json::json!({
+            "name": context.scoped_name("invalid_owner"),
+            "description": "invalid owner",
+            "owner_group_id": 0
+        });
+
+        let response = post_request(
+            &context.pool,
+            &context.admin_token,
+            SERVICE_ACCOUNTS_ENDPOINT,
+            &request,
+        )
+        .await;
+
+        assert_response_status(response, StatusCode::BAD_REQUEST).await;
+    }
+
     async fn service_account_audit_event_count(
         context: &TestContext,
         action_value: Action,
@@ -2893,7 +2913,7 @@ mod tests {
             identity_scope: None,
             name: context.scoped_name("audited_sa"),
             description: Some("audited".to_string()),
-            owner_group_id: group.id,
+            owner_group_id: GroupID::new(group.id).unwrap(),
         };
         let resp = post_request(
             &context.pool,
@@ -3118,7 +3138,7 @@ mod tests {
                 identity_scope: None,
                 name: format!("{prefix}-{index}"),
                 description: None,
-                owner_group_id: group.id,
+                owner_group_id: GroupID::new(group.id).unwrap(),
             }
             .save_without_events(pool, None)
             .await

--- a/tests/api_jobs_suite/export_templates.rs
+++ b/tests/api_jobs_suite/export_templates.rs
@@ -22,7 +22,7 @@ mod tests {
         NewCollectionWithAssignee {
             name: format!("template_collection_{suffix}"),
             description: "template test collection".to_string(),
-            group_id: admin_group.id,
+            group_id: GroupID::new(admin_group.id).unwrap(),
             parent_collection_id: None,
         }
         .save_without_events(pool)


### PR DESCRIPTION
## Summary

Use the validated `GroupID` newtype for collection assignees and service-account owner groups during creation.

Carry the type through request schemas, models, database records, handlers, events, tests, and benchmark fixtures so non-positive group IDs fail at deserialization rather than later persistence work.

## Rationale

Ownership and assignment groups are security-relevant references with an existing positive-ID invariant. Raw integers allow invalid state to cross the public boundary and obscure which identifier kind a field accepts.

## Behavior and compatibility

**Breaking (HTTP and Rust API):** Rust callers must construct `GroupID` for collection assignee and service-account owner fields, and HTTP clients must send positive group IDs. Invalid values now fail at the request boundary. OpenAPI documents the positive minimum and was regenerated. No migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- OpenAPI regenerated with `cargo run --quiet --bin hubuum-openapi > docs/openapi.json`
