### PR TITLE
Bound TLS credential file loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   that hides request, idempotency, token-scope, and worker-lease material.
   Library callers must use the corresponding task response types for public
   payloads.
+- **Breaking:** TLS certificate chains, private keys, and PostgreSQL root CA
+  bundles must now be regular files and are read with explicit 4 MiB
+  certificate and 1 MiB key limits; malformed rustls certificate entries are
+  rejected instead of skipped. Before upgrading, replace non-regular TLS files,
+  reduce oversized PEM material, and correct malformed certificate entries.
 - **Breaking (HTTP and Rust API):** Event-delivery API responses no longer
   expose the internal `claim_token` worker lease capability. API clients must
   stop deserializing or depending on this field. The persistence-only

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -212,7 +212,8 @@ Database TLS behavior follows the URL's `sslmode`:
 
 The platform trust store is used by default. Set `PGSSLROOTCERT` to a PEM CA
 bundle for private certificate authorities, or to `system` to explicitly use
-the platform trust store.
+the platform trust store. Custom CA bundles must be regular files no larger than
+4 MiB.
 
 The database must already exist and be reachable from containers on the host. Avoid `localhost` in the URL unless Postgres is inside the same container; from a container, `localhost` means the API container itself.
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -242,7 +242,10 @@ budgeting, and shared limiter behavior, see
 | `HUBUUM_TLS_KEY_PASSPHRASE` | None | Passphrase for encrypted private key (OpenSSL only) |
 | `HUBUUM_TLS_BACKEND` | Auto / unset | Preferred TLS backend when TLS is enabled (`rustls` or `openssl`) |
 
-**Note**: TLS requires both certificate and key paths to be set. The rustls feature does not support encrypted keys with passphrases.
+**Note**: TLS requires both certificate and key paths to be set. The rustls
+feature does not support encrypted keys with passphrases. Certificate chains
+must be regular PEM files no larger than 4 MiB; private keys must be regular PEM
+files no larger than 1 MiB.
 
 ## Exit Codes
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -42,6 +42,7 @@ use rustls::{ClientConfig, RootCertStore};
 use rustls_platform_verifier::BuilderVerifierExt;
 use std::future::Future;
 use std::net::IpAddr;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -51,6 +52,7 @@ use crate::errors::{ApiError, EXIT_CODE_CONFIG_ERROR, fatal_error};
 use crate::events::MutationProvenance;
 use crate::models::search::StatementTimeoutMs;
 use crate::observability::metrics::{self, ResultKind};
+use crate::utilities::bounded_file::{MAX_CERTIFICATE_BUNDLE_BYTES, read_bounded_regular_file};
 use crate::utilities::db::DatabaseUrlComponents;
 
 pub type DbConnection = AsyncPgConnection;
@@ -271,8 +273,13 @@ fn database_tls_config() -> Result<ClientConfig, diesel::result::ConnectionError
             .map_err(|error| diesel::result::ConnectionError::BadConnection(error.to_string()));
     }
 
-    let certificates = CertificateDer::pem_file_iter(&root_cert_path)
-        .map_err(|error| diesel::result::ConnectionError::BadConnection(error.to_string()))?;
+    let certificate_bytes = read_bounded_regular_file(
+        Path::new(&root_cert_path),
+        "PostgreSQL root certificate bundle",
+        MAX_CERTIFICATE_BUNDLE_BYTES,
+    )
+    .map_err(|error| diesel::result::ConnectionError::BadConnection(error.to_string()))?;
+    let certificates = CertificateDer::pem_slice_iter(&certificate_bytes);
     let mut roots = RootCertStore::empty();
     let mut root_count = 0usize;
     for certificate in certificates {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,8 +1,14 @@
 use actix_http::{Request, Response};
 use actix_service::{IntoServiceFactory, ServiceFactory};
 use actix_web::{Error, HttpServer, body::MessageBody, dev::AppConfig};
+#[cfg(any(feature = "tls-rustls", feature = "tls-openssl"))]
+use std::path::Path;
 
 use crate::config::TlsBackend;
+#[cfg(any(feature = "tls-rustls", feature = "tls-openssl"))]
+use crate::utilities::bounded_file::{
+    MAX_CERTIFICATE_BUNDLE_BYTES, MAX_PRIVATE_KEY_BYTES, read_bounded_regular_file,
+};
 
 type ServerResult<F, I, S, B> = std::io::Result<HttpServer<F, I, S, B>>;
 
@@ -135,6 +141,26 @@ mod tls_rustls {
     };
     use tracing::info;
 
+    fn parse_certificate_chain(
+        certificate_bytes: &[u8],
+    ) -> std::io::Result<Vec<CertificateDer<'static>>> {
+        let cert_chain = CertificateDer::pem_slice_iter(certificate_bytes)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Failed to parse TLS certificate chain: {e}"),
+                )
+            })?;
+        if cert_chain.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "TLS certificate chain contains no certificates",
+            ));
+        }
+        Ok(cert_chain)
+    }
+
     pub fn configure_server<F, I, S, B>(
         server: HttpServer<F, I, S, B>,
         bind_address: &str,
@@ -158,20 +184,19 @@ mod tls_rustls {
             ));
         }
 
