### PR TITLE
Validate external identity refresh policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   echoing credential-bearing source lines. Deployments must replace larger or
   non-regular sources with a bounded regular file; no database migration is
   required.
+- **Breaking:** External identity refresh policy now rejects unrepresentable
+  durations and stale windows shorter than the refresh TTL. Before upgrading,
+  raise `max_stale_seconds` or lower `refresh_ttl_seconds` wherever the stale
+  window is shorter. Future-dated provider sync timestamps also fail closed
+  instead of extending cached authorization state.
 - **Breaking (HTTP and Rust API):** Event-delivery API responses no longer
   expose the internal `claim_token` worker lease capability. API clients must
   stop deserializing or depending on this field. The persistence-only

--- a/docs/external_auth.md
+++ b/docs/external_auth.md
@@ -124,7 +124,11 @@ inside the configured max-stale window. Further requests back off for the scope
 refresh TTL before retrying the provider, so one outage does not serialize
 every request on repeated LDAP timeouts. Once the cache exceeds
 `max_stale_seconds`, requests fail with `503 Service Unavailable` during that
-backoff instead of using stale membership.
+backoff instead of using stale membership. Both durations must be positive and
+representable, and `max_stale_seconds` must be greater than or equal to
+`refresh_ttl_seconds`; invalid policies are rejected during startup. A sync
+timestamp ahead of the server clock is never treated as fresh or as an active
+retry backoff.
 
 ## Users And Groups
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -128,46 +128,72 @@ struct RefreshPolicy {
 
 impl RefreshPolicy {
     fn new(refresh_ttl_seconds: i64, max_stale_seconds: i64) -> Result<Self, ApiError> {
+        let refresh_ttl = RefreshTtl::new(refresh_ttl_seconds)?;
+        let max_stale = MaxStale::new(max_stale_seconds)?;
+        if max_stale.duration() < refresh_ttl.duration() {
+            return Err(ApiError::BadRequest(
+                "ldap max_stale_seconds must be greater than or equal to refresh_ttl_seconds"
+                    .to_string(),
+            ));
+        }
         Ok(Self {
-            refresh_ttl: RefreshTtl::new(refresh_ttl_seconds)?,
-            max_stale: MaxStale::new(max_stale_seconds)?,
+            refresh_ttl,
+            max_stale,
         })
     }
 }
 
 #[derive(Clone, Copy)]
-struct RefreshTtl(chrono::Duration);
+struct RefreshDuration(chrono::Duration);
 
-impl RefreshTtl {
-    fn new(seconds: i64) -> Result<Self, ApiError> {
+impl RefreshDuration {
+    fn new(seconds: i64, field: &str) -> Result<Self, ApiError> {
         if seconds <= 0 {
-            return Err(ApiError::BadRequest(
-                "ldap refresh_ttl_seconds must be positive".to_string(),
-            ));
+            return Err(ApiError::BadRequest(format!(
+                "ldap {field} must be positive"
+            )));
         }
-        Ok(Self(chrono::Duration::seconds(seconds)))
+        chrono::Duration::try_seconds(seconds)
+            .map(Self)
+            .ok_or_else(|| ApiError::BadRequest(format!("ldap {field} is too large")))
     }
 
     fn contains(self, elapsed: chrono::Duration) -> bool {
-        elapsed < self.0
+        elapsed >= chrono::Duration::zero() && elapsed < self.0
     }
 }
 
 #[derive(Clone, Copy)]
-struct MaxStale(chrono::Duration);
+struct RefreshTtl(RefreshDuration);
 
-impl MaxStale {
+impl RefreshTtl {
     fn new(seconds: i64) -> Result<Self, ApiError> {
-        if seconds <= 0 {
-            return Err(ApiError::BadRequest(
-                "ldap max_stale_seconds must be positive".to_string(),
-            ));
-        }
-        Ok(Self(chrono::Duration::seconds(seconds)))
+        RefreshDuration::new(seconds, "refresh_ttl_seconds").map(Self)
     }
 
     fn contains(self, elapsed: chrono::Duration) -> bool {
-        elapsed < self.0
+        self.0.contains(elapsed)
+    }
+
+    fn duration(self) -> chrono::Duration {
+        self.0.0
+    }
+}
+
+#[derive(Clone, Copy)]
+struct MaxStale(RefreshDuration);
+
+impl MaxStale {
+    fn new(seconds: i64) -> Result<Self, ApiError> {
+        RefreshDuration::new(seconds, "max_stale_seconds").map(Self)
+    }
+
+    fn contains(self, elapsed: chrono::Duration) -> bool {
+        self.0.contains(elapsed)
+    }
+
+    fn duration(self) -> chrono::Duration {
+        self.0.0
     }
 }
 
@@ -900,6 +926,28 @@ mod tests {
     }
 
     #[test]
+    fn future_success_timestamp_requires_external_refresh() {
+        let current = timestamp();
+        let future_success = current + chrono::Duration::seconds(1);
+
+        assert_eq!(
+            refresh_status_at(current, Some(future_success), None, refresh_ttl(300)),
+            RefreshStatus::Due
+        );
+    }
+
+    #[test]
+    fn future_attempt_timestamp_does_not_create_retry_backoff() {
+        let current = timestamp();
+        let future_attempt = current + chrono::Duration::seconds(1);
+
+        assert_eq!(
+            refresh_status_at(current, None, Some(future_attempt), refresh_ttl(300)),
+            RefreshStatus::Due
+        );
+    }
+
+    #[test]
     fn retry_backoff_rejects_cache_beyond_max_stale() {
         let current = timestamp();
         let state = ExternalUserState {
@@ -933,6 +981,33 @@ mod tests {
 
         assert!(matches!(error, ApiError::BadRequest(_)));
         assert_eq!(error.to_string(), "ldap max_stale_seconds must be positive");
+    }
+
+    #[rstest::rstest]
+    #[case::refresh_ttl(i64::MAX, 3600, "ldap refresh_ttl_seconds is too large")]
+    #[case::max_stale(300, i64::MAX, "ldap max_stale_seconds is too large")]
+    fn refresh_policy_rejects_unrepresentable_durations(
+        #[case] refresh_ttl_seconds: i64,
+        #[case] max_stale_seconds: i64,
+        #[case] expected: &str,
+    ) {
+        let error = RefreshPolicy::new(refresh_ttl_seconds, max_stale_seconds)
+            .err()
+            .unwrap();
+
+        assert!(matches!(error, ApiError::BadRequest(_)));
+        assert_eq!(error.to_string(), expected);
+    }
+
+    #[test]
+    fn refresh_policy_rejects_a_stale_window_below_the_refresh_ttl() {
+        let error = RefreshPolicy::new(300, 299).err().unwrap();
+
+        assert!(matches!(error, ApiError::BadRequest(_)));
+        assert_eq!(
+            error.to_string(),
+            "ldap max_stale_seconds must be greater than or equal to refresh_ttl_seconds"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Harden LDAP-backed external identity refresh policy at configuration and timestamp boundaries.

Replace panic-capable `chrono::Duration::seconds` construction with a shared validating duration type, require `max_stale_seconds` to be greater than or equal to `refresh_ttl_seconds`, and treat future-dated success or attempt timestamps as neither fresh nor in retry backoff.

Add focused regressions for unrepresentable values, invalid cross-field policy, and both future-timestamp paths. Document the effective policy and add a security changelog entry.

## Rationale

The refresh policy protects the lifetime of cached external group membership, which is authorization state.

An extreme positive TOML integer previously passed the positive-value check and then reached `chrono::Duration::seconds`, whose out-of-range constructor panics. A malformed operator-controlled configuration could therefore abort startup instead of returning an actionable configuration error.

More importantly, a `max_stale_seconds` value below the refresh TTL did not provide the declared stale ceiling. `refresh_status_at` classified a recent success as fresh for the complete TTL before the max-stale check ran, so cached membership could remain accepted beyond the smaller configured window.

Negative elapsed durations also satisfied the old `elapsed < window` predicate. A future-dated imported or otherwise inconsistent sync timestamp could therefore suppress refresh or extend retry backoff until the wall clock caught up.

## Security behavior

The policy now:

- rejects non-positive durations as before;
- rejects positive durations that `chrono` cannot represent;
- rejects `max_stale_seconds < refresh_ttl_seconds` during startup;
- accepts cached state only for non-negative elapsed durations inside the configured window; and
- forces provider refresh when success or attempt timestamps are ahead of the server clock.

## Behavior and compatibility

This is a breaking configuration change for deployments whose stale window is
shorter than their refresh TTL. Before upgrading, raise `max_stale_seconds` or
lower `refresh_ttl_seconds`. Extremely large values that previously panicked now
produce a configuration error.

Existing configurations using positive representable durations with
`max_stale_seconds >= refresh_ttl_seconds` are unchanged. The documented
defaults remain 300 and 3600 seconds. No database migration, API schema change,
dependency update, OpenAPI regeneration, or container rebuild is required.

## Verification

- `cargo test auth::tests --lib`
- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `git diff --check`