### PR TITLE
Certify adjacent-release upgrades and rollbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,10 @@ jobs:
         run: bash scripts/test-install-script-refresh.sh
       - name: Test single-host rolling update
         run: bash scripts/test-single-host-rollout.sh
+      - name: Test migration compatibility policy
+        run: |
+          bash scripts/test-migration-compatibility.sh
+          bash scripts/check-migration-compatibility.sh
 
   release-metadata:
     name: Release metadata
@@ -589,7 +593,15 @@ jobs:
   container-build:
     name: Container build (production features)
     needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.run_container == 'true'
+    if: >-
+      always() &&
+      (
+        startsWith(github.ref, 'refs/tags/v') ||
+        (
+          (github.event_name == 'pull_request' || github.ref == 'refs/heads/main') &&
+          needs.changes.outputs.run_container == 'true'
+        )
+      )
     runs-on: ubuntu-24.04
     services:
       postgres:
@@ -694,6 +706,42 @@ jobs:
           HUBUUM_TEST_IMAGE: hubuum-server:ci
           HUBUUM_OLD_TEST_IMAGE: ghcr.io/hubuum/hubuum-server:v0.0.1@sha256:061fc4cb3af57e2db06c33012db93e60834d4618815e30af4ebb4aa05a21f445
         run: bash scripts/test-single-host-zero-downtime.sh
+      - name: Resolve adjacent stable release
+        id: adjacent_release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HUBUUM_COMPATIBILITY_REPORT: compatibility-report/release-metadata.json
+        run: bash scripts/resolve-adjacent-release.sh
+      - name: Test adjacent-release upgrade and application rollback
+        env:
+          HUBUUM_TEST_IMAGE: hubuum-server:ci
+          HUBUUM_PREVIOUS_IMAGE: ${{ steps.adjacent_release.outputs.previous_image }}
+          HUBUUM_PREVIOUS_RELEASE_TAG: ${{ steps.adjacent_release.outputs.previous_tag }}
+          HUBUUM_COMPATIBILITY_REPORT_DIR: compatibility-report
+        run: bash scripts/test-adjacent-release-upgrade.sh
+      - name: Summarize adjacent-release compatibility
+        if: always() && hashFiles('compatibility-report/report.json') != ''
+        run: |
+          {
+            echo "### Adjacent-release compatibility"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Result | $(jq --raw-output '.result' compatibility-report/report.json) |"
+            echo "| Previous release | $(jq --raw-output '.previous_release.tag' compatibility-report/report.json) |"
+            echo "| Previous digest | $(jq --raw-output '.previous_release.digest' compatibility-report/report.json) |"
+            echo "| Candidate SHA | $(jq --raw-output '.candidate.sha' compatibility-report/report.json) |"
+            echo "| Migration seconds | $(jq --raw-output '.migration.seconds' compatibility-report/report.json) |"
+            echo "| Maximum API latency | $(jq --raw-output '.migration.max_api_latency_seconds' compatibility-report/report.json) s |"
+            echo "| Maximum observed outage | $(jq --raw-output '.migration.max_observed_api_outage_seconds' compatibility-report/report.json) s |"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload adjacent-release compatibility report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: adjacent-release-compatibility
+          path: compatibility-report
+          if-no-files-found: error
 
   ci-gate:
     name: >-
@@ -769,7 +817,9 @@ jobs:
   validate-tag-release:
     name: Validate tagged release
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: verify-tag-main-ci-success
+    needs:
+      - verify-tag-main-ci-success
+      - container-build
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Install clippy
         run: rustup component add clippy
       - name: Install feature build dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Token retention now writes a system-authored `token.purged` audit event with
   the exact final hash-free token and scope snapshot before deleting each token,
   including legacy rows whose earlier events predate complete scope snapshots.
+- Release CI now certifies the immediately previous stable image by immutable
+  digest through migration, a live mixed-version API interval, application
+  rollback, and candidate restoration. Reports include migration timing and API
+  availability measurements while the fixed earliest-release test remains.
 
 ### Changed
 
@@ -44,6 +48,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Import v2 collection, class, and object items support `create_only`,
   unconditional `overwrite`, and numeric `if_revision` write conditions that
   are rechecked by queued workers under row locks.
+- Revision indexes are built concurrently in a separate non-transactional
+  migration so an adjacent-release migration does not take blocking index-build
+  locks on live tables.
 
 - **Breaking (HTTP API):** entity JSON now contains `revision`; principal
   settings return `{revision, settings}`, SQL permission reads return
@@ -74,7 +81,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - **Breaking (backup/restore):** full backups are version 4 and restore rejects
   version 3. Version 4 preserves authoritative, authorization-set, event, and
   temporal revisions. Operators must create a new backup before restore and
-  must deploy this release without mixed-version writers.
+  quiesce backup, restore, and import operations during the certified adjacent
+  API overlap.
 - **Breaking (imports):** imports are version 2 and version 1 is rejected.
   Producers must emit the v2 version number and may attach per-item write
   conditions where supported.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -71,11 +71,12 @@ compatible with the old application version for the duration of the rolling
 update; a migration that blocks application queries can still cause request
 latency even though an HTTP replica remains online.
 
-The resource-revision release is an explicit exception: deploy its migration,
-API replicas, and workers as one coordinated release. Quiesce backup and
-restore operations during the transition because backup v4 and import v2
-intentionally reject their older formats. Do not run old writers after the
-revision triggers are installed.
+The resource-revision release supports the ordinary adjacent-release API
+overlap certified by CI: drain old workers first, run the migration while an
+old API replica serves requests, and then roll API replicas. Quiesce backup,
+restore, and import operations during the transition because backup v4 and
+import v2 intentionally reject their older formats. Do not start new workers
+until the candidate schema is ready.
 
 The standby owns its own database pool and application memory. Capacity-plan
 external PostgreSQL servers for both API pools, the primary's task-lease
@@ -371,6 +372,16 @@ its API and has no API-only standby to own traffic before migration, so the
 task-lease and task-provenance migrations cannot safely transfer an in-flight
 task to a new worker. The tested idle-queue upgrade preserves HTTP
 availability; it does not promise uninterrupted background task execution.
+
+A separate release-blocking test resolves the latest stable release by
+immutable image digest. It seeds users, groups, scoped credentials, nested
+collections, classes, objects, relations, computed fields, events, exports,
+remote targets, and asynchronous work through that release; drains its worker;
+and measures candidate migration availability. It then exercises both API
+versions against the migrated schema and proves an `N-1` application rollback
+before restoring the candidate. This certifies only adjacent application
+rollback and does not downgrade PostgreSQL or promise compatibility with older
+application generations.
 
 ### Re-running The Installer To Update
 

--- a/docs/distributed_deployment.md
+++ b/docs/distributed_deployment.md
@@ -93,11 +93,12 @@ replicas may remain online during the migration: the expanded schema derives
 task initiators from `submitted_by` and treats their legacy `hubuum.actor_id`
 session setting as direct-user attribution.
 
-For the resource-revision migration, stop old API and worker replicas before
-running the migration, then deploy the complete new replica set. This release
-changes authoritative write ordering and deliberately rejects backup v3 and
-import v1, so it is not a mixed-version rolling upgrade. Quiesce backup and
-restore operations until every replica is on the new version.
+For the resource-revision migration, stop old worker replicas before running
+the migration, but an adjacent old API replica may continue serving ordinary
+requests. CI certifies old and candidate API reads and writes against the
+migrated schema before an application rollback smoke test. Backup v3 and import
+v1 are still deliberately rejected by the candidate, so quiesce backup,
+restore, and import operations until every replica is on the new version.
 
 The `api` and `worker` entrypoints wait until the database records the latest
 migration required by the binary. API `/readyz` performs the same schema check.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -9,6 +9,8 @@ This repository uses the CI workflow in
 - `CHANGELOG.md` must contain a section for the release version.
 - `docs/openapi.json` must be regenerated for the release version.
 - A version bump in `Cargo.toml` must come with matching changelog and OpenAPI updates.
+- The candidate must pass the adjacent stable release upgrade and application
+  rollback harness against an immutable release-image digest.
 
 ## Scripted release flow
 
@@ -50,11 +52,35 @@ The helper script:
 Once the tag is pushed, the CI workflow will:
 
 - verify the tagged commit already passed CI on `main`
+- resolve the latest stable release, migrate its representative data under live
+  API probes, exercise a mixed-version interval, and restore its application
+  image against the migrated database before publishing
 - verify that the tag, `Cargo.toml`, changelog, and OpenAPI versions match
 - publish GitHub release archives and SHA-256 checksums for Linux x86_64, Linux ARM64,
   Windows x86_64, and macOS ARM64
 - use the matching changelog section as the GitHub Release notes
 - publish AMD64 and ARM64 GHCR images for the release tag
+
+## Certified Upgrade And Rollback Window
+
+CI certifies exactly one adjacent application transition: the latest stable
+release (`N-1`) to the candidate (`N`). It resolves `N-1` through the GitHub
+release API, pulls the release image, records its immutable digest, and tests it
+with the candidate against one PostgreSQL database. The report records the
+candidate SHA, migration set and duration, maximum observed API latency and
+outage, each test phase, and failure logs.
+
+The certified sequence drains old workers, keeps the old API under ordinary
+read probes while candidate migrations run, starts both API versions for
+cross-version reads and writes, completes the candidate rollout, and then
+restarts the `N-1` API against the migrated schema. That last step is an
+application rollback only. Hubuum does not automatically downgrade the
+database, and releases older than `N-1` are outside this compatibility promise.
+
+Backup, restore, and import document formats may change at a release boundary.
+Quiesce those operations while versions overlap and use the document format
+accepted by the application version that will process it. A successful API
+rollback does not make a newer backup or import document readable by `N-1`.
 
 ## Native archives
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -68,7 +68,7 @@ release (`N-1`) to the candidate (`N`). It resolves `N-1` through the GitHub
 release API, pulls the release image, records its immutable digest, and tests it
 with the candidate against one PostgreSQL database. The report records the
 candidate SHA, migration set and duration, maximum observed API latency and
-outage, each test phase, and failure logs.
+outage, the terminal test phase, and failure logs.
 
 The certified sequence drains old workers, keeps the old API under ordinary
 read probes while candidate migrations run, starts both API versions for

--- a/migrations/2026-08-03-000001_resource_revisions/metadata.toml
+++ b/migrations/2026-08-03-000001_resource_revisions/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-03-000001_resource_revisions/up.sql
+++ b/migrations/2026-08-03-000001_resource_revisions/up.sql
@@ -268,7 +268,8 @@ BEGIN
         WHERE conrelid = 'events'::regclass
           AND conname = 'events_before_revision_positive'
     ) THEN
-        ALTER TABLE events ADD CONSTRAINT events_before_revision_positive CHECK (before_revision > 0) NOT VALID;
+        ALTER TABLE events ADD CONSTRAINT events_before_revision_positive
+            CHECK (before_revision > 0) NOT VALID;
     END IF;
     IF NOT EXISTS (
         SELECT 1
@@ -276,7 +277,8 @@ BEGIN
         WHERE conrelid = 'events'::regclass
           AND conname = 'events_after_revision_positive'
     ) THEN
-        ALTER TABLE events ADD CONSTRAINT events_after_revision_positive CHECK (after_revision > 0) NOT VALID;
+        ALTER TABLE events ADD CONSTRAINT events_after_revision_positive
+            CHECK (after_revision > 0) NOT VALID;
     END IF;
 END $$;
 ALTER TABLE events VALIDATE CONSTRAINT events_before_revision_positive;

--- a/migrations/2026-08-03-000001_resource_revisions/up.sql
+++ b/migrations/2026-08-03-000001_resource_revisions/up.sql
@@ -2,20 +2,108 @@
 -- restore an exact value only while hubuum.restore_revisions is transaction
 -- locally enabled.
 
