### PR TITLE
Trim pull request CI while preserving required coverage

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,14 @@ on:
       - unlabeled
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}-${{
+      (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+      github.event.label.name != 'ci:full' &&
+      github.event.label.name != 'ci:benchmarks' &&
+      format('ignored-label-{0}', github.event.label.name) ||
+      'validation'
+    }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,14 +2,105 @@ name: Benchmarks
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+      - labeled
+      - unlabeled
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
+  changes:
+    name: Classify benchmark changes
+    if: >-
+      (
+        github.event.pull_request.draft == false ||
+        contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+        contains(github.event.pull_request.labels.*.name, 'ci:benchmarks')
+      ) &&
+      (
+        (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+        github.event.label.name == 'ci:full' ||
+        github.event.label.name == 'ci:benchmarks'
+      )
+    runs-on: ubuntu-24.04
+    outputs:
+      run_self_contained: ${{ steps.policy.outputs.run_self_contained }}
+      run_postgres: ${{ steps.policy.outputs.run_postgres }}
+      run_runtime: ${{ steps.policy.outputs.run_runtime }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Test change classifier
+        run: bash scripts/test-classify-ci-changes.sh
+      - name: Classify changed paths
+        id: paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed_files=()
+          while IFS= read -r -d '' path; do
+            changed_files+=("$path")
+          done < <(git diff --name-only -z "$BASE_SHA" "$HEAD_SHA")
+          bash scripts/classify-ci-changes.sh "${changed_files[@]}"
+      - name: Select benchmark tier
+        id: policy
+        env:
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+          FORCE_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+          FORCE_BENCHMARKS: ${{ contains(github.event.pull_request.labels.*.name, 'ci:benchmarks') }}
+          SELF_CONTAINED_CHANGED: ${{ steps.paths.outputs.benchmarks }}
+          POSTGRES_CHANGED: ${{ steps.paths.outputs.postgres_benchmark }}
+          RUNTIME_CHANGED: ${{ steps.paths.outputs.runtime_benchmark }}
+        run: |
+          requested=false
+          if [[ "$IS_DRAFT" != "true" || "$FORCE_FULL" == "true" || "$FORCE_BENCHMARKS" == "true" ]]; then
+            requested=true
+          fi
+
+          force_all=false
+          if [[ "$FORCE_FULL" == "true" || "$FORCE_BENCHMARKS" == "true" ]]; then
+            force_all=true
+          fi
+
+          run_self_contained=false
+          run_postgres=false
+          run_runtime=false
+          if [[ "$requested" == "true" ]]; then
+            if [[ "$force_all" == "true" || "$SELF_CONTAINED_CHANGED" == "true" ]]; then
+              run_self_contained=true
+            fi
+            if [[ "$force_all" == "true" || "$POSTGRES_CHANGED" == "true" ]]; then
+              run_postgres=true
+            fi
+            if [[ "$force_all" == "true" || "$RUNTIME_CHANGED" == "true" ]]; then
+              run_runtime=true
+            fi
+          fi
+
+          {
+            echo "run_self_contained=$run_self_contained"
+            echo "run_postgres=$run_postgres"
+            echo "run_runtime=$run_runtime"
+          } >> "$GITHUB_OUTPUT"
+
   benchmarks:
     name: Self-contained benchmarks
+    needs: changes
+    if: needs.changes.outputs.run_self_contained == 'true'
     uses: terjekv/github-action-iai-callgrind/.github/workflows/rust-pr-bench.yml@v3
     secrets: inherit
     with:
@@ -28,6 +119,8 @@ jobs:
 
   postgres-storage:
     name: PostgreSQL storage benchmarks
+    needs: changes
+    if: needs.changes.outputs.run_postgres == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     services:
@@ -55,32 +148,13 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Detect PostgreSQL storage benchmark changes
-        id: storage_changes
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
-            .github/workflows/benchmarks.yml Cargo.toml Cargo.lock \
-            benches/postgres migrations crates scripts/check-criterion-regressions.sh \
-            scripts/check-criterion-stability.sh src \
-            ':(exclude)src/tests/**'; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No PostgreSQL storage benchmark inputs changed."
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
       - name: Cache Cargo and target directories
-        if: steps.storage_changes.outputs.changed == 'true'
         uses: Swatinem/rust-cache@v2
       - name: Install PostgreSQL build tools
-        if: steps.storage_changes.outputs.changed == 'true'
         run: |
           sudo apt-get update --yes
           sudo apt-get install --yes libpq-dev
       - name: Disable nondeterministic PostgreSQL background work
-        if: steps.storage_changes.outputs.changed == 'true'
         env:
           PGPASSWORD: postgres
         run: |
@@ -96,17 +170,14 @@ jobs:
           )"
           [[ "$autovacuum" == "off" ]]
       - name: Create isolated benchmark databases
-        if: steps.storage_changes.outputs.changed == 'true'
         env:
           PGPASSWORD: postgres
         run: |
           createdb --host localhost --username postgres hubuum_bench_base
           createdb --host localhost --username postgres hubuum_bench_head
       - name: Clear cached PostgreSQL benchmark results
-        if: steps.storage_changes.outputs.changed == 'true'
         run: rm -rf target/criterion/storage_postgres
       - name: Detect an existing base benchmark
-        if: steps.storage_changes.outputs.changed == 'true'
         id: base_benchmark
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -117,9 +188,7 @@ jobs:
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Record base benchmark
-        if: >-
-          steps.storage_changes.outputs.changed == 'true' &&
-          steps.base_benchmark.outputs.available == 'true'
+        if: steps.base_benchmark.outputs.available == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HUBUUM_BENCH_DATABASE_URL: ${{ env.BASE_DATABASE_URL }}
@@ -131,7 +200,6 @@ jobs:
             --bench storage_postgres_criterion -- \
             --save-baseline pr-base --noplot --sample-size 40 --measurement-time 4
       - name: Record and compare pull-request benchmark
-        if: steps.storage_changes.outputs.changed == 'true'
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HUBUUM_BENCH_DATABASE_URL: ${{ env.HEAD_DATABASE_URL }}
@@ -152,9 +220,7 @@ jobs:
               >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: Assess initial PostgreSQL regressions
-        if: >-
-          steps.storage_changes.outputs.changed == 'true' &&
-          steps.base_benchmark.outputs.available == 'true'
+        if: steps.base_benchmark.outputs.available == 'true'
         id: initial_assessment
         env:
           POSTGRES_BENCH_INITIAL_FAILURES: ${{ runner.temp }}/postgres-benchmark-initial-failures.txt
@@ -265,6 +331,8 @@ jobs:
 
   runtime-behavior:
     name: Runtime behavior benchmark
+    needs: changes
+    if: needs.changes.outputs.run_runtime == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     services:
@@ -290,31 +358,13 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Detect runtime behavior inputs
-        id: runtime_changes
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
-            .github/workflows/benchmarks.yml Cargo.toml Cargo.lock \
-            benches/runtime_behavior.rs migrations src \
-            ':(exclude)src/tests/**'; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No runtime behavior benchmark inputs changed."
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
       - name: Cache Cargo and target directories
-        if: steps.runtime_changes.outputs.changed == 'true'
         uses: Swatinem/rust-cache@v2
       - name: Install PostgreSQL build tools
-        if: steps.runtime_changes.outputs.changed == 'true'
         run: |
           sudo apt-get update --yes
           sudo apt-get install --yes libpq-dev
       - name: Create isolated runtime benchmark databases
-        if: steps.runtime_changes.outputs.changed == 'true'
         env:
           PGPASSWORD: postgres
         run: |
@@ -322,7 +372,6 @@ jobs:
           createdb --host localhost --username postgres hubuum_runtime_head
           mkdir -p "$RUNTIME_BEHAVIOR_REPORT_DIR"
       - name: Detect an existing base runtime benchmark
-        if: steps.runtime_changes.outputs.changed == 'true'
         id: base_runtime
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -333,9 +382,7 @@ jobs:
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Measure base runtime behavior
-        if: >-
-          steps.runtime_changes.outputs.changed == 'true' &&
-          steps.base_runtime.outputs.available == 'true'
+        if: steps.base_runtime.outputs.available == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
@@ -353,7 +400,6 @@ jobs:
             --label "$BASE_SHA" \
             --output "$RUNTIME_BEHAVIOR_REPORT_DIR/base.json"
       - name: Measure pull-request runtime behavior
-        if: steps.runtime_changes.outputs.changed == 'true'
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -371,7 +417,6 @@ jobs:
             --label "$HEAD_SHA" \
             --output "$RUNTIME_BEHAVIOR_REPORT_DIR/head.json"
       - name: Assess runtime behavior
-        if: steps.runtime_changes.outputs.changed == 'true'
         env:
           BASE_AVAILABLE: ${{ steps.base_runtime.outputs.available }}
         run: |
@@ -396,7 +441,7 @@ jobs:
             --max-task-claim-latency-ms 1000 \
             --max-relative-regression-percent 25
       - name: Upload runtime behavior reports
-        if: always() && steps.runtime_changes.outputs.changed == 'true'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: runtime-behavior

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -61,7 +61,7 @@ jobs:
           changed_files=()
           while IFS= read -r -d '' path; do
             changed_files+=("$path")
-          done < <(git diff --name-only -z "$BASE_SHA" "$HEAD_SHA")
+          done < <(git diff --no-renames --name-only -z "$BASE_SHA" "$HEAD_SHA")
           bash scripts/classify-ci-changes.sh "${changed_files[@]}"
       - name: Select benchmark tier
         id: policy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,14 @@ on:
     tags:
       - "v*"
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+      - labeled
+      - unlabeled
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,9 +29,137 @@ env:
   HUBUUM_DB_TEST_PASSWORD: postgres
 
 jobs:
+  changes:
+    name: Classify changes
+    if: >-
+      !startsWith(github.ref, 'refs/tags/') &&
+      (
+        github.event_name != 'pull_request' ||
+        (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+        github.event.label.name == 'ci:full'
+      )
+    runs-on: ubuntu-24.04
+    outputs:
+      markdown: ${{ steps.paths.outputs.markdown }}
+      code: ${{ steps.paths.outputs.code }}
+      openapi: ${{ steps.paths.outputs.openapi }}
+      container: ${{ steps.paths.outputs.container }}
+      artifacts: ${{ steps.paths.outputs.artifacts }}
+      run_format: ${{ steps.policy.outputs.run_format }}
+      run_markdown: ${{ steps.policy.outputs.run_markdown }}
+      run_default_suite: ${{ steps.policy.outputs.run_default_suite }}
+      run_full_ci: ${{ steps.policy.outputs.run_full_ci }}
+      run_openapi: ${{ steps.policy.outputs.run_openapi }}
+      run_container: ${{ steps.policy.outputs.run_container }}
+      feature_matrix: ${{ steps.policy.outputs.feature_matrix }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Test change classifier
+        run: bash scripts/test-classify-ci-changes.sh
+      - name: Classify changed paths
+        id: paths
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          changed_files=()
+          if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
+            while IFS= read -r -d '' path; do
+              changed_files+=("$path")
+            done < <(git ls-files --cached --others --exclude-standard -z)
+          else
+            while IFS= read -r -d '' path; do
+              changed_files+=("$path")
+            done < <(git diff --name-only -z "$BASE_SHA" "$HEAD_SHA")
+          fi
+          bash scripts/classify-ci-changes.sh "${changed_files[@]}"
+      - name: Select CI tier
+        id: policy
+        env:
+          CODE_CHANGED: ${{ steps.paths.outputs.code }}
+          CONTAINER_CHANGED: ${{ steps.paths.outputs.container }}
+          OPENAPI_CHANGED: ${{ steps.paths.outputs.openapi }}
+          MARKDOWN_CHANGED: ${{ steps.paths.outputs.markdown }}
+          IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
+          IS_DRAFT: ${{ github.event.pull_request.draft || false }}
+          FORCE_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+        run: |
+          full_requested=false
+          if [[ "$IS_PULL_REQUEST" != "true" || "$IS_DRAFT" != "true" || "$FORCE_FULL" == "true" ]]; then
+            full_requested=true
+          fi
+
+          run_full_ci=false
+          if [[ "$full_requested" == "true" && ("$CODE_CHANGED" == "true" || "$FORCE_FULL" == "true") ]]; then
+            run_full_ci=true
+          fi
+
+          run_default_suite=false
+          if [[ "$CODE_CHANGED" == "true" || "$FORCE_FULL" == "true" ]]; then
+            run_default_suite=true
+          fi
+
+          run_container=false
+          if [[ "$full_requested" == "true" && ("$CONTAINER_CHANGED" == "true" || "$FORCE_FULL" == "true") ]]; then
+            run_container=true
+          fi
+
+          run_openapi=false
+          if [[ "$run_full_ci" == "true" || "$OPENAPI_CHANGED" == "true" ]]; then
+            run_openapi=true
+          fi
+
+          run_format=false
+          if [[ "$CODE_CHANGED" == "true" || "$FORCE_FULL" == "true" ]]; then
+            run_format=true
+          fi
+
+          run_markdown=false
+          if [[ "$MARKDOWN_CHANGED" == "true" || "$FORCE_FULL" == "true" ]]; then
+            run_markdown=true
+          fi
+
+          if [[ "$run_full_ci" == "true" ]]; then
+            feature_matrix='[{"name":"default","args":""},{"name":"no-default-features","args":"--no-default-features"},{"name":"rustls-no-openssl","args":"--no-default-features -F tls-rustls"},{"name":"all-features","args":"--all-features"}]'
+          else
+            feature_matrix='[{"name":"default","args":""}]'
+          fi
+
+          {
+            echo "run_format=$run_format"
+            echo "run_markdown=$run_markdown"
+            echo "run_default_suite=$run_default_suite"
+            echo "run_full_ci=$run_full_ci"
+            echo "run_openapi=$run_openapi"
+            echo "run_container=$run_container"
+            echo "feature_matrix=$feature_matrix"
+          } >> "$GITHUB_OUTPUT"
+
+  static-checks:
+    name: Static checks
+    needs: changes
+    if: needs.changes.outputs.run_format == 'true' || needs.changes.outputs.run_markdown == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Check Rust formatting
+        if: needs.changes.outputs.run_format == 'true'
+        run: cargo fmt --all -- --check
+      - name: Markdown lint
+        if: needs.changes.outputs.run_markdown == 'true'
+        uses: DavidAnson/markdownlint-cli2-action@v24
+        with:
+          config: '.markdownlint.json'
+          globs: '**/*.md'
+
   lint:
     name: Lint
-    if: "!startsWith(github.ref, 'refs/tags/')"
+    needs: changes
+    if: needs.changes.outputs.run_full_ci == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
@@ -44,15 +180,11 @@ jobs:
         run: bash scripts/test-install-script-refresh.sh
       - name: Test single-host rolling update
         run: bash scripts/test-single-host-rollout.sh
-      - name: Markdown lint
-        uses: DavidAnson/markdownlint-cli2-action@v24
-        with:
-          config: '.markdownlint.json'
-          globs: '**/*.md'
 
   release-metadata:
     name: Release metadata
-    if: "!startsWith(github.ref, 'refs/tags/')"
+    needs: changes
+    if: needs.changes.outputs.run_full_ci == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
@@ -66,7 +198,8 @@ jobs:
 
   openapi-contract:
     name: OpenAPI contract
-    if: "!startsWith(github.ref, 'refs/tags/')"
+    needs: changes
+    if: needs.changes.outputs.run_openapi == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
@@ -122,20 +255,13 @@ jobs:
 
   feature-permutations:
     name: Feature smoke (${{ matrix.feature.name }})
-    if: "!startsWith(github.ref, 'refs/tags/')"
+    needs: changes
+    if: needs.changes.outputs.run_default_suite == 'true'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        feature:
-          - name: default
-            args: ""
-          - name: no-default-features
-            args: "--no-default-features"
-          - name: rustls-no-openssl
-            args: "--no-default-features -F tls-rustls"
-          - name: all-features
-            args: "--all-features"
+        feature: ${{ fromJSON(needs.changes.outputs.feature_matrix) }}
     services:
       postgres:
         image: postgres
@@ -191,7 +317,8 @@ jobs:
 
   valkey-rate-limit-contract:
     name: Valkey login limiter contract
-    if: "!startsWith(github.ref, 'refs/tags/')"
+    needs: changes
+    if: needs.changes.outputs.run_full_ci == 'true'
     runs-on: ubuntu-24.04
     services:
       valkey:
@@ -215,7 +342,8 @@ jobs:
 
   test:
     name: ${{ matrix.platform.os_name }}, rust ${{ matrix.toolchain }}
-    if: "!startsWith(github.ref, 'refs/tags/')"
+    needs: changes
+    if: needs.changes.outputs.run_full_ci == 'true'
     runs-on: ${{ matrix.platform.os }}
     env:
       # Production artifact jobs retain the exact fat-LTO release profile.
@@ -437,7 +565,8 @@ jobs:
 
   all-features-release-build:
     name: Release build with all production features
-    if: "!startsWith(github.ref, 'refs/tags/')"
+    needs: changes
+    if: needs.changes.outputs.run_full_ci == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
@@ -453,7 +582,8 @@ jobs:
 
   container-build:
     name: Container build (production features)
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.run_container == 'true'
     runs-on: ubuntu-24.04
     services:
       postgres:
@@ -558,6 +688,36 @@ jobs:
           HUBUUM_TEST_IMAGE: hubuum-server:ci
           HUBUUM_OLD_TEST_IMAGE: ghcr.io/hubuum/hubuum-server:v0.0.1@sha256:061fc4cb3af57e2db06c33012db93e60834d4618815e30af4ebb4aa05a21f445
         run: bash scripts/test-single-host-zero-downtime.sh
+
+  ci-gate:
+    name: >-
+      ${{
+        (
+          (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+          github.event.label.name == 'ci:full'
+        ) && 'CI gate' || 'CI policy event ignored'
+      }}
+    if: always() && github.event_name == 'pull_request' && needs.changes.result != 'skipped'
+    needs:
+      - changes
+      - static-checks
+      - lint
+      - release-metadata
+      - openapi-contract
+      - feature-permutations
+      - valkey-rate-limit-contract
+      - test
+      - all-features-release-build
+      - container-build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require all applicable CI jobs to pass
+        env:
+          JOB_RESULTS: ${{ toJSON(needs) }}
+        run: |
+          jq --exit-status \
+            'all(.[]; .result == "success" or .result == "skipped")' \
+            <<< "$JOB_RESULTS"
 
   verify-tag-main-ci-success:
     name: Verify tagged commit already passed CI on main
@@ -811,8 +971,9 @@ jobs:
 
   build-main-linux-artifacts:
     name: Build static main artifacts (${{ matrix.platform.os_name }}, ${{ matrix.feature.ext }})
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && needs.changes.outputs.artifacts == 'true'
     needs:
+      - changes
       - lint
       - release-metadata
       - openapi-contract
@@ -883,8 +1044,9 @@ jobs:
 
   build-main-native-artifacts:
     name: Build native main artifacts (${{ matrix.platform.os_name }}, ${{ matrix.feature.ext }})
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && needs.changes.outputs.artifacts == 'true'
     needs:
+      - changes
       - lint
       - release-metadata
       - openapi-contract
@@ -1012,8 +1174,9 @@ jobs:
 
   publish-main-container-images:
     name: Build main container (${{ matrix.platform.arch }})
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && needs.changes.outputs.artifacts == 'true'
     needs:
+      - changes
       - lint
       - release-metadata
       - openapi-contract

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           else
             while IFS= read -r -d '' path; do
               changed_files+=("$path")
-            done < <(git diff --name-only -z "$BASE_SHA" "$HEAD_SHA")
+            done < <(git diff --no-renames --name-only -z "$BASE_SHA" "$HEAD_SHA")
           fi
           bash scripts/classify-ci-changes.sh "${changed_files[@]}"
       - name: Select CI tier
@@ -703,7 +703,10 @@ jobs:
           github.event.label.name == 'ci:full'
         ) && 'CI gate' || 'CI policy event ignored'
       }}
-    if: always() && github.event_name == 'pull_request' && needs.changes.result != 'skipped'
+    if: >-
+      always() &&
+      (github.event_name == 'pull_request' || github.ref == 'refs/heads/main') &&
+      needs.changes.result != 'skipped'
     needs:
       - changes
       - static-checks
@@ -980,12 +983,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && needs.changes.outputs.artifacts == 'true'
     needs:
       - changes
-      - lint
-      - release-metadata
-      - openapi-contract
-      - feature-permutations
-      - test
-      - all-features-release-build
+      - ci-gate
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
@@ -1053,12 +1051,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && needs.changes.outputs.artifacts == 'true'
     needs:
       - changes
-      - lint
-      - release-metadata
-      - openapi-contract
-      - feature-permutations
-      - test
-      - all-features-release-build
+      - ci-gate
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
@@ -1183,11 +1176,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && needs.changes.outputs.artifacts == 'true'
     needs:
       - changes
-      - lint
-      - release-metadata
-      - openapi-contract
-      - feature-permutations
-      - test
+      - ci-gate
     runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,13 @@ on:
       - unlabeled
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}-${{
+      (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+      github.event.label.name != 'ci:full' &&
+      format('ignored-label-{0}', github.event.label.name) ||
+      'validation'
+    }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - `rustfmt` should pass for all Rust code. Keep formatting mechanical and avoid hand-formatting that fights `rustfmt`.
 - Regenerate OpenAPI after endpoint or schema changes before considering the change complete.
 - Markdown lint must pass for all `*.md` files. Run it locally with `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"` before considering documentation changes complete. Every fenced code block must declare a language (use `text` for plain ASCII/diagrams), and tables must use a single, consistent column style (MD060).
+- When adding or moving build, test, lint, benchmark, or embedded-file inputs, verify that `scripts/classify-ci-changes.sh` selects the required CI targets and update `scripts/test-classify-ci-changes.sh` when needed. Unknown paths intentionally receive conservative validation. Direct literal `include_str!` and `include_bytes!` inputs are checked automatically; dynamically constructed paths still require manual review.
 
 ## Container Builds
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -124,8 +124,12 @@ The lightweight change classifier is implemented by
 `scripts/classify-ci-changes.sh`. Unknown file types are classified
 conservatively as code, container, artifact, and benchmark inputs. Keep its
 tests in `scripts/test-classify-ci-changes.sh` synchronized with any new build
-inputs. The stable `CI gate` job reports the combined result of every applicable
-PR job and is the check intended for branch protection.
+inputs. Direct literal `include_str!` and `include_bytes!` inputs are discovered
+by that test and must be classified as code automatically. Renames are evaluated
+as a deletion plus an addition so both the old and new paths affect the selected
+tier. The stable `CI gate` job reports the combined result of every applicable
+PR or `main` validation job, is the check intended for branch protection, and
+must pass before `main-latest` artifacts or container images are published.
 
 ## Benchmarks
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -111,7 +111,8 @@ Pull request validation is selected from the complete base-to-head diff:
 - Ready-for-review documentation-only pull requests keep the smaller relevant
   checks. `docs/openapi.json` receives the OpenAPI contract check, while
   `docs/export_template_guide.md` is treated as code because it is embedded in
-  a binary.
+  a binary. `docs/querying.md` is treated as a test input because the API test
+  suite compiles and validates its documented operator lists.
 
 The `ci:full` pull request label forces the complete CI and benchmark suites,
 including on a draft or documentation-only pull request. The `ci:benchmarks`

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,6 +95,37 @@ ancestor must satisfy all requested flags.
 See [Collection Hierarchy](collection_hierarchy.md) for user-facing behavior,
 move constraints, indexes, and the rationale for keeping this logic app-local.
 
+## Pull request CI tiers
+
+Pull request validation is selected from the complete base-to-head diff:
+
+- Draft documentation-only pull requests run Markdown lint when Markdown files
+  changed.
+- Draft code pull requests run Rust formatting and the complete default-feature
+  test suite on Linux with PostgreSQL. They do not run the other feature
+  combinations, cross-platform tests, production container build, release
+  build, or benchmarks.
+- Ready-for-review code pull requests run the complete CI suite. The
+  `ready_for_review` event starts that suite immediately, and later pushes keep
+  running it.
+- Ready-for-review documentation-only pull requests keep the smaller relevant
+  checks. `docs/openapi.json` receives the OpenAPI contract check, while
+  `docs/export_template_guide.md` is treated as code because it is embedded in
+  a binary.
+
+The `ci:full` pull request label forces the complete CI and benchmark suites,
+including on a draft or documentation-only pull request. The `ci:benchmarks`
+label forces all benchmark jobs without expanding the main CI tier. Adding or
+removing either label takes effect immediately; converting a pull request back
+to draft cancels superseded work unless a forcing label remains.
+
+The lightweight change classifier is implemented by
+`scripts/classify-ci-changes.sh`. Unknown file types are classified
+conservatively as code, container, artifact, and benchmark inputs. Keep its
+tests in `scripts/test-classify-ci-changes.sh` synchronized with any new build
+inputs. The stable `CI gate` job reports the combined result of every applicable
+PR job and is the check intended for branch protection.
+
 ## Benchmarks
 
 Benchmarking runs in a separate GitHub workflow, `.github/workflows/benchmarks.yml`, via `terjekv/github-action-iai-callgrind`.
@@ -198,6 +229,11 @@ query nondeterministically to the next operation.
 
 ### CI behavior
 
+- Draft pull requests skip benchmarks unless `ci:full` or `ci:benchmarks` is
+  present. Ready pull requests run only the benchmark jobs affected by their
+  base-to-head diff.
+- Change classification happens before PostgreSQL services or benchmark
+  runners are allocated. Superseded benchmark workflow runs are cancelled.
 - The self-contained benchmark job runs both backends in one combined
   `backend: all` job, so PRs get a single consolidated benchmark export.
 - Gungraun's Callgrind measurements remain the practical gating signal with a

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -86,3 +86,8 @@ The image runs pending embedded Diesel migrations during startup unless
 operators can run migrations explicitly with `hubuum-admin --migrate`.
 
 Publishing from `main` happens in the same workflow run and depends directly on the CI jobs passing.
+Documentation-only and repository-metadata pushes do not rebuild or replace
+`main-latest` archives or container images. The existing artifacts remain valid
+because their binary inputs are unchanged. Changes to Rust sources, embedded
+documentation, migrations, manifests, container inputs, or the publication
+workflow still run the complete validation and publishing path.

--- a/scripts/classify-ci-changes.sh
+++ b/scripts/classify-ci-changes.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+any=false
+markdown=false
+code=false
+openapi=false
+container=false
+artifacts=false
+benchmarks=false
+postgres_benchmark=false
+runtime_benchmark=false
+
+for path in "$@"; do
+  any=true
+
+  if [[ "$path" == *.md ]]; then
+    markdown=true
+  fi
+
+  case "$path" in
+    docs/openapi.json)
+      openapi=true
+      ;;
+    docs/export_template_guide.md)
+      code=true
+      container=true
+      artifacts=true
+      ;;
+    *.md | docs/* | LICENSE | .markdownlint.json | .gitattributes | .gitignore | \
+      .env.example | .env.*.example | .agents/* | .codex/* | \
+      .github/ISSUE_TEMPLATE/* | .github/PULL_REQUEST_TEMPLATE*)
+      ;;
+    .github/workflows/benchmarks.yml)
+      code=true
+      benchmarks=true
+      postgres_benchmark=true
+      runtime_benchmark=true
+      ;;
+    .github/workflows/ci.yml)
+      code=true
+      openapi=true
+      container=true
+      artifacts=true
+      ;;
+    src/tests/* | tests/*)
+      code=true
+      ;;
+    src/*)
+      code=true
+      container=true
+      artifacts=true
+      benchmarks=true
+      if [[ "$path" != src/tests/* ]]; then
+        postgres_benchmark=true
+        runtime_benchmark=true
+      fi
+      ;;
+    crates/*/benches/*)
+      code=true
+      benchmarks=true
+      ;;
+    crates/*)
+      code=true
+      container=true
+      artifacts=true
+      benchmarks=true
+      postgres_benchmark=true
+      ;;
+    benches/postgres/*)
+      code=true
+      benchmarks=true
+      postgres_benchmark=true
+      ;;
+    benches/runtime_behavior.rs)
+      code=true
+      benchmarks=true
+      runtime_benchmark=true
+      ;;
+    benches/*)
+      code=true
+      benchmarks=true
+      ;;
+    migrations/*)
+      code=true
+      container=true
+      artifacts=true
+      postgres_benchmark=true
+      runtime_benchmark=true
+      ;;
+    Cargo.toml | Cargo.lock)
+      code=true
+      openapi=true
+      container=true
+      artifacts=true
+      benchmarks=true
+      postgres_benchmark=true
+      runtime_benchmark=true
+      ;;
+    Cross.toml | diesel.toml | build.rs)
+      code=true
+      container=true
+      artifacts=true
+      ;;
+    Dockerfile | entrypoint.sh | .dockerignore)
+      code=true
+      container=true
+      artifacts=true
+      ;;
+    docker/* | docker-compose.yml | .env | .env.docker.local)
+      code=true
+      container=true
+      ;;
+    scripts/classify-ci-changes.sh | scripts/test-classify-ci-changes.sh)
+      code=true
+      benchmarks=true
+      postgres_benchmark=true
+      runtime_benchmark=true
+      ;;
+    scripts/check-criterion-regressions.sh | scripts/check-criterion-stability.sh)
+      code=true
+      benchmarks=true
+      postgres_benchmark=true
+      ;;
+    scripts/install-single-host.sh | scripts/single-host-rollout.sh | \
+      scripts/test-install-script-refresh.sh | scripts/test-single-host-rollout.sh | \
+      scripts/test-single-host-zero-downtime.sh | scripts/update-single-host.sh | \
+      scripts/uninstall-single-host.sh | scripts/stop-single-host.sh)
+      code=true
+      container=true
+      ;;
+    scripts/* | run_tests.sh | cleanup_test_databases.sh)
+      code=true
+      ;;
+    *)
+      # Unknown inputs are treated conservatively so new build inputs do not
+      # silently bypass validation or main artifact publication.
+      code=true
+      container=true
+      artifacts=true
+      benchmarks=true
+      postgres_benchmark=true
+      runtime_benchmark=true
+      ;;
+  esac
+done
+
+outputs=(
+  "any=$any"
+  "markdown=$markdown"
+  "code=$code"
+  "openapi=$openapi"
+  "container=$container"
+  "artifacts=$artifacts"
+  "benchmarks=$benchmarks"
+  "postgres_benchmark=$postgres_benchmark"
+  "runtime_benchmark=$runtime_benchmark"
+)
+
+printf '%s\n' "${outputs[@]}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  printf '%s\n' "${outputs[@]}" >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/classify-ci-changes.sh
+++ b/scripts/classify-ci-changes.sh
@@ -27,7 +27,13 @@ for path in "$@"; do
       container=true
       artifacts=true
       ;;
-    *.md | docs/* | LICENSE | .markdownlint.json | .gitattributes | .gitignore | \
+    docs/querying.md)
+      code=true
+      ;;
+    .markdownlint.json)
+      markdown=true
+      ;;
+    *.md | docs/* | LICENSE | .gitattributes | .gitignore | \
       .env.example | .env.*.example | .agents/* | .codex/* | \
       .github/ISSUE_TEMPLATE/* | .github/PULL_REQUEST_TEMPLATE*)
       ;;

--- a/scripts/test-classify-ci-changes.sh
+++ b/scripts/test-classify-ci-changes.sh
@@ -16,6 +16,33 @@ assert_flag() {
   fi
 }
 
+assert_literal_include_is_code() {
+  local source_path="$1"
+  local invocation="$2"
+  local relative_path="${invocation#*\"}"
+  relative_path="${relative_path%%\"*}"
+
+  local source_dir
+  source_dir="$repo_root/$(dirname "$source_path")"
+  local include_dir
+  include_dir="$(cd "$source_dir/$(dirname "$relative_path")" && pwd -P)"
+  local include_path
+  include_path="$include_dir/$(basename "$relative_path")"
+
+  case "$include_path" in
+    "$repo_root"/*)
+      include_path="${include_path#"$repo_root"/}"
+      ;;
+    *)
+      return
+      ;;
+  esac
+
+  local output
+  output="$(bash "$classifier" "$include_path")"
+  assert_flag "$output" code true
+}
+
 docs_output="$(bash "$classifier" README.md AGENTS.md docs/development.md)"
 assert_flag "$docs_output" markdown true
 assert_flag "$docs_output" code false
@@ -77,5 +104,21 @@ assert_flag "$unknown_output" code true
 assert_flag "$unknown_output" container true
 assert_flag "$unknown_output" artifacts true
 assert_flag "$unknown_output" benchmarks true
+
+literal_include_count=0
+while IFS=: read -r source_path invocation; do
+  assert_literal_include_is_code "$source_path" "$invocation"
+  ((literal_include_count += 1))
+done < <(
+  cd "$repo_root"
+  rg --with-filename --no-line-number --only-matching \
+    'include_(str|bytes)!\s*\(\s*"[^"]+"\s*\)' \
+    --glob '*.rs' .
+)
+
+if ((literal_include_count == 0)); then
+  echo "Expected to find at least one direct include_str! or include_bytes! input." >&2
+  exit 1
+fi
 
 echo "CI change classifier tests passed."

--- a/scripts/test-classify-ci-changes.sh
+++ b/scripts/test-classify-ci-changes.sh
@@ -21,6 +21,15 @@ assert_flag "$docs_output" markdown true
 assert_flag "$docs_output" code false
 assert_flag "$docs_output" artifacts false
 
+querying_docs_output="$(bash "$classifier" docs/querying.md)"
+assert_flag "$querying_docs_output" markdown true
+assert_flag "$querying_docs_output" code true
+assert_flag "$querying_docs_output" artifacts false
+
+markdown_config_output="$(bash "$classifier" .markdownlint.json)"
+assert_flag "$markdown_config_output" markdown true
+assert_flag "$markdown_config_output" code false
+
 openapi_output="$(bash "$classifier" docs/openapi.json)"
 assert_flag "$openapi_output" openapi true
 assert_flag "$openapi_output" code false

--- a/scripts/test-classify-ci-changes.sh
+++ b/scripts/test-classify-ci-changes.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+classifier="$repo_root/scripts/classify-ci-changes.sh"
+
+assert_flag() {
+  local output="$1"
+  local flag="$2"
+  local expected="$3"
+
+  if ! grep --fixed-strings --line-regexp --quiet "$flag=$expected" <<< "$output"; then
+    echo "Expected $flag=$expected, got:" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+}
+
+docs_output="$(bash "$classifier" README.md AGENTS.md docs/development.md)"
+assert_flag "$docs_output" markdown true
+assert_flag "$docs_output" code false
+assert_flag "$docs_output" artifacts false
+
+openapi_output="$(bash "$classifier" docs/openapi.json)"
+assert_flag "$openapi_output" openapi true
+assert_flag "$openapi_output" code false
+
+embedded_doc_output="$(bash "$classifier" docs/export_template_guide.md)"
+assert_flag "$embedded_doc_output" markdown true
+assert_flag "$embedded_doc_output" code true
+assert_flag "$embedded_doc_output" container true
+assert_flag "$embedded_doc_output" artifacts true
+
+test_output="$(bash "$classifier" tests/api_core_data_suite/querying.rs)"
+assert_flag "$test_output" code true
+assert_flag "$test_output" container false
+assert_flag "$test_output" artifacts false
+assert_flag "$test_output" benchmarks false
+
+source_output="$(bash "$classifier" src/api/v1/mod.rs)"
+assert_flag "$source_output" code true
+assert_flag "$source_output" container true
+assert_flag "$source_output" artifacts true
+assert_flag "$source_output" benchmarks true
+assert_flag "$source_output" postgres_benchmark true
+assert_flag "$source_output" runtime_benchmark true
+
+benchmark_output="$(bash "$classifier" .github/workflows/benchmarks.yml)"
+assert_flag "$benchmark_output" benchmarks true
+assert_flag "$benchmark_output" postgres_benchmark true
+assert_flag "$benchmark_output" runtime_benchmark true
+assert_flag "$benchmark_output" artifacts false
+
+classifier_output="$(bash "$classifier" scripts/classify-ci-changes.sh)"
+assert_flag "$classifier_output" code true
+assert_flag "$classifier_output" benchmarks true
+assert_flag "$classifier_output" postgres_benchmark true
+assert_flag "$classifier_output" runtime_benchmark true
+assert_flag "$classifier_output" artifacts false
+
+docker_output="$(bash "$classifier" Dockerfile)"
+assert_flag "$docker_output" code true
+assert_flag "$docker_output" container true
+assert_flag "$docker_output" artifacts true
+
+unknown_output="$(bash "$classifier" future-build-input.conf)"
+assert_flag "$unknown_output" code true
+assert_flag "$unknown_output" container true
+assert_flag "$unknown_output" artifacts true
+assert_flag "$unknown_output" benchmarks true
+
+echo "CI change classifier tests passed."


### PR DESCRIPTION
## Summary

- classify pull request changes and select a smaller validation tier when the diff does not affect code
- keep a complete Linux default-feature test suite for draft pull requests that change code
- start the full cross-platform, feature, release, container, and benchmark coverage when a pull request becomes ready for review
- add `ci:full` and `ci:benchmarks` override labels, including immediate label-event handling without canceling unrelated in-flight validation
- treat renames, Markdown lint configuration, and Rust-embedded documentation as validation inputs
- make the stable CI gate cover both pull requests and `main`, and require it before publishing `main-latest` artifacts or container images

## Rationale

The previous workflows ran expensive jobs on every pull request update, including drafts and documentation-only changes. This keeps early feedback for draft code changes while deferring expensive platform and packaging coverage until review is requested. Unknown inputs remain conservative so refactors and newly added files receive full validation unless they are deliberately classified more narrowly.

## Behavior notes

- Draft code changes run formatting and the full default-feature Linux/PostgreSQL suite.
- Ready-for-review code changes run the complete CI suite and relevant benchmarks.
- Documentation and metadata changes run only applicable checks unless they affect an embedded or generated build input.
- `ci:full` forces all CI and benchmarks; `ci:benchmarks` forces only benchmarks.
- Renames are evaluated as deletion plus addition, so moving a known build input cannot bypass its original classification.
- Direct literal `include_str!` and `include_bytes!` inputs are covered by an executable classifier contract test.

## Changelog

No changelog-worthy user-facing impact; this changes internal CI policy only.

## Follow-up

- #238 tracks requiring the stable CI gate in branch protection after merge.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `shellcheck scripts/classify-ci-changes.sh scripts/test-classify-ci-changes.sh`
- `actionlint .github/workflows/ci.yml .github/workflows/benchmarks.yml`
- `bash scripts/test-classify-ci-changes.sh`
