### PR TITLE
Bound external authorization working sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - **Breaking (Rust API):** raw dynamic SQL components, bind values, and JSON SQL
   generation helpers are now crate-private. External query integrations should
   use the validated `JsonPredicateExt::as_json_predicate` API instead.
+- External permission-backed list filtering now bounds in-process
+  authorization working sets and avoids retaining authorized rows outside the
+  requested page, reducing peak memory use for large candidate sets.
 
 ### Security
 

--- a/docs/treetop/test-fixture.cedar
+++ b/docs/treetop/test-fixture.cedar
@@ -1,0 +1,13 @@
+// Live parity-test policies for Hubuum's Treetop adapter.
+// Keep the identifiers in sync with test-fixture.md and
+// src/tests/permissions/live_treetop_parity.rs.
+
+permit(principal in Group::"9100", action, resource);
+
+permit(
+    principal in Group::"9101",
+    action == Action::"ReadCollection",
+    resource
+) when {
+    resource is HubuumCollection && resource == HubuumCollection::"9201"
+};

--- a/docs/treetop/test-fixture.md
+++ b/docs/treetop/test-fixture.md
@@ -7,6 +7,9 @@ following test policies loaded.
 
 ## Fixed identifiers
 
+Upload [`test-fixture.cedar`](test-fixture.cedar) alongside the schema. The
+policies are also shown below for context.
+
 The tests use these numeric IDs (chosen high enough to avoid colliding
 with normal Hubuum data):
 
@@ -37,7 +40,7 @@ permit(
 |Test|Expects|
 |---|---|
 |`live_health_check_succeeds`|server reachable, health endpoint returns OK|
-|`live_authorize_many_preserves_request_order`|granted=Allow, missing-resource=Deny, missing-action=Deny in input order|
+|`live_authorize_many_preserves_order_across_wire_batches`|600 mixed grant/resource-denial/action-denial checks retain input order across the 512-check wire boundary|
 |`live_is_admin_distinguishes_admin_from_normal`|Group 9100 -> admin, Group 9101 -> not|
 |`live_collections_user_can_reflects_external_policy`|collection 9201 visible for Group 9101 with ReadCollection|
 |`live_group_permission_on_returns_grant_grid_for_known_group`|synthesized Permission row has `has_read_collection=true` for Group 9101 on collection 9201|

--- a/src/permissions/treetop/mod.rs
+++ b/src/permissions/treetop/mod.rs
@@ -37,7 +37,7 @@ pub use mapping::{cedar_action, cedar_resource, cedar_user};
 /// Production permission backend that delegates to a Treetop policy server.
 ///
 /// - Connect once at startup via `TreetopPermissionBackend::connect`.
-/// - `authorize_many` batches all permission checks into a single Treetop request.
+/// - `authorize_many` sends permission checks in bounded Treetop batches.
 /// - `is_admin` dispatches to Treetop with a System resource check.
 /// - Reverse queries (`collections_user_can`) load candidates from the local DB
 ///   then filter via Treetop batch authorization.
@@ -76,61 +76,34 @@ impl TreetopPermissionBackend {
         Ok(Self { client, pool })
     }
 
-    /// Build the underlying batch authorize request for a vector of
-    /// PermissionRequests. Returns the wire request plus the per-request
-    /// span (start_index, count) so the caller can collapse decisions
-    /// back into per-request results in input order.
-    ///
-    /// Each PermissionRequest may contain multiple permissions (conjunctive
-    /// AND at our layer). We expand each request into N Cedar requests (one
-    /// per permission), then remember the spans so we can AND them back
-    /// together after Treetop returns per-Cedar-request decisions.
-    #[cfg(test)]
-    fn build_batch(
-        principal: &PrincipalRef,
-        requests: &[PermissionRequest],
-    ) -> (AuthorizeRequest, Vec<(usize, usize)>) {
-        let user = cedar_user(principal);
-        let mut batch = AuthorizeRequest::new();
-        let mut spans = Vec::with_capacity(requests.len());
-        let mut idx = 0;
-        for req in requests {
-            let resource = cedar_resource(&req.resource);
-            let count = req.permissions.len();
-            spans.push((idx, count));
-            for perm in &req.permissions {
-                batch = batch.add_request(TreetopRequest::new(
-                    user.clone(),
-                    cedar_action(*perm),
-                    resource.clone(),
-                ));
-                idx += 1;
-            }
-        }
-        (batch, spans)
-    }
-
-    async fn authorize_flat_permission_checks(
+    async fn authorize_cedar_requests(
         &self,
-        checks: &[(PrincipalRef, Permissions, ResourceRef)],
+        mut requests: Box<dyn Iterator<Item = TreetopRequest> + Send + '_>,
+        expected_count: usize,
     ) -> Result<Vec<bool>, ApiError> {
-        let mut decisions = Vec::with_capacity(checks.len());
-        for chunk in checks.chunks(MAX_CEDAR_REQUESTS_PER_BATCH) {
-            let batch = AuthorizeRequest::from_requests(chunk.iter().map(
-                |(principal, permission, resource)| {
-                    TreetopRequest::new(
-                        cedar_user(principal),
-                        cedar_action(*permission),
-                        cedar_resource(resource),
-                    )
-                },
-            ));
+        let mut decisions = Vec::with_capacity(expected_count);
+        loop {
+            let chunk = requests
+                .by_ref()
+                .take(MAX_CEDAR_REQUESTS_PER_BATCH)
+                .collect::<Vec<_>>();
+            if chunk.is_empty() {
+                break;
+            }
+            let chunk_len = chunk.len();
+            let batch = AuthorizeRequest::from_requests(chunk);
             let response = self
                 .client
                 .authorize(&batch)
                 .await
                 .map_err(treetop_to_api_error)?;
-            decisions.extend(extract_decisions(&response, chunk.len())?);
+            decisions.extend(extract_decisions(&response, chunk_len)?);
+        }
+        if decisions.len() != expected_count {
+            return Err(ApiError::InternalServerError(format!(
+                "constructed {} Treetop requests, expected {expected_count}",
+                decisions.len()
+            )));
         }
         Ok(decisions)
     }
@@ -156,6 +129,44 @@ fn load_treetop_ca_certificates(path: &Path) -> Result<Vec<Certificate>, ApiErro
         )));
     }
     Ok(certificates)