-ALTER TABLE identity_scopes ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
-ALTER TABLE principals ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
-ALTER TABLE groups ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
-ALTER TABLE collections ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
-ALTER TABLE group_memberships ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
-ALTER TABLE hubuumclass ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
-ALTER TABLE hubuumobject ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
-ALTER TABLE hubuumclass_relation ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
-ALTER TABLE hubuumobject_relation ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
-ALTER TABLE export_templates ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
-ALTER TABLE remote_targets ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
-ALTER TABLE event_sinks ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
-ALTER TABLE event_subscriptions ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
-ALTER TABLE tokens ADD COLUMN revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0);
+-- Add the history-side column first so an old temporal trigger can continue to
+-- insert rows during the later metadata-only expansion of each live table.
+DO $$
+DECLARE
+    table_name TEXT;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'collections_history',
+        'hubuumclass_history',
+        'hubuumclass_relation_history',
+        'hubuumobject_history',
+        'hubuumobject_relation_history',
+        'export_templates_history',
+        'remote_targets_history'
+    ]
+    LOOP
+        EXECUTE format('ALTER TABLE %I ADD COLUMN revision BIGINT DEFAULT 1', table_name);
+    END LOOP;
+END $$;
+
+DO $$
+DECLARE
+    table_name TEXT;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'principals',
+        'identity_scopes',
+        'groups',
+        'collections',
+        'group_memberships',
+        'hubuumclass',
+        'hubuumobject',
+        'hubuumclass_relation',
+        'hubuumobject_relation',
+        'export_templates',
+        'remote_targets',
+        'event_sinks',
+        'event_subscriptions',
+        'tokens'
+    ]
+    LOOP
+        EXECUTE format('ALTER TABLE %I ADD COLUMN revision BIGINT DEFAULT 1', table_name);
+    END LOOP;
+END $$;
+
+DO $$
+DECLARE
+    table_name TEXT;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'principals', 'identity_scopes', 'groups', 'collections',
+        'group_memberships', 'hubuumclass', 'hubuumobject',
+        'hubuumclass_relation', 'hubuumobject_relation', 'export_templates',
+        'remote_targets', 'event_sinks', 'event_subscriptions', 'tokens'
+    ]
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %I ADD CONSTRAINT %I CHECK (revision > 0) NOT VALID',
+            table_name,
+            table_name || '_revision_positive'
+        );
+    END LOOP;
+END $$;
+
+-- Validation scans may be long on a real installation. They run separately
+-- from the metadata-only ACCESS EXCLUSIVE phases so ordinary reads continue.
+DO $$
+DECLARE
+    table_name TEXT;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'principals', 'identity_scopes', 'groups', 'collections',
+        'group_memberships', 'hubuumclass', 'hubuumobject',
+        'hubuumclass_relation', 'hubuumobject_relation', 'export_templates',
+        'remote_targets', 'event_sinks', 'event_subscriptions', 'tokens'
+    ]
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %I VALIDATE CONSTRAINT %I',
+            table_name,
+            table_name || '_revision_positive'
+        );
+    END LOOP;
+END $$;
+
+DO $$
+DECLARE
+    table_name TEXT;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'principals', 'identity_scopes', 'groups', 'collections',
+        'group_memberships', 'hubuumclass', 'hubuumobject',
+        'hubuumclass_relation', 'hubuumobject_relation', 'export_templates',
+        'remote_targets', 'event_sinks', 'event_subscriptions', 'tokens'
+    ]
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %I ALTER COLUMN revision SET NOT NULL', -- HUBUUM-COMPAT: SET-NOT-NULL-AFTER-BACKFILL
+            table_name
+        );
+    END LOOP;
+END $$;
 
 CREATE TABLE collection_authorization_state (
     collection_id INT PRIMARY KEY REFERENCES collections(id) ON DELETE CASCADE,
@@ -28,10 +116,11 @@ SELECT id FROM collections;
 -- The seven temporal resources predate revisions. An insert starts at one,
 -- every stored update advances once, and a delete tombstone retains the last
 -- live revision.
+-- Backfills hold row locks but do not retain the earlier DDL locks, so temporal
+-- reads can continue while an installation with substantial history is ranked.
 DO $$
 DECLARE
     table_name TEXT;
-    base_table TEXT;
 BEGIN
     FOREACH table_name IN ARRAY ARRAY[
         'collections_history',
@@ -43,7 +132,6 @@ BEGIN
         'remote_targets_history'
     ]
     LOOP
-        EXECUTE format('ALTER TABLE %I ADD COLUMN revision BIGINT', table_name);
         EXECUTE format(
             'WITH ranked AS (
                  SELECT history_id,
@@ -58,18 +146,85 @@ BEGIN
             table_name,
             table_name
         );
-        EXECUTE format(
-            'ALTER TABLE %I ALTER COLUMN revision SET NOT NULL, ADD CHECK (revision > 0)',
-            table_name
-        );
-        EXECUTE format(
-            'CREATE INDEX %I ON %I (id, revision, history_id)',
-            table_name || '_id_revision_idx',
-            table_name
-        );
+    END LOOP;
+END $$;
 
+DO $$
+DECLARE
+    table_name TEXT;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'collections_history', 'hubuumclass_history',
+        'hubuumclass_relation_history', 'hubuumobject_history',
+        'hubuumobject_relation_history', 'export_templates_history',
+        'remote_targets_history'
+    ]
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %I ADD CONSTRAINT %I CHECK (revision > 0) NOT VALID',
+            table_name,
+            table_name || '_revision_positive'
+        );
+    END LOOP;
+END $$;
+
+DO $$
+DECLARE
+    table_name TEXT;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'collections_history', 'hubuumclass_history',
+        'hubuumclass_relation_history', 'hubuumobject_history',
+        'hubuumobject_relation_history', 'export_templates_history',
+        'remote_targets_history'
+    ]
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %I VALIDATE CONSTRAINT %I',
+            table_name,
+            table_name || '_revision_positive'
+        );
+    END LOOP;
+END $$;
+
+DO $$
+DECLARE
+    table_name TEXT;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'collections_history', 'hubuumclass_history',
+        'hubuumclass_relation_history', 'hubuumobject_history',
+        'hubuumobject_relation_history', 'export_templates_history',
+        'remote_targets_history'
+    ]
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %I ALTER COLUMN revision SET NOT NULL', -- HUBUUM-COMPAT: SET-NOT-NULL-AFTER-BACKFILL
+            table_name
+        );
+    END LOOP;
+END $$;
+
+-- Copy the open history revision to the live row without disabling triggers.
+-- The transaction-local restore flag suppresses history writes while retaining
+-- MVCC read availability during a potentially large update.
+DO $$
+DECLARE
+    table_name TEXT;
+    base_table TEXT;
+BEGIN
+    PERFORM set_config('hubuum.restore_history', 'on', true);
+    FOREACH table_name IN ARRAY ARRAY[
+        'collections_history',
+        'hubuumclass_history',
+        'hubuumclass_relation_history',
+        'hubuumobject_history',
+        'hubuumobject_relation_history',
+        'export_templates_history',
+        'remote_targets_history'
+    ]
+    LOOP
         base_table := replace(table_name, '_history', '');
-        EXECUTE format('ALTER TABLE %I DISABLE TRIGGER USER', base_table);
         EXECUTE format(
             'UPDATE %I live
                 SET revision = history.revision
@@ -78,13 +233,18 @@ BEGIN
             base_table,
             table_name
         );
-        EXECUTE format('ALTER TABLE %I ENABLE TRIGGER USER', base_table);
     END LOOP;
 END $$;
 
 ALTER TABLE events
-    ADD COLUMN before_revision BIGINT NULL CHECK (before_revision > 0),
-    ADD COLUMN after_revision BIGINT NULL CHECK (after_revision > 0);
+    ADD COLUMN before_revision BIGINT NULL,
+    ADD COLUMN after_revision BIGINT NULL;
+ALTER TABLE events
+    ADD CONSTRAINT events_before_revision_positive CHECK (before_revision > 0) NOT VALID;
+ALTER TABLE events
+    ADD CONSTRAINT events_after_revision_positive CHECK (after_revision > 0) NOT VALID;
+ALTER TABLE events VALIDATE CONSTRAINT events_before_revision_positive;
+ALTER TABLE events VALIDATE CONSTRAINT events_after_revision_positive;
 
 CREATE OR REPLACE FUNCTION hubuum_revision_owner_first(owner_key TEXT)
 RETURNS BOOLEAN
@@ -164,6 +324,7 @@ DECLARE
     internal_bump BOOLEAN := current_setting('hubuum.internal_revision_bump', true) IS NOT DISTINCT FROM 'on';
     has_updated_at BOOLEAN := TG_ARGV[0] = 'updated_at';
     coalesced BOOLEAN := TG_ARGV[1] = 'coalesce';
+    return_unchanged BOOLEAN := TG_ARGV[1] = 'direct_return_unchanged';
     ignored_fields TEXT[] := ARRAY['revision', 'created_at', 'updated_at'];
     domain_old JSONB;
     domain_new JSONB;
@@ -222,6 +383,13 @@ BEGIN
         operational_old := to_jsonb(OLD) - ARRAY['revision', 'created_at', 'updated_at'];
         operational_new := to_jsonb(NEW) - ARRAY['revision', 'created_at', 'updated_at'];
         IF operational_old = operational_new THEN
+            IF return_unchanged THEN
+                NEW.revision := OLD.revision;
+                IF has_updated_at THEN
+                    NEW.updated_at := OLD.updated_at;
+                END IF;
+                RETURN NEW;
+            END IF;
             RETURN NULL;
         END IF;
         NEW.revision := OLD.revision;
@@ -348,7 +516,7 @@ DECLARE
     table_name TEXT;
 BEGIN
     FOREACH table_name IN ARRAY ARRAY[
-        'identity_scopes', 'principals', 'groups', 'collections',
+        'principals', 'identity_scopes', 'groups', 'collections',
         'group_memberships', 'hubuumclass', 'hubuumobject',
         'hubuumclass_relation', 'hubuumobject_relation', 'export_templates',
         'remote_targets', 'event_sinks', 'event_subscriptions'
@@ -371,7 +539,7 @@ DROP TRIGGER IF EXISTS export_templates_skip_unchanged_temporal_update_trg ON ex
 DROP TRIGGER IF EXISTS remote_targets_skip_unchanged_temporal_update_trg ON remote_targets;
 
 CREATE TRIGGER identity_scopes_revision BEFORE INSERT OR UPDATE ON identity_scopes
-FOR EACH ROW EXECUTE FUNCTION hubuum_manage_resource_revision('updated_at', 'direct');
+FOR EACH ROW EXECUTE FUNCTION hubuum_manage_resource_revision('updated_at', 'direct_return_unchanged');
 CREATE TRIGGER principals_revision BEFORE INSERT OR UPDATE ON principals
 FOR EACH ROW EXECUTE FUNCTION hubuum_manage_resource_revision(
     'updated_at', 'coalesce', 'last_sync_attempted_at', 'last_sync_success_at'
@@ -538,21 +706,3 @@ BEGIN
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
-
-CREATE INDEX identity_scopes_revision_id_idx ON identity_scopes (revision, id);
-CREATE INDEX principals_revision_id_idx ON principals (revision, id);
-CREATE INDEX groups_revision_id_idx ON groups (revision, id);
-CREATE INDEX collections_parent_revision_id_idx ON collections (parent_collection_id, revision, id);
-CREATE INDEX hubuumclass_collection_revision_id_idx ON hubuumclass (collection_id, revision, id);
-CREATE INDEX hubuumobject_class_revision_id_idx ON hubuumobject (hubuum_class_id, revision, id);
-CREATE INDEX hubuumclass_relation_revision_id_idx ON hubuumclass_relation (revision, id);
-CREATE INDEX hubuumobject_relation_revision_id_idx ON hubuumobject_relation (revision, id);
-CREATE INDEX export_templates_collection_revision_id_idx ON export_templates (collection_id, revision, id);
-CREATE INDEX remote_targets_collection_revision_id_idx ON remote_targets (collection_id, revision, id);
-CREATE INDEX event_sinks_revision_id_idx ON event_sinks (revision, id);
-CREATE INDEX event_subscriptions_collection_revision_id_idx ON event_subscriptions (collection_id, revision, id);
-CREATE INDEX computed_field_class_revision_id_idx ON computed_field_definitions (class_id, revision, id);
-CREATE INDEX tokens_principal_revision_id_idx ON tokens (principal_id, revision, id);
-CREATE INDEX group_memberships_group_revision_idx ON group_memberships (group_id, revision, principal_id);
-CREATE INDEX events_before_revision_id_idx ON events (before_revision, id) WHERE before_revision IS NOT NULL;
-CREATE INDEX events_after_revision_id_idx ON events (after_revision, id) WHERE after_revision IS NOT NULL;

--- a/migrations/2026-08-03-000001_resource_revisions/up.sql
+++ b/migrations/2026-08-03-000001_resource_revisions/up.sql
@@ -18,7 +18,10 @@ BEGIN
         'remote_targets_history'
     ]
     LOOP
-        EXECUTE format('ALTER TABLE %I ADD COLUMN revision BIGINT DEFAULT 1', table_name);
+        EXECUTE format(
+            'ALTER TABLE %I ADD COLUMN IF NOT EXISTS revision BIGINT DEFAULT 1',
+            table_name
+        );
     END LOOP;
 END $$;
 
@@ -43,7 +46,10 @@ BEGIN
         'tokens'
     ]
     LOOP
-        EXECUTE format('ALTER TABLE %I ADD COLUMN revision BIGINT DEFAULT 1', table_name);
+        EXECUTE format(
+            'ALTER TABLE %I ADD COLUMN IF NOT EXISTS revision BIGINT DEFAULT 1',
+            table_name
+        );
     END LOOP;
 END $$;
 
