### PR TITLE
Add object service and storage boundary

### DIFF
--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -5,8 +5,8 @@ Diesel details. PostgreSQL remains the production semantic reference; the goal
 is a compile-time dependency boundary and faster contract tests, not generic
 multi-database support.
 
-The first migrated capabilities cover the core collection and class lifecycles.
-Collections include:
+The first migrated capabilities cover the core collection, class, and object
+lifecycles. Collections include:
 
 - point reads;
 - create with an initial assignee grant and lifecycle event;
@@ -23,29 +23,37 @@ Classes include:
 - selector-aware mutations that reject stale name targets; and
 - delete with a lifecycle event.
 
+Objects include:
+
+- explicit point resolution by class/object ID or class/object name;
+- create within a resolved class, including JSON Schema validation;
+- update and atomic JSON Patch, including revision-preserving no-ops;
+- selector-aware mutations that reject stale class or object names; and
+- delete with a lifecycle event.
+
 ## Dependency direction
 
 ```text
-collection/class HTTP handlers
+collection/class/object HTTP handlers
+                 |
+                 v
+ CollectionService / ClassService / ObjectService
+                 |
+                 v
+   CollectionStore / ClassStore / ObjectStore
+              /       \
+             v         v
+       PostgreSQL    memory
+        adapter      adapter
              |
              v
- CollectionService / ClassService
-             |
-             v
-   CollectionStore / ClassStore
-          /       \
-         v         v
-   PostgreSQL    memory
-    adapter      adapter
-         |
-         v
-existing Diesel transactions and queries
+    existing Diesel transactions and queries
 ```
 
 `AppContext` constructs `Services` with `PostgresStorage` in production. Core
-collection and class handlers call their services; they do not choose a Diesel
-query or transaction helper for migrated operations. Permission checks remain
-at the handler boundary.
+collection, class, and object handlers call their services; they do not choose
+a Diesel query or transaction helper for migrated operations. Permission
+checks remain at the handler boundary.
 
 ## Responsibility split
 
@@ -62,17 +70,18 @@ atomic lifecycle events.
 and transaction implementation. `PostgresStorage` delegates to these existing
 operations without changing their query shape.
 
-`MemoryStorage` is compiled for tests and implements the logical collection and
-class contracts. It models hierarchy, selector resolution, schema validation,
-revisions, no-op updates, delete constraints, and lifecycle event occurrence.
-It does not claim PostgreSQL locking, trigger, permission-row, or
+`MemoryStorage` is compiled for tests and implements the logical collection,
+class, and object contracts. It models hierarchy, selector resolution, schema
+validation, bounded JSON Patch behavior, revisions, no-op updates, delete
+constraints, cascades, and lifecycle event occurrence. It does not claim
+PostgreSQL locking, trigger, computed-field materialization, permission-row, or
 temporal-history equivalence.
 
 ## Contract and performance gates
 
-The shared contract suite runs each migrated collection and class behavior
-against both PostgreSQL and memory. Each test focuses on one behavior so
-backend differences cannot be hidden inside a large scenario.
+The shared contract suite runs each migrated collection, class, and object
+behavior against both PostgreSQL and memory. Each test focuses on one behavior
+so backend differences cannot be hidden inside a large scenario.
 
 The PostgreSQL query-capture tests exercise both services and retain exact
 point-read and mutation budgets. The opt-in PostgreSQL Criterion benchmark also
@@ -82,10 +91,11 @@ application-side pagination.
 
 ## Current migration boundary
 
-This is an incremental migration. Collection and class list/search, permission
-management, history, and unrelated aggregates still use `BackendContext` and
-the existing model/database traits. Existing direct persistence APIs also
-remain for fixtures, imports, restore paths, and unmigrated callers.
+This is an incremental migration. Collection, class, and object list/search,
+computed-field enrichment, permission management, relation lifecycles, graph
+traversal, history, and unrelated aggregates still use `BackendContext` and the
+existing model/database traits. Existing direct persistence APIs also remain
+for fixtures, imports, restore paths, and unmigrated callers.
 
 When expanding the boundary:
 

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -38,10 +38,6 @@ use crate::permissions::{
     authorize_resources,
 };
 
-use crate::models::traits::{
-    CreateObjectInResolvedClass, DeleteResolvedObject, PatchObjectData, ResolveObjectTarget,
-    UpdateResolvedObject,
-};
 use crate::models::{
     ClassGraphRow, ClassSelector, CollectionID, GroupPermission, HistoryAuthorizationSnapshot,
     HubuumClass, HubuumClassExpanded, HubuumClassHistory, HubuumClassID, HubuumClassRelation,

--- a/src/api/v1/handlers/classes/class_objects.rs
+++ b/src/api/v1/handlers/classes/class_objects.rs
@@ -303,8 +303,8 @@ async fn create_object_in_resolved_class(
         target.class()
     );
     let event_context = requestor.event_context(req);
-    object
-        .create_object_in_resolved_class(pool, &target, &event_context)
+    pool.object_service()
+        .create(&target, object, &event_context)
         .await
 }
 
@@ -380,8 +380,9 @@ async fn get_object_in_class(
         object_id = object_id.id()
     );
 
-    let target = ObjectSelector::by_id(class_id, object_id)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
     read_resolved_object(&pool, &requestor, &req, target).await
 }
@@ -413,8 +414,9 @@ async fn get_object_in_class_by_name(
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_name, object_name) = paths.into_inner();
-    let target = ObjectSelector::by_name(class_name, object_name)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
     read_resolved_object(&pool, &requestor, &req, target).await
 }
@@ -439,7 +441,8 @@ async fn apply_resolved_object_update(
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,
-        update.update_resolved_object(pool, &target, &event_context),
+        pool.object_service()
+            .update(&target, update, &event_context),
     )
     .await
 }
@@ -480,8 +483,9 @@ async fn patch_object_in_class(
         object_id = object_id.id()
     );
 
-    let target = ObjectSelector::by_id(class_id, object_id)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
     let object = apply_resolved_object_update(&pool, &requestor, &req, target, object_data).await?;
     ApiResponse::ok_revisioned(object)
@@ -516,8 +520,9 @@ async fn patch_object_in_class_by_name(
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_name, object_name) = paths.into_inner();
-    let target = ObjectSelector::by_name(class_name, object_name)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
     let object = apply_resolved_object_update(
         &pool,
@@ -552,7 +557,8 @@ async fn apply_object_data_patch(
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,
-        patch.patch_object_data(pool, &target, &event_context),
+        pool.object_service()
+            .patch_data(&target, patch, &event_context),
     )
     .await
 }
@@ -604,8 +610,9 @@ async fn patch_object_data_in_class(
         object_id = object_id.id()
     );
 
-    let target = ObjectSelector::by_id(class_id, object_id)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
     let object =
         apply_object_data_patch(&pool, &requestor, &req, target, patch.into_inner()).await?;
