### PR TITLE
Validate artifact retention horizons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   ordering and extracts each value once, so failures cannot silently leave rows
   unordered and fallible work is not repeated inside the sort comparator.
 
+### Fixed
+
+- Export, backup, and staged-restore retention horizons now reject durations or
+  expiry timestamps outside the supported range instead of panicking during
+  startup or artifact creation.
+
 ## [0.0.8] - 2026-08-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,9 +75,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - In-memory cursor pagination now computes every row's sort values before
   ordering and extracts each value once, so failures cannot silently leave rows
   unordered and fallible work is not repeated inside the sort comparator.
-
-### Fixed
-
 - Export, backup, and staged-restore retention horizons now reject durations or
   expiry timestamps outside the supported range instead of panicking during
   startup or artifact creation.

--- a/src/backups/mod.rs
+++ b/src/backups/mod.rs
@@ -1,13 +1,14 @@
 use crate::models::token_scope::TokenScope;
 use std::collections::BTreeMap;
 
-use chrono::{Duration, Utc};
+use chrono::Utc;
 use sha2::{Digest, Sha256};
 
 use crate::db::DbPool;
 use crate::db::traits::backup::snapshot_backup_db;
 use crate::db::traits::task::{TaskBackend, TaskStateUpdate};
 use crate::errors::ApiError;
