### PR TITLE
Fix revision precondition gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Conditional collection, class, object, and membership mutations now return
+  `412 Precondition Failed` when their selected target vanishes, changes before
+  delete validation, or produces a membership-source no-op.
+- Import v2 now matches shared computed fields with their null owner, reports
+  vanished `if_revision` execution targets as `stale_revision`, and exposes
+  observed shared-field revisions during dry runs. Permission-scoped group
+  lists now honor the documented `revision` filter.
 - In-memory cursor pagination now computes every row's sort values before
   ordering and extracts each value once, so failures cannot silently leave rows
   unordered and fallible work is not repeated inside the sort comparator.

--- a/src/api/etag.rs
+++ b/src/api/etag.rs
@@ -36,6 +36,62 @@ enum EtagResourceKind {
     Token,
 }
 
+/// Authoritative database rows that own resource revisions.
+///
+/// HTTP representations and mutation backends share this vocabulary so a
+/// table-name typo cannot silently detach an `If-Match` assertion from the row
+/// it is intended to protect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum RevisionOwner {
+    IdentityScope,
+    Group,
+    Principal,
+    Membership,
+    Collection,
+    CollectionPermissions,
+    Class,
+    Object,
+    ClassRelation,
+    ObjectRelation,
+    ExportTemplate,
+    RemoteTarget,
+    EventSink,
+    EventSubscription,
+    ComputedField,
+    Token,
+}
+
+impl RevisionOwner {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::IdentityScope => "identity_scopes",
+            Self::Group => "groups",
+            Self::Principal => "principals",
+            Self::Membership => "group_memberships",
+            Self::Collection => "collections",
+            Self::CollectionPermissions => "collection_authorization_state",
+            Self::Class => "hubuumclass",
+            Self::Object => "hubuumobject",
+            Self::ClassRelation => "hubuumclass_relation",
+            Self::ObjectRelation => "hubuumobject_relation",
+            Self::ExportTemplate => "export_templates",
+            Self::RemoteTarget => "remote_targets",
+            Self::EventSink => "event_sinks",
+            Self::EventSubscription => "event_subscriptions",
+            Self::ComputedField => "computed_field_definitions",
+            Self::Token => "tokens",
+        }
+    }
+
+    pub(crate) fn key(self, resource_key: impl fmt::Display) -> String {
+        format!("{}:{resource_key}", self.as_str())
+    }
+
+    pub(crate) fn membership_key(principal_id: i32, group_id: i32) -> String {
+        Self::Membership.key(format_args!("{principal_id}:{group_id}"))
+    }
+}
+
 impl EtagResourceKind {
     const fn as_str(self) -> &'static str {
         match self {
@@ -86,26 +142,26 @@ impl EtagResourceKind {
         })
     }
 
-    const fn revision_owner_table(self) -> &'static str {
+    const fn revision_owner(self) -> RevisionOwner {
         match self {
-            Self::IdentityScope => "identity_scopes",
-            Self::Group => "groups",
+            Self::IdentityScope => RevisionOwner::IdentityScope,
+            Self::Group => RevisionOwner::Group,
             Self::Principal | Self::User | Self::ServiceAccount | Self::PrincipalSettings => {
-                "principals"
+                RevisionOwner::Principal
             }
-            Self::Membership => "group_memberships",
-            Self::Collection => "collections",
-            Self::CollectionPermissions => "collection_authorization_state",
-            Self::Class => "hubuumclass",
-            Self::Object => "hubuumobject",
-            Self::ClassRelation => "hubuumclass_relation",
-            Self::ObjectRelation => "hubuumobject_relation",
-            Self::ExportTemplate => "export_templates",
-            Self::RemoteTarget => "remote_targets",
-            Self::EventSink => "event_sinks",
-            Self::EventSubscription => "event_subscriptions",
-            Self::ComputedField => "computed_field_definitions",
-            Self::Token => "tokens",
+            Self::Membership => RevisionOwner::Membership,
+            Self::Collection => RevisionOwner::Collection,
+            Self::CollectionPermissions => RevisionOwner::CollectionPermissions,
+            Self::Class => RevisionOwner::Class,
+            Self::Object => RevisionOwner::Object,
+            Self::ClassRelation => RevisionOwner::ClassRelation,
+            Self::ObjectRelation => RevisionOwner::ObjectRelation,
+            Self::ExportTemplate => RevisionOwner::ExportTemplate,
+            Self::RemoteTarget => RevisionOwner::RemoteTarget,
+            Self::EventSink => RevisionOwner::EventSink,
+            Self::EventSubscription => RevisionOwner::EventSubscription,
+            Self::ComputedField => RevisionOwner::ComputedField,
+            Self::Token => RevisionOwner::Token,
         }
     }
 }
