### PR TITLE
Stabilize request log capture lifetime

### DIFF
--- a/src/middlewares/tracing.rs
+++ b/src/middlewares/tracing.rs
@@ -9,6 +9,8 @@ use actix_web::{
     http::header::{HeaderName, HeaderValue},
 };
 use futures_util::future::{self, LocalBoxFuture, Ready};
+#[cfg(feature = "integration-test-support")]
+use tracing::{Dispatch, instrument::WithSubscriber};
 use tracing::{Instrument, Level, Span, debug, error, field, info, span, warn};
 use uuid::Uuid;
 
@@ -65,6 +67,8 @@ fn elapsed_millis(start_time: Instant) -> u64 {
 #[derive(Clone)]
 pub struct TracingMiddleware {
     proxy_trust: ProxyTrust,
+    #[cfg(feature = "integration-test-support")]
+    capture_dispatch: Option<Dispatch>,
 }
 
 impl Default for TracingMiddleware {
@@ -77,11 +81,25 @@ impl TracingMiddleware {
     pub fn new() -> Self {
         Self {
             proxy_trust: ProxyTrust::peer_only(),
+            #[cfg(feature = "integration-test-support")]
+            capture_dispatch: None,
         }
     }
 
     pub fn new_with_trust(proxy_trust: ProxyTrust) -> Self {
-        Self { proxy_trust }
+        Self {
+            proxy_trust,
+            #[cfg(feature = "integration-test-support")]
+            capture_dispatch: None,
+        }
+    }
+
+    #[cfg(feature = "integration-test-support")]
+    pub(crate) fn new_with_capture_dispatch(capture_dispatch: Dispatch) -> Self {
+        Self {
+            proxy_trust: ProxyTrust::peer_only(),
+            capture_dispatch: Some(capture_dispatch),
+        }
     }
 }
 
@@ -101,6 +119,8 @@ where
         future::ready(Ok(TracingMiddlewareService {
             service,
             proxy_trust: self.proxy_trust.clone(),
+            #[cfg(feature = "integration-test-support")]
+            capture_dispatch: self.capture_dispatch.clone(),
         }))
     }
 }
@@ -108,6 +128,8 @@ where
 pub struct TracingMiddlewareService<S> {
     service: S,
     proxy_trust: ProxyTrust,
+    #[cfg(feature = "integration-test-support")]
+    capture_dispatch: Option<Dispatch>,
 }
 
 impl<S, B> Service<ServiceRequest> for TracingMiddlewareService<S>
@@ -124,6 +146,13 @@ where
     }
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
+        #[cfg(feature = "integration-test-support")]
+        let capture_dispatch = self.capture_dispatch.clone();
+        #[cfg(feature = "integration-test-support")]
+        let capture_guard = capture_dispatch
+            .as_ref()
+            .map(tracing::dispatcher::set_default);
+
         let request_id = Uuid::new_v4();
         let request_id_s = request_id.to_string();
 
@@ -168,7 +197,7 @@ where
         let in_flight_guard = metrics::http_request_started_for_route(&route);
         let fut = span.in_scope(|| self.service.call(req));
 
-        Box::pin(
+        let future = Box::pin(
             async move {
                 let _in_flight_guard = in_flight_guard;
                 let mut res = match fut.await {
@@ -277,7 +306,17 @@ where
                 Ok(res)
             }
             .instrument(span),
-        )
+        );
+
+        #[cfg(feature = "integration-test-support")]
+        {
+            drop(capture_guard);
+            if let Some(capture_dispatch) = capture_dispatch {
+                return Box::pin(future.with_subscriber(capture_dispatch));
+            }
+        }
+
+        future
     }
 }
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -5,6 +5,8 @@
 //! process-global reset and capture facilities.
 
 use hubuum_auth_core::AuthenticatedExternalUser;
+use tracing::Dispatch;
+use tracing_subscriber::layer::SubscriberExt;
 
 use crate::auth::ConfiguredLdapScope;
 use crate::db::DbPool;
