### PR TITLE
Fix arm64 container evidence scans

### DIFF
--- a/scripts/generate-container-evidence.sh
+++ b/scripts/generate-container-evidence.sh
@@ -37,9 +37,11 @@ fi
 case "$target" in
   linux-amd64)
     cargo_target=x86_64-unknown-linux-musl
+    container_platform=linux/amd64
     ;;
   linux-arm64)
     cargo_target=aarch64-unknown-linux-musl
+    container_platform=linux/arm64
     ;;
   *)
     echo "container evidence target is unsupported: $target" >&2
@@ -91,6 +93,7 @@ docker run --rm \
   --volume "$repo_root:/workspace:ro" \
   "$TRIVY_IMAGE" \
   image \
+  --platform "$container_platform" \
   --scanners vuln \
   --pkg-types os,library \
   --severity HIGH,CRITICAL \
@@ -107,6 +110,7 @@ docker run --rm \
   --volume "$repo_root:/workspace:ro" \
   "$TRIVY_IMAGE" \
   image \
+  --platform "$container_platform" \
   --scanners vuln \
   --pkg-types os,library \
   --severity HIGH,CRITICAL \

--- a/scripts/test-generate-container-evidence.sh
+++ b/scripts/test-generate-container-evidence.sh
@@ -18,5 +18,110 @@ assert_rejected "example.invalid/hubuum:latest" output "$revision" main linux-am
 assert_rejected "example.invalid/hubuum@sha256:$digest" ../escape "$revision" main linux-amd64
 assert_rejected "example.invalid/hubuum@sha256:$digest" output short main linux-amd64
 assert_rejected "example.invalid/hubuum@sha256:$digest" output "$revision" latest linux-amd64
+assert_rejected "example.invalid/hubuum@sha256:$digest" output "$revision" main linux-s390x
+
+test_tmp="$(mktemp -d "${TMPDIR:-/tmp}/hubuum-container-evidence.XXXXXX")"
+trap 'rm -rf "$test_tmp"' EXIT
+mock_bin="$test_tmp/bin"
+evidence_dir="$test_tmp/evidence"
+docker_log="$test_tmp/docker.log"
+mkdir -p "$mock_bin" "$evidence_dir"
+
+cat > "$mock_bin/python3" <<'PYTHON'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$*" in
+  *"--tool-value SYFT_IMAGE"*)
+    echo mock-syft
+    ;;
+  *"--tool-value TRIVY_IMAGE"*)
+    echo mock-trivy
+    ;;
+  *"generate-release-sbom.py"*)
+    output=""
+    while (($# > 0)); do
+      if [[ "$1" == "--output" ]]; then
+        output="$2"
+        break
+      fi
+      shift
+    done
+    test -n "$output"
+    printf '{}\n' > "$output"
+    ;;
+  *)
+    echo "unexpected python3 invocation: $*" >&2
+    exit 1
+    ;;
+esac
+PYTHON
+
+cat > "$mock_bin/docker" <<'DOCKER'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$MOCK_DOCKER_LOG"
+
+if [[ "$1 $2" == "image inspect" ]]; then
+  echo sha256:mock-platform-image
+  exit 0
+fi
+
+if [[ " $* " == *" mock-trivy image "* ]]; then
+  if [[ " $* " != *" --platform linux/arm64 "* ]]; then
+    echo "Trivy image scan omitted the requested platform: $*" >&2
+    exit 1
+  fi
+
+  output=""
+  while (($# > 0)); do
+    if [[ "$1" == "--output" ]]; then
+      output="$2"
+      break
+    fi
+    shift
+  done
+  test -n "$output"
+  printf '{}\n' > "$MOCK_EVIDENCE_DIR/${output##*/}"
+  exit 0
+fi
+
+case " $* " in
+  *" mock-syft registry:"*)
+    printf '{}\n'
+    ;;
+  *" mock-trivy sbom "*)
+    printf '{}\n'
+    ;;
+  *" mock-syft version "*)
+    echo "syft mock"
+    ;;
+  *" mock-trivy --version "*)
+    echo "trivy mock"
+    ;;
+  *)
+    echo "unexpected docker invocation: $*" >&2
+    exit 1
+    ;;
+esac
+DOCKER
+
+chmod +x "$mock_bin/python3" "$mock_bin/docker"
+PATH="$mock_bin:$PATH" \
+  MOCK_DOCKER_LOG="$docker_log" \
+  MOCK_EVIDENCE_DIR="$evidence_dir" \
+  HUBUUM_EVIDENCE_DIR="$evidence_dir" \
+  bash "$generator" \
+  "example.invalid/hubuum@sha256:$digest" \
+  output \
+  "$revision" \
+  main \
+  linux-arm64 >/dev/null
+
+if [[ "$(grep -c -- '--platform linux/arm64' "$docker_log")" != 2 ]]; then
+  echo "both Trivy image scans must select the requested image platform" >&2
+  exit 1
+fi
 
 echo "Container evidence input validation tests passed."


### PR DESCRIPTION
## Summary

- map each supported container evidence target to its OCI platform
- pass the requested platform to both Trivy image scans
- exercise the arm64 command construction with mocked pinned-tool invocations

## Rationale and behavior

The arm64 main-container evidence job scanned an arm64-only image digest without selecting its platform explicitly. The pinned Trivy runtime defaulted to linux/amd64 and rejected the digest because it had no amd64 child. Container evidence generation now selects linux/amd64 or linux/arm64 from the validated target for both the retained and policy-enforcing scans.

This is a focused follow-up to #273. It has no API or database impact and no breaking operator action. It is not changelog-worthy because it only corrects internal release-build plumbing.

## Verification

- source .env && ./run_tests.sh
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- shellcheck scripts/generate-container-evidence.sh scripts/test-generate-container-evidence.sh
- bash scripts/test-generate-container-evidence.sh
- bash scripts/test-classify-ci-changes.sh
- python3 scripts/test-supply-chain-policy.py
- pinned Trivy 0.73.0 image --help confirms --platform support