@@ -58,11 +64,18 @@ BEGIN
         'remote_targets', 'event_sinks', 'event_subscriptions', 'tokens'
     ]
     LOOP
-        EXECUTE format(
-            'ALTER TABLE %I ADD CONSTRAINT %I CHECK (revision > 0) NOT VALID',
-            table_name,
-            table_name || '_revision_positive'
-        );
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = to_regclass(table_name)
+              AND conname = table_name || '_revision_positive'
+        ) THEN
+            EXECUTE format(
+                'ALTER TABLE %I ADD CONSTRAINT %I CHECK (revision > 0) NOT VALID',
+                table_name,
+                table_name || '_revision_positive'
+            );
+        END IF;
     END LOOP;
 END $$;
 
@@ -105,13 +118,14 @@ BEGIN
     END LOOP;
 END $$;
 
-CREATE TABLE collection_authorization_state (
+CREATE TABLE IF NOT EXISTS collection_authorization_state (
     collection_id INT PRIMARY KEY REFERENCES collections(id) ON DELETE CASCADE,
     revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0)
 );
 
 INSERT INTO collection_authorization_state (collection_id)
-SELECT id FROM collections;
+SELECT id FROM collections
+ON CONFLICT (collection_id) DO NOTHING;
 
 -- The seven temporal resources predate revisions. An insert starts at one,
 -- every stored update advances once, and a delete tombstone retains the last
@@ -160,11 +174,18 @@ BEGIN
         'remote_targets_history'
     ]
     LOOP
-        EXECUTE format(
-            'ALTER TABLE %I ADD CONSTRAINT %I CHECK (revision > 0) NOT VALID',
-            table_name,
-            table_name || '_revision_positive'
-        );
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = to_regclass(table_name)
+              AND conname = table_name || '_revision_positive'
+        ) THEN
+            EXECUTE format(
+                'ALTER TABLE %I ADD CONSTRAINT %I CHECK (revision > 0) NOT VALID',
+                table_name,
+                table_name || '_revision_positive'
+            );
+        END IF;
     END LOOP;
 END $$;
 
@@ -237,14 +258,34 @@ BEGIN
 END $$;
 
 ALTER TABLE events
-    ADD COLUMN before_revision BIGINT NULL,
-    ADD COLUMN after_revision BIGINT NULL;
-ALTER TABLE events
-    ADD CONSTRAINT events_before_revision_positive CHECK (before_revision > 0) NOT VALID;
-ALTER TABLE events
-    ADD CONSTRAINT events_after_revision_positive CHECK (after_revision > 0) NOT VALID;
+    ADD COLUMN IF NOT EXISTS before_revision BIGINT NULL,
+    ADD COLUMN IF NOT EXISTS after_revision BIGINT NULL;
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'events'::regclass
+          AND conname = 'events_before_revision_positive'
+    ) THEN
+        ALTER TABLE events ADD CONSTRAINT events_before_revision_positive CHECK (before_revision > 0) NOT VALID;
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'events'::regclass
+          AND conname = 'events_after_revision_positive'
+    ) THEN
+        ALTER TABLE events ADD CONSTRAINT events_after_revision_positive CHECK (after_revision > 0) NOT VALID;
+    END IF;
+END $$;
 ALTER TABLE events VALIDATE CONSTRAINT events_before_revision_positive;
 ALTER TABLE events VALIDATE CONSTRAINT events_after_revision_positive;
+
+-- Keep the behavioral cutover atomic even though the expansion and backfill
+-- phases above intentionally commit independently. A failed cutover therefore
+-- leaves the old trigger set intact and can be retried safely.
+BEGIN;
 
 CREATE OR REPLACE FUNCTION hubuum_revision_owner_first(owner_key TEXT)
 RETURNS BOOLEAN
@@ -538,6 +579,21 @@ DROP TRIGGER IF EXISTS hubuumobject_relation_skip_unchanged_temporal_update_trg 
 DROP TRIGGER IF EXISTS export_templates_skip_unchanged_temporal_update_trg ON export_templates;
 DROP TRIGGER IF EXISTS remote_targets_skip_unchanged_temporal_update_trg ON remote_targets;
 
+DO $$
+DECLARE
+    table_name TEXT;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'identity_scopes', 'principals', 'groups', 'collections',
+        'group_memberships', 'hubuumclass', 'hubuumobject',
+        'hubuumclass_relation', 'hubuumobject_relation', 'export_templates',
+        'remote_targets', 'event_sinks', 'event_subscriptions',
+        'computed_field_definitions', 'tokens', 'collection_authorization_state'
+    ] LOOP
+        EXECUTE format('DROP TRIGGER IF EXISTS %I ON %I', table_name || '_revision', table_name);
+    END LOOP;
+END $$;
+
 CREATE TRIGGER identity_scopes_revision BEFORE INSERT OR UPDATE ON identity_scopes
 FOR EACH ROW EXECUTE FUNCTION hubuum_manage_resource_revision('updated_at', 'direct_return_unchanged');
 CREATE TRIGGER principals_revision BEFORE INSERT OR UPDATE ON principals