@@ -15,6 +17,20 @@ use crate::models::{CollectionID, NewEventSink, NewEventSubscription, TaskKind};
 
 pub use crate::logger::test_support::JsonLogWriter;
 pub use crate::middlewares::rate_limit::LOGIN_RATE_LIMIT_TEST_LOCK;
+
+pub fn tracing_middleware_with_log_capture()
+-> (crate::middlewares::TracingMiddleware, JsonLogWriter) {
+    let writer = JsonLogWriter::default();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .json()
+            .with_writer(writer.clone())
+            .event_format(crate::logger::HubuumLoggingFormat),
+    );
+    let middleware =
+        crate::middlewares::TracingMiddleware::new_with_capture_dispatch(Dispatch::new(subscriber));
+    (middleware, writer)
+}
 
 #[cfg(not(test))]
 pub fn integration_test_config() -> Result<&'static crate::config::AppConfig, ApiError> {

--- a/tests/api_platform_suite/request_and_correlation.rs
+++ b/tests/api_platform_suite/request_and_correlation.rs
@@ -9,6 +9,7 @@ mod tests {
     };
     use serde_json::json;
     use std::{future::Future, str::FromStr};
+    use tokio::sync::Mutex;
 
     use crate::config::ClientAllowlist;
     use crate::events::RequestProvenance;
