### PR TITLE
Introduce collection service and storage boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,18 @@
   promise. Keep package classifications consistent with
   `docs/rust_api_boundary.md` and the Rust API policy checker.
 - Keep public domain behavior in `src/models/*` and `src/traits/*`.
+- Put migrated application use-case orchestration in `src/services/*` and
+  backend-neutral persistence capabilities in `src/storage/*`.
 - Keep Diesel/Postgres query construction and backend details in `src/db/traits/*`.
 - Model methods should stay thin and delegate persistence-heavy work to backend traits.
-- Use `BackendContext` for APIs that should accept either `DbPool` or wrappers such as `web::Data<DbPool>`.
+- Route migrated high-level callers through services rather than adding new
+  direct `DbPool` dependencies. Use `BackendContext` as the compatibility
+  boundary for APIs that have not migrated and still need to accept either
+  `DbPool` or wrappers such as `web::Data<DbPool>`.
+- Keep storage capabilities aggregate- or query-shaped rather than table-shaped.
+  Shared memory/Postgres contract tests cover logical behavior; PostgreSQL-only
+  tests must retain transaction, locking, trigger, concurrency, and query-budget
+  coverage.
 - Put multi-step database writes in `with_transaction`; use `with_connection` for single reads, single writes, and non-atomic database work.
 - Workspace crates should expose small, explicit interfaces with private fields. Prefer typed request/builder APIs over long positional argument lists when callers must provide several settings.
 - Keep workspace crate boundaries clean of app-specific errors, global config, Actix, Diesel, and task persistence unless the crate explicitly owns that layer.