-        let cert_chain = CertificateDer::pem_file_iter(cert)
-            .map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("Failed to read certificate file: {e}"),
-                )
-            })?
-            .flatten()
-            .collect();
+        let certificate_bytes = read_bounded_regular_file(
+            Path::new(cert),
+            "TLS certificate chain",
+            MAX_CERTIFICATE_BUNDLE_BYTES,
+        )?;
+        let cert_chain = parse_certificate_chain(&certificate_bytes)?;
 
-        let key_der = PrivateKeyDer::from_pem_file(key).map_err(|e| {
+        let key_bytes =
+            read_bounded_regular_file(Path::new(key), "TLS private key", MAX_PRIVATE_KEY_BYTES)?;
+        let key_der = PrivateKeyDer::from_pem_slice(&key_bytes).map_err(|e| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                format!("Failed to read key file: {e}"),
+                format!("Failed to parse TLS private key: {e}"),
             )
         })?;
 
@@ -190,6 +215,37 @@ mod tls_rustls {
             .bind_rustls_0_23(bind_address, rustls_config)
             .map_err(|e| std::io::Error::other(format!("Failed to bind server: {e}")))
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn rustls_rejects_a_malformed_entry_after_a_certificate() {
+            let pem = b"-----BEGIN CERTIFICATE-----\nAQID\n-----END CERTIFICATE-----\n\
+                -----BEGIN CERTIFICATE-----\nnot-base64!\n-----END CERTIFICATE-----\n";
+
+            let error = parse_certificate_chain(pem).unwrap_err();
+
+            assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+            assert!(
+                error
+                    .to_string()
+                    .contains("Failed to parse TLS certificate chain")
+            );
+        }
+
+        #[test]
+        fn rustls_rejects_a_bundle_without_certificates() {
+            let error = parse_certificate_chain(b"").unwrap_err();
+
+            assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+            assert_eq!(
+                error.to_string(),
+                "TLS certificate chain contains no certificates"
+            );
+        }
+    }
 }
 
 #[cfg(feature = "tls-openssl")]
@@ -197,10 +253,71 @@ mod tls_openssl {
     use super::*;
     use openssl::{
         pkey::PKey,
-        ssl::{SslAcceptor, SslFiletype, SslMethod},
+        ssl::{SslAcceptor, SslAcceptorBuilder, SslMethod},
+        x509::X509,
     };
-    use std::{fs::File, io::Read};
     use tracing::info;
+
+    pub(super) fn build_acceptor(
+        certificate_bytes: &[u8],
+        key_bytes: &[u8],
+        pass: Option<&str>,
+    ) -> std::io::Result<SslAcceptorBuilder> {
+        let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls())
+            .map_err(|e| std::io::Error::other(format!("unable to create SSL acceptor: {e}")))?;
+
+        let pkey = match pass {
+            Some(pass) => PKey::private_key_from_pem_passphrase(key_bytes, pass.as_bytes())
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("unable to decrypt private key: {e}"),
+                    )
+                })?,
+            None => PKey::private_key_from_pem(key_bytes).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unable to parse private key: {e}"),
+                )
+            })?,
+        };
+        builder.set_private_key(&pkey).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unable to set private key: {e}"),
+            )
+        })?;
+
+        let certificates = X509::stack_from_pem(certificate_bytes).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unable to parse certificate chain: {e}"),
+            )
+        })?;
+        let mut certificates = certificates.into_iter();
+        let certificate = certificates.next().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "TLS certificate chain contains no certificates",
+            )
+        })?;
+        builder.set_certificate(&certificate).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unable to set TLS certificate: {e}"),
+            )
+        })?;
+        for certificate in certificates {
+            builder.add_extra_chain_cert(certificate).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unable to set TLS certificate chain: {e}"),
+                )
+            })?;
+        }
+        validate_openssl_key_pair(&builder)?;
+        Ok(builder)
+    }
 
     pub fn configure_server<F, I, S, B>(
         server: HttpServer<F, I, S, B>,
@@ -218,43 +335,14 @@ mod tls_openssl {
         S::Response: Into<Response<B>>,
         B: MessageBody + 'static,
     {
-        let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls())
-            .map_err(|e| std::io::Error::other(format!("unable to create SSL acceptor: {e}")))?;
-
-        if let Some(pass) = pass {
-            let mut buf = Vec::new();
-            File::open(key)?.read_to_end(&mut buf)?;
-            let pkey =
-                PKey::private_key_from_pem_passphrase(&buf, pass.as_bytes()).map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("unable to decrypt private key: {e}"),
-                    )
-                })?;
-            builder.set_private_key(&pkey).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("unable to set private key: {e}"),
-                )
-            })?;
-        } else {
-            builder
-                .set_private_key_file(key, SslFiletype::PEM)
-                .map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::NotFound,
-                        format!("unable to load private key file: {e}"),
-                    )
-                })?;
-        }
-
-        builder.set_certificate_chain_file(cert).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("unable to load certificate chain: {e}"),
-            )
-        })?;
-        validate_openssl_key_pair(&builder)?;
+        let key_bytes =
+            read_bounded_regular_file(Path::new(key), "TLS private key", MAX_PRIVATE_KEY_BYTES)?;
+        let certificate_bytes = read_bounded_regular_file(
+            Path::new(cert),
+            "TLS certificate chain",
+            MAX_CERTIFICATE_BUNDLE_BYTES,
+        )?;
+        let builder = build_acceptor(&certificate_bytes, &key_bytes, pass)?;
 
         info!("Server binding with openssl to https://{}", bind_address);
         server
