### PR TITLE
Make external refresh locks cancellation-safe

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -400,7 +400,7 @@ pub async fn refresh_principal_if_needed(pool: &DbPool, principal_id: i32) -> Re
     }
 
     let lock = REFRESH_LOCKS.lock_for(principal_id);
-    let refresh_result = {
+    {
         let _guard = lock.lock().await;
 
         match external_user_state(pool, principal_id).await {
@@ -447,9 +447,7 @@ pub async fn refresh_principal_if_needed(pool: &DbPool, principal_id: i32) -> Re
                 },
             },
         }
-    };
-
-    refresh_result
+    }
 }
 
 pub async fn ensure_configured_identity_scopes(pool: &DbPool) -> Result<(), ApiError> {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -10,7 +10,7 @@ use std::future::Future;
 use std::io::Read;
 use std::path::Path;
 use std::pin::Pin;
-use std::sync::{Arc, LazyLock, OnceLock};
+use std::sync::{Arc, LazyLock, Mutex as StdMutex, OnceLock, Weak};
 use tokio::sync::Mutex;
 
 use crate::db::DbPool;
@@ -27,10 +27,40 @@ const DEFAULT_REFRESH_TTL_SECONDS: i64 = 300;
 const DEFAULT_MAX_STALE_SECONDS: i64 = 3600;
 const MAX_AUTH_CONFIG_BYTES: usize = 1024 * 1024;
 
-static REFRESH_LOCKS: LazyLock<Mutex<HashMap<i32, Arc<Mutex<()>>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static REFRESH_LOCKS: LazyLock<RefreshLockRegistry> = LazyLock::new(RefreshLockRegistry::default);
 static AUTH_PROVIDER_REGISTRY: OnceLock<Result<AuthProviderRegistry, AuthProviderRegistryError>> =
     OnceLock::new();
+
+#[derive(Default)]
+struct RefreshLockRegistry {
+    locks: StdMutex<HashMap<i32, Weak<Mutex<()>>>>,
+}
+
+impl RefreshLockRegistry {
+    fn lock_for(&self, principal_id: i32) -> Arc<Mutex<()>> {
+        let mut locks = self
+            .locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        locks.retain(|_, lock| lock.strong_count() > 0);
+
+        if let Some(lock) = locks.get(&principal_id).and_then(Weak::upgrade) {
+            return lock;
+        }
+
+        let lock = Arc::new(Mutex::new(()));
+        locks.insert(principal_id, Arc::downgrade(&lock));
+        lock
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len()
+    }
+}
 
 #[derive(Debug, Clone)]
 enum AuthProviderRegistryError {
@@ -369,13 +399,7 @@ pub async fn refresh_principal_if_needed(pool: &DbPool, principal_id: i32) -> Re
         RefreshStatus::Due => {}
     }
 
-    let lock = {
-        let mut locks = REFRESH_LOCKS.lock().await;
-        locks
-            .entry(principal_id)
-            .or_insert_with(|| Arc::new(Mutex::new(())))
-            .clone()
-    };
+    let lock = REFRESH_LOCKS.lock_for(principal_id);
     let refresh_result = {
         let _guard = lock.lock().await;
 
@@ -424,13 +448,6 @@ pub async fn refresh_principal_if_needed(pool: &DbPool, principal_id: i32) -> Re
             },
         }
     };
-
-    {
-        let mut locks = REFRESH_LOCKS.lock().await;
-        if Arc::strong_count(&lock) <= 2 {
-            locks.remove(&principal_id);
-        }
-    }
 
     refresh_result
 }
@@ -857,6 +874,28 @@ mod tests {
 
     fn refresh_policy() -> RefreshPolicy {
         RefreshPolicy::new(300, 3600).unwrap()
+    }
+
+    #[test]
+    fn refresh_lock_registry_reuses_live_principal_locks() {
+        let registry = RefreshLockRegistry::default();
+        let first = registry.lock_for(42);
+        let second = registry.lock_for(42);
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn refresh_lock_registry_reclaims_dropped_principal_locks() {
+        let registry = RefreshLockRegistry::default();
+        let dropped = registry.lock_for(42);
+        drop(dropped);
+
+        let live = registry.lock_for(7);
+
+        assert_eq!(registry.len(), 1);
+        assert!(Arc::ptr_eq(&live, &registry.lock_for(7)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Make the external-identity refresh single-flight registry safe when an async
request is canceled.

The registry now stores weak references to per-principal async mutexes behind a
short-lived synchronous map lock. Live requests still share the same mutex,
while a canceled request can no longer leave a strong reference retained by the
global registry. Dead weak entries are pruned on the next lookup.

## Rationale

The previous registry stored an `Arc<Mutex<()>>` for every principal currently
being refreshed and removed it only after the entire async refresh path
returned. Cancellation while waiting for the mutex, querying the database, or
calling the external provider skipped that cleanup block. The global map then
kept the `Arc` alive indefinitely, allowing repeated cancellations for distinct
principals to grow process memory.

Weak registry ownership expresses the intended invariant directly: in-flight
callers own a refresh lock, and the registry only helps concurrent callers find
it. The registry's map critical section performs no async work and never spans
an `.await`.

## Concurrency behavior

- Concurrent refreshes for the same principal reuse one live async mutex.
- Different principals remain independent.
- Dropping every caller also drops the per-principal mutex, even if a future is
  canceled before normal function return.
- Stale weak entries are reclaimed during the next registry lookup.
- A poisoned registry mutex is recovered without turning a prior panic into a
  permanent authentication outage.

## Compatibility and scope

This changes only internal refresh coordination. It does not change the API,
authentication policy, persisted state, configuration, OpenAPI document,
dependencies, migrations, or container build inputs.

There is no changelog-worthy user-facing behavior; this is internal resource
lifecycle hardening.

## Verification

- `cargo test refresh_lock_registry --lib`
- `source .env && ./run_tests.sh` (1,820 passed; 8 ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
