### PR TITLE
Make CI classifier test portable

### DIFF
--- a/scripts/test-classify-ci-changes.sh
+++ b/scripts/test-classify-ci-changes.sh
@@ -111,9 +111,9 @@ while IFS=: read -r source_path invocation; do
   ((literal_include_count += 1))
 done < <(
   cd "$repo_root"
-  rg --with-filename --no-line-number --only-matching \
-    'include_(str|bytes)!\s*\(\s*"[^"]+"\s*\)' \
-    --glob '*.rs' .
+  git grep --only-matching --extended-regexp \
+    'include_(str|bytes)![[:space:]]*\([[:space:]]*"[^"]+"[[:space:]]*\)' \
+    -- '*.rs'
 )
 
 if ((literal_include_count == 0)); then


### PR DESCRIPTION
## Summary

- replace the classifier contract test's `rg` dependency with `git grep`
- keep equivalent discovery for direct literal `include_str!` and `include_bytes!` inputs

## Root cause

The Ubuntu 24.04 GitHub-hosted runner no longer provides `rg`. Both CI workflows run the classifier contract before selecting a tier, so the missing command failed classification and skipped all downstream validation.

`git grep` is available anywhere the checked-out repository and Git are available, avoiding an extra runner dependency.

## Changelog

No changelog-worthy user-facing impact; this is an internal CI portability fix.

## Verification

- `env PATH=/usr/bin:/bin bash scripts/test-classify-ci-changes.sh`
- `bash scripts/test-classify-ci-changes.sh`
- `shellcheck scripts/classify-ci-changes.sh scripts/test-classify-ci-changes.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `source .env && ./run_tests.sh`
