### PR TITLE
Precompute in-memory pagination sort keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   should use the hash-free `PrincipalTokenMetadata` schema returned by token
   listing endpoints.
 
+### Fixed
+
+- In-memory cursor pagination now computes every row's sort values before
+  ordering and extracts each value once, so failures cannot silently leave rows
+  unordered and fallible work is not repeated inside the sort comparator.
+
 ## [0.0.8] - 2026-08-01
 
 ### Fixed

--- a/src/pagination/mod.rs
+++ b/src/pagination/mod.rs
@@ -235,7 +235,7 @@ where
 }
 
 fn paginate_in_memory_with_values<T>(
-    mut items: Vec<T>,
+    items: Vec<T>,
     query_options: &QueryOptions,
     sorts: &[SortParam],
     cursor_values: Option<&[CursorValue]>,
@@ -243,66 +243,48 @@ fn paginate_in_memory_with_values<T>(
 where
     T: CursorPaginated,
 {
-    items.sort_by(|left, right| {
-        compare_cursor_values(left, right, sorts).unwrap_or(Ordering::Equal)
-    });
+    let mut keyed_items = items
+        .into_iter()
+        .map(|item| {
+            let values = sorts
+                .iter()
+                .map(|sort| item.cursor_value(&sort.field))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok((item, values))
+        })
+        .collect::<Result<Vec<_>, ApiError>>()?;
+
+    keyed_items.sort_by(|(_, left), (_, right)| compare_cursor_values(left, right, sorts));
 
     if let Some(cursor_values) = cursor_values {
-        let mut filtered = Vec::with_capacity(items.len());
-        for item in items {
-            if compare_item_to_values(&item, cursor_values, sorts)? == Ordering::Greater {
-                filtered.push(item);
-            }
-        }
-        items = filtered;
+        keyed_items.retain(|(_, values)| {
+            compare_cursor_values(values, cursor_values, sorts) == Ordering::Greater
+        });
     }
 
     if let Some(limit) = query_options.limit {
-        items.truncate(limit);
+        keyed_items.truncate(limit);
     }
-    Ok(items)
+    Ok(keyed_items.into_iter().map(|(item, _)| item).collect())
 }
 
-fn compare_cursor_values<T>(left: &T, right: &T, sorts: &[SortParam]) -> Result<Ordering, ApiError>
-where
-    T: CursorPaginated,
-{
-    for sort in sorts {
-        let ordering = left
-            .cursor_value(&sort.field)?
-            .cmp(&right.cursor_value(&sort.field)?);
-        let ordering = if sort.descending {
-            ordering.reverse()
-        } else {
-            ordering
-        };
-        if ordering != Ordering::Equal {
-            return Ok(ordering);
-        }
-    }
-    Ok(Ordering::Equal)
-}
-
-fn compare_item_to_values<T>(
-    item: &T,
-    values: &[CursorValue],
+fn compare_cursor_values(
+    left: &[CursorValue],
+    right: &[CursorValue],
     sorts: &[SortParam],
-) -> Result<Ordering, ApiError>
-where
-    T: CursorPaginated,
-{
-    for (sort, cursor_value) in sorts.iter().zip(values) {
-        let ordering = item.cursor_value(&sort.field)?.cmp(cursor_value);
+) -> Ordering {
+    for ((left, right), sort) in left.iter().zip(right).zip(sorts) {
+        let ordering = left.cmp(right);
         let ordering = if sort.descending {
             ordering.reverse()
         } else {
             ordering
         };
         if ordering != Ordering::Equal {
-            return Ok(ordering);
+            return ordering;
         }
     }
-    Ok(Ordering::Equal)
+    Ordering::Equal
 }
 
 pub fn pagination_headers(

--- a/src/pagination/tests.rs
+++ b/src/pagination/tests.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
 use chrono::NaiveDate;
 use rstest::rstest;
 
@@ -66,6 +69,47 @@ impl CursorPaginated for NonCloneCursorItem {
     }
 }
 
+#[derive(Clone, Debug)]
+struct InstrumentedCursorItem {
+    id: i64,
+    calls: Option<Arc<AtomicUsize>>,
+    fail: bool,
+}
+
+impl CursorPaginated for InstrumentedCursorItem {
+    fn supports_sort(field: &FilterField) -> bool {
+        field == &FilterField::Id
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        match field {
+            FilterField::Id if self.fail => Err(ApiError::InternalServerError(
+                "failed to extract test cursor value".to_string(),
+            )),
+            FilterField::Id => {
+                if let Some(calls) = &self.calls {
+                    calls.fetch_add(1, AtomicOrdering::Relaxed);
+                }
+                Ok(CursorValue::Integer(self.id))
+            }
+            _ => Err(ApiError::InternalServerError(
+                "unsupported instrumented cursor field".to_string(),
+            )),
+        }
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        vec![SortParam {
+            field: FilterField::Id,
+            descending: false,
+        }]
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        Self::default_sort()
+    }
+}
+
 #[test]
 fn in_memory_pagination_accepts_non_clone_rows() {
     let rows = paginate_in_memory(
@@ -85,6 +129,64 @@ fn in_memory_pagination_accepts_non_clone_rows() {
     .unwrap();
 
     assert_eq!(rows, vec![NonCloneCursorItem(1), NonCloneCursorItem(2)]);
+}
+
+#[test]
+fn in_memory_pagination_extracts_each_sort_key_once() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let items = (0..128)
+        .rev()
+        .map(|id| InstrumentedCursorItem {
+            id,
+            calls: Some(Arc::clone(&calls)),
+            fail: false,
+        })
+        .collect();
+
+    paginate_in_memory(
+        items,
+        &QueryOptions {
+            filters: Vec::new(),
+            sort: Vec::new(),
+            limit: None,
+            cursor: None,
+            include_total: false,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(calls.load(AtomicOrdering::Relaxed), 128);
+}
+
+#[test]
+fn in_memory_pagination_propagates_sort_key_errors() {
+    let error = paginate_in_memory(
+        vec![
+            InstrumentedCursorItem {
+                id: 2,
+                calls: None,
+                fail: false,
+            },
+            InstrumentedCursorItem {
+                id: 1,
+                calls: None,
+                fail: true,
+            },
+        ],
+        &QueryOptions {
+            filters: Vec::new(),
+            sort: Vec::new(),
+            limit: None,
+            cursor: None,
+            include_total: false,
+        },
+    )
+    .unwrap_err();
+
+    assert_eq!(
+        error,
+        ApiError::InternalServerError("failed to extract test cursor value".to_string())
+    );
 }
 
 fn collection(id: i32, name: &str) -> Collection {

--- a/src/pagination/tests.rs
+++ b/src/pagination/tests.rs
@@ -69,47 +69,6 @@ impl CursorPaginated for NonCloneCursorItem {
     }
 }
 
-#[derive(Clone, Debug)]
-struct InstrumentedCursorItem {
-    id: i64,
-    calls: Option<Arc<AtomicUsize>>,
-    fail: bool,
-}
-
-impl CursorPaginated for InstrumentedCursorItem {
-    fn supports_sort(field: &FilterField) -> bool {
-        field == &FilterField::Id
-    }
-
-    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
-        match field {
-            FilterField::Id if self.fail => Err(ApiError::InternalServerError(
-                "failed to extract test cursor value".to_string(),
-            )),
-            FilterField::Id => {
-                if let Some(calls) = &self.calls {
-                    calls.fetch_add(1, AtomicOrdering::Relaxed);
-                }
-                Ok(CursorValue::Integer(self.id))
-            }
-            _ => Err(ApiError::InternalServerError(
-                "unsupported instrumented cursor field".to_string(),
-            )),
-        }
-    }
-
-    fn default_sort() -> Vec<SortParam> {
-        vec![SortParam {
-            field: FilterField::Id,
-            descending: false,
-        }]
-    }
-
-    fn tie_breaker_sort() -> Vec<SortParam> {
-        Self::default_sort()
-    }
-}
-
 #[test]
 fn in_memory_pagination_accepts_non_clone_rows() {
     let rows = paginate_in_memory(
@@ -129,64 +88,6 @@ fn in_memory_pagination_accepts_non_clone_rows() {
     .unwrap();
 
     assert_eq!(rows, vec![NonCloneCursorItem(1), NonCloneCursorItem(2)]);
-}
-
-#[test]
-fn in_memory_pagination_extracts_each_sort_key_once() {
-    let calls = Arc::new(AtomicUsize::new(0));
-    let items = (0..128)
-        .rev()
-        .map(|id| InstrumentedCursorItem {
-            id,
-            calls: Some(Arc::clone(&calls)),
-            fail: false,
-        })
-        .collect();
-
-    paginate_in_memory(
-        items,
-        &QueryOptions {
-            filters: Vec::new(),
-            sort: Vec::new(),
-            limit: None,
-            cursor: None,
-            include_total: false,
-        },
-    )
-    .unwrap();
-
-    assert_eq!(calls.load(AtomicOrdering::Relaxed), 128);
-}
-
-#[test]
-fn in_memory_pagination_propagates_sort_key_errors() {
-    let error = paginate_in_memory(
-        vec![
-            InstrumentedCursorItem {
-                id: 2,
-                calls: None,
-                fail: false,
-            },
-            InstrumentedCursorItem {
-                id: 1,
-                calls: None,
-                fail: true,
-            },
-        ],
-        &QueryOptions {
-            filters: Vec::new(),
-            sort: Vec::new(),
-            limit: None,
-            cursor: None,
-            include_total: false,
-        },
-    )
-    .unwrap_err();
-
-    assert_eq!(
-        error,
-        ApiError::InternalServerError("failed to extract test cursor value".to_string())
-    );
 }
 
 fn collection(id: i32, name: &str) -> Collection {
@@ -773,4 +674,103 @@ fn page_limits_reject_a_zero_requested_limit() {
         .unwrap_err();
 
     assert_eq!(error.to_string(), "limit must be greater than 0");
+}
+
+#[derive(Clone, Debug)]
+struct InstrumentedCursorItem {
+    id: i64,
+    calls: Option<Arc<AtomicUsize>>,
+    fail: bool,
+}
+
+impl CursorPaginated for InstrumentedCursorItem {
+    fn supports_sort(field: &FilterField) -> bool {
+        field == &FilterField::Id
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        match field {
+            FilterField::Id if self.fail => Err(ApiError::InternalServerError(
+                "failed to extract test cursor value".to_string(),
+            )),
+            FilterField::Id => {
+                if let Some(calls) = &self.calls {
+                    calls.fetch_add(1, AtomicOrdering::Relaxed);
+                }
+                Ok(CursorValue::Integer(self.id))
+            }
+            _ => Err(ApiError::InternalServerError(
+                "unsupported instrumented cursor field".to_string(),
+            )),
+        }
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        vec![SortParam {
+            field: FilterField::Id,
+            descending: false,
+        }]
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        Self::default_sort()
+    }
+}
+
+#[test]
+fn in_memory_pagination_extracts_each_sort_key_once() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let items = (0..128)
+        .rev()
+        .map(|id| InstrumentedCursorItem {
+            id,
+            calls: Some(Arc::clone(&calls)),
+            fail: false,
+        })
+        .collect();
+
+    paginate_in_memory(
+        items,
+        &QueryOptions {
+            filters: Vec::new(),
+            sort: Vec::new(),
+            limit: None,
+            cursor: None,
+            include_total: false,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(calls.load(AtomicOrdering::Relaxed), 128);
+}
+
+#[test]
+fn in_memory_pagination_propagates_sort_key_errors() {
+    let error = paginate_in_memory(
+        vec![
+            InstrumentedCursorItem {
+                id: 2,
+                calls: None,
+                fail: false,
+            },
+            InstrumentedCursorItem {
+                id: 1,
+                calls: None,
+                fail: true,
+            },
+        ],
+        &QueryOptions {
+            filters: Vec::new(),
+            sort: Vec::new(),
+            limit: None,
+            cursor: None,
+            include_total: false,
+        },
+    )
+    .unwrap_err();
+
+    assert_eq!(
+        error,
+        ApiError::InternalServerError("failed to extract test cursor value".to_string())
+    );
 }


### PR DESCRIPTION
## Summary

- Extract every in-memory pagination sort key once before sorting.
- Compare the precomputed keys during ordering and cursor filtering.
- Propagate sort-key extraction failures instead of treating failed comparisons
  as equal.

## Rationale

The existing `sort_by` comparator called the fallible `CursorPaginated::cursor_value`
method for both rows on every comparison. Sorting therefore repeated allocations
and domain-specific extraction work throughout the `O(n log n)` comparator path.

More importantly, comparator errors were converted to `Ordering::Equal` because
Rust sort comparators cannot return a `Result`. A malformed enriched row could
therefore be left in an arbitrary position on a first page, and pagination might
only notice if that row was later compared with a cursor or selected as the next
cursor boundary.

This change moves the fallible work before sorting. Each row receives one key per
normalized sort field, so any extraction error aborts the request deterministically.
The infallible comparator and cursor filter then reuse those keys.

## Behavior and compatibility

Valid rows retain the same stable sort directions, tie-breaker semantics, cursor
filtering, and limits. Invalid rows now fail closed rather than silently comparing
equal. The implementation temporarily stores one `CursorValue` per row and sort
field in exchange for eliminating repeated extraction and allocation during sort.

There are no endpoint, wire-format, OpenAPI, database, dependency, migration,
or container-build changes.

## Changelog

The `[Unreleased]` section records the corrected failure behavior and reduced
sort-key work.

## Verification

- `cargo test in_memory_pagination_ --lib`
- `cargo test pagination::tests --lib` (39 passed)
- `source .env && ./run_tests.sh` (1,820 passed; 8 ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `git diff --check`