@@ -363,10 +451,12 @@ mod tests {
             pkey::{PKey, Private},
             rsa::Rsa,
             ssl::{SslAcceptor, SslAcceptorBuilder, SslMethod},
+            symm::Cipher,
             x509::{X509, X509NameBuilder},
         };
+        use rstest::rstest;
 
-        use super::super::validate_openssl_key_pair;
+        use super::super::{tls_openssl::build_acceptor, validate_openssl_key_pair};
 
         fn certificate_for(key: &PKey<Private>) -> X509 {
             let mut name = X509NameBuilder::new().unwrap();
@@ -421,6 +511,25 @@ mod tests {
                     .to_string()
                     .contains("TLS private key does not match the certificate")
             );
+        }
+
+        #[rstest]
+        #[case::unencrypted(None)]
+        #[case::encrypted(Some("test-passphrase"))]
+        fn openssl_builds_an_acceptor_from_pem_material(#[case] passphrase: Option<&str>) {
+            let key = PKey::from_rsa(Rsa::generate(2_048).unwrap()).unwrap();
+            let certificate = certificate_for(&key).to_pem().unwrap();
+            let private_key = match passphrase {
+                Some(passphrase) => key
+                    .private_key_to_pem_pkcs8_passphrase(
+                        Cipher::aes_256_cbc(),
+                        passphrase.as_bytes(),
+                    )
+                    .unwrap(),
+                None => key.private_key_to_pem_pkcs8().unwrap(),
+            };
+
+            build_acceptor(&certificate, &private_key, passphrase).unwrap();
         }
     }
 }

