### PR TITLE
Encapsulate event worker settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - **Breaking (Rust API):** `PermissionsList` is now a permission-specific,
   non-generic domain type that canonicalizes duplicate values. Rust callers
   should replace `PermissionsList<Permissions>` with `PermissionsList`.
+- **Breaking (Rust API):** event delivery, fan-out, and retention worker
+  settings and low-level claim helpers are now crate-private, validated event
+  subsystem APIs instead of public database-layer field bags. Downstream
+  callers must migrate to the validated APIs and stop invoking the private
+  claim helpers. Operators must correct zero, inconsistent, or unrepresentable
+  worker-duration values before upgrading; those values now fail startup.
 
 ### Security
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use std::num::NonZeroUsize;
 use std::str::FromStr;
 
 use crate::errors::ApiError;
+use crate::events::{EventDeliverySettings, EventFanoutSettings, EventRetentionSettings};
 use crate::models::retention::FutureRetention;
 use crate::models::{TokenIssuancePolicy, TokenRetentionSettings};
 
@@ -922,6 +923,35 @@ impl AppConfig {
             .build()
     }
 
+    pub(crate) fn event_fanout_settings(&self) -> Result<EventFanoutSettings, ApiError> {
+        EventFanoutSettings::new(
+            self.event_fanout_batch_size,
+            self.event_fanout_lock_timeout_ms,
+        )
+        .map_err(ApiError::BadRequest)
+    }
+
+    pub(crate) fn event_delivery_settings(&self) -> Result<EventDeliverySettings, ApiError> {
+        EventDeliverySettings::builder()
+            .batch_size(self.event_delivery_batch_size)
+            .lock_timeout_ms(self.event_delivery_lock_timeout_ms)
+            .transport_timeout_ms(self.event_delivery_transport_timeout_ms)
+            .retry_backoff_base_ms(self.event_delivery_retry_backoff_base_ms)
+            .retry_backoff_max_ms(self.event_delivery_retry_backoff_max_ms)
+            .max_attempts(self.event_delivery_max_attempts)
+            .build()
+            .map_err(ApiError::BadRequest)
+    }
+
+    pub(crate) fn event_retention_settings(&self) -> Result<EventRetentionSettings, ApiError> {
+        EventRetentionSettings::new(
+            self.event_retention_days,
+            self.event_delivery_retention_days,
+            self.event_retention_purge_batch_size,
+        )
+        .map_err(ApiError::BadRequest)
+    }
+
     fn validate(self) -> Result<Self, ApiError> {
         if self.actix_workers == 0 {
             return Err(ApiError::BadRequest(
@@ -948,29 +978,13 @@ impl AppConfig {
             ));
         }
 
-        if self.event_fanout_batch_size == 0 {
-            return Err(ApiError::BadRequest(
-                "event_fanout_batch_size must be greater than 0".to_string(),
-            ));
-        }
-
         if self.event_fanout_poll_interval_ms == 0 {
             return Err(ApiError::BadRequest(
                 "event_fanout_poll_interval_ms must be greater than 0".to_string(),
             ));
         }
 
-        if self.event_fanout_lock_timeout_ms == 0 {
-            return Err(ApiError::BadRequest(
-                "event_fanout_lock_timeout_ms must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.event_delivery_batch_size == 0 {
-            return Err(ApiError::BadRequest(
-                "event_delivery_batch_size must be greater than 0".to_string(),
-            ));
-        }
+        self.event_fanout_settings()?;
 
         if self.event_delivery_poll_interval_ms == 0 {
             return Err(ApiError::BadRequest(
@@ -978,71 +992,12 @@ impl AppConfig {
             ));
         }
 
-        if self.event_delivery_lock_timeout_ms == 0 {
-            return Err(ApiError::BadRequest(
-                "event_delivery_lock_timeout_ms must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.event_delivery_transport_timeout_ms == 0 {
-            return Err(ApiError::BadRequest(
-                "event_delivery_transport_timeout_ms must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.event_delivery_transport_timeout_ms >= self.event_delivery_lock_timeout_ms {
-            return Err(ApiError::BadRequest(format!(
-                "event_delivery_transport_timeout_ms ({}) must be less than event_delivery_lock_timeout_ms ({})",
-                self.event_delivery_transport_timeout_ms, self.event_delivery_lock_timeout_ms
-            )));
-        }
-
-        if self.event_delivery_retry_backoff_base_ms == 0 {
-            return Err(ApiError::BadRequest(
-                "event_delivery_retry_backoff_base_ms must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.event_delivery_retry_backoff_max_ms == 0 {
-            return Err(ApiError::BadRequest(
-                "event_delivery_retry_backoff_max_ms must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.event_delivery_retry_backoff_base_ms > self.event_delivery_retry_backoff_max_ms {
-            return Err(ApiError::BadRequest(format!(
-                "event_delivery_retry_backoff_base_ms ({}) must be less than or equal to event_delivery_retry_backoff_max_ms ({})",
-                self.event_delivery_retry_backoff_base_ms, self.event_delivery_retry_backoff_max_ms
-            )));
-        }
-
-        if self.event_delivery_max_attempts <= 0 {
-            return Err(ApiError::BadRequest(
-                "event_delivery_max_attempts must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.event_retention_days <= 0 {
-            return Err(ApiError::BadRequest(
-                "event_retention_days must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.event_delivery_retention_days <= 0 {
-            return Err(ApiError::BadRequest(
-                "event_delivery_retention_days must be greater than 0".to_string(),
-            ));
-        }
+        self.event_delivery_settings()?;
+        self.event_retention_settings()?;
 
         if self.event_retention_purge_interval_seconds == 0 {
             return Err(ApiError::BadRequest(
                 "event_retention_purge_interval_seconds must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.event_retention_purge_batch_size == 0 {
-            return Err(ApiError::BadRequest(
-                "event_retention_purge_batch_size must be greater than 0".to_string(),
             ));
         }
 
@@ -2263,6 +2218,40 @@ mod tests {
             error.to_string(),
             "event_delivery_transport_timeout_ms (1000) must be less than event_delivery_lock_timeout_ms (1000)"
         );
+    }
+
+    #[rstest::rstest]
+    #[case::fanout_timeout(
+        "HUBUUM_EVENT_FANOUT_LOCK_TIMEOUT_MS",
+        "18446744073709551615",
+        "event_fanout_lock_timeout_ms is too large for database timestamps"
+    )]
+    #[case::delivery_timeout(
+        "HUBUUM_EVENT_DELIVERY_LOCK_TIMEOUT_MS",
+        "18446744073709551615",
+        "event_delivery_lock_timeout_ms is too large for database timestamps"
+    )]
+    #[case::delivery_retry(
+        "HUBUUM_EVENT_DELIVERY_RETRY_BACKOFF_MAX_MS",
+        "18446744073709551615",
+        "event_delivery_retry_backoff_max_ms is too large for database timestamps"
+    )]
+    #[case::retention_days(
+        "HUBUUM_EVENT_RETENTION_DAYS",
+        "9223372036854775807",
+        "event_retention_days is too large for database timestamps"
+    )]
+    fn event_worker_database_durations_must_be_representable(
+        #[case] variable: &'static str,
+        #[case] value: &str,
+        #[case] expected: &str,
+    ) {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _guard = EnvVarGuard::set(variable, Some(value));
+
+        let error = get_config_from_env().unwrap_err();
+
+        assert_eq!(error.to_string(), expected);
     }
 
     #[test]

--- a/src/db/traits/event_delivery.rs
+++ b/src/db/traits/event_delivery.rs
@@ -3,26 +3,16 @@ use std::time::Duration as StdDuration;
 
 use crate::db::prelude::*;
 use crate::db::traits::maintenance::maintenance_state_conn;
-use chrono::{Duration, NaiveDateTime, Utc};
+use chrono::{NaiveDateTime, Utc};
 use diesel::sql_types::{Nullable, Timestamp};
 use uuid::Uuid;
 
 use crate::db::{DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
-use crate::events::Event;
+use crate::events::{Event, EventDeliverySettings};
 use crate::models::event_subscription::{EventSinkRow, EventSubscriptionRow};
 use crate::models::search::{FilterField, Operator, ParsedQueryParamExt, QueryOptions};
 use crate::models::{EventDelivery, EventDeliveryID, EventDeliveryStatus};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct EventDeliverySettings {
-    pub batch_size: usize,
-    pub lock_timeout_ms: u64,
-    pub transport_timeout_ms: u64,
-    pub retry_backoff_base_ms: u64,
-    pub retry_backoff_max_ms: u64,
-    pub max_attempts: i32,
-}
 
 #[derive(Debug, Clone)]
 pub(crate) struct ClaimedEventDelivery {
@@ -103,13 +93,6 @@ pub(crate) async fn claim_event_delivery_batch(
         claim_token, event_deliveries, id, locked_until, next_attempt_at, status,
     };
 
-    if settings.batch_size == 0 {
-        return Ok(EventDeliveryClaimBatch {
-            deliveries: Vec::new(),
-            next_wakeup_in: None,
-        });
-    }
-
     with_transaction(
         pool,
         async |conn| -> Result<EventDeliveryClaimBatch, ApiError> {
@@ -135,7 +118,7 @@ pub(crate) async fn claim_event_delivery_batch(
                 .order((next_attempt_at.asc(), id.asc()))
                 .for_update()
                 .skip_locked()
-                .limit(settings.batch_size as i64)
+                .limit(settings.database_batch_size())
                 .select(id)
                 .load::<i64>(conn)
                 .await?;
@@ -148,14 +131,17 @@ pub(crate) async fn claim_event_delivery_batch(
             }
 
             let now = Utc::now().naive_utc();
+            let lock_deadline = settings.lock_deadline(now).ok_or_else(|| {
+                ApiError::InternalServerError(
+                    "event delivery lock timeout exceeds the database timestamp range".to_string(),
+                )
+            })?;
             let claim = Uuid::new_v4();
             let claimed_deliveries =
                 diesel::update(event_deliveries.filter(id.eq_any(delivery_ids)))
                     .set((
                         status.eq(EventDeliveryStatus::InFlight.as_str()),
-                        locked_until.eq(Some(
-                            now + Duration::milliseconds(settings.lock_timeout_ms as i64),
-                        )),
+                        locked_until.eq(Some(lock_deadline)),
                         claim_token.eq(Some(claim)),
                     ))
                     .get_results::<EventDelivery>(conn)
@@ -195,6 +181,11 @@ pub(crate) async fn claim_event_delivery_by_id(
         pool,
         async |conn| -> Result<ClaimedEventDelivery, ApiError> {
             let now = Utc::now().naive_utc();
+            let lock_deadline = settings.lock_deadline(now).ok_or_else(|| {
+                ApiError::InternalServerError(
+                    "event delivery lock timeout exceeds the database timestamp range".to_string(),
+                )
+            })?;
             let claim = Uuid::new_v4();
             let delivery = diesel::update(
                 event_deliveries.filter(id.eq(delivery_id)).filter(
@@ -210,9 +201,7 @@ pub(crate) async fn claim_event_delivery_by_id(
             )
             .set((
                 status.eq(EventDeliveryStatus::InFlight.as_str()),
-                locked_until.eq(Some(
-                    now + Duration::milliseconds(settings.lock_timeout_ms as i64),
-                )),
+                locked_until.eq(Some(lock_deadline)),
                 claim_token.eq(Some(claim)),
             ))
             .get_result::<EventDelivery>(conn)
@@ -310,7 +299,7 @@ async fn load_claimed_delivery_contexts(
         .collect()
 }
 
-pub async fn mark_event_delivery_succeeded(
+pub(crate) async fn mark_event_delivery_succeeded(
     pool: &DbPool,
     delivery_id_value: i64,
     claim_token_value: Uuid,
@@ -338,7 +327,7 @@ pub async fn mark_event_delivery_succeeded(
     .await
 }
 
-pub async fn mark_event_delivery_failed(
+pub(crate) async fn mark_event_delivery_failed(
     pool: &DbPool,
     delivery: &EventDelivery,
     settings: EventDeliverySettings,
@@ -350,17 +339,18 @@ pub async fn mark_event_delivery_failed(
     };
 
     let next_attempts = delivery.attempts + 1;
-    let next_status = if next_attempts >= settings.max_attempts {
+    let next_status = if next_attempts >= settings.max_attempts() {
         EventDeliveryStatus::Dead
     } else {
         EventDeliveryStatus::Failed
     };
-    let next_attempt = Utc::now().naive_utc()
-        + Duration::milliseconds(retry_backoff_ms(
-            next_attempts,
-            settings.retry_backoff_base_ms,
-            settings.retry_backoff_max_ms,
-        ) as i64);
+    let next_attempt = settings
+        .retry_deadline(Utc::now().naive_utc(), next_attempts)
+        .ok_or_else(|| {
+            ApiError::InternalServerError(
+                "event delivery retry backoff exceeds the database timestamp range".to_string(),
+            )
+        })?;
     let error = truncate_delivery_error(error);
 
     with_connection(pool, async |conn| {
@@ -382,13 +372,6 @@ pub async fn mark_event_delivery_failed(
         .await
     })
     .await
-}
-
-pub fn retry_backoff_ms(attempts: i32, base_ms: u64, max_ms: u64) -> u64 {
-    let exponent = attempts.saturating_sub(1).min(31) as u32;
-    base_ms
-        .saturating_mul(2_u64.saturating_pow(exponent))
-        .min(max_ms)
 }
 
 fn truncate_delivery_error(error: &str) -> String {

--- a/src/db/traits/event_fanout.rs
+++ b/src/db/traits/event_fanout.rs
@@ -2,23 +2,17 @@ use std::collections::HashSet;
 
 use crate::db::prelude::*;
 use crate::db::traits::maintenance::maintenance_state_conn;
-use chrono::{Duration, Utc};
+use chrono::Utc;
 use uuid::Uuid;
 
 #[cfg(test)]
 use crate::db::with_connection;
 use crate::db::{DbPool, with_transaction};
 use crate::errors::ApiError;
-use crate::events::{Event, EventEnvelope};
+use crate::events::{Event, EventEnvelope, EventFanoutSettings};
 use crate::models::EventDeliveryStatus;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct EventFanoutSettings {
-    pub batch_size: usize,
-    pub lock_timeout_ms: u64,
-}
-
-pub async fn process_event_fanout_batch(
+pub(crate) async fn process_event_fanout_batch(
     pool: &DbPool,
     settings: EventFanoutSettings,
 ) -> Result<usize, ApiError> {
@@ -27,17 +21,13 @@ pub async fn process_event_fanout_batch(
     fanout_events(pool, &event_ids).await
 }
 
-pub async fn claim_events_for_fanout(
+pub(crate) async fn claim_events_for_fanout(
     pool: &DbPool,
     settings: EventFanoutSettings,
 ) -> Result<Vec<Event>, ApiError> {
     use crate::schema::events::dsl::{
         dispatched_at, events, fanout_claim_token, fanout_locked_until, id, occurred_at,
     };
-
-    if settings.batch_size == 0 {
-        return Ok(Vec::new());
-    }
 
     with_transaction(pool, async |conn| -> Result<Vec<Event>, ApiError> {
         if !maintenance_state_conn(conn).await?.is_normal() {
@@ -55,7 +45,7 @@ pub async fn claim_events_for_fanout(
             .order(occurred_at.asc())
             .for_update()
             .skip_locked()
-            .limit(settings.batch_size as i64)
+            .limit(settings.database_batch_size())
             .select(id)
             .load::<i64>(conn)
             .await?;
@@ -64,11 +54,15 @@ pub async fn claim_events_for_fanout(
             return Ok(Vec::new());
         }
 
-        let lock_timeout = Duration::milliseconds(settings.lock_timeout_ms as i64);
+        let lock_deadline = settings.lock_deadline(now).ok_or_else(|| {
+            ApiError::InternalServerError(
+                "event fan-out lock timeout exceeds the database timestamp range".to_string(),
+            )
+        })?;
         let claim_token = Uuid::new_v4();
         let claimed = diesel::update(events.filter(id.eq_any(event_ids)))
             .set((
-                fanout_locked_until.eq(Some(now + lock_timeout)),
+                fanout_locked_until.eq(Some(lock_deadline)),
                 fanout_claim_token.eq(Some(claim_token)),
             ))
             .get_results::<Event>(conn)

--- a/src/db/traits/event_retention.rs
+++ b/src/db/traits/event_retention.rs
@@ -1,19 +1,12 @@
 use crate::db::prelude::*;
-use chrono::{Duration, NaiveDateTime, Utc};
+use chrono::{NaiveDateTime, Utc};
 use diesel::sql_types::{Array, BigInt, Bool, Timestamp};
 
 use crate::db::DbConnection;
 #[cfg(test)]
 use crate::db::{DbPool, with_transaction};
 use crate::errors::ApiError;
-use crate::events::Event;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct EventRetentionSettings {
-    pub event_retention_days: i64,
-    pub delivery_retention_days: i64,
-    pub batch_size: usize,
-}
+use crate::events::{Event, EventRetentionSettings};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct EventRetentionPurgeSummary {
@@ -56,13 +49,14 @@ pub(crate) async fn select_events_for_retention_purge_conn(
     conn: &mut DbConnection,
     settings: EventRetentionSettings,
 ) -> Result<Vec<Event>, ApiError> {
-    if settings.batch_size == 0 {
-        return Ok(Vec::new());
-    }
-
-    let cutoff = Utc::now().naive_utc() - Duration::days(settings.event_retention_days);
-    let batch_size = i64::try_from(settings.batch_size)
-        .map_err(|_| ApiError::BadRequest("event retention batch size is too large".to_string()))?;
+    let cutoff = settings
+        .event_cutoff(Utc::now().naive_utc())
+        .ok_or_else(|| {
+            ApiError::InternalServerError(
+                "event retention exceeds the database timestamp range".to_string(),
+            )
+        })?;
+    let batch_size = settings.database_batch_size();
     let ids = select_event_ids_for_retention_purge(conn, cutoff, batch_size).await?;
 
     if ids.is_empty() {
@@ -82,9 +76,14 @@ pub(crate) async fn purge_event_retention_batch_conn(
     settings: EventRetentionSettings,
     event_ids: &[i64],
 ) -> Result<EventRetentionPurgeSummary, ApiError> {
-    let delivery_cutoff = Utc::now().naive_utc() - Duration::days(settings.delivery_retention_days);
-    let batch_size = i64::try_from(settings.batch_size)
-        .map_err(|_| ApiError::BadRequest("event retention batch size is too large".to_string()))?;
+    let delivery_cutoff = settings
+        .delivery_cutoff(Utc::now().naive_utc())
+        .ok_or_else(|| {
+            ApiError::InternalServerError(
+                "event delivery retention exceeds the database timestamp range".to_string(),
+            )
+        })?;
+    let batch_size = settings.database_batch_size();
     let purged_terminal_deliveries =
         purge_terminal_event_deliveries(conn, delivery_cutoff, batch_size).await?;
     let purged_events = purge_events_by_id(conn, event_ids).await?;
@@ -96,7 +95,7 @@ pub(crate) async fn purge_event_retention_batch_conn(
 }
 
 #[cfg(test)]
-pub async fn purge_event_retention_without_archive(
+pub(crate) async fn purge_event_retention_without_archive(
     pool: &DbPool,
     settings: EventRetentionSettings,
 ) -> Result<EventRetentionPurgeSummary, ApiError> {

--- a/src/events/delivery.rs
+++ b/src/events/delivery.rs
@@ -14,8 +14,8 @@ use crate::config::{
     DEFAULT_EVENT_DELIVERY_TRANSPORT_TIMEOUT_MS, DEFAULT_EVENT_DELIVERY_WORKERS, get_config,
 };
 use crate::db::traits::event_delivery::{
-    ClaimedEventDelivery, EventDeliverySettings, claim_event_delivery_batch,
-    mark_event_delivery_failed, mark_event_delivery_succeeded,
+    ClaimedEventDelivery, claim_event_delivery_batch, mark_event_delivery_failed,
+    mark_event_delivery_succeeded,
 };
 use crate::db::traits::events::load_queued_task_initiators;
 use crate::db::traits::history::resolve_principal_names;
@@ -24,7 +24,7 @@ use crate::errors::ApiError;
 use crate::events::sink::{
     DefaultSinkResolver, EventEnvelope, SinkError, SinkResolver, event_envelope_with_names,
 };
-use crate::events::{EntityType, PrincipalNames};
+use crate::events::{EntityType, EventDeliverySettings, PrincipalNames};
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::{EventSink, EventSubscription, EventWorkerWakeupStats};
 use crate::observability::metrics;
@@ -72,24 +72,19 @@ fn configured_event_delivery_poll_interval() -> Duration {
     Duration::from_millis(interval_ms)
 }
 
-fn configured_event_delivery_settings() -> EventDeliverySettings {
-    get_config()
-        .map(|config| EventDeliverySettings {
-            batch_size: config.event_delivery_batch_size,
-            lock_timeout_ms: config.event_delivery_lock_timeout_ms,
-            transport_timeout_ms: config.event_delivery_transport_timeout_ms,
-            retry_backoff_base_ms: config.event_delivery_retry_backoff_base_ms,
-            retry_backoff_max_ms: config.event_delivery_retry_backoff_max_ms,
-            max_attempts: config.event_delivery_max_attempts,
-        })
-        .unwrap_or(EventDeliverySettings {
-            batch_size: DEFAULT_EVENT_DELIVERY_BATCH_SIZE,
-            lock_timeout_ms: DEFAULT_EVENT_DELIVERY_LOCK_TIMEOUT_MS,
-            transport_timeout_ms: DEFAULT_EVENT_DELIVERY_TRANSPORT_TIMEOUT_MS,
-            retry_backoff_base_ms: DEFAULT_EVENT_DELIVERY_RETRY_BACKOFF_BASE_MS,
-            retry_backoff_max_ms: DEFAULT_EVENT_DELIVERY_RETRY_BACKOFF_MAX_MS,
-            max_attempts: DEFAULT_EVENT_DELIVERY_MAX_ATTEMPTS,
-        })
+fn configured_event_delivery_settings() -> Result<EventDeliverySettings, ApiError> {
+    match get_config() {
+        Ok(config) => config.event_delivery_settings(),
+        Err(_) => EventDeliverySettings::builder()
+            .batch_size(DEFAULT_EVENT_DELIVERY_BATCH_SIZE)
+            .lock_timeout_ms(DEFAULT_EVENT_DELIVERY_LOCK_TIMEOUT_MS)
+            .transport_timeout_ms(DEFAULT_EVENT_DELIVERY_TRANSPORT_TIMEOUT_MS)
+            .retry_backoff_base_ms(DEFAULT_EVENT_DELIVERY_RETRY_BACKOFF_BASE_MS)
+            .retry_backoff_max_ms(DEFAULT_EVENT_DELIVERY_RETRY_BACKOFF_MAX_MS)
+            .max_attempts(DEFAULT_EVENT_DELIVERY_MAX_ATTEMPTS)
+            .build()
+            .map_err(ApiError::BadRequest),
+    }
 }
 
 async fn process_event_delivery_batch_with_schedule(
@@ -193,14 +188,14 @@ async fn process_claimed_event_delivery_with_names(
     let subscription = EventSubscription::try_from(claimed.subscription)?;
     let sink = EventSink::try_from(claimed.sink)?;
     let result = tokio::time::timeout(
-        Duration::from_millis(settings.transport_timeout_ms),
+        settings.transport_timeout(),
         deliver_one(resolver, &envelope, &subscription, &sink),
     )
     .await
     .map_err(|_| {
         SinkError::new(format!(
             "Event delivery transport timed out after {} ms",
-            settings.transport_timeout_ms
+            settings.transport_timeout_ms()
         ))
     })
     .and_then(|result| result);
@@ -330,11 +325,11 @@ fn spawn_event_delivery_worker_loop(
             info!(
                 message = "Starting event delivery worker loop",
                 worker_index = worker_index,
-                batch_size = settings.batch_size,
-                lock_timeout_ms = settings.lock_timeout_ms,
-                retry_backoff_base_ms = settings.retry_backoff_base_ms,
-                retry_backoff_max_ms = settings.retry_backoff_max_ms,
-                max_attempts = settings.max_attempts,
+                batch_size = settings.batch_size(),
+                lock_timeout_ms = settings.lock_timeout_ms(),
+                retry_backoff_base_ms = settings.retry_backoff_base_ms(),
+                retry_backoff_max_ms = settings.retry_backoff_max_ms(),
+                max_attempts = settings.max_attempts(),
                 poll_interval = ?poll_interval
             );
             let system = actix_rt::System::new();
@@ -356,7 +351,13 @@ pub fn ensure_event_delivery_worker_running(pool: DbPool) {
     }
 
     let poll_interval = configured_event_delivery_poll_interval();
-    let settings = configured_event_delivery_settings();
+    let settings = match configured_event_delivery_settings() {
+        Ok(settings) => settings,
+        Err(error) => {
+            error!(message = "Event delivery settings are invalid", error = %error);
+            return;
+        }
+    };
 
     EVENT_DELIVERY_LISTENER.call_once(|| {
         super::pg_notify::spawn_postgres_notification_listener(
@@ -370,8 +371,8 @@ pub fn ensure_event_delivery_worker_running(pool: DbPool) {
         info!(
             message = "Initializing event delivery workers",
             worker_count = worker_count,
-            batch_size = settings.batch_size,
-            lock_timeout_ms = settings.lock_timeout_ms,
+            batch_size = settings.batch_size(),
+            lock_timeout_ms = settings.lock_timeout_ms(),
             poll_interval = ?poll_interval
         );
         for worker_index in 0..worker_count {

--- a/src/events/fanout.rs
+++ b/src/events/fanout.rs
@@ -10,9 +10,10 @@ use crate::config::{
     DEFAULT_EVENT_FANOUT_BATCH_SIZE, DEFAULT_EVENT_FANOUT_LOCK_TIMEOUT_MS,
     DEFAULT_EVENT_FANOUT_POLL_INTERVAL_MS, DEFAULT_EVENT_FANOUT_WORKERS, get_config,
 };
-use crate::db::traits::event_fanout::{EventFanoutSettings, process_event_fanout_batch};
+use crate::db::traits::event_fanout::process_event_fanout_batch;
 use crate::db::{DbCallSite, DbPool, with_db_call_site};
 use crate::errors::ApiError;
+use crate::events::EventFanoutSettings;
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::EventWorkerWakeupStats;
 use crate::observability::metrics;
@@ -50,16 +51,15 @@ fn configured_event_fanout_poll_interval() -> Duration {
     Duration::from_millis(interval_ms)
 }
 
-fn configured_event_fanout_settings() -> EventFanoutSettings {
-    get_config()
-        .map(|config| EventFanoutSettings {
-            batch_size: config.event_fanout_batch_size,
-            lock_timeout_ms: config.event_fanout_lock_timeout_ms,
-        })
-        .unwrap_or(EventFanoutSettings {
-            batch_size: DEFAULT_EVENT_FANOUT_BATCH_SIZE,
-            lock_timeout_ms: DEFAULT_EVENT_FANOUT_LOCK_TIMEOUT_MS,
-        })
+fn configured_event_fanout_settings() -> Result<EventFanoutSettings, ApiError> {
+    match get_config() {
+        Ok(config) => config.event_fanout_settings(),
+        Err(_) => EventFanoutSettings::new(
+            DEFAULT_EVENT_FANOUT_BATCH_SIZE,
+            DEFAULT_EVENT_FANOUT_LOCK_TIMEOUT_MS,
+        )
+        .map_err(ApiError::BadRequest),
+    }
 }
 
 pub(super) fn fanout_worker_should_continue(result: &Result<usize, ApiError>) -> bool {
@@ -127,8 +127,8 @@ fn spawn_event_fanout_worker_loop(
             info!(
                 message = "Starting event fan-out worker loop",
                 worker_index = worker_index,
-                batch_size = settings.batch_size,
-                lock_timeout_ms = settings.lock_timeout_ms,
+                batch_size = settings.batch_size(),
+                lock_timeout_ms = settings.lock_timeout_ms(),
                 poll_interval = ?poll_interval
             );
             let system = actix_rt::System::new();
@@ -149,7 +149,13 @@ pub fn ensure_event_fanout_worker_running(pool: DbPool) {
     }
 
     let poll_interval = configured_event_fanout_poll_interval();
-    let settings = configured_event_fanout_settings();
+    let settings = match configured_event_fanout_settings() {
+        Ok(settings) => settings,
+        Err(error) => {
+            error!(message = "Event fan-out settings are invalid", error = %error);
+            return;
+        }
+    };
 
     EVENT_FANOUT_LISTENER.call_once(|| {
         super::pg_notify::spawn_postgres_notification_listener(
@@ -163,8 +169,8 @@ pub fn ensure_event_fanout_worker_running(pool: DbPool) {
         info!(
             message = "Initializing event fan-out workers",
             worker_count = worker_count,
-            batch_size = settings.batch_size,
-            lock_timeout_ms = settings.lock_timeout_ms,
+            batch_size = settings.batch_size(),
+            lock_timeout_ms = settings.lock_timeout_ms(),
             poll_interval = ?poll_interval
         );
         for worker_index in 0..worker_count {

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -18,6 +18,7 @@ mod fanout;
 mod model;
 mod pg_notify;
 mod retention;
+mod settings;
 mod sink;
 
 pub use context::RequestProvenance;
@@ -31,6 +32,7 @@ pub use fanout::{
 pub use model::{Event, EventId, EventResponse, NewEvent};
 pub(crate) use model::{PrincipalNames, StoredProvenance};
 pub use retention::ensure_event_retention_worker_running;
+pub(crate) use settings::{EventDeliverySettings, EventFanoutSettings, EventRetentionSettings};
 pub use sink::{
     DefaultSinkResolver, EventEnvelope, NoopSinkResolver, Sink, SinkError, SinkResolver,
 };

--- a/src/events/retention.rs
+++ b/src/events/retention.rs
@@ -16,14 +16,14 @@ use crate::config::{
     get_config,
 };
 use crate::db::traits::event_retention::{
-    EventRetentionPurgeSummary, EventRetentionSettings, purge_event_retention_batch_conn,
+    EventRetentionPurgeSummary, purge_event_retention_batch_conn,
     select_events_for_retention_purge_conn, try_acquire_event_retention_lock,
 };
 use crate::db::traits::maintenance::maintenance_state_conn;
 use crate::db::with_transaction;
 use crate::db::{DbCallSite, DbPool, with_db_call_site};
 use crate::errors::ApiError;
-use crate::events::Event;
+use crate::events::{Event, EventRetentionSettings};
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::restores::MaintenanceActivityGuard;
 
@@ -54,30 +54,28 @@ impl EventArchiveOutput for File {
     }
 }
 
-fn configured_event_retention_worker() -> EventRetentionWorkerConfig {
-    get_config()
-        .map(|config| EventRetentionWorkerConfig {
+fn configured_event_retention_worker() -> Result<EventRetentionWorkerConfig, ApiError> {
+    match get_config() {
+        Ok(config) => Ok(EventRetentionWorkerConfig {
             enabled: config.event_retention_purge_enabled,
-            settings: EventRetentionSettings {
-                event_retention_days: config.event_retention_days,
-                delivery_retention_days: config.event_delivery_retention_days,
-                batch_size: config.event_retention_purge_batch_size,
-            },
+            settings: config.event_retention_settings()?,
             interval: Duration::from_secs(config.event_retention_purge_interval_seconds),
             file_archive_enabled: config.event_retention_file_archive_enabled,
             archive_path: config.event_retention_archive_path.clone(),
-        })
-        .unwrap_or(EventRetentionWorkerConfig {
+        }),
+        Err(_) => Ok(EventRetentionWorkerConfig {
             enabled: DEFAULT_EVENT_RETENTION_PURGE_ENABLED,
-            settings: EventRetentionSettings {
-                event_retention_days: DEFAULT_EVENT_RETENTION_DAYS,
-                delivery_retention_days: DEFAULT_EVENT_DELIVERY_RETENTION_DAYS,
-                batch_size: DEFAULT_EVENT_RETENTION_PURGE_BATCH_SIZE,
-            },
+            settings: EventRetentionSettings::new(
+                DEFAULT_EVENT_RETENTION_DAYS,
+                DEFAULT_EVENT_DELIVERY_RETENTION_DAYS,
+                DEFAULT_EVENT_RETENTION_PURGE_BATCH_SIZE,
+            )
+            .map_err(ApiError::BadRequest)?,
             interval: Duration::from_secs(DEFAULT_EVENT_RETENTION_PURGE_INTERVAL_SECONDS),
             file_archive_enabled: DEFAULT_EVENT_RETENTION_FILE_ARCHIVE_ENABLED,
             archive_path: None,
-        })
+        }),
+    }
 }
 
 pub async fn process_event_retention_batch(
@@ -147,9 +145,9 @@ fn spawn_event_retention_worker_loop(pool: DbPool, config: EventRetentionWorkerC
     spawn_background_worker("event-retention-worker", move |shutdown| {
         info!(
             message = "Starting event retention worker loop",
-            event_retention_days = config.settings.event_retention_days,
-            delivery_retention_days = config.settings.delivery_retention_days,
-            batch_size = config.settings.batch_size,
+            event_retention_days = config.settings.event_retention_days(),
+            delivery_retention_days = config.settings.delivery_retention_days(),
+            batch_size = config.settings.batch_size(),
             interval = ?config.interval,
             file_archive_enabled = config.file_archive_enabled,
             archive_path_configured = config.archive_path.is_some()
@@ -163,7 +161,13 @@ pub fn ensure_event_retention_worker_running(pool: DbPool) {
     if get_config().is_ok_and(|config| !config.runtime_role.runs_background_workers()) {
         return;
     }
-    let config = configured_event_retention_worker();
+    let config = match configured_event_retention_worker() {
+        Ok(config) => config,
+        Err(error) => {
+            error!(message = "Event retention settings are invalid", error = %error);
+            return;
+        }
+    };
     if !config.enabled {
         return;
     }
@@ -171,9 +175,9 @@ pub fn ensure_event_retention_worker_running(pool: DbPool) {
     EVENT_RETENTION_WORKER.call_once(move || {
         info!(
             message = "Initializing event retention worker",
-            event_retention_days = config.settings.event_retention_days,
-            delivery_retention_days = config.settings.delivery_retention_days,
-            batch_size = config.settings.batch_size,
+            event_retention_days = config.settings.event_retention_days(),
+            delivery_retention_days = config.settings.delivery_retention_days(),
+            batch_size = config.settings.batch_size(),
             interval = ?config.interval,
             file_archive_enabled = config.file_archive_enabled,
             archive_path_configured = config.archive_path.is_some()

--- a/src/events/settings.rs
+++ b/src/events/settings.rs
@@ -1,0 +1,461 @@
+use std::num::{NonZeroI32, NonZeroUsize};
+use std::time::Duration as StdDuration;
+
+use chrono::{Duration, NaiveDateTime, Utc};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EventWorkerBatchSize {
+    value: NonZeroUsize,
+    database_limit: i64,
+}
+
+impl EventWorkerBatchSize {
+    fn new(value: usize, field: &str) -> Result<Self, String> {
+        let value =
+            NonZeroUsize::new(value).ok_or_else(|| format!("{field} must be greater than 0"))?;
+        let database_limit = i64::try_from(value.get())
+            .map_err(|_| format!("{field} is too large for database queries"))?;
+        Ok(Self {
+            value,
+            database_limit,
+        })
+    }
+
+    const fn get(self) -> usize {
+        self.value.get()
+    }
+
+    const fn database_limit(self) -> i64 {
+        self.database_limit
+    }
+}
+
+fn database_timeout(milliseconds: u64, field: &str) -> Result<Duration, String> {
+    if milliseconds == 0 {
+        return Err(format!("{field} must be greater than 0"));
+    }
+    let milliseconds = i64::try_from(milliseconds)
+        .map_err(|_| format!("{field} is too large for database timestamps"))?;
+    let duration = Duration::try_milliseconds(milliseconds)
+        .ok_or_else(|| format!("{field} is too large for database timestamps"))?;
+    if Utc::now()
+        .naive_utc()
+        .checked_add_signed(duration)
+        .is_none()
+    {
+        return Err(format!("{field} is too large for database timestamps"));
+    }
+    Ok(duration)
+}
+
+fn retention_duration(days: i64, field: &str) -> Result<Duration, String> {
+    if days <= 0 {
+        return Err(format!("{field} must be greater than 0"));
+    }
+    let duration = Duration::try_days(days)
+        .ok_or_else(|| format!("{field} is too large for database timestamps"))?;
+    if Utc::now()
+        .naive_utc()
+        .checked_sub_signed(duration)
+        .is_none()
+    {
+        return Err(format!("{field} is too large for database timestamps"));
+    }
+    Ok(duration)
+}
+
+/// Validated policy used by event-delivery database claims and transports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EventDeliverySettings {
+    batch_size: EventWorkerBatchSize,
+    lock_timeout: Duration,
+    lock_timeout_ms: u64,
+    transport_timeout: StdDuration,
+    transport_timeout_ms: u64,
+    retry_backoff_base_ms: u64,
+    retry_backoff_max_ms: u64,
+    max_attempts: NonZeroI32,
+}
+
+impl EventDeliverySettings {
+    pub(crate) fn builder() -> EventDeliverySettingsBuilder {
+        EventDeliverySettingsBuilder::default()
+    }
+
+    pub(crate) const fn batch_size(self) -> usize {
+        self.batch_size.get()
+    }
+
+    pub(crate) const fn database_batch_size(self) -> i64 {
+        self.batch_size.database_limit()
+    }
+
+    pub(crate) const fn lock_deadline(self, now: NaiveDateTime) -> Option<NaiveDateTime> {
+        now.checked_add_signed(self.lock_timeout)
+    }
+
+    pub(crate) const fn lock_timeout_ms(self) -> u64 {
+        self.lock_timeout_ms
+    }
+
+    pub(crate) const fn transport_timeout(self) -> StdDuration {
+        self.transport_timeout
+    }
+
+    pub(crate) const fn transport_timeout_ms(self) -> u64 {
+        self.transport_timeout_ms
+    }
+
+    pub(crate) const fn retry_backoff_base_ms(self) -> u64 {
+        self.retry_backoff_base_ms
+    }
+
+    pub(crate) const fn retry_backoff_max_ms(self) -> u64 {
+        self.retry_backoff_max_ms
+    }
+
+    pub(crate) fn retry_deadline(self, now: NaiveDateTime, attempts: i32) -> Option<NaiveDateTime> {
+        let exponent = attempts.saturating_sub(1).min(31) as u32;
+        let delay_ms = self
+            .retry_backoff_base_ms
+            .saturating_mul(2_u64.saturating_pow(exponent))
+            .min(self.retry_backoff_max_ms);
+        let delay_ms = i64::try_from(delay_ms).ok()?;
+        let delay = Duration::try_milliseconds(delay_ms)?;
+        now.checked_add_signed(delay)
+    }
+
+    pub(crate) const fn max_attempts(self) -> i32 {
+        self.max_attempts.get()
+    }
+}
+
+/// Builder for the multi-field event-delivery policy.
+#[derive(Debug, Default)]
+pub(crate) struct EventDeliverySettingsBuilder {
+    batch_size: Option<usize>,
+    lock_timeout_ms: Option<u64>,
+    transport_timeout_ms: Option<u64>,
+    retry_backoff_base_ms: Option<u64>,
+    retry_backoff_max_ms: Option<u64>,
+    max_attempts: Option<i32>,
+}
+
+impl EventDeliverySettingsBuilder {
+    pub(crate) fn batch_size(mut self, value: usize) -> Self {
+        self.batch_size = Some(value);
+        self
+    }
+
+    pub(crate) fn lock_timeout_ms(mut self, value: u64) -> Self {
+        self.lock_timeout_ms = Some(value);
+        self
+    }
+
+    pub(crate) fn transport_timeout_ms(mut self, value: u64) -> Self {
+        self.transport_timeout_ms = Some(value);
+        self
+    }
+
+    pub(crate) fn retry_backoff_base_ms(mut self, value: u64) -> Self {
+        self.retry_backoff_base_ms = Some(value);
+        self
+    }
+
+    pub(crate) fn retry_backoff_max_ms(mut self, value: u64) -> Self {
+        self.retry_backoff_max_ms = Some(value);
+        self
+    }
+
+    pub(crate) fn max_attempts(mut self, value: i32) -> Self {
+        self.max_attempts = Some(value);
+        self
+    }
+
+    pub(crate) fn build(self) -> Result<EventDeliverySettings, String> {
+        let batch_size = self
+            .batch_size
+            .ok_or_else(|| "event_delivery_batch_size is required".to_string())?;
+        let lock_timeout_ms = self
+            .lock_timeout_ms
+            .ok_or_else(|| "event_delivery_lock_timeout_ms is required".to_string())?;
+        let transport_timeout_ms = self
+            .transport_timeout_ms
+            .ok_or_else(|| "event_delivery_transport_timeout_ms is required".to_string())?;
+        let retry_backoff_base_ms = self
+            .retry_backoff_base_ms
+            .ok_or_else(|| "event_delivery_retry_backoff_base_ms is required".to_string())?;
+        let retry_backoff_max_ms = self
+            .retry_backoff_max_ms
+            .ok_or_else(|| "event_delivery_retry_backoff_max_ms is required".to_string())?;
+        let max_attempts = self
+            .max_attempts
+            .ok_or_else(|| "event_delivery_max_attempts is required".to_string())?;
+
+        let batch_size = EventWorkerBatchSize::new(batch_size, "event_delivery_batch_size")?;
+        let lock_timeout = database_timeout(lock_timeout_ms, "event_delivery_lock_timeout_ms")?;
+        if transport_timeout_ms == 0 {
+            return Err("event_delivery_transport_timeout_ms must be greater than 0".to_string());
+        }
+        if transport_timeout_ms >= lock_timeout_ms {
+            return Err(format!(
+                "event_delivery_transport_timeout_ms ({transport_timeout_ms}) must be less than event_delivery_lock_timeout_ms ({lock_timeout_ms})"
+            ));
+        }
+        if retry_backoff_base_ms == 0 {
+            return Err("event_delivery_retry_backoff_base_ms must be greater than 0".to_string());
+        }
+        if retry_backoff_max_ms == 0 {
+            return Err("event_delivery_retry_backoff_max_ms must be greater than 0".to_string());
+        }
+        if retry_backoff_base_ms > retry_backoff_max_ms {
+            return Err(format!(
+                "event_delivery_retry_backoff_base_ms ({retry_backoff_base_ms}) must be less than or equal to event_delivery_retry_backoff_max_ms ({retry_backoff_max_ms})"
+            ));
+        }
+        database_timeout(retry_backoff_max_ms, "event_delivery_retry_backoff_max_ms")?;
+        let max_attempts = NonZeroI32::new(max_attempts)
+            .filter(|value| value.get() > 0)
+            .ok_or_else(|| "event_delivery_max_attempts must be greater than 0".to_string())?;
+
+        Ok(EventDeliverySettings {
+            batch_size,
+            lock_timeout,
+            lock_timeout_ms,
+            transport_timeout: StdDuration::from_millis(transport_timeout_ms),
+            transport_timeout_ms,
+            retry_backoff_base_ms,
+            retry_backoff_max_ms,
+            max_attempts,
+        })
+    }
+}
+
+/// Validated policy used when claiming events for subscription fan-out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EventFanoutSettings {
+    batch_size: EventWorkerBatchSize,
+    lock_timeout: Duration,
+    lock_timeout_ms: u64,
+}
+
+impl EventFanoutSettings {
+    pub(crate) fn new(batch_size: usize, lock_timeout_ms: u64) -> Result<Self, String> {
+        Ok(Self {
+            batch_size: EventWorkerBatchSize::new(batch_size, "event_fanout_batch_size")?,
+            lock_timeout: database_timeout(lock_timeout_ms, "event_fanout_lock_timeout_ms")?,
+            lock_timeout_ms,
+        })
+    }
+
+    pub(crate) const fn batch_size(self) -> usize {
+        self.batch_size.get()
+    }
+
+    pub(crate) const fn database_batch_size(self) -> i64 {
+        self.batch_size.database_limit()
+    }
+
+    pub(crate) const fn lock_deadline(self, now: NaiveDateTime) -> Option<NaiveDateTime> {
+        now.checked_add_signed(self.lock_timeout)
+    }
+
+    pub(crate) const fn lock_timeout_ms(self) -> u64 {
+        self.lock_timeout_ms
+    }
+}
+
+/// Validated policy used by event and terminal-delivery retention queries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EventRetentionSettings {
+    event_retention: Duration,
+    delivery_retention: Duration,
+    batch_size: EventWorkerBatchSize,
+}
+
+impl EventRetentionSettings {
+    pub(crate) fn new(
+        event_retention_days: i64,
+        delivery_retention_days: i64,
+        batch_size: usize,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            event_retention: retention_duration(event_retention_days, "event_retention_days")?,
+            delivery_retention: retention_duration(
+                delivery_retention_days,
+                "event_delivery_retention_days",
+            )?,
+            batch_size: EventWorkerBatchSize::new(batch_size, "event_retention_purge_batch_size")?,
+        })
+    }
+
+    pub(crate) const fn event_cutoff(self, now: NaiveDateTime) -> Option<NaiveDateTime> {
+        now.checked_sub_signed(self.event_retention)
+    }
+
+    pub(crate) const fn delivery_cutoff(self, now: NaiveDateTime) -> Option<NaiveDateTime> {
+        now.checked_sub_signed(self.delivery_retention)
+    }
+
+    pub(crate) const fn event_retention_days(self) -> i64 {
+        self.event_retention.num_days()
+    }
+
+    pub(crate) const fn delivery_retention_days(self) -> i64 {
+        self.delivery_retention.num_days()
+    }
+
+    pub(crate) const fn batch_size(self) -> usize {
+        self.batch_size.get()
+    }
+
+    pub(crate) const fn database_batch_size(self) -> i64 {
+        self.batch_size.database_limit()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_delivery_settings() -> EventDeliverySettings {
+        EventDeliverySettings::builder()
+            .batch_size(100)
+            .lock_timeout_ms(30_000)
+            .transport_timeout_ms(10_000)
+            .retry_backoff_base_ms(100)
+            .retry_backoff_max_ms(5_000)
+            .max_attempts(5)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn delivery_settings_preserve_validated_values() {
+        let settings = valid_delivery_settings();
+
+        assert_eq!(settings.batch_size(), 100);
+        assert_eq!(settings.database_batch_size(), 100);
+        assert_eq!(settings.lock_timeout_ms(), 30_000);
+        assert_eq!(settings.transport_timeout(), StdDuration::from_secs(10));
+        assert_eq!(settings.retry_backoff_base_ms(), 100);
+        assert_eq!(settings.retry_backoff_max_ms(), 5_000);
+        assert_eq!(settings.max_attempts(), 5);
+
+        let now = chrono::DateTime::from_timestamp(1_700_000_000, 0)
+            .unwrap()
+            .naive_utc();
+        assert_eq!(
+            settings.retry_deadline(now, 3),
+            now.checked_add_signed(Duration::milliseconds(400))
+        );
+    }
+
+    #[test]
+    fn delivery_settings_require_every_builder_field() {
+        let error = EventDeliverySettings::builder().build().unwrap_err();
+
+        assert_eq!(error, "event_delivery_batch_size is required");
+    }
+
+    #[rstest::rstest]
+    #[case::batch_size(0, 30_000, 10_000, 100, 5_000, 5, "event_delivery_batch_size")]
+    #[case::lock_timeout(100, 0, 0, 100, 5_000, 5, "event_delivery_lock_timeout_ms")]
+    #[case::transport_timeout(100, 30_000, 0, 100, 5_000, 5, "event_delivery_transport_timeout_ms")]
+    #[case::backoff_base(
+        100,
+        30_000,
+        10_000,
+        0,
+        5_000,
+        5,
+        "event_delivery_retry_backoff_base_ms"
+    )]
+    #[case::backoff_max(100, 30_000, 10_000, 100, 0, 5, "event_delivery_retry_backoff_max_ms")]
+    #[case::attempts(100, 30_000, 10_000, 100, 5_000, 0, "event_delivery_max_attempts")]
+    #[case::negative_attempts(100, 30_000, 10_000, 100, 5_000, -1, "event_delivery_max_attempts")]
+    fn delivery_settings_reject_non_positive_values(
+        #[case] batch_size: usize,
+        #[case] lock_timeout_ms: u64,
+        #[case] transport_timeout_ms: u64,
+        #[case] retry_backoff_base_ms: u64,
+        #[case] retry_backoff_max_ms: u64,
+        #[case] max_attempts: i32,
+        #[case] field: &str,
+    ) {
+        let error = EventDeliverySettings::builder()
+            .batch_size(batch_size)
+            .lock_timeout_ms(lock_timeout_ms)
+            .transport_timeout_ms(transport_timeout_ms)
+            .retry_backoff_base_ms(retry_backoff_base_ms)
+            .retry_backoff_max_ms(retry_backoff_max_ms)
+            .max_attempts(max_attempts)
+            .build()
+            .unwrap_err();
+
+        assert!(error.contains(field));
+    }
+
+    #[test]
+    fn delivery_settings_reject_cross_field_inversions() {
+        let timeout_error = EventDeliverySettings::builder()
+            .batch_size(100)
+            .lock_timeout_ms(10_000)
+            .transport_timeout_ms(10_000)
+            .retry_backoff_base_ms(100)
+            .retry_backoff_max_ms(5_000)
+            .max_attempts(5)
+            .build()
+            .unwrap_err();
+        assert!(timeout_error.contains("must be less than"));
+
+        let backoff_error = EventDeliverySettings::builder()
+            .batch_size(100)
+            .lock_timeout_ms(30_000)
+            .transport_timeout_ms(10_000)
+            .retry_backoff_base_ms(5_001)
+            .retry_backoff_max_ms(5_000)
+            .max_attempts(5)
+            .build()
+            .unwrap_err();
+        assert!(backoff_error.contains("less than or equal"));
+    }
+
+    #[test]
+    fn database_timeouts_reject_unrepresentable_values() {
+        let delivery_error = EventDeliverySettings::builder()
+            .batch_size(100)
+            .lock_timeout_ms(u64::MAX)
+            .transport_timeout_ms(10_000)
+            .retry_backoff_base_ms(100)
+            .retry_backoff_max_ms(5_000)
+            .max_attempts(5)
+            .build()
+            .unwrap_err();
+        assert!(delivery_error.contains("too large for database timestamps"));
+
+        let fanout_error = EventFanoutSettings::new(100, u64::MAX).unwrap_err();
+        assert!(fanout_error.contains("too large for database timestamps"));
+
+        let retry_error = EventDeliverySettings::builder()
+            .batch_size(100)
+            .lock_timeout_ms(30_000)
+            .transport_timeout_ms(10_000)
+            .retry_backoff_base_ms(100)
+            .retry_backoff_max_ms(u64::MAX)
+            .max_attempts(5)
+            .build()
+            .unwrap_err();
+        assert!(retry_error.contains("too large for database timestamps"));
+    }
+
+    #[test]
+    fn retention_settings_reject_invalid_or_unrepresentable_values() {
+        assert!(EventRetentionSettings::new(0, 30, 100).is_err());
+        assert!(EventRetentionSettings::new(30, 0, 100).is_err());
+        assert!(EventRetentionSettings::new(30, 30, 0).is_err());
+
+        let error = EventRetentionSettings::new(i64::MAX, 30, 100).unwrap_err();
+        assert!(error.contains("too large for database timestamps"));
+    }
+}

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -13,15 +13,14 @@ use uuid::Uuid;
 
 use super::delivery::process_claimed_event_delivery;
 use crate::db::traits::event_delivery::{
-    EventDeliverySettings, claim_event_deliveries, claim_event_delivery_by_id,
-    mark_event_delivery_dead, mark_event_delivery_failed, next_event_delivery_wakeup_in_db,
+    claim_event_deliveries, claim_event_delivery_by_id, mark_event_delivery_dead,
+    mark_event_delivery_failed, next_event_delivery_wakeup_in_db,
 };
 use crate::db::traits::event_fanout::{
-    EventFanoutSettings, claim_events_for_fanout, count_event_deliveries_for_event, fanout_event,
-    fanout_events,
+    claim_events_for_fanout, count_event_deliveries_for_event, fanout_event, fanout_events,
 };
 use crate::db::traits::event_retention::{
-    EventRetentionSettings, purge_event_retention_without_archive, try_acquire_event_retention_lock,
+    purge_event_retention_without_archive, try_acquire_event_retention_lock,
 };
 use crate::db::traits::event_subscription::{SaveEventSinkRecord, SaveEventSubscriptionRecord};
 use crate::db::traits::events::{EventListFilters, list_events_with_total_count};
@@ -33,7 +32,8 @@ use crate::db::{capture_queries, with_connection, with_transaction};
 use crate::errors::ApiError;
 use crate::events::retention::process_event_retention_batch;
 use crate::events::{
-    Action, ActorKind, EntityType, Event, EventContext, NewEvent, RequestProvenance, emit_event,
+    Action, ActorKind, EntityType, Event, EventContext, EventDeliverySettings, EventFanoutSettings,
+    EventRetentionSettings, NewEvent, RequestProvenance, emit_event,
 };
 use crate::models::class::{NewHubuumClass, UpdateHubuumClass};
 use crate::models::collection::{NewCollectionWithAssignee, UpdateCollection, move_collection};
@@ -458,22 +458,19 @@ async fn expire_delivery_claim(scope: &TestScope, delivery_id: i64) {
 }
 
 fn make_delivery_settings(max_attempts: i32) -> EventDeliverySettings {
-    EventDeliverySettings {
-        batch_size: 100_000,
-        lock_timeout_ms: 30_000,
-        transport_timeout_ms: 25_000,
-        retry_backoff_base_ms: 1_000,
-        retry_backoff_max_ms: 10_000,
-        max_attempts,
-    }
+    EventDeliverySettings::builder()
+        .batch_size(100_000)
+        .lock_timeout_ms(30_000)
+        .transport_timeout_ms(25_000)
+        .retry_backoff_base_ms(1_000)
+        .retry_backoff_max_ms(10_000)
+        .max_attempts(max_attempts)
+        .build()
+        .unwrap()
 }
 
 fn make_retention_settings() -> EventRetentionSettings {
-    EventRetentionSettings {
-        event_retention_days: 365,
-        delivery_retention_days: 30,
-        batch_size: 100,
-    }
+    EventRetentionSettings::new(365, 30, 100).unwrap()
 }
 
 struct StaticSinkResolver<'a> {
@@ -676,10 +673,7 @@ async fn event_fanout_reclaims_expired_claims() {
     let scope = test_scope();
     let fixture = scope.with_collection().await;
     let event = emit_collection_created_event(&scope, fixture.collection.id).await;
-    let settings = EventFanoutSettings {
-        batch_size: 100_000,
-        lock_timeout_ms: 30_000,
-    };
+    let settings = EventFanoutSettings::new(100_000, 30_000).unwrap();
 
     let claimed = claim_events_for_fanout(&scope.pool, settings)
         .await
@@ -955,10 +949,7 @@ async fn event_retention_bounds_terminal_delivery_deletes_to_the_batch_size() {
     )
     .await
     .unwrap();
-    let settings = EventRetentionSettings {
-        batch_size: 2,
-        ..make_retention_settings()
-    };
+    let settings = EventRetentionSettings::new(365, 30, 2).unwrap();
 
     let first = purge_event_retention_without_archive(&scope.pool, settings)
         .await


### PR DESCRIPTION
## Summary

Introduce private, validated settings APIs for event delivery, fan-out, and retention workers, and move low-level claim helpers behind the event subsystem boundary.

Require all builder fields, reject zero values and invalid cross-field relationships, and reject durations that cannot be represented safely in database timestamps.

## Rationale

Public database-layer field bags let callers construct impossible worker state and exposed persistence mechanics as application APIs. Duration overflow should fail during configuration, not inside a running worker.

## Behavior and compatibility

**Breaking (Rust API and configuration):** Callers constructing event-worker settings must migrate to the validated event-subsystem APIs and stop invoking the now-private claim helpers. Operators must correct zero, inconsistent, or unrepresentable worker-duration values before upgrading; those values now fail startup. Existing valid configuration behaves as before. No migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