--- a/benches/postgres/storage_postgres_criterion.rs
+++ b/benches/postgres/storage_postgres_criterion.rs
@@ -7,9 +7,9 @@ use hubuum::db::{DbPool, ensure_database_schema_ready, init_pool_with_statement_
 use hubuum::events::EventContext;
 use hubuum::models::{
     Collection, CollectionID, Group, GroupID, NewCollectionWithAssignee, NewGroup,
-    collection_ancestors,
 };
-use hubuum::traits::{CanDelete, CanSave, CollectionAccessors};
+use hubuum::services::Services;
+use hubuum::traits::{CanDelete, CanSave};
 use tokio::runtime::{Builder, Runtime};
 
 static NEXT_NAME_ID: AtomicU64 = AtomicU64::new(1);
@@ -136,21 +136,23 @@ fn benchmark_postgres_storage(c: &mut Criterion) {
 
     let runtime = runtime();
     let fixture = StorageFixture::new(&runtime, &database_url);
+    let services = Services::postgres(fixture.pool.clone());
+    let collections = services.collections();
     let point_read_id = fixture.point_read_id();
     let leaf_id = fixture.leaf_id();
 
     runtime
-        .block_on(point_read_id.collection(&fixture.pool))
+        .block_on(collections.get(point_read_id))
         .expect("point-read warmup should succeed");
     runtime
-        .block_on(collection_ancestors(&fixture.pool, leaf_id))
+        .block_on(collections.ancestors(leaf_id))
         .expect("ancestor warmup should succeed");
 
     let mut group = c.benchmark_group("storage_postgres");
     group.bench_function("collection_point_read", |b| {
         b.iter(|| {
             let collection = runtime
-                .block_on(black_box(point_read_id).collection(black_box(&fixture.pool)))
+                .block_on(collections.get(black_box(point_read_id)))
                 .expect("point read should succeed");
             black_box(collection);
         });
@@ -158,10 +160,7 @@ fn benchmark_postgres_storage(c: &mut Criterion) {
     group.bench_function("collection_ancestors_depth_16", |b| {
         b.iter(|| {
             let ancestors = runtime
-                .block_on(collection_ancestors(
-                    black_box(&fixture.pool),
-                    black_box(leaf_id),
-                ))
+                .block_on(collections.ancestors(black_box(leaf_id)))
                 .expect("ancestor read should succeed");
             black_box(ancestors);
         });
@@ -179,7 +178,7 @@ fn benchmark_postgres_storage(c: &mut Criterion) {
                 };
                 let started = Instant::now();
                 let collection = runtime
-                    .block_on(command.save(&fixture.pool, &EventContext::system()))
+                    .block_on(collections.create(command, &EventContext::system()))
                     .expect("timed collection create should succeed");
                 measured += started.elapsed();
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,28 +45,47 @@ cargo run --quiet --bin hubuum-openapi > docs/openapi.json
 
 ## Architecture Overview
 
-The codebase is intentionally split into model-facing APIs and database-facing implementations.
+The codebase is incrementally split into application services, backend-neutral
+storage capabilities, model-facing APIs, and database-facing implementations.
 The root Rust library is an internal application composition crate rather than
 a supported embedding interface. See [Rust API Boundary](rust_api_boundary.md)
 for package classifications, publishing policy, and promotion requirements.
 
+- `src/services/*`:
+  Application-facing use cases. Migrated handlers call services instead of
+  choosing persistence helpers directly.
+- `src/storage/*`:
+  Backend-neutral capability traits plus PostgreSQL adapters. The test-only
+  memory adapter implements selected logical contracts without claiming
+  PostgreSQL concurrency equivalence.
 - `src/models/*`:
   Application domain models and high-level operations.
   These should not contain Diesel query construction for non-trivial backend logic.
 - `src/traits/*`:
   Behavioral interfaces used by handlers and models inside the application.
-  `BackendContext` is the boundary type that allows these APIs to accept either `DbPool` or wrappers (for example `web::Data<DbPool>`).
+  `BackendContext` remains the compatibility boundary for unmigrated APIs that
+  accept either `DbPool` or wrappers such as `web::Data<DbPool>`.
 - `src/db/traits/*`:
-  Diesel/Postgres-backed implementations behind the public traits.
+  Diesel/Postgres-backed implementations behind model and storage adapters.
   This is where query details, joins, filters, and transactions belong.
+
+The collection lifecycle is the first service/storage pilot. See
+[Service and Storage Boundary](storage_boundary.md) for responsibilities,
+contract testing, performance gates, and current migration limits.
 
 ### Practical layering rule
 
 When adding a feature:
 
-1. Extend or add a trait in `src/traits` (or `src/models/traits`) that expresses the behavior.
-2. Implement database details in `src/db/traits`.
-3. Keep model methods thin by delegating to backend traits.
+1. Put new use-case orchestration in `src/services` when the surrounding slice
+   has migrated.
+2. Express persistence as an aggregate- or query-shaped capability in
+   `src/storage`; avoid generic table repositories.
+3. Implement database details in `src/db/traits` and adapt them through the
+   PostgreSQL storage implementation.
+4. Keep model methods thin while they remain in unmigrated paths.
+5. Add shared logical contract tests and retain PostgreSQL-specific query,
+   transaction, and concurrency tests.
 
 ### Module layout notes
 
@@ -87,6 +106,12 @@ closure-table SQL, temporal history, `ApiError`, and Hubuum's permission
 semantics. Keep hierarchy writes in `src/db/traits/collection/records.rs` and
 permission reads in `src/db/traits/collection/permissions.rs` or
 `src/db/traits/user/*`.
+
+Normal collection lifecycle handlers enter this implementation through
+`CollectionService` and `CollectionStore`. Do not bypass that service from a
+migrated handler. Imports, restore code, fixtures, list/search, permissions, and
+history remain explicitly outside the pilot until their complete use cases can
+move without weakening transaction, authorization, or performance behavior.
 
 When adding a collection creation path, use the shared collection insert helper
 from the collection backend so `collections` and `collection_closure` stay in

--- a/docs/rust_api_boundary.md
+++ b/docs/rust_api_boundary.md
@@ -130,6 +130,11 @@ Public traits in internal crates are not third-party extension points. Backend,
 permission, provider, and storage traits become extension contracts only after
 an explicit promotion decision.
 
+The root crate's `services` and `storage` modules are therefore internal
+application boundaries even though Rust visibility is required by binaries and
+benchmarks. See [Service and Storage Boundary](storage_boundary.md) for the
+incremental collection pilot.
+
 ## Promotion policy
 
 Promoting a crate to `experimental-public` or `stable-public` requires a

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -1,0 +1,94 @@
+# Service and Storage Boundary
+
+Hubuum is incrementally separating application use cases from PostgreSQL and
+Diesel details. PostgreSQL remains the production semantic reference; the goal
+is a compile-time dependency boundary and faster contract tests, not generic
+multi-database support.
+
+The first migrated slice is the core collection lifecycle:
+
+- point reads;
+- create with an initial assignee grant and lifecycle event;
+- update, including no-op behavior;
+- delete constraints;
+- direct children and ordered ancestors; and
+- hierarchy moves.
+
+## Dependency direction
+
+```text
+collection HTTP handlers
+          |
+          v
+  CollectionService
+          |
+          v
+    CollectionStore
+       /       \
+      v         v
+PostgreSQL    memory
+ adapter      adapter
+      |
+      v
+existing Diesel transactions and queries
+```
+
+`AppContext` constructs `Services` with `PostgresStorage` in production. Core
+collection handlers call `CollectionService`; they do not choose a Diesel query
+or transaction helper. Permission checks remain at the handler boundary.
+
+## Responsibility split
+
+`src/services/*` owns application-facing use-case entrypoints. Services accept
+domain request types and return application errors after translating the
+backend-neutral storage error taxonomy.
+
+`src/storage/*` owns capability traits and adapters. Capability methods are
+aggregate-shaped rather than table-shaped so implementations retain control of
+transactions, batching, hierarchy maintenance, initial permission grants, and
+atomic lifecycle events.
+
+`src/db/traits/*` continues to own Diesel expressions, PostgreSQL SQL, locks,
+and transaction implementation. `PostgresStorage` delegates to these existing
+operations without changing their query shape.
+
+`MemoryStorage` is compiled for tests and implements the logical collection
+contract. It models hierarchy, revisions, no-op updates, delete constraints,
+and lifecycle event occurrence. It does not claim PostgreSQL locking, trigger,
+permission-row, or temporal-history equivalence.
+
+## Contract and performance gates
+
+The shared contract suite runs each collection behavior against both
+PostgreSQL and memory. Each test focuses on one behavior so backend differences
+cannot be hidden inside a large scenario.
+
+The PostgreSQL query-capture tests exercise `CollectionService` and retain the
+pre-migration query budgets. The opt-in PostgreSQL Criterion benchmark also
+times the service path. Trait dispatch or service composition must therefore
+not introduce extra pool checkouts, SQL statements, or application-side
+pagination.
+
+## Current migration boundary
+
+This is an incremental pilot. Collection list/search, permission management,
+history, and unrelated aggregates still use `BackendContext` and the existing
+model/database traits. Existing direct persistence APIs also remain for
+fixtures, imports, restore paths, and unmigrated callers.
+
+When expanding the boundary:
+
+1. Add a use-case-shaped storage capability rather than a generic repository.
+2. Preserve set-based SQL, batching, transactions, and event atomicity in the
+   PostgreSQL adapter.
+3. Add focused shared logical contract tests.
+4. Keep PostgreSQL-only query-budget, locking, rollback, trigger, and
+   concurrency tests.
+5. Route the selected high-level caller through a service before removing its
+   direct `DbPool` dependency.
+6. Remove old model/database entrypoints only after every production,
+   administrative, worker, import, restore, and test caller has migrated.
+
+Search and cursor pagination remain PostgreSQL-oriented until a concrete
+backend-neutral query contract can preserve filtering, stable ordering, count
+behavior, authorization, and query budgets without leaking SQL types.

--- a/src/api/v1/handlers/collections.rs
+++ b/src/api/v1/handlers/collections.rs
@@ -29,9 +29,7 @@ use actix_web::{
 };
 use tracing::{debug, info};
 
-use crate::traits::{
-    BackendContext, CanDelete, CanSave, CanUpdate, PermissionController, Search, SelfAccessors,
-};
+use crate::traits::{BackendContext, PermissionController, Search};
 
 async fn sql_collection_permission_set(
     pool: &AppContext,
@@ -152,7 +150,10 @@ pub async fn create_collection(
     );
 
     let event_context = requestor.event_context(&req);
-    let created_collection = new_collection_request.save(&pool, &event_context).await?;
+    let created_collection = pool
+        .collection_service()
+        .create(new_collection_request, &event_context)
+        .await?;
 
     let location = api_locations::collection(created_collection.id)?;
     ApiResponse::created_revisioned(created_collection, location)
@@ -184,7 +185,7 @@ pub async fn get_collection(
         collection_id = collection_id.id()
     );
 
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(*collection_id).await?;
 
     can!(
         &pool,
@@ -228,7 +229,7 @@ pub async fn update_collection(
         collection_id = collection_id.id()
     );
 
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(collection_id).await?;
 
     can!(
         &pool,
@@ -242,9 +243,8 @@ pub async fn update_collection(
     let event_context = requestor.event_context(&req);
     let updated_collection = with_revision_precondition_scope(
         precondition,
-        update_data
-            .into_inner()
-            .update(&pool, collection_id, &event_context),
+        pool.collection_service()
+            .update(collection_id, update_data.into_inner(), &event_context),
     )
     .await?;
     ApiResponse::accepted_revisioned(updated_collection)
@@ -277,7 +277,7 @@ pub async fn delete_collection(
         collection_id = collection_id.id()
     );
 
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(*collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -289,8 +289,12 @@ pub async fn delete_collection(
     let etag = collection.entity_tag()?;
     let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
-    with_revision_precondition_scope(precondition, collection.delete(&pool, &event_context))
-        .await?;
+    with_revision_precondition_scope(
+        precondition,
+        pool.collection_service()
+            .delete(*collection_id, &event_context),
+    )
+    .await?;
     Ok(ApiResponse::no_content_with_etag(etag))
 }
 
@@ -314,7 +318,7 @@ pub async fn get_collection_children(
     requestor: Authenticated,
     collection_id: web::Path<CollectionID>,
 ) -> Result<impl Responder, ApiError> {
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(*collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -323,7 +327,7 @@ pub async fn get_collection_children(
         collection.clone()
     );
 
-    let children = collection_model::collection_children(&pool, collection).await?;
+    let children = pool.collection_service().children(*collection_id).await?;
     Ok(ApiResponse::new(children, StatusCode::OK))
 }
 
@@ -347,7 +351,7 @@ pub async fn get_collection_ancestors(
     requestor: Authenticated,
     collection_id: web::Path<CollectionID>,
 ) -> Result<impl Responder, ApiError> {
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(*collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -356,7 +360,7 @@ pub async fn get_collection_ancestors(
         collection.clone()
     );
 
-    let ancestors = collection_model::collection_ancestors(&pool, collection).await?;
+    let ancestors = pool.collection_service().ancestors(*collection_id).await?;
     Ok(ApiResponse::new(ancestors, StatusCode::OK))
 }
 
@@ -386,9 +390,9 @@ pub async fn move_collection_parent(
     update_parent: web::Json<UpdateCollectionParent>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(*collection_id).await?;
     let new_parent_id = update_parent.into_inner().parent_collection_id;
-    let new_parent = new_parent_id.instance(&pool).await?;
+    let new_parent = pool.collection_service().get(new_parent_id).await?;
 
     can!(
         &pool,
@@ -399,7 +403,10 @@ pub async fn move_collection_parent(
     );
 
     if let Some(old_parent_id) = collection.parent_collection_id {
-        let old_parent = CollectionID::new(old_parent_id)?.instance(&pool).await?;
+        let old_parent = pool
+            .collection_service()
+            .get(CollectionID::new(old_parent_id)?)
+            .await?;
         can!(
             &pool,
             &requestor.principal,
@@ -421,12 +428,8 @@ pub async fn move_collection_parent(
     let event_context = requestor.event_context(&req);
     let updated = with_revision_precondition_scope(
         precondition,
-        collection_model::move_collection(
-            &pool,
-            collection.id,
-            new_parent_id.id(),
-            Some(&event_context),
-        ),
+        pool.collection_service()
+            .move_to(*collection_id, new_parent_id, &event_context),
     )
     .await?;
 
@@ -463,7 +466,7 @@ pub async fn get_collection_permissions(
 
     let params = parse_query_parameter(req.query_string())?;
 
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(*collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -522,7 +525,7 @@ pub async fn get_collection_group_permissions(
         group_id = group_id.id()
     );
 
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -581,7 +584,7 @@ pub async fn get_collection_effective_group_permissions(
         ));
     }
     let (collection_id, group_id) = params.into_inner();
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -642,7 +645,7 @@ pub async fn grant_collection_group_permissions(
         permissions = ?permissions
     );
 
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -711,7 +714,7 @@ pub async fn replace_collection_group_permissions(
         permissions = ?permissions
     );
 
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -778,7 +781,7 @@ pub async fn revoke_collection_group_permissions(
         group_id = group_id.id()
     );
 
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -840,7 +843,7 @@ pub async fn get_collection_group_permission(
         permission = ?permission
     );
 
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -898,7 +901,7 @@ pub async fn grant_collection_group_permission(
         permission = ?permission
     );
 
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -964,7 +967,7 @@ pub async fn revoke_collection_group_permission(
         permission = ?permission
     );
 
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -1031,7 +1034,7 @@ pub async fn get_collection_principal_permissions(
         principal_id = principal_id.id()
     );
 
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -1083,7 +1086,7 @@ pub async fn get_collection_effective_principal_permissions(
         ));
     }
     let (collection_id, principal_id) = params.into_inner();
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -1131,7 +1134,7 @@ pub async fn get_collection_groups_with_permission(
         permission = ?permission
     );
 
-    let collection = collection_id.instance(&pool).await?;
+    let collection = pool.collection_service().get(collection_id).await?;
     can!(
         &pool,
         &requestor.principal,
@@ -1193,7 +1196,7 @@ pub async fn get_collection_history(
 
     let user = &requestor.principal;
     let collection_id = collection_id.into_inner();
-    let (entity_id, require_history) = match collection_id.instance(&pool).await {
+    let (entity_id, require_history) = match pool.collection_service().get(collection_id).await {
         Ok(instance) => {
             can!(
                 &pool,
@@ -1308,7 +1311,7 @@ pub async fn get_collection_as_of(
 
     let user = &requestor.principal;
     let collection_id = collection_id.into_inner();
-    let (entity_id, deleted) = match collection_id.instance(&pool).await {
+    let (entity_id, deleted) = match pool.collection_service().get(collection_id).await {
         Ok(instance) => {
             can!(
                 &pool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@ pub mod pagination;
 pub mod permissions;
 pub mod restores;
 pub mod schema;
+pub mod services;
+pub mod storage;
 pub mod tasks;
 #[cfg(feature = "integration-test-support")]
 #[doc(hidden)]

--- a/src/permissions/context.rs
+++ b/src/permissions/context.rs
@@ -8,6 +8,7 @@ use futures_util::future::{Ready, ready};
 use crate::config::get_config;
 use crate::db::DbPool;
 use crate::errors::ApiError;
+use crate::services::{CollectionService, Services};
 use crate::traits::BackendContext;
 
 use super::backend::PermissionBackend;
@@ -18,13 +19,16 @@ use super::local::LocalPermissionBackend;
 pub struct AppContext {
     pub db_pool: DbPool,
     pub permissions: Arc<dyn PermissionBackend>,
+    services: Services,
 }
 
 impl AppContext {
     pub fn new(db_pool: DbPool, permissions: Arc<dyn PermissionBackend>) -> Self {
+        let services = Services::postgres(db_pool.clone());
         Self {
             db_pool,
             permissions,
+            services,
         }
     }
 }
@@ -40,6 +44,10 @@ impl Deref for AppContext {
 impl AppContext {
     pub fn permission_backend(&self) -> &dyn PermissionBackend {
         self.permissions.as_ref()
+    }
+
+    pub fn collection_service(&self) -> &CollectionService {
+        self.services.collections()
     }
 }
 

--- a/src/services/collections.rs
+++ b/src/services/collections.rs
@@ -1,0 +1,455 @@
+use crate::errors::ApiError;
+use crate::events::EventContext;
+use crate::models::{Collection, CollectionID, NewCollectionWithAssignee, UpdateCollection};
+use crate::storage::DynStorage;
+
+/// Application-facing collection use cases.
+///
+/// Handlers depend on this service rather than choosing a PostgreSQL query or
+/// transaction helper directly. Authorization remains at the handler boundary
+/// while persistence invariants stay behind the storage capability.
+#[derive(Clone)]
+pub struct CollectionService {
+    storage: DynStorage,
+}
+
+impl CollectionService {
+    pub(crate) fn new(storage: DynStorage) -> Self {
+        Self { storage }
+    }
+
+    pub async fn get(&self, id: CollectionID) -> Result<Collection, ApiError> {
+        self.storage
+            .inner()
+            .get_collection(id)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn create(
+        &self,
+        command: NewCollectionWithAssignee,
+        context: &EventContext,
+    ) -> Result<Collection, ApiError> {
+        self.storage
+            .inner()
+            .create_collection(command, context)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn update(
+        &self,
+        id: CollectionID,
+        changes: UpdateCollection,
+        context: &EventContext,
+    ) -> Result<Collection, ApiError> {
+        self.storage
+            .inner()
+            .update_collection(id, changes, context)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn delete(&self, id: CollectionID, context: &EventContext) -> Result<(), ApiError> {
+        self.storage
+            .inner()
+            .delete_collection(id, context)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn children(&self, id: CollectionID) -> Result<Vec<Collection>, ApiError> {
+        self.storage
+            .inner()
+            .collection_children(id)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn ancestors(&self, id: CollectionID) -> Result<Vec<Collection>, ApiError> {
+        self.storage
+            .inner()
+            .collection_ancestors(id)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn move_to(
+        &self,
+        id: CollectionID,
+        new_parent_id: CollectionID,
+        context: &EventContext,
+    ) -> Result<Collection, ApiError> {
+        self.storage
+            .inner()
+            .move_collection(id, new_parent_id, context)
+            .await
+            .map_err(ApiError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::web::Data;
+    use rstest::rstest;
+
+    use crate::db::DbPool;
+    use crate::errors::ApiError;
+    use crate::events::{Action, EventContext};
+    use crate::models::{
+        Collection, CollectionID, Group, GroupID, NewCollectionWithAssignee, NewGroup,
+        UpdateCollection,
+    };
+    use crate::services::Services;
+    use crate::storage::{DynStorage, MemoryStorage, PostgresStorage};
+    use crate::tests::TestScope;
+
+    use super::CollectionService;
+
+    #[derive(Clone, Copy, Debug)]
+    enum ContractBackend {
+        Memory,
+        Postgres,
+    }
+
+    struct ContractHarness {
+        service: CollectionService,
+        group_id: GroupID,
+        prefix: String,
+        postgres_cleanup: Option<(Data<DbPool>, Group)>,
+    }
+
+    impl ContractHarness {
+        async fn new(backend: ContractBackend, label: &str) -> Self {
+            match backend {
+                ContractBackend::Memory => Self {
+                    service: Services::from_storage(DynStorage::new(MemoryStorage::new()))
+                        .collections()
+                        .clone(),
+                    group_id: GroupID::new(1).expect("valid memory group id"),
+                    prefix: format!("memory_{label}"),
+                    postgres_cleanup: None,
+                },
+                ContractBackend::Postgres => {
+                    let scope = TestScope::new();
+                    let owner_group = NewGroup {
+                        identity_scope: None,
+                        groupname: scope.scoped_name(&format!("{label}_owner")),
+                        description: Some("collection storage contract owner".to_string()),
+                    }
+                    .save_without_events(&scope.pool)
+                    .await
+                    .expect("contract owner group should save");
+                    Self {
+                        service: Services::from_storage(DynStorage::new(PostgresStorage::new(
+                            scope.pool.get_ref().clone(),
+                        )))
+                        .collections()
+                        .clone(),
+                        group_id: GroupID::new(owner_group.id).expect("valid owner group id"),
+                        prefix: scope.scoped_name(label),
+                        postgres_cleanup: Some((scope.pool, owner_group)),
+                    }
+                }
+            }
+        }
+
+        async fn create(&self, label: &str, parent: Option<CollectionID>) -> Collection {
+            self.service
+                .create(
+                    NewCollectionWithAssignee {
+                        name: format!("{}_{}", self.prefix, label),
+                        description: format!("collection contract {label}"),
+                        group_id: self.group_id,
+                        parent_collection_id: parent,
+                    },
+                    &EventContext::system(),
+                )
+                .await
+                .expect("contract collection should be created")
+        }
+
+        async fn finish(self) {
+            if let Some((pool, owner_group)) = self.postgres_cleanup {
+                owner_group
+                    .delete_without_events(&pool)
+                    .await
+                    .expect("contract owner group cleanup");
+            }
+        }
+    }
+
+    fn id(collection: &Collection) -> CollectionID {
+        CollectionID::new(collection.id).expect("valid collection id")
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn collection_contract_create_is_visible_to_point_reads(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "create_read").await;
+        let created = harness.create("collection", None).await;
+
+        assert_eq!(
+            harness.service.get(id(&created)).await.expect("point read"),
+            created
+        );
+
+        harness
+            .service
+            .delete(id(&created), &EventContext::system())
+            .await
+            .expect("collection cleanup");
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn collection_contract_lists_direct_children(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "children").await;
+        let parent = harness.create("parent", None).await;
+        let child = harness.create("child", Some(id(&parent))).await;
+
+        assert_eq!(
+            harness
+                .service
+                .children(id(&parent))
+                .await
+                .expect("children"),
+            vec![child.clone()]
+        );
+
+        harness
+            .service
+            .delete(id(&child), &EventContext::system())
+            .await
+            .expect("child cleanup");
+        harness
+            .service
+            .delete(id(&parent), &EventContext::system())
+            .await
+            .expect("parent cleanup");
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn collection_contract_orders_ancestors_nearest_first(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "ancestors").await;
+        let parent = harness.create("parent", None).await;
+        let child = harness.create("child", Some(id(&parent))).await;
+
+        let ancestors = harness
+            .service
+            .ancestors(id(&child))
+            .await
+            .expect("ancestors");
+        assert_eq!(ancestors.first().map(|item| item.id), Some(parent.id));
+        assert_eq!(ancestors.len(), 2, "child should have its parent and root");
+
+        harness
+            .service
+            .delete(id(&child), &EventContext::system())
+            .await
+            .expect("child cleanup");
+        harness
+            .service
+            .delete(id(&parent), &EventContext::system())
+            .await
+            .expect("parent cleanup");
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn collection_contract_changed_update_advances_revision(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "changed_update").await;
+        let collection = harness.create("collection", None).await;
+
+        let updated = harness
+            .service
+            .update(
+                id(&collection),
+                UpdateCollection {
+                    name: None,
+                    description: Some("updated contract description".to_string()),
+                },
+                &EventContext::system(),
+            )
+            .await
+            .expect("collection should update");
+        assert_eq!(updated.revision.get(), collection.revision.get() + 1);
+
+        harness
+            .service
+            .delete(id(&updated), &EventContext::system())
+            .await
+            .expect("collection cleanup");
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn collection_contract_no_op_update_preserves_revision(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "no_op_update").await;
+        let collection = harness.create("collection", None).await;
+
+        let unchanged = harness
+            .service
+            .update(
+                id(&collection),
+                UpdateCollection {
+                    name: Some(collection.name.clone()),
+                    description: Some(collection.description.clone()),
+                },
+                &EventContext::system(),
+            )
+            .await
+            .expect("no-op update should return current state");
+        assert_eq!(unchanged, collection);
+
+        harness
+            .service
+            .delete(id(&collection), &EventContext::system())
+            .await
+            .expect("collection cleanup");
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn collection_contract_move_reparents_the_subtree(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "move").await;
+        let old_parent = harness.create("old_parent", None).await;
+        let new_parent = harness.create("new_parent", None).await;
+        let child = harness.create("child", Some(id(&old_parent))).await;
+
+        let moved = harness
+            .service
+            .move_to(id(&child), id(&new_parent), &EventContext::system())
+            .await
+            .expect("child should move");
+        assert_eq!(moved.parent_collection_id, Some(new_parent.id));
+        assert_eq!(moved.revision.get(), child.revision.get() + 1);
+
+        harness
+            .service
+            .delete(id(&moved), &EventContext::system())
+            .await
+            .expect("child cleanup");
+        for parent in [old_parent, new_parent] {
+            harness
+                .service
+                .delete(id(&parent), &EventContext::system())
+                .await
+                .expect("parent cleanup");
+        }
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn collection_contract_rejects_deleting_a_parent_with_children(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "delete_parent").await;
+        let parent = harness.create("parent", None).await;
+        let child = harness.create("child", Some(id(&parent))).await;
+
+        assert!(matches!(
+            harness
+                .service
+                .delete(id(&parent), &EventContext::system())
+                .await,
+            Err(ApiError::Conflict(_))
+        ));
+
+        harness
+            .service
+            .delete(id(&child), &EventContext::system())
+            .await
+            .expect("child cleanup");
+        harness
+            .service
+            .delete(id(&parent), &EventContext::system())
+            .await
+            .expect("parent cleanup");
+        harness.finish().await;
+    }
+
+    #[actix_web::test]
+    async fn memory_collection_events_exclude_no_op_updates() {
+        let storage = MemoryStorage::new();
+        let service = Services::from_storage(DynStorage::new(storage.clone()))
+            .collections()
+            .clone();
+        let context = EventContext::system();
+        let collection = service
+            .create(
+                NewCollectionWithAssignee {
+                    name: "memory_event_contract".to_string(),
+                    description: "memory event contract".to_string(),
+                    group_id: GroupID::new(1).expect("valid memory group id"),
+                    parent_collection_id: None,
+                },
+                &context,
+            )
+            .await
+            .expect("memory collection should be created");
+        let updated = service
+            .update(
+                id(&collection),
+                UpdateCollection {
+                    name: None,
+                    description: Some("changed memory event contract".to_string()),
+                },
+                &context,
+            )
+            .await
+            .expect("memory collection should update");
+        service
+            .update(
+                id(&updated),
+                UpdateCollection {
+                    name: Some(updated.name.clone()),
+                    description: Some(updated.description.clone()),
+                },
+                &context,
+            )
+            .await
+            .expect("memory no-op should succeed");
+        service
+            .delete(id(&updated), &context)
+            .await
+            .expect("memory collection should delete");
+
+        let events = storage.events().await;
+        assert_eq!(
+            events.iter().map(|event| event.action).collect::<Vec<_>>(),
+            vec![Action::Created, Action::Updated, Action::Deleted]
+        );
+        assert!(
+            events
+                .iter()
+                .all(|event| event.collection_id == collection.id && event.context == context)
+        );
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,0 +1,28 @@
+mod collections;
+
+pub use collections::CollectionService;
+
+use crate::db::DbPool;
+use crate::storage::{DynStorage, PostgresStorage};
+
+/// Application use-case facade.
+#[derive(Clone)]
+pub struct Services {
+    collections: CollectionService,
+}
+
+impl Services {
+    pub fn postgres(pool: DbPool) -> Self {
+        Self::from_storage(DynStorage::new(PostgresStorage::new(pool)))
+    }
+
+    pub(crate) fn from_storage(storage: DynStorage) -> Self {
+        Self {
+            collections: CollectionService::new(storage),
+        }
+    }
+
+    pub fn collections(&self) -> &CollectionService {
+        &self.collections
+    }
+}

--- a/src/storage/collections.rs
+++ b/src/storage/collections.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::events::EventContext;
+use crate::models::{Collection, CollectionID, NewCollectionWithAssignee, UpdateCollection};
+
+use super::StorageError;
+
+/// Persistence capability for the core collection lifecycle.
+///
+/// Methods are intentionally aggregate-shaped. Implementations retain control
+/// over transactions, hierarchy maintenance, initial permission grants, and
+/// atomic event persistence.
+#[async_trait]
+pub trait CollectionStore: Send + Sync {
+    async fn get_collection(&self, id: CollectionID) -> Result<Collection, StorageError>;
+
+    async fn create_collection(
+        &self,
+        command: NewCollectionWithAssignee,
+        context: &EventContext,
+    ) -> Result<Collection, StorageError>;
+
+    async fn update_collection(
+        &self,
+        id: CollectionID,
+        changes: UpdateCollection,
+        context: &EventContext,
+    ) -> Result<Collection, StorageError>;
+
+    async fn delete_collection(
+        &self,
+        id: CollectionID,
+        context: &EventContext,
+    ) -> Result<(), StorageError>;
+
+    async fn collection_children(&self, id: CollectionID) -> Result<Vec<Collection>, StorageError>;
+
+    async fn collection_ancestors(&self, id: CollectionID)
+    -> Result<Vec<Collection>, StorageError>;
+
+    async fn move_collection(
+        &self,
+        id: CollectionID,
+        new_parent_id: CollectionID,
+        context: &EventContext,
+    ) -> Result<Collection, StorageError>;
+}
+
+/// Umbrella storage boundary. New aggregate capabilities can be added here as
+/// vertical slices migrate without exposing a database pool to services.
+pub trait Storage: CollectionStore {}
+
+impl<T> Storage for T where T: CollectionStore {}
+
+#[derive(Clone)]
+pub struct DynStorage {
+    inner: Arc<dyn Storage>,
+}
+
+impl DynStorage {
+    pub fn new(storage: impl Storage + 'static) -> Self {
+        Self {
+            inner: Arc::new(storage),
+        }
+    }
+
+    pub(crate) fn inner(&self) -> &dyn Storage {
+        self.inner.as_ref()
+    }
+}

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -1,0 +1,135 @@
+use std::fmt;
+
+use crate::errors::ApiError;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StorageErrorKind {
+    BadRequest,
+    Conflict,
+    Database,
+    Internal,
+    NotFound,
+    PreconditionFailed,
+    Unavailable,
+}
+
+/// Backend-neutral failure returned by storage capabilities.
+///
+/// The representation deliberately carries no Diesel or Actix types. API
+/// adapters translate it into [`ApiError`] only at the application boundary.
+#[derive(Debug, PartialEq, Eq)]
+pub struct StorageError {
+    kind: StorageErrorKind,
+    message: String,
+    current_etag: Option<String>,
+}
+
+impl StorageError {
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self::new(StorageErrorKind::BadRequest, message, None)
+    }
+
+    pub fn conflict(message: impl Into<String>) -> Self {
+        Self::new(StorageErrorKind::Conflict, message, None)
+    }
+
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::new(StorageErrorKind::NotFound, message, None)
+    }
+
+    fn new(
+        kind: StorageErrorKind,
+        message: impl Into<String>,
+        current_etag: Option<String>,
+    ) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            current_etag,
+        }
+    }
+}
+
+impl fmt::Display for StorageError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for StorageError {}
+
+impl From<ApiError> for StorageError {
+    fn from(error: ApiError) -> Self {
+        match error {
+            ApiError::BadRequest(message)
+            | ApiError::InvalidIntegerRange(message)
+            | ApiError::OperatorMismatch(message)
+            | ApiError::ValidationError(message) => {
+                Self::new(StorageErrorKind::BadRequest, message, None)
+            }
+            ApiError::Conflict(message) => Self::new(StorageErrorKind::Conflict, message, None),
+            ApiError::DatabaseError(message) | ApiError::DbConnectionError(message) => {
+                Self::new(StorageErrorKind::Database, message, None)
+            }
+            ApiError::NotFound(message) | ApiError::Gone(message) => {
+                Self::new(StorageErrorKind::NotFound, message, None)
+            }
+            ApiError::PreconditionFailed(message, current_etag) => {
+                Self::new(StorageErrorKind::PreconditionFailed, message, current_etag)
+            }
+            ApiError::ServiceUnavailable(message) => {
+                Self::new(StorageErrorKind::Unavailable, message, None)
+            }
+            error => Self::new(
+                StorageErrorKind::Internal,
+                format!(
+                    "unexpected storage adapter error ({}): {error}",
+                    error.class()
+                ),
+                None,
+            ),
+        }
+    }
+}
+
+impl From<StorageError> for ApiError {
+    fn from(error: StorageError) -> Self {
+        match error.kind {
+            StorageErrorKind::BadRequest => Self::BadRequest(error.message),
+            StorageErrorKind::Conflict => Self::Conflict(error.message),
+            StorageErrorKind::Database => Self::DatabaseError(error.message),
+            StorageErrorKind::Internal => Self::InternalServerError(error.message),
+            StorageErrorKind::NotFound => Self::NotFound(error.message),
+            StorageErrorKind::PreconditionFailed => {
+                Self::PreconditionFailed(error.message, error.current_etag)
+            }
+            StorageErrorKind::Unavailable => Self::ServiceUnavailable(error.message),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::errors::ApiError;
+
+    use super::StorageError;
+
+    #[test]
+    fn storage_errors_preserve_public_collection_failure_categories() {
+        for error in [
+            ApiError::BadRequest("invalid move".to_string()),
+            ApiError::Conflict("collection has children".to_string()),
+            ApiError::NotFound("collection missing".to_string()),
+            ApiError::PreconditionFailed(
+                "stale collection".to_string(),
+                Some("\"collection-1-r2\"".to_string()),
+            ),
+        ] {
+            let expected_class = error.class();
+            let expected_message = error.public_message().to_string();
+            let round_trip = ApiError::from(StorageError::from(error));
+            assert_eq!(round_trip.class(), expected_class);
+            assert_eq!(round_trip.public_message(), expected_message);
+        }
+    }
+}

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -1,0 +1,278 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use tokio::sync::RwLock;
+
+use crate::events::{Action, EventContext};
+use crate::models::{
+    Collection, CollectionID, NewCollectionWithAssignee, ResourceRevision, UpdateCollection,
+};
+
+use super::{CollectionStore, StorageError};
+
+const ROOT_COLLECTION_ID: i32 = 1;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct MemoryCollectionEvent {
+    pub(crate) collection_id: i32,
+    pub(crate) action: Action,
+    pub(crate) context: EventContext,
+}
+
+struct MemoryState {
+    next_collection_id: i32,
+    collections: BTreeMap<i32, Collection>,
+    events: Vec<MemoryCollectionEvent>,
+}
+
+impl MemoryState {
+    fn new() -> Self {
+        let now = Utc::now().naive_utc();
+        let root = Collection {
+            id: ROOT_COLLECTION_ID,
+            name: "root".to_string(),
+            description: "Root collection".to_string(),
+            created_at: now,
+            updated_at: now,
+            parent_collection_id: None,
+            revision: ResourceRevision::INITIAL,
+        };
+        Self {
+            next_collection_id: ROOT_COLLECTION_ID + 1,
+            collections: BTreeMap::from([(root.id, root)]),
+            events: Vec::new(),
+        }
+    }
+
+    fn collection(&self, id: CollectionID) -> Result<&Collection, StorageError> {
+        self.collections
+            .get(&id.id())
+            .ok_or_else(|| StorageError::not_found(format!("Collection {} was not found", id.id())))
+    }
+
+    fn name_in_use(&self, name: &str, except_id: Option<i32>) -> bool {
+        self.collections
+            .values()
+            .any(|collection| collection.name == name && Some(collection.id) != except_id)
+    }
+
+    fn record_event(&mut self, collection_id: i32, action: Action, context: &EventContext) {
+        self.events.push(MemoryCollectionEvent {
+            collection_id,
+            action,
+            context: context.clone(),
+        });
+    }
+}
+
+/// Deterministic collection adapter used by shared storage contract tests.
+#[derive(Clone)]
+pub(crate) struct MemoryStorage {
+    state: Arc<RwLock<MemoryState>>,
+}
+
+impl MemoryStorage {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Arc::new(RwLock::new(MemoryState::new())),
+        }
+    }
+
+    pub(crate) async fn events(&self) -> Vec<MemoryCollectionEvent> {
+        self.state.read().await.events.clone()
+    }
+}
+
+#[async_trait]
+impl CollectionStore for MemoryStorage {
+    async fn get_collection(&self, id: CollectionID) -> Result<Collection, StorageError> {
+        self.state.read().await.collection(id).cloned()
+    }
+
+    async fn create_collection(
+        &self,
+        command: NewCollectionWithAssignee,
+        context: &EventContext,
+    ) -> Result<Collection, StorageError> {
+        let mut state = self.state.write().await;
+        if state.name_in_use(&command.name, None) {
+            return Err(StorageError::conflict(format!(
+                "A collection named '{}' already exists",
+                command.name
+            )));
+        }
+        let parent_id = command
+            .parent_collection_id
+            .map(CollectionID::id)
+            .unwrap_or(ROOT_COLLECTION_ID);
+        if !state.collections.contains_key(&parent_id) {
+            return Err(StorageError::not_found(format!(
+                "Parent collection {parent_id} was not found"
+            )));
+        }
+
+        let id = state.next_collection_id;
+        state.next_collection_id += 1;
+        let now = Utc::now().naive_utc();
+        let collection = Collection {
+            id,
+            name: command.name,
+            description: command.description,
+            created_at: now,
+            updated_at: now,
+            parent_collection_id: Some(parent_id),
+            revision: ResourceRevision::INITIAL,
+        };
+        state.collections.insert(id, collection.clone());
+        state.record_event(id, Action::Created, context);
+        Ok(collection)
+    }
+
+    async fn update_collection(
+        &self,
+        id: CollectionID,
+        changes: UpdateCollection,
+        context: &EventContext,
+    ) -> Result<Collection, StorageError> {
+        let mut state = self.state.write().await;
+        let current = state.collection(id)?.clone();
+        if !changes.has_changes(&current) {
+            return Ok(current);
+        }
+        if let Some(name) = changes.name.as_deref()
+            && state.name_in_use(name, Some(id.id()))
+        {
+            return Err(StorageError::conflict(format!(
+                "A collection named '{name}' already exists"
+            )));
+        }
+
+        let collection = state
+            .collections
+            .get_mut(&id.id())
+            .expect("collection existence was checked");
+        if let Some(name) = changes.name {
+            collection.name = name;
+        }
+        if let Some(description) = changes.description {
+            collection.description = description;
+        }
+        collection.updated_at = Utc::now().naive_utc();
+        collection.revision = collection
+            .revision
+            .checked_advance()
+            .map_err(StorageError::from)?;
+        let updated = collection.clone();
+        state.record_event(id.id(), Action::Updated, context);
+        Ok(updated)
+    }
+
+    async fn delete_collection(
+        &self,
+        id: CollectionID,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        let mut state = self.state.write().await;
+        let collection = state.collection(id)?.clone();
+        if collection.parent_collection_id.is_none() {
+            return Err(StorageError::conflict(
+                "The root collection cannot be deleted",
+            ));
+        }
+        if state
+            .collections
+            .values()
+            .any(|candidate| candidate.parent_collection_id == Some(id.id()))
+        {
+            return Err(StorageError::conflict(
+                "Collections with child collections cannot be deleted",
+            ));
+        }
+        state.collections.remove(&id.id());
+        state.record_event(id.id(), Action::Deleted, context);
+        Ok(())
+    }
+
+    async fn collection_children(&self, id: CollectionID) -> Result<Vec<Collection>, StorageError> {
+        let state = self.state.read().await;
+        state.collection(id)?;
+        let mut children = state
+            .collections
+            .values()
+            .filter(|collection| collection.parent_collection_id == Some(id.id()))
+            .cloned()
+            .collect::<Vec<_>>();
+        children.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(children)
+    }
+
+    async fn collection_ancestors(
+        &self,
+        id: CollectionID,
+    ) -> Result<Vec<Collection>, StorageError> {
+        let state = self.state.read().await;
+        let mut parent_id = state.collection(id)?.parent_collection_id;
+        let mut ancestors = Vec::new();
+        while let Some(current_id) = parent_id {
+            let ancestor = state.collections.get(&current_id).ok_or_else(|| {
+                StorageError::not_found(format!("Ancestor collection {current_id} was not found"))
+            })?;
+            ancestors.push(ancestor.clone());
+            parent_id = ancestor.parent_collection_id;
+        }
+        Ok(ancestors)
+    }
+
+    async fn move_collection(
+        &self,
+        id: CollectionID,
+        new_parent_id: CollectionID,
+        context: &EventContext,
+    ) -> Result<Collection, StorageError> {
+        let mut state = self.state.write().await;
+        let collection = state.collection(id)?.clone();
+        if collection.parent_collection_id.is_none() {
+            return Err(StorageError::conflict(
+                "The root collection cannot be moved",
+            ));
+        }
+        if collection.parent_collection_id == Some(new_parent_id.id()) {
+            return Ok(collection);
+        }
+        if id == new_parent_id {
+            return Err(StorageError::bad_request(
+                "A collection cannot be moved under itself",
+            ));
+        }
+        state.collection(new_parent_id)?;
+
+        let mut ancestor_id = Some(new_parent_id.id());
+        while let Some(current_id) = ancestor_id {
+            if current_id == id.id() {
+                return Err(StorageError::bad_request(
+                    "A collection cannot be moved under one of its descendants",
+                ));
+            }
+            ancestor_id = state
+                .collections
+                .get(&current_id)
+                .and_then(|current| current.parent_collection_id);
+        }
+
+        let collection = state
+            .collections
+            .get_mut(&id.id())
+            .expect("collection existence was checked");
+        collection.parent_collection_id = Some(new_parent_id.id());
+        collection.updated_at = Utc::now().naive_utc();
+        collection.revision = collection
+            .revision
+            .checked_advance()
+            .map_err(StorageError::from)?;
+        let moved = collection.clone();
+        state.record_event(id.id(), Action::Updated, context);
+        Ok(moved)
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,11 @@
+mod collections;
+mod error;
+#[cfg(test)]
+mod memory;
+mod postgres;
+
+pub use collections::{CollectionStore, DynStorage, Storage};
+pub use error::StorageError;
+#[cfg(test)]
+pub(crate) use memory::MemoryStorage;
+pub use postgres::PostgresStorage;

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -1,0 +1,93 @@
+use async_trait::async_trait;
+
+use crate::db::DbPool;
+use crate::db::traits::GetCollection;
+use crate::db::traits::collection::{
+    DeleteCollectionRecord, SaveCollectionWithAssigneeRecord, UpdateCollectionRecord,
+    collection_ancestors_from_backend, collection_children_from_backend,
+    move_collection_record_from_backend,
+};
+use crate::events::EventContext;
+use crate::models::{Collection, CollectionID, NewCollectionWithAssignee, UpdateCollection};
+
+use super::{CollectionStore, StorageError};
+
+/// Canonical production storage adapter.
+#[derive(Clone)]
+pub struct PostgresStorage {
+    pool: DbPool,
+}
+
+impl PostgresStorage {
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl CollectionStore for PostgresStorage {
+    async fn get_collection(&self, id: CollectionID) -> Result<Collection, StorageError> {
+        id.collection_from_backend(&self.pool)
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn create_collection(
+        &self,
+        command: NewCollectionWithAssignee,
+        context: &EventContext,
+    ) -> Result<Collection, StorageError> {
+        command
+            .save_collection_with_assignee_record(&self.pool, Some(context))
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn update_collection(
+        &self,
+        id: CollectionID,
+        changes: UpdateCollection,
+        context: &EventContext,
+    ) -> Result<Collection, StorageError> {
+        changes
+            .update_collection_record(&self.pool, id.id(), Some(context))
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn delete_collection(
+        &self,
+        id: CollectionID,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        id.delete_collection_record(&self.pool, Some(context))
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn collection_children(&self, id: CollectionID) -> Result<Vec<Collection>, StorageError> {
+        collection_children_from_backend(&self.pool, id)
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn collection_ancestors(
+        &self,
+        id: CollectionID,
+    ) -> Result<Vec<Collection>, StorageError> {
+        collection_ancestors_from_backend(&self.pool, id)
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn move_collection(
+        &self,
+        id: CollectionID,
+        new_parent_id: CollectionID,
+        context: &EventContext,
+    ) -> Result<Collection, StorageError> {
+        move_collection_record_from_backend(&self.pool, id.id(), new_parent_id.id(), Some(context))
+            .await
+            .map_err(StorageError::from)
+    }
+}

--- a/src/tests/storage_performance.rs
+++ b/src/tests/storage_performance.rs
@@ -1,4 +1,4 @@
-//! Pre-refactor PostgreSQL query budgets for the storage boundary.
+//! PostgreSQL query budgets for the storage boundary.
 //!
 //! These are deliberately model/storage-level checks rather than HTTP tests:
 //! authentication and routing should not hide an extra pool checkout or an
@@ -19,10 +19,11 @@ use crate::models::collection::effective_group_on;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
     CollectionID, GroupID, NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation,
-    NewHubuumObject, NewHubuumObjectRelation, UpdateCollection, UserID, collection_ancestors,
+    NewHubuumObject, NewHubuumObjectRelation, UpdateCollection, UserID,
 };
+use crate::services::Services;
 use crate::tests::{TestScope, ensure_admin_user};
-use crate::traits::{CanDelete, CanSave, CanUpdate, CollectionAccessors};
+use crate::traits::{CanDelete, CanSave, CanUpdate};
 
 const REPRESENTATIVE_COLLECTION_ROWS: i32 = 2_000;
 
@@ -146,8 +147,9 @@ async fn collection_point_read_uses_one_query() {
     let scope = TestScope::new();
     let fixture = scope.collection_fixture("query_budget_point_read").await;
     let collection_id = CollectionID::new(fixture.collection.id).expect("valid collection id");
+    let services = Services::postgres(scope.pool.get_ref().clone());
 
-    let (loaded, queries) = capture_queries(collection_id.collection(&scope.pool)).await;
+    let (loaded, queries) = capture_queries(services.collections().get(collection_id)).await;
     assert_eq!(loaded.expect("collection should load"), fixture.collection);
     assert_eq!(queries.total_queries(), 1, "{:#?}", queries.query_counts());
     assert_eq!(queries.domain_queries(), 1);
@@ -192,6 +194,7 @@ async fn collection_point_read_plan_has_bounded_logical_work_at_representative_s
 #[actix_web::test]
 async fn collection_ancestor_query_count_is_constant_with_depth() {
     let scope = TestScope::new();
+    let services = Services::postgres(scope.pool.get_ref().clone());
     let root_fixture = scope.collection_fixture("query_budget_ancestors").await;
     let mut collections = vec![root_fixture.collection.clone()];
 
@@ -213,12 +216,12 @@ async fn collection_ancestor_query_count_is_constant_with_depth() {
 
     let shallow_id = CollectionID::new(collections[1].id).expect("valid shallow collection id");
     let (shallow_ancestors, shallow_queries) =
-        capture_queries(collection_ancestors(&scope.pool, shallow_id)).await;
+        capture_queries(services.collections().ancestors(shallow_id)).await;
     assert_eq!(shallow_ancestors.expect("shallow ancestors").len(), 2);
 
     let leaf_id =
         CollectionID::new(collections.last().expect("leaf").id).expect("valid leaf collection id");
-    let (ancestors, queries) = capture_queries(collection_ancestors(&scope.pool, leaf_id)).await;
+    let (ancestors, queries) = capture_queries(services.collections().ancestors(leaf_id)).await;
     let ancestors = ancestors.expect("ancestors should load");
 
     assert_eq!(ancestors.len(), 33);
@@ -304,6 +307,7 @@ async fn collection_ancestor_plan_has_bounded_logical_work_at_representative_sca
 #[actix_web::test]
 async fn collection_create_with_event_has_a_fixed_query_budget() {
     let scope = TestScope::new();
+    let services = Services::postgres(scope.pool.get_ref().clone());
     let parent = scope.collection_fixture("query_budget_create_parent").await;
     let command = NewCollectionWithAssignee {
         name: scope.scoped_name("query_budget_create_child"),
@@ -314,8 +318,12 @@ async fn collection_create_with_event_has_a_fixed_query_budget() {
         ),
     };
 
-    let (created, queries) =
-        capture_queries(command.save(&scope.pool, &EventContext::system())).await;
+    let (created, queries) = capture_queries(
+        services
+            .collections()
+            .create(command, &EventContext::system()),
+    )
+    .await;
     let created = created.expect("collection should save with an event");
 
     assert_eq!(queries.total_queries(), 7, "{:#?}", queries.query_counts());
@@ -341,15 +349,16 @@ async fn collection_create_with_event_has_a_fixed_query_budget() {
 #[actix_web::test]
 async fn collection_no_op_update_does_not_write_or_emit_an_event() {
     let scope = TestScope::new();
+    let services = Services::postgres(scope.pool.get_ref().clone());
     let fixture = scope.collection_fixture("query_budget_no_op_update").await;
     let update = UpdateCollection {
         name: Some(fixture.collection.name.clone()),
         description: Some(fixture.collection.description.clone()),
     };
 
-    let (updated, queries) = capture_queries(update.update(
-        &scope.pool,
+    let (updated, queries) = capture_queries(services.collections().update(
         CollectionID::new(fixture.collection.id).unwrap(),
+        update,
         &EventContext::system(),
     ))
     .await;
@@ -506,6 +515,7 @@ async fn effective_permission_query_count_is_constant_with_collection_depth() {
 #[actix_web::test]
 async fn changed_collection_update_writes_once_and_emits_one_event() {
     let scope = TestScope::new();
+    let services = Services::postgres(scope.pool.get_ref().clone());
     let fixture = scope
         .collection_fixture("query_budget_changed_update")
         .await;
@@ -514,9 +524,9 @@ async fn changed_collection_update_writes_once_and_emits_one_event() {
         description: Some("changed query budget description".to_string()),
     };
 
-    let (updated, queries) = capture_queries(update.update(
-        &scope.pool,
+    let (updated, queries) = capture_queries(services.collections().update(
         CollectionID::new(fixture.collection.id).unwrap(),
+        update,
         &EventContext::system(),
     ))
     .await;


### PR DESCRIPTION
## Summary

- introduce an application-facing `Services` facade and `CollectionService` for the core collection lifecycle
- define an aggregate-shaped `CollectionStore` capability with PostgreSQL and test-only in-memory adapters
- route collection point reads, create, update, delete, hierarchy reads, and moves through the new boundary
- run shared behavioral contracts against both adapters while retaining PostgreSQL query budgets and Criterion coverage
- document the dependency direction, compatibility boundary, and intentional limits of the pilot

## Why

High-level collection code currently selects PostgreSQL/Diesel-backed model helpers directly. That makes application behavior difficult to exercise independently of PostgreSQL and leaves the persistence boundary shaped around `DbPool`.

This pilot establishes a use-case-oriented boundary without changing PostgreSQL as the production semantic reference or attempting to abstract SQL-heavy search and pagination prematurely.

## Behavior and design notes

Production requests still use the existing PostgreSQL queries and transactions through `PostgresStorage`, preserving hierarchy maintenance, permission grants, lifecycle-event atomicity, and query shape.

The in-memory adapter is compiled for tests and covers logical collection behavior: hierarchy, revisions, no-op updates, delete constraints, moves, and lifecycle event occurrence. It intentionally does not claim parity for PostgreSQL locking, triggers, permission rows, or temporal history.

Collection list/search, permission management, history, imports, restores, and unrelated aggregates remain on the existing compatibility path for later slices. There are no HTTP API or schema changes.

Part of #27.

## Changelog

No changelog entry: this is an internal architecture refactor with no user-facing behavior or API change.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `./scripts/test-classify-ci-changes.sh`
- `git diff --check`