### PR TITLE
Add class service and storage boundary

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -69,7 +69,8 @@ for package classifications, publishing policy, and promotion requirements.
   Diesel/Postgres-backed implementations behind model and storage adapters.
   This is where query details, joins, filters, and transactions belong.
 
-The collection lifecycle is the first service/storage pilot. See
+The collection lifecycle and class resolution/lifecycle are the first
+service/storage capabilities. See
 [Service and Storage Boundary](storage_boundary.md) for responsibilities,
 contract testing, performance gates, and current migration limits.
 
@@ -107,11 +108,12 @@ semantics. Keep hierarchy writes in `src/db/traits/collection/records.rs` and
 permission reads in `src/db/traits/collection/permissions.rs` or
 `src/db/traits/user/*`.
 
-Normal collection lifecycle handlers enter this implementation through
-`CollectionService` and `CollectionStore`. Do not bypass that service from a
-migrated handler. Imports, restore code, fixtures, list/search, permissions, and
-history remain explicitly outside the pilot until their complete use cases can
-move without weakening transaction, authorization, or performance behavior.
+Normal collection and class lifecycle handlers enter this implementation
+through their service and storage capabilities. Do not bypass those services
+from a migrated handler. Imports, restore code, fixtures, list/search,
+permissions, and history remain explicitly outside the pilot until their
+complete use cases can move without weakening transaction, authorization, or
+performance behavior.
 
 When adding a collection creation path, use the shared collection insert helper
 from the collection backend so `collections` and `collection_closure` stay in

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -5,7 +5,8 @@ Diesel details. PostgreSQL remains the production semantic reference; the goal
 is a compile-time dependency boundary and faster contract tests, not generic
 multi-database support.
 
-The first migrated slice is the core collection lifecycle:
+The first migrated capabilities cover the core collection and class lifecycles.
+Collections include:
 
 - point reads;
 - create with an initial assignee grant and lifecycle event;
@@ -14,28 +15,37 @@ The first migrated slice is the core collection lifecycle:
 - direct children and ordered ancestors; and
 - hierarchy moves.
 
+Classes include:
+
+- explicit point resolution by ID or name;
+- create with schema validation and a lifecycle event;
+- update, including no-op behavior and collection moves;
+- selector-aware mutations that reject stale name targets; and
+- delete with a lifecycle event.
+
 ## Dependency direction
 
 ```text
-collection HTTP handlers
-          |
-          v
-  CollectionService
-          |
-          v
-    CollectionStore
-       /       \
-      v         v
-PostgreSQL    memory
- adapter      adapter
-      |
-      v
+collection/class HTTP handlers
+             |
+             v
+ CollectionService / ClassService
+             |
+             v
+   CollectionStore / ClassStore
+          /       \
+         v         v
+   PostgreSQL    memory
+    adapter      adapter
+         |
+         v
 existing Diesel transactions and queries
 ```
 
 `AppContext` constructs `Services` with `PostgresStorage` in production. Core
-collection handlers call `CollectionService`; they do not choose a Diesel query
-or transaction helper. Permission checks remain at the handler boundary.
+collection and class handlers call their services; they do not choose a Diesel
+query or transaction helper for migrated operations. Permission checks remain
+at the handler boundary.
 
 ## Responsibility split
 
@@ -52,29 +62,30 @@ atomic lifecycle events.
 and transaction implementation. `PostgresStorage` delegates to these existing
 operations without changing their query shape.
 
-`MemoryStorage` is compiled for tests and implements the logical collection
-contract. It models hierarchy, revisions, no-op updates, delete constraints,
-and lifecycle event occurrence. It does not claim PostgreSQL locking, trigger,
-permission-row, or temporal-history equivalence.
+`MemoryStorage` is compiled for tests and implements the logical collection and
+class contracts. It models hierarchy, selector resolution, schema validation,
+revisions, no-op updates, delete constraints, and lifecycle event occurrence.
+It does not claim PostgreSQL locking, trigger, permission-row, or
+temporal-history equivalence.
 
 ## Contract and performance gates
 
-The shared contract suite runs each collection behavior against both
-PostgreSQL and memory. Each test focuses on one behavior so backend differences
-cannot be hidden inside a large scenario.
+The shared contract suite runs each migrated collection and class behavior
+against both PostgreSQL and memory. Each test focuses on one behavior so
+backend differences cannot be hidden inside a large scenario.
 
-The PostgreSQL query-capture tests exercise `CollectionService` and retain the
-pre-migration query budgets. The opt-in PostgreSQL Criterion benchmark also
-times the service path. Trait dispatch or service composition must therefore
-not introduce extra pool checkouts, SQL statements, or application-side
-pagination.
+The PostgreSQL query-capture tests exercise both services and retain exact
+point-read and mutation budgets. The opt-in PostgreSQL Criterion benchmark also
+times the collection service path. Trait dispatch or service composition must
+therefore not introduce extra pool checkouts, SQL statements, or
+application-side pagination.
 
 ## Current migration boundary
 