+}
+
+fn permission_check_count(requests: &[PermissionRequest]) -> Result<usize, ApiError> {
+    requests.iter().try_fold(0_usize, |count, request| {
+        count
+            .checked_add(request.permissions.len())
+            .ok_or_else(|| ApiError::InternalServerError("too many permission checks".into()))
+    })
+}
+
+fn collapse_permission_decisions(
+    requests: &[PermissionRequest],
+    cedar_decisions: &[bool],
+) -> Result<Vec<PermissionDecision>, ApiError> {
+    let expected_count = permission_check_count(requests)?;
+    if cedar_decisions.len() != expected_count {
+        return Err(ApiError::InternalServerError(format!(
+            "received {} Cedar decisions for {expected_count} permission checks",
+            cedar_decisions.len()
+        )));
+    }
+
+    let mut decision_offset = 0;
+    Ok(requests
+        .iter()
+        .map(|request| {
+            let end = decision_offset + request.permissions.len();
+            let all_allow = cedar_decisions[decision_offset..end]
+                .iter()
+                .all(|allowed| *allowed);
+            decision_offset = end;
+            if all_allow {
+                PermissionDecision::Allow
+            } else {
+                PermissionDecision::Deny
+            }
+        })
+        .collect())
 }
 
 /// Helper to extract boolean decisions from a Treetop authorize response.
@@ -239,34 +250,21 @@ impl PermissionBackend for TreetopPermissionBackend {
             return Ok(Vec::new());
         }
 