--- a/src/utilities/bounded_file.rs
+++ b/src/utilities/bounded_file.rs
@@ -1,0 +1,135 @@
+use std::fs::{self, File};
+use std::io::{self, Read};
+use std::path::Path;
+
+pub(crate) const MAX_CERTIFICATE_BUNDLE_BYTES: usize = 4 * 1024 * 1024;
+#[cfg(any(feature = "tls-rustls", feature = "tls-openssl"))]
+pub(crate) const MAX_PRIVATE_KEY_BYTES: usize = 1024 * 1024;
+
+pub(crate) fn read_bounded_regular_file(
+    path: &Path,
+    description: &str,
+    max_bytes: usize,
+) -> io::Result<Vec<u8>> {
+    let max_bytes_u64 = u64::try_from(max_bytes).unwrap_or(u64::MAX);
+    let path_metadata = fs::metadata(path).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("Failed to inspect {description} {path:?}: {error}"),
+        )
+    })?;
+    validate_metadata(path, description, max_bytes, max_bytes_u64, &path_metadata)?;
+
+    let file = File::open(path).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("Failed to open {description} {path:?}: {error}"),
+        )
+    })?;
+    let file_metadata = file.metadata().map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("Failed to inspect open {description} {path:?}: {error}"),
+        )
+    })?;
+    validate_metadata(path, description, max_bytes, max_bytes_u64, &file_metadata)?;
+
+    let mut bytes = Vec::with_capacity(file_metadata.len() as usize);
+    file.take(max_bytes_u64.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!("Failed to read {description} {path:?}: {error}"),
+            )
+        })?;
+    if bytes.len() > max_bytes {
+        return Err(size_error(path, description, max_bytes));
+    }
+    Ok(bytes)
+}
+
+fn validate_metadata(
+    path: &Path,
+    description: &str,
+    max_bytes: usize,
+    max_bytes_u64: u64,
+    metadata: &fs::Metadata,
+) -> io::Result<()> {
+    if !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{description} {path:?} must be a regular file"),
+        ));
+    }
+    if metadata.len() > max_bytes_u64 {
+        return Err(size_error(path, description, max_bytes));
+    }
+    Ok(())
+}
+
+fn size_error(path: &Path, description: &str, max_bytes: usize) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("{description} {path:?} exceeds the {max_bytes}-byte limit"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use uuid::Uuid;
+
+    use super::*;
+
+    struct TestFile(PathBuf);
+
+    impl TestFile {
+        fn new(contents: &[u8]) -> Self {
+            let path = std::env::temp_dir().join(format!("hubuum-bounded-file-{}", Uuid::new_v4()));
+            fs::write(&path, contents).unwrap();
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestFile {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.0);
+        }
+    }
+
+    #[test]
+    fn reads_a_regular_file_at_the_limit() {
+        let file = TestFile::new(b"1234");
+
+        assert_eq!(
+            read_bounded_regular_file(file.path(), "test material", 4).unwrap(),
+            b"1234"
+        );
+    }
+
+    #[test]
+    fn rejects_a_regular_file_over_the_limit() {
+        let file = TestFile::new(b"12345");
+
+        let error = read_bounded_regular_file(file.path(), "test material", 4).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("exceeds the 4-byte limit"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_non_regular_files_before_opening_them() {
+        let error =
+            read_bounded_regular_file(Path::new("/dev/null"), "test material", 4).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("must be a regular file"));
+    }
+}

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -1,5 +1,6 @@
 pub mod aliases;
 pub mod auth;
+pub(crate) mod bounded_file;
 pub mod db;
 pub mod exporting;
 pub mod extensions;


### PR DESCRIPTION
## Summary

Bound and validate every local PEM file consumed by Hubuum's server and
database TLS setup.

- Add a shared crate-private regular-file reader with a read-time size guard.
- Limit server certificate chains and `PGSSLROOTCERT` bundles to 4 MiB.
- Limit server private keys to 1 MiB.
- Parse bounded bytes through rustls or OpenSSL instead of delegating unbounded
  file reads to backend-specific APIs.
- Reject malformed rustls certificate entries rather than silently dropping
  iterator errors.
- Document the operator-visible file requirements and add a security changelog
  entry.

## Rationale

The TLS paths previously mixed several backend-specific file APIs. The OpenSSL
encrypted-key path explicitly used an unbounded `read_to_end`, while rustls and
the other OpenSSL paths delegated file consumption to parser APIs without an
application-level limit or regular-file check. A misconfigured device, pipe, or
very large file could block startup or consume excessive memory.

The rustls certificate path also called `flatten()` on an iterator of
`Result<CertificateDer, _>`. Because `Result` implements `IntoIterator`, this
discarded malformed PEM entries instead of failing the configuration.

## Design

The shared reader checks path metadata before opening, checks descriptor
metadata again after opening, and reads at most one byte beyond the configured
limit so concurrent file growth is detected. Symlinks to ordinary files remain
supported because metadata follows the target.

Both server backends now receive bounded byte slices:

- rustls collects the complete certificate iterator as a `Result` and rejects
  empty bundles;
- OpenSSL parses encrypted and unencrypted private keys from the same byte path,
  parses the first certificate as the leaf, installs remaining certificates as
  the chain, and retains the existing key-pair validation;
- PostgreSQL root certificates use the same certificate-bundle bound before
  populating the root store.

## Behavior and compatibility

This is a breaking configuration change for deployments whose TLS material is
non-regular, oversized, or malformed. Before upgrading, replace non-regular TLS
files, reduce certificate bundles to at most 4 MiB and private keys to at most
1 MiB, and correct malformed certificate entries.

Normal regular PEM files within those limits remain compatible. Symlinks to
ordinary files remain supported. No API or OpenAPI shape, database schema,
dependency, migration, workspace manifest, Dockerfile, or container build input
changes.

## Verification

- `cargo test utilities::bounded_file::tests --lib`
- `cargo test tls::tls_rustls::tests --lib --features tls-rustls`
- `cargo test tls::tests::openssl --lib --features tls-openssl`
- `cargo check --all-targets --no-default-features --features tls-rustls`
- `cargo check --all-targets --features tls-openssl`
- `cargo check --all-targets --features "tls-rustls tls-openssl"`
- `source .env && ./run_tests.sh` (1,821 passed; 8 ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --features "tls-rustls tls-openssl" -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `git diff --check`