### PR TITLE
Harden event archive files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   are also rejected. Clients must keep queries within those limits and send one
   value for each sort field and history `at` parameter before upgrading. This
   bounds query-parser allocation and quadratic cursor-predicate growth.
+- Event retention archives now restrict existing Unix files to owner-only
+  permissions before appending and reject archive paths whose final component
+  is a symbolic link.
 - **Breaking (HTTP and Rust API):** Event-delivery API responses no longer
   expose the internal `claim_token` worker lease capability. API clients must
   stop deserializing or depending on this field. The persistence-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,9 +102,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   are also rejected. Clients must keep queries within those limits and send one
   value for each sort field and history `at` parameter before upgrading. This
   bounds query-parser allocation and quadratic cursor-predicate growth.
-- Event retention archives now restrict existing Unix files to owner-only
-  permissions before appending and reject archive paths whose final component
-  is a symbolic link.
+- **Breaking (Unix deployments):** event retention archives now restrict
+  existing files to owner-only permissions before appending and reject archive
+  paths whose final component is a symbolic link or another non-regular file.
+  Operators relying on group-readable archives must move that access behind an
+  owner-controlled collector; no database migration is required.
 - **Breaking (HTTP and Rust API):** Event-delivery API responses no longer
   expose the internal `claim_token` worker lease capability. API clients must
   stop deserializing or depending on this field. The persistence-only

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ lru = "0.18.0"
 treetop-client = { git = "https://github.com/terjekv/treetop-client", optional = true }
 toml = "1.1"
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]

--- a/docs/events.md
+++ b/docs/events.md
@@ -528,5 +528,5 @@ remains `1` because these nullable fields are additive. If archive writing or
 durable file synchronization fails, the worker does not delete that batch. On
 Unix, newly created archive files are created with mode `0600`; existing file
 permissions are restricted to `0600` before every append. An archive path whose
-final Unix path component is a symbolic link is rejected so the worker cannot
-be redirected to another file at that boundary.
+final Unix path component is a symbolic link or another non-regular file is
+rejected so the worker cannot be redirected at that boundary.

--- a/docs/events.md
+++ b/docs/events.md
@@ -527,4 +527,6 @@ durable `initiator_user_id` and `task_id` values. Event `schema_version`
 remains `1` because these nullable fields are additive. If archive writing or
 durable file synchronization fails, the worker does not delete that batch. On
 Unix, newly created archive files are created with mode `0600`; existing file
-permissions are not changed.
+permissions are restricted to `0600` before every append. An archive path whose
+final Unix path component is a symbolic link is rejected so the worker cannot
+be redirected to another file at that boundary.

--- a/src/events/retention.rs
+++ b/src/events/retention.rs
@@ -206,6 +206,12 @@ fn append_event_archive(path: &Path, events: &[Event]) -> Result<(), ApiError> {
 fn secure_event_archive_file(file: &File) -> io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
+    if !file.metadata()?.file_type().is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "event archive must be a regular file",
+        ));
+    }
     file.set_permissions(std::fs::Permissions::from_mode(0o600))
 }
 
@@ -385,6 +391,19 @@ mod tests {
         assert_eq!(std::fs::read(&target).unwrap(), b"existing\n");
         std::fs::remove_file(link).unwrap();
         std::fs::remove_file(target).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secure_event_archive_rejects_non_regular_file() {
+        let path = std::env::temp_dir().join(format!("hubuum-event-archive-{}", Uuid::new_v4()));
+        std::fs::create_dir(&path).unwrap();
+        let directory = File::open(&path).unwrap();
+
+        let error = secure_event_archive_file(&directory).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        std::fs::remove_dir(path).unwrap();
     }
 
     #[test]

--- a/src/events/retention.rs
+++ b/src/events/retention.rs
@@ -191,12 +191,27 @@ fn append_event_archive(path: &Path, events: &[Event]) -> Result<(), ApiError> {
     let mut options = OpenOptions::new();
     options.create(true).append(true);
     #[cfg(unix)]
-    options.mode(0o600);
+    options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
     let mut file = options.open(path).map_err(|error| {
         ApiError::InternalServerError(format!("Failed to open event archive: {error}"))
     })?;
+    secure_event_archive_file(&file).map_err(|error| {
+        ApiError::InternalServerError(format!("Failed to secure event archive: {error}"))
+    })?;
 
     write_event_archive(&mut file, archived_at, events)
+}
+
+#[cfg(unix)]
+fn secure_event_archive_file(file: &File) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    file.set_permissions(std::fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn secure_event_archive_file(_file: &File) -> io::Result<()> {
+    Ok(())
 }
 
 fn write_event_archive(
@@ -328,6 +343,48 @@ mod tests {
         assert!(archived.contains("\"initiator_user_id\":17"));
         assert!(archived.contains("\"task_id\":18"));
         std::fs::remove_file(path).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn append_event_archive_restricts_existing_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path =
+            std::env::temp_dir().join(format!("hubuum-event-archive-{}.jsonl", Uuid::new_v4()));
+        std::fs::write(&path, b"").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        append_event_archive(&path, &[event()]).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn append_event_archive_rejects_symbolic_link_path() {
+        use std::os::unix::fs::symlink;
+
+        let suffix = Uuid::new_v4();
+        let target = std::env::temp_dir().join(format!("hubuum-event-archive-{suffix}.jsonl"));
+        let link = std::env::temp_dir().join(format!("hubuum-event-archive-{suffix}.link"));
+        std::fs::write(&target, b"existing\n").unwrap();
+        symlink(&target, &link).unwrap();
+
+        let result = append_event_archive(&link, &[event()]);
+
+        assert!(matches!(
+            result,
+            Err(ApiError::InternalServerError(message))
+                if message.starts_with("Failed to open event archive:")
+        ));
+        assert_eq!(std::fs::read(&target).unwrap(), b"existing\n");
+        std::fs::remove_file(link).unwrap();
+        std::fs::remove_file(target).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Harden Unix event-retention archive appends by opening the configured final path component with `O_NOFOLLOW` and applying owner-only `0600` permissions through the opened file descriptor before every write.

Add regressions proving that a reused permissive archive is tightened and that a symbolic-link final component is rejected without modifying its target. Update the event-retention documentation and changelog to state the exact guarantees.

## Rationale

Archive records contain the complete durable event row, including before/after snapshots and identity/task metadata. The existing creation mode protected only newly created files: a pre-existing `0644` file stayed readable by other users, and a symlink path could redirect append writes to another file accessible to the Hubuum process.

Descriptor-based permission changes avoid a path re-resolution race after open, while `O_NOFOLLOW` prevents following a symbolic link at the configured final component. Because `O_NOFOLLOW` is used on every Unix target, the existing `libc` target dependency is now available under `cfg(unix)` instead of macOS only.

## Behavior and compatibility

Existing Unix archive files are changed to mode `0600` on the next append. Deployments that intentionally rely on group-readable archive files must move access behind an owner-controlled collector instead of retaining broader file permissions.

An archive path whose final component is a symbolic link now causes that retention iteration to fail safely; the database batch is not purged because archive writing remains inside the guarded transaction.

Non-Unix behavior is unchanged. No database migration or API change is required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`