-This is an incremental pilot. Collection list/search, permission management,
-history, and unrelated aggregates still use `BackendContext` and the existing
-model/database traits. Existing direct persistence APIs also remain for
-fixtures, imports, restore paths, and unmigrated callers.
+This is an incremental migration. Collection and class list/search, permission
+management, history, and unrelated aggregates still use `BackendContext` and
+the existing model/database traits. Existing direct persistence APIs also
+remain for fixtures, imports, restore paths, and unmigrated callers.
 
 When expanding the boundary:
 

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -39,8 +39,8 @@ use crate::permissions::{
 };
 
 use crate::models::traits::{
-    CreateObjectInResolvedClass, DeleteResolvedClass, DeleteResolvedObject, PatchObjectData,
-    ResolveClassTarget, ResolveObjectTarget, UpdateResolvedClass, UpdateResolvedObject,
+    CreateObjectInResolvedClass, DeleteResolvedObject, PatchObjectData, ResolveObjectTarget,
+    UpdateResolvedObject,
 };
 use crate::models::{
     ClassGraphRow, ClassSelector, CollectionID, GroupPermission, HistoryAuthorizationSnapshot,
@@ -416,7 +416,10 @@ async fn create_class(
     );
 
     let event_context = requestor.event_context(&req);
-    let class = class_data.save(&pool, &event_context).await?;
+    let class = pool
+        .class_service()
+        .create(class_data, &event_context)
+        .await?;
     let expanded = class.expand_collection(&pool).await?;
 
     let location = api_locations::class(class.id)?;
@@ -468,8 +471,9 @@ async fn get_class(
         class_id = class_id.id()
     );
 
-    let target = ClassSelector::by_id(class_id)
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_id(class_id))
         .await?;
     let class = read_resolved_class(&pool, &requestor, target).await?;
     if parse_collection_include(req.query_string())? {
@@ -500,8 +504,9 @@ async fn get_class_by_name(
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_name(class_name.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
     let class = read_resolved_class(&pool, &requestor, target).await?;
     if parse_collection_include(req.query_string())? {
@@ -542,7 +547,7 @@ async fn apply_resolved_class_update(
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,
-        update.update_resolved_class(pool, &target, &event_context),
+        pool.class_service().update(&target, update, &event_context),
     )
     .await
 }
@@ -581,8 +586,9 @@ async fn update_class(
         class_id = class_id.id()
     );
 
-    let target = ClassSelector::by_id(class_id)
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_id(class_id))
         .await?;
     let class = apply_resolved_class_update(&pool, &requestor, &req, target, class_data).await?;
     let expanded = class.expand_collection(&pool).await?;
@@ -614,8 +620,9 @@ async fn update_class_by_name(
     class_data: web::Json<UpdateHubuumClass>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_name(class_name.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
     let class =
         apply_resolved_class_update(&pool, &requestor, &req, target, class_data.into_inner())
@@ -643,7 +650,7 @@ async fn delete_resolved_class(
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,
-        target.delete_resolved_class(pool, &event_context),
+        pool.class_service().delete(&target, &event_context),
     )
     .await?;
     Ok(etag)
@@ -679,8 +686,9 @@ async fn delete_class(
         class_id = class_id.id()
     );
 
-    let target = ClassSelector::by_id(class_id)
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_id(class_id))
         .await?;
     let etag = delete_resolved_class(&pool, &requestor, &req, target).await?;
     Ok(ApiResponse::no_content_with_etag(etag))
@@ -708,8 +716,9 @@ async fn delete_class_by_name(
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_name(class_name.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
     let etag = delete_resolved_class(&pool, &requestor, &req, target).await?;
     Ok(ApiResponse::no_content_with_etag(etag))
@@ -736,8 +745,9 @@ async fn get_class_permissions(
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_id(class_id.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_id(class_id.into_inner()))
         .await?;
     read_resolved_class_permissions(pool, requestor, target, req).await
 }
@@ -762,8 +772,9 @@ async fn get_class_permissions_by_name(
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_name(class_name.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
     read_resolved_class_permissions(pool, requestor, target, req).await
 }

--- a/src/api/v1/handlers/classes/class_objects.rs
+++ b/src/api/v1/handlers/classes/class_objects.rs
@@ -67,8 +67,9 @@ async fn get_objects_in_class_by_name(
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_name(class_name.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
     let class_id = HubuumClassID::new(target.class().id)?;
     let class = target.class().clone();
@@ -231,8 +232,9 @@ async fn create_object_in_class(
     object_data: web::Json<NewHubuumObjectRequest>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_id(class_id.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_id(class_id.into_inner()))
         .await?;
     let object =
         create_object_in_resolved_class(&pool, &requestor, &req, target, object_data.into_inner())
@@ -267,8 +269,9 @@ async fn create_object_in_class_by_name(
     object_data: web::Json<NewHubuumObjectRequest>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_name(class_name.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
     let object =
         create_object_in_resolved_class(&pool, &requestor, &req, target, object_data.into_inner())

--- a/src/api/v1/handlers/classes/class_related.rs
+++ b/src/api/v1/handlers/classes/class_related.rs
@@ -24,8 +24,9 @@ async fn get_related_classes(
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_id(class_id.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_id(class_id.into_inner()))
         .await?;
     read_related_classes(pool, requestor, target, req).await
 }
@@ -51,8 +52,9 @@ async fn get_related_classes_by_name(
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_name(class_name.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
     read_related_classes(pool, requestor, target, req).await
 }
@@ -279,8 +281,9 @@ async fn get_related_class_relations(
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_id(class_id.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_id(class_id.into_inner()))
         .await?;
     read_related_class_relations(pool, requestor, target, req).await
 }
@@ -306,8 +309,9 @@ async fn get_related_class_relations_by_name(
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_name(class_name.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
     read_related_class_relations(pool, requestor, target, req).await
 }
@@ -408,8 +412,9 @@ async fn get_related_class_graph(
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_id(class_id.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_id(class_id.into_inner()))
         .await?;
     read_related_class_graph(pool, requestor, target, req).await
 }
@@ -435,8 +440,9 @@ async fn get_related_class_graph_by_name(
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_name(class_name.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
     read_related_class_graph(pool, requestor, target, req).await
 }

--- a/src/api/v1/handlers/classes/object_aggregates.rs
+++ b/src/api/v1/handlers/classes/object_aggregates.rs
@@ -11,7 +11,6 @@ use crate::errors::ApiError;
 use crate::extractors::Authenticated;
 use crate::models::object_aggregate::parse_object_aggregate_query;
 use crate::models::search::QueryParamsExt;
-use crate::models::traits::ResolveClassTarget;
 use crate::models::{
     ClassSelector, HubuumClassID, ObjectAggregateAuthorization, ObjectAggregateBackendRequest,
     ObjectAggregateCursorBudget, ObjectAggregateRow, ObjectAggregateTarget, Permissions,
@@ -50,8 +49,9 @@ pub(crate) async fn get_object_aggregates(
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_id(class_id.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_id(class_id.into_inner()))
         .await?;
     read_object_aggregates(pool, requestor, target, req).await
 }
@@ -84,8 +84,9 @@ pub(crate) async fn get_object_aggregates_by_name(
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = ClassSelector::by_name(class_name.into_inner())
-        .resolve_class_target(&pool)
+    let target = pool
+        .class_service()
+        .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
     read_object_aggregates(pool, requestor, target, req).await
 }

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -85,6 +85,19 @@ impl UpdateHubuumClass {
     }
 }
 
+impl NewHubuumClass {
+    pub(crate) fn validate_schema(&self) -> Result<(), ApiError> {
+        let Some(schema) = self.json_schema.as_ref() else {
+            return Ok(());
+        };
+        crate::utilities::json_schema::validate_json_schema(schema)?;
+        if self.validate_schema.unwrap_or(false) {
+            crate::utilities::json_schema::compile_json_schema(schema)?;
+        }
+        Ok(())
+    }
+}
+
 impl HubuumClass {
     pub(crate) fn authorization_resource(&self) -> ResourceRef {
         ResourceRef {

--- a/src/models/traits/class.rs
+++ b/src/models/traits/class.rs
@@ -83,17 +83,6 @@ impl DeleteResolvedClass for ResolvedClassTarget {
     }
 }
 
-fn validate_new_class_schema(class: &NewHubuumClass) -> Result<(), ApiError> {
-    let Some(schema) = class.json_schema.as_ref() else {
-        return Ok(());
-    };
-    crate::utilities::json_schema::validate_json_schema(schema)?;
-    if class.validate_schema.unwrap_or(false) {
-        crate::utilities::json_schema::compile_json_schema(schema)?;
-    }
-    Ok(())
-}
-
 impl SaveAdapter for HubuumClass {
     type Output = HubuumClass;
 
@@ -144,7 +133,7 @@ impl SaveAdapter for NewHubuumClass {
     type Output = HubuumClass;
 
     async fn save_adapter_without_events(&self, pool: &DbPool) -> Result<HubuumClass, ApiError> {
-        validate_new_class_schema(self)?;
+        self.validate_schema()?;
         self.create_class_record_without_events(pool).await
     }
 
@@ -153,7 +142,7 @@ impl SaveAdapter for NewHubuumClass {
         pool: &DbPool,
         context: &EventContext,
     ) -> Result<HubuumClass, ApiError> {
-        validate_new_class_schema(self)?;
+        self.validate_schema()?;
         self.create_class_record(pool, Some(context)).await
     }
 }

--- a/src/permissions/context.rs
+++ b/src/permissions/context.rs
@@ -8,7 +8,7 @@ use futures_util::future::{Ready, ready};
 use crate::config::get_config;
 use crate::db::DbPool;
 use crate::errors::ApiError;
-use crate::services::{CollectionService, Services};
+use crate::services::{ClassService, CollectionService, Services};
 use crate::traits::BackendContext;
 
 use super::backend::PermissionBackend;
@@ -48,6 +48,10 @@ impl AppContext {
 
     pub fn collection_service(&self) -> &CollectionService {
         self.services.collections()
+    }
+
+    pub fn class_service(&self) -> &ClassService {
+        self.services.classes()
     }
 }
 

--- a/src/services/classes.rs
+++ b/src/services/classes.rs
@@ -1,0 +1,589 @@
+use crate::errors::ApiError;
+use crate::events::EventContext;
+use crate::models::{
+    ClassSelector, HubuumClass, NewHubuumClass, ResolvedClassTarget, UpdateHubuumClass,
+};
+use crate::storage::DynStorage;
+
+/// Application-facing class resolution and lifecycle use cases.
+#[derive(Clone)]
+pub struct ClassService {
+    storage: DynStorage,
+}
+
+impl ClassService {
+    pub(crate) fn new(storage: DynStorage) -> Self {
+        Self { storage }
+    }
+
+    pub async fn resolve(&self, selector: ClassSelector) -> Result<ResolvedClassTarget, ApiError> {
+        self.storage
+            .inner()
+            .resolve_class(selector)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn create(
+        &self,
+        command: NewHubuumClass,
+        context: &EventContext,
+    ) -> Result<HubuumClass, ApiError> {
+        self.storage
+            .inner()
+            .create_class(command, context)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn update(
+        &self,
+        target: &ResolvedClassTarget,
+        changes: UpdateHubuumClass,
+        context: &EventContext,
+    ) -> Result<HubuumClass, ApiError> {
+        self.storage
+            .inner()
+            .update_class(target, changes, context)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn delete(
+        &self,
+        target: &ResolvedClassTarget,
+        context: &EventContext,
+    ) -> Result<(), ApiError> {
+        self.storage
+            .inner()
+            .delete_class(target, context)
+            .await
+            .map_err(ApiError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use serde_json::json;
+
+    use crate::errors::ApiError;
+    use crate::events::{Action, EventContext};
+    use crate::models::{
+        ClassSelector, Collection, CollectionID, GroupID, HubuumClass, HubuumClassID,
+        NewCollectionWithAssignee, NewGroup, NewHubuumClass, UpdateHubuumClass,
+    };
+    use crate::services::{
+        CollectionService, Services, storage_contract_pool, storage_contract_postgres_permit,
+        storage_contract_prefix,
+    };
+    use crate::storage::{DynStorage, MemoryStorage, PostgresStorage};
+    use crate::tests::CollectionFixture;
+    use crate::traits::CanSave;
+
+    use super::ClassService;
+
+    #[derive(Clone, Copy, Debug)]
+    enum ContractBackend {
+        Memory,
+        Postgres,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum ClassAddress {
+        Id,
+        Name,
+    }
+
+    struct ContractHarness {
+        service: ClassService,
+        collections: CollectionService,
+        collection_id: i32,
+        group_id: GroupID,
+        prefix: String,
+        postgres_cleanup: Option<CollectionFixture>,
+        _postgres_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    }
+
+    impl ContractHarness {
+        async fn new(backend: ContractBackend, label: &str) -> Self {
+            match backend {
+                ContractBackend::Memory => {
+                    let services = Services::from_storage(DynStorage::new(MemoryStorage::new()));
+                    Self {
+                        service: services.classes().clone(),
+                        collections: services.collections().clone(),
+                        collection_id: CollectionID::new(1).expect("valid root collection id").id(),
+                        group_id: GroupID::new(1).expect("valid memory group id"),
+                        prefix: format!("memory_{label}"),
+                        postgres_cleanup: None,
+                        _postgres_permit: None,
+                    }
+                }
+                ContractBackend::Postgres => {
+                    let permit = storage_contract_postgres_permit().await;
+                    let pool = storage_contract_pool();
+                    let prefix = storage_contract_prefix(label);
+                    let owner_group = NewGroup {
+                        identity_scope: None,
+                        groupname: format!("{prefix}_owner"),
+                        description: Some("class storage contract owner".to_string()),
+                    }
+                    .save_without_events(&pool)
+                    .await
+                    .expect("contract owner group should save");
+                    let collection = NewCollectionWithAssignee {
+                        name: format!("{prefix}_collection"),
+                        description: "class storage contract collection".to_string(),
+                        group_id: GroupID::new(owner_group.id).expect("valid owner group id"),
+                        parent_collection_id: None,
+                    }
+                    .save_without_events(&pool)
+                    .await
+                    .expect("contract collection should save");
+                    let fixture = CollectionFixture {
+                        pool: pool.clone(),
+                        collection,
+                        owner_group,
+                        prefix: prefix.clone(),
+                    };
+                    let services = Services::from_storage(DynStorage::new(PostgresStorage::new(
+                        pool.get_ref().clone(),
+                    )));
+                    Self {
+                        service: services.classes().clone(),
+                        collections: services.collections().clone(),
+                        collection_id: fixture.collection.id,
+                        group_id: GroupID::new(fixture.owner_group.id)
+                            .expect("valid owner group id"),
+                        prefix,
+                        postgres_cleanup: Some(fixture),
+                        _postgres_permit: Some(permit),
+                    }
+                }
+            }
+        }
+
+        async fn create(&self, label: &str) -> HubuumClass {
+            self.service
+                .create(
+                    NewHubuumClass {
+                        name: format!("{}_{}", self.prefix, label),
+                        collection_id: self.collection_id,
+                        json_schema: None,
+                        validate_schema: None,
+                        description: format!("class contract {label}"),
+                    },
+                    &EventContext::system(),
+                )
+                .await
+                .expect("contract class should be created")
+        }
+
+        async fn delete(&self, class: &HubuumClass) {
+            let target = self
+                .service
+                .resolve(ClassSelector::by_id(
+                    HubuumClassID::new(class.id).expect("valid class id"),
+                ))
+                .await
+                .expect("class cleanup target should resolve");
+            self.service
+                .delete(&target, &EventContext::system())
+                .await
+                .expect("contract class cleanup");
+        }
+
+        async fn create_collection(&self, label: &str) -> Collection {
+            self.collections
+                .create(
+                    NewCollectionWithAssignee {
+                        name: format!("{}_{}", self.prefix, label),
+                        description: format!("class contract collection {label}"),
+                        group_id: self.group_id,
+                        parent_collection_id: None,
+                    },
+                    &EventContext::system(),
+                )
+                .await
+                .expect("contract collection should be created")
+        }
+
+        async fn finish(self) {
+            if let Some(fixture) = self.postgres_cleanup {
+                fixture.cleanup().await.expect("contract fixture cleanup");
+            }
+        }
+    }
+
+    fn selector(address: ClassAddress, class: &HubuumClass) -> ClassSelector {
+        match address {
+            ClassAddress::Id => {
+                ClassSelector::by_id(HubuumClassID::new(class.id).expect("valid class id"))
+            }
+            ClassAddress::Name => ClassSelector::by_name(class.name.clone()),
+        }
+    }
+
+    #[rstest]
+    #[case::postgres_id(ContractBackend::Postgres, ClassAddress::Id)]
+    #[case::postgres_name(ContractBackend::Postgres, ClassAddress::Name)]
+    #[case::memory_id(ContractBackend::Memory, ClassAddress::Id)]
+    #[case::memory_name(ContractBackend::Memory, ClassAddress::Name)]
+    #[actix_web::test]
+    async fn class_contract_resolves_explicit_addresses(
+        #[case] backend: ContractBackend,
+        #[case] address: ClassAddress,
+    ) {
+        let harness = ContractHarness::new(backend, "resolve").await;
+        let class = harness.create("class").await;
+
+        let resolved = harness
+            .service
+            .resolve(selector(address, &class))
+            .await
+            .expect("class should resolve");
+        assert_eq!(resolved.class(), &class);
+
+        harness.delete(&class).await;
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_contract_changed_update_advances_revision(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "changed_update").await;
+        let class = harness.create("class").await;
+        let target = harness
+            .service
+            .resolve(selector(ClassAddress::Id, &class))
+            .await
+            .expect("class should resolve");
+
+        let updated = harness
+            .service
+            .update(
+                &target,
+                UpdateHubuumClass {
+                    name: None,
+                    collection_id: None,
+                    json_schema: None,
+                    validate_schema: None,
+                    description: Some("updated class contract".to_string()),
+                },
+                &EventContext::system(),
+            )
+            .await
+            .expect("class should update");
+        assert_eq!(updated.revision.get(), class.revision.get() + 1);
+
+        harness.delete(&updated).await;
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_contract_no_op_update_preserves_revision(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "no_op_update").await;
+        let class = harness.create("class").await;
+        let target = harness
+            .service
+            .resolve(selector(ClassAddress::Id, &class))
+            .await
+            .expect("class should resolve");
+
+        let unchanged = harness
+            .service
+            .update(
+                &target,
+                UpdateHubuumClass {
+                    name: Some(class.name.clone()),
+                    collection_id: Some(class.collection_id),
+                    json_schema: None,
+                    validate_schema: Some(class.validate_schema),
+                    description: Some(class.description.clone()),
+                },
+                &EventContext::system(),
+            )
+            .await
+            .expect("no-op update should return current state");
+        assert_eq!(unchanged, class);
+
+        harness.delete(&class).await;
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_contract_update_moves_the_class_between_collections(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "move_collection").await;
+        let target_collection = harness.create_collection("target").await;
+        let class = harness.create("class").await;
+        let target = harness
+            .service
+            .resolve(selector(ClassAddress::Id, &class))
+            .await
+            .expect("class should resolve");
+
+        let updated = harness
+            .service
+            .update(
+                &target,
+                UpdateHubuumClass {
+                    name: None,
+                    collection_id: Some(target_collection.id),
+                    json_schema: None,
+                    validate_schema: None,
+                    description: None,
+                },
+                &EventContext::system(),
+            )
+            .await
+            .expect("class should move");
+        assert_eq!(updated.collection_id, target_collection.id);
+
+        harness.delete(&updated).await;
+        harness
+            .collections
+            .delete(
+                CollectionID::new(target_collection.id).expect("valid collection id"),
+                &EventContext::system(),
+            )
+            .await
+            .expect("target collection cleanup");
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_contract_collection_delete_cascades_the_class(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "collection_cascade").await;
+        let collection = harness.create_collection("target").await;
+        let class = harness
+            .service
+            .create(
+                NewHubuumClass {
+                    name: format!("{}_class", harness.prefix),
+                    collection_id: collection.id,
+                    json_schema: None,
+                    validate_schema: None,
+                    description: "collection cascade contract".to_string(),
+                },
+                &EventContext::system(),
+            )
+            .await
+            .expect("class should be created in target collection");
+
+        harness
+            .collections
+            .delete(
+                CollectionID::new(collection.id).expect("valid collection id"),
+                &EventContext::system(),
+            )
+            .await
+            .expect("target collection should delete");
+        assert!(matches!(
+            harness
+                .service
+                .resolve(selector(ClassAddress::Id, &class))
+                .await,
+            Err(ApiError::NotFound(_))
+        ));
+
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_contract_rejects_a_stale_name_target(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "stale_name").await;
+        let class = harness.create("class").await;
+        let name_target = harness
+            .service
+            .resolve(selector(ClassAddress::Name, &class))
+            .await
+            .expect("name target should resolve");
+        let id_target = harness
+            .service
+            .resolve(selector(ClassAddress::Id, &class))
+            .await
+            .expect("id target should resolve");
+        let renamed = harness
+            .service
+            .update(
+                &id_target,
+                UpdateHubuumClass {
+                    name: Some(format!("{}_renamed", harness.prefix)),
+                    collection_id: None,
+                    json_schema: None,
+                    validate_schema: None,
+                    description: None,
+                },
+                &EventContext::system(),
+            )
+            .await
+            .expect("class should rename");
+
+        assert!(matches!(
+            harness
+                .service
+                .update(
+                    &name_target,
+                    UpdateHubuumClass {
+                        name: None,
+                        collection_id: None,
+                        json_schema: None,
+                        validate_schema: None,
+                        description: Some("stale write".to_string()),
+                    },
+                    &EventContext::system(),
+                )
+                .await,
+            Err(ApiError::NotFound(_))
+        ));
+
+        harness.delete(&renamed).await;
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_contract_rejects_invalid_json_schema(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "invalid_schema").await;
+
+        assert!(matches!(
+            harness
+                .service
+                .create(
+                    NewHubuumClass {
+                        name: format!("{}_class", harness.prefix),
+                        collection_id: harness.collection_id,
+                        json_schema: Some(json!({"type": 7})),
+                        validate_schema: Some(true),
+                        description: "invalid schema contract".to_string(),
+                    },
+                    &EventContext::system(),
+                )
+                .await,
+            Err(ApiError::BadRequest(_))
+        ));
+
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_contract_delete_removes_the_resolved_class(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "delete").await;
+        let class = harness.create("class").await;
+        let target = harness
+            .service
+            .resolve(selector(ClassAddress::Id, &class))
+            .await
+            .expect("class should resolve");
+
+        harness
+            .service
+            .delete(&target, &EventContext::system())
+            .await
+            .expect("class should delete");
+        assert!(matches!(
+            harness
+                .service
+                .resolve(selector(ClassAddress::Id, &class))
+                .await,
+            Err(ApiError::NotFound(_))
+        ));
+
+        harness.finish().await;
+    }
+
+    #[actix_web::test]
+    async fn memory_class_events_exclude_no_op_updates() {
+        let storage = MemoryStorage::new();
+        let service = Services::from_storage(DynStorage::new(storage.clone()))
+            .classes()
+            .clone();
+        let context = EventContext::system();
+        let class = service
+            .create(
+                NewHubuumClass {
+                    name: "memory_class_event_contract".to_string(),
+                    collection_id: 1,
+                    json_schema: None,
+                    validate_schema: None,
+                    description: "memory class event contract".to_string(),
+                },
+                &context,
+            )
+            .await
+            .expect("memory class should be created");
+        let target = service
+            .resolve(selector(ClassAddress::Id, &class))
+            .await
+            .expect("memory class should resolve");
+        let updated = service
+            .update(
+                &target,
+                UpdateHubuumClass {
+                    name: None,
+                    collection_id: None,
+                    json_schema: None,
+                    validate_schema: None,
+                    description: Some("changed memory class event contract".to_string()),
+                },
+                &context,
+            )
+            .await
+            .expect("memory class should update");
+        let updated_target = service
+            .resolve(selector(ClassAddress::Id, &updated))
+            .await
+            .expect("updated memory class should resolve");
+        service
+            .update(
+                &updated_target,
+                UpdateHubuumClass {
+                    name: Some(updated.name.clone()),
+                    collection_id: Some(updated.collection_id),
+                    json_schema: None,
+                    validate_schema: Some(updated.validate_schema),
+                    description: Some(updated.description.clone()),
+                },
+                &context,
+            )
+            .await
+            .expect("memory no-op should succeed");
+        service
+            .delete(&updated_target, &context)
+            .await
+            .expect("memory class should delete");
+
+        let events = storage.class_events().await;
+        assert_eq!(
+            events.iter().map(|event| event.action).collect::<Vec<_>>(),
+            vec![Action::Created, Action::Updated, Action::Deleted]
+        );
+        assert!(
+            events
+                .iter()
+                .all(|event| event.class_id == class.id && event.context == context)
+        );
+    }
+}

--- a/src/services/collections.rs
+++ b/src/services/collections.rs
@@ -101,9 +101,10 @@ mod tests {
         Collection, CollectionID, Group, GroupID, NewCollectionWithAssignee, NewGroup,
         UpdateCollection,
     };
-    use crate::services::Services;
+    use crate::services::{
+        Services, storage_contract_pool, storage_contract_postgres_permit, storage_contract_prefix,
+    };
     use crate::storage::{DynStorage, MemoryStorage, PostgresStorage};
-    use crate::tests::TestScope;
 
     use super::CollectionService;
 
@@ -118,6 +119,7 @@ mod tests {
         group_id: GroupID,
         prefix: String,
         postgres_cleanup: Option<(Data<DbPool>, Group)>,
+        _postgres_permit: Option<tokio::sync::OwnedSemaphorePermit>,
     }
 
     impl ContractHarness {
@@ -130,26 +132,30 @@ mod tests {
                     group_id: GroupID::new(1).expect("valid memory group id"),
                     prefix: format!("memory_{label}"),
                     postgres_cleanup: None,
+                    _postgres_permit: None,
                 },
                 ContractBackend::Postgres => {
-                    let scope = TestScope::new();
+                    let permit = storage_contract_postgres_permit().await;
+                    let pool = storage_contract_pool();
+                    let prefix = storage_contract_prefix(label);
                     let owner_group = NewGroup {
                         identity_scope: None,
-                        groupname: scope.scoped_name(&format!("{label}_owner")),
+                        groupname: format!("{prefix}_owner"),
                         description: Some("collection storage contract owner".to_string()),
                     }
-                    .save_without_events(&scope.pool)
+                    .save_without_events(&pool)
                     .await
                     .expect("contract owner group should save");
                     Self {
                         service: Services::from_storage(DynStorage::new(PostgresStorage::new(
-                            scope.pool.get_ref().clone(),
+                            pool.get_ref().clone(),
                         )))
                         .collections()
                         .clone(),
                         group_id: GroupID::new(owner_group.id).expect("valid owner group id"),
-                        prefix: scope.scoped_name(label),
-                        postgres_cleanup: Some((scope.pool, owner_group)),
+                        prefix,
+                        postgres_cleanup: Some((pool, owner_group)),
+                        _postgres_permit: Some(permit),
                     }
                 }
             }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,13 +1,42 @@
+mod classes;
 mod collections;
 
+pub use classes::ClassService;
 pub use collections::CollectionService;
 
 use crate::db::DbPool;
 use crate::storage::{DynStorage, PostgresStorage};
 
+#[cfg(test)]
+pub(crate) async fn storage_contract_postgres_permit() -> tokio::sync::OwnedSemaphorePermit {
+    use std::sync::{Arc, LazyLock};
+    use tokio::sync::Semaphore;
+
+    static LIMITER: LazyLock<Arc<Semaphore>> = LazyLock::new(|| Arc::new(Semaphore::new(4)));
+    LIMITER
+        .clone()
+        .acquire_owned()
+        .await
+        .expect("storage contract semaphore should remain open")
+}
+
+#[cfg(test)]
+pub(crate) fn storage_contract_pool() -> actix_web::web::Data<DbPool> {
+    let config = crate::tests::integration_test_config()
+        .expect("integration test config should be initialized");
+    actix_web::web::Data::new(crate::db::init_pool(&config.database_url, 2))
+}
+
+#[cfg(test)]
+pub(crate) fn storage_contract_prefix(label: &str) -> String {
+    let suffix = crate::utilities::auth::generate_random_password(12).to_ascii_lowercase();
+    format!("storage_contract_{label}_{suffix}")
+}
+
 /// Application use-case facade.
 #[derive(Clone)]
 pub struct Services {
+    classes: ClassService,
     collections: CollectionService,
 }
 
@@ -18,8 +47,13 @@ impl Services {
 
     pub(crate) fn from_storage(storage: DynStorage) -> Self {
         Self {
+            classes: ClassService::new(storage.clone()),
             collections: CollectionService::new(storage),
         }
+    }
+
+    pub fn classes(&self) -> &ClassService {
+        &self.classes
     }
 
     pub fn collections(&self) -> &CollectionService {

--- a/src/storage/classes.rs
+++ b/src/storage/classes.rs
@@ -1,0 +1,39 @@
+use async_trait::async_trait;
+
+use crate::events::EventContext;
+use crate::models::{
+    ClassSelector, HubuumClass, NewHubuumClass, ResolvedClassTarget, UpdateHubuumClass,
+};
+
+use super::StorageError;
+
+/// Persistence capability for class resolution and lifecycle mutations.
+///
+/// Resolved targets preserve the route-selected address so implementations can
+/// recheck ID- and name-based mutations atomically before writing.
+#[async_trait]
+pub trait ClassStore: Send + Sync {
+    async fn resolve_class(
+        &self,
+        selector: ClassSelector,
+    ) -> Result<ResolvedClassTarget, StorageError>;
+
+    async fn create_class(
+        &self,
+        command: NewHubuumClass,
+        context: &EventContext,
+    ) -> Result<HubuumClass, StorageError>;
+
+    async fn update_class(
+        &self,
+        target: &ResolvedClassTarget,
+        changes: UpdateHubuumClass,
+        context: &EventContext,
+    ) -> Result<HubuumClass, StorageError>;
+
+    async fn delete_class(
+        &self,
+        target: &ResolvedClassTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError>;
+}

--- a/src/storage/collections.rs
+++ b/src/storage/collections.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use crate::events::EventContext;
 use crate::models::{Collection, CollectionID, NewCollectionWithAssignee, UpdateCollection};
 
-use super::StorageError;
+use super::{ClassStore, StorageError};
 
 /// Persistence capability for the core collection lifecycle.
 ///
@@ -50,9 +50,9 @@ pub trait CollectionStore: Send + Sync {
 
 /// Umbrella storage boundary. New aggregate capabilities can be added here as
 /// vertical slices migrate without exposing a database pool to services.
-pub trait Storage: CollectionStore {}
+pub trait Storage: CollectionStore + ClassStore {}
 
-impl<T> Storage for T where T: CollectionStore {}
+impl<T> Storage for T where T: CollectionStore + ClassStore {}
 
 #[derive(Clone)]
 pub struct DynStorage {

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -7,10 +7,12 @@ use tokio::sync::RwLock;
 
 use crate::events::{Action, EventContext};
 use crate::models::{
-    Collection, CollectionID, NewCollectionWithAssignee, ResourceRevision, UpdateCollection,
+    ClassSelector, ClassSelectorKind, Collection, CollectionID, HubuumClass,
+    NewCollectionWithAssignee, NewHubuumClass, ResolvedClassTarget, ResourceRevision,
+    UpdateCollection, UpdateHubuumClass,
 };
 
-use super::{CollectionStore, StorageError};
+use super::{ClassStore, CollectionStore, StorageError};
 
 const ROOT_COLLECTION_ID: i32 = 1;
 
@@ -21,10 +23,20 @@ pub(crate) struct MemoryCollectionEvent {
     pub(crate) context: EventContext,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct MemoryClassEvent {
+    pub(crate) class_id: i32,
+    pub(crate) action: Action,
+    pub(crate) context: EventContext,
+}
+
 struct MemoryState {
     next_collection_id: i32,
+    next_class_id: i32,
     collections: BTreeMap<i32, Collection>,
+    classes: BTreeMap<i32, HubuumClass>,
     events: Vec<MemoryCollectionEvent>,
+    class_events: Vec<MemoryClassEvent>,
 }
 
 impl MemoryState {
@@ -41,8 +53,11 @@ impl MemoryState {
         };
         Self {
             next_collection_id: ROOT_COLLECTION_ID + 1,
+            next_class_id: 1,
             collections: BTreeMap::from([(root.id, root)]),
+            classes: BTreeMap::new(),
             events: Vec::new(),
+            class_events: Vec::new(),
         }
     }
 
@@ -58,9 +73,48 @@ impl MemoryState {
             .any(|collection| collection.name == name && Some(collection.id) != except_id)
     }
 
+    fn class_name_in_use(&self, name: &str, except_id: Option<i32>) -> bool {
+        self.classes
+            .values()
+            .any(|class| class.name == name && Some(class.id) != except_id)
+    }
+
+    fn class_for_selector(&self, selector: &ClassSelector) -> Result<&HubuumClass, StorageError> {
+        match selector.kind() {
+            ClassSelectorKind::ById(class_id) => self.classes.get(&class_id.id()),
+            ClassSelectorKind::ByName(class_name) => self
+                .classes
+                .values()
+                .find(|class| class.name == *class_name),
+        }
+        .ok_or_else(|| StorageError::not_found("Class was not found"))
+    }
+
+    fn class_target(&self, target: &ResolvedClassTarget) -> Result<&HubuumClass, StorageError> {
+        let current = self.class_for_selector(target.selector())?;
+        let resolved = target.class();
+        if current.id != resolved.id
+            || current.name != resolved.name
+            || current.collection_id != resolved.collection_id
+        {
+            return Err(StorageError::not_found(
+                "Class no longer matches the resolved route target",
+            ));
+        }
+        Ok(current)
+    }
+
     fn record_event(&mut self, collection_id: i32, action: Action, context: &EventContext) {
         self.events.push(MemoryCollectionEvent {
             collection_id,
+            action,
+            context: context.clone(),
+        });
+    }
+
+    fn record_class_event(&mut self, class_id: i32, action: Action, context: &EventContext) {
+        self.class_events.push(MemoryClassEvent {
+            class_id,
             action,
             context: context.clone(),
         });
@@ -82,6 +136,10 @@ impl MemoryStorage {
 
     pub(crate) async fn events(&self) -> Vec<MemoryCollectionEvent> {
         self.state.read().await.events.clone()
+    }
+
+    pub(crate) async fn class_events(&self) -> Vec<MemoryClassEvent> {
+        self.state.read().await.class_events.clone()
     }
 }
 
@@ -191,6 +249,9 @@ impl CollectionStore for MemoryStorage {
             ));
         }
         state.collections.remove(&id.id());
+        state
+            .classes
+            .retain(|_, class| class.collection_id != id.id());
         state.record_event(id.id(), Action::Deleted, context);
         Ok(())
     }
@@ -274,5 +335,126 @@ impl CollectionStore for MemoryStorage {
         let moved = collection.clone();
         state.record_event(id.id(), Action::Updated, context);
         Ok(moved)
+    }
+}
+
+#[async_trait]
+impl ClassStore for MemoryStorage {
+    async fn resolve_class(
+        &self,
+        selector: ClassSelector,
+    ) -> Result<ResolvedClassTarget, StorageError> {
+        let state = self.state.read().await;
+        let class = state.class_for_selector(&selector)?.clone();
+        Ok(ResolvedClassTarget::new(selector, class))
+    }
+
+    async fn create_class(
+        &self,
+        command: NewHubuumClass,
+        context: &EventContext,
+    ) -> Result<HubuumClass, StorageError> {
+        command.validate_schema().map_err(StorageError::from)?;
+        let mut state = self.state.write().await;
+        if state.class_name_in_use(&command.name, None) {
+            return Err(StorageError::conflict(format!(
+                "A class named '{}' already exists",
+                command.name
+            )));
+        }
+        if !state.collections.contains_key(&command.collection_id) {
+            return Err(StorageError::not_found(format!(
+                "Collection {} was not found",
+                command.collection_id
+            )));
+        }
+
+        let id = state.next_class_id;
+        state.next_class_id += 1;
+        let now = Utc::now().naive_utc();
+        let class = HubuumClass {
+            id,
+            name: command.name,
+            collection_id: command.collection_id,
+            json_schema: command.json_schema,
+            validate_schema: command.validate_schema.unwrap_or(false),
+            description: command.description,
+            created_at: now,
+            updated_at: now,
+            revision: ResourceRevision::INITIAL,
+        };
+        state.classes.insert(id, class.clone());
+        state.record_class_event(id, Action::Created, context);
+        Ok(class)
+    }
+
+    async fn update_class(
+        &self,
+        target: &ResolvedClassTarget,
+        changes: UpdateHubuumClass,
+        context: &EventContext,
+    ) -> Result<HubuumClass, StorageError> {
+        let mut state = self.state.write().await;
+        let current = state.class_target(target)?.clone();
+        changes
+            .validate_schema_update(&current)
+            .map_err(StorageError::from)?;
+        if !changes.has_changes(&current) {
+            return Ok(current);
+        }
+        if let Some(name) = changes.name.as_deref()
+            && state.class_name_in_use(name, Some(current.id))
+        {
+            return Err(StorageError::conflict(format!(
+                "A class named '{name}' already exists"
+            )));
+        }
+        if let Some(collection_id) = changes.collection_id
+            && !state.collections.contains_key(&collection_id)
+        {
+            return Err(StorageError::not_found(format!(
+                "Collection {collection_id} was not found"
+            )));
+        }
+
+        let class = state
+            .classes
+            .get_mut(&current.id)
+            .expect("class existence was checked");
+        if let Some(name) = changes.name {
+            class.name = name;
+        }
+        if let Some(collection_id) = changes.collection_id {
+            class.collection_id = collection_id;
+        }
+        if let Some(json_schema) = changes.json_schema {
+            class.json_schema = Some(json_schema);
+        }
+        if let Some(validate_schema) = changes.validate_schema {
+            class.validate_schema = validate_schema;
+        }
+        if let Some(description) = changes.description {
+            class.description = description;
+        }
+        class.updated_at = Utc::now().naive_utc();
+        class.revision = class
+            .revision
+            .checked_advance()
+            .map_err(StorageError::from)?;
+        let updated = class.clone();
+        state.record_class_event(updated.id, Action::Updated, context);
+        Ok(updated)
+    }
+
+    async fn delete_class(
+        &self,
+        target: &ResolvedClassTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        let mut state = self.state.write().await;
+        let class = state.class_target(target)?.clone();
+        state.classes.remove(&class.id);
+        state.record_class_event(class.id, Action::Deleted, context);
+        Ok(())
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,9 +1,11 @@
+mod classes;
 mod collections;
 mod error;
 #[cfg(test)]
 mod memory;
 mod postgres;
 
+pub use classes::ClassStore;
 pub use collections::{CollectionStore, DynStorage, Storage};
 pub use error::StorageError;
 #[cfg(test)]

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -2,15 +2,22 @@ use async_trait::async_trait;
 
 use crate::db::DbPool;
 use crate::db::traits::GetCollection;
+use crate::db::traits::class::{
+    CreateClassRecord, DeleteResolvedClassRecord, ResolveClassSelectorRecord,
+    UpdateResolvedClassRecord,
+};
 use crate::db::traits::collection::{
     DeleteCollectionRecord, SaveCollectionWithAssigneeRecord, UpdateCollectionRecord,
     collection_ancestors_from_backend, collection_children_from_backend,
     move_collection_record_from_backend,
 };
 use crate::events::EventContext;
-use crate::models::{Collection, CollectionID, NewCollectionWithAssignee, UpdateCollection};
+use crate::models::{
+    ClassSelector, Collection, CollectionID, HubuumClass, NewCollectionWithAssignee,
+    NewHubuumClass, ResolvedClassTarget, UpdateCollection, UpdateHubuumClass,
+};
 
-use super::{CollectionStore, StorageError};
+use super::{ClassStore, CollectionStore, StorageError};
 
 /// Canonical production storage adapter.
 #[derive(Clone)]
@@ -87,6 +94,55 @@ impl CollectionStore for PostgresStorage {
         context: &EventContext,
     ) -> Result<Collection, StorageError> {
         move_collection_record_from_backend(&self.pool, id.id(), new_parent_id.id(), Some(context))
+            .await
+            .map_err(StorageError::from)
+    }
+}
+
+#[async_trait]
+impl ClassStore for PostgresStorage {
+    async fn resolve_class(
+        &self,
+        selector: ClassSelector,
+    ) -> Result<ResolvedClassTarget, StorageError> {
+        let class = selector
+            .resolve_class_selector_record(&self.pool)
+            .await
+            .map_err(StorageError::from)?;
+        Ok(ResolvedClassTarget::new(selector, class))
+    }
+
+    async fn create_class(
+        &self,
+        command: NewHubuumClass,
+        context: &EventContext,
+    ) -> Result<HubuumClass, StorageError> {
+        command.validate_schema().map_err(StorageError::from)?;
+        command
+            .create_class_record(&self.pool, Some(context))
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn update_class(
+        &self,
+        target: &ResolvedClassTarget,
+        changes: UpdateHubuumClass,
+        context: &EventContext,
+    ) -> Result<HubuumClass, StorageError> {
+        changes
+            .update_resolved_class_record(&self.pool, target, context)
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn delete_class(
+        &self,
+        target: &ResolvedClassTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        target
+            .delete_resolved_class_record(&self.pool, context)
             .await
             .map_err(StorageError::from)
     }

--- a/src/tests/storage_performance.rs
+++ b/src/tests/storage_performance.rs
@@ -18,8 +18,9 @@ use crate::events::EventContext;
 use crate::models::collection::effective_group_on;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
-    CollectionID, GroupID, NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation,
-    NewHubuumObject, NewHubuumObjectRelation, UpdateCollection, UserID,
+    ClassSelector, CollectionID, GroupID, HubuumClassID, NewCollectionWithAssignee, NewHubuumClass,
+    NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, UpdateCollection,
+    UpdateHubuumClass, UserID,
 };
 use crate::services::Services;
 use crate::tests::{TestScope, ensure_admin_user};
@@ -158,6 +159,127 @@ async fn collection_point_read_uses_one_query() {
     assert_eq!(queries.queries_matching("FROM \"collections\""), 1);
 
     fixture.cleanup().await.expect("fixture cleanup");
+}
+
+#[actix_web::test]
+async fn class_storage_query_budget_point_read_uses_one_query() {
+    let scope = TestScope::new();
+    let fixture = scope
+        .collection_fixture("query_budget_class_point_read")
+        .await;
+    let services = Services::postgres(scope.pool.get_ref().clone());
+    let class = NewHubuumClass {
+        name: scope.scoped_name("query_budget_class_point_read"),
+        collection_id: fixture.collection.id,
+        json_schema: None,
+        validate_schema: None,
+        description: "class point read query budget".to_string(),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("class fixture should save");
+
+    let (loaded, queries) = capture_queries(services.classes().resolve(ClassSelector::by_id(
+        HubuumClassID::new(class.id).expect("valid class id"),
+    )))
+    .await;
+    assert_eq!(loaded.expect("class should load").class(), &class);
+    assert_eq!(queries.total_queries(), 1, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 1);
+    assert_eq!(queries.control_queries(), 0);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(queries.queries_matching("FROM \"hubuumclass\""), 1);
+
+    class
+        .delete_without_events(&scope.pool)
+        .await
+        .expect("class fixture cleanup");
+    fixture.cleanup().await.expect("collection fixture cleanup");
+}
+
+#[actix_web::test]
+async fn class_storage_query_budget_create_with_event_is_fixed() {
+    let scope = TestScope::new();
+    let fixture = scope.collection_fixture("query_budget_class_create").await;
+    let services = Services::postgres(scope.pool.get_ref().clone());
+    let command = NewHubuumClass {
+        name: scope.scoped_name("query_budget_class_create"),
+        collection_id: fixture.collection.id,
+        json_schema: None,
+        validate_schema: None,
+        description: "class create query budget".to_string(),
+    };
+
+    let (created, queries) =
+        capture_queries(services.classes().create(command, &EventContext::system())).await;
+    let created = created.expect("class should save with an event");
+    assert_eq!(queries.total_queries(), 4, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 2);
+    assert_eq!(queries.control_queries(), 2);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(queries.queries_matching("INSERT INTO \"hubuumclass\""), 1);
+    assert_eq!(queries.queries_matching("INSERT INTO \"events\""), 1);
+
+    created
+        .delete_without_events(&scope.pool)
+        .await
+        .expect("class cleanup");
+    fixture.cleanup().await.expect("collection fixture cleanup");
+}
+
+#[actix_web::test]
+async fn class_storage_query_budget_no_op_avoids_writes_and_events() {
+    let scope = TestScope::new();
+    let fixture = scope.collection_fixture("query_budget_class_no_op").await;
+    let services = Services::postgres(scope.pool.get_ref().clone());
+    let class = NewHubuumClass {
+        name: scope.scoped_name("query_budget_class_no_op"),
+        collection_id: fixture.collection.id,
+        json_schema: None,
+        validate_schema: None,
+        description: "class no-op query budget".to_string(),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("class fixture should save");
+    let target = services
+        .classes()
+        .resolve(ClassSelector::by_id(
+            HubuumClassID::new(class.id).expect("valid class id"),
+        ))
+        .await
+        .expect("class fixture should resolve");
+    let update = UpdateHubuumClass {
+        name: Some(class.name.clone()),
+        collection_id: Some(class.collection_id),
+        json_schema: None,
+        validate_schema: Some(class.validate_schema),
+        description: Some(class.description.clone()),
+    };
+
+    let (updated, queries) = capture_queries(services.classes().update(
+        &target,
+        update,
+        &EventContext::system(),
+    ))
+    .await;
+    assert_eq!(updated.expect("no-op update should succeed"), class);
+    assert_eq!(queries.total_queries(), 4, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 2);
+    assert_eq!(queries.control_queries(), 2);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(
+        queries.queries_matching("SELECT hubuum_assert_revision_precondition"),
+        1
+    );
+    assert_eq!(queries.queries_matching("UPDATE \"hubuumclass\""), 0);
+    assert_eq!(queries.queries_matching("INSERT INTO \"events\""), 0);
+
+    class
+        .delete_without_events(&scope.pool)
+        .await
+        .expect("class cleanup");
+    fixture.cleanup().await.expect("collection fixture cleanup");
 }
 
 #[actix_web::test]


### PR DESCRIPTION
## Stack

Depends on #284, which introduces the service/storage foundation and collection pilot. GitHub tracks both pull requests as stack #286; review this PR against `agent/backend-query-baselines`.

## Summary

- add an application-facing `ClassService` and aggregate-shaped `ClassStore` capability
- implement class resolution and lifecycle behavior in the PostgreSQL and test-only memory adapters
- route ID- and name-addressed class resolution, creation, update, and deletion through the new boundary
- preserve selector-aware mutation safety by carrying resolved route targets into the PostgreSQL transaction
- add shared PostgreSQL/memory contracts for resolution, revisions, no-op updates, collection moves and cascades, schema validation, stale name targets, deletion, and lifecycle events
- add exact PostgreSQL query budgets for class point reads, eventful creates, and no-op updates
- bound contract-test pool usage so the expanded parallel suite stays within the database connection budget
- update the service/storage boundary documentation for the class slice

## Why

PR #284 establishes the boundary with collections. This dependent slice demonstrates that the same capability-oriented design can support another aggregate without exposing `DbPool` or Diesel helpers to high-level class handlers.

Class resolution is deliberately included with lifecycle mutations because name-addressed routes must retain their current concurrency guarantee: a target authorized by name must still match that name when the row is locked for mutation.

## Behavior and design notes

Production behavior remains backed by the existing PostgreSQL queries and transactions. Schema validation, revision preconditions, lifecycle-event atomicity, collection foreign keys and cascades, and stale selector rejection are preserved.

The memory adapter models the logical contract but does not claim parity for PostgreSQL row locking, triggers, or temporal history. Class list/search, permissions, history, imports, restores, and SQL-heavy reporting remain on the compatibility path.

There are no HTTP API or schema changes.

Part of #27.

## Changelog

No changelog entry: this is an internal architecture refactor with no user-facing behavior or API change.

## Verification

- `source .env && ./run_tests.sh`
- `source .env && ./run_tests.sh contract_ -- --nocapture`
- `source .env && ./run_tests.sh class_storage_query_budget_ -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `./scripts/test-classify-ci-changes.sh`
- `git diff --check`