### PR TITLE
Relax cursor pagination row bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   effective maximum alongside the default lifetime. Before upgrading, clients
   that request longer expirations must shorten them, or operators must raise
   the new limit; no database migration is required.
+- The public `CursorPaginated` trait no longer requires row types to implement
+  `Clone`; pagination borrows or moves rows and accepts non-clone domain types.
 
 ### Security
 

--- a/src/pagination/tests.rs
+++ b/src/pagination/tests.rs
@@ -37,6 +37,56 @@ impl CursorPaginated for JsonCursorItem {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct NonCloneCursorItem(i64);
+
+impl CursorPaginated for NonCloneCursorItem {
+    fn supports_sort(field: &FilterField) -> bool {
+        field == &FilterField::Id
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        match field {
+            FilterField::Id => Ok(CursorValue::Integer(self.0)),
+            _ => Err(ApiError::InternalServerError(
+                "unsupported non-clone cursor field".to_string(),
+            )),
+        }
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        vec![SortParam {
+            field: FilterField::Id,
+            descending: false,
+        }]
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        Self::default_sort()
+    }
+}
+
+#[test]
+fn in_memory_pagination_accepts_non_clone_rows() {
+    let rows = paginate_in_memory(
+        vec![
+            NonCloneCursorItem(3),
+            NonCloneCursorItem(1),
+            NonCloneCursorItem(2),
+        ],
+        &QueryOptions {
+            filters: Vec::new(),
+            sort: Vec::new(),
+            limit: Some(2),
+            cursor: None,
+            include_total: false,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(rows, vec![NonCloneCursorItem(1), NonCloneCursorItem(2)]);
+}
+
 fn collection(id: i32, name: &str) -> Collection {
     Collection {
         id,

--- a/src/traits/pagination.rs
+++ b/src/traits/pagination.rs
@@ -121,7 +121,7 @@ fn compare_jsonb_sequences(left: &[serde_json::Value], right: &[serde_json::Valu
         .unwrap_or(Ordering::Equal)
 }
 
-pub trait CursorPaginated: Clone {
+pub trait CursorPaginated {
     fn supports_sort(field: &FilterField) -> bool;
     fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError>;
     fn default_sort() -> Vec<SortParam>;


### PR DESCRIPTION
## Summary

- Remove the unnecessary `Clone` supertrait from the public `CursorPaginated`
  interface.
- Exercise the real in-memory pagination path with a row type that cannot be
  cloned.

## Rationale

Cursor pagination borrows rows to extract and compare cursor values, then moves
the selected rows out of the input vector. It never clones a row. Requiring
`Clone` therefore constrained domain and persistence response types, including
external implementations of this public trait, without protecting an actual
invariant.

The focused regression test makes that API property compile-time visible: its
row type deliberately omits `Clone`, while still being sorted and truncated by
the production in-memory pagination implementation.

## Behavior and compatibility

This is a source-compatible relaxation. Existing implementations and callers
continue to work, while non-clone domain types can now participate in cursor
pagination.

There are no endpoint, wire-format, OpenAPI, database, dependency, migration,
or container-build changes.

## Changelog

The `[Unreleased]` section records the public Rust API relaxation.

## Verification

- `cargo test in_memory_pagination_accepts_non_clone_rows --lib`
- `source .env && ./run_tests.sh` (1,819 passed; 8 ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `git diff --check`