@@ -651,8 +658,9 @@ async fn patch_object_data_by_name_in_class(
 ) -> Result<impl Responder, ApiError> {
     let user = &requestor.principal;
     let (class_name, object_name) = paths.into_inner();
-    let target = ObjectSelector::by_name(class_name, object_name)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
 
     debug!(
@@ -686,7 +694,7 @@ async fn delete_resolved_object(
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,
-        target.delete_resolved_object(pool, &event_context),
+        pool.object_service().delete(&target, &event_context),
     )
     .await?;
     Ok(etag)
@@ -724,8 +732,9 @@ async fn delete_object_in_class(
         object_id = object_id.id()
     );
 
-    let target = ObjectSelector::by_id(class_id, object_id)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
     let etag = delete_resolved_object(&pool, &requestor, &req, target).await?;
     Ok(ApiResponse::no_content_with_etag(etag))
@@ -757,8 +766,9 @@ async fn delete_object_in_class_by_name(
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_name, object_name) = paths.into_inner();
-    let target = ObjectSelector::by_name(class_name, object_name)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
     let etag = delete_resolved_object(&pool, &requestor, &req, target).await?;
     Ok(ApiResponse::no_content_with_etag(etag))

--- a/src/api/v1/handlers/classes/object_related.rs
+++ b/src/api/v1/handlers/classes/object_related.rs
@@ -28,8 +28,9 @@ async fn get_related_objects(
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_id, object_id) = paths.into_inner();
-    let target = ObjectSelector::by_id(class_id, object_id)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
     read_related_objects(pool, requestor, target, req).await
 }
@@ -61,8 +62,9 @@ async fn get_related_objects_by_name(
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_name, object_name) = paths.into_inner();
-    let target = ObjectSelector::by_name(class_name, object_name)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
     read_related_objects(pool, requestor, target, req).await
 }
@@ -154,8 +156,9 @@ async fn get_related_object_relations(
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_id, object_id) = paths.into_inner();
-    let target = ObjectSelector::by_id(class_id, object_id)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
     read_related_object_relations(pool, requestor, target, req).await
 }
@@ -185,8 +188,9 @@ async fn get_related_object_relations_by_name(
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_name, object_name) = paths.into_inner();
-    let target = ObjectSelector::by_name(class_name, object_name)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
     read_related_object_relations(pool, requestor, target, req).await
 }
@@ -297,8 +301,9 @@ async fn get_related_object_graph(
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_id, object_id) = paths.into_inner();
-    let target = ObjectSelector::by_id(class_id, object_id)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
     read_related_object_graph(pool, requestor, target, req).await
 }
@@ -328,8 +333,9 @@ async fn get_related_object_graph_by_name(
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_name, object_name) = paths.into_inner();
-    let target = ObjectSelector::by_name(class_name, object_name)
-        .resolve_object_target(&pool)
+    let target = pool
+        .object_service()
+        .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
     read_related_object_graph(pool, requestor, target, req).await
 }

--- a/src/permissions/context.rs
+++ b/src/permissions/context.rs
@@ -8,7 +8,7 @@ use futures_util::future::{Ready, ready};
 use crate::config::get_config;
 use crate::db::DbPool;
 use crate::errors::ApiError;
-use crate::services::{ClassService, CollectionService, Services};
+use crate::services::{ClassService, CollectionService, ObjectService, Services};
 use crate::traits::BackendContext;
 
 use super::backend::PermissionBackend;
@@ -52,6 +52,10 @@ impl AppContext {
 
     pub fn class_service(&self) -> &ClassService {
         self.services.classes()
+    }
+
+    pub fn object_service(&self) -> &ObjectService {
+        self.services.objects()
     }
 }
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,8 +1,10 @@
 mod classes;
 mod collections;
+mod objects;
 
 pub use classes::ClassService;
 pub use collections::CollectionService;
+pub use objects::ObjectService;
 
 use crate::db::DbPool;
 use crate::storage::{DynStorage, PostgresStorage};