@@ -113,17 +169,17 @@ impl EtagResourceKind {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EntityTag {
     kind: EtagResourceKind,
-    key: Vec<u8>,
+    key: String,
     revision: ResourceRevision,
 }
 
 impl EntityTag {
     fn new(
         kind: EtagResourceKind,
-        key: impl AsRef<[u8]>,
+        key: impl Into<String>,
         revision: ResourceRevision,
     ) -> Result<Self, ApiError> {
-        let key = key.as_ref();
+        let key = key.into();
         if key.is_empty() || key.len() > MAX_RESOURCE_KEY_BYTES {
             return Err(ApiError::InternalServerError(
                 "ETag resource key is outside its bounded size".to_string(),
@@ -131,7 +187,7 @@ impl EntityTag {
         }
         Ok(Self {
             kind,
-            key: key.to_vec(),
+            key,
             revision,
         })
     }
@@ -184,6 +240,8 @@ impl EntityTag {
         let key = URL_SAFE_NO_PAD
             .decode(encoded_key)
             .map_err(|_| invalid_if_match("validator resource key is malformed"))?;
+        let key = String::from_utf8(key)
+            .map_err(|_| invalid_if_match("validator resource key is malformed"))?;
         if key.is_empty() || key.len() > MAX_RESOURCE_KEY_BYTES {
             return Err(invalid_if_match(
                 "validator resource key is outside its bounded size",
@@ -205,11 +263,8 @@ impl EntityTag {
         self.kind == other.kind && self.key == other.key
     }
 
-    fn revision_owner_key(&self) -> Result<String, ApiError> {
-        let key = std::str::from_utf8(&self.key).map_err(|_| {
-            ApiError::InternalServerError("ETag resource key is not valid UTF-8".to_string())
-        })?;
-        Ok(format!("{}:{key}", self.kind.revision_owner_table()))
+    fn revision_owner_key(&self) -> String {
+        self.kind.revision_owner().key(&self.key)
     }
 }
 
@@ -219,7 +274,7 @@ impl fmt::Display for EntityTag {
             formatter,
             "\"{ETAG_PREFIX}.{}.{}.{}\"",
             self.kind.as_str(),
-            URL_SAFE_NO_PAD.encode(&self.key),
+            URL_SAFE_NO_PAD.encode(self.key.as_bytes()),
             self.revision
         )
     }
@@ -332,7 +387,7 @@ impl IfMatchCondition {
             }
         };
         Ok(Some(RevisionPrecondition {
-            owner_key: current.revision_owner_key()?,
+            owner_key: current.revision_owner_key(),
             revisions,
         }))
     }
@@ -340,6 +395,29 @@ impl IfMatchCondition {
 
 pub trait RevisionedResource {
     fn entity_tag(&self) -> Result<EntityTag, ApiError>;
+}
+
+/// Build the database-owned conditional mutation assertion for `resource`.
+///
+/// Keeping request parsing and resource compatibility checks together avoids
+/// subtly different `If-Match` handling across mutation handlers.
+pub fn revision_precondition<R>(
+    request: &HttpRequest,
+    resource: &R,
+) -> Result<Option<RevisionPrecondition>, ApiError>
+where
+    R: RevisionedResource,
+{
+    revision_precondition_for_tag(request, &resource.entity_tag()?)
+}
+
+/// Build a precondition from an already materialized tag. Delete handlers use
+/// this form when the same tag is also returned with the successful response.
+pub fn revision_precondition_for_tag(
+    request: &HttpRequest,
+    current: &EntityTag,
+) -> Result<Option<RevisionPrecondition>, ApiError> {
+    IfMatchCondition::from_request(request)?.database_precondition(current)
 }
 
 fn invalid_if_match(detail: &str) -> ApiError {
@@ -509,7 +587,12 @@ mod tests {
 
     #[test]
     fn weak_malformed_and_mixed_wildcards_are_rejected() {
-        for value in ["W/\"hubuum-v1.collection.NDI.1\"", "* , \"x\"", "plain"] {
+        for value in [
+            "W/\"hubuum-v1.collection.NDI.1\"",
+            "* , \"x\"",
+            "plain",
+            "\"hubuum-v1.collection._w.1\"",
+        ] {
             let request = TestRequest::default()
                 .insert_header((header::IF_MATCH, value))
                 .to_http_request();

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -6,7 +6,7 @@ use actix_web::{
 
 use tracing::{debug, info};
 
-use crate::api::etag::{IfMatchCondition, RevisionedResource};
+use crate::api::etag::{RevisionedResource, revision_precondition, revision_precondition_for_tag};
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
@@ -535,8 +535,7 @@ async fn apply_resolved_class_update(
         );
     }
 
-    let precondition = IfMatchCondition::from_request(req)?
-        .database_precondition(&target.class().entity_tag()?)?;
+    let precondition = revision_precondition(req, target.class())?;
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,
@@ -637,7 +636,7 @@ async fn delete_resolved_class(
     );
 
     let etag = target.class().entity_tag()?;
-    let precondition = IfMatchCondition::from_request(req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition_for_tag(req, &etag)?;
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,

--- a/src/api/v1/handlers/classes/class_objects.rs
+++ b/src/api/v1/handlers/classes/class_objects.rs
@@ -416,8 +416,7 @@ async fn apply_resolved_object_update(
     );
     ensure_object_update_stays_in_path_class(&update, target.object())?;
 
-    let precondition = IfMatchCondition::from_request(req)?
-        .database_precondition(&target.object().entity_tag()?)?;
+    let precondition = revision_precondition(req, target.object())?;
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,
@@ -530,8 +529,7 @@ async fn apply_object_data_patch(
     // The resource validator is evaluated by the database before any RFC 6902
     // operation, so a stale request is a 412 even when a later `test` would
     // otherwise fail with 409.
-    let precondition = IfMatchCondition::from_request(req)?
-        .database_precondition(&target.object().entity_tag()?)?;
+    let precondition = revision_precondition(req, target.object())?;
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,
@@ -665,7 +663,7 @@ async fn delete_resolved_object(
     );
 
     let etag = target.object().entity_tag()?;
-    let precondition = IfMatchCondition::from_request(req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition_for_tag(req, &etag)?;
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,

--- a/src/api/v1/handlers/classes/class_related.rs
+++ b/src/api/v1/handlers/classes/class_related.rs
@@ -233,7 +233,7 @@ async fn delete_class_relation(
         || relation.to_hubuum_class_id == class_id.id()
     {
         let etag = relation.entity_tag()?;
-        let precondition = IfMatchCondition::from_request(&req)?.database_precondition(&etag)?;
+        let precondition = revision_precondition_for_tag(&req, &etag)?;
         let event_context = requestor.event_context(&req);
         with_revision_precondition_scope(precondition, relation.delete(&pool, &event_context))
             .await?;

--- a/src/api/v1/handlers/classes/object_related.rs
+++ b/src/api/v1/handlers/classes/object_related.rs
@@ -524,7 +524,7 @@ async fn delete_object_relation(
     );
 
     let etag = relation.entity_tag()?;
-    let precondition = IfMatchCondition::from_request(&req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(precondition, relation.delete(&pool, &event_context)).await?;
     Ok(ApiResponse::no_content_with_etag(etag))

--- a/src/api/v1/handlers/collections.rs
+++ b/src/api/v1/handlers/collections.rs
@@ -1,4 +1,4 @@
-use crate::api::etag::{IfMatchCondition, RevisionedResource};
+use crate::api::etag::{RevisionedResource, revision_precondition, revision_precondition_for_tag};
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
@@ -49,8 +49,7 @@ fn collection_precondition(
     request: &HttpRequest,
     resource: &impl RevisionedResource,
 ) -> Result<Option<crate::api::etag::RevisionPrecondition>, ApiError> {
-    let current = resource.entity_tag()?;
-    IfMatchCondition::from_request(request)?.database_precondition(&current)
+    revision_precondition(request, resource)
 }
 
 #[utoipa::path(
@@ -288,7 +287,7 @@ pub async fn delete_collection(
     );
 
     let etag = collection.entity_tag()?;
-    let precondition = IfMatchCondition::from_request(&req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(precondition, collection.delete(&pool, &event_context))
         .await?;

--- a/src/api/v1/handlers/computed_fields.rs
+++ b/src/api/v1/handlers/computed_fields.rs
@@ -1,6 +1,6 @@
 use actix_web::{HttpRequest, Responder, delete, get, http::StatusCode, patch, post, web};
 
-use crate::api::etag::{IfMatchCondition, RevisionedResource};
+use crate::api::etag::{RevisionedResource, revision_precondition};
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
 use crate::can;
@@ -39,9 +39,7 @@ fn computed_field_precondition(
     request: &HttpRequest,
     definition: &ComputedFieldDefinition,
 ) -> Result<Option<crate::api::etag::RevisionPrecondition>, ApiError> {
-    let condition = IfMatchCondition::from_request(request)?;
-    let current = definition.entity_tag()?;
-    condition.database_precondition(&current)
+    revision_precondition(request, definition)
 }
 
 #[utoipa::path(

--- a/src/api/v1/handlers/event_sinks.rs
+++ b/src/api/v1/handlers/event_sinks.rs
@@ -1,6 +1,6 @@
 use actix_web::{HttpRequest, Responder, delete, get, patch, routes, web};
 
-use crate::api::etag::{IfMatchCondition, RevisionedResource};
+use crate::api::etag::{RevisionedResource, revision_precondition, revision_precondition_for_tag};
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::{ApiResponse, ResponseLocation};
 use crate::db::traits::event_subscription::{
@@ -127,8 +127,7 @@ pub async fn patch_event_sink(
         ));
     }
     let existing = sink_id.instance(&pool).await?;
-    let precondition =
-        IfMatchCondition::from_request(&req)?.database_precondition(&existing.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &existing)?;
     let event_context = admin.event_context(&req);
     let updated: EventSink = with_revision_precondition_scope(
         precondition,
@@ -164,7 +163,7 @@ pub async fn delete_event_sink(
     let sink_id = sink_id.into_inner();
     let existing = sink_id.instance(&pool).await?;
     let etag = existing.entity_tag()?;
-    let precondition = IfMatchCondition::from_request(&req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = admin.event_context(&req);
     with_revision_precondition_scope(
         precondition,

--- a/src/api/v1/handlers/event_subscriptions.rs
+++ b/src/api/v1/handlers/event_subscriptions.rs
@@ -1,6 +1,6 @@
 use actix_web::{HttpRequest, Responder, delete, get, patch, routes, web};
 
-use crate::api::etag::{IfMatchCondition, RevisionedResource};
+use crate::api::etag::{RevisionedResource, revision_precondition, revision_precondition_for_tag};
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::{ApiResponse, ResponseLocation};
 use crate::can;
@@ -186,8 +186,7 @@ pub async fn patch_event_subscription(
     }
     let existing = subscription_id.instance(&pool).await?;
     ensure_subscription_collection(&existing, collection_id)?;
-    let precondition =
-        IfMatchCondition::from_request(&req)?.database_precondition(&existing.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &existing)?;
     let event_context = requestor.event_context(&req);
     let updated: EventSubscription = with_revision_precondition_scope(
         precondition,
@@ -234,7 +233,7 @@ pub async fn delete_event_subscription(
     let existing = subscription_id.instance(&pool).await?;
     ensure_subscription_collection(&existing, collection_id)?;
     let etag = existing.entity_tag()?;
-    let precondition = IfMatchCondition::from_request(&req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(
         precondition,

--- a/src/api/v1/handlers/export_templates.rs
+++ b/src/api/v1/handlers/export_templates.rs
@@ -1,7 +1,7 @@
 use actix_web::{HttpRequest, Responder, delete, get, http::StatusCode, patch, post, routes, web};
 use tracing::{debug, info};
 
-use crate::api::etag::{IfMatchCondition, RevisionedResource};
+use crate::api::etag::{RevisionedResource, revision_precondition, revision_precondition_for_tag};
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
@@ -340,8 +340,7 @@ pub async fn patch_template(
         );
     }
 
-    let precondition =
-        IfMatchCondition::from_request(&req)?.database_precondition(&existing.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &existing)?;
     let event_context = requestor.event_context(&req);
     let updated = with_revision_precondition_scope(
         precondition,
@@ -394,7 +393,7 @@ pub async fn delete_template(
     );
 
     let etag = template.entity_tag()?;
-    let precondition = IfMatchCondition::from_request(&req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(precondition, template_id.delete(&pool, &event_context))
         .await?;

--- a/src/api/v1/handlers/groups.rs
+++ b/src/api/v1/handlers/groups.rs
@@ -1,4 +1,6 @@
-use crate::api::etag::{IfMatchCondition, RevisionedResource};
+use crate::api::etag::{
+    IfMatchCondition, RevisionedResource, revision_precondition, revision_precondition_for_tag,
+};
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
@@ -168,8 +170,7 @@ pub async fn update_group(
     );
 
     let current = group_id.group(&pool).await?;
-    let precondition =
-        IfMatchCondition::from_request(&req)?.database_precondition(&current.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let updated = with_revision_precondition_scope(
         precondition,
@@ -212,7 +213,7 @@ pub async fn delete_group(
 
     let group = group_id.group(&pool).await?;
     let etag = group.entity_tag()?;
-    let precondition = IfMatchCondition::from_request(&req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(precondition, group_id.delete(&pool, Some(&event_context)))
         .await?;
@@ -393,8 +394,7 @@ pub async fn delete_group_member(
 
     let membership =
         crate::db::traits::group::principal_group_by_ids(&pool, principal.id, group.id).await?;
-    let etag = membership.entity_tag()?;
-    let precondition = IfMatchCondition::from_request(&req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition(&req, &membership)?;
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(
         precondition,

--- a/src/api/v1/handlers/me.rs
+++ b/src/api/v1/handlers/me.rs
@@ -2,7 +2,7 @@ use actix_web::{HttpRequest, Responder, delete, get, http::StatusCode, patch, pu
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::api::etag::{IfMatchCondition, RevisionedResource};
+use crate::api::etag::{RevisionedResource, revision_precondition};
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
 use crate::api::v1::handlers::principals::{
@@ -202,8 +202,7 @@ pub async fn put_my_settings(
 ) -> Result<impl Responder, ApiError> {
     let principal_id = PrincipalID::new(requestor.principal.id)?;
     let current = principal_id.settings(&pool).await?;
-    let condition = IfMatchCondition::from_request(&req)?;
-    let precondition = condition.database_precondition(&current.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let settings = with_revision_precondition_scope(
         precondition,
@@ -242,8 +241,7 @@ pub async fn patch_my_settings(
 ) -> Result<impl Responder, ApiError> {
     let principal_id = PrincipalID::new(requestor.principal.id)?;
     let current = principal_id.settings(&pool).await?;
-    let condition = IfMatchCondition::from_request(&req)?;
-    let precondition = condition.database_precondition(&current.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let settings = with_revision_precondition_scope(
         precondition,
@@ -271,8 +269,7 @@ pub async fn delete_my_settings(
 ) -> Result<impl Responder, ApiError> {
     let principal_id = PrincipalID::new(requestor.principal.id)?;
     let current = principal_id.settings(&pool).await?;
-    let condition = IfMatchCondition::from_request(&req)?;
-    let precondition = condition.database_precondition(&current.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let reset = with_revision_precondition_scope(
         precondition,

--- a/src/api/v1/handlers/principals.rs
+++ b/src/api/v1/handlers/principals.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 use utoipa::ToSchema;
 
-use crate::api::etag::{IfMatchCondition, RevisionedResource};
+use crate::api::etag::{RevisionedResource, revision_precondition};
 use crate::api::openapi::{ApiErrorResponse, LoginResponse};
 use crate::api::response::ApiResponse;
 use crate::db::traits::active_tokens::retained_token_metadata_by_principal_id_paginated_with_total_count;
@@ -393,8 +393,7 @@ pub async fn revoke_token(
         PrincipalTokenMetadata::load_for_principal_token(&pool, path.principal_id, path.token_id)
             .await?;
     let current = PrincipalTokenPointResponse::from(current);
-    let precondition =
-        IfMatchCondition::from_request(&req)?.database_precondition(&current.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &current)?;
 
     let event_context = requestor.event_context(&req);
     let revoked = with_revision_precondition_scope(
@@ -543,8 +542,7 @@ pub async fn put_principal_settings(
     let principal_id = principal_id.into_inner();
     ensure_can_manage_principal_settings(&pool, &requestor, principal_id.id()).await?;
     let current = principal_id.settings(&pool).await?;
-    let condition = IfMatchCondition::from_request(&req)?;
-    let precondition = condition.database_precondition(&current.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let settings = with_revision_precondition_scope(
         precondition,
@@ -587,8 +585,7 @@ pub async fn patch_principal_settings(
     let principal_id = principal_id.into_inner();
     ensure_can_manage_principal_settings(&pool, &requestor, principal_id.id()).await?;
     let current = principal_id.settings(&pool).await?;
-    let condition = IfMatchCondition::from_request(&req)?;
-    let precondition = condition.database_precondition(&current.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let settings = with_revision_precondition_scope(
         precondition,
@@ -620,8 +617,7 @@ pub async fn delete_principal_settings(
     let principal_id = principal_id.into_inner();
     ensure_can_manage_principal_settings(&pool, &requestor, principal_id.id()).await?;
     let current = principal_id.settings(&pool).await?;
-    let condition = IfMatchCondition::from_request(&req)?;
-    let precondition = condition.database_precondition(&current.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let reset = with_revision_precondition_scope(
         precondition,

--- a/src/api/v1/handlers/relations.rs
+++ b/src/api/v1/handlers/relations.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::api::etag::{IfMatchCondition, RevisionedResource};
+use crate::api::etag::{RevisionedResource, revision_precondition_for_tag};
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
 use crate::db::traits::authz::scope_allows;
@@ -243,7 +243,7 @@ async fn delete_class_relation(
     .await?;
 
     let etag = relation.entity_tag()?;
-    let precondition = IfMatchCondition::from_request(&req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(precondition, relation_id.delete(&pool, &event_context))
         .await?;
@@ -467,7 +467,7 @@ async fn delete_object_relation(
     .await?;
 
     let etag = relation.entity_tag()?;
-    let precondition = IfMatchCondition::from_request(&req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(precondition, relation_id.delete(&pool, &event_context))
         .await?;

--- a/src/api/v1/handlers/remote_targets.rs
+++ b/src/api/v1/handlers/remote_targets.rs
@@ -2,7 +2,7 @@ use actix_web::{HttpRequest, Responder, delete, get, http::StatusCode, patch, po
 use hubuum_task_core::IdempotencyKey;
 use tracing::{debug, info};
 
-use crate::api::etag::{IfMatchCondition, RevisionedResource};
+use crate::api::etag::{RevisionedResource, revision_precondition, revision_precondition_for_tag};
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
@@ -229,8 +229,7 @@ pub async fn patch_remote_target(
     };
     validate_remote_target_class_scope(&pool, effective_collection_id, effective_class_id).await?;
 
-    let precondition =
-        IfMatchCondition::from_request(&req)?.database_precondition(&existing.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &existing)?;
     let row = update.into_row(&existing)?;
     let event_context = requestor.event_context(&req);
     let updated: RemoteTarget = with_revision_precondition_scope(
@@ -285,7 +284,7 @@ pub async fn delete_remote_target(
         CollectionID::new(existing.collection_id)?
     );
     let etag = existing.entity_tag()?;
-    let precondition = IfMatchCondition::from_request(&req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(
         precondition,

--- a/src/api/v1/handlers/service_accounts.rs
+++ b/src/api/v1/handlers/service_accounts.rs
@@ -1,7 +1,7 @@
 use actix_web::{HttpRequest, Responder, delete, get, patch, post, routes, web};
 use tracing::debug;
 
-use crate::api::etag::{IfMatchCondition, RevisionedResource};
+use crate::api::etag::{RevisionedResource, revision_precondition, revision_precondition_for_tag};
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
@@ -212,8 +212,7 @@ pub async fn update_service_account(
     }
 
     let current = sa.to_point_response(&pool).await?;
-    let precondition =
-        IfMatchCondition::from_request(&req)?.database_precondition(&current.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let updated =
         with_revision_precondition_scope(precondition, update.update(&pool, id, &event_context))
@@ -246,8 +245,7 @@ pub async fn disable_service_account(
     ensure_can_manage(&pool, &requestor, &sa).await?;
 
     let current = sa.to_point_response(&pool).await?;
-    let precondition =
-        IfMatchCondition::from_request(&req)?.database_precondition(&current.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let disabled =
         with_revision_precondition_scope(precondition, id.disable(&pool, &event_context)).await?;
@@ -286,7 +284,7 @@ pub async fn delete_service_account(
     ensure_can_manage(&pool, &requestor, &sa).await?;
     let current = sa.to_point_response(&pool).await?;
     let etag = current.entity_tag()?;
-    let precondition = IfMatchCondition::from_request(&req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(precondition, id.delete(&pool, &event_context)).await?;
     Ok(ApiResponse::no_content_with_etag(etag))

--- a/src/api/v1/handlers/users.rs
+++ b/src/api/v1/handlers/users.rs
@@ -1,4 +1,4 @@
-use crate::api::etag::{IfMatchCondition, RevisionedResource};
+use crate::api::etag::{RevisionedResource, revision_precondition, revision_precondition_for_tag};
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
@@ -161,8 +161,7 @@ pub async fn update_user(
     );
 
     let current = user_id.user(&pool).await?.to_point_response(&pool).await?;
-    let precondition =
-        IfMatchCondition::from_request(&req)?.database_precondition(&current.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let user = with_revision_precondition_scope(
         precondition,
@@ -205,7 +204,7 @@ pub async fn delete_user(
     let user_id = user_id.into_inner();
     let current = user_id.user(&pool).await?.to_point_response(&pool).await?;
     let etag = current.entity_tag()?;
-    let precondition = IfMatchCondition::from_request(&req)?.database_precondition(&etag)?;
+    let precondition = revision_precondition_for_tag(&req, &etag)?;
 
     let event_context = requestor.event_context(&req);
     let delete_result =
@@ -246,8 +245,7 @@ pub async fn anonymize_user(
         requestor = requestor.user.id
     );
     let current = user_id.user(&pool).await?.to_point_response(&pool).await?;
-    let precondition =
-        IfMatchCondition::from_request(&req)?.database_precondition(&current.entity_tag()?)?;
+    let precondition = revision_precondition(&req, &current)?;
     with_revision_precondition_scope(precondition, user_id.anonymize(&pool)).await?;
     let updated = user_id.user(&pool).await?.to_point_response(&pool).await?;
     Ok(ApiResponse::no_content_with_etag(updated.entity_tag()?))

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -512,8 +512,9 @@ pub(crate) async fn assert_locked_revision_precondition(
 
 /// Reject a conditional mutation when the authoritative row disappeared
 /// before it could be locked. `If-Match` (including `*`) requires the selected
-/// resource to still exist; an unconditional mutation may create it.
-pub(crate) fn assert_revision_precondition_allows_insert(
+/// resource to still exist; unconditional callers retain their ordinary
+/// missing-target behavior.
+pub(crate) fn assert_revision_precondition_allows_missing_target(
     owner_key: &str,
 ) -> Result<(), crate::errors::ApiError> {
     if ambient_revision_precondition()
@@ -526,6 +527,23 @@ pub(crate) fn assert_revision_precondition_allows_insert(
         ));
     }
     Ok(())
+}
+
+/// Require an authoritative row that was resolved before entering the
+/// mutation transaction. If a matching conditional request lost the row
+/// before it could be locked, report a stale resource instead of an ordinary
+/// not-found response.
+pub(crate) fn require_existing_revision_target<T>(
+    target: Option<T>,
+    owner_key: &str,
+) -> Result<T, crate::errors::ApiError> {
+    match target {
+        Some(target) => Ok(target),
+        None => {
+            assert_revision_precondition_allows_missing_target(owner_key)?;
+            Err(diesel::result::Error::NotFound.into())
+        }
+    }
 }
 
 /// Apply transaction-local provenance settings consumed by history triggers.

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -599,6 +599,45 @@ async fn set_local_statement_timeout(
     Ok(())
 }
 
+struct TransactionLocalContext {
+    statement_timeout: Option<StatementTimeoutMs>,
+    provenance: Option<MutationProvenance>,
+    revision_precondition: Option<RevisionPrecondition>,
+}
+
+impl TransactionLocalContext {
+    fn ambient() -> Self {
+        Self::with_statement_timeout(ambient_statement_timeout())
+    }
+
+    fn with_statement_timeout(statement_timeout: Option<StatementTimeoutMs>) -> Self {
+        Self {
+            statement_timeout,
+            provenance: ambient_mutation_provenance(),
+            revision_precondition: ambient_revision_precondition(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.statement_timeout.is_none()
+            && self.provenance.is_none()
+            && self.revision_precondition.is_none()
+    }
+
+    async fn apply(&self, conn: &mut DbConnection) -> Result<(), diesel::result::Error> {
+        if let Some(statement_timeout) = self.statement_timeout {
+            set_local_statement_timeout(conn, statement_timeout).await?;
+        }
+        if let Some(provenance) = &self.provenance {
+            set_local_mutation_provenance(conn, provenance).await?;
+        }
+        if let Some(precondition) = &self.revision_precondition {
+            set_local_revision_precondition(conn, precondition).await?;
+        }
+        Ok(())
+    }
+}
+
 /// Run database work on a single pooled connection without starting an explicit transaction.
 ///
 /// Use this for:
@@ -640,17 +679,12 @@ where
     E: Send,
     ApiError: From<E>,
 {
-    let statement_timeout = ambient_statement_timeout();
-    let provenance = ambient_mutation_provenance();
-    let precondition = ambient_revision_precondition();
-    with_connection_context(&pool, statement_timeout, provenance, precondition, f).await
+    with_connection_context(&pool, TransactionLocalContext::ambient(), f).await
 }
 
 async fn with_connection_context<F, R, E>(
     pool: &DbPool,
-    statement_timeout: Option<StatementTimeoutMs>,
-    provenance: Option<MutationProvenance>,
-    precondition: Option<RevisionPrecondition>,
+    context: TransactionLocalContext,
     f: F,
 ) -> Result<R, ApiError>
 where
@@ -664,19 +698,11 @@ where
     let call_site = ambient_db_call_site();
     let mut conn = acquire_connection(pool).await?;
     let start = std::time::Instant::now();
-    let result = if statement_timeout.is_none() && provenance.is_none() && precondition.is_none() {
+    let result = if context.is_empty() {
         f(&mut conn).await.map_err(ApiError::from)
     } else {
         conn.transaction::<R, ApiError, _>(async move |conn| {
-            if let Some(statement_timeout) = statement_timeout {
-                set_local_statement_timeout(conn, statement_timeout).await?;
-            }
-            if let Some(provenance) = provenance {
-                set_local_mutation_provenance(conn, &provenance).await?;
-            }
-            if let Some(precondition) = precondition {
-                set_local_revision_precondition(conn, &precondition).await?;
-            }
+            context.apply(conn).await?;
             f(conn).await.map_err(ApiError::from)
         })
         .await
@@ -748,9 +774,7 @@ where
 {
     with_connection_context(
         pool,
-        statement_timeout,
-        ambient_mutation_provenance(),
-        ambient_revision_precondition(),
+        TransactionLocalContext::with_statement_timeout(statement_timeout),
         f,
     )
     .await
@@ -784,23 +808,13 @@ where
     E: Send,
     ApiError: From<E>,
 {
-    let statement_timeout = ambient_statement_timeout();
-    let provenance = ambient_mutation_provenance();
-    let precondition = ambient_revision_precondition();
+    let context = TransactionLocalContext::ambient();
     let call_site = ambient_db_call_site();
     let mut conn = acquire_connection(pool).await?;
     let start = std::time::Instant::now();
     let result = crate::logger::defer_operation_mutation_logs_until_commit(
         conn.transaction::<R, ApiError, _>(async move |conn| {
-            if let Some(statement_timeout) = statement_timeout {
-                set_local_statement_timeout(conn, statement_timeout).await?;
-            }
-            if let Some(provenance) = provenance {
-                set_local_mutation_provenance(conn, &provenance).await?;
-            }
-            if let Some(precondition) = precondition {
-                set_local_revision_precondition(conn, &precondition).await?;
-            }
+            context.apply(conn).await?;
             f(conn).await.map_err(ApiError::from)
         }),
     )

--- a/src/db/traits/class.rs
+++ b/src/db/traits/class.rs
@@ -1,5 +1,6 @@
 use crate::db::prelude::*;
 
+use crate::api::etag::RevisionOwner;
 use crate::db::traits::GetClass;
 use crate::db::{DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
@@ -371,7 +372,7 @@ pub(crate) async fn lock_resolved_class_target(
             .await
             .optional()?,
     };
-    let owner_key = format!("hubuumclass:{}", resolved.id);
+    let owner_key = RevisionOwner::Class.key(resolved.id);
     let locked = crate::db::require_existing_revision_target(locked, &owner_key)?;
     crate::db::assert_locked_revision_precondition(conn, &owner_key, locked.revision).await?;
     Ok(locked)

--- a/src/db/traits/class.rs
+++ b/src/db/traits/class.rs
@@ -353,32 +353,27 @@ pub(crate) async fn lock_resolved_class_target(
 
     let resolved = target.class();
     let locked = match target.selector().kind() {
-        ClassSelectorKind::ById(class_id) => {
-            hubuumclass
-                .filter(id.eq(class_id.id()))
-                .filter(id.eq(resolved.id))
-                .filter(name.eq(&resolved.name))
-                .filter(collection_id.eq(resolved.collection_id))
-                .for_update()
-                .first::<HubuumClass>(conn)
-                .await?
-        }
-        ClassSelectorKind::ByName(class_name) => {
-            hubuumclass
-                .filter(id.eq(resolved.id))
-                .filter(name.eq(class_name))
-                .filter(collection_id.eq(resolved.collection_id))
-                .for_update()
-                .first::<HubuumClass>(conn)
-                .await?
-        }
+        ClassSelectorKind::ById(class_id) => hubuumclass
+            .filter(id.eq(class_id.id()))
+            .filter(id.eq(resolved.id))
+            .filter(name.eq(&resolved.name))
+            .filter(collection_id.eq(resolved.collection_id))
+            .for_update()
+            .first::<HubuumClass>(conn)
+            .await
+            .optional()?,
+        ClassSelectorKind::ByName(class_name) => hubuumclass
+            .filter(id.eq(resolved.id))
+            .filter(name.eq(class_name))
+            .filter(collection_id.eq(resolved.collection_id))
+            .for_update()
+            .first::<HubuumClass>(conn)
+            .await
+            .optional()?,
     };
-    crate::db::assert_locked_revision_precondition(
-        conn,
-        &format!("hubuumclass:{}", locked.id),
-        locked.revision,
-    )
-    .await?;
+    let owner_key = format!("hubuumclass:{}", resolved.id);
+    let locked = crate::db::require_existing_revision_target(locked, &owner_key)?;
+    crate::db::assert_locked_revision_precondition(conn, &owner_key, locked.revision).await?;
     Ok(locked)
 }
 

--- a/src/db/traits/collection/permissions.rs
+++ b/src/db/traits/collection/permissions.rs
@@ -484,12 +484,12 @@ pub async fn groups_can_on_paginated_with_total_count_from_backend(
         ancestor_collection_id, collection_closure, descendant_collection_id,
     };
     use crate::schema::groups::dsl::{
-        created_at, description, groupname, groups, id as group_table_id, updated_at,
+        created_at, description, groupname, groups, id as group_table_id, revision, updated_at,
     };
     use crate::schema::permissions::dsl::{
         collection_id as permission_collection_id, group_id, permissions,
     };
-    use crate::{date_search, numeric_search, string_search};
+    use crate::{date_search, numeric_search, revision_search, string_search};
 
     let build_query = || -> Result<_, ApiError> {
         let base_query = permissions.into_boxed();
@@ -520,6 +520,7 @@ pub async fn groups_can_on_paginated_with_total_count_from_backend(
                 FilterField::Description => string_search!(query, param, operator, description),
                 FilterField::CreatedAt => date_search!(query, param, operator, created_at),
                 FilterField::UpdatedAt => date_search!(query, param, operator, updated_at),
+                FilterField::Revision => revision_search!(query, param, operator, revision),
                 _ => {
                     return Err(ApiError::BadRequest(format!(
                         "Field '{}' isn't searchable (or does not exist) for groups",

--- a/src/db/traits/collection/records.rs
+++ b/src/db/traits/collection/records.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::api::etag::RevisionOwner;
 use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
 use chrono::NaiveDateTime;
 use diesel_async::RunQueryDsl;
@@ -80,13 +81,13 @@ async fn validate_collection_can_be_deleted(
     Ok(())
 }
 
-async fn lock_collection_for_delete(
+async fn lock_and_validate_collection_for_delete(
     conn: &mut crate::db::DbConnection,
     collection_id: i32,
 ) -> Result<Collection, ApiError> {
     use crate::schema::collections::dsl::{collections, id};
 
-    let owner_key = format!("collections:{collection_id}");
+    let owner_key = RevisionOwner::Collection.key(collection_id);
     let collection = collections
         .filter(id.eq(collection_id))
         .for_update()
@@ -281,6 +282,35 @@ fn collection_event(
     .with_collection_id(collection.id))
 }
 
+async fn delete_collection_by_id(
+    pool: &DbPool,
+    collection_id: i32,
+    context: Option<&EventContext>,
+) -> Result<(), ApiError> {
+    use crate::schema::collections::dsl::{collections, id};
+
+    with_transaction(pool, async |conn| -> Result<(), ApiError> {
+        let collection = lock_and_validate_collection_for_delete(conn, collection_id).await?;
+        diesel::delete(collections.filter(id.eq(collection.id)))
+            .execute(conn)
+            .await?;
+
+        if let Some(context) = context {
+            let event = collection_event(
+                &collection,
+                Action::Deleted,
+                context,
+                format!("Collection '{}' deleted", collection.name),
+            )?
+            .with_before(collection_snapshot(&collection));
+            emit_event(conn, &event).await?;
+        }
+
+        Ok(())
+    })
+    .await
+}
+
 pub trait DeleteCollectionRecord {
     async fn delete_collection_record_without_events(&self, pool: &DbPool) -> Result<(), ApiError>;
 
@@ -296,16 +326,7 @@ pub trait DeleteCollectionRecord {
 
 impl DeleteCollectionRecord for Collection {
     async fn delete_collection_record_without_events(&self, pool: &DbPool) -> Result<(), ApiError> {
-        use crate::schema::collections::dsl::{collections, id};
-
-        with_transaction(pool, async |conn| -> Result<_, ApiError> {
-            let collection = lock_collection_for_delete(conn, self.id).await?;
-            Ok(diesel::delete(collections.filter(id.eq(collection.id)))
-                .execute(conn)
-                .await?)
-        })
-        .await?;
-        Ok(())
+        delete_collection_by_id(pool, self.id, None).await
     }
 
     async fn delete_collection_record(
@@ -313,43 +334,13 @@ impl DeleteCollectionRecord for Collection {
         pool: &DbPool,
         context: Option<&EventContext>,
     ) -> Result<(), ApiError> {
-        let Some(context) = context else {
-            return self.delete_collection_record_without_events(pool).await;
-        };
-
-        use crate::schema::collections::dsl::{collections, id};
-
-        with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let before = lock_collection_for_delete(conn, self.id).await?;
-            diesel::delete(collections.filter(id.eq(before.id)))
-                .execute(conn)
-                .await?;
-            let event = collection_event(
-                &before,
-                Action::Deleted,
-                context,
-                format!("Collection '{}' deleted", before.name),
-            )?
-            .with_before(collection_snapshot(&before));
-            emit_event(conn, &event).await?;
-            Ok(())
-        })
-        .await
+        delete_collection_by_id(pool, self.id, context).await
     }
 }
 
 impl DeleteCollectionRecord for CollectionID {
     async fn delete_collection_record_without_events(&self, pool: &DbPool) -> Result<(), ApiError> {
-        use crate::schema::collections::dsl::{collections, id};
-
-        with_transaction(pool, async |conn| -> Result<_, ApiError> {
-            let collection = lock_collection_for_delete(conn, self.id()).await?;
-            Ok(diesel::delete(collections.filter(id.eq(collection.id)))
-                .execute(conn)
-                .await?)
-        })
-        .await?;
-        Ok(())
+        delete_collection_by_id(pool, self.id(), None).await
     }
 
     async fn delete_collection_record(
@@ -357,28 +348,7 @@ impl DeleteCollectionRecord for CollectionID {
         pool: &DbPool,
         context: Option<&EventContext>,
     ) -> Result<(), ApiError> {
-        let Some(context) = context else {
-            return self.delete_collection_record_without_events(pool).await;
-        };
-
-        use crate::schema::collections::dsl::{collections, id};
-
-        with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let collection = lock_collection_for_delete(conn, self.id()).await?;
-            diesel::delete(collections.filter(id.eq(collection.id)))
-                .execute(conn)
-                .await?;
-            let event = collection_event(
-                &collection,
-                Action::Deleted,
-                context,
-                format!("Collection '{}' deleted", collection.name),
-            )?
-            .with_before(collection_snapshot(&collection));
-            emit_event(conn, &event).await?;
-            Ok(())
-        })
-        .await
+        delete_collection_by_id(pool, self.id(), context).await
     }
 }
 
@@ -439,7 +409,7 @@ impl UpdateCollectionRecord for UpdateCollection {
         use crate::schema::collections::dsl::{collections, id};
 
         with_transaction(pool, async |conn| -> Result<Collection, ApiError> {
-            let owner_key = format!("collections:{collection_id}");
+            let owner_key = RevisionOwner::Collection.key(collection_id);
             let before = collections
                 .filter(id.eq(collection_id))
                 .for_update()

--- a/src/db/traits/collection/records.rs
+++ b/src/db/traits/collection/records.rs
@@ -80,6 +80,25 @@ async fn validate_collection_can_be_deleted(
     Ok(())
 }
 
+async fn lock_collection_for_delete(
+    conn: &mut crate::db::DbConnection,
+    collection_id: i32,
+) -> Result<Collection, ApiError> {
+    use crate::schema::collections::dsl::{collections, id};
+
+    let owner_key = format!("collections:{collection_id}");
+    let collection = collections
+        .filter(id.eq(collection_id))
+        .for_update()
+        .first::<Collection>(conn)
+        .await
+        .optional()?;
+    let collection = crate::db::require_existing_revision_target(collection, &owner_key)?;
+    crate::db::assert_locked_revision_precondition(conn, &owner_key, collection.revision).await?;
+    validate_collection_can_be_deleted(conn, collection.id).await?;
+    Ok(collection)
+}
+
 pub(crate) async fn insert_collection_closure_rows(
     conn: &mut crate::db::DbConnection,
     target_collection_id: i32,
@@ -279,9 +298,9 @@ impl DeleteCollectionRecord for Collection {
     async fn delete_collection_record_without_events(&self, pool: &DbPool) -> Result<(), ApiError> {
         use crate::schema::collections::dsl::{collections, id};
 
-        with_connection(pool, async |conn| -> Result<_, ApiError> {
-            validate_collection_can_be_deleted(conn, self.id).await?;
-            Ok(diesel::delete(collections.filter(id.eq(self.id)))
+        with_transaction(pool, async |conn| -> Result<_, ApiError> {
+            let collection = lock_collection_for_delete(conn, self.id).await?;
+            Ok(diesel::delete(collections.filter(id.eq(collection.id)))
                 .execute(conn)
                 .await?)
         })
@@ -301,13 +320,8 @@ impl DeleteCollectionRecord for Collection {
         use crate::schema::collections::dsl::{collections, id};
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let before = collections
-                .filter(id.eq(self.id))
-                .for_update()
-                .first::<Collection>(conn)
-                .await?;
-            validate_collection_can_be_deleted(conn, before.id).await?;
-            diesel::delete(collections.filter(id.eq(self.id)))
+            let before = lock_collection_for_delete(conn, self.id).await?;
+            diesel::delete(collections.filter(id.eq(before.id)))
                 .execute(conn)
                 .await?;
             let event = collection_event(
@@ -328,9 +342,9 @@ impl DeleteCollectionRecord for CollectionID {
     async fn delete_collection_record_without_events(&self, pool: &DbPool) -> Result<(), ApiError> {
         use crate::schema::collections::dsl::{collections, id};
 
-        with_connection(pool, async |conn| -> Result<_, ApiError> {
-            validate_collection_can_be_deleted(conn, self.id()).await?;
-            Ok(diesel::delete(collections.filter(id.eq(self.id())))
+        with_transaction(pool, async |conn| -> Result<_, ApiError> {
+            let collection = lock_collection_for_delete(conn, self.id()).await?;
+            Ok(diesel::delete(collections.filter(id.eq(collection.id)))
                 .execute(conn)
                 .await?)
         })
@@ -350,12 +364,7 @@ impl DeleteCollectionRecord for CollectionID {
         use crate::schema::collections::dsl::{collections, id};
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let collection = collections
-                .filter(id.eq(self.id()))
-                .for_update()
-                .first::<Collection>(conn)
-                .await?;
-            validate_collection_can_be_deleted(conn, collection.id).await?;
+            let collection = lock_collection_for_delete(conn, self.id()).await?;
             diesel::delete(collections.filter(id.eq(collection.id)))
                 .execute(conn)
                 .await?;
@@ -430,17 +439,16 @@ impl UpdateCollectionRecord for UpdateCollection {
         use crate::schema::collections::dsl::{collections, id};
 
         with_transaction(pool, async |conn| -> Result<Collection, ApiError> {
+            let owner_key = format!("collections:{collection_id}");
             let before = collections
                 .filter(id.eq(collection_id))
                 .for_update()
                 .first::<Collection>(conn)
+                .await
+                .optional()?;
+            let before = crate::db::require_existing_revision_target(before, &owner_key)?;
+            crate::db::assert_locked_revision_precondition(conn, &owner_key, before.revision)
                 .await?;
-            crate::db::assert_locked_revision_precondition(
-                conn,
-                &format!("collections:{}", before.id),
-                before.revision,
-            )
-            .await?;
             if !self.has_changes(&before) {
                 return Ok(before);
             }

--- a/src/db/traits/computed_field.rs
+++ b/src/db/traits/computed_field.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
+use crate::api::etag::RevisionOwner;
 use crate::db::prelude::*;
 use crate::db::traits::search::{JsonSqlPredicate, dynamic_sql_predicate};
 use crate::db::traits::task::{
@@ -529,7 +530,7 @@ pub async fn update_shared_definition(
         let current = locked_definition(conn, definition_id).await?;
         crate::db::assert_locked_revision_precondition(
             conn,
-            &format!("computed_field_definitions:{}", current.id),
+            &RevisionOwner::ComputedField.key(current.id),
             current.revision,
         )
         .await?;
@@ -654,7 +655,7 @@ pub async fn update_personal_definition(
         let current = locked_definition(conn, definition_id).await?;
         crate::db::assert_locked_revision_precondition(
             conn,
-            &format!("computed_field_definitions:{}", current.id),
+            &RevisionOwner::ComputedField.key(current.id),
             current.revision,
         )
         .await?;

--- a/src/db/traits/event_subscription.rs
+++ b/src/db/traits/event_subscription.rs
@@ -1,6 +1,7 @@
 use crate::db::prelude::*;
 use serde_json::json;
 
+use crate::api::etag::RevisionOwner;
 use crate::apply_query_options;
 use crate::db::{DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
@@ -116,7 +117,7 @@ async fn update_event_sink_record_impl(
             .await?;
         crate::db::assert_locked_revision_precondition(
             conn,
-            &format!("event_sinks:{}", before.id),
+            &RevisionOwner::EventSink.key(before.id),
             before.revision,
         )
         .await?;
@@ -299,7 +300,7 @@ async fn update_event_subscription_record_impl(
                 .await?;
             crate::db::assert_locked_revision_precondition(
                 conn,
-                &format!("event_subscriptions:{}", before.id),
+                &RevisionOwner::EventSubscription.key(before.id),
                 before.revision,
             )
             .await?;

--- a/src/db/traits/export_template.rs
+++ b/src/db/traits/export_template.rs
@@ -9,6 +9,7 @@
 
 use crate::db::prelude::*;
 
+use crate::api::etag::RevisionOwner;
 use crate::db::{DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
@@ -195,7 +196,7 @@ impl UpdateExportTemplateRecord for UpdateExportTemplateRow {
                 .await?;
             crate::db::assert_locked_revision_precondition(
                 conn,
-                &format!("export_templates:{}", before.id()),
+                &RevisionOwner::ExportTemplate.key(before.id()),
                 before.revision(),
             )
             .await?;

--- a/src/db/traits/group.rs
+++ b/src/db/traits/group.rs
@@ -81,7 +81,7 @@ async fn insert_effective_membership(
         return Ok((membership, false));
     }
 
-    crate::db::assert_revision_precondition_allows_insert(&owner_key)?;
+    crate::db::assert_revision_precondition_allows_missing_target(&owner_key)?;
 
     let inserted = diesel::insert_into(group_memberships)
         .values((
@@ -140,10 +140,24 @@ async fn remove_manual_membership_source(
     conn: &mut DbConnection,
     principal: i32,
     group: i32,
-) -> Result<bool, ApiError> {
+) -> Result<(Option<PrincipalGroup>, bool), ApiError> {
     use crate::schema::{group_membership_sources, group_memberships};
 
     ensure_group_allows_local_write(conn, group).await?;
+    let owner_key = format!("group_memberships:{principal}:{group}");
+    let membership = group_memberships::table
+        .filter(group_memberships::principal_id.eq(principal))
+        .filter(group_memberships::group_id.eq(group))
+        .for_update()
+        .first::<PrincipalGroup>(conn)
+        .await
+        .optional()?;
+    let Some(membership) = membership else {
+        crate::db::assert_revision_precondition_allows_missing_target(&owner_key)?;
+        return Ok((None, false));
+    };
+    crate::db::assert_locked_revision_precondition(conn, &owner_key, membership.revision).await?;
+
     let local_scope_id = identity_scope_id_by_name_conn(conn, LOCAL_IDENTITY_SCOPE).await?;
     diesel::delete(
         group_membership_sources::table
@@ -170,9 +184,9 @@ async fn remove_manual_membership_source(
         )
         .execute(conn)
         .await?;
-        return Ok(deleted > 0);
+        return Ok((Some(membership), deleted > 0));
     }
-    Ok(false)
+    Ok((Some(membership), false))
 }
 
 async fn ensure_group_allows_local_write(
@@ -745,10 +759,7 @@ impl GroupMembersBackend for Group {
         };
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let membership = load_principal_group(conn, member_principal_id, self.id)
-                .await
-                .optional()?;
-            let removed_effective =
+            let (membership, removed_effective) =
                 remove_manual_membership_source(conn, member_principal_id, self.id).await?;
 
             if let Some(membership) = membership.filter(|_| removed_effective) {

--- a/src/db/traits/group.rs
+++ b/src/db/traits/group.rs
@@ -1,5 +1,6 @@
 use crate::db::prelude::*;
 
+use crate::api::etag::RevisionOwner;
 use crate::db::traits::identity::{identity_scope_by_name, identity_scope_id_by_name_conn};
 use crate::db::{DbConnection, DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
@@ -64,10 +65,10 @@ async fn insert_effective_membership(
     conn: &mut DbConnection,
     principal: i32,
     group: i32,
-) -> Result<(PrincipalGroup, bool), ApiError> {
+) -> Result<bool, ApiError> {
     use crate::schema::group_memberships::dsl::{group_id, group_memberships, principal_id};
 
-    let owner_key = format!("group_memberships:{principal}:{group}");
+    let owner_key = RevisionOwner::membership_key(principal, group);
     let current = group_memberships
         .filter(principal_id.eq(principal))
         .filter(group_id.eq(group))
@@ -78,7 +79,7 @@ async fn insert_effective_membership(
     if let Some(membership) = current {
         crate::db::assert_locked_revision_precondition(conn, &owner_key, membership.revision)
             .await?;
-        return Ok((membership, false));
+        return Ok(false);
     }
 
     crate::db::assert_revision_precondition_allows_missing_target(&owner_key)?;
@@ -89,13 +90,21 @@ async fn insert_effective_membership(
             crate::schema::group_memberships::group_id.eq(group),
         ))
         .on_conflict_do_nothing()
-        .get_result(conn)
+        .get_result::<PrincipalGroup>(conn)
         .await
         .optional()?;
     match inserted {
-        Some(membership) => Ok((membership, true)),
-        None => Ok((load_principal_group(conn, principal, group).await?, false)),
+        Some(_) => Ok(true),
+        None => {
+            load_principal_group(conn, principal, group).await?;
+            Ok(false)
+        }
     }
+}
+
+struct ManualMembershipInsert {
+    membership: PrincipalGroup,
+    effective_membership_created: bool,
 }
 
 async fn insert_manual_membership_source(
@@ -125,26 +134,26 @@ async fn insert_manual_membership(
     conn: &mut DbConnection,
     principal: i32,
     group: i32,
-) -> Result<(PrincipalGroup, bool), ApiError> {
-    let (_, inserted) = insert_effective_membership(conn, principal, group).await?;
+) -> Result<ManualMembershipInsert, ApiError> {
+    let effective_membership_created = insert_effective_membership(conn, principal, group).await?;
     insert_manual_membership_source(conn, principal, group).await?;
     // The source row owns the effective membership revision and may have
     // advanced it. Always return the final committed representation.
-    Ok((
-        load_principal_group(conn, principal, group).await?,
-        inserted,
-    ))
+    Ok(ManualMembershipInsert {
+        membership: load_principal_group(conn, principal, group).await?,
+        effective_membership_created,
+    })
 }
 
 async fn remove_manual_membership_source(
     conn: &mut DbConnection,
     principal: i32,
     group: i32,
-) -> Result<(Option<PrincipalGroup>, bool), ApiError> {
+) -> Result<Option<PrincipalGroup>, ApiError> {
     use crate::schema::{group_membership_sources, group_memberships};
 
     ensure_group_allows_local_write(conn, group).await?;
-    let owner_key = format!("group_memberships:{principal}:{group}");
+    let owner_key = RevisionOwner::membership_key(principal, group);
     let membership = group_memberships::table
         .filter(group_memberships::principal_id.eq(principal))
         .filter(group_memberships::group_id.eq(group))
@@ -154,7 +163,7 @@ async fn remove_manual_membership_source(
         .optional()?;
     let Some(membership) = membership else {
         crate::db::assert_revision_precondition_allows_missing_target(&owner_key)?;
-        return Ok((None, false));
+        return Ok(None);
     };
     crate::db::assert_locked_revision_precondition(conn, &owner_key, membership.revision).await?;
 
@@ -184,9 +193,9 @@ async fn remove_manual_membership_source(
         )
         .execute(conn)
         .await?;
-        return Ok((Some(membership), deleted > 0));
+        return Ok((deleted > 0).then_some(membership));
     }
-    Ok((Some(membership), false))
+    Ok(None)
 }
 
 async fn ensure_group_allows_local_write(
@@ -253,13 +262,42 @@ async fn lock_group_for_delete(conn: &mut DbConnection, group_id: i32) -> Result
         .await?;
     crate::db::assert_locked_revision_precondition(
         conn,
-        &format!("groups:{}", group.id),
+        &RevisionOwner::Group.key(group.id),
         group.revision,
     )
     .await?;
     ensure_group_has_no_owned_service_accounts(conn, group.id).await?;
     ensure_group_allows_local_write(conn, group.id).await?;
     Ok(group)
+}
+
+async fn delete_group_by_id(
+    pool: &DbPool,
+    group_id: i32,
+    context: Option<&EventContext>,
+) -> Result<usize, ApiError> {
+    use crate::schema::groups::dsl::{groups, id};
+
+    with_transaction(pool, async |conn| -> Result<usize, ApiError> {
+        let group = lock_group_for_delete(conn, group_id).await?;
+        let deleted = diesel::delete(groups.filter(id.eq(group.id)))
+            .execute(conn)
+            .await?;
+
+        if let Some(context) = context {
+            let event = group_event(
+                &group,
+                Action::Deleted,
+                context,
+                format!("Group '{}' deleted", group.groupname),
+            )?
+            .with_before(group_snapshot(&group));
+            emit_event(conn, &event).await?;
+        }
+
+        Ok(deleted)
+    })
+    .await
 }
 
 pub trait LoadGroupRecord {
@@ -316,15 +354,7 @@ pub trait DeleteGroupRecord {
 
 impl DeleteGroupRecord for GroupID {
     async fn delete_group_record_without_events(&self, pool: &DbPool) -> Result<usize, ApiError> {
-        use crate::schema::groups::dsl::{groups, id};
-
-        with_transaction(pool, async |conn| -> Result<usize, ApiError> {
-            lock_group_for_delete(conn, self.id()).await?;
-            Ok(diesel::delete(groups.filter(id.eq(self.id())))
-                .execute(conn)
-                .await?)
-        })
-        .await
+        delete_group_by_id(pool, self.id(), None).await
     }
 
     async fn delete_group_record(
@@ -332,42 +362,13 @@ impl DeleteGroupRecord for GroupID {
         pool: &DbPool,
         context: Option<&EventContext>,
     ) -> Result<usize, ApiError> {
-        let Some(context) = context else {
-            return self.delete_group_record_without_events(pool).await;
-        };
-
-        use crate::schema::groups::dsl::{groups, id};
-
-        with_transaction(pool, async |conn| -> Result<usize, ApiError> {
-            let group = lock_group_for_delete(conn, self.id()).await?;
-            let deleted = diesel::delete(groups.filter(id.eq(self.id())))
-                .execute(conn)
-                .await?;
-            let event = group_event(
-                &group,
-                Action::Deleted,
-                context,
-                format!("Group '{}' deleted", group.groupname),
-            )?
-            .with_before(group_snapshot(&group));
-            emit_event(conn, &event).await?;
-            Ok(deleted)
-        })
-        .await
+        delete_group_by_id(pool, self.id(), context).await
     }
 }
 
 impl DeleteGroupRecord for Group {
     async fn delete_group_record_without_events(&self, pool: &DbPool) -> Result<usize, ApiError> {
-        use crate::schema::groups::dsl::{groups, id};
-
-        with_transaction(pool, async |conn| -> Result<usize, ApiError> {
-            lock_group_for_delete(conn, self.id).await?;
-            Ok(diesel::delete(groups.filter(id.eq(self.id)))
-                .execute(conn)
-                .await?)
-        })
-        .await
+        delete_group_by_id(pool, self.id, None).await
     }
 
     async fn delete_group_record(
@@ -375,28 +376,7 @@ impl DeleteGroupRecord for Group {
         pool: &DbPool,
         context: Option<&EventContext>,
     ) -> Result<usize, ApiError> {
-        let Some(context) = context else {
-            return self.delete_group_record_without_events(pool).await;
-        };
-
-        use crate::schema::groups::dsl::{groups, id};
-
-        with_transaction(pool, async |conn| -> Result<usize, ApiError> {
-            let before = lock_group_for_delete(conn, self.id).await?;
-            let deleted = diesel::delete(groups.filter(id.eq(self.id)))
-                .execute(conn)
-                .await?;
-            let event = group_event(
-                &before,
-                Action::Deleted,
-                context,
-                format!("Group '{}' deleted", before.groupname),
-            )?
-            .with_before(group_snapshot(&before));
-            emit_event(conn, &event).await?;
-            Ok(deleted)
-        })
-        .await
+        delete_group_by_id(pool, self.id, context).await
     }
 }
 
@@ -550,7 +530,7 @@ impl UpdateGroupRecord for UpdateGroup {
                 .await?;
             crate::db::assert_locked_revision_precondition(
                 conn,
-                &format!("groups:{}", before.id),
+                &RevisionOwner::Group.key(before.id),
                 before.revision,
             )
             .await?;
@@ -739,7 +719,7 @@ impl GroupMembersBackend for Group {
         pool: &DbPool,
     ) -> Result<(), ApiError> {
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let _ = remove_manual_membership_source(conn, member_principal_id, self.id).await?;
+            remove_manual_membership_source(conn, member_principal_id, self.id).await?;
             Ok(())
         })
         .await?;
@@ -759,10 +739,10 @@ impl GroupMembersBackend for Group {
         };
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let (membership, removed_effective) =
+            let removed_membership =
                 remove_manual_membership_source(conn, member_principal_id, self.id).await?;
 
-            if let Some(membership) = membership.filter(|_| removed_effective) {
+            if let Some(membership) = removed_membership {
                 let event = NewEvent::new(
                     EntityType::UserGroup,
                     Action::Removed,
@@ -787,6 +767,44 @@ impl GroupMembersBackend for Group {
     }
 }
 
+async fn save_manual_membership(
+    pool: &DbPool,
+    principal_id: i32,
+    group_id: i32,
+    context: Option<&EventContext>,
+) -> Result<PrincipalGroup, ApiError> {
+    with_transaction(pool, async |conn| -> Result<PrincipalGroup, ApiError> {
+        let ManualMembershipInsert {
+            membership,
+            effective_membership_created,
+        } = insert_manual_membership(conn, principal_id, group_id).await?;
+
+        if let Some(context) = context
+            && effective_membership_created
+        {
+            let event = NewEvent::new(
+                EntityType::UserGroup,
+                Action::Added,
+                context.actor_kind(),
+                format!(
+                    "Principal {} added to group {}",
+                    membership.principal_id, membership.group_id
+                ),
+            )?
+            .with_context(context)
+            .with_after(membership_snapshot(&membership))
+            .with_metadata(user_group_metadata(
+                membership.principal_id,
+                membership.group_id,
+            ));
+            emit_event(conn, &event).await?;
+        }
+
+        Ok(membership)
+    })
+    .await
+}
+
 pub trait SavePrincipalGroupRecord {
     async fn save_principal_group_record_without_events(
         &self,
@@ -808,12 +826,7 @@ impl SavePrincipalGroupRecord for NewPrincipalGroup {
         &self,
         pool: &DbPool,
     ) -> Result<PrincipalGroup, ApiError> {
-        with_transaction(pool, async |conn| -> Result<PrincipalGroup, ApiError> {
-            let (membership, _) =
-                insert_manual_membership(conn, self.principal_id, self.group_id).await?;
-            Ok(membership)
-        })
-        .await
+        save_manual_membership(pool, self.principal_id, self.group_id, None).await
     }
 
     async fn save_principal_group_record(
@@ -821,34 +834,7 @@ impl SavePrincipalGroupRecord for NewPrincipalGroup {
         pool: &DbPool,
         context: Option<&EventContext>,
     ) -> Result<PrincipalGroup, ApiError> {
-        let Some(context) = context else {
-            return self.save_principal_group_record_without_events(pool).await;
-        };
-
-        with_transaction(pool, async |conn| -> Result<PrincipalGroup, ApiError> {
-            let (membership, inserted) =
-                insert_manual_membership(conn, self.principal_id, self.group_id).await?;
-            if inserted {
-                let event = NewEvent::new(
-                    EntityType::UserGroup,
-                    Action::Added,
-                    context.actor_kind(),
-                    format!(
-                        "Principal {} added to group {}",
-                        membership.principal_id, membership.group_id
-                    ),
-                )?
-                .with_context(context)
-                .with_after(membership_snapshot(&membership))
-                .with_metadata(user_group_metadata(
-                    membership.principal_id,
-                    membership.group_id,
-                ));
-                emit_event(conn, &event).await?;
-            }
-            Ok(membership)
-        })
-        .await
+        save_manual_membership(pool, self.principal_id, self.group_id, context).await
     }
 }
 
@@ -857,12 +843,7 @@ impl SavePrincipalGroupRecord for PrincipalGroup {
         &self,
         pool: &DbPool,
     ) -> Result<PrincipalGroup, ApiError> {
-        with_transaction(pool, async |conn| -> Result<PrincipalGroup, ApiError> {
-            let (membership, _) =
-                insert_manual_membership(conn, self.principal_id, self.group_id).await?;
-            Ok(membership)
-        })
-        .await
+        save_manual_membership(pool, self.principal_id, self.group_id, None).await
     }
 
     async fn save_principal_group_record(
@@ -870,34 +851,7 @@ impl SavePrincipalGroupRecord for PrincipalGroup {
         pool: &DbPool,
         context: Option<&EventContext>,
     ) -> Result<PrincipalGroup, ApiError> {
-        let Some(context) = context else {
-            return self.save_principal_group_record_without_events(pool).await;
-        };
-
-        with_transaction(pool, async |conn| -> Result<PrincipalGroup, ApiError> {
-            let (membership, inserted) =
-                insert_manual_membership(conn, self.principal_id, self.group_id).await?;
-            if inserted {
-                let event = NewEvent::new(
-                    EntityType::UserGroup,
-                    Action::Added,
-                    context.actor_kind(),
-                    format!(
-                        "Principal {} added to group {}",
-                        membership.principal_id, membership.group_id
-                    ),
-                )?
-                .with_context(context)
-                .with_after(membership_snapshot(&membership))
-                .with_metadata(user_group_metadata(
-                    membership.principal_id,
-                    membership.group_id,
-                ));
-                emit_event(conn, &event).await?;
-            }
-            Ok(membership)
-        })
-        .await
+        save_manual_membership(pool, self.principal_id, self.group_id, context).await
     }
 }
 
@@ -932,7 +886,7 @@ pub trait DeletePrincipalGroupRecord {
 impl DeletePrincipalGroupRecord for PrincipalGroup {
     async fn delete_principal_group_record(&self, pool: &DbPool) -> Result<(), ApiError> {
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let _ = remove_manual_membership_source(conn, self.principal_id, self.group_id).await?;
+            remove_manual_membership_source(conn, self.principal_id, self.group_id).await?;
             Ok(())
         })
         .await?;

--- a/src/db/traits/object.rs
+++ b/src/db/traits/object.rs
@@ -2,6 +2,7 @@ use crate::db::prelude::*;
 use diesel::sql_query;
 use serde_json;
 
+use crate::api::etag::RevisionOwner;
 use crate::db::traits::GetObject;
 use crate::db::traits::class::lock_resolved_class_target;
 use crate::db::traits::computed_field::{
@@ -664,7 +665,7 @@ async fn lock_resolved_object_target(
 
     let resolved_class = target.class();
     let resolved = target.object();
-    let owner_key = format!("hubuumobject:{}", resolved.id);
+    let owner_key = RevisionOwner::Object.key(resolved.id);
     acquire_object_write_class_advisory_lock(conn, resolved_class.id).await?;
     let locked_class = match target.selector().kind() {
         ObjectSelectorKind::ById {

--- a/src/db/traits/object.rs
+++ b/src/db/traits/object.rs
@@ -664,72 +664,67 @@ async fn lock_resolved_object_target(
 
     let resolved_class = target.class();
     let resolved = target.object();
+    let owner_key = format!("hubuumobject:{}", resolved.id);
     acquire_object_write_class_advisory_lock(conn, resolved_class.id).await?;
     let locked_class = match target.selector().kind() {
         ObjectSelectorKind::ById {
             class_id,
             object_id: _,
-        } => {
-            class::hubuumclass
-                .filter(class::id.eq(class_id.id()))
-                .filter(class::id.eq(resolved_class.id))
-                .filter(class::name.eq(&resolved_class.name))
-                .filter(class::collection_id.eq(resolved_class.collection_id))
-                .for_update()
-                .first::<HubuumClass>(conn)
-                .await?
-        }
+        } => class::hubuumclass
+            .filter(class::id.eq(class_id.id()))
+            .filter(class::id.eq(resolved_class.id))
+            .filter(class::name.eq(&resolved_class.name))
+            .filter(class::collection_id.eq(resolved_class.collection_id))
+            .for_update()
+            .first::<HubuumClass>(conn)
+            .await
+            .optional()?,
         ObjectSelectorKind::ByName {
             class_name,
             object_name: _,
-        } => {
-            class::hubuumclass
-                .filter(class::id.eq(resolved_class.id))
-                .filter(class::name.eq(class_name))
-                .filter(class::collection_id.eq(resolved_class.collection_id))
-                .for_update()
-                .first::<HubuumClass>(conn)
-                .await?
-        }
+        } => class::hubuumclass
+            .filter(class::id.eq(resolved_class.id))
+            .filter(class::name.eq(class_name))
+            .filter(class::collection_id.eq(resolved_class.collection_id))
+            .for_update()
+            .first::<HubuumClass>(conn)
+            .await
+            .optional()?,
     };
+    let locked_class = crate::db::require_existing_revision_target(locked_class, &owner_key)?;
 
     let locked_object = match target.selector().kind() {
         ObjectSelectorKind::ById {
             class_id,
             object_id,
-        } => {
-            object::hubuumobject
-                .filter(object::id.eq(object_id.id()))
-                .filter(object::id.eq(resolved.id))
-                .filter(object::name.eq(&resolved.name))
-                .filter(object::collection_id.eq(resolved.collection_id))
-                .filter(object::hubuum_class_id.eq(class_id.id()))
-                .filter(object::hubuum_class_id.eq(resolved.hubuum_class_id))
-                .for_update()
-                .first::<HubuumObject>(conn)
-                .await?
-        }
+        } => object::hubuumobject
+            .filter(object::id.eq(object_id.id()))
+            .filter(object::id.eq(resolved.id))
+            .filter(object::name.eq(&resolved.name))
+            .filter(object::collection_id.eq(resolved.collection_id))
+            .filter(object::hubuum_class_id.eq(class_id.id()))
+            .filter(object::hubuum_class_id.eq(resolved.hubuum_class_id))
+            .for_update()
+            .first::<HubuumObject>(conn)
+            .await
+            .optional()?,
         ObjectSelectorKind::ByName {
             class_name: _,
             object_name,
-        } => {
-            object::hubuumobject
-                .filter(object::id.eq(resolved.id))
-                .filter(object::hubuum_class_id.eq(resolved.hubuum_class_id))
-                .filter(object::collection_id.eq(resolved.collection_id))
-                .filter(object::name.eq(object_name))
-                .for_update()
-                .first::<HubuumObject>(conn)
-                .await?
-        }
+        } => object::hubuumobject
+            .filter(object::id.eq(resolved.id))
+            .filter(object::hubuum_class_id.eq(resolved.hubuum_class_id))
+            .filter(object::collection_id.eq(resolved.collection_id))
+            .filter(object::name.eq(object_name))
+            .for_update()
+            .first::<HubuumObject>(conn)
+            .await
+            .optional()?,
     };
+    let locked_object = crate::db::require_existing_revision_target(locked_object, &owner_key)?;
 
-    crate::db::assert_locked_revision_precondition(
-        conn,
-        &format!("hubuumobject:{}", locked_object.id),
-        locked_object.revision,
-    )
-    .await?;
+    crate::db::assert_locked_revision_precondition(conn, &owner_key, locked_object.revision)
+        .await?;
 
     Ok((locked_class, locked_object))
 }

--- a/src/db/traits/permissions.rs
+++ b/src/db/traits/permissions.rs
@@ -2,6 +2,7 @@ use crate::db::prelude::*;
 use crate::models::token_scope::TokenScope;
 use serde::Serialize;
 
+use crate::api::etag::RevisionOwner;
 use crate::db::{DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
@@ -44,7 +45,7 @@ async fn lock_permission_owner(
         .await?;
     crate::db::assert_locked_revision_precondition(
         conn,
-        &format!("collection_authorization_state:{target_collection_id}"),
+        &RevisionOwner::CollectionPermissions.key(target_collection_id),
         owner_revision,
     )
     .await?;

--- a/src/db/traits/principal.rs
+++ b/src/db/traits/principal.rs
@@ -1,6 +1,7 @@
 use hubuum_events_core::EventContext;
 use serde_json::json;
 
+use crate::api::etag::RevisionOwner;
 use crate::db::prelude::*;
 use crate::db::{DbConnection, DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
@@ -73,7 +74,7 @@ pub(crate) async fn lock_principal_revision_conn(
         .await?;
     crate::db::assert_locked_revision_precondition(
         conn,
-        &format!("principals:{principal_id_value}"),
+        &RevisionOwner::Principal.key(principal_id_value),
         owner_revision,
     )
     .await?;
@@ -138,7 +139,7 @@ pub async fn mutate_principal_settings(
                 .await?;
             crate::db::assert_locked_revision_precondition(
                 conn,
-                &format!("principals:{principal_id_value}"),
+                &RevisionOwner::Principal.key(principal_id_value),
                 before_revision,
             )
             .await?;

--- a/src/db/traits/remote_target.rs
+++ b/src/db/traits/remote_target.rs
@@ -1,5 +1,6 @@
 use crate::db::prelude::*;
 
+use crate::api::etag::RevisionOwner;
 use crate::apply_query_options;
 use crate::db::{DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
@@ -172,7 +173,7 @@ impl UpdateRemoteTargetRecord for UpdateRemoteTargetRow {
                 .await?;
             crate::db::assert_locked_revision_precondition(
                 conn,
-                &format!("remote_targets:{}", before.id),
+                &RevisionOwner::RemoteTarget.key(before.id),
                 before.revision,
             )
             .await?;

--- a/src/db/traits/task_import.rs
+++ b/src/db/traits/task_import.rs
@@ -50,6 +50,19 @@ fn assert_import_create_condition(condition: Option<ImportWriteCondition>) -> Re
     Ok(())
 }
 
+fn require_existing_import_target<T>(
+    target: Option<T>,
+    condition: Option<ImportWriteCondition>,
+) -> Result<T, ApiError> {
+    match target {
+        Some(target) => Ok(target),
+        None => {
+            assert_import_create_condition(condition)?;
+            Err(diesel::result::Error::NotFound.into())
+        }
+    }
+}
+
 pub async fn lookup_collections_by_name(
     pool: &DbPool,
     value: &str,
@@ -463,7 +476,9 @@ pub async fn update_collection_db(
         .select(crate::schema::collections::revision)
         .for_update()
         .first::<ResourceRevision>(conn)
-        .await?;
+        .await
+        .optional()?;
+    let current_revision = require_existing_import_target(current_revision, input.condition)?;
     assert_import_revision(input.condition, current_revision)?;
 
     let update = UpdateCollection {
@@ -559,7 +574,9 @@ pub async fn update_class_db(
         .select(crate::schema::hubuumclass::revision)
         .for_update()
         .first::<ResourceRevision>(conn)
-        .await?;
+        .await
+        .optional()?;
+    let current_revision = require_existing_import_target(current_revision, input.condition)?;
     assert_import_revision(input.condition, current_revision)?;
 
     let update = UpdateHubuumClass {
@@ -650,7 +667,9 @@ pub async fn update_object_db(
         .select(crate::schema::hubuumobject::revision)
         .for_update()
         .first::<ResourceRevision>(conn)
-        .await?;
+        .await
+        .optional()?;
+    let current_revision = require_existing_import_target(current_revision, input.condition)?;
     assert_import_revision(input.condition, current_revision)?;
 
     let update = UpdateHubuumObject {
@@ -1253,7 +1272,7 @@ pub async fn upsert_computed_field_db(
         .filter(d::class_id.eq(class_id_value))
         .filter(d::visibility.eq(visibility))
         .filter(d::key.eq(&input.key))
-        .filter(d::owner_user_id.eq(owner_id_value))
+        .filter(d::owner_user_id.is_not_distinct_from(owner_id_value))
         .for_update()
         .select(crate::models::ComputedFieldDefinition::as_select())
         .first(conn)
@@ -1783,7 +1802,9 @@ pub async fn check_class_relation_import_condition_db(
         .select(revision)
         .for_update()
         .first::<ResourceRevision>(conn)
-        .await?;
+        .await
+        .optional()?;
+    let current_revision = require_existing_import_target(current_revision, condition)?;
     assert_import_revision(condition, current_revision)
 }
 
@@ -1890,7 +1911,9 @@ pub async fn check_object_relation_import_condition_db(
         .select(revision)
         .for_update()
         .first::<ResourceRevision>(conn)
-        .await?;
+        .await
+        .optional()?;
+    let current_revision = require_existing_import_target(current_revision, condition)?;
     assert_import_revision(condition, current_revision)
 }
 
@@ -1912,7 +1935,9 @@ pub async fn apply_permissions_db(
         .select(crate::schema::collection_authorization_state::revision)
         .for_update()
         .first::<ResourceRevision>(conn)
-        .await?;
+        .await
+        .optional()?;
+    let authorization_revision = require_existing_import_target(authorization_revision, condition)?;
     assert_import_revision(condition, authorization_revision)?;
 
     let existing = permissions_table
@@ -2096,6 +2121,23 @@ mod tests {
     use crate::db::traits::identity::ensure_identity_scope;
     use crate::models::{GroupKey, LDAP_PROVIDER_KIND, NewGroup};
     use crate::tests::TestScope;
+
+    #[test]
+    fn conditional_import_reports_a_missing_execution_target_as_stale() {
+        let error = require_existing_import_target::<()>(
+            None,
+            Some(ImportWriteCondition::IfRevision {
+                expected_revision: ResourceRevision::INITIAL,
+            }),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ApiError::PreconditionFailed(message, _)
+                if message == CONDITIONAL_IMPORT_TARGET_MISSING
+        ));
+    }
 
     #[actix_rt::test]
     async fn group_lookup_disambiguates_identity_scopes() {

--- a/src/db/traits/token.rs
+++ b/src/db/traits/token.rs
@@ -1,5 +1,6 @@
 use crate::db::prelude::*;
 
+use crate::api::etag::RevisionOwner;
 use crate::db::traits::authz::{load_token_scope_conn, load_token_scopes_for_tokens_conn};
 use crate::db::{DbConnection, DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
@@ -235,7 +236,7 @@ pub async fn revoke_token_by_id_for_principal_db(
         };
         crate::db::assert_locked_revision_precondition(
             conn,
-            &format!("tokens:{}", before.id),
+            &RevisionOwner::Token.key(before.id),
             before.revision,
         )
         .await?;

--- a/src/tasks/execution.rs
+++ b/src/tasks/execution.rs
@@ -691,8 +691,8 @@ pub(super) async fn observed_revision_for_planned_item(
             d::computed_field_definitions
                 .filter(d::class_id.eq(class.id))
                 .filter(d::visibility.eq(visibility))
-                .filter(d::owner_user_id.eq(owner_id))
                 .filter(d::key.eq(&input.key))
+                .filter(d::owner_user_id.is_not_distinct_from(owner_id))
                 .select(d::revision)
                 .first(conn)
                 .await

--- a/tests/api_core_data_suite/collections.rs
+++ b/tests/api_core_data_suite/collections.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    use crate::api::etag::{IfMatchCondition, RevisionedResource};
+    use crate::db::with_revision_precondition_scope;
     use crate::models::{
         Collection, CollectionID, CollectionPermissionSet, GroupID, GroupPermission, GroupResponse,
         NewCollectionWithAssignee, NewGroup, Permission, Permissions, UpdateCollection,
@@ -20,7 +22,7 @@ mod tests {
         CollectionFixture, TestContext, create_test_group, create_test_user, ensure_admin_group,
         test_context,
     };
-    use crate::traits::{CanDelete, PermissionController};
+    use crate::traits::{CanDelete, CanSave, CanUpdate, PermissionController};
     use crate::{assert_contains, assert_contains_all};
     use actix_web::{http, test};
     use rstest::rstest;
@@ -118,6 +120,90 @@ mod tests {
         assert_response_status(response, http::StatusCode::PRECONDITION_FAILED).await;
 
         fixture.cleanup().await.unwrap();
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn stale_collection_delete_precedes_child_validation(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let fixture = context.collection_fixture("stale_collection_delete").await;
+        let child = NewCollectionWithAssignee {
+            name: context.scoped_name("stale_collection_delete_child"),
+            description: "Child collection".to_string(),
+            group_id: GroupID::new(fixture.owner_group.id).unwrap(),
+            parent_collection_id: Some(CollectionID::new(fixture.collection.id).unwrap()),
+        }
+        .save_without_events(&context.pool)
+        .await
+        .unwrap();
+        let stale_tag = fixture.collection.entity_tag().unwrap();
+        let precondition = IfMatchCondition::Tags(vec![stale_tag.clone()])
+            .database_precondition(&stale_tag)
+            .unwrap();
+
+        UpdateCollection {
+            name: None,
+            description: Some("A newer description".to_string()),
+        }
+        .update_without_events(
+            &context.pool,
+            CollectionID::new(fixture.collection.id).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let error = with_revision_precondition_scope(
+            precondition,
+            fixture.collection.delete_without_events(&context.pool),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::errors::ApiError::PreconditionFailed(_, _)
+        ));
+
+        child.delete_without_events(&context.pool).await.unwrap();
+        fixture.cleanup().await.unwrap();
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn conditional_collection_delete_reports_a_vanished_target_as_stale(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let fixture = context
+            .collection_fixture("vanished_collection_delete")
+            .await;
+        let tag = fixture.collection.entity_tag().unwrap();
+        let precondition = IfMatchCondition::Tags(vec![tag.clone()])
+            .database_precondition(&tag)
+            .unwrap();
+
+        fixture
+            .collection
+            .delete_without_events(&context.pool)
+            .await
+            .unwrap();
+        let error = with_revision_precondition_scope(
+            precondition,
+            fixture.collection.delete_without_events(&context.pool),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            crate::errors::ApiError::PreconditionFailed(_, _)
+        ));
+        fixture
+            .owner_group
+            .delete_without_events(&context.pool)
+            .await
+            .unwrap();
     }
 
     #[rstest]
@@ -469,6 +555,51 @@ mod tests {
 
         assert_eq!(renamed_body, original_body);
         assert_eq!(renamed_etag, original_etag);
+        fixture.cleanup().await.unwrap();
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn permission_scoped_group_list_filters_by_revision(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let fixture = context
+            .collection_fixture("permission_group_revision_filter")
+            .await;
+        let group = create_test_group(&context.pool).await;
+        fixture
+            .collection
+            .grant_one(
+                &context.pool,
+                GroupID::new(group.id).unwrap(),
+                Permissions::ReadCollection,
+            )
+            .await
+            .unwrap();
+        let updated = UpdateGroup {
+            groupname: Some(context.scoped_name("permission_group_revision_updated")),
+        }
+        .save_without_events(GroupID::new(group.id).unwrap(), &context.pool)
+        .await
+        .unwrap();
+
+        let response = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!(
+                "{COLLECTION_ENDPOINT}/{}/has_permissions/ReadCollection?revision={}",
+                fixture.collection.id, updated.revision
+            ),
+        )
+        .await;
+        let response = assert_response_status(response, http::StatusCode::OK).await;
+        let groups: Vec<GroupResponse> = test::read_body_json(response).await;
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].id, updated.id);
+
+        group.delete_without_events(&context.pool).await.unwrap();
         fixture.cleanup().await.unwrap();
     }
 

--- a/tests/api_identity_suite/groups.rs
+++ b/tests/api_identity_suite/groups.rs
@@ -650,6 +650,65 @@ mod tests {
 
     #[rstest]
     #[actix_web::test]
+    async fn stale_membership_delete_rejects_an_absent_manual_source(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let group = create_test_group(&context.pool).await;
+        let user = create_test_user(&context.pool).await;
+        group
+            .add_member_without_events(&context.pool, &user)
+            .await
+            .unwrap();
+        let scope = crate::db::traits::identity::identity_scope_by_name(
+            &context.pool,
+            crate::models::LOCAL_IDENTITY_SCOPE,
+        )
+        .await
+        .unwrap();
+        with_connection(&context.pool, async |conn| {
+            use crate::schema::group_membership_sources;
+            diesel::insert_into(group_membership_sources::table)
+                .values((
+                    group_membership_sources::principal_id.eq(user.id),
+                    group_membership_sources::group_id.eq(group.id),
+                    group_membership_sources::source.eq(crate::models::EXTERNAL_MEMBERSHIP_SOURCE),
+                    group_membership_sources::source_scope_id.eq(scope.id),
+                    group_membership_sources::source_key.eq("surviving-stale-source"),
+                ))
+                .execute(conn)
+                .await
+        })
+        .await
+        .unwrap();
+        let before =
+            crate::db::traits::group::principal_group_by_ids(&context.pool, user.id, group.id)
+                .await
+                .unwrap();
+        let stale_tag = before.entity_tag().unwrap();
+        let precondition = IfMatchCondition::Tags(vec![stale_tag.clone()])
+            .database_precondition(&stale_tag)
+            .unwrap();
+
+        group
+            .remove_member_without_events(&user, &context.pool)
+            .await
+            .unwrap();
+        let error = with_revision_precondition_scope(
+            precondition,
+            group.remove_member_without_events(&user, &context.pool),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            crate::errors::ApiError::PreconditionFailed(_, _)
+        ));
+    }
+
+    #[rstest]
+    #[actix_web::test]
     async fn tagged_group_points_exclude_revision_exempt_sync_bookkeeping(
         #[future(awt)] test_context: TestContext,
     ) {

--- a/tests/api_jobs_suite/imports.rs
+++ b/tests/api_jobs_suite/imports.rs
@@ -11,15 +11,16 @@ mod tests {
 
     use crate::db::{DbPool, with_connection};
     use crate::models::{
-        CURRENT_IMPORT_VERSION, CollectionKey, GroupID, GroupKey, HubuumClassRelation,
-        IdentityScopeKey, ImportAtomicity, ImportClassInput, ImportClassRelationInput,
-        ImportCollectionInput, ImportCollectionPermissionInput, ImportCollisionPolicy,
+        CURRENT_IMPORT_VERSION, ClassKey, CollectionKey, ComputedResultType, GroupID, GroupKey,
+        HubuumClass, HubuumClassRelation, IdentityScopeKey, ImportAtomicity, ImportClassInput,
+        ImportClassRelationInput, ImportCollectionInput, ImportCollectionPermissionInput,
+        ImportCollisionPolicy, ImportComputedFieldInput, ImportComputedFieldVisibility,
         ImportEventSubscriptionInput, ImportGraph, ImportGroupInput, ImportGroupMembershipInput,
         ImportIdentityScopeInput, ImportMode, ImportObjectInput, ImportObjectRelationInput,
         ImportPermissionPolicy, ImportPrincipalInput, ImportPrincipalSubtype, ImportRequest,
-        ImportTaskResultResponse, ImportWriteCondition, NewTaskRecord, ObjectRelationLimit,
-        Permissions, ResourceRevision, RestoreTimestamps, TaskEventResponse, TaskKind,
-        TaskResponse, TaskStatus,
+        ImportTaskResultResponse, ImportWriteCondition, NewHubuumClass, NewTaskRecord,
+        ObjectRelationLimit, Permissions, ResourceRevision, RestoreTimestamps, TaskEventResponse,
+        TaskKind, TaskResponse, TaskStatus,
     };
     use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER};
     use crate::schema::collections::dsl::{
@@ -285,6 +286,53 @@ mod tests {
                     timestamps: None,
                     parent_collection_ref: None,
                     parent_collection_key: None,
+                }],
+                ..ImportGraph::default()
+            },
+        }
+    }
+
+    fn shared_computed_field_import_request(
+        class: &HubuumClass,
+        collection_name: &str,
+        key: &str,
+        label: &str,
+        dry_run: bool,
+    ) -> ImportRequest {
+        ImportRequest {
+            version: CURRENT_IMPORT_VERSION,
+            dry_run: Some(dry_run),
+            mode: Some(ImportMode {
+                atomicity: Some(ImportAtomicity::Strict),
+                collision_policy: Some(ImportCollisionPolicy::Overwrite),
+                permission_policy: Some(ImportPermissionPolicy::Abort),
+            }),
+            graph: ImportGraph {
+                computed_fields: vec![ImportComputedFieldInput {
+                    ref_: Some("computed-field:shared".to_string()),
+                    class_ref: None,
+                    class_key: Some(ClassKey {
+                        name: class.name.clone(),
+                        collection_ref: None,
+                        collection_key: Some(CollectionKey {
+                            name: collection_name.to_string(),
+                            path: None,
+                        }),
+                    }),
+                    visibility: ImportComputedFieldVisibility::Shared,
+                    owner_ref: None,
+                    owner_key: None,
+                    key: key.to_string(),
+                    label: label.to_string(),
+                    description: String::new(),
+                    operation: serde_json::json!({
+                        "type": "first_non_null",
+                        "paths": ["/name"]
+                    }),
+                    result_type: ComputedResultType::String,
+                    enabled: true,
+                    condition: Some(ImportWriteCondition::Overwrite),
+                    timestamps: None,
                 }],
                 ..ImportGraph::default()
             },
@@ -1482,6 +1530,151 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(description, updated_description);
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn shared_computed_field_import_overwrites_the_null_owner_scope(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let fixture = context
+            .class_fixture(
+                "shared_computed_import_overwrite",
+                vec![NewHubuumClass {
+                    name: context.scoped_name("shared_computed_import_class"),
+                    collection_id: 0,
+                    json_schema: None,
+                    validate_schema: Some(false),
+                    description: "Shared computed import class".to_string(),
+                }],
+            )
+            .await
+            .unwrap();
+        let class = &fixture.classes[0];
+        let key = context.scoped_name("shared_computed_import_key");
+
+        for label in ["Original label", "Updated label"] {
+            let body = shared_computed_field_import_request(
+                class,
+                &fixture.collection.collection.name,
+                &key,
+                label,
+                false,
+            );
+            let response = post_request_with_headers(
+                &context.pool,
+                &context.admin_token,
+                IMPORTS_ENDPOINT,
+                &body,
+                Vec::new(),
+            )
+            .await;
+            let response = assert_response_status(response, StatusCode::ACCEPTED).await;
+            let task: TaskResponse = test::read_body_json(response).await;
+            wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+        }
+
+        let labels = with_connection(&context.pool, async |conn| {
+            use crate::schema::computed_field_definitions::dsl as definition;
+            definition::computed_field_definitions
+                .filter(definition::class_id.eq(class.id))
+                .filter(definition::owner_user_id.is_null())
+                .filter(definition::key.eq(&key))
+                .select(definition::label)
+                .load::<String>(conn)
+                .await
+        })
+        .await
+        .unwrap();
+        assert_eq!(labels, vec!["Updated label".to_string()]);
+
+        fixture.cleanup().await.unwrap();
+    }
+
+    #[rstest]
+    #[actix_web::test]
+    async fn dry_run_reports_a_shared_computed_field_revision(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        let context = test_context;
+        let fixture = context
+            .class_fixture(
+                "shared_computed_import_dry_run",
+                vec![NewHubuumClass {
+                    name: context.scoped_name("shared_computed_dry_run_class"),
+                    collection_id: 0,
+                    json_schema: None,
+                    validate_schema: Some(false),
+                    description: "Shared computed dry-run class".to_string(),
+                }],
+            )
+            .await
+            .unwrap();
+        let class = &fixture.classes[0];
+        let key = context.scoped_name("shared_computed_dry_run_key");
+        let initial = shared_computed_field_import_request(
+            class,
+            &fixture.collection.collection.name,
+            &key,
+            "Original label",
+            false,
+        );
+        let response = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            IMPORTS_ENDPOINT,
+            &initial,
+            Vec::new(),
+        )
+        .await;
+        let response = assert_response_status(response, StatusCode::ACCEPTED).await;
+        let task: TaskResponse = test::read_body_json(response).await;
+        wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+        let revision = with_connection(&context.pool, async |conn| {
+            use crate::schema::computed_field_definitions::dsl as definition;
+            definition::computed_field_definitions
+                .filter(definition::class_id.eq(class.id))
+                .filter(definition::owner_user_id.is_null())
+                .filter(definition::key.eq(&key))
+                .select(definition::revision)
+                .first::<ResourceRevision>(conn)
+                .await
+        })
+        .await
+        .unwrap();
+
+        let dry_run = shared_computed_field_import_request(
+            class,
+            &fixture.collection.collection.name,
+            &key,
+            "Dry-run label",
+            true,
+        );
+        let response = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            IMPORTS_ENDPOINT,
+            &dry_run,
+            Vec::new(),
+        )
+        .await;
+        let response = assert_response_status(response, StatusCode::ACCEPTED).await;
+        let task: TaskResponse = test::read_body_json(response).await;
+        wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
+        let response = get_request(
+            &context.pool,
+            &context.admin_token,
+            &format!("/api/v1/imports/{}/results", task.id),
+        )
+        .await;
+        let response = assert_response_status(response, StatusCode::OK).await;
+        let results: Vec<ImportTaskResultResponse> = test::read_body_json(response).await;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].observed_revision, Some(revision));
+
+        fixture.cleanup().await.unwrap();
     }
 
     #[rstest]

--- a/tests/api_jobs_suite/imports.rs
+++ b/tests/api_jobs_suite/imports.rs
@@ -268,6 +268,19 @@ mod tests {
         panic!("Task {task_id} did not reach a terminal status in time");
     }
 
+    async fn submit_import(context: &TestContext, request: &ImportRequest) -> TaskResponse {
+        let response = post_request_with_headers(
+            &context.pool,
+            &context.admin_token,
+            IMPORTS_ENDPOINT,
+            request,
+            Vec::new(),
+        )
+        .await;
+        let response = assert_response_status(response, StatusCode::ACCEPTED).await;
+        test::read_body_json(response).await
+    }
+
     fn collection_import_request(
         name: String,
         description: &str,
@@ -464,16 +477,7 @@ mod tests {
             core_timestamp_import_request(&names, initial.clone(), ImportCollisionPolicy::Abort),
             core_timestamp_import_request(&names, restored, ImportCollisionPolicy::Overwrite),
         ] {
-            let response = post_request_with_headers(
-                &context.pool,
-                &context.admin_token,
-                IMPORTS_ENDPOINT,
-                &body,
-                Vec::new(),
-            )
-            .await;
-            let response = assert_response_status(response, StatusCode::ACCEPTED).await;
-            let task: TaskResponse = test::read_body_json(response).await;
+            let task = submit_import(&context, &body).await;
             wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
 
             let timestamps = load_core_timestamp_pairs(&context.pool, &names).await;
@@ -1507,16 +1511,7 @@ mod tests {
             },
         );
 
-        let resp = post_request_with_headers(
-            &context.pool,
-            &context.admin_token,
-            IMPORTS_ENDPOINT,
-            &body,
-            vec![],
-        )
-        .await;
-        let resp = assert_response_status(resp, StatusCode::ACCEPTED).await;
-        let task: TaskResponse = test::read_body_json(resp).await;
+        let task = submit_import(&context, &body).await;
         let completed = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
         assert_eq!(completed.status, TaskStatus::Succeeded);
 
@@ -1562,16 +1557,7 @@ mod tests {
                 label,
                 false,
             );
-            let response = post_request_with_headers(
-                &context.pool,
-                &context.admin_token,
-                IMPORTS_ENDPOINT,
-                &body,
-                Vec::new(),
-            )
-            .await;
-            let response = assert_response_status(response, StatusCode::ACCEPTED).await;
-            let task: TaskResponse = test::read_body_json(response).await;
+            let task = submit_import(&context, &body).await;
             wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
         }
 
@@ -1620,16 +1606,7 @@ mod tests {
             "Original label",
             false,
         );
-        let response = post_request_with_headers(
-            &context.pool,
-            &context.admin_token,
-            IMPORTS_ENDPOINT,
-            &initial,
-            Vec::new(),
-        )
-        .await;
-        let response = assert_response_status(response, StatusCode::ACCEPTED).await;
-        let task: TaskResponse = test::read_body_json(response).await;
+        let task = submit_import(&context, &initial).await;
         wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
         let revision = with_connection(&context.pool, async |conn| {
             use crate::schema::computed_field_definitions::dsl as definition;
@@ -1651,16 +1628,7 @@ mod tests {
             "Dry-run label",
             true,
         );
-        let response = post_request_with_headers(
-            &context.pool,
-            &context.admin_token,
-            IMPORTS_ENDPOINT,
-            &dry_run,
-            Vec::new(),
-        )
-        .await;
-        let response = assert_response_status(response, StatusCode::ACCEPTED).await;
-        let task: TaskResponse = test::read_body_json(response).await;
+        let task = submit_import(&context, &dry_run).await;
         wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
         let response = get_request(
             &context.pool,


### PR DESCRIPTION
## Summary

- make shared computed-field imports and dry-run revision reads match the null owner scope correctly
- return stale-resource failures when conditional collection, class, object, or membership targets change or disappear before locking
- classify vanished `if_revision` import targets as `stale_revision`
- support revision filtering on permission-scoped group lists
- centralize revision precondition derivation, owner-key construction, and transaction-local database context
- consolidate duplicated collection, group, and membership mutation workflows
- add focused regression coverage and an Unreleased changelog entry

## Root cause

The revision work merged in #267 used SQL equality for nullable computed-field owners and let several lock queries surface Diesel `NotFound` before the ambient revision precondition could be evaluated. Collection delete validation and membership source no-ops could likewise bypass the expected stale check. The permission-scoped group query also omitted the shared revision filter branch.

The follow-up initially repeated request parsing, revision-owner table strings, transaction-local context setup, and event/no-event mutation flows. Centralizing those invariants keeps future revision-owned resources and mutation paths consistent.

## Impact

Conditional mutations now consistently return `412 Precondition Failed` instead of success, conflict, or not-found when the selected resource is stale. Shared computed-field imports can safely overwrite existing definitions, dry runs report their observed revisions, and clients can filter permission-scoped groups by revision as documented.

The maintenance pass does not change the public API. It reduces duplicated persistence code and makes the ETag-to-database precondition boundary explicit; malformed non-UTF-8 ETag keys are rejected as bad requests.

Follow-up to #267 and #263.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