+use crate::models::retention::FutureRetention;
 use crate::models::{
     BackupDocument, BackupHistory, BackupManifest, BackupRequest, BackupState,
     CURRENT_BACKUP_VERSION, NewBackupTaskOutputRecord, NewTaskEventRecord, TaskRecord,
@@ -18,7 +19,7 @@ use crate::traits::AuthzSubject;
 
 #[derive(Clone, Debug)]
 pub struct BackupSettings {
-    output_retention_hours: i64,
+    output_retention: FutureRetention,
     max_active_tasks_per_user: usize,
     max_output_bytes: usize,
 }
@@ -29,9 +30,8 @@ impl BackupSettings {
         max_active_tasks_per_user: usize,
         max_output_bytes: usize,
     ) -> Result<Self, String> {
-        if output_retention_hours <= 0 {
-            return Err("backup output retention must be greater than zero".to_string());
-        }
+        let output_retention =
+            FutureRetention::from_hours(output_retention_hours, "backup output retention")?;
         if max_active_tasks_per_user == 0 {
             return Err("backup active-task limit must be greater than zero".to_string());
         }
@@ -39,18 +39,27 @@ impl BackupSettings {
             return Err("backup output size limit must be greater than zero".to_string());
         }
         Ok(Self {
-            output_retention_hours,
+            output_retention,
             max_active_tasks_per_user,
             max_output_bytes,
         })
     }
 
-    pub fn output_retention_hours(&self) -> i64 {
-        self.output_retention_hours
+    fn output_expires_at(
+        &self,
+        now: chrono::NaiveDateTime,
+    ) -> Result<chrono::NaiveDateTime, ApiError> {
+        self.output_retention
+            .expires_at(now)
+            .map_err(ApiError::BadRequest)
     }
 
     pub fn max_active_tasks_per_user(&self) -> usize {
         self.max_active_tasks_per_user
+    }
+
+    pub fn output_retention_hours(&self) -> i64 {
+        self.output_retention.hours()
     }
 
     pub fn max_output_bytes(&self) -> usize {
@@ -128,7 +137,7 @@ pub async fn execute_backup_task(
         .map(|byte| format!("{byte:02x}"))
         .collect::<String>();
     let byte_size = i64::try_from(bytes.len()).unwrap_or(i64::MAX);
-    let expires_at = Utc::now().naive_utc() + Duration::hours(settings.output_retention_hours());
+    let expires_at = settings.output_expires_at(Utc::now().naive_utc())?;
     let total_items = document.manifest.item_counts.values().copied().sum::<i64>();
     let total_items = i32::try_from(total_items).unwrap_or(i32::MAX);
     let summary = format!(
@@ -233,5 +242,15 @@ mod tests {
         #[case] output_bytes: usize,
     ) {
         assert!(BackupSettings::new(retention_hours, active_tasks, output_bytes).is_err());
+    }
+
+    #[test]
+    fn backup_settings_reject_unrepresentable_retention() {
+        let error = BackupSettings::new(i64::MAX, 1, 1024).unwrap_err();
+
+        assert_eq!(
+            error,
+            "backup output retention is outside the supported duration range"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use std::num::NonZeroUsize;
 use std::str::FromStr;
 
 use crate::errors::ApiError;
+use crate::models::retention::FutureRetention;
 use crate::models::{TokenIssuancePolicy, TokenRetentionSettings};
 
 mod client_network;
@@ -1052,7 +1053,7 @@ impl AppConfig {
             ));
         }
 
-        crate::models::retention::FutureRetention::from_hours(
+        FutureRetention::from_hours(
             self.export_output_retention_hours,
             "export_output_retention_hours",
         )
@@ -1064,7 +1065,7 @@ impl AppConfig {
             ));
         }
 
-        crate::models::retention::FutureRetention::from_hours(
+        FutureRetention::from_hours(
             self.backup_output_retention_hours,
             "backup_output_retention_hours",
         )
@@ -1082,7 +1083,7 @@ impl AppConfig {
             ));
         }
 
-        crate::models::retention::FutureRetention::from_minutes(
+        FutureRetention::from_minutes(
             self.restore_stage_retention_minutes,
             "restore_stage_retention_minutes",
         )

--- a/src/config.rs
+++ b/src/config.rs
@@ -1052,11 +1052,11 @@ impl AppConfig {
             ));
         }
 
-        if self.export_output_retention_hours <= 0 {
-            return Err(ApiError::BadRequest(
-                "export_output_retention_hours must be greater than 0".to_string(),
-            ));
-        }
+        crate::models::retention::FutureRetention::from_hours(
+            self.export_output_retention_hours,
+            "export_output_retention_hours",
+        )
+        .map_err(ApiError::BadRequest)?;
 
         if self.export_output_cleanup_interval_seconds == 0 {
             return Err(ApiError::BadRequest(
@@ -1064,11 +1064,11 @@ impl AppConfig {
             ));
         }
 
-        if self.backup_output_retention_hours <= 0 {
-            return Err(ApiError::BadRequest(
-                "backup_output_retention_hours must be greater than 0".to_string(),
-            ));
-        }
+        crate::models::retention::FutureRetention::from_hours(
+            self.backup_output_retention_hours,
+            "backup_output_retention_hours",
+        )
+        .map_err(ApiError::BadRequest)?;
 
         if self.backup_max_active_tasks_per_user == 0 {
             return Err(ApiError::BadRequest(
@@ -1082,11 +1082,11 @@ impl AppConfig {
             ));
         }
 
-        if self.restore_stage_retention_minutes <= 0 {
-            return Err(ApiError::BadRequest(
-                "restore_stage_retention_minutes must be greater than 0".to_string(),
-            ));
-        }
+        crate::models::retention::FutureRetention::from_minutes(
+            self.restore_stage_retention_minutes,
+            "restore_stage_retention_minutes",
+        )
+        .map_err(ApiError::BadRequest)?;
 
         if self.restore_max_upload_bytes == 0 {
             return Err(ApiError::BadRequest(
@@ -2484,6 +2484,34 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "export_max_output_bytes must be greater than 0"
+        );
+    }
+
+    #[rstest]
+    #[case(
+        "HUBUUM_EXPORT_OUTPUT_RETENTION_HOURS",
+        "export_output_retention_hours"
+    )]
+    #[case(
+        "HUBUUM_BACKUP_OUTPUT_RETENTION_HOURS",
+        "backup_output_retention_hours"
+    )]
+    #[case(
+        "HUBUUM_RESTORE_STAGE_RETENTION_MINUTES",
+        "restore_stage_retention_minutes"
+    )]
+    fn artifact_retention_horizons_must_be_representable(
+        #[case] key: &'static str,
+        #[case] field: &str,
+    ) {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _guard = EnvVarGuard::set(key, Some("9223372036854775807"));
+
+        let error = get_config_from_env().unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!("{field} is outside the supported duration range")
         );
     }
 

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -1342,8 +1342,12 @@ fn artifact_to_output_record(
     let retention_hours = get_config()
         .map(|config| config.export_output_retention_hours)
         .unwrap_or(DEFAULT_EXPORT_OUTPUT_RETENTION_HOURS);
-    let output_expires_at =
-        chrono::Utc::now().naive_utc() + chrono::Duration::hours(retention_hours);
+    let output_expires_at = crate::models::retention::FutureRetention::from_hours(
+        retention_hours,
+        "export_output_retention_hours",
+    )
+    .and_then(|retention| retention.expires_at(chrono::Utc::now().naive_utc()))
+    .map_err(ApiError::BadRequest)?;
     Ok(NewExportTaskOutputRecord {
         task_id,
         template_name: artifact.template_name,

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -21,6 +21,7 @@ use crate::db::traits::task::{TaskBackend, TaskCreateRequest, TaskScopeSnapshot,
 use crate::db::traits::user::UserSearchBackend;
 use crate::db::{DbPool, with_statement_timeout_scope};
 use crate::errors::ApiError;
+use crate::models::retention::FutureRetention;
 use crate::models::search::{
     FilterField, ParsedQueryParam, QueryOptions, QueryParamsExt, SearchOperator,
     StatementTimeoutMs, parse_query_parameter,
@@ -1342,12 +1343,10 @@ fn artifact_to_output_record(
     let retention_hours = get_config()
         .map(|config| config.export_output_retention_hours)
         .unwrap_or(DEFAULT_EXPORT_OUTPUT_RETENTION_HOURS);
-    let output_expires_at = crate::models::retention::FutureRetention::from_hours(
-        retention_hours,
-        "export_output_retention_hours",
-    )
-    .and_then(|retention| retention.expires_at(chrono::Utc::now().naive_utc()))
-    .map_err(ApiError::BadRequest)?;
+    let output_expires_at =
+        FutureRetention::from_hours(retention_hours, "export_output_retention_hours")
+            .and_then(|retention| retention.expires_at(chrono::Utc::now().naive_utc()))
+            .map_err(ApiError::BadRequest)?;
     Ok(NewExportTaskOutputRecord {
         task_id,
         template_name: artifact.template_name,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -28,6 +28,7 @@ pub mod principal;
 pub mod principal_group;
 pub mod relation;
 pub mod remote_target;
+pub(crate) mod retention;
 pub mod search;
 pub mod service_account;
 pub mod task;

--- a/src/models/retention.rs
+++ b/src/models/retention.rs
@@ -1,0 +1,117 @@
+use chrono::{Duration, NaiveDateTime};
+
+/// A positive, representable duration used to place an artifact expiry in the future.
+///
+/// Construction validates the configured unit without binding the value to one wall-clock
+/// sample. Expiry calculation remains checked because even a representable duration can exceed
+/// `NaiveDateTime` when added to a timestamp near its upper bound.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FutureRetention {
+    duration: Duration,
+    field: &'static str,
+}
+
+impl FutureRetention {
+    pub(crate) fn from_hours(value: i64, field: &'static str) -> Result<Self, String> {
+        Self::new(value, field, Duration::try_hours)
+    }
+
+    pub(crate) fn from_minutes(value: i64, field: &'static str) -> Result<Self, String> {
+        Self::new(value, field, Duration::try_minutes)
+    }
+
+    fn new(
+        value: i64,
+        field: &'static str,
+        convert: fn(i64) -> Option<Duration>,
+    ) -> Result<Self, String> {
+        if value <= 0 {
+            return Err(format!("{field} must be greater than 0"));
+        }
+        let duration = convert(value)
+            .ok_or_else(|| format!("{field} is outside the supported duration range"))?;
+        Ok(Self { duration, field })
+    }
+
+    pub(crate) fn expires_at(self, now: NaiveDateTime) -> Result<NaiveDateTime, String> {
+        now.checked_add_signed(self.duration).ok_or_else(|| {
+            format!(
+                "{0} produces a timestamp outside the supported range",
+                self.field
+            )
+        })
+    }
+
+    pub(crate) fn hours(self) -> i64 {
+        self.duration.num_hours()
+    }
+
+    pub(crate) fn minutes(self) -> i64 {
+        self.duration.num_minutes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case::hours(0, FutureRetention::from_hours)]
+    #[case::minutes(-1, FutureRetention::from_minutes)]
+    fn rejects_non_positive_values(
+        #[case] value: i64,
+        #[case] constructor: fn(i64, &'static str) -> Result<FutureRetention, String>,
+    ) {
+        let error = constructor(value, "artifact_retention").unwrap_err();
+
+        assert_eq!(error, "artifact_retention must be greater than 0");
+    }
+
+    #[rstest]
+    #[case::hours(FutureRetention::from_hours)]
+    #[case::minutes(FutureRetention::from_minutes)]
+    fn rejects_unrepresentable_durations(
+        #[case] constructor: fn(i64, &'static str) -> Result<FutureRetention, String>,
+    ) {
+        let error = constructor(i64::MAX, "artifact_retention").unwrap_err();
+
+        assert_eq!(
+            error,
+            "artifact_retention is outside the supported duration range"
+        );
+    }
+
+    #[test]
+    fn computes_expiry_from_the_supplied_clock() {
+        let now = NaiveDate::from_ymd_opt(2026, 8, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let retention = FutureRetention::from_hours(24, "artifact_retention").unwrap();
+
+        assert_eq!(
+            retention.expires_at(now).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 8, 2)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap()
+        );
+        assert_eq!(retention.hours(), 24);
+        assert_eq!(retention.minutes(), 24 * 60);
+    }
+
+    #[test]
+    fn rejects_an_expiry_outside_the_timestamp_range() {
+        let retention = FutureRetention::from_hours(1, "artifact_retention").unwrap();
+
+        let error = retention.expires_at(NaiveDateTime::MAX).unwrap_err();
+
+        assert_eq!(
+            error,
+            "artifact_retention produces a timestamp outside the supported range"
+        );
+    }
+}

--- a/src/restores/mod.rs
+++ b/src/restores/mod.rs
@@ -26,6 +26,7 @@ use crate::models::backup::{
     BACKUP_STATE_SECTIONS, backup_history_sections, is_backup_history_section,
 };
 use crate::models::identity::{LOCAL_IDENTITY_SCOPE, LOCAL_PROVIDER_KIND};
+use crate::models::retention::FutureRetention;
 use crate::models::{
     BackupDocument, COMPUTED_FIELD_VISIBILITY_PERSONAL, COMPUTED_FIELD_VISIBILITY_SHARED,
     ComputedFieldDefinitionRequest, ComputedResultType, MaintenanceState, NewRestoreJobRecord,
@@ -71,30 +72,35 @@ fn confirmation_is_stale(confirmed_at: NaiveDateTime, now: NaiveDateTime) -> boo
 
 #[derive(Clone, Debug)]
 pub struct RestoreSettings {
-    stage_retention_minutes: i64,
+    stage_retention: FutureRetention,
     max_upload_bytes: usize,
 }
 
 impl RestoreSettings {
     pub fn new(stage_retention_minutes: i64, max_upload_bytes: usize) -> Result<Self, String> {
-        if stage_retention_minutes <= 0 {
-            return Err("restore stage retention must be greater than zero".to_string());
-        }
+        let stage_retention =
+            FutureRetention::from_minutes(stage_retention_minutes, "restore stage retention")?;
         if max_upload_bytes == 0 {
             return Err("restore upload size limit must be greater than zero".to_string());
         }
         Ok(Self {
-            stage_retention_minutes,
+            stage_retention,
             max_upload_bytes,
         })
     }
 
-    pub fn stage_retention_minutes(&self) -> i64 {
-        self.stage_retention_minutes
+    fn stage_expires_at(&self, now: NaiveDateTime) -> Result<NaiveDateTime, ApiError> {
+        self.stage_retention
+            .expires_at(now)
+            .map_err(ApiError::BadRequest)
     }
 
     pub fn max_upload_bytes(&self) -> usize {
         self.max_upload_bytes
+    }
+
+    pub fn stage_retention_minutes(&self) -> i64 {
+        self.stage_retention.minutes()
     }
 }
 
@@ -453,7 +459,7 @@ pub async fn stage_restore(
     let document_sha = sha256(&document_bytes);
     let capability = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
     let capability_hash = sha256(capability.as_bytes());
-    let expires_at = Utc::now().naive_utc() + Duration::minutes(settings.stage_retention_minutes());
+    let expires_at = settings.stage_expires_at(Utc::now().naive_utc())?;
     let validation_json = serde_json::to_value(&validation)?;
     let byte_size = i64::try_from(document_bytes.len()).unwrap_or(i64::MAX);
     let (requested_by, requested_by_identity_scope, requested_by_name) = initiator.into_parts();
@@ -964,6 +970,16 @@ mod tests {
         #[case] upload_bytes: usize,
     ) {
         assert!(RestoreSettings::new(retention_minutes, upload_bytes).is_err());
+    }
+
+    #[test]
+    fn restore_settings_reject_unrepresentable_retention() {
+        let error = RestoreSettings::new(i64::MAX, 1024).unwrap_err();
+
+        assert_eq!(
+            error,
+            "restore stage retention is outside the supported duration range"
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

Introduce a shared crate-private `FutureRetention` newtype for export output,
backup output, and staged-restore retention.

The new type validates that configured horizons are positive and representable,
and it uses checked timestamp arithmetic when calculating an artifact expiry.
The existing public backup and restore settings accessors remain unchanged.

## Rationale

All three retention settings previously accepted any positive `i64` and later
passed it to `chrono::Duration::hours` or `chrono::Duration::minutes`. Those
constructors can panic for an out-of-range value. Adding an otherwise valid
duration to a `NaiveDateTime` could also overflow near the timestamp ceiling.

That made malformed operator configuration capable of aborting startup, an
artifact worker, or restore staging. The affected paths also implemented the
same future-retention invariant independently.

## Behavior and compatibility

- Existing positive, representable retention settings behave as before.
- Out-of-range durations now fail configuration or settings validation.
- Timestamp overflow now returns an error rather than panicking.
- Existing `BackupSettings::output_retention_hours` and
  `RestoreSettings::stage_retention_minutes` accessors are preserved.
- The shared type remains crate-private and exposes only unit-specific
  constructors, checked expiry calculation, and the accessors current callers
  require.
- No database migration, endpoint or schema change, OpenAPI regeneration,
  dependency update, or container rebuild is required.

## Changelog

The `[Unreleased]` section documents the panic-to-validation behavior change.

## Verification

- `cargo test models::retention::tests --lib`
- `cargo test artifact_retention_horizons_must_be_representable --lib`
- `cargo test settings_reject_unrepresentable_retention --lib`
- `source .env && ./run_tests.sh` (1,833 passed; 2 ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `git diff --check`
