### PR TITLE
Prepare v0.0.10 recovery release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -956,7 +956,12 @@ jobs:
 
   validate-tag-release:
     name: Validate tagged release
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      !contains(needs.*.result, 'skipped')
     needs:
       - verify-tag-main-ci-success
       - dependency-policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.0.10] - 2026-08-06
+
+### Fixed
+
+- Tagged release workflows now publish binaries, SBOMs, signed checksums,
+  provenance attestations, and multi-architecture container images after all
+  validation prerequisites pass. The `v0.0.9` tag exposed skip propagation and
+  published no release assets; use `v0.0.10` instead.
+
 ## [0.0.9] - 2026-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
-## [0.0.10] - 2026-08-06
+## [0.0.10] - 2026-08-07
 
 ### Fixed
 
@@ -15,6 +15,35 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   provenance attestations, and multi-architecture container images after all
   validation prerequisites pass. The `v0.0.9` tag exposed skip propagation and
   published no release assets; use `v0.0.10` instead.
+
+### Changed
+
+- **Breaking (HTTP API, carried forward from v0.0.9):** entity JSON now contains
+  `revision`; principal settings return `{revision, settings}`, SQL permission
+  reads return `{collection_id, revision, permissions}`, and group member lists
+  return membership entities with an optional nested principal. Clients must
+  update deserializers for these response shapes.
+- **Breaking (HTTP API, carried forward from v0.0.9):** class point routes return
+  the class entity by default. Use `include=collection` for the expanded,
+  untagged representation. Raw object points are tagged; `include=computed`
+  remains expanded and untagged.
+- **Breaking (HTTP API, carried forward from v0.0.9):** canonical tagged group
+  points omit directory-sync timestamps, and canonical tagged token points omit
+  `last_used_at`, because those operational fields do not advance resource
+  revisions. The fields remain available in untagged group and token lists.
+- **Breaking (HTTP API, carried forward from v0.0.9):** canonical tagged user and
+  service-account points use stable `identity_scope_id` values and omit
+  independently mutable provider and synchronization metadata. Tagged
+  group-membership points omit the expanded principal, and SQL permission-set
+  entries expose permission rows with stable `group_id` values instead of
+  expanded groups. Rich metadata remains available from the corresponding
+  untagged list responses.
+
+### Security
+
+- **Breaking (HTTP API, carried forward from v0.0.9):** Event-delivery API
+  responses no longer expose the internal `claim_token` worker lease capability.
+  API clients must stop deserializing or depending on this field.
 
 ## [0.0.9] - 2026-08-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2068,7 +2068,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hubuum"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hubuum"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2024"
 description = "Flexible asset management REST service."
 license = "MIT"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.0.9"
+    "version": "0.0.10"
   },
   "servers": [
     {

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -707,3 +707,21 @@ fn container_ci_exercises_live_single_host_http_continuity() {
     assert!(live_test.is_file());
     assert!(workflow.contains("bash scripts/test-single-host-zero-downtime.sh"));
 }
+
+#[test]
+fn tagged_release_validation_handles_the_skipped_change_classifier() {
+    let workflow = read_repository_text(".github/workflows/ci.yml");
+    let validation_start = workflow
+        .find("\n  validate-tag-release:")
+        .expect("CI should define tagged release validation");
+    let validation_end = workflow[validation_start + 1..]
+        .find("\n  build-tag-linux-artifacts:")
+        .map(|offset| validation_start + 1 + offset)
+        .expect("tagged release validation should have a known end marker");
+    let validation = &workflow[validation_start..validation_end];
+
+    assert!(validation.contains("always() &&"));
+    assert!(validation.contains("!contains(needs.*.result, 'failure')"));
+    assert!(validation.contains("!contains(needs.*.result, 'cancelled')"));
+    assert!(validation.contains("!contains(needs.*.result, 'skipped')"));
+}


### PR DESCRIPTION
## Summary

- recover from the immutable `v0.0.9` tag, whose validation prerequisites passed but whose publication jobs were skipped
- prepare Hubuum `v0.0.10` and update compatible locked dependencies
- make tagged-release validation run despite the intentionally skipped change-classifier job
- require every direct validation prerequisite to succeed before artifact or container publication
- add a regression test for the tag workflow guard

## Impact

The `v0.0.9` tag remains immutable and published no release assets. Users should use `v0.0.10`, which will publish binaries, SBOMs, signed checksums, provenance attestations, and multi-architecture container images after successful validation.

For users upgrading from the latest stable release, v0.0.8, v0.0.10 carries forward the HTTP API breaking changes documented for the unpublished v0.0.9 candidate:

- entity, permission, and membership response shapes now expose revision-owning representations; clients must update deserializers
- class point routes return the class entity by default; use `include=collection` for the expanded representation
- canonical group, user, service-account, and token points omit independently mutable operational metadata; use the corresponding untagged lists for rich metadata
- event-delivery responses no longer expose the internal `claim_token`; clients must stop depending on it

No additional breaking behavior was introduced by the v0.0.10 recovery fix.

## Release notes

### Fixed

- Tagged release workflows now publish binaries, SBOMs, signed checksums, provenance attestations, and multi-architecture container images after all validation prerequisites pass. The `v0.0.9` tag exposed skip propagation and published no release assets; use `v0.0.10` instead.

### Changed

- Carried the reviewed v0.0.9 HTTP API compatibility exceptions and migration guidance into v0.0.10 because v0.0.8 remains the latest stable publication baseline.

## Verification

- `actionlint .github/workflows/ci.yml`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- exact OpenAPI regeneration comparison
- OpenAPI compatibility against the v0.0.8 evidence: 70 accepted, 0 unaccepted, 0 policy errors
- `bash scripts/run-cargo-deny.sh /private/tmp/hubuum-v0.0.10-cargo-deny.log`
- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `bash scripts/test-classify-ci-changes.sh`
- `./scripts/check-version-bump.sh`
- `./scripts/check-release-readiness.sh v0.0.10`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`
