### PR TITLE
Add JSON Patch support for principal settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Principal settings PATCH endpoints now accept bounded RFC 6902 JSON Patch via
+  `application/json-patch+json`, including atomic `test`, precise array updates,
+  literal JSON `null`, and rollback-safe `add`, `remove`, `replace`, `move`, and
+  `copy` operations. Existing `application/json` JSON Merge Patch behavior is
+  unchanged, with `application/merge-patch+json` also accepted as an alias.
 - OpenAPI validation now blocks pull requests, `main`, and tagged releases on
   generated-document drift or unaccepted compatibility breaks from the latest
   stable release. CI publishes the generated document, exact drift diff,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 
 - Principal settings PATCH endpoints now accept bounded RFC 6902 JSON Patch via
-  `application/json-patch+json`, including atomic `test`, precise array updates,
-  literal JSON `null`, and rollback-safe `add`, `remove`, `replace`, `move`, and
-  `copy` operations. Existing `application/json` JSON Merge Patch behavior is
-  unchanged, with `application/merge-patch+json` also accepted as an alias.
+  `application/json-patch+json`, including atomic `test` with numeric-value
+  equality, precise array updates, literal JSON `null`, and rollback-safe `add`,
+  `remove`, `replace`, `move`, and `copy` operations. Existing `application/json`
+  JSON Merge Patch behavior is unchanged, with `application/merge-patch+json`
+  also accepted as an alias.
 - OpenAPI validation now blocks pull requests, `main`, and tagged releases on
   generated-document drift or unaccepted compatibility breaks from the latest
   stable release. CI publishes the generated document, exact drift diff,

--- a/docs/auth_model.md
+++ b/docs/auth_model.md
@@ -390,14 +390,16 @@ not searchable.
 | --- | --- | --- |
 | `GET /api/v1/iam/me/settings` | Read the current principal settings | Any valid token for the current principal |
 | `PUT /api/v1/iam/me/settings` | Replace the current principal settings | Any valid token for the current principal |
-| `PATCH /api/v1/iam/me/settings` | Merge a patch into the current principal settings | Any valid token for the current principal |
+| `PATCH /api/v1/iam/me/settings` | Apply JSON Merge Patch or JSON Patch to the current principal settings | Any valid token for the current principal |
 | `DELETE /api/v1/iam/me/settings` | Reset the current principal settings to `{}` | Any valid token for the current principal |
 | `/api/v1/iam/principals/{principal_id}/settings` | The same operations for a named principal | Self, or an unscoped human admin; denied cross-principal requests return `404` |
 
 The settings document root must be a JSON object. Nested values may be any JSON
 type. `PUT` replaces the entire document, so it can retain a nested `null` value.
 
-`PATCH` applies object-only JSON Merge Patch semantics:
+`PATCH` selects its semantics from `Content-Type`. `application/json` retains the
+existing object-only JSON Merge Patch behavior. The standards-oriented
+`application/merge-patch+json` media type is accepted as an alias:
 
 - Object values merge recursively.
 - A `null` patch value removes that key; it does not store a JSON `null`.