@@ -590,6 +646,10 @@ BEGIN
         'computed_field_definitions', 'tokens', 'collection_authorization_state'
     ] LOOP
         EXECUTE format(
+            'DROP TRIGGER IF EXISTS %I ON %I',
+            table_name || '_delete_revision', table_name
+        );
+        EXECUTE format(
             'CREATE TRIGGER %I BEFORE DELETE ON %I
              FOR EACH ROW EXECUTE FUNCTION hubuum_check_delete_revision()',
             table_name || '_delete_revision', table_name
@@ -597,6 +657,10 @@ BEGIN
     END LOOP;
 END $$;
 
+DROP TRIGGER IF EXISTS users_revision_child ON users;
+DROP TRIGGER IF EXISTS service_accounts_revision_child ON service_accounts;
+DROP TRIGGER IF EXISTS group_membership_sources_revision_child ON group_membership_sources;
+DROP TRIGGER IF EXISTS permissions_revision_child ON permissions;
 CREATE TRIGGER users_revision_child BEFORE UPDATE ON users
 FOR EACH ROW EXECUTE FUNCTION hubuum_skip_unchanged_revision_child('updated_at');
 CREATE TRIGGER service_accounts_revision_child BEFORE UPDATE ON service_accounts
@@ -606,6 +670,10 @@ FOR EACH ROW EXECUTE FUNCTION hubuum_skip_unchanged_revision_child('updated_at')
 CREATE TRIGGER permissions_revision_child BEFORE UPDATE ON permissions
 FOR EACH ROW EXECUTE FUNCTION hubuum_skip_unchanged_revision_child('updated_at');
 
+DROP TRIGGER IF EXISTS users_bump_principal_revision ON users;
+DROP TRIGGER IF EXISTS service_accounts_bump_principal_revision ON service_accounts;
+DROP TRIGGER IF EXISTS membership_sources_bump_revision ON group_membership_sources;
+DROP TRIGGER IF EXISTS permissions_bump_revision ON permissions;
 CREATE TRIGGER users_bump_principal_revision AFTER INSERT OR UPDATE OR DELETE ON users
 FOR EACH ROW EXECUTE FUNCTION hubuum_bump_revision_owner('principals', 'id');
 CREATE TRIGGER service_accounts_bump_principal_revision AFTER INSERT OR UPDATE OR DELETE ON service_accounts
@@ -625,6 +693,7 @@ BEGIN
     RETURN NEW;
 END;
 $$;
+DROP TRIGGER IF EXISTS collections_create_authorization_state ON collections;
 CREATE TRIGGER collections_create_authorization_state
 AFTER INSERT ON collections FOR EACH ROW
 EXECUTE FUNCTION hubuum_create_collection_authorization_state();
@@ -636,6 +705,10 @@ BEGIN
     FOREACH table_name IN ARRAY ARRAY[
         'token_scopes', 'token_collection_scopes', 'token_class_scopes', 'token_object_scopes'
     ] LOOP
+        EXECUTE format(
+            'DROP TRIGGER IF EXISTS %I ON %I',
+            table_name || '_bump_token_revision', table_name
+        );
         EXECUTE format(
             'CREATE TRIGGER %I AFTER INSERT OR UPDATE OR DELETE ON %I
              FOR EACH ROW EXECUTE FUNCTION hubuum_bump_revision_owner(''tokens'', ''token_id'')',
@@ -666,6 +739,7 @@ BEGIN
     RETURN NEW;
 END;
 $$;
+DROP TRIGGER IF EXISTS events_fill_revisions ON events;
 CREATE TRIGGER events_fill_revisions BEFORE INSERT ON events
 FOR EACH ROW EXECUTE FUNCTION hubuum_fill_event_revisions();
 
@@ -706,3 +780,5 @@ BEGIN
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/migrations/2026-08-03-000001_resource_revisions/up.sql
+++ b/migrations/2026-08-03-000001_resource_revisions/up.sql
@@ -2,6 +2,8 @@
 -- restore an exact value only while hubuum.restore_revisions is transaction
 -- locally enabled.
 
+BEGIN;
+
 -- Add the history-side column first so an old temporal trigger can continue to
 -- insert rows during the later metadata-only expansion of each live table.
 DO $$
@@ -24,6 +26,9 @@ BEGIN
         );
     END LOOP;
 END $$;
+
+COMMIT;
+BEGIN;
 
 DO $$
 DECLARE
@@ -53,6 +58,9 @@ BEGIN
     END LOOP;
 END $$;
 
+COMMIT;
+BEGIN;
+
 DO $$
 DECLARE
     table_name TEXT;
@@ -79,6 +87,9 @@ BEGIN
     END LOOP;
 END $$;
 
+COMMIT;
+BEGIN;
+
 -- Validation scans may be long on a real installation. They run separately
 -- from the metadata-only ACCESS EXCLUSIVE phases so ordinary reads continue.
 DO $$
@@ -100,6 +111,9 @@ BEGIN
     END LOOP;
 END $$;
 
+COMMIT;
+BEGIN;
+
 DO $$
 DECLARE
     table_name TEXT;
@@ -118,6 +132,9 @@ BEGIN
     END LOOP;
 END $$;
 
+COMMIT;
+BEGIN;
+
 CREATE TABLE IF NOT EXISTS collection_authorization_state (
     collection_id INT PRIMARY KEY REFERENCES collections(id) ON DELETE CASCADE,
     revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0)
@@ -126,6 +143,9 @@ CREATE TABLE IF NOT EXISTS collection_authorization_state (
 INSERT INTO collection_authorization_state (collection_id)
 SELECT id FROM collections
 ON CONFLICT (collection_id) DO NOTHING;
+
+COMMIT;
+BEGIN;
 
 -- The seven temporal resources predate revisions. An insert starts at one,
 -- every stored update advances once, and a delete tombstone retains the last
@@ -163,6 +183,9 @@ BEGIN
     END LOOP;
 END $$;
 
+COMMIT;
+BEGIN;
+
 DO $$
 DECLARE
     table_name TEXT;
@@ -189,6 +212,9 @@ BEGIN
     END LOOP;
 END $$;
 
+COMMIT;
+BEGIN;
+
 DO $$
 DECLARE
     table_name TEXT;
@@ -208,6 +234,9 @@ BEGIN
     END LOOP;
 END $$;
 
+COMMIT;
+BEGIN;
+
 DO $$
 DECLARE
     table_name TEXT;
@@ -225,6 +254,9 @@ BEGIN
         );
     END LOOP;
 END $$;
+
+COMMIT;
+BEGIN;
 
 -- Copy the open history revision to the live row without disabling triggers.
 -- The transaction-local restore flag suppresses history writes while retaining
@@ -257,9 +289,16 @@ BEGIN
     END LOOP;
 END $$;
 
+COMMIT;
+BEGIN;
+
 ALTER TABLE events
     ADD COLUMN IF NOT EXISTS before_revision BIGINT NULL,
     ADD COLUMN IF NOT EXISTS after_revision BIGINT NULL;
+
+COMMIT;
+BEGIN;
+
 DO $$
 BEGIN
     IF NOT EXISTS (
@@ -281,13 +320,23 @@ BEGIN
             CHECK (after_revision > 0) NOT VALID;
     END IF;
 END $$;
+
+COMMIT;
+BEGIN;
+
 ALTER TABLE events VALIDATE CONSTRAINT events_before_revision_positive;
+
+COMMIT;
+BEGIN;
+
 ALTER TABLE events VALIDATE CONSTRAINT events_after_revision_positive;
+
+COMMIT;
+BEGIN;
 
 -- Keep the behavioral cutover atomic even though the expansion and backfill
 -- phases above intentionally commit independently. A failed cutover therefore
 -- leaves the old trigger set intact and can be retried safely.
-BEGIN;
 
 CREATE OR REPLACE FUNCTION hubuum_revision_owner_first(owner_key TEXT)
 RETURNS BOOLEAN

--- a/migrations/2026-08-04-000002_collections_history_revision_index/down.sql
+++ b/migrations/2026-08-04-000002_collections_history_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS collections_history_id_revision_idx;

--- a/migrations/2026-08-04-000002_collections_history_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000002_collections_history_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000002_collections_history_revision_index/up.sql
+++ b/migrations/2026-08-04-000002_collections_history_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY collections_history_id_revision_idx ON collections_history (id, revision, history_id);

--- a/migrations/2026-08-04-000003_classes_history_revision_index/down.sql
+++ b/migrations/2026-08-04-000003_classes_history_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS hubuumclass_history_id_revision_idx;

--- a/migrations/2026-08-04-000003_classes_history_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000003_classes_history_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000003_classes_history_revision_index/up.sql
+++ b/migrations/2026-08-04-000003_classes_history_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY hubuumclass_history_id_revision_idx ON hubuumclass_history (id, revision, history_id);

--- a/migrations/2026-08-04-000004_class_relations_history_revision_index/down.sql
+++ b/migrations/2026-08-04-000004_class_relations_history_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS hubuumclass_relation_history_id_revision_idx;

--- a/migrations/2026-08-04-000004_class_relations_history_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000004_class_relations_history_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000004_class_relations_history_revision_index/up.sql
+++ b/migrations/2026-08-04-000004_class_relations_history_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY hubuumclass_relation_history_id_revision_idx ON hubuumclass_relation_history (id, revision, history_id);

--- a/migrations/2026-08-04-000005_objects_history_revision_index/down.sql
+++ b/migrations/2026-08-04-000005_objects_history_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS hubuumobject_history_id_revision_idx;

--- a/migrations/2026-08-04-000005_objects_history_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000005_objects_history_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000005_objects_history_revision_index/up.sql
+++ b/migrations/2026-08-04-000005_objects_history_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY hubuumobject_history_id_revision_idx ON hubuumobject_history (id, revision, history_id);

--- a/migrations/2026-08-04-000006_object_relations_history_revision_index/down.sql
+++ b/migrations/2026-08-04-000006_object_relations_history_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS hubuumobject_relation_history_id_revision_idx;

--- a/migrations/2026-08-04-000006_object_relations_history_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000006_object_relations_history_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000006_object_relations_history_revision_index/up.sql
+++ b/migrations/2026-08-04-000006_object_relations_history_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY hubuumobject_relation_history_id_revision_idx ON hubuumobject_relation_history (id, revision, history_id);

--- a/migrations/2026-08-04-000007_export_templates_history_revision_index/down.sql
+++ b/migrations/2026-08-04-000007_export_templates_history_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS export_templates_history_id_revision_idx;

--- a/migrations/2026-08-04-000007_export_templates_history_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000007_export_templates_history_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000007_export_templates_history_revision_index/up.sql
+++ b/migrations/2026-08-04-000007_export_templates_history_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY export_templates_history_id_revision_idx ON export_templates_history (id, revision, history_id);

--- a/migrations/2026-08-04-000008_remote_targets_history_revision_index/down.sql
+++ b/migrations/2026-08-04-000008_remote_targets_history_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS remote_targets_history_id_revision_idx;

--- a/migrations/2026-08-04-000008_remote_targets_history_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000008_remote_targets_history_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000008_remote_targets_history_revision_index/up.sql
+++ b/migrations/2026-08-04-000008_remote_targets_history_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY remote_targets_history_id_revision_idx ON remote_targets_history (id, revision, history_id);

--- a/migrations/2026-08-04-000009_identity_scopes_revision_index/down.sql
+++ b/migrations/2026-08-04-000009_identity_scopes_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS identity_scopes_revision_id_idx;

--- a/migrations/2026-08-04-000009_identity_scopes_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000009_identity_scopes_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000009_identity_scopes_revision_index/up.sql
+++ b/migrations/2026-08-04-000009_identity_scopes_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY identity_scopes_revision_id_idx ON identity_scopes (revision, id);

--- a/migrations/2026-08-04-000010_principals_revision_index/down.sql
+++ b/migrations/2026-08-04-000010_principals_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS principals_revision_id_idx;

--- a/migrations/2026-08-04-000010_principals_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000010_principals_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000010_principals_revision_index/up.sql
+++ b/migrations/2026-08-04-000010_principals_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY principals_revision_id_idx ON principals (revision, id);

--- a/migrations/2026-08-04-000011_groups_revision_index/down.sql
+++ b/migrations/2026-08-04-000011_groups_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS groups_revision_id_idx;

--- a/migrations/2026-08-04-000011_groups_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000011_groups_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000011_groups_revision_index/up.sql
+++ b/migrations/2026-08-04-000011_groups_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY groups_revision_id_idx ON groups (revision, id);

--- a/migrations/2026-08-04-000012_collections_revision_index/down.sql
+++ b/migrations/2026-08-04-000012_collections_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS collections_parent_revision_id_idx;

--- a/migrations/2026-08-04-000012_collections_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000012_collections_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000012_collections_revision_index/up.sql
+++ b/migrations/2026-08-04-000012_collections_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY collections_parent_revision_id_idx ON collections (parent_collection_id, revision, id);

--- a/migrations/2026-08-04-000013_classes_revision_index/down.sql
+++ b/migrations/2026-08-04-000013_classes_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS hubuumclass_collection_revision_id_idx;

--- a/migrations/2026-08-04-000013_classes_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000013_classes_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000013_classes_revision_index/up.sql
+++ b/migrations/2026-08-04-000013_classes_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY hubuumclass_collection_revision_id_idx ON hubuumclass (collection_id, revision, id);

--- a/migrations/2026-08-04-000014_objects_revision_index/down.sql
+++ b/migrations/2026-08-04-000014_objects_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS hubuumobject_class_revision_id_idx;

--- a/migrations/2026-08-04-000014_objects_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000014_objects_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000014_objects_revision_index/up.sql
+++ b/migrations/2026-08-04-000014_objects_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY hubuumobject_class_revision_id_idx ON hubuumobject (hubuum_class_id, revision, id);

--- a/migrations/2026-08-04-000015_class_relations_revision_index/down.sql
+++ b/migrations/2026-08-04-000015_class_relations_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS hubuumclass_relation_revision_id_idx;

--- a/migrations/2026-08-04-000015_class_relations_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000015_class_relations_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000015_class_relations_revision_index/up.sql
+++ b/migrations/2026-08-04-000015_class_relations_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY hubuumclass_relation_revision_id_idx ON hubuumclass_relation (revision, id);

--- a/migrations/2026-08-04-000016_object_relations_revision_index/down.sql
+++ b/migrations/2026-08-04-000016_object_relations_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS hubuumobject_relation_revision_id_idx;

--- a/migrations/2026-08-04-000016_object_relations_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000016_object_relations_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000016_object_relations_revision_index/up.sql
+++ b/migrations/2026-08-04-000016_object_relations_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY hubuumobject_relation_revision_id_idx ON hubuumobject_relation (revision, id);

--- a/migrations/2026-08-04-000017_export_templates_revision_index/down.sql
+++ b/migrations/2026-08-04-000017_export_templates_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS export_templates_collection_revision_id_idx;

--- a/migrations/2026-08-04-000017_export_templates_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000017_export_templates_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000017_export_templates_revision_index/up.sql
+++ b/migrations/2026-08-04-000017_export_templates_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY export_templates_collection_revision_id_idx ON export_templates (collection_id, revision, id);

--- a/migrations/2026-08-04-000018_remote_targets_revision_index/down.sql
+++ b/migrations/2026-08-04-000018_remote_targets_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS remote_targets_collection_revision_id_idx;

--- a/migrations/2026-08-04-000018_remote_targets_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000018_remote_targets_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000018_remote_targets_revision_index/up.sql
+++ b/migrations/2026-08-04-000018_remote_targets_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY remote_targets_collection_revision_id_idx ON remote_targets (collection_id, revision, id);

--- a/migrations/2026-08-04-000019_event_sinks_revision_index/down.sql
+++ b/migrations/2026-08-04-000019_event_sinks_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_sinks_revision_id_idx;

--- a/migrations/2026-08-04-000019_event_sinks_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000019_event_sinks_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000019_event_sinks_revision_index/up.sql
+++ b/migrations/2026-08-04-000019_event_sinks_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY event_sinks_revision_id_idx ON event_sinks (revision, id);

--- a/migrations/2026-08-04-000020_event_subscriptions_revision_index/down.sql
+++ b/migrations/2026-08-04-000020_event_subscriptions_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_subscriptions_collection_revision_id_idx;

--- a/migrations/2026-08-04-000020_event_subscriptions_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000020_event_subscriptions_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000020_event_subscriptions_revision_index/up.sql
+++ b/migrations/2026-08-04-000020_event_subscriptions_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY event_subscriptions_collection_revision_id_idx ON event_subscriptions (collection_id, revision, id);

--- a/migrations/2026-08-04-000021_computed_fields_revision_index/down.sql
+++ b/migrations/2026-08-04-000021_computed_fields_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS computed_field_class_revision_id_idx;

--- a/migrations/2026-08-04-000021_computed_fields_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000021_computed_fields_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000021_computed_fields_revision_index/up.sql
+++ b/migrations/2026-08-04-000021_computed_fields_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY computed_field_class_revision_id_idx ON computed_field_definitions (class_id, revision, id);

--- a/migrations/2026-08-04-000022_tokens_revision_index/down.sql
+++ b/migrations/2026-08-04-000022_tokens_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tokens_principal_revision_id_idx;

--- a/migrations/2026-08-04-000022_tokens_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000022_tokens_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000022_tokens_revision_index/up.sql
+++ b/migrations/2026-08-04-000022_tokens_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY tokens_principal_revision_id_idx ON tokens (principal_id, revision, id);

--- a/migrations/2026-08-04-000023_group_memberships_revision_index/down.sql
+++ b/migrations/2026-08-04-000023_group_memberships_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS group_memberships_group_revision_idx;

--- a/migrations/2026-08-04-000023_group_memberships_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000023_group_memberships_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000023_group_memberships_revision_index/up.sql
+++ b/migrations/2026-08-04-000023_group_memberships_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY group_memberships_group_revision_idx ON group_memberships (group_id, revision, principal_id);

--- a/migrations/2026-08-04-000024_events_before_revision_index/down.sql
+++ b/migrations/2026-08-04-000024_events_before_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS events_before_revision_id_idx;

--- a/migrations/2026-08-04-000024_events_before_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000024_events_before_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000024_events_before_revision_index/up.sql
+++ b/migrations/2026-08-04-000024_events_before_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY events_before_revision_id_idx ON events (before_revision, id) WHERE before_revision IS NOT NULL;

--- a/migrations/2026-08-04-000025_events_after_revision_index/down.sql
+++ b/migrations/2026-08-04-000025_events_after_revision_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS events_after_revision_id_idx;

--- a/migrations/2026-08-04-000025_events_after_revision_index/metadata.toml
+++ b/migrations/2026-08-04-000025_events_after_revision_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-08-04-000025_events_after_revision_index/up.sql
+++ b/migrations/2026-08-04-000025_events_after_revision_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY events_after_revision_id_idx ON events (after_revision, id) WHERE after_revision IS NOT NULL;

--- a/scripts/check-migration-compatibility.sh
+++ b/scripts/check-migration-compatibility.sh
@@ -34,6 +34,29 @@ report_failure() {
   failures=$((failures + 1))
 }
 
+sql_statements() {
+  local file="$1"
+
+  awk '
+    /^[[:space:]]*(--|$)/ { next }
+    statement == "" { first_line = NR }
+    {
+      statement = statement " " $0
+      if ($0 ~ /;/) {
+        sub(/^[[:space:]]+/, "", statement)
+        print first_line ":" statement
+        statement = ""
+      }
+    }
+    END {
+      if (statement != "") {
+        sub(/^[[:space:]]+/, "", statement)
+        print first_line ":" statement
+      }
+    }
+  ' "$file"
+}
+
 while IFS= read -r file; do
   [[ -n "$file" ]] || continue
   checked=$((checked + 1))
@@ -62,7 +85,7 @@ while IFS= read -r file; do
       && [[ ! "$upper_statement" =~ INDEX[[:space:]]+CONCURRENTLY[[:space:]] ]]; then
       report_failure "$file" "$line_number" "indexes on an adjacent-release path must be created concurrently"
     fi
-  done < <(grep -nEiv '^[[:space:]]*(--|$)' "$repository_root/$file" || true)
+  done < <(sql_statements "$repository_root/$file")
 done < <(
   git -C "$repository_root" diff --diff-filter=AM --name-only "$base_ref"...HEAD -- 'migrations/*/up.sql'
 )

--- a/scripts/check-migration-compatibility.sh
+++ b/scripts/check-migration-compatibility.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+base_ref="${1:-}"
+
+if [[ -z "$base_ref" ]]; then
+  base_ref="$(git -C "$repository_root" tag --list 'v[0-9]*' --sort=-v:refname | head -n 1)"
+fi
+[[ -n "$base_ref" ]] || {
+  echo "ERROR: no stable release tag is available for migration review" >&2
+  exit 1
+}
+git -C "$repository_root" rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null || {
+  echo "ERROR: migration compatibility baseline '$base_ref' does not exist" >&2
+  exit 1
+}
+
+failures=0
+checked=0
+
+report_failure() {
+  local file="$1"
+  local line="$2"
+  local reason="$3"
+
+  printf '%s:%s: %s\n' "$file" "$line" "$reason" >&2
+  failures=$((failures + 1))
+}
+
+while IFS= read -r file; do
+  [[ -n "$file" ]] || continue
+  checked=$((checked + 1))
+
+  while IFS=: read -r line_number statement; do
+    [[ -n "$line_number" ]] || continue
+    upper_statement="$(printf '%s' "$statement" | tr '[:lower:]' '[:upper:]')"
+
+    if [[ "$upper_statement" =~ DROP[[:space:]]+(TABLE|COLUMN|CONSTRAINT|INDEX) ]]; then
+      report_failure "$file" "$line_number" "dropping schema objects is not adjacent-release compatible"
+    elif [[ "$upper_statement" =~ RENAME[[:space:]]+(TO|COLUMN|CONSTRAINT) ]]; then
+      report_failure "$file" "$line_number" "renaming schema objects is not adjacent-release compatible"
+    elif [[ "$upper_statement" =~ ALTER[[:space:]]+COLUMN.*[[:space:]]TYPE[[:space:]] ]]; then
+      report_failure "$file" "$line_number" "changing a column type in place is not adjacent-release compatible"
+    elif [[ "$upper_statement" =~ ADD[[:space:]]+COLUMN.*NOT[[:space:]]+NULL ]] \
+      && [[ ! "$upper_statement" =~ DEFAULT[[:space:]] ]]; then
+      report_failure "$file" "$line_number" "a new NOT NULL column must have an old-writer-compatible default"
+    elif [[ "$upper_statement" =~ ALTER[[:space:]]+COLUMN.*SET[[:space:]]+NOT[[:space:]]+NULL ]]; then
+      if [[ "$upper_statement" != *"HUBUUM-COMPAT: SET-NOT-NULL-AFTER-BACKFILL"* ]]; then
+        report_failure "$file" "$line_number" "setting NOT NULL requires a separately reviewed backfill phase"
+      fi
+    elif [[ "$upper_statement" =~ ADD[[:space:]]+CONSTRAINT ]] \
+      && [[ ! "$upper_statement" =~ NOT[[:space:]]+VALID ]]; then
+      report_failure "$file" "$line_number" "new constraints must use NOT VALID before separate validation"
+    elif [[ "$upper_statement" =~ CREATE([[:space:]]+UNIQUE)?[[:space:]]+INDEX[[:space:]] ]] \
+      && [[ ! "$upper_statement" =~ INDEX[[:space:]]+CONCURRENTLY[[:space:]] ]]; then
+      report_failure "$file" "$line_number" "indexes on an adjacent-release path must be created concurrently"
+    fi
+  done < <(grep -nEiv '^[[:space:]]*(--|$)' "$repository_root/$file" || true)
+done < <(
+  git -C "$repository_root" diff --diff-filter=AM --name-only "$base_ref"...HEAD -- 'migrations/*/up.sql'
+)
+
+if ((failures > 0)); then
+  echo "Migration compatibility review failed with $failures unsafe pattern(s)." >&2
+  exit 1
+fi
+
+echo "Migration compatibility review passed for $checked migration file(s) since $base_ref."

--- a/scripts/check-migration-compatibility.sh
+++ b/scripts/check-migration-compatibility.sh
@@ -5,7 +5,13 @@ repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 base_ref="${1:-}"
 
 if [[ -z "$base_ref" ]]; then
-  base_ref="$(git -C "$repository_root" tag --list 'v[0-9]*' --sort=-v:refname | head -n 1)"
+  while IFS= read -r candidate_ref; do
+    if [[ "${GITHUB_REF_TYPE:-}" == "tag" && "$candidate_ref" == "${GITHUB_REF_NAME:-}" ]]; then
+      continue
+    fi
+    base_ref="$candidate_ref"
+    break
+  done < <(git -C "$repository_root" tag --list 'v[0-9]*' --sort=-v:refname)
 fi
 [[ -n "$base_ref" ]] || {
   echo "ERROR: no stable release tag is available for migration review" >&2

--- a/scripts/classify-ci-changes.sh
+++ b/scripts/classify-ci-changes.sh
@@ -129,6 +129,8 @@ for path in "$@"; do
       postgres_benchmark=true
       ;;
     scripts/install-single-host.sh | scripts/single-host-rollout.sh | \
+      scripts/check-migration-compatibility.sh | scripts/resolve-adjacent-release.sh | \
+      scripts/test-adjacent-release-upgrade.sh | scripts/test-migration-compatibility.sh | \
       scripts/test-install-script-refresh.sh | scripts/test-single-host-rollout.sh | \
       scripts/test-single-host-zero-downtime.sh | scripts/update-single-host.sh | \
       scripts/uninstall-single-host.sh | scripts/stop-single-host.sh)

--- a/scripts/resolve-adjacent-release.sh
+++ b/scripts/resolve-adjacent-release.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository="${GITHUB_REPOSITORY:-hubuum/hubuum}"
+image_repository="${HUBUUM_RELEASE_IMAGE_REPOSITORY:-ghcr.io/hubuum/hubuum-server}"
+api_url="${GITHUB_API_URL:-https://api.github.com}"
+report_path="${HUBUUM_COMPATIBILITY_REPORT:-adjacent-release-metadata.json}"
+mkdir -p "$(dirname -- "$report_path")"
+
+headers=(
+  --header "Accept: application/vnd.github+json"
+  --header "X-GitHub-Api-Version: 2022-11-28"
+)
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  headers+=(--header "Authorization: Bearer ${GH_TOKEN}")
+fi
+
+if [[ -n "${HUBUUM_PREVIOUS_RELEASE_TAG:-}" ]]; then
+  previous_tag="$HUBUUM_PREVIOUS_RELEASE_TAG"
+else
+  previous_tag="$(
+    curl --fail --silent --show-error "${headers[@]}" \
+      "$api_url/repos/$repository/releases/latest" | jq --raw-output '.tag_name'
+  )"
+fi
+[[ "$previous_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "ERROR: latest stable release tag '$previous_tag' is not semantic version vMAJOR.MINOR.PATCH" >&2
+  exit 1
+}
+
+tagged_image="$image_repository:$previous_tag"
+docker pull "$tagged_image" >/dev/null
+previous_image="$(
+  docker image inspect "$tagged_image" \
+    --format '{{range .RepoDigests}}{{println .}}{{end}}' \
+    | grep -E "^${image_repository//./\.}@sha256:[0-9a-f]{64}$" \
+    | head -n 1
+)"
+[[ "$previous_image" =~ @sha256:[0-9a-f]{64}$ ]] || {
+  echo "ERROR: could not resolve an immutable digest for $tagged_image" >&2
+  exit 1
+}
+
+jq --null-input \
+  --arg previous_tag "$previous_tag" \
+  --arg previous_image "$previous_image" \
+  --arg candidate_sha "${GITHUB_SHA:-$(git rev-parse HEAD)}" \
+  '{previous_tag: $previous_tag, previous_image: $previous_image, candidate_sha: $candidate_sha}' \
+  > "$report_path"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "previous_tag=$previous_tag"
+    echo "previous_image=$previous_image"
+    echo "report_path=$report_path"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+echo "Resolved adjacent release $previous_tag as $previous_image"

--- a/scripts/test-adjacent-release-upgrade.sh
+++ b/scripts/test-adjacent-release-upgrade.sh
@@ -47,22 +47,43 @@ compose=(
   --file "$test_root/compose.yml"
 )
 
+applied_migrations() {
+  local migration_table
+  local versions
+
+  if ! "${compose[@]}" ps postgres >/dev/null 2>&1; then
+    printf '[]'
+    return
+  fi
+  migration_table="$(
+    "${compose[@]}" exec -T postgres psql \
+      --username hubuum --dbname hubuum --tuples-only --no-align \
+      --command "SELECT to_regclass('public.__diesel_schema_migrations')" \
+      2>/dev/null || true
+  )"
+  if [[ "$migration_table" != "__diesel_schema_migrations" ]]; then
+    printf '[]'
+    return
+  fi
+  versions="$(
+    "${compose[@]}" exec -T postgres psql \
+      --username hubuum --dbname hubuum --tuples-only --no-align \
+      --command 'SELECT version FROM __diesel_schema_migrations ORDER BY version' \
+      2>/dev/null || true
+  )"
+  jq --null-input --arg versions "$versions" \
+    '$versions | split("\n") | map(select(length > 0))'
+}
+
 write_report() {
   local result="$1"
   local previous_digest
   local candidate_id
-  local migrations="[]"
+  local migrations
 
   previous_digest="${previous_image##*@}"
   candidate_id="$(docker image inspect "$candidate_image" --format '{{.Id}}' 2>/dev/null || true)"
-  if "${compose[@]}" ps postgres >/dev/null 2>&1; then
-    migrations="$(
-      "${compose[@]}" exec -T postgres psql \
-        --username hubuum --dbname hubuum --tuples-only --no-align \
-        --command 'SELECT version FROM __diesel_schema_migrations ORDER BY version' \
-        2>/dev/null | jq --raw-input --slurp 'split("\n") | map(select(length > 0))'
-    )"
-  fi
+  migrations="$(applied_migrations)"
 
   jq --null-input \
     --arg result "$result" \