-        let mut checks = Vec::new();
-        let mut spans = Vec::with_capacity(requests.len());
-        for request in &requests {
-            let start = checks.len();
-            checks.extend(
-                request
-                    .permissions
-                    .iter()
-                    .map(|permission| (principal.clone(), *permission, request.resource.clone())),
-            );
-            spans.push((start, request.permissions.len()));
-        }
-        let cedar_request_count = checks.len();
-        let cedar_decisions = self.authorize_flat_permission_checks(&checks).await?;
-
-        // Collapse across the spans: each input PermissionRequest is Allow
-        // iff ALL its per-permission Cedar decisions are Allow.
-        let decisions: Vec<PermissionDecision> = spans
-            .into_iter()
-            .map(|(start, count)| {
-                let all_allow = (start..start + count).all(|i| cedar_decisions[i]);
-                if all_allow {
-                    PermissionDecision::Allow
-                } else {
-                    PermissionDecision::Deny
-                }
+        let cedar_request_count = permission_check_count(&requests)?;
+        let user = cedar_user(principal);
+        let cedar_requests = requests.iter().flat_map(|request| {
+            let user = user.clone();
+            let resource = cedar_resource(&request.resource);
+            request.permissions.iter().map(move |permission| {
+                TreetopRequest::new(user.clone(), cedar_action(*permission), resource.clone())
             })
-            .collect();
+        });
+        let cedar_decisions = self
+            .authorize_cedar_requests(Box::new(cedar_requests), cedar_request_count)
+            .await?;
+
+        // Each input request is allowed iff all of its contiguous Cedar checks allow it.
+        let decisions = collapse_permission_decisions(&requests, &cedar_decisions)?;
 
         let allow_count = decisions
             .iter()
@@ -327,31 +325,22 @@ impl PermissionBackend for TreetopPermissionBackend {
         principal: &PrincipalRef,
         tasks: &[ResourceRef],
     ) -> Result<Vec<PermissionDecision>, ApiError> {
-        let mut decisions = Vec::with_capacity(tasks.len());
-        for chunk in tasks.chunks(MAX_CEDAR_REQUESTS_PER_BATCH) {
-            let batch = AuthorizeRequest::from_requests(chunk.iter().map(|task| {
-                TreetopRequest::new(
-                    cedar_user(principal),
-                    Action::new("ReadTask"),
-                    cedar_resource(task),
-                )
-            }));
-            let response = self
-                .client
-                .authorize(&batch)
-                .await
-                .map_err(treetop_to_api_error)?;
-            decisions.extend(extract_decisions(&response, chunk.len())?.into_iter().map(
-                |allowed| {
-                    if allowed {
-                        PermissionDecision::Allow
-                    } else {
-                        PermissionDecision::Deny
-                    }
-                },
-            ));
-        }
-        Ok(decisions)
+        let user = cedar_user(principal);
+        let requests = tasks.iter().map(|task| {
+            TreetopRequest::new(user.clone(), Action::new("ReadTask"), cedar_resource(task))
+        });
+        Ok(self
+            .authorize_cedar_requests(Box::new(requests), tasks.len())
+            .await?
+            .into_iter()
+            .map(|allowed| {
+                if allowed {
+                    PermissionDecision::Allow
+                } else {
+                    PermissionDecision::Deny
+                }
+            })
+            .collect())
     }
 
     async fn collections_user_can(
@@ -373,20 +362,26 @@ impl PermissionBackend for TreetopPermissionBackend {
         } else {
             permissions
         };
-        let checks = all_collections
-            .iter()
-            .flat_map(|collection| {
-                tested_permissions.iter().map(move |permission| {
-                    (
-                        principal.clone(),
-                        *permission,
-                        ResourceRef::for_permission_on_collection(*permission, collection.id),
-                    )
-                })
-            })
-            .collect::<Vec<_>>();
-        let decisions = self.authorize_flat_permission_checks(&checks).await?;
         let width = tested_permissions.len();
+        let check_count = candidate_count.checked_mul(width).ok_or_else(|| {
+            ApiError::InternalServerError("too many collection permission checks".into())
+        })?;
+        let user = cedar_user(principal);
+        let requests = all_collections.iter().flat_map(|collection| {
+            let user = user.clone();
+            tested_permissions.iter().map(move |permission| {
+                let resource =
+                    ResourceRef::for_permission_on_collection(*permission, collection.id);
+                TreetopRequest::new(
+                    user.clone(),
+                    cedar_action(*permission),
+                    cedar_resource(&resource),
+                )
+            })
+        });
+        let decisions = self
+            .authorize_cedar_requests(Box::new(requests), check_count)
+            .await?;
         let rows = all_collections
             .into_iter()
             .zip(decisions.chunks(width))
@@ -457,25 +452,29 @@ impl PermissionBackend for TreetopPermissionBackend {
         }
 
         // For each group, build every Permission request against this
-        // collection. Flatten into one big batch — Treetop returns decisions
-        // in input order, so we know which group/permission each maps to.
+        // collection. Treetop returns decisions in input order, so we know
+        // which group/permission each maps to.
         let perms = Permissions::all();
         let mut effective_filter = page.filters.permissions()?;
         effective_filter.ensure_contains(permissions_filter);
-        let checks = all_groups
-            .iter()
-            .flat_map(|group| {
-                let principal = PrincipalRef::new(0, [group.id]);
-                perms.iter().map(move |permission| {
-                    (
-                        principal.clone(),
-                        *permission,
-                        ResourceRef::for_permission_on_collection(*permission, collection_id),
-                    )
-                })
+        let check_count = all_groups.len().checked_mul(perms.len()).ok_or_else(|| {
+            ApiError::InternalServerError("too many group permission checks".into())
+        })?;
+        let requests = all_groups.iter().flat_map(|group| {
+            let user = cedar_user(&PrincipalRef::new(0, [group.id]));
+            perms.iter().map(move |permission| {
+                let resource =
+                    ResourceRef::for_permission_on_collection(*permission, collection_id);
+                TreetopRequest::new(
+                    user.clone(),
+                    cedar_action(*permission),
+                    cedar_resource(&resource),
+                )
             })
-            .collect::<Vec<_>>();
-        let decisions = self.authorize_flat_permission_checks(&checks).await?;
+        });
+        let decisions = self
+            .authorize_cedar_requests(Box::new(requests), check_count)
+            .await?;
 
         let mut all_results: Vec<GroupPermission> = Vec::new();
         for (group, decisions) in all_groups.iter().zip(decisions.chunks(perms.len())) {
@@ -731,8 +730,7 @@ mod tests {
     }
 
     #[test]
-    fn build_batch_produces_correct_spans() {
-        let principal = PrincipalRef::new(42, vec![100, 200]);
+    fn per_request_decisions_are_collapsed_conjunctively() {
         let requests = vec![
             PermissionRequest {
                 resource: ResourceRef::collection(1),
@@ -752,15 +750,31 @@ mod tests {
             },
         ];
 
-        let (batch, spans) = TreetopPermissionBackend::build_batch(&principal, &requests);
+        let decisions =
+            collapse_permission_decisions(&requests, &[true, true, false, true, false, true])
+                .unwrap();
 
-        // First request: 2 permissions -> span (0, 2)
-        // Second request: 1 permission -> span (2, 1)
-        // Third request: 3 permissions -> span (3, 3)
-        assert_eq!(spans, vec![(0, 2), (2, 1), (3, 3)]);
+        assert_eq!(
+            decisions,
+            vec![
+                PermissionDecision::Allow,
+                PermissionDecision::Deny,
+                PermissionDecision::Deny,
+            ]
+        );
+    }
 
-        // Total Cedar requests = 2 + 1 + 3 = 6
-        assert_eq!(batch.requests.len(), 6);
+    #[test]
+    fn collapsing_an_incomplete_decision_set_fails_closed() {
+        let requests = vec![PermissionRequest {
+            resource: ResourceRef::collection(1),
+            permissions: vec![Permissions::ReadCollection, Permissions::UpdateCollection],
+        }];
+
+        assert!(matches!(
+            collapse_permission_decisions(&requests, &[true]),
+            Err(ApiError::InternalServerError(_))
+        ));
     }
 
     #[test]

--- a/src/permissions/visibility.rs
+++ b/src/permissions/visibility.rs
@@ -11,13 +11,14 @@ use super::backend::PermissionBackend;
 use super::observability::record_paginate_authorized;
 use super::types::{PermissionDecision, PermissionRequest, PrincipalRef, ResourceRef};
 
+/// Bound duplicate request/resource allocations while walking a candidate set.
+/// Backends may apply a smaller wire-level limit of their own.
+const MAX_AUTHORIZATION_CHECKS_PER_BATCH: usize = 512;
+
 /// A page of authorized rows plus the total authorized count.
 ///
-/// Constructed only by `paginate_authorized`, which today is called from
-/// the Treetop backend's reverse queries. The Local backend uses the SQL
-/// join fast path instead. Marked `dead_code`-allow because a build without
-/// the optional Treetop backend has no caller for either type, and the lints
-/// would otherwise fire.
+/// Constructed by the candidate-authorization visibility helpers. The Local
+/// backend normally uses its SQL join fast path instead.
 pub struct AuthorizedPage<T> {
     pub rows: Vec<T>,
     pub total_count: i64,
@@ -97,6 +98,10 @@ fn permission_requests<T>(
         .collect()
 }
 
+fn candidate_batch_size(permissions: &[Permissions]) -> usize {
+    (MAX_AUTHORIZATION_CHECKS_PER_BATCH / permissions.len().max(1)).max(1)
+}
+
 fn allowed_candidate_values<T>(
     candidates: Vec<ResourceScopedCandidate<T>>,
     decisions: Vec<PermissionDecision>,
@@ -115,6 +120,36 @@ fn allowed_candidate_values<T>(
         .collect())
 }
 
+async fn visit_authorized_candidates<T, F>(
+    backend: &dyn PermissionBackend,
+    principal: &PrincipalRef,
+    candidates: Vec<ResourceScopedCandidate<T>>,
+    permissions: &[Permissions],
+    mut visit: F,
+) -> Result<usize, ApiError>
+where
+    F: FnMut(T),
+{
+    let mut candidates = candidates.into_iter();
+    let mut authorized_count = 0;
+    let batch_size = candidate_batch_size(permissions);
+
+    loop {
+        let batch = candidates.by_ref().take(batch_size).collect::<Vec<_>>();
+        if batch.is_empty() {
+            break;
+        }
+
+        let requests = permission_requests(&batch, permissions);
+        let decisions = backend.authorize_many(principal, requests).await?;
+        let allowed = allowed_candidate_values(batch, decisions)?;
+        authorized_count += allowed.len();
+        allowed.into_iter().for_each(&mut visit);
+    }
+
+    Ok(authorized_count)
+}
+
 pub async fn authorize_all_candidates<T, F>(
     backend: &dyn PermissionBackend,
     principal: &PrincipalRef,
@@ -127,9 +162,12 @@ where
     F: Fn(&T) -> ResourceRef,
 {
     let candidates = resource_scoped_candidates(candidates, scope, &to_resource);
-    let requests = permission_requests(&candidates, &permissions);
-    let decisions = backend.authorize_many(principal, requests).await?;
-    allowed_candidate_values(candidates, decisions)
+    let mut authorized = Vec::new();
+    visit_authorized_candidates(backend, principal, candidates, &permissions, |candidate| {
+        authorized.push(candidate)
+    })
+    .await?;
+    Ok(authorized)
 }
 
 pub async fn authorize_cursor_page<T, F>(
@@ -149,10 +187,12 @@ where
     let backend_kind = backend.kind();
     let candidate_count = candidates.len();
     let candidates = resource_scoped_candidates(candidates, scope, &to_resource);
-    let requests = permission_requests(&candidates, &permissions);
-    let decisions = backend.authorize_many(principal, requests).await?;
-    let authorized = allowed_candidate_values(candidates, decisions)?;
-    let authorized_count = authorized.len();
+    let mut authorized = Vec::new();
+    let authorized_count =
+        visit_authorized_candidates(backend, principal, candidates, &permissions, |candidate| {
+            authorized.push(candidate)
+        })
+        .await?;
     let total_count = known_count_or_skipped(query_options, authorized_count as i64);
     let rows = paginate_in_memory(authorized, query_options)?;
     record_paginate_authorized(
@@ -174,6 +214,8 @@ where
 /// caller is responsible for fetching this list via a SQL query that
 /// applies all NON-permission filters (name, collection, JSON body,
 /// etc.) but skips the `permissions`-table join.
+/// Authorization requests are assembled and dispatched in bounded batches;
+/// the candidate vector itself remains the caller's responsibility.
 ///
 /// `to_resource` maps each candidate to the [`ResourceRef`] used for
 /// authorization. `permissions` is the conjunctive permission set
@@ -205,40 +247,17 @@ where
     let backend_kind = backend.kind();
     let candidate_count = candidates.len();
     let candidates = resource_scoped_candidates(candidates, scope, &to_resource);
-
-    if candidates.is_empty() {
-        record_paginate_authorized(backend_kind, 0, 0, offset, limit, 0, start.elapsed());
-        return Ok(AuthorizedPage {
-            rows: Vec::new(),
-            total_count: 0,
-        });
-    }
-
-    let requests = permission_requests(&candidates, &permissions);
-
-    let decisions = backend.authorize_candidates(principal, requests).await?;
-
-    if candidates.len() != decisions.len() {
-        return Err(ApiError::InternalServerError(
-            "Permission backend returned an unexpected number of decisions".to_string(),
-        ));
-    }
-
-    let authorized: Vec<T> = candidates
-        .into_iter()
-        .zip(decisions)
-        .filter_map(|(row, result)| {
-            if result.decision == PermissionDecision::Allow {
-                Some(row.value)
-            } else {
-                None
+    let mut rows = Vec::new();
+    let mut authorized_seen = 0;
+    let authorized_count =
+        visit_authorized_candidates(backend, principal, candidates, &permissions, |candidate| {
+            if authorized_seen >= offset && rows.len() < limit {
+                rows.push(candidate);
             }
+            authorized_seen += 1;
         })
-        .collect();
-
-    let authorized_count = authorized.len();
+        .await?;
     let total_count = authorized_count as i64;
-    let rows: Vec<T> = authorized.into_iter().skip(offset).take(limit).collect();
     let returned_count = rows.len();
 
     record_paginate_authorized(

--- a/src/tests/permissions/live_treetop_parity.rs
+++ b/src/tests/permissions/live_treetop_parity.rs
@@ -66,10 +66,11 @@ async fn live_health_check_succeeds() {
 }
 
 #[actix_test]
-async fn live_authorize_many_preserves_request_order() {
+async fn live_authorize_many_preserves_order_across_wire_batches() {
     let Some(url) = treetop_url() else {
         eprintln!(
-            "skipping live_authorize_many_preserves_request_order: HUBUUM_TREETOP_TEST_URL not set"
+            "skipping live_authorize_many_preserves_order_across_wire_batches: \
+             HUBUUM_TREETOP_TEST_URL not set"
         );
         return;
     };
@@ -94,22 +95,30 @@ async fn live_authorize_many_preserves_request_order() {
         permissions: vec![Permissions::DeleteCollection],
     };
 
+    // Repeat the mixed decision pattern past the 512-check wire limit. The
+    // boundary falls inside the pattern, so concatenating batches in the wrong
+    // order cannot accidentally satisfy the expected sequence.
+    let request_pattern = [granted, denied_by_resource, denied_by_action];
+    let requests = (0..600)
+        .map(|index| request_pattern[index % request_pattern.len()].clone())
+        .collect();
+    let expected_pattern = [
+        PermissionDecision::Allow,
+        PermissionDecision::Deny,
+        PermissionDecision::Deny,
+    ];
+    let expected = (0..600)
+        .map(|index| expected_pattern[index % expected_pattern.len()])
+        .collect::<Vec<_>>();
+
     let decisions = backend
-        .authorize_many(
-            &principal,
-            vec![granted, denied_by_resource, denied_by_action],
-        )
+        .authorize_many(&principal, requests)
         .await
         .expect("authorize_many failed");
 
     assert_eq!(
-        decisions,
-        vec![
-            PermissionDecision::Allow,
-            PermissionDecision::Deny,
-            PermissionDecision::Deny,
-        ],
-        "Treetop must return decisions in input order"
+        decisions, expected,
+        "Treetop must preserve cross-batch order"
     );
 }
 

--- a/src/tests/permissions/visibility.rs
+++ b/src/tests/permissions/visibility.rs
@@ -18,10 +18,14 @@ use crate::models::{
 };
 use crate::permissions::backend::PermissionBackend;
 use crate::permissions::local::LocalPermissionBackend;
+use crate::permissions::test_support::{MockAllowRule, MockTreetopBackend};
 use crate::permissions::types::{
-    AuthorizationResult, PermissionDecision, PermissionRequest, PrincipalRef, ResourceRef,
+    AuthorizationResult, PermissionDecision, PermissionRequest, PrincipalRef, ResourceAttrs,
+    ResourceKind, ResourceRef,
 };
-use crate::permissions::visibility::{AuthorizationPage, AuthorizedObjectIds, paginate_authorized};
+use crate::permissions::visibility::{
+    AuthorizationPage, AuthorizedObjectIds, authorize_all_candidates, paginate_authorized,
+};
 use crate::tests::{
     create_collection_fixture, create_test_group, create_test_user, get_pool_and_config,
 };
@@ -42,6 +46,65 @@ fn authorized_object_ids_reject_non_positive_values() {
         error,
         ApiError::InternalServerError("Authorized object ids must be positive".to_string())
     );
+}
+
+#[actix_test]
+async fn candidate_authorization_bounds_each_expanded_permission_batch() {
+    let backend = MockTreetopBackend::new();
+    for action in [Permissions::ReadCollection, Permissions::UpdateCollection] {
+        backend.add_rule(MockAllowRule {
+            group_id: 7,
+            action,
+            resource_kind: ResourceKind::Collection,
+            resource_id: None,
+            attrs: ResourceAttrs::default(),
+        });
+    }
+    let principal = PrincipalRef::new(1, [7]);
+    let candidates = (1..=300).collect::<Vec<_>>();
+
+    let authorized = authorize_all_candidates(
+        &backend,
+        &principal,
+        candidates.clone(),
+        None,
+        vec![Permissions::ReadCollection, Permissions::UpdateCollection],
+        |collection_id| ResourceRef::collection(*collection_id),
+    )
+    .await
+    .expect("candidate authorization should succeed");
+
+    assert_eq!(authorized, candidates);
+    assert_eq!(backend.authorization_batch_sizes(), vec![256, 44]);
+}
+
+#[actix_test]
+async fn authorized_page_preserves_order_across_batch_boundaries() {
+    let backend = MockTreetopBackend::new();
+    backend.add_rule(MockAllowRule {
+        group_id: 7,
+        action: Permissions::ReadCollection,
+        resource_kind: ResourceKind::Collection,
+        resource_id: None,
+        attrs: ResourceAttrs::default(),
+    });
+    let principal = PrincipalRef::new(1, [7]);
+
+    let page = paginate_authorized(
+        &backend,
+        &principal,
+        (1..=600).collect(),
+        None,
+        vec![Permissions::ReadCollection],
+        AuthorizationPage::new(510, 4),
+        |collection_id| ResourceRef::collection(*collection_id),
+    )
+    .await
+    .expect("authorized pagination should succeed");
+
+    assert_eq!(page.total_count, 600);
+    assert_eq!(page.rows, vec![511, 512, 513, 514]);
+    assert_eq!(backend.authorization_batch_sizes(), vec![512, 88]);
 }
 
 /// Wrapper that forces the slow-path branch by returning false from


### PR DESCRIPTION
## Summary

Bound external authorization work by batching expanded permission checks to the Treetop wire limit and streaming authorized candidates without retaining rows outside the requested page.

Preserve source ordering and total authorized counts across batch boundaries, fail closed on incomplete decision sets, and add both deterministic mock regressions and an optional live Treetop parity test over 600 mixed decisions.

## Rationale

Large candidate sets multiplied by requested permissions could create oversized authorization payloads and retain every authorized row merely to return one page. The batching strategy must account for expanded permission checks, not only candidate count.

## Behavior and compatibility

List ordering, pagination, and authorization semantics remain unchanged. Peak in-process memory and per-request Treetop working sets are bounded. No API or migration change is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- Live parity test included; local execution skipped because `HUBUUM_TREETOP_TEST_URL` was not configured
