### PR TITLE
Fix v0.0.9 release job propagation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -983,7 +983,10 @@ jobs:
 
   build-tag-linux-artifacts:
     name: Build static release artifacts (${{ matrix.platform.name }})
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.validate-tag-release.result == 'success'
     needs: validate-tag-release
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -1042,7 +1045,10 @@ jobs:
 
   build-tag-native-artifacts:
     name: Build native release artifacts (${{ matrix.platform.name }})
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.validate-tag-release.result == 'success'
     needs: validate-tag-release
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -1142,7 +1148,11 @@ jobs:
 
   publish-github-release:
     name: Publish GitHub release
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.build-tag-linux-artifacts.result == 'success' &&
+      needs.build-tag-native-artifacts.result == 'success'
     needs:
       - build-tag-linux-artifacts
       - build-tag-native-artifacts
@@ -1594,7 +1604,10 @@ jobs:
 
   publish-tag-container-images:
     name: Build release container (${{ matrix.platform.arch }})
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.validate-tag-release.result == 'success'
     needs: validate-tag-release
     runs-on: ${{ matrix.platform.runner }}
     permissions:
@@ -1691,7 +1704,10 @@ jobs:
 
   publish-tag-container-manifests:
     name: Create release multi-arch manifest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.publish-tag-container-images.result == 'success'
     needs: publish-tag-container-images
     runs-on: ubuntu-24.04
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,9 +255,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-- Tagged release validation now checks each direct prerequisite explicitly, so
-  skipped non-release jobs do not suppress binaries, SBOMs, signed checksums,
-  provenance attestations, or multi-architecture container publication.
+- Tagged release validation and every downstream publication job now check
+  their direct prerequisites explicitly, so skipped non-release jobs do not
+  suppress binaries, SBOMs, signed checksums, provenance attestations, or
+  multi-architecture container publication.
 - Conditional collection, class, object, and membership mutations now return
   `412 Precondition Failed` when their selected target vanishes, changes before
   delete validation, or produces a membership-source no-op.

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -731,3 +731,61 @@ fn tagged_release_validation_requires_each_direct_prerequisite() {
     }
     assert!(!validation.contains("needs.*.result"));
 }
+
+#[test]
+fn tagged_release_jobs_explicitly_require_successful_dependencies() {
+    let workflow = read_repository_text(".github/workflows/ci.yml");
+    let jobs: [(&str, Option<&str>, &[&str]); 5] = [
+        (
+            "build-tag-linux-artifacts",
+            Some("build-tag-native-artifacts"),
+            &["validate-tag-release"],
+        ),
+        (
+            "build-tag-native-artifacts",
+            Some("publish-github-release"),
+            &["validate-tag-release"],
+        ),
+        (
+            "publish-github-release",
+            Some("build-main-linux-artifacts"),
+            &["build-tag-linux-artifacts", "build-tag-native-artifacts"],
+        ),
+        (
+            "publish-tag-container-images",
+            Some("publish-tag-container-manifests"),
+            &["validate-tag-release"],
+        ),
+        (
+            "publish-tag-container-manifests",
+            None,
+            &["publish-tag-container-images"],
+        ),
+    ];
+
+    for (job, next_job, dependencies) in jobs {
+        let job_marker = format!("\n  {job}:");
+        let job_start = workflow
+            .find(&job_marker)
+            .unwrap_or_else(|| panic!("CI should define {job}"));
+        let job_end = next_job
+            .map(|next_job| {
+                let next_marker = format!("\n  {next_job}:");
+                workflow[job_start + 1..]
+                    .find(&next_marker)
+                    .map(|offset| job_start + 1 + offset)
+                    .unwrap_or_else(|| panic!("{job} should precede {next_job}"))
+            })
+            .unwrap_or(workflow.len());
+        let job_definition = &workflow[job_start..job_end];
+
+        assert!(job_definition.contains("always() &&"));
+        assert!(job_definition.contains("startsWith(github.ref, 'refs/tags/v')"));
+        for dependency in dependencies {
+            assert!(
+                job_definition.contains(&format!("needs.{dependency}.result == 'success'")),
+                "{job} should require {dependency} to succeed"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Repair the second release gating failure observed while republishing v0.0.9. The tagged-release validator now passes, but GitHub Actions still propagates skipped non-release dependencies into downstream release jobs unless each job explicitly opts into evaluation.

This change gives every tagged-release edge an explicit always guard and requires each direct dependency to report success. It covers static and native archives, GitHub Release publication, platform container images, and the final multi-architecture manifest.

## Root cause

Tag workflow run 31166822563 proved that exact-main verification, dependency policy, OpenAPI contract validation, the production container prerequisite, and Validate tagged release all succeeded. Despite that, every artifact and container publication job was skipped because their simpler job-level conditions did not override skipped-job propagation.

## Behavior

A tagged release now advances only when its direct predecessor succeeded. Failed prerequisites remain fail-closed, while unrelated jobs that are intentionally skipped on tag events can no longer suppress publication. A repository regression test covers all five downstream guards.

## Release handling

The v0.0.9 tag remains mutable during this repair and will be recreated on the exact green main commit after merge. No v0.0.10 tag or release will be published.

## Changelog

The existing v0.0.9 fix entry now states that both validation and downstream publication jobs check their direct prerequisites explicitly.

## Breaking changes

None.