@@ -359,6 +380,7 @@ probe_previous_api() {
   local url
   local status
   local duration
+  local result
 
   url="$(service_url previous-api)/api/v1/tasks/$probe_task_id"
   while [[ ! -e "$probe_stop_file" ]]; do
@@ -373,7 +395,10 @@ probe_previous_api() {
       duration="${result#*$'\t'}"
     else
       status="curl-error"
-      duration="3"
+      duration="${result#*$'\t'}"
+      if [[ "$result" != *$'\t'* || ! "$duration" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+        duration="3"
+      fi
     fi
     printf '%s\t%s\n' "$status" "$duration" >> "$probe_log"
     sleep 0.1
@@ -388,8 +413,8 @@ analyze_probes() {
   max_probe_outage_seconds="$(
     awk '
       $1 == 200 {current=0; next}
-      {current += 0.1; if (current > max) max=current}
-      END {printf "%.1f", max + 0}
+      {current += $2 + 0.1; if (current > max) max=current}
+      END {printf "%.6f", max + 0}
     ' "$probe_log"
   )"
   if ((failures > 0)); then

--- a/scripts/test-adjacent-release-upgrade.sh
+++ b/scripts/test-adjacent-release-upgrade.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+candidate_image="${HUBUUM_TEST_IMAGE:-hubuum-server:ci}"
+previous_image="${HUBUUM_PREVIOUS_IMAGE:?HUBUUM_PREVIOUS_IMAGE must be an immutable release image digest}"
+previous_tag="${HUBUUM_PREVIOUS_RELEASE_TAG:?HUBUUM_PREVIOUS_RELEASE_TAG must identify the adjacent stable release}"
+postgres_image="${POSTGRES_TEST_IMAGE:-postgres:18.4@sha256:22c89fe0d0f507606260237fd55e51f6137f58b2d5bcf6152242b96d9fe8f9a4}"
+report_root="${HUBUUM_COMPATIBILITY_REPORT_DIR:-$repository_root/compatibility-report}"
+test_root="$(mktemp -d)"
+project_name="hubuum-adjacent-${RANDOM}-${RANDOM}"
+phase="initialize"
+probe_pid=""
+probe_stop_file="$test_root/stop-probe"
+probe_log="$report_root/api-probes.tsv"
+migration_log="$report_root/migration.log"
+compose_log="$report_root/compose.log"
+report_file="$report_root/report.json"
+database_url="postgres://hubuum:adjacent-release@postgres/hubuum?sslmode=disable"
+admin_token=""
+collection_id=""
+class_id=""
+object_id=""
+probe_task_id=""
+migration_seconds=0
+max_probe_latency_seconds=0
+max_probe_outage_seconds=0
+api_body=""
+api_headers=""
+
+[[ "$previous_image" =~ @sha256:[0-9a-f]{64}$ ]] || {
+  echo "ERROR: HUBUUM_PREVIOUS_IMAGE must be pinned by sha256 digest" >&2
+  exit 1
+}
+docker image inspect "$candidate_image" >/dev/null
+docker image inspect "$previous_image" >/dev/null
+
+mkdir -p "$report_root"
+: > "$probe_log"
+: > "$migration_log"
+: > "$compose_log"
+
+compose=(
+  docker compose
+  --project-name "$project_name"
+  --env-file "$test_root/.env"
+  --file "$test_root/compose.yml"
+)
+
+write_report() {
+  local result="$1"
+  local previous_digest
+  local candidate_id
+  local migrations="[]"
+
+  previous_digest="${previous_image##*@}"
+  candidate_id="$(docker image inspect "$candidate_image" --format '{{.Id}}' 2>/dev/null || true)"
+  if "${compose[@]}" ps postgres >/dev/null 2>&1; then
+    migrations="$(
+      "${compose[@]}" exec -T postgres psql \
+        --username hubuum --dbname hubuum --tuples-only --no-align \
+        --command 'SELECT version FROM __diesel_schema_migrations ORDER BY version' \
+        2>/dev/null | jq --raw-input --slurp 'split("\n") | map(select(length > 0))'
+    )"
+  fi
+
+  jq --null-input \
+    --arg result "$result" \
+    --arg phase "$phase" \
+    --arg previous_tag "$previous_tag" \
+    --arg previous_image "$previous_image" \
+    --arg previous_digest "$previous_digest" \
+    --arg candidate_image "$candidate_image" \
+    --arg candidate_image_id "$candidate_id" \
+    --arg candidate_sha "${GITHUB_SHA:-$(git -C "$repository_root" rev-parse HEAD)}" \
+    --argjson migration_seconds "$migration_seconds" \
+    --argjson max_probe_latency_seconds "$max_probe_latency_seconds" \
+    --argjson max_probe_outage_seconds "$max_probe_outage_seconds" \
+    --argjson migrations "$migrations" \
+    '{
+      result: $result,
+      phase: $phase,
+      previous_release: {tag: $previous_tag, image: $previous_image, digest: $previous_digest},
+      candidate: {sha: $candidate_sha, image: $candidate_image, image_id: $candidate_image_id},
+      migration: {
+        seconds: $migration_seconds,
+        max_api_latency_seconds: $max_probe_latency_seconds,
+        max_observed_api_outage_seconds: $max_probe_outage_seconds,
+        applied_versions: $migrations
+      }
+    }' > "$report_file"
+}
+
+stop_probe() {
+  touch "$probe_stop_file"
+  if [[ -n "$probe_pid" ]]; then
+    wait "$probe_pid" 2>/dev/null || true
+    probe_pid=""
+  fi
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  set +e
+  stop_probe
+  "${compose[@]}" logs --no-color --timestamps > "$compose_log" 2>&1
+  if [[ "$status" -eq 0 ]]; then
+    write_report passed
+  else
+    write_report failed
+    echo "Adjacent-release compatibility failed during phase '$phase'." >&2
+    echo "Report: $report_file" >&2
+    tail -n 200 "$compose_log" >&2
+  fi
+  "${compose[@]}" down --volumes --remove-orphans >/dev/null 2>&1
+  rm -rf "$test_root"
+  exit "$status"
+}
+trap cleanup EXIT
+
+cat > "$test_root/.env" <<EOF
+HUBUUM_CANDIDATE_IMAGE=$candidate_image
+HUBUUM_PREVIOUS_IMAGE=$previous_image
+POSTGRES_TEST_IMAGE=$postgres_image
+HUBUUM_DATABASE_URL=$database_url
+EOF
+
+cat > "$test_root/compose.yml" <<'EOF'
+services:
+  postgres:
+    image: ${POSTGRES_TEST_IMAGE}
+    environment:
+      POSTGRES_DB: hubuum
+      POSTGRES_USER: hubuum
+      POSTGRES_PASSWORD: adjacent-release
+      PGUSER: hubuum
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U hubuum -d hubuum"]
+      interval: 1s
+      timeout: 2s
+      retries: 60
+
+  previous-api:
+    image: ${HUBUUM_PREVIOUS_IMAGE}
+    command: ["--runtime-role", "api"]
+    ports:
+      - "127.0.0.1::8080"
+    environment: &hubuum-environment
+      HUBUUM_BIND_IP: 0.0.0.0
+      HUBUUM_BIND_PORT: 8080
+      HUBUUM_DATABASE_URL: ${HUBUUM_DATABASE_URL}
+      HUBUUM_CLIENT_ALLOWLIST: "*"
+      HUBUUM_LOG_LEVEL: info
+      HUBUUM_TOKEN_HASH_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck: &hubuum-healthcheck
+      test: ["CMD-SHELL", "wget --quiet --output-document=/dev/null http://127.0.0.1:8080/readyz"]
+      interval: 1s
+      timeout: 2s
+      retries: 60
+
+  previous-worker:
+    image: ${HUBUUM_PREVIOUS_IMAGE}
+    command: ["--runtime-role", "worker"]
+    environment: *hubuum-environment
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  candidate-api:
+    image: ${HUBUUM_CANDIDATE_IMAGE}
+    command: ["--runtime-role", "api"]
+    ports:
+      - "127.0.0.1::8080"
+    environment: *hubuum-environment
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck: *hubuum-healthcheck
+
+  candidate-worker:
+    image: ${HUBUUM_CANDIDATE_IMAGE}
+    command: ["--runtime-role", "worker"]
+    environment: *hubuum-environment
+    depends_on:
+      postgres:
+        condition: service_healthy
+EOF
+
+service_url() {
+  local service="$1"
+  local address
+
+  address="$("${compose[@]}" port "$service" 8080)"
+  printf 'http://%s' "$address"
+}
+
+wait_for_ready() {
+  local service="$1"
+  local url
+
+  url="$(service_url "$service")"
+  for _ in $(seq 1 90); do
+    if curl --fail --silent --show-error --max-time 2 "$url/readyz" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: $service did not become ready" >&2
+  return 1
+}
+
+api_request() {
+  local service="$1"
+  local method="$2"
+  local path="$3"
+  local payload="${4:-}"
+  local etag="${5:-}"
+  local status
+  local url
+  local body_file="$test_root/api-body.json"
+  local headers_file="$test_root/api-headers.txt"
+  local args=(
+    --silent --show-error
+    --request "$method"
+    --output "$body_file"
+    --dump-header "$headers_file"
+    --write-out '%{http_code}'
+    --header 'Accept: application/json'
+  )
+
+  url="$(service_url "$service")"
+  if [[ -n "$admin_token" ]]; then
+    args+=(--header "Authorization: Bearer $admin_token")
+  fi
+  if [[ -n "$payload" ]]; then
+    args+=(--header 'Content-Type: application/json' --data "$payload")
+  fi
+  if [[ -n "$etag" ]]; then
+    args+=(--header "If-Match: $etag")
+  fi
+
+  status="$(curl "${args[@]}" "$url$path")"
+  api_body="$(cat "$body_file")"
+  api_headers="$(cat "$headers_file")"
+  if [[ ! "$status" =~ ^2[0-9][0-9]$ ]]; then
+    echo "ERROR: $service $method $path returned HTTP $status" >&2
+    printf '%s\n' "$api_body" >&2
+    return 1
+  fi
+}
+
+json_id() {
+  jq --exit-status --raw-output '.id' <<< "$api_body"
+}
+
+seed_previous_release() {
+  local group_id
+  local user_id
+  local service_account_id
+  local child_collection_id
+  local related_class_id
+  local related_object_id
+  local class_relation_id
+  local sink_id
+  local template_id
+  local task_id
+
+  api_request previous-api POST /api/v1/iam/groups \
+    '{"groupname":"compat-operators","description":"adjacent release operators"}'
+  group_id="$(json_id)"
+
+  api_request previous-api POST /api/v1/iam/users \
+    '{"name":"compat-user","password":"compatibility-password","proper_name":"Compatibility User","email":"compat@example.com"}'
+  user_id="$(json_id)"
+  api_request previous-api POST "/api/v1/iam/groups/$group_id/members/$user_id"
+
+  api_request previous-api POST /api/v1/iam/service-accounts \
+    "{\"name\":\"compat-agent\",\"description\":\"adjacent release fixture\",\"owner_group_id\":$group_id}"
+  service_account_id="$(json_id)"
+  api_request previous-api POST "/api/v1/iam/principals/$service_account_id/tokens" \
+    '{"name":"compat-agent-token","description":"adjacent release fixture","scope":{"permissions":["ReadCollection","ReadClass","ReadObject"]}}'
+  jq --exit-status --raw-output '.token' <<< "$api_body" >/dev/null
+
+  api_request previous-api POST /api/v1/collections \
+    "{\"name\":\"compat-root\",\"description\":\"adjacent release root\",\"group_id\":$group_id}"
+  collection_id="$(json_id)"
+  api_request previous-api POST /api/v1/collections \
+    "{\"name\":\"compat-child\",\"description\":\"adjacent release child\",\"group_id\":$group_id,\"parent_collection_id\":$collection_id}"
+  child_collection_id="$(json_id)"
+
+  api_request previous-api POST /api/v1/classes \
+    "{\"name\":\"compat-host\",\"description\":\"host fixture\",\"collection_id\":$collection_id,\"json_schema\":{\"type\":\"object\",\"properties\":{\"owner\":{\"type\":\"string\"}},\"required\":[\"owner\"]},\"validate_schema\":true}"
+  class_id="$(json_id)"
+  api_request previous-api POST /api/v1/classes \
+    "{\"name\":\"compat-room\",\"description\":\"room fixture\",\"collection_id\":$child_collection_id,\"json_schema\":null,\"validate_schema\":false}"
+  related_class_id="$(json_id)"
+
+  api_request previous-api POST "/api/v1/classes/$class_id/" \
+    "{\"name\":\"compat-host-01\",\"description\":\"host fixture\",\"collection_id\":$collection_id,\"hubuum_class_id\":$class_id,\"data\":{\"owner\":\"previous\"}}"
+  object_id="$(json_id)"
+  api_request previous-api POST "/api/v1/classes/$related_class_id/" \
+    "{\"name\":\"compat-room-01\",\"description\":\"room fixture\",\"collection_id\":$child_collection_id,\"hubuum_class_id\":$related_class_id,\"data\":{}}"
+  related_object_id="$(json_id)"
+
+  api_request previous-api POST /api/v1/relations/classes \
+    "{\"from_hubuum_class_id\":$class_id,\"to_hubuum_class_id\":$related_class_id,\"forward_template_alias\":\"rooms\",\"reverse_template_alias\":\"hosts\"}"
+  class_relation_id="$(json_id)"
+  api_request previous-api POST /api/v1/relations/objects \
+    "{\"from_hubuum_object_id\":$object_id,\"to_hubuum_object_id\":$related_object_id,\"class_relation_id\":$class_relation_id}"
+
+  api_request previous-api POST "/api/v1/classes/$class_id/computed-fields" \
+    '{"key":"owner_copy","label":"Owner copy","description":"compatibility fixture","operation":{"type":"first_non_null","paths":["/owner"]},"result_type":"string","enabled":true}'
+
+  api_request previous-api POST /api/v1/event-sinks \
+    '{"name":"compat-sink","kind":"webhook","config":{},"enabled":false}'
+  sink_id="$(json_id)"
+  api_request previous-api POST "/api/v1/collections/$collection_id/event-subscriptions" \
+    "{\"sink_id\":$sink_id,\"name\":\"compat-events\",\"description\":\"adjacent release fixture\",\"entity_types\":[\"object\"],\"actions\":[\"created\",\"updated\"],\"filter\":{},\"routing\":{},\"enabled\":false}"
+
+  api_request previous-api POST /api/v1/remote-targets \
+    "{\"collection_id\":$collection_id,\"class_id\":$class_id,\"name\":\"compat-target\",\"description\":\"adjacent release fixture\",\"method\":\"post\",\"url_template\":\"https://example.invalid/{{ object.id }}\",\"headers_template\":{},\"body_template\":null,\"auth_config\":{\"type\":\"none\"},\"timeout_ms\":1000,\"allowed_subject_types\":[\"object\"],\"enabled\":false}"
+
+  api_request previous-api POST /api/v1/export-templates \
+    "{\"collection_id\":$collection_id,\"class_id\":$class_id,\"name\":\"compat-export\",\"description\":\"adjacent release fixture\",\"content_type\":\"text/plain\",\"template\":\"{% for item in items %}{{ item.name }}\\n{% endfor %}\",\"kind\":\"export\",\"scope_kind\":\"objects_in_class\"}"
+  template_id="$(json_id)"
+  api_request previous-api POST "/api/v1/export-templates/$template_id/exports" '{}'
+  task_id="$(json_id)"
+  probe_task_id="$task_id"
+  for _ in $(seq 1 100); do
+    api_request previous-api GET "/api/v1/tasks/$task_id"
+    case "$(jq --raw-output '.status' <<< "$api_body")" in
+      succeeded)
+        break
+        ;;
+      failed|cancelled)
+        echo "ERROR: previous-release export task failed" >&2
+        return 1
+        ;;
+    esac
+    sleep 0.1
+  done
+  [[ "$(jq --raw-output '.status' <<< "$api_body")" == "succeeded" ]] || {
+    echo "ERROR: previous-release export task did not complete" >&2
+    return 1
+  }
+
+  api_request previous-api GET "/api/v1/collections/$collection_id/events?limit=50"
+  [[ "$(jq 'length' <<< "$api_body")" -gt 0 ]] || {
+    echo "ERROR: representative fixture did not create audit events" >&2
+    return 1
+  }
+}
+
+probe_previous_api() {
+  local url
+  local status
+  local duration
+
+  url="$(service_url previous-api)/api/v1/tasks/$probe_task_id"
+  while [[ ! -e "$probe_stop_file" ]]; do
+    if result="$(
+      curl --silent --show-error --output /dev/null \
+        --write-out '%{http_code}\t%{time_total}' \
+        --connect-timeout 1 --max-time 3 \
+        --header "Authorization: Bearer $admin_token" \
+        "$url" 2>/dev/null
+    )"; then
+      status="${result%%$'\t'*}"
+      duration="${result#*$'\t'}"
+    else
+      status="curl-error"
+      duration="3"
+    fi
+    printf '%s\t%s\n' "$status" "$duration" >> "$probe_log"
+    sleep 0.1
+  done
+}
+
+analyze_probes() {
+  local failures
+
+  failures="$(awk '$1 != 200 {count++} END {print count + 0}' "$probe_log")"
+  max_probe_latency_seconds="$(awk 'BEGIN {max=0} $2 > max {max=$2} END {printf "%.6f", max}' "$probe_log")"
+  max_probe_outage_seconds="$(
+    awk '
+      $1 == 200 {current=0; next}
+      {current += 0.1; if (current > max) max=current}
+      END {printf "%.1f", max + 0}
+    ' "$probe_log"
+  )"
+  if ((failures > 0)); then
+    echo "ERROR: previous API had $failures failed request(s) during candidate migration" >&2
+    return 1
+  fi
+}
+
+phase="start-previous-release"
+"${compose[@]}" up -d postgres
+for _ in $(seq 1 60); do
+  if "${compose[@]}" exec -T postgres pg_isready --username hubuum --dbname hubuum >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+"${compose[@]}" exec -T postgres pg_isready --username hubuum --dbname hubuum >/dev/null
+"${compose[@]}" run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin previous-api --migrate
+"${compose[@]}" up -d previous-api previous-worker
+wait_for_ready previous-api
+
+phase="authenticate-previous-release"
+password_output="$(
+  "${compose[@]}" run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin \
+    previous-api --reset-password admin
+)"
+admin_password="${password_output##*reset to: }"
+[[ -n "$admin_password" && "$admin_password" != "$password_output" ]]
+api_request previous-api POST /api/v0/auth/login \
+  "{\"name\":\"admin\",\"password\":\"$admin_password\"}"
+admin_token="$(jq --exit-status --raw-output '.token' <<< "$api_body")"
+
+phase="seed-previous-release"
+seed_previous_release
+
+phase="drain-previous-worker"
+"${compose[@]}" stop --timeout 75 previous-worker
+[[ -z "$("${compose[@]}" ps --status running -q previous-worker)" ]]
+
+phase="candidate-migration"
+rm -f "$probe_stop_file"
+probe_previous_api &
+probe_pid=$!
+migration_started=$SECONDS
+"${compose[@]}" run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin \
+  candidate-api --migrate > "$migration_log" 2>&1
+migration_seconds=$((SECONDS - migration_started))
+stop_probe
+analyze_probes
+
+phase="mixed-version"
+"${compose[@]}" up -d candidate-api
+wait_for_ready candidate-api
+api_request previous-api PATCH "/api/v1/collections/$collection_id" \
+  '{"description":"written by previous release after migration"}'
+api_request candidate-api GET "/api/v1/collections/$collection_id"
+[[ "$(jq --raw-output '.description' <<< "$api_body")" == "written by previous release after migration" ]]
+etag="$(awk 'BEGIN {IGNORECASE=1} /^etag:/ {sub(/\r$/, "", $2); print $2}' <<< "$api_headers")"
+[[ -n "$etag" ]]
+api_request candidate-api PATCH "/api/v1/collections/$collection_id" \
+  '{"description":"written by candidate during overlap"}' "$etag"
+api_request previous-api GET "/api/v1/collections/$collection_id"
+[[ "$(jq --raw-output '.description' <<< "$api_body")" == "written by candidate during overlap" ]]
+api_request candidate-api GET "/api/v1/classes/$class_id/$object_id"
+[[ "$(jq --raw-output '.data.owner' <<< "$api_body")" == "previous" ]]
+
+phase="candidate-rollout"
+"${compose[@]}" stop --timeout 75 previous-api
+"${compose[@]}" up -d candidate-worker
+sleep 2
+[[ -n "$("${compose[@]}" ps --status running -q candidate-worker)" ]]
+
+phase="application-rollback"
+"${compose[@]}" stop --timeout 75 candidate-api candidate-worker
+"${compose[@]}" up -d previous-api
+wait_for_ready previous-api
+api_request previous-api GET "/api/v1/collections/$collection_id"
+[[ "$(jq --raw-output '.description' <<< "$api_body")" == "written by candidate during overlap" ]]
+api_request previous-api PATCH "/api/v1/collections/$collection_id" \
+  '{"description":"verified by previous release rollback"}'
+
+phase="restore-candidate"
+"${compose[@]}" stop --timeout 75 previous-api
+"${compose[@]}" up -d candidate-api candidate-worker
+wait_for_ready candidate-api
+api_request candidate-api GET "/api/v1/collections/$collection_id"
+[[ "$(jq --raw-output '.description' <<< "$api_body")" == "verified by previous release rollback" ]]
+api_request candidate-api GET /readyz
+
+phase="complete"
+echo "Adjacent release compatibility passed: $previous_tag -> ${GITHUB_SHA:-local candidate}."

