### PR TITLE
Harden auth config loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   paths whose final component is a symbolic link or another non-regular file.
   Operators relying on group-readable archives must move that access behind an
   owner-controlled collector; no database migration is required.
+- Auth provider configuration loading now bounds regular UTF-8 files to 1 MiB
+  and reports TOML error locations without echoing credential-bearing source
+  lines.
 - **Breaking (HTTP and Rust API):** Event-delivery API responses no longer
   expose the internal `claim_token` worker lease capability. API clients must
   stop deserializing or depending on this field. The persistence-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,9 +107,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   paths whose final component is a symbolic link or another non-regular file.
   Operators relying on group-readable archives must move that access behind an
   owner-controlled collector; no database migration is required.
-- Auth provider configuration loading now bounds regular UTF-8 files to 1 MiB
-  and reports TOML error locations without echoing credential-bearing source
-  lines.
+- **Breaking (configuration):** auth provider configuration loading now accepts
+  only regular UTF-8 files up to 1 MiB and reports TOML error locations without
+  echoing credential-bearing source lines. Deployments must replace larger or
+  non-regular sources with a bounded regular file; no database migration is
+  required.
 - **Breaking (HTTP and Rust API):** Event-delivery API responses no longer
   expose the internal `claim_token` worker lease capability. API clients must
   stop deserializing or depending on this field. The persistence-only