@@ -22,6 +23,7 @@ mod tests {
     use crate::tests::{TestContext, test_context};
 
     const ENDPOINT: &str = "/api/v1/classes/";
+    static REQUEST_LOG_CAPTURE_LOCK: Mutex<()> = Mutex::const_new(());
 
     #[rstest]
     #[case::with_correlation_id(Some("test-correlation-id"), true)]
@@ -109,6 +111,10 @@ mod tests {
     where
         F: Future<Output = T>,
     {
+        // Subscriber registration updates tracing's process-wide callsite interest cache.
+        // Keep capture subscribers alive one at a time so parallel request-log tests cannot
+        // invalidate another request's capture while its authenticated DB work is in flight.
+        let _capture_guard = REQUEST_LOG_CAPTURE_LOCK.lock().await;
         let (tracing_middleware, writer) = tracing_middleware_with_log_capture();
         let output = run(tracing_middleware).await;
         (output, writer)

--- a/tests/api_platform_suite/request_and_correlation.rs
+++ b/tests/api_platform_suite/request_and_correlation.rs
@@ -9,21 +9,19 @@ mod tests {
     };
     use serde_json::json;
     use std::{future::Future, str::FromStr};
-    use tokio::sync::Mutex;
-    use tracing_subscriber::layer::SubscriberExt;
 
     use crate::config::ClientAllowlist;
     use crate::events::RequestProvenance;
-    use crate::logger::HubuumLoggingFormat;
     use crate::middlewares::actor_context;
     use crate::middlewares::{ClientAllowlistMiddleware, TracingMiddleware};
-    use crate::test_support::{JsonLogWriter, record_principal_on_current_span};
+    use crate::test_support::{
+        JsonLogWriter, record_principal_on_current_span, tracing_middleware_with_log_capture,
+    };
     use crate::tests::api_operations::get_request_with_correlation;
     use crate::tests::asserts::assert_response_status;
     use crate::tests::{TestContext, test_context};
 
     const ENDPOINT: &str = "/api/v1/classes/";
-    static REQUEST_LOG_CAPTURE_LOCK: Mutex<()> = Mutex::const_new(());
 
     #[rstest]
     #[case::with_correlation_id(Some("test-correlation-id"), true)]
@@ -105,20 +103,14 @@ mod tests {
         assert_eq!(body["correlation_id"], "context-correlation");
     }
 
-    async fn capture_request_logs<T>(future: impl Future<Output = T>) -> (T, JsonLogWriter) {
-        // Actix test services may poll nested middleware work outside the immediate future's
-        // task-local dispatch. Keep one thread-default capture subscriber installed for the
-        // complete request and serialize capture windows so every middleware event reaches it.
-        let _capture_guard = REQUEST_LOG_CAPTURE_LOCK.lock().await;
-        let writer = JsonLogWriter::default();
-        let subscriber = tracing_subscriber::registry().with(
-            tracing_subscriber::fmt::layer()
-                .json()
-                .with_writer(writer.clone())
-                .event_format(HubuumLoggingFormat),
-        );
-        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
-        let output = future.await;
+    async fn capture_request_logs<T, F>(
+        run: impl FnOnce(TracingMiddleware) -> F,
+    ) -> (T, JsonLogWriter)
+    where
+        F: Future<Output = T>,
+    {
+        let (tracing_middleware, writer) = tracing_middleware_with_log_capture();
+        let output = run(tracing_middleware).await;
         (output, writer)
     }
 
@@ -153,10 +145,10 @@ mod tests {
         #[case] expected_status: StatusCode,
         #[case] expected_severity: &str,
     ) {
-        let (resp, writer) = capture_request_logs(async {
+        let (resp, writer) = capture_request_logs(|tracing_middleware| async move {
             let app = test::init_service(
                 App::new()
-                    .wrap(TracingMiddleware::new())
+                    .wrap(tracing_middleware)
                     .route("/ok", web::get().to(ok_handler))
                     .route("/bad-request", web::get().to(bad_request_handler))
                     .route("/server-error", web::get().to(server_error_handler)),
@@ -191,10 +183,10 @@ mod tests {
     #[case::readiness("/readyz")]
     #[actix_web::test]
     async fn tracing_middleware_logs_successful_probes_at_debug(#[case] path: &str) {
-        let (resp, writer) = capture_request_logs(async {
+        let (resp, writer) = capture_request_logs(|tracing_middleware| async move {
             let app = test::init_service(
                 App::new()
-                    .wrap(TracingMiddleware::new())
+                    .wrap(tracing_middleware)
                     .route("/healthz", web::get().to(ok_handler))
                     .route("/readyz", web::get().to(ok_handler)),
             )
@@ -216,10 +208,10 @@ mod tests {
 
     #[actix_web::test]
     async fn tracing_middleware_keeps_failed_readiness_probes_at_error() {
-        let (resp, writer) = capture_request_logs(async {
+        let (resp, writer) = capture_request_logs(|tracing_middleware| async move {
             let app = test::init_service(
                 App::new()
-                    .wrap(TracingMiddleware::new())
+                    .wrap(tracing_middleware)
                     .route("/readyz", web::get().to(service_unavailable_handler)),
             )
             .await;
@@ -243,10 +235,10 @@ mod tests {
 
     #[actix_web::test]
     async fn tracing_middleware_includes_recorded_principal_on_request_logs() {
-        let (resp, writer) = capture_request_logs(async {
+        let (resp, writer) = capture_request_logs(|tracing_middleware| async move {
             let app = test::init_service(
                 App::new()
-                    .wrap(TracingMiddleware::new())
+                    .wrap(tracing_middleware)
                     .route("/principal", web::get().to(principal_handler)),
             )
             .await;
@@ -270,11 +262,12 @@ mod tests {
     #[actix_web::test]
     async fn production_middleware_stack_records_authenticated_principal_on_request_logs() {
         let test_context = TestContext::new().await;
-        let (resp, writer) = capture_request_logs(async {
+        let expected_principal_id = test_context.admin_user.id;
+        let (resp, writer) = capture_request_logs(|tracing_middleware| async move {
             let app = test::init_service(
                 App::new()
                     .wrap(actix_web::middleware::from_fn(actor_context))
-                    .wrap(TracingMiddleware::new())
+                    .wrap(tracing_middleware)
                     .app_data(test_context.pool.clone())
                     .app_data(crate::tests::app_context(&test_context.pool))
                     .route("/principal", web::get().to(ok_handler)),
@@ -298,19 +291,19 @@ mod tests {
             .iter()
             .find(|event| event["message"] == "request complete")
             .expect("request completion log");
-        assert_eq!(event["principal_id"], test_context.admin_user.id);
+        assert_eq!(event["principal_id"], expected_principal_id);
     }
 
     #[actix_web::test]
     async fn production_middleware_stack_traces_allowlist_rejections() {
-        let (resp, writer) = capture_request_logs(async {
+        let (resp, writer) = capture_request_logs(|tracing_middleware| async move {
             let app = test::init_service(
                 App::new()
                     .wrap(actix_web::middleware::from_fn(actor_context))
                     .wrap(ClientAllowlistMiddleware::new(
                         ClientAllowlist::from_str("10.0.0.0/24").expect("allowlist"),
                     ))
-                    .wrap(TracingMiddleware::new())
+                    .wrap(tracing_middleware)
                     .route("/denied", web::get().to(ok_handler)),
             )
             .await;

--- a/tests/api_platform_suite/request_and_correlation.rs
+++ b/tests/api_platform_suite/request_and_correlation.rs
@@ -10,7 +10,6 @@ mod tests {
     use serde_json::json;
     use std::{future::Future, str::FromStr};
     use tokio::sync::Mutex;
-    use tracing::instrument::WithSubscriber;
     use tracing_subscriber::layer::SubscriberExt;
 
     use crate::config::ClientAllowlist;
@@ -107,9 +106,9 @@ mod tests {
     }
 
     async fn capture_request_logs<T>(future: impl Future<Output = T>) -> (T, JsonLogWriter) {
-        // These tests install distinct task-local tracing subscribers around nested Actix
-        // middleware futures. Keep capture windows from overlapping: parallel capture has
-        // intermittently dropped the final middleware event on CI.
+        // Actix test services may poll nested middleware work outside the immediate future's
+        // task-local dispatch. Keep one thread-default capture subscriber installed for the
+        // complete request and serialize capture windows so every middleware event reaches it.
         let _capture_guard = REQUEST_LOG_CAPTURE_LOCK.lock().await;
         let writer = JsonLogWriter::default();
         let subscriber = tracing_subscriber::registry().with(
@@ -118,7 +117,8 @@ mod tests {
                 .with_writer(writer.clone())
                 .event_format(HubuumLoggingFormat),
         );
-        let output = future.with_subscriber(subscriber).await;
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+        let output = future.await;
         (output, writer)
     }
 


### PR DESCRIPTION
## Summary

Bind request-log integration-test capture directly to the test `TracingMiddleware` instance instead of relying on an ambient task-local or thread-local subscriber.

The integration-test support layer builds an explicit tracing dispatch and writer, and the middleware uses that dispatch both while creating the request span and while polling the request future. Request-log capture windows are also serialized so concurrently created subscribers cannot invalidate one another's callsite interest while authenticated database work is in flight.

## Root cause

Ambient subscriber capture was not stable across the complete authenticated Actix middleware path on every CI runner. The final `request complete` event could be emitted after execution moved outside the ambient capture context, leaving the writer without the event even though the request succeeded.

Carrying the test-only dispatch with the middleware makes the request span and completion event retain the intended subscriber regardless of where nested middleware work is polled.

A remaining ARM64 reproduction showed a second race: the parallel request-log tests each created and dropped a subscriber, and subscriber registration rebuilds tracing's process-wide callsite interest cache. Serializing only those capture windows keeps one capture subscriber alive through the complete request.

## Behavior and compatibility

Production behavior and the production `TracingMiddleware` constructors are unchanged. The explicit dispatch and capture lock exist only behind the `integration-test-support` test path.

There is no changelog-worthy user impact.

## Verification

- `source .env && ./run_tests.sh`
- 11 consecutive full `source .env && ./run_tests.sh --test api_platform` runs after the serialization follow-up: 605 tests passed, including 11/11 authenticated request-log assertions
- Linux ARM64 production-feature CI passed on the propagated serialization revision
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
