### PR TITLE
Prepare v0.0.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.0.9] - 2026-08-06
+
 ### Added
 
 - Principal settings PATCH endpoints now accept bounded RFC 6902 JSON Patch via

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -2068,7 +2068,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hubuum"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "actix-http",
  "actix-rt",
@@ -2665,9 +2665,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da60094fc1968bbd091e2cfa004415cb7b19e25e592376e66a64aa832bb6039"
+checksum = "7e17384278234b10419a63c93fc85695ac9fc2da0833e3c59167f9986499590c"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2694,18 +2694,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36539f34ef9e5da418433fbbf7294522d8f930ecf6a540ccd1ec6481c9ff9056"
+checksum = "ac634e339e73bf9629f6fb207f7b064d872253ae3b3f5c6e0ce8fd762b16e40f"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc513dfee68c6fe29498451df95a32951ea227801b476f4a1f236433986c891"
+checksum = "92b8e258eb4515a3fc912a9c46e3987040dc07280592280097ea2085527870b8"
 dependencies = [
  "ahash",
  "bytecount",
@@ -3873,9 +3873,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.5"
+version = "0.49.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05915176d843da9ec5c925e5e2631be9aa61b27430acfdd562e79cae8f559725"
+checksum = "42902112f88a27e9afd5683e2ba31956fed2a5d43395f166dd26775ae9c0dedb"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -5751,18 +5751,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hubuum"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2024"
 description = "Flexible asset management REST service."
 license = "MIT"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.0.8"
+    "version": "0.0.9"
   },
   "servers": [
     {


### PR DESCRIPTION
## Summary

- Bump Hubuum from 0.0.8 to 0.0.9 and regenerate the committed OpenAPI version.
- Refresh the lockfile to the newest Rust 1.97-compatible dependency releases allowed by the workspace manifests.
- Move the accumulated `[Unreleased]` notes into the dated v0.0.9 release section.
- Prepare the signed native archives, SBOMs, attestations, and multi-architecture container images published by tagged CI.

## Impact

Hubuum v0.0.9 adds principal-settings JSON Patch, retained-token inspection and renewal, database-owned resource revisions, strong ETags and conditional mutations, and substantially hardened release and runtime security controls.

This pre-1.0 release contains intentional breaking HTTP, OpenAPI, Rust, backup/import, configuration, and operational changes. Every breaking change and required upgrade action is reproduced in the complete release notes below.

## Complete v0.0.9 release notes

## [0.0.9] - 2026-08-06

### Added

- Principal settings PATCH endpoints now accept bounded RFC 6902 JSON Patch via
  `application/json-patch+json`, including atomic `test` with numeric-value
  equality, precise array updates, literal JSON `null`, and rollback-safe `add`,
  `remove`, `replace`, `move`, and `copy` operations. Existing `application/json`
  JSON Merge Patch behavior is unchanged, with `application/merge-patch+json`
  also accepted as an alias.
- OpenAPI validation now blocks pull requests, `main`, and tagged releases on
  generated-document drift or unaccepted compatibility breaks from the latest
  stable release. CI publishes the generated document, exact drift diff,
  baseline tag and digest, structured compatibility data, and a grouped
  Markdown report for review.
- `HUBUUM_TREETOP_CA_CERT` now loads PEM CA certificate bundles from regular
  files up to 4 MiB into the Treetop client's trust store, enabling private PKI
  without disabling TLS certificate validation.
- Token managers can inspect retained expired and revoked credentials through
  lifecycle-filtered lists and point lookups, and can renew an active or expired
  token into a fresh secret with the same descriptive metadata and exact scope.
  Token audit snapshots now retain that hash-free scope and link renewals to
  their source token.
- Token retention now writes a system-authored `token.purged` audit event with
  the exact final hash-free token and scope snapshot before deleting each token,
  including legacy rows whose earlier events predate complete scope snapshots.
- Release CI now certifies the immediately previous stable image by immutable
  digest through migration, a live mixed-version API interval, application
  rollback, and candidate restoration. Reports include migration timing and API
  availability measurements while the fixed earliest-release test remains.

### Changed

- **Breaking (Rust API):** `hubuum_events_core::Action` now includes `Purged`.
  Downstream exhaustive matches must handle the new variant. Token purge events
  use this action and identify their retention basis in event metadata.
- **Breaking (Rust API):** `PrincipalTokenMetadata` now includes the
  server-derived `active` and `expired` lifecycle fields. Downstream struct
  literals must initialize both fields; token-management clients should prefer
  them over reproducing expiry rules locally.
- Token retention now starts at the earlier of revocation and effective expiry,
  so explicitly revoked long-lived credentials are purged after the configured
  retention window instead of remaining until their original expiry.
- Added database-owned positive 64-bit revisions to authoritative resources,
  aggregate permission, membership, principal, and token state, temporal
  history, and revision-aware audit events. Revision filtering and sorting are
  available through the shared list-query contract.
- Added strong opaque ETags to canonical entity reads and mutation responses,
  with bounded `If-Match` parsing and lock-protected conditional updates and
  deletes. Stale validators return `412 Precondition Failed` with the stable
  `stale_resource` reason.
- Import v2 collection, class, and object items support `create_only`,
  unconditional `overwrite`, and numeric `if_revision` write conditions that
  are rechecked by queued workers under row locks.
- Revision indexes are built concurrently in a separate non-transactional
  migration so an adjacent-release migration does not take blocking index-build
  locks on live tables.

- **Breaking (HTTP API):** entity JSON now contains `revision`; principal
  settings return `{revision, settings}`, SQL permission reads return
  `{collection_id, revision, permissions}`, and group member lists return
  membership entities with an optional nested principal. Clients must update
  deserializers for these response shapes.
- **Breaking (HTTP API):** class point routes return the class entity by
  default. Use `include=collection` for the expanded, untagged representation.
  Raw object points are tagged; `include=computed` remains expanded and
  untagged.
- **Breaking (HTTP API):** canonical tagged group points omit directory-sync
  timestamps, and canonical tagged token points omit `last_used_at`, because
  those operational fields do not advance resource revisions. The fields
  remain available in untagged group and token lists.
- **Breaking (HTTP API):** canonical tagged user and service-account points use
  stable `identity_scope_id` values and omit independently mutable provider and
  synchronization metadata. Tagged group-membership points omit the expanded
  principal, and SQL permission-set entries expose permission rows with stable
  `group_id` values instead of expanded groups. Rich metadata remains available
  from the corresponding untagged list responses.
- Actor-expanded historical snapshots and shared computed-field mutation
  responses are intentionally untagged because their composite fields do not
  share one revision owner. Fetch the canonical point resource before a later
  conditional mutation.
- **Breaking (computed fields):** mutation bodies and delete queries no longer
  accept `expected_revision`. Obtain the opaque ETag from a computed-field
  point route and send it in `If-Match` instead.
- **Breaking (backup/restore):** full backups are version 4 and restore rejects
  version 3. Version 4 preserves authoritative, authorization-set, event, and
  temporal revisions. Operators must create a new backup before restore and
  quiesce backup, restore, and import operations during the certified adjacent
  API overlap.
- **Breaking (imports):** imports are version 2 and version 1 is rejected.
  Producers must emit the v2 version number and may attach per-item write
  conditions where supported.

- **Breaking (Rust API):** permission-controller group parameters and
  permission-backend collection and group parameters now use validated
  `CollectionID` and `GroupID` values instead of raw integers. Downstream
  callers and backend implementations must construct the newtypes at their
  input boundaries and update their method signatures.
- **Breaking (HTTP API):** token mint requests now reject expirations that are
  not in the future or exceed the new `HUBUUM_MAX_TOKEN_LIFETIME_HOURS` policy
  (default 8760 hours). The client-safe configuration endpoint exposes the
  effective maximum alongside the default lifetime. Before upgrading, clients
  that request longer expirations must shorten them, or operators must raise
  the new limit; no database migration is required.
- The public `CursorPaginated` trait no longer requires row types to implement
  `Clone`; pagination borrows or moves rows and accepts non-clone domain types.
- External identity refresh removes stale group memberships with one set-based
  database write instead of issuing one delete per stale membership.
- **Breaking (Rust API):** Encapsulated event-sink delivery and webhook settings
  fields. Workspace-crate consumers must use `SinkDelivery` accessors and the
  validating `WebhookSinkSettings` constructor and configuration methods.
- **Breaking (Rust API):** `PermissionsList` is now a permission-specific,
  non-generic domain type that canonicalizes duplicate values. Rust callers
  should replace `PermissionsList<Permissions>` with `PermissionsList`.
- **Breaking (Rust API):** event delivery, fan-out, and retention worker
  settings and low-level claim helpers are now crate-private, validated event
  subsystem APIs instead of public database-layer field bags. Downstream
  callers must migrate to the validated APIs and stop invoking the private
  claim helpers. Operators must correct zero, inconsistent, or unrepresentable
  worker-duration values before upgrading; those values now fail startup.
- **Breaking (Rust API):** task-worker settings now use a validating builder,
  and low-level task claim and lease-renewal helpers are crate-private.
  Downstream callers must migrate to the builder and stop invoking the private
  helpers. Operators must correct zero, inconsistent, or unrepresentable
  worker-duration values before upgrading; those values now fail startup.
- **Breaking (Rust API):** `UpdateUser::save`,
  `UpdateUser::save_without_events`, `UpdateGroup::save`, and
  `UpdateGroup::save_without_events` now accept validated `UserID` or
  `GroupID` values instead of raw `i32` identifiers. Library callers must
  construct the matching ID newtype before invoking these domain update
  methods.
- **Breaking Rust API:** `CanUpdate` and its adapter now declare an associated
  `Identifier` type. Built-in collection, class, object, export-template, and
  service-account updates require their validated ID newtypes instead of raw
  `i32` values. Downstream update adapters must declare the associated type,
  and callers must construct the matching ID before invoking `update` or
  `update_without_events`.
- **Breaking (Rust API):** restore confirmation and status functions now
  accept a validated `RestoreJobID` instead of a raw `i64`. Downstream callers
  must construct `RestoreJobID` at their input boundary. Versioned restore
  paths reject non-positive stage IDs at the request boundary.
- **Breaking (Rust API):** `NewCollectionWithAssignee::group_id` and
  `NewServiceAccount::owner_group_id` now use the validated `GroupID` newtype.
  Library callers must construct `GroupID` values for those fields. Collection
  and service-account creation reject non-positive group IDs at the request
  boundary.
- **Breaking (Rust API):** replaced the partial `FilterField::table_field`
  helper, which panicked for non-JSON fields, with the total
  `FilterField::json_column` mapping. Callers must handle its optional result.
- **Breaking (Rust API):** raw dynamic SQL components, bind values, and JSON SQL
  generation helpers are now crate-private. External query integrations should
  use the validated `JsonPredicateExt::as_json_predicate` API instead.
- External permission-backed list filtering now bounds in-process
  authorization working sets and avoids retaining authorized rows outside the
  requested page, reducing peak memory use for large candidate sets.
- Outbound HTTP client construction no longer holds the process-wide client
  cache lock, allowing unrelated first-time integration destinations to
  initialize concurrently.

### Security

- Stable release archives now include CycloneDX SBOMs, signed authoritative
  checksums, and SLSA provenance. Published container platforms include Rust
  and Alpine SBOM data, signed provenance, keyless manifest signatures, and
  blocking scans for fixed HIGH or CRITICAL vulnerabilities. CI also enforces
  Rust advisory, license, immutable-input, and time-bounded exception policies.
- **Breaking (Rust API):** persisted task, event, import-result, and
  export-output rows no longer implement broad Serde or `Debug` traits that
  could expose raw stored content. `TaskRecord` retains redacted debug output
  that hides request, idempotency, token-scope, and worker-lease material.
  Library callers must use the corresponding task response types for public
  payloads.
- **Breaking:** TLS certificate chains, private keys, and PostgreSQL root CA
  bundles must now be regular files and are read with explicit 4 MiB
  certificate and 1 MiB key limits; malformed rustls certificate entries are
  rejected instead of skipped. Before upgrading, replace non-regular TLS files,
  reduce oversized PEM material, and correct malformed certificate entries.
- **Breaking (HTTP API):** Login identity scopes and names are now limited to
  255 characters, and login passwords to 4096 characters. Clients must keep
  those fields within the new limits before upgrading. Oversized requests are
  rejected before rate-limit state or password workers are used, bounding
  unauthenticated limiter-key memory and password-processing work.
- **Breaking (HTTP API):** Common resource queries now reject more than 128
  parameters, 64 filters, or 8 distinct sort fields before building database
  queries. Duplicate sort fields and ambiguous repeated history `at` parameters
  are also rejected. Clients must keep queries within those limits and send one
  value for each sort field and history `at` parameter before upgrading. This
  bounds query-parser allocation and quadratic cursor-predicate growth.
- **Breaking (Unix deployments):** event retention archives now restrict
  existing files to owner-only permissions before appending and reject archive
  paths whose final component is a symbolic link or another non-regular file.
  Operators relying on group-readable archives must move that access behind an
  owner-controlled collector; no database migration is required.
- **Breaking (configuration):** auth provider configuration loading now accepts
  only regular UTF-8 files up to 1 MiB and reports TOML error locations without
  echoing credential-bearing source lines. Deployments must replace larger or
  non-regular sources with a bounded regular file; no database migration is
  required.
- **Breaking:** External identity refresh policy now rejects unrepresentable
  durations and stale windows shorter than the refresh TTL. Before upgrading,
  raise `max_stale_seconds` or lower `refresh_ttl_seconds` wherever the stale
  window is shorter. Future-dated provider sync timestamps also fail closed
  instead of extending cached authorization state.
- **Breaking (HTTP and Rust API):** Event-delivery API responses no longer
  expose the internal `claim_token` worker lease capability. API clients must
  stop deserializing or depending on this field. The persistence-only
  `EventDelivery` model no longer implements Serde or OpenAPI schema traits,
  and its claim token is crate-private.
- **Breaking:** LDAP provider URLs now reject embedded user information. Move
  service credentials into `bind_dn` and `bind_password`; configuration debug
  output now shows only the LDAP URL scheme, host, and port.
- Local password changes and administrative password resets now atomically
  revoke all active bearer tokens for the affected user.
- Redacted embedded URL credentials and common secret-header spellings from
  event sink configuration and subscription routing responses and audit
  snapshots.
- **Breaking (Rust API):** `OutboundHttpError::ClientBuild`,
  `OutboundHttpError::ResponseRead`, and `OutboundHttpError::Request` no longer
  carry low-level error strings, keeping endpoint details out of integration
  diagnostics and persisted event-delivery failures. Downstream matches and
  constructors must remove the former string payloads. Credential-resolved
  AMQP, email, and Valkey transport failures are likewise reported without
  transport-library detail. The underlying failures remain available to
  administrators in contextual server logs.
- Restore-status capability checks no longer disclose whether a restore stage
  ID exists when the supplied capability is invalid. Server logs distinguish
  missing stages from capability mismatches without recording the capability.
- Response debug logs no longer include custom HTTP header values, preventing
  pagination cursors and future secret-bearing headers from leaking into logs.
- Debug formatting now redacts authentication credentials, including raw
  logout bearer tokens and stored token digests, along with task request and
  lease data, worker claim tokens, audit-event payloads, outbound HTTP headers,
  URLs and response previews, remote-target configuration and results,
  event-sink configuration and routing, full backup contents, restore
  capabilities and errors, login-limiter connection URLs, and
  credential-bearing connection cache keys.
- Failed restore status responses now retain only public-safe error messages;
  detailed database, connection, hashing, and internal failures remain in
  server logs with the restore job identifier instead of being persisted for
  capability-authenticated clients.
- **Breaking (OpenAPI):** removed the internal `PrincipalToken` storage schema,
  which contains the persisted bearer-token HMAC, from OpenAPI and made the
  storage model non-serializable. Consumers that referenced that unbound schema
  should use the hash-free `PrincipalTokenMetadata` schema returned by token
  listing endpoints.

### Fixed

- Conditional collection, class, object, and membership mutations now return
  `412 Precondition Failed` when their selected target vanishes, changes before
  delete validation, or produces a membership-source no-op.
- Import v2 now matches shared computed fields with their null owner, reports
  vanished `if_revision` execution targets as `stale_revision`, and exposes
  observed shared-field revisions during dry runs. Permission-scoped group
  lists now honor the documented `revision` filter.
- In-memory cursor pagination now computes every row's sort values before
  ordering and extracts each value once, so failures cannot silently leave rows
  unordered and fallible work is not repeated inside the sort comparator.
- Export, backup, and staged-restore retention horizons now reject durations or
  expiry timestamps outside the supported range instead of panicking during
  startup or artifact creation.
- Concurrent first deliveries to the same AMQP, email, or Valkey endpoint now
  share one connection initializer instead of opening duplicate connections
  and discarding all but one.
- Event-sink connection caches now retain at most 64 recently used endpoint
  configurations, bounding stale connections and credential-resolved URI keys
  after sink configuration or secret rotation.

## Verification

- `./scripts/check-version-bump.sh`
- `./scripts/check-release-readiness.sh v0.0.9`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `bash scripts/run-cargo-deny.sh /tmp/hubuum-v0.0.9-cargo-deny.log`
- regenerated OpenAPI compared byte-for-byte with `docs/openapi.json`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`
