### PR TITLE
Validate task worker settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   callers must migrate to the validated APIs and stop invoking the private
   claim helpers. Operators must correct zero, inconsistent, or unrepresentable
   worker-duration values before upgrading; those values now fail startup.
+- **Breaking (Rust API):** task-worker settings now use a validating builder,
+  and low-level task claim and lease-renewal helpers are crate-private.
+  Downstream callers must migrate to the builder and stop invoking the private
+  helpers. Operators must correct zero, inconsistent, or unrepresentable
+  worker-duration values before upgrading; those values now fail startup.
 
 ### Security
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,11 +10,13 @@ use clap::{Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroUsize;
 use std::str::FromStr;
+use std::time::Duration;
 
 use crate::errors::ApiError;
 use crate::events::{EventDeliverySettings, EventFanoutSettings, EventRetentionSettings};
 use crate::models::retention::FutureRetention;
 use crate::models::{TokenIssuancePolicy, TokenRetentionSettings};
+use crate::tasks::TaskWorkerSettings;
 
 mod client_network;
 mod defaults;
@@ -923,6 +925,20 @@ impl AppConfig {
             .build()
     }
 
+    pub fn task_worker_settings(&self) -> Result<TaskWorkerSettings, ApiError> {
+        TaskWorkerSettings::builder()
+            .worker_count(self.runtime_role.effective_worker_count(self.task_workers))
+            .poll_interval(Duration::from_millis(self.task_poll_interval_ms))
+            .lease_duration(Duration::from_secs(self.task_lease_seconds))
+            .heartbeat_interval(Duration::from_secs(self.task_heartbeat_seconds))
+            .recovery_interval(Duration::from_secs(self.task_recovery_interval_seconds))
+            .export_output_cleanup_interval(Duration::from_secs(
+                self.export_output_cleanup_interval_seconds,
+            ))
+            .build()
+            .map_err(ApiError::BadRequest)
+    }
+
     pub(crate) fn event_fanout_settings(&self) -> Result<EventFanoutSettings, ApiError> {
         EventFanoutSettings::new(
             self.event_fanout_batch_size,
@@ -972,11 +988,7 @@ impl AppConfig {
             ));
         }
 
-        if self.task_poll_interval_ms == 0 {
-            return Err(ApiError::BadRequest(
-                "task_poll_interval_ms must be greater than 0".to_string(),
-            ));
-        }
+        self.task_worker_settings()?;
 
         if self.event_fanout_poll_interval_ms == 0 {
             return Err(ApiError::BadRequest(
@@ -1013,12 +1025,6 @@ impl AppConfig {
             "export_output_retention_hours",
         )
         .map_err(ApiError::BadRequest)?;
-
-        if self.export_output_cleanup_interval_seconds == 0 {
-            return Err(ApiError::BadRequest(
-                "export_output_cleanup_interval_seconds must be greater than 0".to_string(),
-            ));
-        }
 
         FutureRetention::from_hours(
             self.backup_output_retention_hours,
@@ -1170,31 +1176,6 @@ impl AppConfig {
         {
             return Err(ApiError::BadRequest(
                 "login_rate_limit_subnet_prefix_v6 must be between 1 and 128".to_string(),
-            ));
-        }
-
-        if self.task_lease_seconds == 0 {
-            return Err(ApiError::BadRequest(
-                "task_lease_seconds must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.task_heartbeat_seconds == 0 {
-            return Err(ApiError::BadRequest(
-                "task_heartbeat_seconds must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.task_heartbeat_seconds >= self.task_lease_seconds {
-            return Err(ApiError::BadRequest(format!(
-                "task_heartbeat_seconds ({}) must be less than task_lease_seconds ({})",
-                self.task_heartbeat_seconds, self.task_lease_seconds
-            )));
-        }
-
-        if self.task_recovery_interval_seconds == 0 {
-            return Err(ApiError::BadRequest(
-                "task_recovery_interval_seconds must be greater than 0".to_string(),
             ));
         }
 
@@ -2074,7 +2055,21 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "task_heartbeat_seconds (30) must be less than task_lease_seconds (30)"
+            "task worker heartbeat interval must be greater than zero and shorter than the lease"
+        );
+    }
+
+    #[test]
+    fn task_lease_duration_must_fit_database_timestamps() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _lease_guard =
+            EnvVarGuard::set("HUBUUM_TASK_LEASE_SECONDS", Some("18446744073709551615"));
+
+        let error = get_config_from_env().unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "task worker lease duration is too large for database timestamps"
         );
     }
 

--- a/src/db/traits/task.rs
+++ b/src/db/traits/task.rs
@@ -29,6 +29,7 @@ use crate::models::{
 };
 use crate::observability::metrics;
 use crate::pagination::{CursorValue, decode_cursor_values, page_limits_or_defaults};
+use crate::tasks::TaskLeaseDuration;
 
 const DATABASE_UTC_NOW_SQL: &str = "clock_timestamp() AT TIME ZONE 'UTC'";
 const DATABASE_UTC_NOW_QUERY: &str = "SELECT clock_timestamp() AT TIME ZONE 'UTC' AS now";
@@ -1322,9 +1323,9 @@ fn task_kind_claim_order(start: usize) -> [&'static str; TaskKind::ALL.len()] {
     std::array::from_fn(|offset| kinds[(start + offset) % kinds.len()])
 }
 
-pub async fn claim_next_queued_task(
+pub(crate) async fn claim_next_queued_task(
     pool: &DbPool,
-    lease_duration: std::time::Duration,
+    lease_duration: TaskLeaseDuration,
 ) -> Result<Option<TaskRecord>, ApiError> {
     use crate::schema::tasks::dsl::{
         attempt_count, id, lease_expires_at, lease_token, started_at, status, tasks, updated_at,
@@ -1350,7 +1351,7 @@ pub async fn claim_next_queued_task(
         };
 
         let claim_token = Uuid::new_v4();
-        let lease_milliseconds = lease_duration_milliseconds(lease_duration);
+        let lease_milliseconds = lease_duration.database_milliseconds();
         let record = diesel::update(tasks.filter(id.eq(task_id_value)))
             .set((
                 status.eq(TaskStatus::Validating.as_str()),
@@ -1399,22 +1400,18 @@ pub async fn claim_next_queued_task(
     Ok(record)
 }
 
-fn lease_duration_milliseconds(lease_duration: std::time::Duration) -> i64 {
-    i64::try_from(lease_duration.as_millis()).unwrap_or(i64::MAX)
-}
-
 /// Extend an active task lease if this worker still owns it.
-pub async fn renew_task_lease(
+pub(crate) async fn renew_task_lease(
     pool: &DbPool,
     task_id_value: i32,
     claim_token: Uuid,
-    lease_duration: std::time::Duration,
+    lease_duration: TaskLeaseDuration,
 ) -> Result<bool, ApiError> {
     use crate::schema::tasks::dsl::{id, lease_expires_at, lease_token, status, tasks, updated_at};
 
     let active_statuses = TaskStatus::ACTIVE.map(TaskStatus::as_str);
     let updated = with_connection(pool, async |conn| -> Result<usize, ApiError> {
-        let lease_milliseconds = lease_duration_milliseconds(lease_duration);
+        let lease_milliseconds = lease_duration.database_milliseconds();
         diesel::update(
             tasks
                 .filter(id.eq(task_id_value))
@@ -1879,7 +1876,12 @@ mod tests {
         StoredRemoteCallTaskPayload, TaskID, TaskKind, TaskResultCounts, TaskStatus, TokenID,
         TokenScope,
     };
+    use crate::tasks::TaskLeaseDuration;
     use crate::tests::{TestContext, create_test_user};
+
+    fn test_lease_duration() -> TaskLeaseDuration {
+        TaskLeaseDuration::new(std::time::Duration::from_secs(60)).unwrap()
+    }
 
     #[derive(QueryableByName)]
     struct TaskCapacityIndex {
@@ -2289,11 +2291,8 @@ mod tests {
         });
 
         let locked_id = locked_rx.await.unwrap();
-        let (claimed, queries) = capture_queries(claim_next_queued_task(
-            &context.pool,
-            std::time::Duration::from_secs(60),
-        ))
-        .await;
+        let (claimed, queries) =
+            capture_queries(claim_next_queued_task(&context.pool, test_lease_duration())).await;
         let claimed = claimed.unwrap().map(|task| task.id);
         release_tx.send(()).unwrap();
         locker.await.unwrap();
@@ -2563,7 +2562,7 @@ mod tests {
                 &context.pool,
                 leased.id,
                 Uuid::new_v4(),
-                std::time::Duration::from_secs(60),
+                test_lease_duration(),
             )
             .await
             .unwrap()
@@ -2573,7 +2572,7 @@ mod tests {
                 &context.pool,
                 leased.id,
                 leased.lease_token.unwrap(),
-                std::time::Duration::from_secs(60),
+                test_lease_duration(),
             )
             .await
             .unwrap()
@@ -2595,7 +2594,7 @@ mod tests {
                 &context.pool,
                 leased.id,
                 leased.lease_token.unwrap(),
-                std::time::Duration::from_secs(60),
+                test_lease_duration(),
             )
             .await
             .unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,9 +43,7 @@ use hubuum::middlewares::rate_limit::{
 };
 use hubuum::permissions::{AppContext, build_permission_backend};
 use hubuum::restores::{RestoreSettings, ensure_restore_coordinator_running};
-use hubuum::tasks::{
-    TaskWorkerSettings, ensure_task_worker_running_with_settings, initialize_task_worker_settings,
-};
+use hubuum::tasks::{ensure_task_worker_running_with_settings, initialize_task_worker_settings};
 use hubuum::token_retention::ensure_token_retention_worker_running;
 use hubuum::utilities::is_valid_log_level;
 use hubuum::{api, db, logger, middlewares, observability, tls, utilities};
@@ -130,26 +128,11 @@ async fn main() -> std::io::Result<()> {
     )
     .unwrap_or_else(|error| fatal_error(&error, EXIT_CODE_CONFIG_ERROR));
 
-    let task_worker_count = if config.runtime_role.runs_background_workers() {
-        config.task_workers
-    } else {
-        0
-    };
-    let task_worker_settings = TaskWorkerSettings::new(
-        task_worker_count,
-        Duration::from_millis(config.task_poll_interval_ms),
-        Duration::from_secs(config.task_lease_seconds),
-        Duration::from_secs(config.task_heartbeat_seconds),
-        Duration::from_secs(config.task_recovery_interval_seconds),
-        Duration::from_secs(config.export_output_cleanup_interval_seconds),
-    )
-    .unwrap_or_else(|error| fatal_error(&error, EXIT_CODE_CONFIG_ERROR));
+    let task_worker_settings = config
+        .task_worker_settings()
+        .unwrap_or_else(|error| fatal_error(&error.to_string(), EXIT_CODE_CONFIG_ERROR));
     initialize_task_worker_settings(task_worker_settings)
         .unwrap_or_else(|error| fatal_error(&error, EXIT_CODE_INIT_ERROR));
-    observability::metrics::task_worker_config(
-        task_worker_count,
-        Duration::from_millis(config.task_poll_interval_ms),
-    );
 
     let initialization_settings =
         utilities::init::InitializationSettings::new(config.admin_groupname.clone())

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -4,14 +4,17 @@ mod planning;
 mod preload;
 mod remote_call;
 mod resolution;
+mod settings;
 mod types;
 mod worker;
 
 pub use helpers::{idempotency_key_from_headers, request_hash};
 #[cfg(feature = "integration-test-support")]
 pub(crate) use remote_call::{enter_local_remote_target_test, exit_local_remote_target_test};
+pub(crate) use settings::TaskLeaseDuration;
+pub use settings::{TaskWorkerSettings, TaskWorkerSettingsBuilder};
 pub use worker::{
-    TaskWorkerSettings, ensure_task_worker_running, ensure_task_worker_running_with_settings,
+    ensure_task_worker_running, ensure_task_worker_running_with_settings,
     initialize_task_worker_settings, kick_task_worker,
 };
 

--- a/src/tasks/settings.rs
+++ b/src/tasks/settings.rs
@@ -1,0 +1,268 @@
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+
+/// Validated settings for task execution, lease renewal, and maintenance work.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TaskWorkerSettings {
+    worker_count: usize,
+    poll_interval: Duration,
+    lease_duration: TaskLeaseDuration,
+    heartbeat_interval: Duration,
+    recovery_interval: Duration,
+    export_output_cleanup_interval: Duration,
+}
+
+impl TaskWorkerSettings {
+    pub fn builder() -> TaskWorkerSettingsBuilder {
+        TaskWorkerSettingsBuilder::default()
+    }
+
+    pub const fn worker_count(self) -> usize {
+        self.worker_count
+    }
+
+    pub const fn poll_interval(self) -> Duration {
+        self.poll_interval
+    }
+
+    pub const fn lease_duration(self) -> Duration {
+        self.lease_duration.duration()
+    }
+
+    pub const fn heartbeat_interval(self) -> Duration {
+        self.heartbeat_interval
+    }
+
+    pub const fn recovery_interval(self) -> Duration {
+        self.recovery_interval
+    }
+
+    pub const fn export_output_cleanup_interval(self) -> Duration {
+        self.export_output_cleanup_interval
+    }
+
+    pub(crate) const fn validated_lease_duration(self) -> TaskLeaseDuration {
+        self.lease_duration
+    }
+}
+
+/// Builder for the multi-field task-worker policy.
+#[derive(Debug, Default)]
+pub struct TaskWorkerSettingsBuilder {
+    worker_count: Option<usize>,
+    poll_interval: Option<Duration>,
+    lease_duration: Option<Duration>,
+    heartbeat_interval: Option<Duration>,
+    recovery_interval: Option<Duration>,
+    export_output_cleanup_interval: Option<Duration>,
+}
+
+impl TaskWorkerSettingsBuilder {
+    pub fn worker_count(mut self, value: usize) -> Self {
+        self.worker_count = Some(value);
+        self
+    }
+
+    pub fn poll_interval(mut self, value: Duration) -> Self {
+        self.poll_interval = Some(value);
+        self
+    }
+
+    pub fn lease_duration(mut self, value: Duration) -> Self {
+        self.lease_duration = Some(value);
+        self
+    }
+
+    pub fn heartbeat_interval(mut self, value: Duration) -> Self {
+        self.heartbeat_interval = Some(value);
+        self
+    }
+
+    pub fn recovery_interval(mut self, value: Duration) -> Self {
+        self.recovery_interval = Some(value);
+        self
+    }
+
+    pub fn export_output_cleanup_interval(mut self, value: Duration) -> Self {
+        self.export_output_cleanup_interval = Some(value);
+        self
+    }
+
+    pub fn build(self) -> Result<TaskWorkerSettings, String> {
+        let worker_count = self
+            .worker_count
+            .ok_or_else(|| "task worker count is required".to_string())?;
+        let poll_interval = self
+            .poll_interval
+            .ok_or_else(|| "task worker poll interval is required".to_string())?;
+        let lease_duration = self
+            .lease_duration
+            .ok_or_else(|| "task worker lease duration is required".to_string())?;
+        let heartbeat_interval = self
+            .heartbeat_interval
+            .ok_or_else(|| "task worker heartbeat interval is required".to_string())?;
+        let recovery_interval = self
+            .recovery_interval
+            .ok_or_else(|| "task recovery interval is required".to_string())?;
+        let export_output_cleanup_interval = self
+            .export_output_cleanup_interval
+            .ok_or_else(|| "export output cleanup interval is required".to_string())?;
+
+        if poll_interval.is_zero() {
+            return Err("task worker poll interval must be greater than zero".to_string());
+        }
+        let lease_duration = TaskLeaseDuration::new(lease_duration)?;
+        if heartbeat_interval.is_zero() || heartbeat_interval >= lease_duration.duration() {
+            return Err(
+                "task worker heartbeat interval must be greater than zero and shorter than the lease"
+                    .to_string(),
+            );
+        }
+        if recovery_interval.is_zero() {
+            return Err("task recovery interval must be greater than zero".to_string());
+        }
+        if export_output_cleanup_interval.is_zero() {
+            return Err("export output cleanup interval must be greater than zero".to_string());
+        }
+
+        Ok(TaskWorkerSettings {
+            worker_count,
+            poll_interval,
+            lease_duration,
+            heartbeat_interval,
+            recovery_interval,
+            export_output_cleanup_interval,
+        })
+    }
+}
+
+/// A task lease duration that is safe for both worker clocks and PostgreSQL.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TaskLeaseDuration {
+    duration: Duration,
+    database_milliseconds: i64,
+}
+
+impl TaskLeaseDuration {
+    pub(crate) fn new(duration: Duration) -> Result<Self, String> {
+        if duration.is_zero() {
+            return Err("task worker lease duration must be greater than zero".to_string());
+        }
+        let database_milliseconds = i64::try_from(duration.as_millis()).map_err(|_| {
+            "task worker lease duration is too large for database timestamps".to_string()
+        })?;
+        let chrono_duration = chrono::Duration::from_std(duration).map_err(|_| {
+            "task worker lease duration is too large for database timestamps".to_string()
+        })?;
+        if Utc::now()
+            .naive_utc()
+            .checked_add_signed(chrono_duration)
+            .is_none()
+        {
+            return Err(
+                "task worker lease duration is too large for database timestamps".to_string(),
+            );
+        }
+        if Instant::now().checked_add(duration).is_none() {
+            return Err("task worker lease duration is too large for worker clocks".to_string());
+        }
+        Ok(Self {
+            duration,
+            database_milliseconds,
+        })
+    }
+
+    pub(crate) const fn duration(self) -> Duration {
+        self.duration
+    }
+
+    pub(crate) const fn database_milliseconds(self) -> i64 {
+        self.database_milliseconds
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_builder() -> TaskWorkerSettingsBuilder {
+        TaskWorkerSettings::builder()
+            .worker_count(2)
+            .poll_interval(Duration::from_millis(250))
+            .lease_duration(Duration::from_secs(60))
+            .heartbeat_interval(Duration::from_secs(10))
+            .recovery_interval(Duration::from_secs(30))
+            .export_output_cleanup_interval(Duration::from_secs(300))
+    }
+
+    #[test]
+    fn task_worker_settings_preserve_validated_values() {
+        let settings = valid_builder().build().unwrap();
+
+        assert_eq!(settings.worker_count(), 2);
+        assert_eq!(settings.poll_interval(), Duration::from_millis(250));
+        assert_eq!(settings.lease_duration(), Duration::from_secs(60));
+        assert_eq!(settings.heartbeat_interval(), Duration::from_secs(10));
+        assert_eq!(settings.recovery_interval(), Duration::from_secs(30));
+        assert_eq!(
+            settings.export_output_cleanup_interval(),
+            Duration::from_secs(300)
+        );
+        assert_eq!(
+            settings.validated_lease_duration().database_milliseconds(),
+            60_000
+        );
+    }
+
+    #[test]
+    fn task_worker_settings_require_every_builder_field() {
+        assert_eq!(
+            TaskWorkerSettings::builder().build().unwrap_err(),
+            "task worker count is required"
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::poll("poll")]
+    #[case::lease("lease")]
+    #[case::heartbeat("heartbeat")]
+    #[case::recovery("recovery")]
+    #[case::cleanup("cleanup")]
+    fn task_worker_settings_reject_zero_durations(#[case] zero_field: &str) {
+        let mut builder = valid_builder();
+        builder = match zero_field {
+            "poll" => builder.poll_interval(Duration::ZERO),
+            "lease" => builder.lease_duration(Duration::ZERO),
+            "heartbeat" => builder.heartbeat_interval(Duration::ZERO),
+            "recovery" => builder.recovery_interval(Duration::ZERO),
+            "cleanup" => builder.export_output_cleanup_interval(Duration::ZERO),
+            _ => unreachable!(),
+        };
+
+        assert!(builder.build().is_err());
+    }
+
+    #[test]
+    fn task_worker_settings_reject_heartbeat_at_or_beyond_lease() {
+        let error = valid_builder()
+            .heartbeat_interval(Duration::from_secs(60))
+            .build()
+            .unwrap_err();
+
+        assert!(error.contains("shorter than the lease"));
+    }
+
+    #[test]
+    fn task_worker_settings_reject_unrepresentable_lease_duration() {
+        let error = valid_builder()
+            .lease_duration(Duration::from_secs(u64::MAX))
+            .build()
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            "task worker lease duration is too large for database timestamps"
+        );
+    }
+}

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -35,6 +35,7 @@ use crate::permissions::LocalPermissionBackend;
 use crate::permissions::{AppContext, require_unscoped_runtime_admin};
 use crate::restores::{MaintenanceActivityGuard, current_maintenance_state};
 
+use super::TaskWorkerSettings;
 use super::execution::execute_import_task;
 use super::helpers::sanitize_error_for_storage;
 use super::remote_call::execute_remote_call_task;
@@ -59,59 +60,11 @@ static TASK_LEASE_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| 
 
 const TASK_LEASE_POOL_SIZE: u32 = 1;
 
-#[derive(Clone, Copy, Debug)]
-pub struct TaskWorkerSettings {
-    worker_count: usize,
-    poll_interval: Duration,
-    lease_duration: Duration,
-    heartbeat_interval: Duration,
-    recovery_interval: Duration,
-    export_output_cleanup_interval: Duration,
-}
-
-impl TaskWorkerSettings {
-    pub fn new(
-        worker_count: usize,
-        poll_interval: Duration,
-        lease_duration: Duration,
-        heartbeat_interval: Duration,
-        recovery_interval: Duration,
-        export_output_cleanup_interval: Duration,
-    ) -> Result<Self, String> {
-        if poll_interval.is_zero() {
-            return Err("task worker poll interval must be greater than zero".to_string());
-        }
-        if lease_duration.is_zero() {
-            return Err("task worker lease duration must be greater than zero".to_string());
-        }
-        if heartbeat_interval.is_zero() || heartbeat_interval >= lease_duration {
-            return Err(
-                "task worker heartbeat interval must be greater than zero and shorter than the lease"
-                    .to_string(),
-            );
-        }
-        if recovery_interval.is_zero() {
-            return Err("task recovery interval must be greater than zero".to_string());
-        }
-        if export_output_cleanup_interval.is_zero() {
-            return Err("export output cleanup interval must be greater than zero".to_string());
-        }
-        Ok(Self {
-            worker_count,
-            poll_interval,
-            lease_duration,
-            heartbeat_interval,
-            recovery_interval,
-            export_output_cleanup_interval,
-        })
-    }
-}
-
 pub fn initialize_task_worker_settings(settings: TaskWorkerSettings) -> Result<(), String> {
     TASK_WORKER_SETTINGS
         .set(settings)
         .map_err(|_| "task worker settings were already initialized".to_string())?;
-    metrics::task_worker_config(settings.worker_count, settings.poll_interval);
+    metrics::task_worker_config(settings.worker_count(), settings.poll_interval());
     Ok(())
 }
 
@@ -132,27 +85,27 @@ fn recovery_state() -> &'static Mutex<Option<Instant>> {
 }
 
 fn task_worker_settings() -> TaskWorkerSettings {
-    TASK_WORKER_SETTINGS
-        .get()
-        .copied()
-        .unwrap_or(TaskWorkerSettings {
-            worker_count: 1,
-            poll_interval: Duration::from_millis(DEFAULT_TASK_POLL_INTERVAL_MS),
-            lease_duration: Duration::from_secs(DEFAULT_TASK_LEASE_SECONDS),
-            heartbeat_interval: Duration::from_secs(DEFAULT_TASK_HEARTBEAT_SECONDS),
-            recovery_interval: Duration::from_secs(DEFAULT_TASK_RECOVERY_INTERVAL_SECONDS),
-            export_output_cleanup_interval: Duration::from_secs(
+    TASK_WORKER_SETTINGS.get().copied().unwrap_or_else(|| {
+        TaskWorkerSettings::builder()
+            .worker_count(1)
+            .poll_interval(Duration::from_millis(DEFAULT_TASK_POLL_INTERVAL_MS))
+            .lease_duration(Duration::from_secs(DEFAULT_TASK_LEASE_SECONDS))
+            .heartbeat_interval(Duration::from_secs(DEFAULT_TASK_HEARTBEAT_SECONDS))
+            .recovery_interval(Duration::from_secs(DEFAULT_TASK_RECOVERY_INTERVAL_SECONDS))
+            .export_output_cleanup_interval(Duration::from_secs(
                 DEFAULT_EXPORT_OUTPUT_CLEANUP_INTERVAL_SECONDS,
-            ),
-        })
+            ))
+            .build()
+            .expect("default task worker settings must be valid")
+    })
 }
 
 fn configured_task_worker_count() -> usize {
-    task_worker_settings().worker_count
+    task_worker_settings().worker_count()
 }
 
 fn configured_task_poll_interval() -> Duration {
-    task_worker_settings().poll_interval
+    task_worker_settings().poll_interval()
 }
 
 fn new_task_lease_pool() -> DbPool {
@@ -368,7 +321,7 @@ async fn process_one_task_with_settings(
 
     let settings = task_worker_settings();
     let claim_started_at = TokioInstant::now();
-    let task = match claim_next_queued_task(context, settings.lease_duration).await {
+    let task = match claim_next_queued_task(context, settings.validated_lease_duration()).await {
         Ok(task) => task,
         Err(error) => {
             metrics::task_worker_iteration("error");
@@ -396,7 +349,7 @@ async fn process_one_task_with_settings(
         let mut heartbeat = start_task_lease_heartbeat(
             task_lease_pool(),
             &task,
-            claim_started_at + settings.lease_duration,
+            claim_started_at + settings.lease_duration(),
         );
         let execution = async {
             match shutdown {
@@ -532,7 +485,12 @@ fn start_task_lease_heartbeat(
             async move {
                 with_db_call_site(
                     DbCallSite::TaskLease,
-                    renew_task_lease(&pool, task_id, claim_token, settings.lease_duration),
+                    renew_task_lease(
+                        &pool,
+                        task_id,
+                        claim_token,
+                        settings.validated_lease_duration(),
+                    ),
                 )
                 .await
             }
@@ -586,7 +544,7 @@ where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<bool, ApiError>>,
 {
-    let mut next_heartbeat = TokioInstant::now() + settings.heartbeat_interval;
+    let mut next_heartbeat = TokioInstant::now() + settings.heartbeat_interval();
     loop {
         tokio::select! {
             biased;
@@ -618,7 +576,7 @@ where
                         // PostgreSQL extends the lease after this request starts, so anchoring the
                         // new deadline at request start is conservative even if the response is
                         // delayed in transit.
-                        confirmed_expiry = renewal_started_at + settings.lease_duration;
+                        confirmed_expiry = renewal_started_at + settings.lease_duration();
                     }
                     Ok(false) => {
                         warn!(
@@ -635,7 +593,7 @@ where
                         );
                     }
                 }
-                next_heartbeat = TokioInstant::now() + settings.heartbeat_interval;
+                next_heartbeat = TokioInstant::now() + settings.heartbeat_interval();
             }
         }
     }
@@ -668,7 +626,7 @@ where
 }
 
 async fn maybe_recover_expired_task_leases(pool: &DbPool) -> Result<(), ApiError> {
-    let recovery_interval = task_worker_settings().recovery_interval;
+    let recovery_interval = task_worker_settings().recovery_interval();
     let previous_last_run = {
         let mut state = recovery_state().lock().map_err(|_| {
             ApiError::InternalServerError("Task recovery state lock poisoned".to_string())
@@ -707,7 +665,7 @@ async fn maybe_recover_expired_task_leases(pool: &DbPool) -> Result<(), ApiError
 }
 
 async fn maybe_cleanup_expired_task_outputs(pool: &DbPool) -> Result<(), ApiError> {
-    let cleanup_interval = task_worker_settings().export_output_cleanup_interval;
+    let cleanup_interval = task_worker_settings().export_output_cleanup_interval();
     let Some(reservation) = CleanupReservation::reserve(cleanup_state(), cleanup_interval)? else {
         return Ok(());
     };
@@ -931,6 +889,21 @@ mod lease_heartbeat_tests {
         assert!(!source.contains(&optional_token_field));
     }
 
+    fn lease_test_settings(
+        lease_duration: Duration,
+        heartbeat_interval: Duration,
+    ) -> TaskWorkerSettings {
+        TaskWorkerSettings::builder()
+            .worker_count(1)
+            .poll_interval(Duration::from_millis(10))
+            .lease_duration(lease_duration)
+            .heartbeat_interval(heartbeat_interval)
+            .recovery_interval(Duration::from_secs(1))
+            .export_output_cleanup_interval(Duration::from_secs(1))
+            .build()
+            .unwrap()
+    }
+
     fn new_single_connection_execution_pool() -> DbPool {
         let config = get_config().expect("test requires database configuration");
         let settings = DatabasePoolSettings::builder(config.database_url.clone())
@@ -946,21 +919,13 @@ mod lease_heartbeat_tests {
     fn heartbeat_progresses_while_task_runtime_thread_is_blocked() {
         let renewal_attempts = Arc::new(AtomicUsize::new(0));
         let attempts = renewal_attempts.clone();
-        let settings = TaskWorkerSettings::new(
-            1,
-            Duration::from_millis(10),
-            Duration::from_millis(500),
-            Duration::from_millis(10),
-            Duration::from_secs(1),
-            Duration::from_secs(1),
-        )
-        .unwrap();
+        let settings = lease_test_settings(Duration::from_millis(500), Duration::from_millis(10));
 
         actix_rt::System::new().block_on(async move {
             let heartbeat = spawn_task_lease_monitor(
                 1,
                 settings,
-                TokioInstant::now() + settings.lease_duration,
+                TokioInstant::now() + settings.lease_duration(),
                 move || {
                     attempts.fetch_add(1, Ordering::Relaxed);
                     async { Ok(true) }
@@ -979,21 +944,13 @@ mod lease_heartbeat_tests {
 
     #[test]
     fn lease_loss_is_detected_while_task_runtime_thread_is_blocked() {
-        let settings = TaskWorkerSettings::new(
-            1,
-            Duration::from_millis(10),
-            Duration::from_millis(75),
-            Duration::from_millis(10),
-            Duration::from_secs(1),
-            Duration::from_secs(1),
-        )
-        .unwrap();
+        let settings = lease_test_settings(Duration::from_millis(75), Duration::from_millis(10));
 
         actix_rt::System::new().block_on(async move {
             let mut heartbeat = spawn_task_lease_monitor(
                 1,
                 settings,
-                TokioInstant::now() + settings.lease_duration,
+                TokioInstant::now() + settings.lease_duration(),
                 || async {
                     Err(ApiError::DbConnectionError(
                         "database unavailable".to_string(),
@@ -1054,18 +1011,10 @@ mod lease_heartbeat_tests {
 
     #[tokio::test]
     async fn renewal_errors_signal_loss_at_the_confirmed_expiry() {
-        let settings = TaskWorkerSettings::new(
-            1,
-            Duration::from_millis(10),
-            Duration::from_millis(60),
-            Duration::from_millis(10),
-            Duration::from_secs(1),
-            Duration::from_secs(1),
-        )
-        .unwrap();
+        let settings = lease_test_settings(Duration::from_millis(60), Duration::from_millis(10));
         let renewal_attempts = AtomicUsize::new(0);
         let (_stop_tx, mut stop_rx) = oneshot::channel();
-        let confirmed_expiry = TokioInstant::now() + settings.lease_duration;
+        let confirmed_expiry = TokioInstant::now() + settings.lease_duration();
 
         let lost = timeout(
             Duration::from_millis(250),


### PR DESCRIPTION
## Summary

Replace task-worker field bags with a validating builder and move low-level claim and lease-renewal helpers behind the task subsystem boundary.

Require all durations, reject zero values, require heartbeat intervals to remain below the lease duration, and reject leases that cannot be represented safely by worker clocks or database timestamps.

## Rationale

Worker timing invariants should be established once during configuration. Allowing arbitrary values reaches runtime as hot loops, expired leases, clock overflow, or database timestamp failures.

## Behavior and compatibility

**Breaking (Rust API and configuration):** Callers constructing task-worker settings must migrate to the validating builder and stop invoking the now-private claim and lease-renewal helpers. Operators must correct zero, inconsistent, or unrepresentable worker-duration values before upgrading; those values now fail startup. Existing valid configuration behaves as before. No migration is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