@@ -428,6 +430,35 @@ For example:
   "tags": ["b"]
 }
 ```
+
+Use `Content-Type: application/json-patch+json` to apply an RFC 6902 operation
+array instead. Hubuum supports `add`, `remove`, `replace`, `move`, `copy`, and
+`test`. Every `path` and `from` is an RFC 6901 JSON Pointer relative to the
+settings document root. For example, this patch compares the current theme,
+updates it, inserts one array element, and stores a literal JSON `null`:
+
+```json
+[
+  { "op": "test", "path": "/theme", "value": "light" },
+  { "op": "replace", "path": "/theme", "value": "dark" },
+  { "op": "add", "path": "/shortcuts/1", "value": "search" },
+  { "op": "add", "path": "/dismissed_tip", "value": null }
+]
+```
+
+The complete JSON Patch is applied to the latest settings value after the
+principal row is locked. A failed operation, including a failed `test`, returns
+`409 Conflict` and rolls back all operations and audit side effects. The final
+document root must remain an object; replacing it with another JSON type returns
+`400 Bad Request`. A successful no-op returns the current document without
+advancing its revision or emitting an event.
+
+JSON Patch requests and results are limited to 2 MiB, 1,000 operations, 128
+pointer segments per `path` or `from`, 64 nested containers, and 32 MiB of
+cumulative application work. Intermediate results are checked after every
+operation for these bounds and for PostgreSQL JSONB representability. Array
+indices can become stale when another client changes the array first; pair
+index-sensitive operations with `test` when element identity matters.
 
 Settings mutations are serialized with a principal row lock, so concurrent patches
 preserve unrelated changes. Each mutation that changes the settings records a

--- a/docs/auth_model.md
+++ b/docs/auth_model.md
@@ -434,8 +434,10 @@ For example:
 Use `Content-Type: application/json-patch+json` to apply an RFC 6902 operation
 array instead. Hubuum supports `add`, `remove`, `replace`, `move`, `copy`, and
 `test`. Every `path` and `from` is an RFC 6901 JSON Pointer relative to the
-settings document root. For example, this patch compares the current theme,
-updates it, inserts one array element, and stores a literal JSON `null`:
+settings document root. `test` compares arrays and objects recursively and
+compares JSON numbers by numeric value, so representations such as `1`, `1.0`,
+and `1e0` are equal. For example, this patch compares the current theme, updates
+it, inserts one array element, and stores a literal JSON `null`:
 
 ```json
 [

--- a/docs/object_data_json_patch.md
+++ b/docs/object_data_json_patch.md
@@ -72,6 +72,8 @@ Normal JSON Patch object and array rules apply:
 - A missing intermediate parent makes an operation fail.
 - `/-` appends to an existing array.
 - Array indices use the RFC 6901 canonical decimal form and must be in range.
+- `test` compares arrays and objects recursively and compares JSON numbers by
+  numeric value, so representations such as `1`, `1.0`, and `1e0` are equal.
 - `~1` represents `/` and `~0` represents `~` inside a pointer token.
 - `move` and `copy` interpret `from` relative to the same raw data root.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13699,8 +13699,8 @@
         "tags": [
           "principals"
         ],
-        "summary": "Patch Api V1 Iam Me Settings",
-        "description": "Applies an object-only JSON Merge Patch to the current principal settings. Object values merge recursively; a `null` value removes its key; arrays, strings, numbers, and booleans replace the existing value. An object patch applied to a missing or non-object value starts from an empty object. The document root must be an object. Use PUT, rather than PATCH, when a setting itself must retain a null value.",
+        "summary": "Patch current principal settings",
+        "description": "Selects patch semantics from Content-Type and applies the complete patch to the latest row-locked settings document. `application/json` and `application/merge-patch+json` use object-only JSON Merge Patch: object values merge recursively, `null` removes a key, and other values replace it. `application/json-patch+json` uses bounded RFC 6902 add, remove, replace, move, copy, and test operations. The final document root must remain an object. A no-op returns the unchanged settings without advancing the revision or emitting an event.",
         "operationId": "patchApiV1IamMeSettings",
         "parameters": [
           {
@@ -13714,9 +13714,38 @@
           }
         ],
         "requestBody": {
-          "description": "The settings patch object.",
+          "description": "An object-only JSON Merge Patch or RFC 6902 operation array, selected by Content-Type.",
           "content": {
             "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrincipalSettings"
+              },
+              "example": {
+                "layout": {
+                  "columns": 2,
+                  "sidebar": null
+                },
+                "theme": "dark"
+              }
+            },
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrincipalSettingsPatchDocument"
+              },
+              "example": [
+                {
+                  "op": "test",
+                  "path": "/theme",
+                  "value": "light"
+                },
+                {
+                  "op": "replace",
+                  "path": "/theme",
+                  "value": "dark"
+                }
+              ]
+            },
+            "application/merge-patch+json": {
               "schema": {
                 "$ref": "#/components/schemas/PrincipalSettings"
               },
@@ -13733,7 +13762,7 @@
         },
         "responses": {
           "200": {
-            "description": "Merged current principal settings",
+            "description": "Patched current principal settings, or the unchanged settings for a no-op",
             "headers": {
               "ETag": {
                 "schema": {
@@ -13751,7 +13780,7 @@
             }
           },
           "400": {
-            "description": "Settings root is not an object",
+            "description": "Malformed patch, invalid patch bounds, an invalid final root, or a result PostgreSQL JSONB cannot represent",
             "content": {
               "application/json": {
                 "schema": {
@@ -13770,8 +13799,48 @@
               }
             }
           },
+          "409": {
+            "description": "A JSON Patch operation failed, including a failed test; nothing was persisted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
           "412": {
             "description": "Precondition failed because If-Match does not match the current resource revision."
+          },
+          "413": {
+            "description": "The patch request, result, nesting, or cumulative application work exceeds its limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Content-Type is not application/json, application/merge-patch+json, or application/json-patch+json",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Persistence or event emission failed and the transaction was rolled back",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -14321,8 +14390,8 @@
         "tags": [
           "principals"
         ],
-        "summary": "Patch Api V1 Iam Principals By Principal Id Settings",
-        "description": "Applies an object-only JSON Merge Patch to the target principal settings. Object values merge recursively; a `null` value removes its key; arrays, strings, numbers, and booleans replace the existing value. An object patch applied to a missing or non-object value starts from an empty object. The document root must be an object. Use PUT, rather than PATCH, when a setting itself must retain a null value.",
+        "summary": "Patch principal settings",
+        "description": "Selects patch semantics from Content-Type and applies the complete patch to the latest row-locked settings document. `application/json` and `application/merge-patch+json` use object-only JSON Merge Patch: object values merge recursively, `null` removes a key, and other values replace it. `application/json-patch+json` uses bounded RFC 6902 add, remove, replace, move, copy, and test operations. The final document root must remain an object. A no-op returns the unchanged settings without advancing the revision or emitting an event.",
         "operationId": "patchApiV1IamPrincipalsByPrincipalIdSettings",
         "parameters": [
           {
@@ -14346,9 +14415,38 @@
           }
         ],
         "requestBody": {
-          "description": "The settings patch object.",
+          "description": "An object-only JSON Merge Patch or RFC 6902 operation array, selected by Content-Type.",
           "content": {
             "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrincipalSettings"
+              },
+              "example": {
+                "layout": {
+                  "columns": 2,
+                  "sidebar": null
+                },
+                "theme": "dark"
+              }
+            },
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrincipalSettingsPatchDocument"
+              },
+              "example": [
+                {
+                  "op": "test",
+                  "path": "/theme",
+                  "value": "light"
+                },
+                {
+                  "op": "replace",
+                  "path": "/theme",
+                  "value": "dark"
+                }
+              ]
+            },
+            "application/merge-patch+json": {
               "schema": {
                 "$ref": "#/components/schemas/PrincipalSettings"
               },
@@ -14365,7 +14463,7 @@
         },
         "responses": {
           "200": {
-            "description": "Merged principal settings",
+            "description": "Patched principal settings, or the unchanged settings for a no-op",
             "headers": {
               "ETag": {
                 "schema": {
@@ -14383,7 +14481,7 @@
             }
           },
           "400": {
-            "description": "Settings root is not an object",
+            "description": "Malformed patch, invalid patch bounds, an invalid final root, or a result PostgreSQL JSONB cannot represent",
             "content": {
               "application/json": {
                 "schema": {
@@ -14412,8 +14510,48 @@
               }
             }
           },
+          "409": {
+            "description": "A JSON Patch operation failed, including a failed test; nothing was persisted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
           "412": {
             "description": "Precondition failed because If-Match does not match the current resource revision."
+          },
+          "413": {
+            "description": "The patch request, result, nesting, or cumulative application work exceeds its limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Content-Type is not application/json, application/merge-patch+json, or application/json-patch+json",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Persistence or event emission failed and the transaction was rolled back",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -26803,6 +26941,168 @@
       "PrincipalSettings": {
         "type": "object",
         "description": "An object-only JSON document containing a principal's local preferences.\n\nValues below the document root may be any JSON type. The private\nrepresentation keeps callers from constructing an invalid non-object root."
+      },
+      "PrincipalSettingsPatchDocument": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AddOperation",
+                  "description": "'add' operation"
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "op"
+                  ],
+                  "properties": {
+                    "op": {
+                      "type": "string",
+                      "enum": [
+                        "add"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "description": "'add' operation"
+            },
+            {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RemoveOperation",
+                  "description": "'remove' operation"
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "op"
+                  ],
+                  "properties": {
+                    "op": {
+                      "type": "string",
+                      "enum": [
+                        "remove"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "description": "'remove' operation"
+            },
+            {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ReplaceOperation",
+                  "description": "'replace' operation"
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "op"
+                  ],
+                  "properties": {
+                    "op": {
+                      "type": "string",
+                      "enum": [
+                        "replace"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "description": "'replace' operation"
+            },
+            {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/MoveOperation",
+                  "description": "'move' operation"
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "op"
+                  ],
+                  "properties": {
+                    "op": {
+                      "type": "string",
+                      "enum": [
+                        "move"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "description": "'move' operation"
+            },
+            {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/CopyOperation",
+                  "description": "'copy' operation"
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "op"
+                  ],
+                  "properties": {
+                    "op": {
+                      "type": "string",
+                      "enum": [
+                        "copy"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "description": "'copy' operation"
+            },
+            {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/TestOperation",
+                  "description": "'test' operation"
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "op"
+                  ],
+                  "properties": {
+                    "op": {
+                      "type": "string",
+                      "enum": [
+                        "test"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "description": "'test' operation"
+            }
+          ],
+          "description": "JSON Patch single patch operation"
+        },
+        "description": "RFC 6902 operations applied relative to the principal-settings document root. Supports add, remove, replace, move, copy, and test. The final root must remain an object. The request and result are limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
+        "examples": [
+          [
+            {
+              "op": "test",
+              "path": "/theme",
+              "value": "light"
+            },
+            {
+              "op": "replace",
+              "path": "/theme",
+              "value": "dark"
+            }
+          ]
+        ],
+        "maxItems": 1000
       },
       "PrincipalSettingsResponse": {
         "type": "object",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -26375,7 +26375,7 @@
           ],
           "description": "JSON Patch single patch operation"
         },
-        "description": "RFC 6902 operations applied relative to the root of an object's raw data document. Supports add, remove, replace, move, copy, and test. The resulting document is limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
+        "description": "RFC 6902 operations applied relative to the root of an object's raw data document. Supports add, remove, replace, move, copy, and test; test compares JSON numbers by numeric value. The resulting document is limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
         "examples": [
           [
             {
@@ -27087,7 +27087,7 @@
           ],
           "description": "JSON Patch single patch operation"
         },
-        "description": "RFC 6902 operations applied relative to the principal-settings document root. Supports add, remove, replace, move, copy, and test. The final root must remain an object. The request and result are limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
+        "description": "RFC 6902 operations applied relative to the principal-settings document root. Supports add, remove, replace, move, copy, and test; test compares JSON numbers by numeric value. The final root must remain an object. The request and result are limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
         "examples": [
           [
             {

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -47,19 +47,20 @@ use crate::models::{
     ObjectAggregateMeasureValue, ObjectAggregateRow, ObjectAggregateValueState,
     ObjectDataPatchDocument, ObjectKey, ObjectsByClass, Permission, Permissions,
     PersonalComputedFieldDefinitionRequest, PrincipalKey, PrincipalMemberResponse,
-    PrincipalSettings, PrincipalSettingsResponse, PrincipalTokenMetadata,
-    PrincipalTokenPointResponse, RelatedClassGraph, RelatedObjectGraph, RemoteAuthConfig,
-    RemoteCallResult, RemoteHttpMethod, RemoteInvocationBodyOverride, RemoteInvocationParameters,
-    RemoteInvocationSubject, RemoteTarget, RemoteTargetHistory, RemoteTargetID,
-    RemoteTargetInvokeRequest, RemoteTargetSubjectType, ResourceRevision, RestoreConfirmRequest,
-    RestoreJobStatus, RestoreStageResponse, RestoreTimestamps, RestoreValidationSummary,
-    ServiceAccountPointResponse, ServiceAccountResponse, SharedComputedScopeResponse, TaskDetails,
-    TaskEventResponse, TaskKind, TaskLinks, TaskProgress, TaskResponse, TaskStatus, TokenListState,
-    TokenResourceScope, TokenScopeDetails, UnifiedSearchBatchResponse, UnifiedSearchDoneEvent,
-    UnifiedSearchErrorEvent, UnifiedSearchKind, UnifiedSearchResponse, UnifiedSearchStartedEvent,
-    UpdateCollection, UpdateEventSink, UpdateEventSubscription, UpdateExportTemplate, UpdateGroup,
-    UpdateHubuumClass, UpdateHubuumObject, UpdateHubuumObjectRequest, UpdateRemoteTarget,
-    UpdateServiceAccount, UpdateUser, UserPointResponse, UserResponse,
+    PrincipalSettings, PrincipalSettingsPatchDocument, PrincipalSettingsResponse,
+    PrincipalTokenMetadata, PrincipalTokenPointResponse, RelatedClassGraph, RelatedObjectGraph,
+    RemoteAuthConfig, RemoteCallResult, RemoteHttpMethod, RemoteInvocationBodyOverride,
+    RemoteInvocationParameters, RemoteInvocationSubject, RemoteTarget, RemoteTargetHistory,
+    RemoteTargetID, RemoteTargetInvokeRequest, RemoteTargetSubjectType, ResourceRevision,
+    RestoreConfirmRequest, RestoreJobStatus, RestoreStageResponse, RestoreTimestamps,
+    RestoreValidationSummary, ServiceAccountPointResponse, ServiceAccountResponse,
+    SharedComputedScopeResponse, TaskDetails, TaskEventResponse, TaskKind, TaskLinks, TaskProgress,
+    TaskResponse, TaskStatus, TokenListState, TokenResourceScope, TokenScopeDetails,
+    UnifiedSearchBatchResponse, UnifiedSearchDoneEvent, UnifiedSearchErrorEvent, UnifiedSearchKind,
+    UnifiedSearchResponse, UnifiedSearchStartedEvent, UpdateCollection, UpdateEventSink,
+    UpdateEventSubscription, UpdateExportTemplate, UpdateGroup, UpdateHubuumClass,
+    UpdateHubuumObject, UpdateHubuumObjectRequest, UpdateRemoteTarget, UpdateServiceAccount,
+    UpdateUser, UserPointResponse, UserResponse,
 };
 use crate::pagination::{
     NEXT_CURSOR_HEADER, PAGE_LIMIT_HEADER, TOTAL_COUNT_HEADER, page_limits_or_defaults,
@@ -335,6 +336,7 @@ use utoipa::{Modify, OpenApi, ToSchema};
             PrincipalMemberResponse,
             MembershipPrincipalResponse,
             PrincipalSettings,
+            PrincipalSettingsPatchDocument,
             PrincipalSettingsResponse,
             ResourceRevision,
             NewServiceAccount,
@@ -1784,6 +1786,57 @@ mod tests {
         assert_eq!(schema["type"], "array");
         assert_eq!(schema["maxItems"], 1_000);
         assert!(schema["items"].is_object());
+    }
+
+    #[test]
+    fn principal_settings_patch_media_types_limits_and_statuses_are_documented() {
+        let json = openapi_json();
+        let operation_pointers = [
+            "/paths/~1api~1v1~1iam~1me~1settings/patch",
+            "/paths/~1api~1v1~1iam~1principals~1{principal_id}~1settings/patch",
+        ];
+
+        for operation_pointer in operation_pointers {
+            let operation = json
+                .pointer(operation_pointer)
+                .expect("principal-settings patch operation");
+            assert_eq!(
+                operation
+                    .pointer("/requestBody/content/application~1json/schema/$ref")
+                    .and_then(Value::as_str),
+                Some("#/components/schemas/PrincipalSettings")
+            );
+            assert_eq!(
+                operation
+                    .pointer("/requestBody/content/application~1merge-patch+json/schema/$ref",)
+                    .and_then(Value::as_str),
+                Some("#/components/schemas/PrincipalSettings")
+            );
+            assert_eq!(
+                operation
+                    .pointer("/requestBody/content/application~1json-patch+json/schema/$ref")
+                    .and_then(Value::as_str),
+                Some("#/components/schemas/PrincipalSettingsPatchDocument")
+            );
+            for status in ["200", "400", "401", "409", "412", "413", "415", "500"] {
+                assert!(
+                    operation["responses"].get(status).is_some(),
+                    "missing documented principal-settings patch response {status}"
+                );
+            }
+        }
+        let principal_operation = json
+            .pointer(operation_pointers[1])
+            .expect("principal-addressed settings patch operation");
+        assert!(principal_operation["responses"].get("404").is_some());
+
+        let schema = &json["components"]["schemas"]["PrincipalSettingsPatchDocument"];
+        assert_eq!(schema["type"], "array");
+        assert_eq!(schema["maxItems"], 1_000);
+        assert!(schema["items"].is_object());
+        assert!(schema["description"]
+            .as_str()
+            .is_some_and(|description| description.contains("final root must remain an object")));
     }
 
     #[test]

--- a/src/api/v1/handlers/me.rs
+++ b/src/api/v1/handlers/me.rs
@@ -11,10 +11,13 @@ use crate::api::v1::handlers::principals::{
 use crate::db::traits::active_tokens::retained_token_metadata_by_principal_id_paginated_with_total_count;
 use crate::db::{DbPool, with_revision_precondition_scope};
 use crate::errors::ApiError;
-use crate::extractors::{AccessEventContext, Authenticated, ManagementAccess};
+use crate::extractors::{
+    AccessEventContext, Authenticated, ManagementAccess, PrincipalSettingsPatchPayload,
+};
 use crate::models::search::parse_query_parameter;
 use crate::models::{
-    Group, GroupResponse, PrincipalID, PrincipalSettings, PrincipalToken, TokenListState,
+    Group, GroupResponse, PrincipalID, PrincipalSettings, PrincipalSettingsPatchDocument,
+    PrincipalToken, TokenListState,
 };
 use crate::pagination::{effective_page_limit, finalize_page, prepare_db_pagination};
 use crate::traits::GroupAccessors;
@@ -217,26 +220,40 @@ pub async fn put_my_settings(
     path = "/api/v1/iam/me/settings",
     tag = "principals",
     security(("bearer_auth" = [])),
-    description = "Applies an object-only JSON Merge Patch to the current principal settings. Object values merge recursively; a `null` value removes its key; arrays, strings, numbers, and booleans replace the existing value. An object patch applied to a missing or non-object value starts from an empty object. The document root must be an object. Use PUT, rather than PATCH, when a setting itself must retain a null value.",
+    summary = "Patch current principal settings",
+    description = "Selects patch semantics from Content-Type and applies the complete patch to the latest row-locked settings document. `application/json` and `application/merge-patch+json` use object-only JSON Merge Patch: object values merge recursively, `null` removes a key, and other values replace it. `application/json-patch+json` uses bounded RFC 6902 add, remove, replace, move, copy, and test operations. The final document root must remain an object. A no-op returns the unchanged settings without advancing the revision or emitting an event.",
     request_body(
-        content = PrincipalSettings,
-        description = "The settings patch object.",
-        example = json!({
-            "theme": "dark",
-            "layout": { "sidebar": null, "columns": 2 }
-        })
+        description = "An object-only JSON Merge Patch or RFC 6902 operation array, selected by Content-Type.",
+        content(
+            (PrincipalSettings = "application/json", example = json!({
+                "theme": "dark",
+                "layout": { "sidebar": null, "columns": 2 }
+            })),
+            (PrincipalSettings = "application/merge-patch+json", example = json!({
+                "theme": "dark",
+                "layout": { "sidebar": null, "columns": 2 }
+            })),
+            (PrincipalSettingsPatchDocument = "application/json-patch+json", example = json!([
+                { "op": "test", "path": "/theme", "value": "light" },
+                { "op": "replace", "path": "/theme", "value": "dark" }
+            ]))
+        )
     ),
     responses(
-        (status = 200, description = "Merged current principal settings", body = crate::models::PrincipalSettingsResponse),
-        (status = 400, description = "Settings root is not an object", body = ApiErrorResponse),
-        (status = 401, description = "Unauthorized", body = ApiErrorResponse)
+        (status = 200, description = "Patched current principal settings, or the unchanged settings for a no-op", body = crate::models::PrincipalSettingsResponse),
+        (status = 400, description = "Malformed patch, invalid patch bounds, an invalid final root, or a result PostgreSQL JSONB cannot represent", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 409, description = "A JSON Patch operation failed, including a failed test; nothing was persisted", body = ApiErrorResponse),
+        (status = 413, description = "The patch request, result, nesting, or cumulative application work exceeds its limit", body = ApiErrorResponse),
+        (status = 415, description = "Content-Type is not application/json, application/merge-patch+json, or application/json-patch+json", body = ApiErrorResponse),
+        (status = 500, description = "Persistence or event emission failed and the transaction was rolled back", body = ApiErrorResponse)
     )
 )]
 #[patch("/settings")]
 pub async fn patch_my_settings(
     pool: web::Data<DbPool>,
     requestor: Authenticated,
-    patch: web::Json<PrincipalSettings>,
+    patch: PrincipalSettingsPatchPayload,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let principal_id = PrincipalID::new(requestor.principal.id)?;
@@ -245,7 +262,7 @@ pub async fn patch_my_settings(
     let event_context = requestor.event_context(&req);
     let settings = with_revision_precondition_scope(
         precondition,
-        principal_id.patch_settings(&pool, patch.into_inner(), &event_context),
+        principal_id.apply_settings_patch(&pool, patch.into_inner(), &event_context),
     )
     .await?;
     ApiResponse::ok_revisioned(settings)

--- a/src/api/v1/handlers/principals.rs
+++ b/src/api/v1/handlers/principals.rs
@@ -12,9 +12,13 @@ use crate::db::traits::service_account::{
 };
 use crate::db::{DbPool, with_revision_precondition_scope};
 use crate::errors::ApiError;
-use crate::extractors::{AccessEventContext, Authenticated, ManagementAccess};
+use crate::extractors::{
+    AccessEventContext, Authenticated, ManagementAccess, PrincipalSettingsPatchPayload,
+};
 use crate::models::collection::principal_all_permissions;
-use crate::models::principal::{Principal, PrincipalKind, PrincipalSettings};
+use crate::models::principal::{
+    Principal, PrincipalKind, PrincipalSettings, PrincipalSettingsPatchDocument,
+};
 use crate::models::search::{
     QueryOptions, parse_query_parameter, parse_query_parameter_with_passthrough,
 };
@@ -558,20 +562,34 @@ pub async fn put_principal_settings(
     tag = "principals",
     security(("bearer_auth" = [])),
     params(("principal_id" = i32, Path, description = "Principal id")),
-    description = "Applies an object-only JSON Merge Patch to the target principal settings. Object values merge recursively; a `null` value removes its key; arrays, strings, numbers, and booleans replace the existing value. An object patch applied to a missing or non-object value starts from an empty object. The document root must be an object. Use PUT, rather than PATCH, when a setting itself must retain a null value.",
+    summary = "Patch principal settings",
+    description = "Selects patch semantics from Content-Type and applies the complete patch to the latest row-locked settings document. `application/json` and `application/merge-patch+json` use object-only JSON Merge Patch: object values merge recursively, `null` removes a key, and other values replace it. `application/json-patch+json` uses bounded RFC 6902 add, remove, replace, move, copy, and test operations. The final document root must remain an object. A no-op returns the unchanged settings without advancing the revision or emitting an event.",
     request_body(
-        content = PrincipalSettings,
-        description = "The settings patch object.",
-        example = json!({
-            "theme": "dark",
-            "layout": { "sidebar": null, "columns": 2 }
-        })
+        description = "An object-only JSON Merge Patch or RFC 6902 operation array, selected by Content-Type.",
+        content(
+            (PrincipalSettings = "application/json", example = json!({
+                "theme": "dark",
+                "layout": { "sidebar": null, "columns": 2 }
+            })),
+            (PrincipalSettings = "application/merge-patch+json", example = json!({
+                "theme": "dark",
+                "layout": { "sidebar": null, "columns": 2 }
+            })),
+            (PrincipalSettingsPatchDocument = "application/json-patch+json", example = json!([
+                { "op": "test", "path": "/theme", "value": "light" },
+                { "op": "replace", "path": "/theme", "value": "dark" }
+            ]))
+        )
     ),
     responses(
-        (status = 200, description = "Merged principal settings", body = crate::models::PrincipalSettingsResponse),
-        (status = 400, description = "Settings root is not an object", body = ApiErrorResponse),
+        (status = 200, description = "Patched principal settings, or the unchanged settings for a no-op", body = crate::models::PrincipalSettingsResponse),
+        (status = 400, description = "Malformed patch, invalid patch bounds, an invalid final root, or a result PostgreSQL JSONB cannot represent", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
-        (status = 404, description = "Principal not found", body = ApiErrorResponse)
+        (status = 404, description = "Principal not found", body = ApiErrorResponse),
+        (status = 409, description = "A JSON Patch operation failed, including a failed test; nothing was persisted", body = ApiErrorResponse),
+        (status = 413, description = "The patch request, result, nesting, or cumulative application work exceeds its limit", body = ApiErrorResponse),
+        (status = 415, description = "Content-Type is not application/json, application/merge-patch+json, or application/json-patch+json", body = ApiErrorResponse),
+        (status = 500, description = "Persistence or event emission failed and the transaction was rolled back", body = ApiErrorResponse)
     )
 )]
 #[patch("/{principal_id}/settings")]
@@ -579,7 +597,7 @@ pub async fn patch_principal_settings(
     pool: web::Data<DbPool>,
     requestor: Authenticated,
     principal_id: web::Path<PrincipalID>,
-    patch: web::Json<PrincipalSettings>,
+    patch: PrincipalSettingsPatchPayload,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let principal_id = principal_id.into_inner();
@@ -589,7 +607,7 @@ pub async fn patch_principal_settings(
     let event_context = requestor.event_context(&req);
     let settings = with_revision_precondition_scope(
         precondition,
-        principal_id.patch_settings(&pool, patch.into_inner(), &event_context),
+        principal_id.apply_settings_patch(&pool, patch.into_inner(), &event_context),
     )
     .await?;
     ApiResponse::ok_revisioned(settings)

--- a/src/db/traits/principal.rs
+++ b/src/db/traits/principal.rs
@@ -7,9 +7,9 @@ use crate::db::{DbConnection, DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, NewEvent, emit_event};
 use crate::models::{
-    NewPrincipal, Principal, PrincipalKind, PrincipalSettings, PrincipalSettingsResponse,
-    ServiceAccount, ServiceAccountPointResponse, User, UserPointResponse, UserResponse,
-    UserWithName,
+    NewPrincipal, Principal, PrincipalKind, PrincipalSettings, PrincipalSettingsPatch,
+    PrincipalSettingsResponse, ServiceAccount, ServiceAccountPointResponse, User,
+    UserPointResponse, UserResponse, UserWithName,
 };
 
 pub trait InsertPrincipalRecord {
@@ -116,6 +116,43 @@ pub async fn mutate_principal_settings(
     input: PrincipalSettings,
     event_context: &EventContext,
 ) -> Result<PrincipalSettingsResponse, ApiError> {
+    let mutation = match mutation {
+        PrincipalSettingsMutation::Replace => PrincipalSettingsWrite::Replace(input),
+        PrincipalSettingsMutation::Patch => {
+            PrincipalSettingsWrite::Patch(PrincipalSettingsPatch::MergePatch(input))
+        }
+        PrincipalSettingsMutation::Reset => PrincipalSettingsWrite::Reset,
+    };
+    mutate_principal_settings_with(pool, principal_id_value, mutation, event_context).await
+}
+
+pub(crate) async fn apply_principal_settings_patch(
+    pool: &DbPool,
+    principal_id_value: i32,
+    patch: PrincipalSettingsPatch,
+    event_context: &EventContext,
+) -> Result<PrincipalSettingsResponse, ApiError> {
+    mutate_principal_settings_with(
+        pool,
+        principal_id_value,
+        PrincipalSettingsWrite::Patch(patch),
+        event_context,
+    )
+    .await
+}
+
+enum PrincipalSettingsWrite {
+    Replace(PrincipalSettings),
+    Patch(PrincipalSettingsPatch),
+    Reset,
+}
+
+async fn mutate_principal_settings_with(
+    pool: &DbPool,
+    principal_id_value: i32,
+    mutation: PrincipalSettingsWrite,
+    event_context: &EventContext,
+) -> Result<PrincipalSettingsResponse, ApiError> {
     use crate::schema::principals;
 
     with_transaction(
@@ -145,9 +182,9 @@ pub async fn mutate_principal_settings(
             .await?;
             let before = stored_principal_settings(principal_id_value, stored_before)?;
             let after = match mutation {
-                PrincipalSettingsMutation::Replace => input,
-                PrincipalSettingsMutation::Patch => before.clone().merge_patch(&input),
-                PrincipalSettingsMutation::Reset => PrincipalSettings::default(),
+                PrincipalSettingsWrite::Replace(settings) => settings,
+                PrincipalSettingsWrite::Patch(patch) => patch.apply(&before)?,
+                PrincipalSettingsWrite::Reset => PrincipalSettings::default(),
             };
 
             if before == after {

--- a/src/db/traits/principal.rs
+++ b/src/db/traits/principal.rs
@@ -1,14 +1,16 @@
 use hubuum_events_core::EventContext;
-use serde_json::json;
+use serde_json::{Value, json};
 
 use crate::api::etag::RevisionOwner;
 use crate::db::prelude::*;
-use crate::db::{DbConnection, DbPool, with_connection, with_transaction};
+use crate::db::{
+    DbConnection, DbPool, assert_locked_revision_precondition, with_connection, with_transaction,
+};
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, NewEvent, emit_event};
 use crate::models::{
     NewPrincipal, Principal, PrincipalKind, PrincipalSettings, PrincipalSettingsPatch,
-    PrincipalSettingsResponse, ServiceAccount, ServiceAccountPointResponse, User,
+    PrincipalSettingsResponse, ResourceRevision, ServiceAccount, ServiceAccountPointResponse, User,
     UserPointResponse, UserResponse, UserWithName,
 };
 
@@ -123,7 +125,7 @@ pub async fn mutate_principal_settings(
         }
         PrincipalSettingsMutation::Reset => PrincipalSettingsWrite::Reset,
     };
-    mutate_principal_settings_with(pool, principal_id_value, mutation, event_context).await
+    write_principal_settings(pool, principal_id_value, mutation, event_context).await
 }
 
 pub(crate) async fn apply_principal_settings_patch(
@@ -132,7 +134,7 @@ pub(crate) async fn apply_principal_settings_patch(
     patch: PrincipalSettingsPatch,
     event_context: &EventContext,
 ) -> Result<PrincipalSettingsResponse, ApiError> {
-    mutate_principal_settings_with(
+    write_principal_settings(
         pool,
         principal_id_value,
         PrincipalSettingsWrite::Patch(patch),
@@ -147,7 +149,17 @@ enum PrincipalSettingsWrite {
     Reset,
 }
 
-async fn mutate_principal_settings_with(
+impl PrincipalSettingsWrite {
+    fn apply(self, before: &PrincipalSettings) -> Result<PrincipalSettings, ApiError> {
+        match self {
+            Self::Replace(settings) => Ok(settings),
+            Self::Patch(patch) => patch.apply(before),
+            Self::Reset => Ok(PrincipalSettings::default()),
+        }
+    }
+}
+
+async fn write_principal_settings(
     pool: &DbPool,
     principal_id_value: i32,
     mutation: PrincipalSettingsWrite,
@@ -167,25 +179,16 @@ async fn mutate_principal_settings_with(
                     principals::revision,
                 ))
                 .for_update()
-                .first::<(
-                    String,
-                    String,
-                    serde_json::Value,
-                    crate::models::ResourceRevision,
-                )>(conn)
+                .first::<(String, String, Value, ResourceRevision)>(conn)
                 .await?;
-            crate::db::assert_locked_revision_precondition(
+            assert_locked_revision_precondition(
                 conn,
                 &RevisionOwner::Principal.key(principal_id_value),
                 before_revision,
             )
             .await?;
             let before = stored_principal_settings(principal_id_value, stored_before)?;
-            let after = match mutation {
-                PrincipalSettingsWrite::Replace(settings) => settings,
-                PrincipalSettingsWrite::Patch(patch) => patch.apply(&before)?,
-                PrincipalSettingsWrite::Reset => PrincipalSettings::default(),
-            };
+            let after = mutation.apply(&before)?;
 
             if before == after {
                 return Ok(PrincipalSettingsResponse::new(
@@ -199,7 +202,7 @@ async fn mutate_principal_settings_with(
                 diesel::update(principals::table.filter(principals::id.eq(principal_id_value)))
                     .set(principals::settings.eq(after.as_value()))
                     .returning(principals::revision)
-                    .get_result::<crate::models::ResourceRevision>(conn)
+                    .get_result::<ResourceRevision>(conn)
                     .await?;
 
             let entity_type = match PrincipalKind::from_db(&kind)? {
@@ -231,7 +234,7 @@ async fn mutate_principal_settings_with(
 
 fn stored_principal_settings(
     principal_id_value: i32,
-    value: serde_json::Value,
+    value: Value,
 ) -> Result<PrincipalSettings, ApiError> {
     PrincipalSettings::new(value).map_err(|_| {
         ApiError::InternalServerError(format!(

--- a/src/extractors/mod.rs
+++ b/src/extractors/mod.rs
@@ -7,7 +7,10 @@ use crate::events::{EventContext, RequestProvenance};
 use crate::models::principal::{Principal, load_principal_by_id};
 use crate::models::token::{PrincipalToken, Token};
 use crate::models::user::User;
-use crate::models::{MAX_OBJECT_DATA_PATCH_BYTES, ObjectDataPatchDocument, TokenScope};
+use crate::models::{
+    MAX_OBJECT_DATA_PATCH_BYTES, MAX_PRINCIPAL_SETTINGS_PATCH_BYTES, ObjectDataPatchDocument,
+    PrincipalSettings, PrincipalSettingsPatch, PrincipalSettingsPatchDocument, TokenScope,
+};
 use crate::permissions::{AppContext, PrincipalRef};
 
 use actix_web::{
@@ -23,6 +26,8 @@ use tracing::debug;
 use crate::middlewares::actor_context::ResolvedAuth;
 
 const JSON_PATCH_MEDIA_TYPE: &str = "application/json-patch+json";
+const JSON_MEDIA_TYPE: &str = "application/json";
+const JSON_MERGE_PATCH_MEDIA_TYPE: &str = "application/merge-patch+json";
 
 /// Strict JSON Patch request extractor for object-data patching.
 pub struct ObjectDataPatchPayload(ObjectDataPatchDocument);
@@ -81,6 +86,86 @@ fn object_data_patch_payload_error(error: JsonPayloadError) -> ApiError {
             ApiError::BadRequest(format!("Could not read JSON Patch payload: {error}"))
         }
         _ => ApiError::BadRequest("Could not read JSON Patch payload".to_string()),
+    }
+}
+
+/// Content-type-aware extractor for principal-settings merge and JSON Patch requests.
+pub struct PrincipalSettingsPatchPayload(PrincipalSettingsPatch);
+
+impl PrincipalSettingsPatchPayload {
+    pub fn into_inner(self) -> PrincipalSettingsPatch {
+        self.0
+    }
+}
+
+impl FromRequest for PrincipalSettingsPatchPayload {
+    type Error = ApiError;
+    type Future = Pin<Box<dyn future::Future<Output = Result<Self, Self::Error>>>>;
+
+    fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
+        let content_type = req
+            .mime_type()
+            .ok()
+            .flatten()
+            .map(|mime| mime.essence_str().to_string());
+
+        match content_type.as_deref() {
+            Some(JSON_PATCH_MEDIA_TYPE) => {
+                let body =
+                    JsonBody::<PrincipalSettingsPatchDocument>::new(req, payload, None, true)
+                        .limit(MAX_PRINCIPAL_SETTINGS_PATCH_BYTES);
+                Box::pin(async move {
+                    body.await
+                        .map(|patch| Self(PrincipalSettingsPatch::JsonPatch(patch)))
+                        .map_err(|error| {
+                            principal_settings_patch_payload_error(error, "JSON Patch")
+                        })
+                })
+            }
+            Some(JSON_MEDIA_TYPE | JSON_MERGE_PATCH_MEDIA_TYPE) => {
+                let body = JsonBody::<PrincipalSettings>::new(req, payload, None, true)
+                    .limit(MAX_PRINCIPAL_SETTINGS_PATCH_BYTES);
+                Box::pin(async move {
+                    body.await
+                        .map(|patch| Self(PrincipalSettingsPatch::MergePatch(patch)))
+                        .map_err(|error| {
+                            principal_settings_patch_payload_error(error, "JSON Merge Patch")
+                        })
+                })
+            }
+            _ => Box::pin(future::ready(Err(ApiError::UnsupportedMediaType(format!(
+                "Content-Type must be {JSON_MEDIA_TYPE}, {JSON_MERGE_PATCH_MEDIA_TYPE}, or {JSON_PATCH_MEDIA_TYPE}"
+            ))))),
+        }
+    }
+}
+
+fn principal_settings_patch_payload_error(
+    error: JsonPayloadError,
+    document_kind: &str,
+) -> ApiError {
+    match error {
+        JsonPayloadError::OverflowKnownLength { length, limit } => {
+            ApiError::PayloadTooLarge(format!(
+                "Principal settings patch payload is {length} bytes; the limit is {limit} bytes"
+            ))
+        }
+        JsonPayloadError::Overflow { limit } => ApiError::PayloadTooLarge(format!(
+            "Principal settings patch payload exceeded the {limit} byte limit"
+        )),
+        JsonPayloadError::ContentType => ApiError::UnsupportedMediaType(format!(
+            "Content-Type must be {JSON_MEDIA_TYPE}, {JSON_MERGE_PATCH_MEDIA_TYPE}, or {JSON_PATCH_MEDIA_TYPE}"
+        )),
+        JsonPayloadError::Deserialize(error) => {
+            ApiError::BadRequest(format!("Invalid {document_kind} document: {error}"))
+        }
+        JsonPayloadError::Serialize(error) => ApiError::InternalServerError(format!(
+            "Unexpected principal settings patch serialization error: {error}"
+        )),
+        JsonPayloadError::Payload(error) => ApiError::BadRequest(format!(
+            "Could not read principal settings patch payload: {error}"
+        )),
+        _ => ApiError::BadRequest("Could not read principal settings patch payload".to_string()),
     }
 }
 

--- a/src/extractors/mod.rs
+++ b/src/extractors/mod.rs
@@ -28,6 +28,41 @@ use crate::middlewares::actor_context::ResolvedAuth;
 const JSON_PATCH_MEDIA_TYPE: &str = "application/json-patch+json";
 const JSON_MEDIA_TYPE: &str = "application/json";
 const JSON_MERGE_PATCH_MEDIA_TYPE: &str = "application/merge-patch+json";
+const SUPPORTED_PRINCIPAL_SETTINGS_PATCH_MEDIA_TYPES: &str =
+    "application/json, application/merge-patch+json, or application/json-patch+json";
+
+#[derive(Clone, Copy)]
+struct PatchPayloadErrorContext {
+    sentence_subject: &'static str,
+    embedded_subject: &'static str,
+    document_kind: &'static str,
+    supported_media_types: &'static str,
+}
+
+const OBJECT_DATA_PATCH_ERROR_CONTEXT: PatchPayloadErrorContext = PatchPayloadErrorContext {
+    sentence_subject: "JSON Patch",
+    embedded_subject: "JSON Patch",
+    document_kind: "JSON Patch",
+    supported_media_types: JSON_PATCH_MEDIA_TYPE,
+};
+
+const PRINCIPAL_SETTINGS_JSON_PATCH_ERROR_CONTEXT: PatchPayloadErrorContext =
+    PatchPayloadErrorContext {
+        sentence_subject: "Principal settings patch",
+        embedded_subject: "principal settings patch",
+        document_kind: "JSON Patch",
+        supported_media_types: SUPPORTED_PRINCIPAL_SETTINGS_PATCH_MEDIA_TYPES,
+    };
+
+const PRINCIPAL_SETTINGS_MERGE_PATCH_ERROR_CONTEXT: PatchPayloadErrorContext =
+    PatchPayloadErrorContext {
+        document_kind: "JSON Merge Patch",
+        ..PRINCIPAL_SETTINGS_JSON_PATCH_ERROR_CONTEXT
+    };
+
+fn unsupported_patch_media_type(supported_media_types: &str) -> ApiError {
+    ApiError::UnsupportedMediaType(format!("Content-Type must be {supported_media_types}"))
+}
 
 /// Strict JSON Patch request extractor for object-data patching.
 pub struct ObjectDataPatchPayload(ObjectDataPatchDocument);
@@ -43,16 +78,12 @@ impl FromRequest for ObjectDataPatchPayload {
     type Future = Pin<Box<dyn future::Future<Output = Result<Self, Self::Error>>>>;
 
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
-        let content_type = req
-            .mime_type()
-            .ok()
-            .flatten()
-            .map(|mime| mime.essence_str().to_string());
+        let content_type = req.mime_type().ok().flatten();
 
-        if content_type.as_deref() != Some(JSON_PATCH_MEDIA_TYPE) {
-            return Box::pin(future::ready(Err(ApiError::UnsupportedMediaType(format!(
-                "Content-Type must be {JSON_PATCH_MEDIA_TYPE}"
-            )))));
+        if content_type.as_ref().map(|mime| mime.essence_str()) != Some(JSON_PATCH_MEDIA_TYPE) {
+            return Box::pin(future::ready(Err(unsupported_patch_media_type(
+                JSON_PATCH_MEDIA_TYPE,
+            ))));
         }
 
         let body = JsonBody::<ObjectDataPatchDocument>::new(req, payload, None, true)
@@ -60,32 +91,8 @@ impl FromRequest for ObjectDataPatchPayload {
         Box::pin(async move {
             body.await
                 .map(Self)
-                .map_err(object_data_patch_payload_error)
+                .map_err(|error| patch_payload_error(error, OBJECT_DATA_PATCH_ERROR_CONTEXT))
         })
-    }
-}
-
-fn object_data_patch_payload_error(error: JsonPayloadError) -> ApiError {
-    match error {
-        JsonPayloadError::OverflowKnownLength { length, limit } => ApiError::PayloadTooLarge(
-            format!("JSON Patch payload is {length} bytes; the limit is {limit} bytes"),
-        ),
-        JsonPayloadError::Overflow { limit } => ApiError::PayloadTooLarge(format!(
-            "JSON Patch payload exceeded the {limit} byte limit"
-        )),
-        JsonPayloadError::ContentType => {
-            ApiError::UnsupportedMediaType(format!("Content-Type must be {JSON_PATCH_MEDIA_TYPE}"))
-        }
-        JsonPayloadError::Deserialize(error) => {
-            ApiError::BadRequest(format!("Invalid JSON Patch document: {error}"))
-        }
-        JsonPayloadError::Serialize(error) => ApiError::InternalServerError(format!(
-            "Unexpected JSON Patch serialization error: {error}"
-        )),
-        JsonPayloadError::Payload(error) => {
-            ApiError::BadRequest(format!("Could not read JSON Patch payload: {error}"))
-        }
-        _ => ApiError::BadRequest("Could not read JSON Patch payload".to_string()),
     }
 }
 
@@ -93,7 +100,7 @@ fn object_data_patch_payload_error(error: JsonPayloadError) -> ApiError {
 pub struct PrincipalSettingsPatchPayload(PrincipalSettingsPatch);
 
 impl PrincipalSettingsPatchPayload {
-    pub fn into_inner(self) -> PrincipalSettingsPatch {
+    pub(crate) fn into_inner(self) -> PrincipalSettingsPatch {
         self.0
     }
 }
@@ -103,13 +110,9 @@ impl FromRequest for PrincipalSettingsPatchPayload {
     type Future = Pin<Box<dyn future::Future<Output = Result<Self, Self::Error>>>>;
 
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
-        let content_type = req
-            .mime_type()
-            .ok()
-            .flatten()
-            .map(|mime| mime.essence_str().to_string());
+        let content_type = req.mime_type().ok().flatten();
 
-        match content_type.as_deref() {
+        match content_type.as_ref().map(|mime| mime.essence_str()) {
             Some(JSON_PATCH_MEDIA_TYPE) => {
                 let body =
                     JsonBody::<PrincipalSettingsPatchDocument>::new(req, payload, None, true)
@@ -118,7 +121,7 @@ impl FromRequest for PrincipalSettingsPatchPayload {
                     body.await
                         .map(|patch| Self(PrincipalSettingsPatch::JsonPatch(patch)))
                         .map_err(|error| {
-                            principal_settings_patch_payload_error(error, "JSON Patch")
+                            patch_payload_error(error, PRINCIPAL_SETTINGS_JSON_PATCH_ERROR_CONTEXT)
                         })
                 })
             }
@@ -129,43 +132,48 @@ impl FromRequest for PrincipalSettingsPatchPayload {
                     body.await
                         .map(|patch| Self(PrincipalSettingsPatch::MergePatch(patch)))
                         .map_err(|error| {
-                            principal_settings_patch_payload_error(error, "JSON Merge Patch")
+                            patch_payload_error(error, PRINCIPAL_SETTINGS_MERGE_PATCH_ERROR_CONTEXT)
                         })
                 })
             }
-            _ => Box::pin(future::ready(Err(ApiError::UnsupportedMediaType(format!(
-                "Content-Type must be {JSON_MEDIA_TYPE}, {JSON_MERGE_PATCH_MEDIA_TYPE}, or {JSON_PATCH_MEDIA_TYPE}"
-            ))))),
+            _ => Box::pin(future::ready(Err(unsupported_patch_media_type(
+                SUPPORTED_PRINCIPAL_SETTINGS_PATCH_MEDIA_TYPES,
+            )))),
         }
     }
 }
 
-fn principal_settings_patch_payload_error(
-    error: JsonPayloadError,
-    document_kind: &str,
-) -> ApiError {
+fn patch_payload_error(error: JsonPayloadError, context: PatchPayloadErrorContext) -> ApiError {
     match error {
         JsonPayloadError::OverflowKnownLength { length, limit } => {
             ApiError::PayloadTooLarge(format!(
-                "Principal settings patch payload is {length} bytes; the limit is {limit} bytes"
+                "{} payload is {length} bytes; the limit is {limit} bytes",
+                context.sentence_subject
             ))
         }
         JsonPayloadError::Overflow { limit } => ApiError::PayloadTooLarge(format!(
-            "Principal settings patch payload exceeded the {limit} byte limit"
+            "{} payload exceeded the {limit} byte limit",
+            context.sentence_subject
         )),
-        JsonPayloadError::ContentType => ApiError::UnsupportedMediaType(format!(
-            "Content-Type must be {JSON_MEDIA_TYPE}, {JSON_MERGE_PATCH_MEDIA_TYPE}, or {JSON_PATCH_MEDIA_TYPE}"
-        )),
-        JsonPayloadError::Deserialize(error) => {
-            ApiError::BadRequest(format!("Invalid {document_kind} document: {error}"))
+        JsonPayloadError::ContentType => {
+            unsupported_patch_media_type(context.supported_media_types)
         }
+        JsonPayloadError::Deserialize(error) => ApiError::BadRequest(format!(
+            "Invalid {} document: {error}",
+            context.document_kind
+        )),
         JsonPayloadError::Serialize(error) => ApiError::InternalServerError(format!(
-            "Unexpected principal settings patch serialization error: {error}"
+            "Unexpected {} serialization error: {error}",
+            context.embedded_subject
         )),
         JsonPayloadError::Payload(error) => ApiError::BadRequest(format!(
-            "Could not read principal settings patch payload: {error}"
+            "Could not read {} payload: {error}",
+            context.embedded_subject
         )),
-        _ => ApiError::BadRequest("Could not read principal settings patch payload".to_string()),
+        _ => ApiError::BadRequest(format!(
+            "Could not read {} payload",
+            context.embedded_subject
+        )),
     }
 }
 

--- a/src/models/json_patch.rs
+++ b/src/models/json_patch.rs
@@ -1,3 +1,6 @@
+use std::cmp::Ordering;
+use std::fmt::Display;
+
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 use crate::db::json::{
@@ -51,12 +54,7 @@ impl BoundedJsonPatch {
         let mut cumulative_bytes = validate_json_patch_result(document, None)?;
         let mut patched = document.clone();
         for (operation_index, operation) in self.0.iter().enumerate() {
-            json_patch::patch(&mut patched, std::slice::from_ref(operation)).map_err(|error| {
-                ApiError::Conflict(format!(
-                    "JSON Patch operation at index {operation_index} failed at path '{}': {}",
-                    error.path, error.kind
-                ))
-            })?;
+            apply_json_patch_operation(&mut patched, operation, operation_index)?;
             let result_bytes = validate_json_patch_result(&patched, Some(operation_index))?;
             cumulative_bytes = cumulative_bytes
                 .checked_add(result_bytes)
@@ -67,6 +65,77 @@ impl BoundedJsonPatch {
         }
         Ok(patched)
     }
+}
+
+fn apply_json_patch_operation(
+    document: &mut serde_json::Value,
+    operation: &json_patch::PatchOperation,
+    operation_index: usize,
+) -> Result<(), ApiError> {
+    if let json_patch::PatchOperation::Test(test) = operation {
+        let result = document
+            .pointer(test.path.as_str())
+            .ok_or(json_patch::PatchErrorKind::InvalidPointer)
+            .and_then(|actual| {
+                json_patch_values_equal(actual, &test.value)
+                    .then_some(())
+                    .ok_or(json_patch::PatchErrorKind::TestFailed)
+            });
+        return result
+            .map_err(|kind| json_patch_operation_error(operation_index, &test.path, &kind));
+    }
+
+    json_patch::patch(document, std::slice::from_ref(operation))
+        .map_err(|error| json_patch_operation_error(operation_index, &error.path, &error.kind))
+}
+
+fn json_patch_operation_error(
+    operation_index: usize,
+    path: &impl Display,
+    kind: &impl Display,
+) -> ApiError {
+    ApiError::Conflict(format!(
+        "JSON Patch operation at index {operation_index} failed at path '{path}': {kind}"
+    ))
+}
+
+/// RFC 6902 defines `test` equality recursively and compares JSON numbers by
+/// numeric value rather than their serialized representation.
+fn json_patch_values_equal(left: &serde_json::Value, right: &serde_json::Value) -> bool {
+    match (left, right) {
+        (serde_json::Value::Number(left), serde_json::Value::Number(right)) => {
+            if json_number_is_zero(left) && json_number_is_zero(right) {
+                return true;
+            }
+            hubuum_computed_fields::compare_decimal_strings(&left.to_string(), &right.to_string())
+                == Some(Ordering::Equal)
+        }
+        (serde_json::Value::Array(left), serde_json::Value::Array(right)) => {
+            left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right)
+                    .all(|(left, right)| json_patch_values_equal(left, right))
+        }
+        (serde_json::Value::Object(left), serde_json::Value::Object(right)) => {
+            left.len() == right.len()
+                && left.iter().all(|(key, left)| {
+                    right
+                        .get(key)
+                        .is_some_and(|right| json_patch_values_equal(left, right))
+                })
+        }
+        _ => left == right,
+    }
+}
+
+fn json_number_is_zero(number: &serde_json::Number) -> bool {
+    number
+        .to_string()
+        .trim_start_matches('-')
+        .split(['e', 'E'])
+        .next()
+        .is_some_and(|mantissa| mantissa.bytes().all(|byte| matches!(byte, b'0' | b'.')))
 }
 
 fn validate_json_patch_result(

--- a/src/models/json_patch.rs
+++ b/src/models/json_patch.rs
@@ -1,0 +1,145 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+use crate::db::json::{
+    MAX_POSTGRES_JSONB_NESTING_DEPTH, PostgresJsonbValidationError, validate_postgres_jsonb_value,
+};
+use crate::errors::ApiError;
+
+pub(crate) const MAX_JSON_PATCH_OPERATIONS: usize = 1_000;
+pub(crate) const MAX_JSON_PATCH_POINTER_DEPTH: usize = 128;
+pub(crate) const MAX_JSON_PATCH_BYTES: usize = 2_097_152;
+pub(crate) const MAX_JSON_PATCH_WORK_BYTES: usize = 32 * 1024 * 1024;
+pub(crate) const MAX_JSON_PATCH_RESULT_NESTING_DEPTH: usize = MAX_POSTGRES_JSONB_NESTING_DEPTH;
+
+/// Reusable RFC 6902 document with bounds suitable for JSONB-backed resources.
+///
+/// Domain wrappers keep their own public descriptions and final-root invariants
+/// while this type owns operation, pointer, result, and application-work bounds.
+#[derive(Clone, Debug)]
+pub(crate) struct BoundedJsonPatch(json_patch::Patch);
+
+impl BoundedJsonPatch {
+    fn validate(patch: json_patch::Patch) -> Result<Self, String> {
+        if patch.0.len() > MAX_JSON_PATCH_OPERATIONS {
+            return Err(format!(
+                "JSON Patch contains {} operations; at most {MAX_JSON_PATCH_OPERATIONS} are allowed",
+                patch.0.len()
+            ));
+        }
+
+        for (index, operation) in patch.0.iter().enumerate() {
+            validate_patch_pointer_depth(index, "path", operation.path().count())?;
+            let from_depth = match operation {
+                json_patch::PatchOperation::Move(operation) => Some(operation.from.count()),
+                json_patch::PatchOperation::Copy(operation) => Some(operation.from.count()),
+                _ => None,
+            };
+            if let Some(depth) = from_depth {
+                validate_patch_pointer_depth(index, "from", depth)?;
+            }
+        }
+
+        Ok(Self(patch))
+    }
+
+    /// Apply every operation to a clone of `document` and return it only when
+    /// the complete bounded patch succeeds.
+    pub(crate) fn apply(
+        &self,
+        document: &serde_json::Value,
+    ) -> Result<serde_json::Value, ApiError> {
+        let mut cumulative_bytes = validate_json_patch_result(document, None)?;
+        let mut patched = document.clone();
+        for (operation_index, operation) in self.0.iter().enumerate() {
+            json_patch::patch(&mut patched, std::slice::from_ref(operation)).map_err(|error| {
+                ApiError::Conflict(format!(
+                    "JSON Patch operation at index {operation_index} failed at path '{}': {}",
+                    error.path, error.kind
+                ))
+            })?;
+            let result_bytes = validate_json_patch_result(&patched, Some(operation_index))?;
+            cumulative_bytes = cumulative_bytes
+                .checked_add(result_bytes)
+                .ok_or_else(json_patch_work_limit_error)?;
+            if cumulative_bytes > MAX_JSON_PATCH_WORK_BYTES {
+                return Err(json_patch_work_limit_error());
+            }
+        }
+        Ok(patched)
+    }
+}
+
+fn validate_json_patch_result(
+    document: &serde_json::Value,
+    operation_index: Option<usize>,
+) -> Result<usize, ApiError> {
+    match validate_postgres_jsonb_value(document) {
+        Ok(()) => {}
+        Err(PostgresJsonbValidationError::UnsupportedValue) => {
+            return Err(ApiError::BadRequest(format!(
+                "JSON Patch result after {} contains JSON that PostgreSQL JSONB cannot represent",
+                patch_result_stage(operation_index)
+            )));
+        }
+        Err(PostgresJsonbValidationError::NestingTooDeep) => {
+            return Err(ApiError::PayloadTooLarge(format!(
+                "JSON Patch result after {} exceeds the maximum nesting depth of {MAX_JSON_PATCH_RESULT_NESTING_DEPTH}",
+                patch_result_stage(operation_index)
+            )));
+        }
+    }
+
+    let serialized_bytes = serde_json::to_vec(document)?.len();
+    if serialized_bytes > MAX_JSON_PATCH_BYTES {
+        return Err(ApiError::PayloadTooLarge(format!(
+            "JSON Patch result after {} is {serialized_bytes} bytes; the limit is {MAX_JSON_PATCH_BYTES} bytes",
+            patch_result_stage(operation_index)
+        )));
+    }
+    Ok(serialized_bytes)
+}
+
+fn patch_result_stage(operation_index: Option<usize>) -> String {
+    operation_index.map_or_else(
+        || "loading the current document".to_string(),
+        |index| format!("operation {index}"),
+    )
+}
+
+fn json_patch_work_limit_error() -> ApiError {
+    ApiError::PayloadTooLarge(format!(
+        "JSON Patch exceeds the cumulative application-work limit of {MAX_JSON_PATCH_WORK_BYTES} bytes"
+    ))
+}
+
+fn validate_patch_pointer_depth(
+    operation_index: usize,
+    pointer_name: &str,
+    depth: usize,
+) -> Result<(), String> {
+    if depth > MAX_JSON_PATCH_POINTER_DEPTH {
+        return Err(format!(
+            "JSON Patch operation at index {operation_index} has a `{pointer_name}` pointer depth of {depth}; at most {MAX_JSON_PATCH_POINTER_DEPTH} segments are allowed"
+        ));
+    }
+    Ok(())
+}
+
+impl<'de> Deserialize<'de> for BoundedJsonPatch {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let patch = json_patch::Patch::deserialize(deserializer)?;
+        Self::validate(patch).map_err(de::Error::custom)
+    }
+}
+
+impl Serialize for BoundedJsonPatch {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}

--- a/src/models/json_patch.rs
+++ b/src/models/json_patch.rs
@@ -1,7 +1,13 @@
 use std::cmp::Ordering;
 use std::fmt::Display;
 
+use json_patch::{
+    Patch, PatchErrorKind, PatchOperation, TestOperation, patch as apply_patch_operation,
+};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use serde_json::{Number, Value};
+use utoipa::openapi::{RefOr, schema::Schema};
+use utoipa::{PartialSchema, ToSchema};
 
 use crate::db::json::{
     MAX_POSTGRES_JSONB_NESTING_DEPTH, PostgresJsonbValidationError, validate_postgres_jsonb_value,
@@ -19,10 +25,10 @@ pub(crate) const MAX_JSON_PATCH_RESULT_NESTING_DEPTH: usize = MAX_POSTGRES_JSONB
 /// Domain wrappers keep their own public descriptions and final-root invariants
 /// while this type owns operation, pointer, result, and application-work bounds.
 #[derive(Clone, Debug)]
-pub(crate) struct BoundedJsonPatch(json_patch::Patch);
+pub(crate) struct BoundedJsonPatch(Patch);
 
 impl BoundedJsonPatch {
-    fn validate(patch: json_patch::Patch) -> Result<Self, String> {
+    fn validate(patch: Patch) -> Result<Self, String> {
         if patch.0.len() > MAX_JSON_PATCH_OPERATIONS {
             return Err(format!(
                 "JSON Patch contains {} operations; at most {MAX_JSON_PATCH_OPERATIONS} are allowed",
@@ -33,8 +39,8 @@ impl BoundedJsonPatch {
         for (index, operation) in patch.0.iter().enumerate() {
             validate_patch_pointer_depth(index, "path", operation.path().count())?;
             let from_depth = match operation {
-                json_patch::PatchOperation::Move(operation) => Some(operation.from.count()),
-                json_patch::PatchOperation::Copy(operation) => Some(operation.from.count()),
+                PatchOperation::Move(operation) => Some(operation.from.count()),
+                PatchOperation::Copy(operation) => Some(operation.from.count()),
                 _ => None,
             };
             if let Some(depth) = from_depth {
@@ -47,15 +53,14 @@ impl BoundedJsonPatch {
 
     /// Apply every operation to a clone of `document` and return it only when
     /// the complete bounded patch succeeds.
-    pub(crate) fn apply(
-        &self,
-        document: &serde_json::Value,
-    ) -> Result<serde_json::Value, ApiError> {
-        let mut cumulative_bytes = validate_json_patch_result(document, None)?;
+    pub(crate) fn apply(&self, document: &Value) -> Result<Value, ApiError> {
+        let mut cumulative_bytes =
+            validate_json_patch_result(document, PatchResultStage::InitialDocument)?;
         let mut patched = document.clone();
         for (operation_index, operation) in self.0.iter().enumerate() {
-            apply_json_patch_operation(&mut patched, operation, operation_index)?;
-            let result_bytes = validate_json_patch_result(&patched, Some(operation_index))?;
+            apply_bounded_patch_operation(&mut patched, operation, operation_index)?;
+            let result_bytes =
+                validate_json_patch_result(&patched, PatchResultStage::Operation(operation_index))?;
             cumulative_bytes = cumulative_bytes
                 .checked_add(result_bytes)
                 .ok_or_else(json_patch_work_limit_error)?;
@@ -65,28 +70,49 @@ impl BoundedJsonPatch {
         }
         Ok(patched)
     }
+
+    pub(crate) fn openapi_schema(description: &str, example: Value) -> RefOr<Schema> {
+        utoipa::openapi::schema::ArrayBuilder::new()
+            .items(PatchOperation::schema())
+            .max_items(Some(MAX_JSON_PATCH_OPERATIONS))
+            .description(Some(description))
+            .examples([example])
+            .build()
+            .into()
+    }
+
+    pub(crate) fn register_openapi_schemas(schemas: &mut Vec<(String, RefOr<Schema>)>) {
+        schemas.push((
+            PatchOperation::name().into_owned(),
+            PatchOperation::schema(),
+        ));
+        PatchOperation::schemas(schemas);
+    }
 }
 
-fn apply_json_patch_operation(
-    document: &mut serde_json::Value,
-    operation: &json_patch::PatchOperation,
+fn apply_bounded_patch_operation(
+    document: &mut Value,
+    operation: &PatchOperation,
     operation_index: usize,
 ) -> Result<(), ApiError> {
-    if let json_patch::PatchOperation::Test(test) = operation {
-        let result = document
-            .pointer(test.path.as_str())
-            .ok_or(json_patch::PatchErrorKind::InvalidPointer)
-            .and_then(|actual| {
-                json_patch_values_equal(actual, &test.value)
-                    .then_some(())
-                    .ok_or(json_patch::PatchErrorKind::TestFailed)
-            });
-        return result
+    if let PatchOperation::Test(test) = operation {
+        return apply_test_operation(document, test)
             .map_err(|kind| json_patch_operation_error(operation_index, &test.path, &kind));
     }
 
-    json_patch::patch(document, std::slice::from_ref(operation))
+    apply_patch_operation(document, std::slice::from_ref(operation))
         .map_err(|error| json_patch_operation_error(operation_index, &error.path, &error.kind))
+}
+
+fn apply_test_operation(document: &Value, test: &TestOperation) -> Result<(), PatchErrorKind> {
+    let actual = document
+        .pointer(test.path.as_str())
+        .ok_or(PatchErrorKind::InvalidPointer)?;
+    if json_patch_values_equal(actual, &test.value) {
+        Ok(())
+    } else {
+        Err(PatchErrorKind::TestFailed)
+    }
 }
 
 fn json_patch_operation_error(
@@ -101,23 +127,17 @@ fn json_patch_operation_error(
 
 /// RFC 6902 defines `test` equality recursively and compares JSON numbers by
 /// numeric value rather than their serialized representation.
-fn json_patch_values_equal(left: &serde_json::Value, right: &serde_json::Value) -> bool {
+fn json_patch_values_equal(left: &Value, right: &Value) -> bool {
     match (left, right) {
-        (serde_json::Value::Number(left), serde_json::Value::Number(right)) => {
-            if json_number_is_zero(left) && json_number_is_zero(right) {
-                return true;
-            }
-            hubuum_computed_fields::compare_decimal_strings(&left.to_string(), &right.to_string())
-                == Some(Ordering::Equal)
-        }
-        (serde_json::Value::Array(left), serde_json::Value::Array(right)) => {
+        (Value::Number(left), Value::Number(right)) => json_patch_numbers_equal(left, right),
+        (Value::Array(left), Value::Array(right)) => {
             left.len() == right.len()
                 && left
                     .iter()
                     .zip(right)
                     .all(|(left, right)| json_patch_values_equal(left, right))
         }
-        (serde_json::Value::Object(left), serde_json::Value::Object(right)) => {
+        (Value::Object(left), Value::Object(right)) => {
             left.len() == right.len()
                 && left.iter().all(|(key, left)| {
                     right
@@ -129,31 +149,52 @@ fn json_patch_values_equal(left: &serde_json::Value, right: &serde_json::Value) 
     }
 }
 
-fn json_number_is_zero(number: &serde_json::Number) -> bool {
+fn json_patch_numbers_equal(left: &Number, right: &Number) -> bool {
+    let left = left.to_string();
+    let right = right.to_string();
+    if json_number_source_is_zero(&left) && json_number_source_is_zero(&right) {
+        return true;
+    }
+    hubuum_computed_fields::compare_decimal_strings(&left, &right) == Some(Ordering::Equal)
+}
+
+fn json_number_source_is_zero(number: &str) -> bool {
     number
-        .to_string()
         .trim_start_matches('-')
         .split(['e', 'E'])
         .next()
         .is_some_and(|mantissa| mantissa.bytes().all(|byte| matches!(byte, b'0' | b'.')))
 }
 
+#[derive(Clone, Copy)]
+enum PatchResultStage {
+    InitialDocument,
+    Operation(usize),
+}
+
+impl Display for PatchResultStage {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InitialDocument => formatter.write_str("loading the current document"),
+            Self::Operation(index) => write!(formatter, "operation {index}"),
+        }
+    }
+}
+
 fn validate_json_patch_result(
-    document: &serde_json::Value,
-    operation_index: Option<usize>,
+    document: &Value,
+    stage: PatchResultStage,
 ) -> Result<usize, ApiError> {
     match validate_postgres_jsonb_value(document) {
         Ok(()) => {}
         Err(PostgresJsonbValidationError::UnsupportedValue) => {
             return Err(ApiError::BadRequest(format!(
-                "JSON Patch result after {} contains JSON that PostgreSQL JSONB cannot represent",
-                patch_result_stage(operation_index)
+                "JSON Patch result after {stage} contains JSON that PostgreSQL JSONB cannot represent"
             )));
         }
         Err(PostgresJsonbValidationError::NestingTooDeep) => {
             return Err(ApiError::PayloadTooLarge(format!(
-                "JSON Patch result after {} exceeds the maximum nesting depth of {MAX_JSON_PATCH_RESULT_NESTING_DEPTH}",
-                patch_result_stage(operation_index)
+                "JSON Patch result after {stage} exceeds the maximum nesting depth of {MAX_JSON_PATCH_RESULT_NESTING_DEPTH}"
             )));
         }
     }
@@ -161,18 +202,10 @@ fn validate_json_patch_result(
     let serialized_bytes = serde_json::to_vec(document)?.len();
     if serialized_bytes > MAX_JSON_PATCH_BYTES {
         return Err(ApiError::PayloadTooLarge(format!(
-            "JSON Patch result after {} is {serialized_bytes} bytes; the limit is {MAX_JSON_PATCH_BYTES} bytes",
-            patch_result_stage(operation_index)
+            "JSON Patch result after {stage} is {serialized_bytes} bytes; the limit is {MAX_JSON_PATCH_BYTES} bytes"
         )));
     }
     Ok(serialized_bytes)
-}
-
-fn patch_result_stage(operation_index: Option<usize>) -> String {
-    operation_index.map_or_else(
-        || "loading the current document".to_string(),
-        |index| format!("operation {index}"),
-    )
 }
 
 fn json_patch_work_limit_error() -> ApiError {
@@ -199,7 +232,7 @@ impl<'de> Deserialize<'de> for BoundedJsonPatch {
     where
         D: Deserializer<'de>,
     {
-        let patch = json_patch::Patch::deserialize(deserializer)?;
+        let patch = Patch::deserialize(deserializer)?;
         Self::validate(patch).map_err(de::Error::custom)
     }
 }
@@ -210,5 +243,26 @@ impl Serialize for BoundedJsonPatch {
         S: Serializer,
     {
         self.0.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_operation_compares_numeric_representations_recursively() {
+        let patch = serde_json::from_str::<BoundedJsonPatch>(
+            r#"[
+                {"op":"add","path":"/value","value":{"direct":1.0,"nested":[2e0]}},
+                {"op":"test","path":"/value","value":{"nested":[2.00],"direct":1}},
+                {"op":"add","path":"/test_passed","value":true}
+            ]"#,
+        )
+        .unwrap();
+
+        let patched = patch.apply(&serde_json::json!({})).unwrap();
+
+        assert_eq!(patched["test_passed"], true);
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -18,6 +18,7 @@ pub mod group;
 pub mod history;
 pub mod identity;
 pub mod import;
+pub(crate) mod json_patch;
 pub(crate) mod maintenance;
 pub mod object;
 pub mod object_aggregate;

--- a/src/models/object_data_patch.rs
+++ b/src/models/object_data_patch.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use utoipa::openapi::{RefOr, schema::Schema};
 use utoipa::{PartialSchema, ToSchema};
 
 use crate::errors::ApiError;
@@ -31,33 +32,19 @@ pub const MAX_OBJECT_DATA_PATCH_RESULT_NESTING_DEPTH: usize = MAX_JSON_PATCH_RES
 pub struct ObjectDataPatchDocument(BoundedJsonPatch);
 
 impl PartialSchema for ObjectDataPatchDocument {
-    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-        utoipa::openapi::schema::ArrayBuilder::new()
-            .items(json_patch::PatchOperation::schema())
-            .max_items(Some(MAX_OBJECT_DATA_PATCH_OPERATIONS))
-            .description(Some(
-                "RFC 6902 operations applied relative to the root of an object's raw data document. Supports add, remove, replace, move, copy, and test; test compares JSON numbers by numeric value. The resulting document is limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
-            ))
-            .examples([serde_json::json!([
+    fn schema() -> RefOr<Schema> {
+        BoundedJsonPatch::openapi_schema(
+            "RFC 6902 operations applied relative to the root of an object's raw data document. Supports add, remove, replace, move, copy, and test; test compares JSON numbers by numeric value. The resulting document is limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
+            serde_json::json!([
                 {"op": "add", "path": "/facts", "value": {"source": "inventory"}}
-            ])])
-            .build()
-            .into()
+            ]),
+        )
     }
 }
 
 impl ToSchema for ObjectDataPatchDocument {
-    fn schemas(
-        schemas: &mut Vec<(
-            String,
-            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
-        )>,
-    ) {
-        schemas.push((
-            json_patch::PatchOperation::name().into_owned(),
-            json_patch::PatchOperation::schema(),
-        ));
-        json_patch::PatchOperation::schemas(schemas);
+    fn schemas(schemas: &mut Vec<(String, RefOr<Schema>)>) {
+        BoundedJsonPatch::register_openapi_schemas(schemas);
     }
 }
 
@@ -115,22 +102,6 @@ mod tests {
         let patched = patch_document(patch).apply(&original).unwrap();
 
         assert_eq!(patched, expected);
-    }
-
-    #[test]
-    fn object_data_patch_test_compares_numeric_representations_recursively() {
-        let patch = serde_json::from_str::<ObjectDataPatchDocument>(
-            r#"[
-                {"op":"add","path":"/value","value":{"direct":1.0,"nested":[2e0]}},
-                {"op":"test","path":"/value","value":{"nested":[2.00],"direct":1}},
-                {"op":"add","path":"/test_passed","value":true}
-            ]"#,
-        )
-        .unwrap();
-
-        let patched = patch.apply(&serde_json::json!({})).unwrap();
-
-        assert_eq!(patched["test_passed"], true);
     }
 
     #[rstest::rstest]

--- a/src/models/object_data_patch.rs
+++ b/src/models/object_data_patch.rs
@@ -36,7 +36,7 @@ impl PartialSchema for ObjectDataPatchDocument {
             .items(json_patch::PatchOperation::schema())
             .max_items(Some(MAX_OBJECT_DATA_PATCH_OPERATIONS))
             .description(Some(
-                "RFC 6902 operations applied relative to the root of an object's raw data document. Supports add, remove, replace, move, copy, and test. The resulting document is limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
+                "RFC 6902 operations applied relative to the root of an object's raw data document. Supports add, remove, replace, move, copy, and test; test compares JSON numbers by numeric value. The resulting document is limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
             ))
             .examples([serde_json::json!([
                 {"op": "add", "path": "/facts", "value": {"source": "inventory"}}
@@ -115,6 +115,22 @@ mod tests {
         let patched = patch_document(patch).apply(&original).unwrap();
 
         assert_eq!(patched, expected);
+    }
+
+    #[test]
+    fn object_data_patch_test_compares_numeric_representations_recursively() {
+        let patch = serde_json::from_str::<ObjectDataPatchDocument>(
+            r#"[
+                {"op":"add","path":"/value","value":{"direct":1.0,"nested":[2e0]}},
+                {"op":"test","path":"/value","value":{"nested":[2.00],"direct":1}},
+                {"op":"add","path":"/test_passed","value":true}
+            ]"#,
+        )
+        .unwrap();
+
+        let patched = patch.apply(&serde_json::json!({})).unwrap();
+
+        assert_eq!(patched["test_passed"], true);
     }
 
     #[rstest::rstest]

--- a/src/models/object_data_patch.rs
+++ b/src/models/object_data_patch.rs
@@ -1,32 +1,34 @@
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use serde::{Deserialize, Serialize};
 use utoipa::{PartialSchema, ToSchema};
 
-use crate::db::json::{
-    MAX_POSTGRES_JSONB_NESTING_DEPTH, PostgresJsonbValidationError, validate_postgres_jsonb_value,
-};
 use crate::errors::ApiError;
+use crate::models::json_patch::{
+    BoundedJsonPatch, MAX_JSON_PATCH_BYTES, MAX_JSON_PATCH_OPERATIONS,
+    MAX_JSON_PATCH_POINTER_DEPTH, MAX_JSON_PATCH_RESULT_NESTING_DEPTH, MAX_JSON_PATCH_WORK_BYTES,
+};
 
 /// Maximum number of operations accepted in one object-data JSON Patch document.
-pub const MAX_OBJECT_DATA_PATCH_OPERATIONS: usize = 1_000;
+pub const MAX_OBJECT_DATA_PATCH_OPERATIONS: usize = MAX_JSON_PATCH_OPERATIONS;
 
 /// Maximum number of reference tokens accepted in a JSON Pointer used by a patch operation.
-pub const MAX_OBJECT_DATA_PATCH_POINTER_DEPTH: usize = 128;
+pub const MAX_OBJECT_DATA_PATCH_POINTER_DEPTH: usize = MAX_JSON_PATCH_POINTER_DEPTH;
 
 /// Maximum serialized size of a JSON Patch request or its resulting raw object data.
-pub const MAX_OBJECT_DATA_PATCH_BYTES: usize = 2_097_152;
+pub const MAX_OBJECT_DATA_PATCH_BYTES: usize = MAX_JSON_PATCH_BYTES;
 
 /// Maximum cumulative serialized result bytes inspected while applying one JSON Patch document.
-pub const MAX_OBJECT_DATA_PATCH_WORK_BYTES: usize = 32 * 1024 * 1024;
+pub const MAX_OBJECT_DATA_PATCH_WORK_BYTES: usize = MAX_JSON_PATCH_WORK_BYTES;
 
 /// Maximum number of nested JSON containers accepted in patched object data.
-pub const MAX_OBJECT_DATA_PATCH_RESULT_NESTING_DEPTH: usize = MAX_POSTGRES_JSONB_NESTING_DEPTH;
+pub const MAX_OBJECT_DATA_PATCH_RESULT_NESTING_DEPTH: usize = MAX_JSON_PATCH_RESULT_NESTING_DEPTH;
 
 /// An RFC 6902 patch document whose pointers are relative to an object's raw `data` value.
 ///
 /// The private representation keeps the third-party patch implementation behind a small,
 /// validating domain interface.
-#[derive(Clone, Debug)]
-pub struct ObjectDataPatchDocument(json_patch::Patch);
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct ObjectDataPatchDocument(BoundedJsonPatch);
 
 impl PartialSchema for ObjectDataPatchDocument {
     fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
@@ -60,124 +62,9 @@ impl ToSchema for ObjectDataPatchDocument {
 }
 
 impl ObjectDataPatchDocument {
-    fn validate(patch: json_patch::Patch) -> Result<Self, String> {
-        if patch.0.len() > MAX_OBJECT_DATA_PATCH_OPERATIONS {
-            return Err(format!(
-                "JSON Patch contains {} operations; at most {MAX_OBJECT_DATA_PATCH_OPERATIONS} are allowed",
-                patch.0.len()
-            ));
-        }
-
-        for (index, operation) in patch.0.iter().enumerate() {
-            validate_patch_pointer_depth(index, "path", operation.path().count())?;
-            let from_depth = match operation {
-                json_patch::PatchOperation::Move(operation) => Some(operation.from.count()),
-                json_patch::PatchOperation::Copy(operation) => Some(operation.from.count()),
-                _ => None,
-            };
-            if let Some(depth) = from_depth {
-                validate_patch_pointer_depth(index, "from", depth)?;
-            }
-        }
-
-        Ok(Self(patch))
-    }
-
     /// Apply the complete patch to `data`, returning a new value only if every operation succeeds.
     pub fn apply(&self, data: &serde_json::Value) -> Result<serde_json::Value, ApiError> {
-        let mut cumulative_bytes = validate_object_data_patch_result(data, None)?;
-        let mut patched = data.clone();
-        for (operation_index, operation) in self.0.iter().enumerate() {
-            json_patch::patch(&mut patched, std::slice::from_ref(operation)).map_err(|error| {
-                ApiError::Conflict(format!(
-                    "JSON Patch operation at index {operation_index} failed at path '{}': {}",
-                    error.path, error.kind
-                ))
-            })?;
-            let result_bytes = validate_object_data_patch_result(&patched, Some(operation_index))?;
-            cumulative_bytes = cumulative_bytes
-                .checked_add(result_bytes)
-                .ok_or_else(object_data_patch_work_limit_error)?;
-            if cumulative_bytes > MAX_OBJECT_DATA_PATCH_WORK_BYTES {
-                return Err(object_data_patch_work_limit_error());
-            }
-        }
-        Ok(patched)
-    }
-}
-
-fn validate_object_data_patch_result(
-    data: &serde_json::Value,
-    operation_index: Option<usize>,
-) -> Result<usize, ApiError> {
-    match validate_postgres_jsonb_value(data) {
-        Ok(()) => {}
-        Err(PostgresJsonbValidationError::UnsupportedValue) => {
-            return Err(ApiError::BadRequest(format!(
-                "JSON Patch result after {} contains JSON that PostgreSQL JSONB cannot represent",
-                patch_result_stage(operation_index)
-            )));
-        }
-        Err(PostgresJsonbValidationError::NestingTooDeep) => {
-            return Err(ApiError::PayloadTooLarge(format!(
-                "JSON Patch result after {} exceeds the maximum nesting depth of {MAX_OBJECT_DATA_PATCH_RESULT_NESTING_DEPTH}",
-                patch_result_stage(operation_index)
-            )));
-        }
-    }
-
-    let serialized_bytes = serde_json::to_vec(data)?.len();
-    if serialized_bytes > MAX_OBJECT_DATA_PATCH_BYTES {
-        return Err(ApiError::PayloadTooLarge(format!(
-            "JSON Patch result after {} is {serialized_bytes} bytes; the limit is {MAX_OBJECT_DATA_PATCH_BYTES} bytes",
-            patch_result_stage(operation_index)
-        )));
-    }
-    Ok(serialized_bytes)
-}
-
-fn patch_result_stage(operation_index: Option<usize>) -> String {
-    operation_index.map_or_else(
-        || "loading the current object data".to_string(),
-        |index| format!("operation {index}"),
-    )
-}
-
-fn object_data_patch_work_limit_error() -> ApiError {
-    ApiError::PayloadTooLarge(format!(
-        "JSON Patch exceeds the cumulative application-work limit of {MAX_OBJECT_DATA_PATCH_WORK_BYTES} bytes"
-    ))
-}
-
-fn validate_patch_pointer_depth(
-    operation_index: usize,
-    pointer_name: &str,
-    depth: usize,
-) -> Result<(), String> {
-    if depth > MAX_OBJECT_DATA_PATCH_POINTER_DEPTH {
-        return Err(format!(
-            "JSON Patch operation at index {operation_index} has a `{pointer_name}` pointer depth of {depth}; at most {MAX_OBJECT_DATA_PATCH_POINTER_DEPTH} segments are allowed"
-        ));
-    }
-    Ok(())
-}
-
-impl<'de> Deserialize<'de> for ObjectDataPatchDocument {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let patch = json_patch::Patch::deserialize(deserializer)?;
-        Self::validate(patch).map_err(de::Error::custom)
-    }
-}
-
-impl Serialize for ObjectDataPatchDocument {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.0.serialize(serializer)
+        self.0.apply(data)
     }
 }
 

--- a/src/models/principal.rs
+++ b/src/models/principal.rs
@@ -1,5 +1,6 @@
 use crate::db::prelude::*;
 use serde::{Deserialize, Serialize};
+use utoipa::openapi::{RefOr, schema::Schema};
 use utoipa::{PartialSchema, ToSchema};
 
 use crate::db::DbPool;
@@ -109,40 +110,26 @@ pub const MAX_PRINCIPAL_SETTINGS_PATCH_RESULT_NESTING_DEPTH: usize =
 pub struct PrincipalSettingsPatchDocument(BoundedJsonPatch);
 
 impl PartialSchema for PrincipalSettingsPatchDocument {
-    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-        utoipa::openapi::schema::ArrayBuilder::new()
-            .items(json_patch::PatchOperation::schema())
-            .max_items(Some(MAX_PRINCIPAL_SETTINGS_PATCH_OPERATIONS))
-            .description(Some(
-                "RFC 6902 operations applied relative to the principal-settings document root. Supports add, remove, replace, move, copy, and test; test compares JSON numbers by numeric value. The final root must remain an object. The request and result are limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
-            ))
-            .examples([serde_json::json!([
+    fn schema() -> RefOr<Schema> {
+        BoundedJsonPatch::openapi_schema(
+            "RFC 6902 operations applied relative to the principal-settings document root. Supports add, remove, replace, move, copy, and test; test compares JSON numbers by numeric value. The final root must remain an object. The request and result are limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
+            serde_json::json!([
                 {"op": "test", "path": "/theme", "value": "light"},
                 {"op": "replace", "path": "/theme", "value": "dark"}
-            ])])
-            .build()
-            .into()
+            ]),
+        )
     }
 }
 
 impl ToSchema for PrincipalSettingsPatchDocument {
-    fn schemas(
-        schemas: &mut Vec<(
-            String,
-            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
-        )>,
-    ) {
-        schemas.push((
-            json_patch::PatchOperation::name().into_owned(),
-            json_patch::PatchOperation::schema(),
-        ));
-        json_patch::PatchOperation::schemas(schemas);
+    fn schemas(schemas: &mut Vec<(String, RefOr<Schema>)>) {
+        BoundedJsonPatch::register_openapi_schemas(schemas);
     }
 }
 
 /// Content-type-selected semantics for a principal-settings PATCH request.
 #[derive(Clone, Debug)]
-pub enum PrincipalSettingsPatch {
+pub(crate) enum PrincipalSettingsPatch {
     MergePatch(PrincipalSettings),
     JsonPatch(PrincipalSettingsPatchDocument),
 }
@@ -591,7 +578,7 @@ impl PrincipalID {
         .await
     }
 
-    pub async fn apply_settings_patch<C>(
+    pub(crate) async fn apply_settings_patch<C>(
         &self,
         backend: &C,
         patch: PrincipalSettingsPatch,

--- a/src/models/principal.rs
+++ b/src/models/principal.rs
@@ -114,7 +114,7 @@ impl PartialSchema for PrincipalSettingsPatchDocument {
             .items(json_patch::PatchOperation::schema())
             .max_items(Some(MAX_PRINCIPAL_SETTINGS_PATCH_OPERATIONS))
             .description(Some(
-                "RFC 6902 operations applied relative to the principal-settings document root. Supports add, remove, replace, move, copy, and test. The final root must remain an object. The request and result are limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
+                "RFC 6902 operations applied relative to the principal-settings document root. Supports add, remove, replace, move, copy, and test; test compares JSON numbers by numeric value. The final root must remain an object. The request and result are limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
             ))
             .examples([serde_json::json!([
                 {"op": "test", "path": "/theme", "value": "light"},

--- a/src/models/principal.rs
+++ b/src/models/principal.rs
@@ -1,12 +1,16 @@
 use crate::db::prelude::*;
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+use utoipa::{PartialSchema, ToSchema};
 
 use crate::db::DbPool;
 use crate::db::traits::principal::PrincipalSettingsMutation;
 use crate::errors::ApiError;
 use crate::events::EventContext;
 use crate::models::ResourceRevision;
+use crate::models::json_patch::{
+    BoundedJsonPatch, MAX_JSON_PATCH_BYTES, MAX_JSON_PATCH_OPERATIONS,
+    MAX_JSON_PATCH_POINTER_DEPTH, MAX_JSON_PATCH_RESULT_NESTING_DEPTH, MAX_JSON_PATCH_WORK_BYTES,
+};
 use crate::models::search::{FilterField, SortParam};
 use crate::schema::principals;
 use crate::traits::BackendContext;
@@ -83,6 +87,66 @@ pub struct Principal {
 #[schema(value_type = Object)]
 pub struct PrincipalSettings(serde_json::Value);
 
+/// Maximum number of operations accepted in one principal-settings JSON Patch document.
+pub const MAX_PRINCIPAL_SETTINGS_PATCH_OPERATIONS: usize = MAX_JSON_PATCH_OPERATIONS;
+
+/// Maximum pointer depth accepted in a principal-settings JSON Patch operation.
+pub const MAX_PRINCIPAL_SETTINGS_PATCH_POINTER_DEPTH: usize = MAX_JSON_PATCH_POINTER_DEPTH;
+
+/// Maximum request or result size accepted for principal-settings JSON Patch.
+pub const MAX_PRINCIPAL_SETTINGS_PATCH_BYTES: usize = MAX_JSON_PATCH_BYTES;
+
+/// Maximum cumulative application work accepted for principal-settings JSON Patch.
+pub const MAX_PRINCIPAL_SETTINGS_PATCH_WORK_BYTES: usize = MAX_JSON_PATCH_WORK_BYTES;
+
+/// Maximum result nesting accepted for principal-settings JSON Patch.
+pub const MAX_PRINCIPAL_SETTINGS_PATCH_RESULT_NESTING_DEPTH: usize =
+    MAX_JSON_PATCH_RESULT_NESTING_DEPTH;
+
+/// An RFC 6902 operation array applied relative to the principal-settings root.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct PrincipalSettingsPatchDocument(BoundedJsonPatch);
+
+impl PartialSchema for PrincipalSettingsPatchDocument {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::schema::ArrayBuilder::new()
+            .items(json_patch::PatchOperation::schema())
+            .max_items(Some(MAX_PRINCIPAL_SETTINGS_PATCH_OPERATIONS))
+            .description(Some(
+                "RFC 6902 operations applied relative to the principal-settings document root. Supports add, remove, replace, move, copy, and test. The final root must remain an object. The request and result are limited to 2 MiB and 64 nested containers, with a bounded cumulative application-work budget.",
+            ))
+            .examples([serde_json::json!([
+                {"op": "test", "path": "/theme", "value": "light"},
+                {"op": "replace", "path": "/theme", "value": "dark"}
+            ])])
+            .build()
+            .into()
+    }
+}
+
+impl ToSchema for PrincipalSettingsPatchDocument {
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        schemas.push((
+            json_patch::PatchOperation::name().into_owned(),
+            json_patch::PatchOperation::schema(),
+        ));
+        json_patch::PatchOperation::schemas(schemas);
+    }
+}
+
+/// Content-type-selected semantics for a principal-settings PATCH request.
+#[derive(Clone, Debug)]
+pub enum PrincipalSettingsPatch {
+    MergePatch(PrincipalSettings),
+    JsonPatch(PrincipalSettingsPatchDocument),
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct PrincipalSettingsResponse {
     #[serde(skip, default)]
@@ -144,6 +208,21 @@ impl PrincipalSettings {
             .expect("PrincipalSettings always contains an object");
         merge_settings_objects(target, patch);
         self
+    }
+}
+
+impl PrincipalSettingsPatchDocument {
+    fn apply(&self, settings: &PrincipalSettings) -> Result<PrincipalSettings, ApiError> {
+        PrincipalSettings::new(self.0.apply(settings.as_value())?)
+    }
+}
+
+impl PrincipalSettingsPatch {
+    pub(crate) fn apply(self, settings: &PrincipalSettings) -> Result<PrincipalSettings, ApiError> {
+        match self {
+            Self::MergePatch(patch) => Ok(settings.clone().merge_patch(&patch)),
+            Self::JsonPatch(patch) => patch.apply(settings),
+        }
     }
 }
 
@@ -506,6 +585,24 @@ impl PrincipalID {
             backend.db_pool(),
             self.id(),
             PrincipalSettingsMutation::Patch,
+            patch,
+            event_context,
+        )
+        .await
+    }
+
+    pub async fn apply_settings_patch<C>(
+        &self,
+        backend: &C,
+        patch: PrincipalSettingsPatch,
+        event_context: &EventContext,
+    ) -> Result<PrincipalSettingsResponse, ApiError>
+    where
+        C: BackendContext + ?Sized,
+    {
+        crate::db::traits::principal::apply_principal_settings_patch(
+            backend.db_pool(),
+            self.id(),
             patch,
             event_context,
         )

--- a/tests/api_core_data_suite/object_data_patch/semantics.rs
+++ b/tests/api_core_data_suite/object_data_patch/semantics.rs
@@ -286,3 +286,34 @@ async fn failed_test_operation_leaves_the_object_unchanged(
     assert_eq!(current_object(&test_context, object.id).await, object);
     fixture.cleanup().await.unwrap();
 }
+
+#[rstest]
+#[actix_web::test]
+async fn test_operation_compares_numbers_by_rfc_value(#[future(awt)] test_context: TestContext) {
+    let fixture = object_fixture(
+        &test_context,
+        "numeric test equality",
+        serde_json::json!({}),
+    )
+    .await;
+    let object = &fixture.objects[0];
+
+    let response = patch_request_with_raw_body(
+        &test_context.pool,
+        &test_context.admin_token,
+        &data_patch_endpoint(fixture.class.id, object.id),
+        br#"[
+            {"op":"add","path":"/value","value":{"direct":1.0,"nested":[2e0]}},
+            {"op":"test","path":"/value","value":{"nested":[2.00],"direct":1}},
+            {"op":"add","path":"/test_passed","value":true}
+        ]"#
+        .as_slice(),
+        JSON_PATCH_MEDIA_TYPE,
+    )
+    .await;
+    let response = assert_response_status(response, StatusCode::OK).await;
+    let updated: HubuumObject = test::read_body_json(response).await;
+
+    assert_eq!(updated.data["test_passed"], true);
+    fixture.cleanup().await.unwrap();
+}

--- a/tests/api_identity_suite/mod.rs
+++ b/tests/api_identity_suite/mod.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod groups;
 mod principal_settings;
+mod principal_settings_json_patch;
 mod service_accounts;
 mod users;

--- a/tests/api_identity_suite/principal_settings_json_patch.rs
+++ b/tests/api_identity_suite/principal_settings_json_patch.rs
@@ -290,6 +290,29 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn json_patch_test_compares_numbers_by_rfc_value() {
+        let context = TestContext::new().await;
+
+        let response = patch_request_with_raw_body(
+            &context.pool,
+            &context.normal_token,
+            ME_SETTINGS,
+            br#"[
+                {"op":"add","path":"/value","value":{"direct":1.0,"nested":[2e0]}},
+                {"op":"test","path":"/value","value":{"nested":[2.00],"direct":1}},
+                {"op":"add","path":"/test_passed","value":true}
+            ]"#
+            .as_slice(),
+            JSON_PATCH_MEDIA_TYPE,
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let settings: PrincipalSettingsResponse = test::read_body_json(response).await;
+        assert_eq!(settings.as_value()["test_passed"], true);
+    }
+
+    #[actix_web::test]
     async fn a_json_patch_no_op_does_not_advance_revision_or_emit_an_event() {
         let context = TestContext::new().await;
         let principal_id = context.normal_user.id;

--- a/tests/api_identity_suite/principal_settings_json_patch.rs
+++ b/tests/api_identity_suite/principal_settings_json_patch.rs
@@ -1,0 +1,672 @@
+#[cfg(test)]
+mod tests {
+    use crate::db::prelude::*;
+    use actix_web::{http::StatusCode, test};
+    use chrono::NaiveDateTime;
+    use rstest::rstest;
+
+    use crate::db::{DbPool, with_connection};
+    use crate::errors::ApiError;
+    use crate::events::{Action, EntityType, Event};
+    use crate::models::{
+        MAX_PRINCIPAL_SETTINGS_PATCH_BYTES, MAX_PRINCIPAL_SETTINGS_PATCH_OPERATIONS, Permissions,
+        PrincipalID, PrincipalSettingsResponse, ResourceRevision,
+    };
+    use crate::tests::api_operations::{
+        get_request, patch_request_with_content_type, patch_request_with_raw_body, put_request,
+    };
+    use crate::tests::{TestContext, create_test_group, create_test_service_account, scoped_token};
+
+    const JSON_PATCH_MEDIA_TYPE: &str = "application/json-patch+json";
+    const JSON_MERGE_PATCH_MEDIA_TYPE: &str = "application/merge-patch+json";
+    const ME_SETTINGS: &str = "/api/v1/iam/me/settings";
+    const PRINCIPALS: &str = "/api/v1/iam/principals";
+
+    #[derive(Clone, Copy, Debug)]
+    enum RouteFamily {
+        Me,
+        Principal,
+    }
+
+    fn settings_endpoint(family: RouteFamily, principal_id: i32) -> String {
+        match family {
+            RouteFamily::Me => ME_SETTINGS.to_string(),
+            RouteFamily::Principal => format!("{PRINCIPALS}/{principal_id}/settings"),
+        }
+    }
+
+    async fn patch_settings(
+        context: &TestContext,
+        token: &str,
+        endpoint: &str,
+        patch: serde_json::Value,
+    ) -> actix_web::dev::ServiceResponse {
+        patch_request_with_content_type(
+            &context.pool,
+            token,
+            endpoint,
+            patch,
+            JSON_PATCH_MEDIA_TYPE,
+        )
+        .await
+    }
+
+    async fn current_settings(
+        context: &TestContext,
+        token: &str,
+        endpoint: &str,
+    ) -> PrincipalSettingsResponse {
+        let response = get_request(&context.pool, token, endpoint).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        test::read_body_json(response).await
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct MutationState {
+        revision: ResourceRevision,
+        updated_at: NaiveDateTime,
+        event_count: i64,
+    }
+
+    async fn mutation_state(pool: &DbPool, principal_id: i32) -> MutationState {
+        use crate::schema::{events, principals};
+
+        let (revision, updated_at, event_count) = with_connection(pool, async |conn| {
+            let (revision, updated_at) = principals::table
+                .filter(principals::id.eq(principal_id))
+                .select((principals::revision, principals::updated_at))
+                .first::<(ResourceRevision, NaiveDateTime)>(conn)
+                .await?;
+            let event_count = events::table
+                .filter(events::entity_type.eq(EntityType::User.as_str()))
+                .filter(events::entity_id.eq(principal_id))
+                .filter(events::action.eq(Action::Updated.as_str()))
+                .count()
+                .get_result::<i64>(conn)
+                .await?;
+            Ok::<_, ApiError>((revision, updated_at, event_count))
+        })
+        .await
+        .unwrap();
+        MutationState {
+            revision,
+            updated_at,
+            event_count,
+        }
+    }
+
+    #[rstest]
+    #[case::me(RouteFamily::Me)]
+    #[case::principal(RouteFamily::Principal)]
+    #[actix_web::test]
+    async fn both_settings_route_families_accept_json_patch(#[case] family: RouteFamily) {
+        let context = TestContext::new().await;
+        let endpoint = settings_endpoint(family, context.normal_user.id);
+        let setup = put_request(
+            &context.pool,
+            &context.normal_token,
+            &endpoint,
+            serde_json::json!({"theme": "light"}),
+        )
+        .await;
+        assert_eq!(setup.status(), StatusCode::OK);
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            &endpoint,
+            serde_json::json!([
+                {"op": "replace", "path": "/theme", "value": "dark"}
+            ]),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let settings: PrincipalSettingsResponse = test::read_body_json(response).await;
+        assert_eq!(settings.as_value(), &serde_json::json!({"theme": "dark"}));
+    }
+
+    #[rstest]
+    #[case::add(
+        serde_json::json!({"source": 1}),
+        serde_json::json!([{"op": "add", "path": "/added", "value": true}]),
+        serde_json::json!({"source": 1, "added": true})
+    )]
+    #[case::remove(
+        serde_json::json!({"remove": 1, "keep": 2}),
+        serde_json::json!([{"op": "remove", "path": "/remove"}]),
+        serde_json::json!({"keep": 2})
+    )]
+    #[case::replace(
+        serde_json::json!({"value": "before"}),
+        serde_json::json!([{"op": "replace", "path": "/value", "value": "after"}]),
+        serde_json::json!({"value": "after"})
+    )]
+    #[case::move_value(
+        serde_json::json!({"source": {"value": 1}}),
+        serde_json::json!([{"op": "move", "from": "/source", "path": "/moved"}]),
+        serde_json::json!({"moved": {"value": 1}})
+    )]
+    #[case::copy(
+        serde_json::json!({"source": {"value": 1}}),
+        serde_json::json!([{"op": "copy", "from": "/source", "path": "/copied"}]),
+        serde_json::json!({"source": {"value": 1}, "copied": {"value": 1}})
+    )]
+    #[case::test_success(
+        serde_json::json!({"value": 1}),
+        serde_json::json!([{"op": "test", "path": "/value", "value": 1}]),
+        serde_json::json!({"value": 1})
+    )]
+    #[actix_web::test]
+    async fn principal_settings_support_each_rfc_6902_operation(
+        #[case] initial: serde_json::Value,
+        #[case] patch: serde_json::Value,
+        #[case] expected: serde_json::Value,
+    ) {
+        let context = TestContext::new().await;
+        let setup = put_request(&context.pool, &context.normal_token, ME_SETTINGS, initial).await;
+        assert_eq!(setup.status(), StatusCode::OK);
+
+        let response = patch_settings(&context, &context.normal_token, ME_SETTINGS, patch).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let settings: PrincipalSettingsResponse = test::read_body_json(response).await;
+        assert_eq!(settings.as_value(), &expected);
+    }
+
+    #[rstest]
+    #[case::json("application/json")]
+    #[case::merge_patch(JSON_MERGE_PATCH_MEDIA_TYPE)]
+    #[actix_web::test]
+    async fn object_content_types_retain_json_merge_patch_semantics(#[case] content_type: &str) {
+        let context = TestContext::new().await;
+        let initial = serde_json::json!({
+            "nested": {"keep": true, "remove": true},
+            "array": [1, 2]
+        });
+        let setup = put_request(&context.pool, &context.normal_token, ME_SETTINGS, &initial).await;
+        assert_eq!(setup.status(), StatusCode::OK);
+
+        let response = patch_request_with_content_type(
+            &context.pool,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!({
+                "nested": {"remove": null, "added": 2},
+                "array": [3]
+            }),
+            content_type,
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let settings: PrincipalSettingsResponse = test::read_body_json(response).await;
+        assert_eq!(
+            settings.as_value(),
+            &serde_json::json!({
+                "nested": {"keep": true, "added": 2},
+                "array": [3]
+            })
+        );
+    }
+
+    #[actix_web::test]
+    async fn json_patch_can_insert_an_individual_array_element() {
+        let context = TestContext::new().await;
+        let setup = put_request(
+            &context.pool,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!({"items": ["first", "third"]}),
+        )
+        .await;
+        assert_eq!(setup.status(), StatusCode::OK);
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!([
+                {"op": "add", "path": "/items/1", "value": "second"}
+            ]),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let settings: PrincipalSettingsResponse = test::read_body_json(response).await;
+        assert_eq!(
+            settings.as_value(),
+            &serde_json::json!({"items": ["first", "second", "third"]})
+        );
+    }
+
+    #[actix_web::test]
+    async fn json_patch_can_store_a_literal_null() {
+        let context = TestContext::new().await;
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!([
+                {"op": "add", "path": "/nullable", "value": null}
+            ]),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let settings: PrincipalSettingsResponse = test::read_body_json(response).await;
+        assert_eq!(settings.as_value(), &serde_json::json!({"nullable": null}));
+    }
+
+    #[actix_web::test]
+    async fn a_failed_test_rolls_back_prior_operations_and_audit_side_effects() {
+        let context = TestContext::new().await;
+        let principal_id = context.normal_user.id;
+        let initial = serde_json::json!({"version": 1, "state": "before"});
+        let setup = put_request(&context.pool, &context.normal_token, ME_SETTINGS, &initial).await;
+        assert_eq!(setup.status(), StatusCode::OK);
+        let before = mutation_state(&context.pool, principal_id).await;
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!([
+                {"op": "replace", "path": "/state", "value": "intermediate"},
+                {"op": "test", "path": "/version", "value": 2}
+            ]),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(mutation_state(&context.pool, principal_id).await, before);
+        assert_eq!(
+            current_settings(&context, &context.normal_token, ME_SETTINGS)
+                .await
+                .as_value(),
+            &initial
+        );
+    }
+
+    #[actix_web::test]
+    async fn a_json_patch_no_op_does_not_advance_revision_or_emit_an_event() {
+        let context = TestContext::new().await;
+        let principal_id = context.normal_user.id;
+        let setup = put_request(
+            &context.pool,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!({"version": 1}),
+        )
+        .await;
+        assert_eq!(setup.status(), StatusCode::OK);
+        let before = mutation_state(&context.pool, principal_id).await;
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!([
+                {"op": "test", "path": "/version", "value": 1}
+            ]),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let settings: PrincipalSettingsResponse = test::read_body_json(response).await;
+        assert_eq!(settings.revision, before.revision);
+        assert_eq!(mutation_state(&context.pool, principal_id).await, before);
+    }
+
+    #[actix_web::test]
+    async fn concurrent_json_patches_apply_to_the_latest_row_locked_settings() {
+        let context = TestContext::new().await;
+        let setup = put_request(
+            &context.pool,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!({"base": true}),
+        )
+        .await;
+        assert_eq!(setup.status(), StatusCode::OK);
+        let left_patch = serde_json::json!([
+            {"op": "add", "path": "/left", "value": 1}
+        ]);
+        let right_patch = serde_json::json!([
+            {"op": "add", "path": "/right", "value": 2}
+        ]);
+
+        let (left, right) = tokio::join!(
+            patch_settings(&context, &context.normal_token, ME_SETTINGS, left_patch,),
+            patch_settings(&context, &context.normal_token, ME_SETTINGS, right_patch,)
+        );
+
+        assert_eq!(left.status(), StatusCode::OK);
+        assert_eq!(right.status(), StatusCode::OK);
+        assert_eq!(
+            current_settings(&context, &context.normal_token, ME_SETTINGS)
+                .await
+                .as_value(),
+            &serde_json::json!({"base": true, "left": 1, "right": 2})
+        );
+    }
+
+    #[actix_web::test]
+    async fn json_patch_rejects_a_non_object_final_root_without_persisting_it() {
+        let context = TestContext::new().await;
+        let initial = serde_json::json!({"keep": true});
+        let setup = put_request(&context.pool, &context.normal_token, ME_SETTINGS, &initial).await;
+        assert_eq!(setup.status(), StatusCode::OK);
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!([
+                {"op": "replace", "path": "", "value": ["invalid"]}
+            ]),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            current_settings(&context, &context.normal_token, ME_SETTINGS)
+                .await
+                .as_value(),
+            &initial
+        );
+    }
+
+    #[actix_web::test]
+    async fn json_patch_rejects_an_oversized_request() {
+        let context = TestContext::new().await;
+        let body = format!("[]{}", " ".repeat(MAX_PRINCIPAL_SETTINGS_PATCH_BYTES));
+
+        let response = patch_request_with_raw_body(
+            &context.pool,
+            &context.normal_token,
+            ME_SETTINGS,
+            body,
+            JSON_PATCH_MEDIA_TYPE,
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[actix_web::test]
+    async fn json_patch_rejects_an_oversized_result() {
+        let context = TestContext::new().await;
+        let setup = put_request(
+            &context.pool,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!({
+                "blob": "x".repeat(MAX_PRINCIPAL_SETTINGS_PATCH_BYTES / 2 + 1)
+            }),
+        )
+        .await;
+        assert_eq!(setup.status(), StatusCode::OK);
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!([
+                {"op": "copy", "from": "/blob", "path": "/copy"}
+            ]),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[actix_web::test]
+    async fn malformed_json_patch_documents_are_rejected() {
+        let context = TestContext::new().await;
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!({"op": "add", "path": "/invalid", "value": true}),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn json_patch_rejects_too_many_operations() {
+        let context = TestContext::new().await;
+        let operations = (0..=MAX_PRINCIPAL_SETTINGS_PATCH_OPERATIONS)
+            .map(|_| serde_json::json!({"op": "test", "path": "", "value": {}}))
+            .collect::<Vec<_>>();
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::Value::Array(operations),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn json_patch_rejects_an_excessively_deep_pointer() {
+        let context = TestContext::new().await;
+        let path = format!("/{}", vec!["segment"; 129].join("/"));
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!([
+                {"op": "remove", "path": path}
+            ]),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn json_patch_rejects_an_excessively_nested_intermediate_result() {
+        let context = TestContext::new().await;
+        let nested = (0..=64).fold(serde_json::Value::Null, |value, _| {
+            serde_json::Value::Array(vec![value])
+        });
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!([
+                {"op": "add", "path": "/nested", "value": nested},
+                {"op": "remove", "path": "/nested"}
+            ]),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(
+            current_settings(&context, &context.normal_token, ME_SETTINGS)
+                .await
+                .as_value(),
+            &serde_json::json!({})
+        );
+    }
+
+    #[actix_web::test]
+    async fn json_patch_bounds_cumulative_application_work() {
+        let context = TestContext::new().await;
+        let setup = put_request(
+            &context.pool,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!({
+                "padding": "x".repeat(40 * 1024),
+                "value": true
+            }),
+        )
+        .await;
+        assert_eq!(setup.status(), StatusCode::OK);
+        let operations = (0..MAX_PRINCIPAL_SETTINGS_PATCH_OPERATIONS)
+            .map(|_| serde_json::json!({"op": "test", "path": "/value", "value": true}))
+            .collect::<Vec<_>>();
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::Value::Array(operations),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[actix_web::test]
+    async fn json_patch_rejects_results_postgresql_jsonb_cannot_represent() {
+        let context = TestContext::new().await;
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!([
+                {"op": "add", "path": "/invalid", "value": "contains\u{0}null"}
+            ]),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            current_settings(&context, &context.normal_token, ME_SETTINGS)
+                .await
+                .as_value(),
+            &serde_json::json!({})
+        );
+    }
+
+    #[actix_web::test]
+    async fn service_accounts_can_json_patch_their_own_settings() {
+        let context = TestContext::new().await;
+        let owner_group = create_test_group(&context.pool).await;
+        let account = create_test_service_account(&context.pool, &owner_group, None).await;
+        let token = scoped_token(&context.pool, account.id, &[Permissions::ReadCollection]).await;
+
+        let response = patch_settings(
+            &context,
+            &token,
+            ME_SETTINGS,
+            serde_json::json!([
+                {"op": "add", "path": "/automation", "value": true}
+            ]),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let settings: PrincipalSettingsResponse = test::read_body_json(response).await;
+        assert_eq!(
+            settings.as_value(),
+            &serde_json::json!({"automation": true})
+        );
+    }
+
+    #[actix_web::test]
+    async fn cross_principal_json_patch_preserves_existing_authorization_rules() {
+        let context = TestContext::new().await;
+        let endpoint = format!("{PRINCIPALS}/{}/settings", context.admin_user.id);
+
+        let response = patch_settings(
+            &context,
+            &context.normal_token,
+            &endpoint,
+            serde_json::json!([
+                {"op": "add", "path": "/unauthorized", "value": true}
+            ]),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            PrincipalID::new(context.admin_user.id)
+                .unwrap()
+                .settings(&context.pool)
+                .await
+                .unwrap()
+                .as_value(),
+            &serde_json::json!({})
+        );
+    }
+
+    #[actix_web::test]
+    async fn successful_json_patch_emits_complete_service_account_snapshots() {
+        let context = TestContext::new().await;
+        let owner_group = create_test_group(&context.pool).await;
+        let account = create_test_service_account(&context.pool, &owner_group, None).await;
+        let endpoint = format!("{PRINCIPALS}/{}/settings", account.id);
+        let initial = serde_json::json!({"mode": "before", "keep": true});
+        let setup = put_request(&context.pool, &context.admin_token, &endpoint, &initial).await;
+        assert_eq!(setup.status(), StatusCode::OK);
+
+        let response = patch_settings(
+            &context,
+            &context.admin_token,
+            &endpoint,
+            serde_json::json!([
+                {"op": "replace", "path": "/mode", "value": "after"}
+            ]),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let updated: PrincipalSettingsResponse = test::read_body_json(response).await;
+
+        let event = with_connection(&context.pool, async |conn| {
+            crate::schema::events::table
+                .filter(crate::schema::events::entity_type.eq(EntityType::ServiceAccount.as_str()))
+                .filter(crate::schema::events::entity_id.eq(account.id))
+                .filter(crate::schema::events::action.eq(Action::Updated.as_str()))
+                .order(crate::schema::events::id.desc())
+                .first::<Event>(conn)
+                .await
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            event.before,
+            Some(serde_json::json!({
+                "revision": event.before_revision.unwrap(),
+                "settings": initial
+            }))
+        );
+        assert_eq!(
+            event.after,
+            Some(serde_json::json!({
+                "revision": updated.revision,
+                "settings": {"mode": "after", "keep": true}
+            }))
+        );
+    }
+
+    #[actix_web::test]
+    async fn unsupported_principal_settings_patch_media_types_are_rejected() {
+        let context = TestContext::new().await;
+
+        let response = patch_request_with_content_type(
+            &context.pool,
+            &context.normal_token,
+            ME_SETTINGS,
+            serde_json::json!({"theme": "dark"}),
+            "application/problem+json",
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+}


### PR DESCRIPTION
## Summary

- add RFC 6902 JSON Patch support to both principal-settings PATCH endpoints when `Content-Type: application/json-patch+json`
- preserve the existing object merge behavior for `application/json` and accept `application/merge-patch+json` as an alias
- apply patches to the latest row-locked settings document in the existing audit transaction, with no revision or event for semantic no-ops
- factor the bounded patch execution into a reusable internal engine shared with object-data patching
- document the behavior and limits, update the committed OpenAPI artifact, and add comprehensive integration coverage

## Why

Principal settings could only be patched by deserializing an object and merging its top-level keys. Clients could not target nested values or array elements, remove values, use RFC 6902 preconditions, or select patch semantics through the media type.

## Behavior

JSON Patch now supports `add`, `remove`, `replace`, `move`, `copy`, and `test`. A failed operation or test returns 409 and rolls back the entire request. Malformed documents and final non-object settings return 400. Request size, operation count, pointer depth, nesting, result size, JSONB compatibility, and cumulative work are bounded.

The existing Rust merge-patch API remains source-compatible, and both endpoint families retain their existing authorization and revision-precondition behavior.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- regenerated OpenAPI and compared it byte-for-byte with `docs/openapi.json`
- `scripts/test-classify-ci-changes.sh`

Closes #164