### PR TITLE
Make JSON filter column mapping total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   Library callers must construct `GroupID` values for those fields. Collection
   and service-account creation reject non-positive group IDs at the request
   boundary.
+- **Breaking (Rust API):** replaced the partial `FilterField::table_field`
+  helper, which panicked for non-JSON fields, with the total
+  `FilterField::json_column` mapping. Callers must handle its optional result.
 
 ### Security
 

--- a/crates/hubuum-query/src/lib.rs
+++ b/crates/hubuum-query/src/lib.rs
@@ -1072,16 +1072,18 @@ macro_rules! filter_fields {
         }
 
         impl FilterField {
-            pub fn table_field(&self) -> &'static str {
+            /// Return the JSONB column addressed by this query field.
+            ///
+            /// Most filter fields map to typed SQL columns and therefore have no
+            /// JSONB column. Keeping that distinction in the return type prevents
+            /// callers from turning an ordinary parsed field into a panic.
+            pub fn json_column(&self) -> Option<&'static str> {
                 match self {
-                    FilterField::JsonSchema => "json_schema",
+                    FilterField::JsonSchema => Some("json_schema"),
                     FilterField::JsonData
                     | FilterField::JsonDataFrom
-                    | FilterField::JsonDataTo => "data",
-                    FilterField::Computed(_) => {
-                        panic!("computed query fields should not be used as table fields")
-                    }
-                    _ => panic!("{:?} should not be used as a table field", self),
+                    | FilterField::JsonDataTo => Some("data"),
+                    _ => None,
                 }
             }
 
@@ -1330,6 +1332,18 @@ mod tests {
             std::mem::size_of::<FilterField>() <= 2 * std::mem::size_of::<usize>(),
             "FilterField should keep computed sort state behind indirection"
         );
+    }
+
+    #[test]
+    fn filter_field_json_column_mapping_is_total() {
+        assert_eq!(FilterField::JsonSchema.json_column(), Some("json_schema"));
+        assert_eq!(FilterField::JsonData.json_column(), Some("data"));
+        assert_eq!(FilterField::JsonDataFrom.json_column(), Some("data"));
+        assert_eq!(FilterField::JsonDataTo.json_column(), Some("data"));
+        assert_eq!(FilterField::Id.json_column(), None);
+
+        let computed = FilterField::from_str("computed.shared.rank").unwrap();
+        assert_eq!(computed.json_column(), None);
     }
 
     #[test]

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -321,7 +321,10 @@ impl ParsedQueryParamExt for ParsedQueryParam {
     }
 
     fn as_json_sql(&self) -> Result<SQLComponent, ApiError> {
-        self.as_json_sql_for_field_expr(self.field.table_field())
+        let json_column = self.field.json_column().ok_or_else(|| {
+            ApiError::InternalServerError(format!("Attempt to filter '{}' as JSON!", self.field))
+        })?;
+        self.as_json_sql_for_field_expr(json_column)
     }
 
     fn as_json_sql_for_field_expr(&self, jsonb_field_expr: &str) -> Result<SQLComponent, ApiError> {
@@ -1882,9 +1885,23 @@ mod test {
     // Covers docs/querying.md "JSON filtering" (`json_data` aliases target object JSON payload data).
     #[test]
     fn docs_json_data_aliases_map_to_object_data_column() {
-        assert_eq!(FilterField::JsonData.table_field(), "data");
-        assert_eq!(FilterField::JsonDataFrom.table_field(), "data");
-        assert_eq!(FilterField::JsonDataTo.table_field(), "data");
+        assert_eq!(FilterField::JsonData.json_column(), Some("data"));
+        assert_eq!(FilterField::JsonDataFrom.json_column(), Some("data"));
+        assert_eq!(FilterField::JsonDataTo.json_column(), Some("data"));
+    }
+
+    #[test]
+    fn non_json_field_cannot_abort_json_sql_generation() {
+        let error = pq(
+            "name",
+            SearchOperator::Equals { is_negated: false },
+            "value",
+        )
+        .as_json_sql()
+        .unwrap_err();
+
+        assert!(matches!(error, ApiError::InternalServerError(_)));
+        assert_eq!(error.to_string(), "Attempt to filter 'name' as JSON!");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replace the partial `FilterField::table_field` helper with a total `FilterField::json_column` mapping that returns `None` for non-JSON fields.

Update JSON predicate generation to handle that result explicitly and add regressions proving non-JSON fields cannot trigger a panic.

## Rationale

The old helper was callable for every filter variant but panicked outside JSON-backed fields. A public-looking partial mapping turns ordinary input or future call-site mistakes into process aborts.

## Behavior and compatibility

This is a breaking Rust API change: callers must use `json_column` and handle its optional result. Valid JSON filtering is unchanged; invalid internal combinations now return an error instead of panicking. No migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