@@ -38,6 +40,7 @@ pub(crate) fn storage_contract_prefix(label: &str) -> String {
 pub struct Services {
     classes: ClassService,
     collections: CollectionService,
+    objects: ObjectService,
 }
 
 impl Services {
@@ -48,7 +51,8 @@ impl Services {
     pub(crate) fn from_storage(storage: DynStorage) -> Self {
         Self {
             classes: ClassService::new(storage.clone()),
-            collections: CollectionService::new(storage),
+            collections: CollectionService::new(storage.clone()),
+            objects: ObjectService::new(storage),
         }
     }
 
@@ -58,5 +62,9 @@ impl Services {
 
     pub fn collections(&self) -> &CollectionService {
         &self.collections
+    }
+
+    pub fn objects(&self) -> &ObjectService {
+        &self.objects
     }
 }

--- a/src/services/objects.rs
+++ b/src/services/objects.rs
@@ -1,0 +1,630 @@
+use crate::errors::ApiError;
+use crate::events::EventContext;
+use crate::models::{
+    HubuumObject, NewHubuumObject, ObjectDataPatchDocument, ObjectSelector, ResolvedClassTarget,
+    ResolvedObjectTarget, UpdateHubuumObject,
+};
+use crate::storage::DynStorage;
+
+/// Application-facing object resolution and lifecycle use cases.
+#[derive(Clone)]
+pub struct ObjectService {
+    storage: DynStorage,
+}
+
+impl ObjectService {
+    pub(crate) fn new(storage: DynStorage) -> Self {
+        Self { storage }
+    }
+
+    pub async fn resolve(
+        &self,
+        selector: ObjectSelector,
+    ) -> Result<ResolvedObjectTarget, ApiError> {
+        self.storage
+            .inner()
+            .resolve_object(selector)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn create(
+        &self,
+        class: &ResolvedClassTarget,
+        command: NewHubuumObject,
+        context: &EventContext,
+    ) -> Result<HubuumObject, ApiError> {
+        self.storage
+            .inner()
+            .create_object(class, command, context)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn update(
+        &self,
+        target: &ResolvedObjectTarget,
+        changes: UpdateHubuumObject,
+        context: &EventContext,
+    ) -> Result<HubuumObject, ApiError> {
+        self.storage
+            .inner()
+            .update_object(target, changes, context)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn patch_data(
+        &self,
+        target: &ResolvedObjectTarget,
+        patch: ObjectDataPatchDocument,
+        context: &EventContext,
+    ) -> Result<HubuumObject, ApiError> {
+        self.storage
+            .inner()
+            .patch_object_data(target, patch, context)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn delete(
+        &self,
+        target: &ResolvedObjectTarget,
+        context: &EventContext,
+    ) -> Result<(), ApiError> {
+        self.storage
+            .inner()
+            .delete_object(target, context)
+            .await
+            .map_err(ApiError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use serde_json::json;
+
+    use crate::errors::ApiError;
+    use crate::events::{Action, EventContext};
+    use crate::models::{
+        ClassSelector, CollectionID, GroupID, HubuumClass, HubuumClassID, HubuumObject,
+        HubuumObjectID, NewCollectionWithAssignee, NewGroup, NewHubuumClass, NewHubuumObject,
+        ObjectDataPatchDocument, ObjectSelector, UpdateHubuumObject,
+    };
+    use crate::services::{
+        ClassService, Services, storage_contract_pool, storage_contract_postgres_permit,
+        storage_contract_prefix,
+    };
+    use crate::storage::{DynStorage, MemoryStorage, PostgresStorage};
+    use crate::tests::CollectionFixture;
+    use crate::traits::CanSave;
+
+    use super::ObjectService;
+
+    #[derive(Clone, Copy, Debug)]
+    enum ContractBackend {
+        Memory,
+        Postgres,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum ObjectAddress {
+        Id,
+        Name,
+    }
+
+    struct ContractHarness {
+        service: ObjectService,
+        classes: ClassService,
+        class: HubuumClass,
+        prefix: String,
+        postgres_cleanup: Option<CollectionFixture>,
+        _postgres_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    }
+
+    impl ContractHarness {
+        async fn new(backend: ContractBackend, label: &str) -> Self {
+            match backend {
+                ContractBackend::Memory => {
+                    let services = Services::from_storage(DynStorage::new(MemoryStorage::new()));
+                    let prefix = format!("memory_{label}");
+                    let class = create_class(
+                        services.classes(),
+                        &prefix,
+                        CollectionID::new(1).expect("valid root collection id").id(),
+                        None,
+                    )
+                    .await;
+                    Self {
+                        service: services.objects().clone(),
+                        classes: services.classes().clone(),
+                        class,
+                        prefix,
+                        postgres_cleanup: None,
+                        _postgres_permit: None,
+                    }
+                }
+                ContractBackend::Postgres => {
+                    let permit = storage_contract_postgres_permit().await;
+                    let pool = storage_contract_pool();
+                    let prefix = storage_contract_prefix(label);
+                    let owner_group = NewGroup {
+                        identity_scope: None,
+                        groupname: format!("{prefix}_owner"),
+                        description: Some("object storage contract owner".to_string()),
+                    }
+                    .save_without_events(&pool)
+                    .await
+                    .expect("contract owner group should save");
+                    let collection = NewCollectionWithAssignee {
+                        name: format!("{prefix}_collection"),
+                        description: "object storage contract collection".to_string(),
+                        group_id: GroupID::new(owner_group.id).expect("valid owner group id"),
+                        parent_collection_id: None,
+                    }
+                    .save_without_events(&pool)
+                    .await
+                    .expect("contract collection should save");
+                    let fixture = CollectionFixture {
+                        pool: pool.clone(),
+                        collection,
+                        owner_group,
+                        prefix: prefix.clone(),
+                    };
+                    let services = Services::from_storage(DynStorage::new(PostgresStorage::new(
+                        pool.get_ref().clone(),
+                    )));
+                    let class =
+                        create_class(services.classes(), &prefix, fixture.collection.id, None)
+                            .await;
+                    Self {
+                        service: services.objects().clone(),
+                        classes: services.classes().clone(),
+                        class,
+                        prefix,
+                        postgres_cleanup: Some(fixture),
+                        _postgres_permit: Some(permit),
+                    }
+                }
+            }
+        }
+
+        async fn create(&self, label: &str, data: serde_json::Value) -> HubuumObject {
+            let target = self
+                .classes
+                .resolve(ClassSelector::by_id(
+                    HubuumClassID::new(self.class.id).expect("valid class id"),
+                ))
+                .await
+                .expect("class should resolve");
+            self.service
+                .create(
+                    &target,
+                    NewHubuumObject {
+                        name: format!("{}_{}", self.prefix, label),
+                        collection_id: self.class.collection_id,
+                        hubuum_class_id: self.class.id,
+                        data,
+                        description: format!("object contract {label}"),
+                    },
+                    &EventContext::system(),
+                )
+                .await
+                .expect("contract object should be created")
+        }
+
+        async fn finish(self) {
+            if let Some(fixture) = self.postgres_cleanup {
+                fixture.cleanup().await.expect("contract fixture cleanup");
+            }
+        }
+    }
+
+    async fn create_class(
+        service: &ClassService,
+        prefix: &str,
+        collection_id: i32,
+        schema: Option<serde_json::Value>,
+    ) -> HubuumClass {
+        service
+            .create(
+                NewHubuumClass {
+                    name: format!("{prefix}_class"),
+                    collection_id,
+                    json_schema: schema.clone(),
+                    validate_schema: Some(schema.is_some()),
+                    description: "object storage contract class".to_string(),
+                },
+                &EventContext::system(),
+            )
+            .await
+            .expect("contract class should be created")
+    }
+
+    fn selector(
+        address: ObjectAddress,
+        class: &HubuumClass,
+        object: &HubuumObject,
+    ) -> ObjectSelector {
+        match address {
+            ObjectAddress::Id => ObjectSelector::by_id(
+                HubuumClassID::new(class.id).expect("valid class id"),
+                HubuumObjectID::new(object.id).expect("valid object id"),
+            ),
+            ObjectAddress::Name => ObjectSelector::by_name(class.name.clone(), object.name.clone()),
+        }
+    }
+
+    fn patch(value: serde_json::Value) -> ObjectDataPatchDocument {
+        serde_json::from_value(value).expect("valid object data patch")
+    }
+
+    #[rstest]
+    #[case::postgres_id(ContractBackend::Postgres, ObjectAddress::Id)]
+    #[case::postgres_name(ContractBackend::Postgres, ObjectAddress::Name)]
+    #[case::memory_id(ContractBackend::Memory, ObjectAddress::Id)]
+    #[case::memory_name(ContractBackend::Memory, ObjectAddress::Name)]
+    #[actix_web::test]
+    async fn object_contract_resolves_explicit_addresses(
+        #[case] backend: ContractBackend,
+        #[case] address: ObjectAddress,
+    ) {
+        let harness = ContractHarness::new(backend, "resolve").await;
+        let object = harness.create("object", json!({"value": 1})).await;
+
+        let resolved = harness
+            .service
+            .resolve(selector(address, &harness.class, &object))
+            .await
+            .expect("object should resolve");
+        assert_eq!(resolved.class(), &harness.class);
+        assert_eq!(resolved.object(), &object);
+
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_contract_changed_update_advances_revision(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "changed_update").await;
+        let object = harness.create("object", json!({"value": 1})).await;
+        let target = harness
+            .service
+            .resolve(selector(ObjectAddress::Id, &harness.class, &object))
+            .await
+            .expect("object should resolve");
+
+        let updated = harness
+            .service
+            .update(
+                &target,
+                UpdateHubuumObject {
+                    name: None,
+                    collection_id: None,
+                    hubuum_class_id: None,
+                    data: None,
+                    description: Some("updated object contract".to_string()),
+                },
+                &EventContext::system(),
+            )
+            .await
+            .expect("object should update");
+        assert_eq!(updated.revision.get(), object.revision.get() + 1);
+
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_contract_no_op_update_preserves_revision(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "no_op_update").await;
+        let object = harness.create("object", json!({"value": 1})).await;
+        let target = harness
+            .service
+            .resolve(selector(ObjectAddress::Id, &harness.class, &object))
+            .await
+            .expect("object should resolve");
+
+        let unchanged = harness
+            .service
+            .update(
+                &target,
+                UpdateHubuumObject {
+                    name: Some(object.name.clone()),
+                    collection_id: Some(object.collection_id),
+                    hubuum_class_id: Some(object.hubuum_class_id),
+                    data: Some(object.data.clone()),
+                    description: Some(object.description.clone()),
+                },
+                &EventContext::system(),
+            )
+            .await
+            .expect("no-op update should return current state");
+        assert_eq!(unchanged, object);
+
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_contract_patch_updates_data_and_revision(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "patch").await;
+        let object = harness.create("object", json!({"value": 1})).await;
+        let target = harness
+            .service
+            .resolve(selector(ObjectAddress::Id, &harness.class, &object))
+            .await
+            .expect("object should resolve");
+
+        let updated = harness
+            .service
+            .patch_data(
+                &target,
+                patch(json!([{"op": "replace", "path": "/value", "value": 2}])),
+                &EventContext::system(),
+            )
+            .await
+            .expect("object data should patch");
+        assert_eq!(updated.data, json!({"value": 2}));
+        assert_eq!(updated.revision.get(), object.revision.get() + 1);
+
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_contract_no_op_patch_preserves_revision(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "no_op_patch").await;
+        let object = harness.create("object", json!({"value": 1})).await;
+        let target = harness
+            .service
+            .resolve(selector(ObjectAddress::Id, &harness.class, &object))
+            .await
+            .expect("object should resolve");
+
+        let unchanged = harness
+            .service
+            .patch_data(
+                &target,
+                patch(json!([{"op": "replace", "path": "/value", "value": 1}])),
+                &EventContext::system(),
+            )
+            .await
+            .expect("no-op patch should return current state");
+        assert_eq!(unchanged, object);
+
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_contract_rejects_data_outside_the_class_schema(
+        #[case] backend: ContractBackend,
+    ) {
+        let mut harness = ContractHarness::new(backend, "schema").await;
+        let schema_class = create_class(
+            &harness.classes,
+            &format!("{}_schema", harness.prefix),
+            harness.class.collection_id,
+            Some(json!({
+                "type": "object",
+                "properties": {"value": {"type": "integer"}},
+                "required": ["value"]
+            })),
+        )
+        .await;
+        harness.class = schema_class.clone();
+        let target = harness
+            .classes
+            .resolve(ClassSelector::by_id(
+                HubuumClassID::new(schema_class.id).expect("valid class id"),
+            ))
+            .await
+            .expect("schema class should resolve");
+
+        assert!(matches!(
+            harness
+                .service
+                .create(
+                    &target,
+                    NewHubuumObject {
+                        name: format!("{}_invalid", harness.prefix),
+                        collection_id: schema_class.collection_id,
+                        hubuum_class_id: schema_class.id,
+                        data: json!({"value": "not an integer"}),
+                        description: "invalid schema object".to_string(),
+                    },
+                    &EventContext::system(),
+                )
+                .await,
+            Err(ApiError::ValidationError(_))
+        ));
+
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_contract_rejects_a_stale_name_target(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "stale_name").await;
+        let object = harness.create("object", json!({"value": 1})).await;
+        let name_target = harness
+            .service
+            .resolve(selector(ObjectAddress::Name, &harness.class, &object))
+            .await
+            .expect("name target should resolve");
+        let id_target = harness
+            .service
+            .resolve(selector(ObjectAddress::Id, &harness.class, &object))
+            .await
+            .expect("id target should resolve");
+        let renamed = harness
+            .service
+            .update(
+                &id_target,
+                UpdateHubuumObject {
+                    name: Some(format!("{}_renamed", harness.prefix)),
+                    collection_id: None,
+                    hubuum_class_id: None,
+                    data: None,
+                    description: None,
+                },
+                &EventContext::system(),
+            )
+            .await
+            .expect("object should rename");
+
+        assert!(matches!(
+            harness
+                .service
+                .update(
+                    &name_target,
+                    UpdateHubuumObject {
+                        name: None,
+                        collection_id: None,
+                        hubuum_class_id: None,
+                        data: None,
+                        description: Some("stale write".to_string()),
+                    },
+                    &EventContext::system(),
+                )
+                .await,
+            Err(ApiError::NotFound(_))
+        ));
+        assert_ne!(renamed.name, object.name);
+
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_contract_delete_removes_the_resolved_object(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "delete").await;
+        let object = harness.create("object", json!({"value": 1})).await;
+        let selector = selector(ObjectAddress::Id, &harness.class, &object);
+        let target = harness
+            .service
+            .resolve(selector.clone())
+            .await
+            .expect("object should resolve");
+
+        harness
+            .service
+            .delete(&target, &EventContext::system())
+            .await
+            .expect("object should delete");
+        assert!(matches!(
+            harness.service.resolve(selector).await,
+            Err(ApiError::NotFound(_))
+        ));
+
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_contract_class_delete_cascades_the_object(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "class_cascade").await;
+        let object = harness.create("object", json!({"value": 1})).await;
+        let object_selector = selector(ObjectAddress::Id, &harness.class, &object);
+        let class_target = harness
+            .classes
+            .resolve(ClassSelector::by_id(
+                HubuumClassID::new(harness.class.id).expect("valid class id"),
+            ))
+            .await
+            .expect("class should resolve");
+
+        harness
+            .classes
+            .delete(&class_target, &EventContext::system())
+            .await
+            .expect("class should delete");
+        assert!(matches!(
+            harness.service.resolve(object_selector).await,
+            Err(ApiError::NotFound(_))
+        ));
+
+        harness.finish().await;
+    }
+
+    #[actix_web::test]
+    async fn memory_object_events_exclude_no_op_mutations() {
+        let storage = MemoryStorage::new();
+        let services = Services::from_storage(DynStorage::new(storage.clone()));
+        let class = create_class(services.classes(), "memory_object_events", 1, None).await;
+        let class_target = services
+            .classes()
+            .resolve(ClassSelector::by_id(
+                HubuumClassID::new(class.id).expect("valid class id"),
+            ))
+            .await
+            .expect("class should resolve");
+        let context = EventContext::system();
+        let object = services
+            .objects()
+            .create(
+                &class_target,
+                NewHubuumObject {
+                    name: "memory_object_event_contract".to_string(),
+                    collection_id: class.collection_id,
+                    hubuum_class_id: class.id,
+                    data: json!({"value": 1}),
+                    description: "memory object event contract".to_string(),
+                },
+                &context,
+            )
+            .await
+            .expect("memory object should create");
+        let target = services
+            .objects()
+            .resolve(selector(ObjectAddress::Id, &class, &object))
+            .await
+            .expect("memory object should resolve");
+        services
+            .objects()
+            .update(
+                &target,
+                UpdateHubuumObject {
+                    name: Some(object.name.clone()),
+                    collection_id: Some(object.collection_id),
+                    hubuum_class_id: Some(object.hubuum_class_id),
+                    data: Some(object.data.clone()),
+                    description: Some(object.description.clone()),
+                },
+                &context,
+            )
+            .await
+            .expect("memory no-op update should succeed");
+        services
+            .objects()
+            .patch_data(
+                &target,
+                patch(json!([{"op": "replace", "path": "/value", "value": 1}])),
+                &context,
+            )
+            .await
+            .expect("memory no-op patch should succeed");
+
+        let events = storage.object_events().await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].action, Action::Created);
+    }
+}

--- a/src/storage/collections.rs
+++ b/src/storage/collections.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use crate::events::EventContext;
 use crate::models::{Collection, CollectionID, NewCollectionWithAssignee, UpdateCollection};
 
-use super::{ClassStore, StorageError};
+use super::{ClassStore, ObjectStore, StorageError};
 
 /// Persistence capability for the core collection lifecycle.
 ///
@@ -50,9 +50,9 @@ pub trait CollectionStore: Send + Sync {
 
 /// Umbrella storage boundary. New aggregate capabilities can be added here as
 /// vertical slices migrate without exposing a database pool to services.
-pub trait Storage: CollectionStore + ClassStore {}
+pub trait Storage: CollectionStore + ClassStore + ObjectStore {}
 
-impl<T> Storage for T where T: CollectionStore + ClassStore {}
+impl<T> Storage for T where T: CollectionStore + ClassStore + ObjectStore {}
 
 #[derive(Clone)]
 pub struct DynStorage {

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -9,8 +9,11 @@ enum StorageErrorKind {
     Database,
     Internal,
     NotFound,
+    NotAcceptable,
+    PayloadTooLarge,
     PreconditionFailed,
     Unavailable,
+    Validation,
 }
 
 /// Backend-neutral failure returned by storage capabilities.
@@ -63,9 +66,17 @@ impl From<ApiError> for StorageError {
         match error {
             ApiError::BadRequest(message)
             | ApiError::InvalidIntegerRange(message)
-            | ApiError::OperatorMismatch(message)
-            | ApiError::ValidationError(message) => {
+            | ApiError::OperatorMismatch(message) => {
                 Self::new(StorageErrorKind::BadRequest, message, None)
+            }
+            ApiError::NotAcceptable(message) => {
+                Self::new(StorageErrorKind::NotAcceptable, message, None)
+            }
+            ApiError::ValidationError(message) => {
+                Self::new(StorageErrorKind::Validation, message, None)
+            }
+            ApiError::PayloadTooLarge(message) => {
+                Self::new(StorageErrorKind::PayloadTooLarge, message, None)
             }
             ApiError::Conflict(message) => Self::new(StorageErrorKind::Conflict, message, None),
             ApiError::DatabaseError(message) | ApiError::DbConnectionError(message) => {
@@ -100,10 +111,13 @@ impl From<StorageError> for ApiError {
             StorageErrorKind::Database => Self::DatabaseError(error.message),
             StorageErrorKind::Internal => Self::InternalServerError(error.message),
             StorageErrorKind::NotFound => Self::NotFound(error.message),
+            StorageErrorKind::NotAcceptable => Self::NotAcceptable(error.message),
+            StorageErrorKind::PayloadTooLarge => Self::PayloadTooLarge(error.message),
             StorageErrorKind::PreconditionFailed => {
                 Self::PreconditionFailed(error.message, error.current_etag)
             }
             StorageErrorKind::Unavailable => Self::ServiceUnavailable(error.message),
+            StorageErrorKind::Validation => Self::ValidationError(error.message),
         }
     }
 }
@@ -115,11 +129,13 @@ mod tests {
     use super::StorageError;
 
     #[test]
-    fn storage_errors_preserve_public_collection_failure_categories() {
+    fn storage_errors_preserve_public_failure_categories() {
         for error in [
             ApiError::BadRequest("invalid move".to_string()),
             ApiError::Conflict("collection has children".to_string()),
             ApiError::NotFound("collection missing".to_string()),
+            ApiError::ValidationError("object schema mismatch".to_string()),
+            ApiError::PayloadTooLarge("object data exceeds its limit".to_string()),
             ApiError::PreconditionFailed(
                 "stale collection".to_string(),
                 Some("\"collection-1-r2\"".to_string()),

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -7,12 +7,13 @@ use tokio::sync::RwLock;
 
 use crate::events::{Action, EventContext};
 use crate::models::{
-    ClassSelector, ClassSelectorKind, Collection, CollectionID, HubuumClass,
-    NewCollectionWithAssignee, NewHubuumClass, ResolvedClassTarget, ResourceRevision,
-    UpdateCollection, UpdateHubuumClass,
+    ClassSelector, ClassSelectorKind, Collection, CollectionID, HubuumClass, HubuumObject,
+    NewCollectionWithAssignee, NewHubuumClass, NewHubuumObject, ObjectDataPatchDocument,
+    ObjectSelector, ObjectSelectorKind, ResolvedClassTarget, ResolvedObjectTarget,
+    ResourceRevision, UpdateCollection, UpdateHubuumClass, UpdateHubuumObject,
 };
 
-use super::{ClassStore, CollectionStore, StorageError};
+use super::{ClassStore, CollectionStore, ObjectStore, StorageError};
 
 const ROOT_COLLECTION_ID: i32 = 1;
 
@@ -30,13 +31,23 @@ pub(crate) struct MemoryClassEvent {
     pub(crate) context: EventContext,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct MemoryObjectEvent {
+    pub(crate) object_id: i32,
+    pub(crate) action: Action,
+    pub(crate) context: EventContext,
+}
+
 struct MemoryState {
     next_collection_id: i32,
     next_class_id: i32,
+    next_object_id: i32,
     collections: BTreeMap<i32, Collection>,
     classes: BTreeMap<i32, HubuumClass>,
+    objects: BTreeMap<i32, HubuumObject>,
     events: Vec<MemoryCollectionEvent>,
     class_events: Vec<MemoryClassEvent>,
+    object_events: Vec<MemoryObjectEvent>,
 }
 
 impl MemoryState {
@@ -54,10 +65,13 @@ impl MemoryState {
         Self {
             next_collection_id: ROOT_COLLECTION_ID + 1,
             next_class_id: 1,
+            next_object_id: 1,
             collections: BTreeMap::from([(root.id, root)]),
             classes: BTreeMap::new(),
+            objects: BTreeMap::new(),
             events: Vec::new(),
             class_events: Vec::new(),
+            object_events: Vec::new(),
         }
     }
 
@@ -104,6 +118,76 @@ impl MemoryState {
         Ok(current)
     }
 
+    fn object_for_selector(
+        &self,
+        selector: &ObjectSelector,
+    ) -> Result<(&HubuumClass, &HubuumObject), StorageError> {
+        let (class, object) = match selector.kind() {
+            ObjectSelectorKind::ById {
+                class_id,
+                object_id,
+            } => {
+                let class = self.classes.get(&class_id.id());
+                let object = self
+                    .objects
+                    .get(&object_id.id())
+                    .filter(|object| object.hubuum_class_id == class_id.id());
+                (class, object)
+            }
+            ObjectSelectorKind::ByName {
+                class_name,
+                object_name,
+            } => {
+                let class = self
+                    .classes
+                    .values()
+                    .find(|class| class.name == *class_name);
+                let object = class.and_then(|class| {
+                    self.objects.values().find(|object| {
+                        object.hubuum_class_id == class.id && object.name == *object_name
+                    })
+                });
+                (class, object)
+            }
+        };
+        match (class, object) {
+            (Some(class), Some(object)) => Ok((class, object)),
+            _ => Err(StorageError::not_found(
+                "Object was not found in the selected class",
+            )),
+        }
+    }
+
+    fn object_target(
+        &self,
+        target: &ResolvedObjectTarget,
+    ) -> Result<(&HubuumClass, &HubuumObject), StorageError> {
+        let (class, object) = self.object_for_selector(target.selector())?;
+        let resolved_class = target.class();
+        let resolved_object = target.object();
+        if class.id != resolved_class.id
+            || class.name != resolved_class.name
+            || class.collection_id != resolved_class.collection_id
+            || object.id != resolved_object.id
+            || object.name != resolved_object.name
+            || object.collection_id != resolved_object.collection_id
+            || object.hubuum_class_id != resolved_object.hubuum_class_id
+        {
+            return Err(StorageError::not_found(
+                "Object no longer matches the resolved route target",
+            ));
+        }
+        Ok((class, object))
+    }
+
+    fn object_name_in_use(&self, class_id: i32, name: &str, except_id: Option<i32>) -> bool {
+        self.objects.values().any(|object| {
+            object.hubuum_class_id == class_id
+                && object.name == name
+                && Some(object.id) != except_id
+        })
+    }
+
     fn record_event(&mut self, collection_id: i32, action: Action, context: &EventContext) {
         self.events.push(MemoryCollectionEvent {
             collection_id,
@@ -115,6 +199,14 @@ impl MemoryState {
     fn record_class_event(&mut self, class_id: i32, action: Action, context: &EventContext) {
         self.class_events.push(MemoryClassEvent {
             class_id,
+            action,
+            context: context.clone(),
+        });
+    }
+
+    fn record_object_event(&mut self, object_id: i32, action: Action, context: &EventContext) {
+        self.object_events.push(MemoryObjectEvent {
+            object_id,
             action,
             context: context.clone(),
         });
@@ -140,6 +232,10 @@ impl MemoryStorage {
 
     pub(crate) async fn class_events(&self) -> Vec<MemoryClassEvent> {
         self.state.read().await.class_events.clone()
+    }
+
+    pub(crate) async fn object_events(&self) -> Vec<MemoryObjectEvent> {
+        self.state.read().await.object_events.clone()
     }
 }
 
@@ -252,6 +348,9 @@ impl CollectionStore for MemoryStorage {
         state
             .classes
             .retain(|_, class| class.collection_id != id.id());
+        state
+            .objects
+            .retain(|_, object| object.collection_id != id.id());
         state.record_event(id.id(), Action::Deleted, context);
         Ok(())
     }
@@ -454,7 +553,145 @@ impl ClassStore for MemoryStorage {
         let mut state = self.state.write().await;
         let class = state.class_target(target)?.clone();
         state.classes.remove(&class.id);
+        state
+            .objects
+            .retain(|_, object| object.hubuum_class_id != class.id);
         state.record_class_event(class.id, Action::Deleted, context);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ObjectStore for MemoryStorage {
+    async fn resolve_object(
+        &self,
+        selector: ObjectSelector,
+    ) -> Result<ResolvedObjectTarget, StorageError> {
+        let state = self.state.read().await;
+        let (class, object) = state.object_for_selector(&selector)?;
+        Ok(ResolvedObjectTarget::new(
+            selector,
+            class.clone(),
+            object.clone(),
+        ))
+    }
+
+    async fn create_object(
+        &self,
+        class: &ResolvedClassTarget,
+        command: NewHubuumObject,
+        context: &EventContext,
+    ) -> Result<HubuumObject, StorageError> {
+        let mut state = self.state.write().await;
+        let current_class = state.class_target(class)?.clone();
+        command
+            .validate_for_class(&current_class)
+            .map_err(StorageError::from)?;
+        if state.object_name_in_use(current_class.id, &command.name, None) {
+            return Err(StorageError::conflict(format!(
+                "An object named '{}' already exists in class {}",
+                command.name, current_class.id
+            )));
+        }
+
+        let id = state.next_object_id;
+        state.next_object_id += 1;
+        let now = Utc::now().naive_utc();
+        let object = HubuumObject {
+            id,
+            name: command.name,
+            collection_id: command.collection_id,
+            hubuum_class_id: command.hubuum_class_id,
+            data: command.data,
+            description: command.description,
+            created_at: now,
+            updated_at: now,
+            revision: ResourceRevision::INITIAL,
+        };
+        state.objects.insert(id, object.clone());
+        state.record_object_event(id, Action::Created, context);
+        Ok(object)
+    }
+
+    async fn update_object(
+        &self,
+        target: &ResolvedObjectTarget,
+        changes: UpdateHubuumObject,
+        context: &EventContext,
+    ) -> Result<HubuumObject, StorageError> {
+        let mut state = self.state.write().await;
+        let (class, current) = state.object_target(target)?;
+        let class = class.clone();
+        let current = current.clone();
+        changes
+            .validate_for_class(&current, &class)
+            .map_err(StorageError::from)?;
+        if !changes.has_changes(&current) {
+            return Ok(current);
+        }
+        if let Some(name) = changes.name.as_deref()
+            && state.object_name_in_use(class.id, name, Some(current.id))
+        {
+            return Err(StorageError::conflict(format!(
+                "An object named '{name}' already exists in class {}",
+                class.id
+            )));
+        }
+
+        let mut updated = current.merge_update(&changes);
+        updated.updated_at = Utc::now().naive_utc();
+        updated.revision = current
+            .revision
+            .checked_advance()
+            .map_err(StorageError::from)?;
+        state.objects.insert(updated.id, updated.clone());
+        state.record_object_event(updated.id, Action::Updated, context);
+        Ok(updated)
+    }
+
+    async fn patch_object_data(
+        &self,
+        target: &ResolvedObjectTarget,
+        patch: ObjectDataPatchDocument,
+        context: &EventContext,
+    ) -> Result<HubuumObject, StorageError> {
+        let mut state = self.state.write().await;
+        let (class, current) = state.object_target(target)?;
+        let class = class.clone();
+        let current = current.clone();
+        let patched_data = patch.apply(&current.data).map_err(StorageError::from)?;
+        if class.validate_schema
+            && let Some(schema) = class.json_schema.as_ref()
+        {
+            crate::utilities::json_schema::validate_json_value(schema, &patched_data)
+                .map_err(StorageError::from)?;
+        }
+        if patched_data == current.data {
+            return Ok(current);
+        }
+
+        let mut updated = current.clone();
+        updated.data = patched_data;
+        updated.updated_at = Utc::now().naive_utc();
+        updated.revision = current
+            .revision
+            .checked_advance()
+            .map_err(StorageError::from)?;
+        state.objects.insert(updated.id, updated.clone());
+        state.record_object_event(updated.id, Action::Updated, context);
+        Ok(updated)
+    }
+
+    async fn delete_object(
+        &self,
+        target: &ResolvedObjectTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        let mut state = self.state.write().await;
+        let (_, object) = state.object_target(target)?;
+        let object_id = object.id;
+        state.objects.remove(&object_id);
+        state.record_object_event(object_id, Action::Deleted, context);
         Ok(())
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,6 +3,7 @@ mod collections;
 mod error;
 #[cfg(test)]
 mod memory;
+mod objects;
 mod postgres;
 
 pub use classes::ClassStore;
@@ -10,4 +11,5 @@ pub use collections::{CollectionStore, DynStorage, Storage};
 pub use error::StorageError;
 #[cfg(test)]
 pub(crate) use memory::MemoryStorage;
+pub use objects::ObjectStore;
 pub use postgres::PostgresStorage;

--- a/src/storage/objects.rs
+++ b/src/storage/objects.rs
@@ -1,0 +1,49 @@
+use async_trait::async_trait;
+
+use crate::events::EventContext;
+use crate::models::{
+    HubuumObject, NewHubuumObject, ObjectDataPatchDocument, ObjectSelector, ResolvedClassTarget,
+    ResolvedObjectTarget, UpdateHubuumObject,
+};
+
+use super::StorageError;
+
+/// Persistence capability for object resolution and lifecycle mutations.
+///
+/// Resolved class and object targets preserve the route-selected address so
+/// implementations can recheck ID- and name-based mutations atomically before
+/// writing.
+#[async_trait]
+pub trait ObjectStore: Send + Sync {
+    async fn resolve_object(
+        &self,
+        selector: ObjectSelector,
+    ) -> Result<ResolvedObjectTarget, StorageError>;
+
+    async fn create_object(
+        &self,
+        class: &ResolvedClassTarget,
+        command: NewHubuumObject,
+        context: &EventContext,
+    ) -> Result<HubuumObject, StorageError>;
+
+    async fn update_object(
+        &self,
+        target: &ResolvedObjectTarget,
+        changes: UpdateHubuumObject,
+        context: &EventContext,
+    ) -> Result<HubuumObject, StorageError>;
+
+    async fn patch_object_data(
+        &self,
+        target: &ResolvedObjectTarget,
+        patch: ObjectDataPatchDocument,
+        context: &EventContext,
+    ) -> Result<HubuumObject, StorageError>;
+
+    async fn delete_object(
+        &self,
+        target: &ResolvedObjectTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError>;
+}

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -11,13 +11,18 @@ use crate::db::traits::collection::{
     collection_ancestors_from_backend, collection_children_from_backend,
     move_collection_record_from_backend,
 };
+use crate::db::traits::object::{
+    CreateObjectInResolvedClassRecord, DeleteResolvedObjectRecord, PatchObjectDataRecord,
+    ResolveObjectSelectorRecord, UpdateResolvedObjectRecord,
+};
 use crate::events::EventContext;
 use crate::models::{
-    ClassSelector, Collection, CollectionID, HubuumClass, NewCollectionWithAssignee,
-    NewHubuumClass, ResolvedClassTarget, UpdateCollection, UpdateHubuumClass,
+    ClassSelector, Collection, CollectionID, HubuumClass, HubuumObject, NewCollectionWithAssignee,
+    NewHubuumClass, NewHubuumObject, ObjectDataPatchDocument, ObjectSelector, ResolvedClassTarget,
+    ResolvedObjectTarget, UpdateCollection, UpdateHubuumClass, UpdateHubuumObject,
 };
 
-use super::{ClassStore, CollectionStore, StorageError};
+use super::{ClassStore, CollectionStore, ObjectStore, StorageError};
 
 /// Canonical production storage adapter.
 #[derive(Clone)]
@@ -143,6 +148,67 @@ impl ClassStore for PostgresStorage {
     ) -> Result<(), StorageError> {
         target
             .delete_resolved_class_record(&self.pool, context)
+            .await
+            .map_err(StorageError::from)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for PostgresStorage {
+    async fn resolve_object(
+        &self,
+        selector: ObjectSelector,
+    ) -> Result<ResolvedObjectTarget, StorageError> {
+        let (class, object) = selector
+            .resolve_object_selector_record(&self.pool)
+            .await
+            .map_err(StorageError::from)?;
+        Ok(ResolvedObjectTarget::new(selector, class, object))
+    }
+
+    async fn create_object(
+        &self,
+        class: &ResolvedClassTarget,
+        command: NewHubuumObject,
+        context: &EventContext,
+    ) -> Result<HubuumObject, StorageError> {
+        command
+            .create_object_in_resolved_class_record(&self.pool, class, context)
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn update_object(
+        &self,
+        target: &ResolvedObjectTarget,
+        changes: UpdateHubuumObject,
+        context: &EventContext,
+    ) -> Result<HubuumObject, StorageError> {
+        changes
+            .update_resolved_object_record(&self.pool, target, context)
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn patch_object_data(
+        &self,
+        target: &ResolvedObjectTarget,
+        patch: ObjectDataPatchDocument,
+        context: &EventContext,
+    ) -> Result<HubuumObject, StorageError> {
+        patch
+            .patch_object_data_record(&self.pool, target, context)
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn delete_object(
+        &self,
+        target: &ResolvedObjectTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        target
+            .delete_resolved_object_record(&self.pool, context)
             .await
             .map_err(StorageError::from)
     }

--- a/src/tests/storage_performance.rs
+++ b/src/tests/storage_performance.rs
@@ -18,9 +18,9 @@ use crate::events::EventContext;
 use crate::models::collection::effective_group_on;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
-    ClassSelector, CollectionID, GroupID, HubuumClassID, NewCollectionWithAssignee, NewHubuumClass,
-    NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, UpdateCollection,
-    UpdateHubuumClass, UserID,
+    ClassSelector, CollectionID, GroupID, HubuumClassID, HubuumObjectID, NewCollectionWithAssignee,
+    NewHubuumClass, NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation,
+    ObjectSelector, UpdateCollection, UpdateHubuumClass, UpdateHubuumObject, UserID,
 };
 use crate::services::Services;
 use crate::tests::{TestScope, ensure_admin_user};
@@ -279,6 +279,158 @@ async fn class_storage_query_budget_no_op_avoids_writes_and_events() {
         .delete_without_events(&scope.pool)
         .await
         .expect("class cleanup");
+    fixture.cleanup().await.expect("collection fixture cleanup");
+}
+
+#[actix_web::test]
+async fn object_storage_query_budget_point_read_uses_one_query() {
+    let scope = TestScope::new();
+    let fixture = scope
+        .collection_fixture("query_budget_object_point_read")
+        .await;
+    let services = Services::postgres(scope.pool.get_ref().clone());
+    let class = NewHubuumClass {
+        name: scope.scoped_name("query_budget_object_point_read_class"),
+        collection_id: fixture.collection.id,
+        json_schema: None,
+        validate_schema: None,
+        description: "object point read query budget class".to_string(),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("class fixture should save");
+    let object = NewHubuumObject {
+        name: scope.scoped_name("query_budget_object_point_read"),
+        collection_id: fixture.collection.id,
+        hubuum_class_id: class.id,
+        data: serde_json::json!({"value": 1}),
+        description: "object point read query budget".to_string(),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("object fixture should save");
+
+    let (loaded, queries) = capture_queries(services.objects().resolve(ObjectSelector::by_id(
+        HubuumClassID::new(class.id).expect("valid class id"),
+        HubuumObjectID::new(object.id).expect("valid object id"),
+    )))
+    .await;
+    assert_eq!(loaded.expect("object should load").object(), &object);
+    assert_eq!(queries.total_queries(), 1, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 1);
+    assert_eq!(queries.control_queries(), 0);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(queries.queries_matching("INNER JOIN \"hubuumclass\""), 1);
+
+    fixture.cleanup().await.expect("collection fixture cleanup");
+}
+
+#[actix_web::test]
+async fn object_storage_query_budget_create_with_event_is_fixed() {
+    let scope = TestScope::new();
+    let fixture = scope.collection_fixture("query_budget_object_create").await;
+    let services = Services::postgres(scope.pool.get_ref().clone());
+    let class = NewHubuumClass {
+        name: scope.scoped_name("query_budget_object_create_class"),
+        collection_id: fixture.collection.id,
+        json_schema: None,
+        validate_schema: None,
+        description: "object create query budget class".to_string(),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("class fixture should save");
+    let class_target = services
+        .classes()
+        .resolve(ClassSelector::by_id(
+            HubuumClassID::new(class.id).expect("valid class id"),
+        ))
+        .await
+        .expect("class fixture should resolve");
+    let command = NewHubuumObject {
+        name: scope.scoped_name("query_budget_object_create"),
+        collection_id: fixture.collection.id,
+        hubuum_class_id: class.id,
+        data: serde_json::json!({"value": 1}),
+        description: "object create query budget".to_string(),
+    };
+
+    let (created, queries) = capture_queries(services.objects().create(
+        &class_target,
+        command,
+        &EventContext::system(),
+    ))
+    .await;
+    created.expect("object should save with an event");
+    assert_eq!(queries.total_queries(), 10, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 8);
+    assert_eq!(queries.control_queries(), 2);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(queries.queries_matching("INSERT INTO \"hubuumobject\""), 1);
+    assert_eq!(queries.queries_matching("INSERT INTO \"events\""), 1);
+
+    fixture.cleanup().await.expect("collection fixture cleanup");
+}
+
+#[actix_web::test]
+async fn object_storage_query_budget_no_op_avoids_object_writes_and_events() {
+    let scope = TestScope::new();
+    let fixture = scope.collection_fixture("query_budget_object_no_op").await;
+    let services = Services::postgres(scope.pool.get_ref().clone());
+    let class = NewHubuumClass {
+        name: scope.scoped_name("query_budget_object_no_op_class"),
+        collection_id: fixture.collection.id,
+        json_schema: None,
+        validate_schema: None,
+        description: "object no-op query budget class".to_string(),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("class fixture should save");
+    let object = NewHubuumObject {
+        name: scope.scoped_name("query_budget_object_no_op"),
+        collection_id: fixture.collection.id,
+        hubuum_class_id: class.id,
+        data: serde_json::json!({"value": 1}),
+        description: "object no-op query budget".to_string(),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("object fixture should save");
+    let target = services
+        .objects()
+        .resolve(ObjectSelector::by_id(
+            HubuumClassID::new(class.id).expect("valid class id"),
+            HubuumObjectID::new(object.id).expect("valid object id"),
+        ))
+        .await
+        .expect("object fixture should resolve");
+    let update = UpdateHubuumObject {
+        name: Some(object.name.clone()),
+        collection_id: Some(object.collection_id),
+        hubuum_class_id: Some(object.hubuum_class_id),
+        data: Some(object.data.clone()),
+        description: Some(object.description.clone()),
+    };
+
+    let (updated, queries) = capture_queries(services.objects().update(
+        &target,
+        update,
+        &EventContext::system(),
+    ))
+    .await;
+    assert_eq!(updated.expect("no-op update should succeed"), object);
+    assert_eq!(queries.total_queries(), 9, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 7);
+    assert_eq!(queries.control_queries(), 2);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(
+        queries.queries_matching("SELECT hubuum_assert_revision_precondition"),
+        1
+    );
+    assert_eq!(queries.queries_matching("UPDATE \"hubuumobject\""), 0);
+    assert_eq!(queries.queries_matching("INSERT INTO \"events\""), 0);
+
     fixture.cleanup().await.expect("collection fixture cleanup");
 }
 


### PR DESCRIPTION
## Stack

Depends on #285, which adds the class service/storage capability. GitHub tracks this as the third layer of stack #286; review this PR against `agent/class-storage-boundary`.

## Summary

- add an application-facing `ObjectService` and aggregate-shaped `ObjectStore` capability
- implement object resolution and lifecycle behavior in the PostgreSQL and test-only memory adapters
- route ID- and name-addressed object resolution, creation, update, atomic JSON Patch, and deletion through the new boundary
- preserve selector-aware mutation safety by carrying resolved class/object route targets into PostgreSQL transactions
- preserve bounded JSON Patch errors, JSON Schema validation, revision preconditions, computed-field materialization, and lifecycle-event atomicity
- add shared PostgreSQL/memory contracts for explicit resolution, revisions, no-op updates and patches, schema validation, stale names, cascades, deletion, and lifecycle events
- add exact PostgreSQL query budgets for object point reads, eventful creates, and no-op updates
- update the service/storage boundary documentation for the object slice

## Why

The collection and class layers establish the boundary, but objects are Hubuum's primary data-bearing aggregate. Leaving their point reads and writes on direct `DbPool`/Diesel helpers would make the new application boundary incomplete and prevent meaningful memory-backed domain tests.

## Behavior and design notes

Production behavior remains backed by the existing PostgreSQL queries and transactions. JSON Schema validation, revision preconditions, computed-field locks and materialization, lifecycle events, class/collection invariants, and stale selector rejection are preserved.

The memory adapter models the logical object contract, including bounded JSON Patch semantics, but does not claim parity for PostgreSQL row/advisory locking, triggers, computed-field materialization, or temporal history.

Object list/search, computed response enrichment, imports/restores, relation traversal, and SQL-heavy reporting remain on the compatibility path. There are no HTTP API or schema changes.

Part of #27.

## Changelog

No changelog entry: this is an internal architecture refactor with no user-facing behavior or API change.

## Verification

- `source .env && ./run_tests.sh`
- `source .env && ./run_tests.sh object_contract_ -- --nocapture`
- `source .env && ./run_tests.sh object_storage_query_budget_ -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `./scripts/test-classify-ci-changes.sh`
- `git diff --check`