--- a/docs/external_auth.md
+++ b/docs/external_auth.md
@@ -12,6 +12,9 @@ For single-host container deployments, pass the host file to
 `install-single-host.sh --auth-config`; the installer mounts it read-only and
 sets the container path automatically. See
 [Single-Host Container Deployment](deployment.md#external-authentication-configuration).
+The configuration source must be a regular UTF-8 file no larger than 1 MiB.
+Parse errors identify the line and column but deliberately omit the source line
+because it may contain credentials such as `bind_password`.
 
 ```toml
 [[ldap]]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -5,7 +5,9 @@ use hubuum_auth_core::{AuthProviderError, ExternalIdentityProvider, ExternalUser
 use hubuum_auth_ldap::{LdapIdentityProvider, LdapScopeConfig};
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::fs::File;
 use std::future::Future;
+use std::io::Read;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::{Arc, LazyLock, OnceLock};
@@ -23,6 +25,7 @@ use crate::models::{LDAP_PROVIDER_KIND, LOCAL_IDENTITY_SCOPE, LOCAL_PROVIDER_KIN
 
 const DEFAULT_REFRESH_TTL_SECONDS: i64 = 300;
 const DEFAULT_MAX_STALE_SECONDS: i64 = 3600;
+const MAX_AUTH_CONFIG_BYTES: usize = 1024 * 1024;
 
 static REFRESH_LOCKS: LazyLock<Mutex<HashMap<i32, Arc<Mutex<()>>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -427,15 +430,77 @@ fn build_auth_provider_registry() -> Result<AuthProviderRegistry, ApiError> {
 }
 
 fn load_auth_config() -> Result<AuthProvidersConfig, ApiError> {
-    let Some(path) = crate::config::get_config()?.auth_config_path.clone() else {
+    let config = crate::config::get_config()?;
+    let Some(path) = config.auth_config_path.as_deref() else {
         return Ok(AuthProvidersConfig { ldap: Vec::new() });
     };
-    let raw = std::fs::read_to_string(Path::new(&path)).map_err(|e| {
-        ApiError::InternalServerError(format!("Failed to read auth config '{path}': {e}"))
+    let path = Path::new(path);
+    let source = read_auth_config_source(path)?;
+    parse_auth_config_source(path, &source)
+}
+
+fn read_auth_config_source(path: &Path) -> Result<String, ApiError> {
+    let file = File::open(path).map_err(|error| {
+        ApiError::InternalServerError(format!("Failed to open auth config {path:?}: {error}"))
     })?;
-    toml::from_str::<AuthProvidersConfig>(&raw).map_err(|e| {
-        ApiError::InternalServerError(format!("Failed to parse auth config '{path}': {e}"))
+    let metadata = file.metadata().map_err(|error| {
+        ApiError::InternalServerError(format!("Failed to inspect auth config {path:?}: {error}"))
+    })?;
+    if !metadata.is_file() {
+        return Err(ApiError::InternalServerError(format!(
+            "Auth config {path:?} must be a regular file"
+        )));
+    }
+    if metadata.len() > MAX_AUTH_CONFIG_BYTES as u64 {
+        return Err(auth_config_size_error(path));
+    }
+
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_AUTH_CONFIG_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| {
+            ApiError::InternalServerError(format!("Failed to read auth config {path:?}: {error}"))
+        })?;
+    if bytes.len() > MAX_AUTH_CONFIG_BYTES {
+        return Err(auth_config_size_error(path));
+    }
+    String::from_utf8(bytes).map_err(|_| {
+        ApiError::InternalServerError(format!("Auth config {path:?} must contain valid UTF-8"))
     })
+}
+
+fn auth_config_size_error(path: &Path) -> ApiError {
+    ApiError::InternalServerError(format!(
+        "Auth config {path:?} exceeds the {MAX_AUTH_CONFIG_BYTES}-byte limit"
+    ))
+}
+
+fn parse_auth_config_source(path: &Path, source: &str) -> Result<AuthProvidersConfig, ApiError> {
+    toml::from_str::<AuthProvidersConfig>(source).map_err(|error| {
+        let location = error.span().map(|span| {
+            let (line, column) = source_position(source, span.start);
+            format!(" at line {line}, column {column}")
+        });
+        ApiError::InternalServerError(format!(
+            "Failed to parse auth config {path:?}{}; source content omitted because it may contain credentials",
+            location.as_deref().unwrap_or_default()
+        ))
+    })
+}
+
+fn source_position(source: &str, byte_offset: usize) -> (usize, usize) {
+    let bytes = source.as_bytes();
+    let offset = byte_offset.min(bytes.len());
+    let line = bytes[..offset]
+        .iter()
+        .filter(|byte| **byte == b'\n')
+        .count()
+        + 1;
+    let line_start = bytes[..offset]
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |newline| newline + 1);
+    (line, offset - line_start + 1)
 }
 
 fn provider_error(err: AuthProviderError) -> ApiError {
@@ -617,8 +682,46 @@ pub(crate) async fn sync_external_user(
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
     use hubuum_auth_ldap::{LdapScopeConfig, LdapSearchScope};
+    use rstest::rstest;
+    use uuid::Uuid;
+
+    const CONFIG_SECRET: &str = "auth-config-secret";
+
+    struct TestAuthConfigFile {
+        path: PathBuf,
+    }
+
+    impl TestAuthConfigFile {
+        fn new(contents: &[u8]) -> Self {
+            let path =
+                std::env::temp_dir().join(format!("hubuum-auth-config-{}.toml", Uuid::new_v4()));
+            std::fs::write(&path, contents).expect("test auth config should be written");
+            Self { path }
+        }
+
+        fn with_len(len: u64) -> Self {
+            let path =
+                std::env::temp_dir().join(format!("hubuum-auth-config-{}.toml", Uuid::new_v4()));
+            File::create(&path)
+                .and_then(|file| file.set_len(len))
+                .expect("sized test auth config should be created");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestAuthConfigFile {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
 
     fn ldap_scope(scope: &str) -> ConfiguredLdapScope {
         ConfiguredLdapScope {
@@ -643,6 +746,65 @@ mod tests {
             refresh_ttl_seconds: Some(300),
             max_stale_seconds: Some(3600),
         }
+    }
+
+    #[rstest]
+    #[case::syntax(concat!("[[ldap]]\n", "bind_password = \"auth-config-secret\n"))]
+    #[case::type_mismatch(concat!(
+        "[[ldap]]\n",
+        "connect_timeout_seconds = \"auth-config-secret\"\n"
+    ))]
+    fn auth_config_parse_errors_do_not_disclose_source(#[case] source: &str) {
+        let error = parse_auth_config_source(Path::new("auth.toml"), source)
+            .expect_err("test auth config should be rejected");
+        let message = error.to_string();
+
+        assert!(!message.contains(CONFIG_SECRET));
+        assert!(message.contains(" at line "));
+        assert!(message.contains(", column "));
+        assert!(message.contains("source content omitted"));
+    }
+
+    #[test]
+    fn auth_config_reader_rejects_oversized_files() {
+        let file = TestAuthConfigFile::with_len(MAX_AUTH_CONFIG_BYTES as u64 + 1);
+
+        let error = read_auth_config_source(file.path())
+            .expect_err("oversized auth config should be rejected");
+
+        assert_eq!(error, auth_config_size_error(file.path()));
+    }
+
+    #[test]
+    fn auth_config_reader_rejects_invalid_utf8() {
+        let file = TestAuthConfigFile::new(&[0xff]);
+
+        let error = read_auth_config_source(file.path())
+            .expect_err("non-UTF-8 auth config should be rejected");
+
+        assert_eq!(
+            error,
+            ApiError::InternalServerError(format!(
+                "Auth config {:?} must contain valid UTF-8",
+                file.path()
+            ))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn auth_config_reader_rejects_non_regular_files() {
+        let path = Path::new("/dev/null");
+
+        let error =
+            read_auth_config_source(path).expect_err("non-regular auth config should be rejected");
+
+        assert_eq!(
+            error,
+            ApiError::InternalServerError(
+                "Auth config \"/dev/null\" must be a regular file".to_string()
+            )
+        );
     }
 
     fn timestamp() -> NaiveDateTime {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -500,7 +500,10 @@ fn source_position(source: &str, byte_offset: usize) -> (usize, usize) {
         .iter()
         .rposition(|byte| *byte == b'\n')
         .map_or(0, |newline| newline + 1);
-    (line, offset - line_start + 1)
+    let column = source
+        .get(line_start..offset)
+        .map_or(offset - line_start + 1, |prefix| prefix.chars().count() + 1);
+    (line, column)
 }
 
 fn provider_error(err: AuthProviderError) -> ApiError {
@@ -763,6 +766,14 @@ mod tests {
         assert!(message.contains(" at line "));
         assert!(message.contains(", column "));
         assert!(message.contains("source content omitted"));
+    }
+
+    #[test]
+    fn auth_config_source_positions_count_unicode_characters() {
+        let source = "øx = true";
+        let x_offset = source.find('x').unwrap();
+
+        assert_eq!(source_position(source, x_offset), (1, 2));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Treat the external authentication configuration as a credential-bearing input boundary.

Replace the unbounded `read_to_string` path with a descriptor-based loader that accepts only regular UTF-8 files up to 1 MiB. Check both the opened file's metadata and the result of a bounded read so file growth cannot bypass the limit.

Replace TOML's source-rendering error formatter with a credential-safe diagnostic that retains the parser-provided line and column but never includes the source line or deserialized value.

Add regressions for syntax and type errors containing an injected credential, oversized files, invalid UTF-8, and non-regular files. Document the resulting operator contract and add a security changelog entry.

## Rationale

The pinned TOML deserializer retains the original document in parse errors. Its `Display` implementation prints the complete offending source line.

Hubuum previously embedded that display output directly in its startup error. A malformed line such as `bind_password = "..."` could therefore copy an LDAP service credential into process logs, container logs, deployment diagnostics, or another error-collection system.

The previous `read_to_string` call was also unbounded and accepted device or pseudo-file paths. A mistaken or compromised configuration path could cause excessive memory consumption or an indefinitely producing source to be read during startup.

Authentication configuration contains credentials and should be handled with tighter rules than an ordinary document.

## Security behavior

Parse failures now report the TOML parser's line and column while deliberately omitting:

- the source line;
- the parser's potentially value-bearing message; and
- all parsed configuration values.

Configured paths use escaped debug formatting in diagnostics so control characters cannot create misleading multiline log entries.

The loader:

- opens the configured path once;
- inspects metadata through the opened descriptor;
- requires the resolved object to be a regular file;
- rejects files larger than 1 MiB before reading;
- reads at most 1 MiB plus one byte to detect concurrent growth; and
- rejects non-UTF-8 input without including its bytes in the error.

## Behavior and compatibility

Existing regular UTF-8 authentication configuration files no larger than 1 MiB continue to work unchanged. Symbolic links that resolve to regular files remain supported, including the mounted-secret patterns commonly used by container platforms.

Device files, FIFOs, sockets, invalid UTF-8, and files larger than 1 MiB are now rejected during startup.

Detailed TOML source excerpts are intentionally no longer returned. Operators still receive the configuration path and parser-provided line and column.

This is a standalone change. It requires no database migration, API schema change, dependency update, OpenAPI regeneration, or container rebuild.

## Verification

- `cargo test auth_config_`
- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `git diff --check`