--- a/scripts/test-adjacent-release-upgrade.sh
+++ b/scripts/test-adjacent-release-upgrade.sh
@@ -170,6 +170,9 @@ services:
     environment: &hubuum-environment
       HUBUUM_BIND_IP: 0.0.0.0
       HUBUUM_BIND_PORT: 8080
+      # v0.0.8 and earlier read the unprefixed name. Keep both variables so
+      # this harness can exercise the actual adjacent-version boundary.
+      DATABASE_URL: ${HUBUUM_DATABASE_URL}
       HUBUUM_DATABASE_URL: ${HUBUUM_DATABASE_URL}
       HUBUUM_CLIENT_ALLOWLIST: "*"
       HUBUUM_LOG_LEVEL: info

--- a/scripts/test-adjacent-release-upgrade.sh
+++ b/scripts/test-adjacent-release-upgrade.sh
@@ -144,7 +144,7 @@ cat > "$test_root/.env" <<EOF
 HUBUUM_CANDIDATE_IMAGE=$candidate_image
 HUBUUM_PREVIOUS_IMAGE=$previous_image
 POSTGRES_TEST_IMAGE=$postgres_image
-HUBUUM_DATABASE_URL=$database_url
+HUBUUM_COMPATIBILITY_DATABASE_URL=$database_url
 EOF
 
 cat > "$test_root/compose.yml" <<'EOF'
