### PR TITLE
Batch stale external membership removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   the new limit; no database migration is required.
 - The public `CursorPaginated` trait no longer requires row types to implement
   `Clone`; pagination borrows or moves rows and accepts non-clone domain types.
+- External identity refresh removes stale group memberships with one set-based
+  database write instead of issuing one delete per stale membership.
 
 ### Security
 

--- a/src/db/traits/external_identity.rs
+++ b/src/db/traits/external_identity.rs
@@ -1,6 +1,5 @@
 use chrono::NaiveDateTime;
 use hubuum_auth_core::AuthenticatedExternalUser;
-use std::collections::HashSet;
 
 use crate::db::prelude::*;
 use crate::db::traits::identity::ensure_identity_scope;
@@ -267,29 +266,20 @@ pub async fn sync_external_user(
         .execute(conn)
         .await?;
 
-        let retained: HashSet<i32> = group_membership_sources::table
+        let retained_group_ids: Vec<i32> = group_membership_sources::table
             .filter(group_membership_sources::principal_id.eq(user.id))
             .select(group_membership_sources::group_id)
-            .load::<i32>(conn)
-            .await?
-            .into_iter()
-            .collect();
-        let current: Vec<i32> = group_memberships::table
-            .filter(group_memberships::principal_id.eq(user.id))
-            .select(group_memberships::group_id)
             .load(conn)
             .await?;
-        for group_id in current {
-            if !retained.contains(&group_id) {
-                diesel::delete(
-                    group_memberships::table
-                        .filter(group_memberships::principal_id.eq(user.id))
-                        .filter(group_memberships::group_id.eq(group_id)),
-                )
-                .execute(conn)
-                .await?;
-            }
-        }
+        diesel::delete(
+            group_memberships::table
+                .filter(group_memberships::principal_id.eq(user.id))
+                .filter(diesel::dsl::not(
+                    group_memberships::group_id.eq_any(retained_group_ids),
+                )),
+        )
+        .execute(conn)
+        .await?;
 
         let event_context = EventContext::system();
         let event = NewEvent::new(
@@ -325,6 +315,7 @@ fn now() -> NaiveDateTime {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::capture_queries;
     use crate::models::LDAP_PROVIDER_KIND;
     use crate::models::group::NewGroup;
     use crate::schema::{group_memberships, groups as groups_table, identity_scopes, principals};
@@ -512,6 +503,50 @@ mod tests {
         assert!(memberships.contains(&manual_group.id));
         assert!(memberships.contains(&second_group_id));
         assert!(!memberships.contains(&first_group_id));
+    }
+
+    #[actix_rt::test]
+    async fn sync_external_user_batches_stale_membership_removal() {
+        let scope = TestScope::new();
+        let identity_scope = scope.scoped_name("batched_directory");
+        let subject = format!(
+            "uid={},ou=people,dc=example,dc=org",
+            scope.scoped_name("batched_membership_subject")
+        );
+        let username = scope.scoped_name("batched_membership_user");
+        let groups = (0..8)
+            .map(|index| {
+                external_group(
+                    &scope.scoped_name(&format!("batched_group_key_{index}")),
+                    &scope.scoped_name(&format!("batched_group_{index}")),
+                )
+            })
+            .collect();
+
+        sync_external_user(
+            &scope.pool,
+            &identity_scope,
+            LDAP_PROVIDER_KIND,
+            external_user(&subject, &username, groups),
+        )
+        .await
+        .unwrap();
+
+        let (result, queries) = capture_queries(sync_external_user(
+            &scope.pool,
+            &identity_scope,
+            LDAP_PROVIDER_KIND,
+            external_user(&subject, &username, Vec::new()),
+        ))
+        .await;
+        result.unwrap();
+
+        assert_eq!(
+            queries.queries_matching("DELETE FROM \"group_memberships\""),
+            1,
+            "{:#?}",
+            queries.query_counts()
+        );
     }
 
     async fn group_id_by_external_key(pool: &DbPool, external_key: &str) -> i32 {

--- a/src/db/traits/external_identity.rs
+++ b/src/db/traits/external_identity.rs
@@ -1,4 +1,5 @@
 use chrono::NaiveDateTime;
+use diesel::dsl::not;
 use hubuum_auth_core::AuthenticatedExternalUser;
 
 use crate::db::prelude::*;
@@ -274,9 +275,7 @@ pub async fn sync_external_user(
         diesel::delete(
             group_memberships::table
                 .filter(group_memberships::principal_id.eq(user.id))
-                .filter(diesel::dsl::not(
-                    group_memberships::group_id.eq_any(retained_group_ids),
-                )),
+                .filter(not(group_memberships::group_id.eq_any(retained_group_ids))),
         )
         .execute(conn)
         .await?;


### PR DESCRIPTION
## Summary

- Replace per-membership stale cleanup during external identity sync with one
  set-based `DELETE`.
- Preserve memberships that still have any manual or external source row.
- Add a query-capture regression proving that eight stale memberships require
  exactly one membership delete statement.

## Rationale

After reconciling provider membership-source rows, external identity sync loaded
all retained group IDs, loaded all current memberships, built a Rust `HashSet`,
and issued one database delete for every membership without a remaining source.
Refresh cost therefore grew by one round trip per stale directory membership,
all while the surrounding transaction stayed open.

PostgreSQL can apply the same predicate in one write. The revised path loads the
remaining source-backed group IDs once and deletes every other membership for the
principal with a single set-based statement. An empty retained set correctly
deletes all source-less memberships.

## Behavior and compatibility

Membership semantics are unchanged: current provider memberships remain,
memberships backed by manual sources remain, and stale source-less memberships
are removed atomically with the rest of the identity refresh. Only the number of
database reads and writes changes.

There are no endpoint, wire-format, OpenAPI, schema, dependency, migration, or
container-build changes.

## Changelog

The `[Unreleased]` section records the set-based refresh behavior.

## Verification

- `source .env && ./run_tests.sh sync_external_user_batches_stale_membership_removal --lib`
- `source .env && ./run_tests.sh db::traits::external_identity::tests --lib` (4 passed)
- `source .env && ./run_tests.sh` (1,819 passed; 8 ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `git diff --check`
