### PR TITLE
Fix v0.0.9 container attestations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1163,6 +1163,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -1617,6 +1618,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     strategy:
       fail-fast: false
       matrix:
@@ -1717,6 +1719,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     steps:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1152,10 +1152,12 @@ jobs:
       always() &&
       startsWith(github.ref, 'refs/tags/v') &&
       needs.build-tag-linux-artifacts.result == 'success' &&
-      needs.build-tag-native-artifacts.result == 'success'
+      needs.build-tag-native-artifacts.result == 'success' &&
+      needs.publish-tag-container-manifests.result == 'success'
     needs:
       - build-tag-linux-artifacts
       - build-tag-native-artifacts
+      - publish-tag-container-manifests
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,7 +260,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   suppress binaries, SBOMs, signed checksums, provenance attestations, or
   multi-architecture container publication. GitHub Release publication waits
   for the successfully attested multi-architecture manifest, and generated
-  CycloneDX release SBOMs include the required RFC 4122 document serial.
+  CycloneDX release SBOMs include the required RFC 4122 document serial. Release
+  attestors can also persist GitHub artifact-metadata storage records.
 - Conditional collection, class, object, and membership mutations now return
   `412 Precondition Failed` when their selected target vanishes, changes before
   delete validation, or produces a membership-source no-op.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,7 +258,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Tagged release validation and every downstream publication job now check
   their direct prerequisites explicitly, so skipped non-release jobs do not
   suppress binaries, SBOMs, signed checksums, provenance attestations, or
-  multi-architecture container publication.
+  multi-architecture container publication. GitHub Release publication waits
+  for the successfully attested multi-architecture manifest, and generated
+  CycloneDX release SBOMs include the required RFC 4122 document serial.
 - Conditional collection, class, object, and membership mutations now return
   `412 Precondition Failed` when their selected target vanishes, changes before
   delete validation, or produces a membership-source no-op.

--- a/scripts/generate-release-sbom.py
+++ b/scripts/generate-release-sbom.py
@@ -10,6 +10,7 @@ import json
 import re
 import subprocess
 import urllib.parse
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -316,10 +317,12 @@ def main() -> None:
     root_dependencies = sorted(set(base_root_dependencies + workspace_refs))
     dependencies.append({"ref": root_ref, "dependsOn": root_dependencies})
     dependencies = merge_dependencies(dependencies)
+    serial_number = uuid.uuid5(uuid.NAMESPACE_URL, f"{root_ref}:{args.target}")
 
     document = {
         "bomFormat": "CycloneDX",
         "specVersion": "1.6",
+        "serialNumber": f"urn:uuid:{serial_number}",
         "version": 1,
         "metadata": {
             "timestamp": dt.datetime.now(dt.UTC).isoformat().replace("+00:00", "Z"),

--- a/scripts/test-generate-release-sbom.sh
+++ b/scripts/test-generate-release-sbom.sh
@@ -90,6 +90,7 @@ import hashlib
 import json
 import pathlib
 import sys
+import uuid
 
 document = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 assert document["bomFormat"] == "CycloneDX"
@@ -99,6 +100,11 @@ assert {"hubuum", "serde", "ca-certificates", "unreferenced"} <= components
 root = document["metadata"]["component"]
 expected = hashlib.sha256(b"release archive contents").hexdigest()
 assert root["hashes"] == [{"alg": "SHA-256", "content": expected}]
+expected_serial = uuid.uuid5(
+    uuid.NAMESPACE_URL,
+    f"{root['bom-ref']}:linux-amd64",
+)
+assert document["serialNumber"] == f"urn:uuid:{expected_serial}"
 properties = {item["name"]: item["value"] for item in root["properties"]}
 assert properties["hubuum:cargo_target"] == "x86_64-unknown-linux-musl"
 assert properties["hubuum:cargo_features"] == "production-all"

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -793,3 +793,38 @@ fn tagged_release_jobs_explicitly_require_successful_dependencies() {
         }
     }
 }
+
+#[test]
+fn tagged_release_attestors_can_persist_artifact_metadata() {
+    let workflow = read_repository_text(".github/workflows/ci.yml");
+
+    for (job, next_job) in [
+        ("publish-github-release", Some("build-main-linux-artifacts")),
+        (
+            "publish-tag-container-images",
+            Some("publish-tag-container-manifests"),
+        ),
+        ("publish-tag-container-manifests", None),
+    ] {
+        let job_marker = format!("\n  {job}:");
+        let job_start = workflow
+            .find(&job_marker)
+            .unwrap_or_else(|| panic!("CI should define {job}"));
+        let job_end = next_job
+            .map(|next_job| {
+                let next_marker = format!("\n  {next_job}:");
+                workflow[job_start + 1..]
+                    .find(&next_marker)
+                    .map(|offset| job_start + 1 + offset)
+                    .unwrap_or_else(|| panic!("{job} should precede {next_job}"))
+            })
+            .unwrap_or(workflow.len());
+        let job_definition = &workflow[job_start..job_end];
+
+        assert!(job_definition.contains("actions/attest@"));
+        assert!(
+            job_definition.contains("artifact-metadata: write"),
+            "{job} should be able to persist artifact metadata storage records"
+        );
+    }
+}

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -749,7 +749,11 @@ fn tagged_release_jobs_explicitly_require_successful_dependencies() {
         (
             "publish-github-release",
             Some("build-main-linux-artifacts"),
-            &["build-tag-linux-artifacts", "build-tag-native-artifacts"],
+            &[
+                "build-tag-linux-artifacts",
+                "build-tag-native-artifacts",
+                "publish-tag-container-manifests",
+            ],
         ),
         (
             "publish-tag-container-images",


### PR DESCRIPTION
## Summary

- add a deterministic RFC 4122 `serialNumber` to generated CycloneDX release SBOMs
- grant release attestors `artifact-metadata: write` so GitHub storage records are persisted
- make GitHub Release publication wait for the successfully attested multi-architecture container manifest
- extend release dependency, permission, and SBOM regression coverage

## Failure analysis

The v0.0.9 tag run built and pushed both platform images, but the pinned `actions/attest` action rejected each merged CycloneDX SBOM. Its validator requires `bomFormat`, `specVersion`, and `serialNumber`; the Hubuum merger emitted the first two but discarded the Syft document serial and emitted no replacement.

The attestor also warned that it could not persist artifact-metadata storage records because the release jobs lacked `artifact-metadata: write`. The pinned official action documentation requires that permission in addition to `id-token: write` and `attestations: write`.

The binary publication path did not depend on the container publication path, so it also created a public GitHub Release while both container attestation jobs had failed. That incomplete release and its tag were removed before this pull request was opened.

## Behavior

This change affects release evidence and publication ordering only. Runtime and API behavior are unchanged. A GitHub Release can no longer appear unless the binary jobs and the attested, signed multi-architecture container manifest all succeed. All release attestors can persist their GitHub artifact-metadata storage records.

## Changelog

The v0.0.9 Fixed entry now records the CycloneDX serial requirement, artifact-metadata storage records, and the atomic publication gate.

## Breaking changes

None.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo run --quiet --bin hubuum-openapi | cmp - docs/openapi.json`
- `bash scripts/test-generate-release-sbom.sh`
- `bash scripts/test-generate-container-evidence.sh`
- `python3 scripts/test-supply-chain-policy.py`
- `bash scripts/test-classify-ci-changes.sh`
- `actionlint .github/workflows/ci.yml`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `scripts/check-release-readiness.sh v0.0.9`