@@ -157,7 +157,7 @@ services:
       POSTGRES_PASSWORD: adjacent-release
       PGUSER: hubuum
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U hubuum -d hubuum"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U hubuum -d hubuum"]
       interval: 1s
       timeout: 2s
       retries: 60
@@ -172,8 +172,8 @@ services:
       HUBUUM_BIND_PORT: 8080
       # v0.0.8 and earlier read the unprefixed name. Keep both variables so
       # this harness can exercise the actual adjacent-version boundary.
-      DATABASE_URL: ${HUBUUM_DATABASE_URL}
-      HUBUUM_DATABASE_URL: ${HUBUUM_DATABASE_URL}
+      DATABASE_URL: ${HUBUUM_COMPATIBILITY_DATABASE_URL}
+      HUBUUM_DATABASE_URL: ${HUBUUM_COMPATIBILITY_DATABASE_URL}
       HUBUUM_CLIENT_ALLOWLIST: "*"
       HUBUUM_LOG_LEVEL: info
       HUBUUM_TOKEN_HASH_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -429,12 +429,14 @@ analyze_probes() {
 phase="start-previous-release"
 "${compose[@]}" up -d postgres
 for _ in $(seq 1 60); do
-  if "${compose[@]}" exec -T postgres pg_isready --username hubuum --dbname hubuum >/dev/null 2>&1; then
+  if "${compose[@]}" exec -T postgres pg_isready \
+    --host 127.0.0.1 --username hubuum --dbname hubuum >/dev/null 2>&1; then
     break
   fi
   sleep 1
 done
-"${compose[@]}" exec -T postgres pg_isready --username hubuum --dbname hubuum >/dev/null
+"${compose[@]}" exec -T postgres pg_isready \
+  --host 127.0.0.1 --username hubuum --dbname hubuum >/dev/null
 "${compose[@]}" run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin previous-api --migrate
 "${compose[@]}" up -d previous-api previous-worker
 wait_for_ready previous-api

--- a/scripts/test-classify-ci-changes.sh
+++ b/scripts/test-classify-ci-changes.sh
@@ -99,6 +99,11 @@ assert_flag "$docker_output" code true
 assert_flag "$docker_output" container true
 assert_flag "$docker_output" artifacts true
 
+compatibility_output="$(bash "$classifier" scripts/test-adjacent-release-upgrade.sh)"
+assert_flag "$compatibility_output" code true
+assert_flag "$compatibility_output" container true
+assert_flag "$compatibility_output" artifacts false
+
 unknown_output="$(bash "$classifier" future-build-input.conf)"
 assert_flag "$unknown_output" code true
 assert_flag "$unknown_output" container true

--- a/scripts/test-migration-compatibility.sh
+++ b/scripts/test-migration-compatibility.sh
@@ -48,4 +48,16 @@ if bash "$test_root/scripts/check-migration-compatibility.sh" v1.0.0 >/dev/null 
   exit 1
 fi
 
+printf '%s\n' \
+  'ALTER TABLE widgets' \
+  '    ADD CONSTRAINT widgets_name_required' \
+  '    CHECK (length(name) > 0);' \
+  > "$test_root/migrations/0002_candidate/up.sql"
+git -C "$test_root" add .
+git -C "$test_root" commit --quiet -m unsafe-multiline-constraint
+if bash "$test_root/scripts/check-migration-compatibility.sh" v1.0.0 >/dev/null 2>&1; then
+  echo "multiline blocking constraint unexpectedly passed compatibility review" >&2
+  exit 1
+fi
+
 echo "Migration compatibility checker tests passed."

--- a/scripts/test-migration-compatibility.sh
+++ b/scripts/test-migration-compatibility.sh
@@ -27,6 +27,10 @@ git -C "$test_root" add .
 git -C "$test_root" commit --quiet -m safe
 bash "$test_root/scripts/check-migration-compatibility.sh" v1.0.0 >/dev/null
 
+git -C "$test_root" tag v1.1.0
+GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.1.0 \
+  bash "$test_root/scripts/check-migration-compatibility.sh" >/dev/null
+
 printf '%s\n' 'ALTER TABLE widgets DROP COLUMN name;' > "$test_root/migrations/0002_candidate/up.sql"
 git -C "$test_root" add .
 git -C "$test_root" commit --quiet -m unsafe

--- a/scripts/test-migration-compatibility.sh
+++ b/scripts/test-migration-compatibility.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+git -C "$test_root" init --quiet
+git -C "$test_root" config user.email test@example.com
+git -C "$test_root" config user.name test
+git -C "$test_root" config commit.gpgsign false
+mkdir -p "$test_root/scripts" "$test_root/migrations/0001_safe"
+cp "$repository_root/scripts/check-migration-compatibility.sh" "$test_root/scripts/"
+printf '%s\n' 'SELECT 1;' > "$test_root/migrations/0001_safe/up.sql"
+git -C "$test_root" add .
+git -C "$test_root" commit --quiet -m baseline
+git -C "$test_root" tag v1.0.0
+
+mkdir -p "$test_root/migrations/0002_candidate"
+printf '%s\n' \
+  'ALTER TABLE widgets ADD COLUMN revision BIGINT NOT NULL DEFAULT 1;' \
+  'ALTER TABLE widgets ADD CONSTRAINT widgets_revision_positive CHECK (revision > 0) NOT VALID;' \
+  'ALTER TABLE widgets VALIDATE CONSTRAINT widgets_revision_positive;' \
+  'CREATE INDEX CONCURRENTLY widgets_revision_idx ON widgets (revision);' \
+  > "$test_root/migrations/0002_candidate/up.sql"
+git -C "$test_root" add .
+git -C "$test_root" commit --quiet -m safe
+bash "$test_root/scripts/check-migration-compatibility.sh" v1.0.0 >/dev/null
+
+printf '%s\n' 'ALTER TABLE widgets DROP COLUMN name;' > "$test_root/migrations/0002_candidate/up.sql"
+git -C "$test_root" add .
+git -C "$test_root" commit --quiet -m unsafe
+if bash "$test_root/scripts/check-migration-compatibility.sh" v1.0.0 >/dev/null 2>&1; then
+  echo "unsafe migration unexpectedly passed compatibility review" >&2
+  exit 1
+fi
+
+printf '%s\n' 'ALTER TABLE widgets ADD CONSTRAINT widgets_name_required CHECK (length(name) > 0);' \
+  > "$test_root/migrations/0002_candidate/up.sql"
+git -C "$test_root" add .
+git -C "$test_root" commit --quiet -m unsafe-constraint
+if bash "$test_root/scripts/check-migration-compatibility.sh" v1.0.0 >/dev/null 2>&1; then
+  echo "blocking constraint unexpectedly passed compatibility review" >&2
+  exit 1
+fi
+
+echo "Migration compatibility checker tests passed."

--- a/scripts/test-single-host-zero-downtime.sh
+++ b/scripts/test-single-host-zero-downtime.sh
@@ -14,6 +14,7 @@ READY_PROBES_FILE="$TEST_ROOT/enable-ready-probes"
 PROBE_PIDS=""
 HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS="${HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS:-12}"
 HUBUUM_ROLLOUT_CADDY_TIMEOUT_SECONDS="${HUBUUM_ROLLOUT_CADDY_TIMEOUT_SECONDS:-45}"
+HUBUUM_ZERO_DOWNTIME_PROBE_TIMEOUT_SECONDS="${HUBUUM_ZERO_DOWNTIME_PROBE_TIMEOUT_SECONDS:-7}"
 INSTALL_MODE="backend"
 
 docker image inspect "$HUBUUM_TEST_IMAGE" >/dev/null 2>&1 || {
@@ -260,7 +261,8 @@ probe_worker() {
     fi
 
     if status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
-      --connect-timeout 1 --max-time 2 "$PUBLIC_URL/$path" \
+      --connect-timeout 1 --max-time "$HUBUUM_ZERO_DOWNTIME_PROBE_TIMEOUT_SECONDS" \
+      "$PUBLIC_URL/$path" \
       2>> "$TEST_ROOT/probe-${worker}.stderr")"; then
       printf '%s %s\n' "$path" "$status" >> "$TEST_ROOT/probe-${worker}.log"
     else
@@ -295,6 +297,12 @@ assert_probes_succeeded() {
   if [[ -s "$failures" ]]; then
     echo "ERROR: public HTTP requests failed during the rollout:" >&2
     cat "$failures" >&2
+    for stderr_file in "$TEST_ROOT"/probe-*.stderr; do
+      if [[ -s "$stderr_file" ]]; then
+        echo "--- $stderr_file" >&2
+        cat "$stderr_file" >&2
+      fi
+    done
     return 1
   fi
   if (( request_count < 100 )); then
@@ -353,6 +361,9 @@ container_uses_candidate_image() {
 
 # shellcheck source=scripts/single-host-rollout.sh
 source "$REPOSITORY_ROOT/scripts/single-host-rollout.sh"
+hubuum_require_positive_seconds \
+  "HUBUUM_ZERO_DOWNTIME_PROBE_TIMEOUT_SECONDS" \
+  "$HUBUUM_ZERO_DOWNTIME_PROBE_TIMEOUT_SECONDS"
 
 echo "Starting the live single-host fixture on Hubuum v0.0.1..."
 COMPOSE_CMD=("${BASE_COMPOSE_CMD[@]}" --file "$TEST_ROOT/old-version.yml")

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1058,11 +1058,18 @@ mod tests {
             include_str!("../../migrations/2026-08-03-000001_resource_revisions/up.sql");
         let metadata =
             include_str!("../../migrations/2026-08-03-000001_resource_revisions/metadata.toml");
-        let transaction_count = migration.matches("\nBEGIN;\n").count();
+        let transaction_count = migration
+            .lines()
+            .filter(|line| line.trim() == "BEGIN;")
+            .count();
+        let commit_count = migration
+            .lines()
+            .filter(|line| line.trim() == "COMMIT;")
+            .count();
 
         assert_eq!(metadata.trim(), "run_in_transaction = false");
         assert_eq!(transaction_count, 16);
-        assert_eq!(migration.matches("\nCOMMIT;").count(), transaction_count);
+        assert_eq!(commit_count, transaction_count);
     }
 
     #[tokio::test]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1052,6 +1052,19 @@ mod tests {
         assert!(rollback.contains("DROP INDEX IF EXISTS computed_field_class_revision_id_idx;"));
     }
 
+    #[test]
+    fn resource_revision_migration_has_explicit_phase_transactions() {
+        let migration =
+            include_str!("../../migrations/2026-08-03-000001_resource_revisions/up.sql");
+        let metadata =
+            include_str!("../../migrations/2026-08-03-000001_resource_revisions/metadata.toml");
+        let transaction_count = migration.matches("\nBEGIN;\n").count();
+
+        assert_eq!(metadata.trim(), "run_in_transaction = false");
+        assert_eq!(transaction_count, 16);
+        assert_eq!(migration.matches("\nCOMMIT;").count(), transaction_count);
+    }
+
     #[tokio::test]
     async fn database_schema_readiness_accepts_the_migrated_test_database() {
         let config = get_config().expect("Failed to load config for test");

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -103,7 +103,7 @@ impl DbCallSite {
 /// Latest migration required by this binary. The test below keeps this value
 /// synchronized with the migration directory so readiness cannot silently lag
 /// behind a newly added schema change.
-pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260804000001";
+pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260804000025";
 
 #[derive(diesel::QueryableByName)]
 struct DatabaseSchemaReadiness {

--- a/tests/api_identity_suite/groups.rs
+++ b/tests/api_identity_suite/groups.rs
@@ -11,8 +11,8 @@ mod tests {
     use crate::models::group::{Group, GroupResponse, NewGroup, UpdateGroup};
     use crate::models::user::{NewUser, User};
     use crate::models::{
-        IdentityScope, MembershipPrincipalResponse, NewIdentityScope, Principal, PrincipalGroup,
-        PrincipalID, PrincipalKind, PrincipalMemberResponse,
+        IdentityScope, LDAP_PROVIDER_KIND, MembershipPrincipalResponse, NewIdentityScope,
+        Principal, PrincipalGroup, PrincipalID, PrincipalKind, PrincipalMemberResponse,
     };
     use crate::pagination::NEXT_CURSOR_HEADER;
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
@@ -33,19 +33,15 @@ mod tests {
 
         let context = test_context;
         let scope_name = context.scoped_name("legacy_identity_scope_upsert");
-        let created = ensure_identity_scope(
-            &context.pool,
-            &scope_name,
-            crate::models::LDAP_PROVIDER_KIND,
-        )
-        .await
-        .unwrap();
+        let created = ensure_identity_scope(&context.pool, &scope_name, LDAP_PROVIDER_KIND)
+            .await
+            .unwrap();
 
         let returned = with_connection(&context.pool, async |conn| {
             diesel::insert_into(identity_scopes::table)
                 .values(NewIdentityScope {
                     name: &scope_name,
-                    provider_kind: crate::models::LDAP_PROVIDER_KIND,
+                    provider_kind: LDAP_PROVIDER_KIND,
                 })
                 .on_conflict(identity_scopes::name)
                 .do_update()

--- a/tests/api_identity_suite/groups.rs
+++ b/tests/api_identity_suite/groups.rs
@@ -11,8 +11,8 @@ mod tests {
     use crate::models::group::{Group, GroupResponse, NewGroup, UpdateGroup};
     use crate::models::user::{NewUser, User};
     use crate::models::{
-        MembershipPrincipalResponse, Principal, PrincipalGroup, PrincipalID, PrincipalKind,
-        PrincipalMemberResponse,
+        IdentityScope, MembershipPrincipalResponse, NewIdentityScope, Principal, PrincipalGroup,
+        PrincipalID, PrincipalKind, PrincipalMemberResponse,
     };
     use crate::pagination::NEXT_CURSOR_HEADER;
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
@@ -23,6 +23,43 @@ mod tests {
 
     const GROUPS_ENDPOINT: &str = "/api/v1/iam/groups";
     const PRINCIPALS_ENDPOINT: &str = "/api/v1/iam/principals";
+
+    #[rstest]
+    #[actix_web::test]
+    async fn legacy_identity_scope_upsert_returns_an_unchanged_row(
+        #[future(awt)] test_context: TestContext,
+    ) {
+        use crate::schema::identity_scopes;
+
+        let context = test_context;
+        let scope_name = context.scoped_name("legacy_identity_scope_upsert");
+        let created = ensure_identity_scope(
+            &context.pool,
+            &scope_name,
+            crate::models::LDAP_PROVIDER_KIND,
+        )
+        .await
+        .unwrap();
+
+        let returned = with_connection(&context.pool, async |conn| {
+            diesel::insert_into(identity_scopes::table)
+                .values(NewIdentityScope {
+                    name: &scope_name,
+                    provider_kind: crate::models::LDAP_PROVIDER_KIND,
+                })
+                .on_conflict(identity_scopes::name)
+                .do_update()
+                .set(identity_scopes::provider_kind.eq(crate::models::LDAP_PROVIDER_KIND))
+                .get_result::<IdentityScope>(conn)
+                .await
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(returned.id, created.id);
+        assert_eq!(returned.revision, created.revision);
+        assert_eq!(returned.updated_at, created.updated_at);
+    }
 
     async fn check_show_group(
         context: &TestContext,


### PR DESCRIPTION
## Summary

Certify every release candidate against the immediately previous stable Hubuum image before tag publication.

- resolve the latest stable release through the GitHub release API and pin its GHCR image by immutable digest
- seed representative identity, authorization, resource, relation, event, remote-target, export-template, and asynchronous task state through the previous API/worker topology
- drain the previous worker, migrate under authenticated previous-API read traffic, exercise mixed-version reads and writes, roll forward, restart the previous binary against the migrated schema, write through it, and restore the candidate
- retain the fixed v0.0.1 single-host continuity test as a separate long-horizon compatibility check
- upload structured timing, availability, migration, digest, SHA, and container logs; block tagged publication on the production container/compatibility job
- add a static expand/migrate/contract migration policy check with focused self-tests, including multiline SQL statements

## Migration safety

The unreleased resource-revision migration was not suitable for live rollout as written: it built indexes with blocking DDL, retained exclusive locks across validation/backfill work, and its no-op identity-scope trigger prevented v0.0.8 from starting after an application rollback.

This change:

- runs the revision migration without one outer transaction and uses explicit, independently committed transactions so locks are released between phases
- makes the expand, validation, authorization, event, and trigger phases safe to retry after an interrupted migration
- adds history columns before live columns so previous temporal triggers retain a compatible target
- builds each revision index concurrently in its own non-transactional Diesel migration
- preserves the row returned by the v0.0.8 identity-scope upsert without advancing its revision or timestamp
- updates the required migration readiness version to the final concurrent-index migration
- documents that only adjacent application rollback is certified; database downgrade is not

The continuity harness now accounts for failed-request duration and uses a probe timeout beyond Caddy's upstream retry budget, avoiding false outage reports while retaining per-worker diagnostics.

There is no new HTTP API breaking change in this PR. The existing unreleased backup/import format breaks remain documented, and operators must quiesce backup, restore, and import work during the mixed-version interval.

## Verification

- four complete runs of `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `cargo run --quiet --bin hubuum-openapi` matches `docs/openapi.json`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- migration policy, classifier, Bash syntax, and ShellCheck suites
- exact production image build with `-F tls-rustls -F tls-openssl --locked --release`
- fixed v0.0.1 single-host continuity test: 20,209 requests and zero failures
- immutable adjacent-release certification against v0.0.8 / `sha256:850bfd95a2802485f93c1700fbff5a33465cbc7855cbc94962982c1074fd96f6`

The final local adjacent compatibility report passed with 0.0 seconds observed outage and 0.009213 seconds maximum authenticated API latency.

Closes #243
