### PR TITLE
Add class relation service and storage boundary

### DIFF
--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -5,8 +5,8 @@ Diesel details. PostgreSQL remains the production semantic reference; the goal
 is a compile-time dependency boundary and faster contract tests, not generic
 multi-database support.
 
-The first migrated capabilities cover the core collection, class, and object
-lifecycles. Collections include:
+The first migrated capabilities cover the core collection, class, object, and
+class-relation lifecycles. Collections include:
 
 - point reads;
 - create with an initial assignee grant and lifecycle event;
@@ -31,29 +31,46 @@ Objects include:
 - selector-aware mutations that reject stale class or object names; and
 - delete with a lifecycle event.
 
+Class relations include:
+
+- normalization and endpoint preparation before authorization;
+- point resolution with both endpoint classes;
+- create and delete with atomic lifecycle events;
+- stale endpoint rejection between authorization and a transactional write;
+- directional alias and cardinality-limit preservation; and
+- class and collection delete cascades.
+
 ## Dependency direction
 
 ```text
-collection/class/object HTTP handlers
-                 |
-                 v
+collection/class/object/class-relation HTTP handlers
+                         |
+                         v
  CollectionService / ClassService / ObjectService
-                 |
-                 v
-   CollectionStore / ClassStore / ObjectStore
-              /       \
-             v         v
-       PostgreSQL    memory
-        adapter      adapter
-             |
-             v
-    existing Diesel transactions and queries
+               / ClassRelationService
+                         |
+                         v
+ CollectionStore / ClassStore / ObjectStore
+               / ClassRelationStore
+                    /       \
+                   v         v
+             PostgreSQL    memory
+              adapter      adapter
+                   |
+                   v
+          Diesel transactions and queries
 ```
 
 `AppContext` constructs `Services` with `PostgresStorage` in production. Core
-collection, class, and object handlers call their services; they do not choose
-a Diesel query or transaction helper for migrated operations. Permission
-checks remain at the handler boundary.
+collection, class, object, and class-relation point/lifecycle handlers call
+their services; they do not choose a Diesel query or transaction helper for
+migrated operations. Permission checks remain at the handler boundary.
+
+Class-relation preparation and resolution return aggregates containing both
+endpoint classes. Handlers build permission resources from those aggregates,
+so authorization does not perform hidden PostgreSQL lookups. Transactional
+writes lock and recheck the same endpoint snapshots before inserting or
+deleting a relation.
 
 ## Responsibility split
 
@@ -71,17 +88,19 @@ and transaction implementation. `PostgresStorage` delegates to these existing
 operations without changing their query shape.
 
 `MemoryStorage` is compiled for tests and implements the logical collection,
-class, and object contracts. It models hierarchy, selector resolution, schema
-validation, bounded JSON Patch behavior, revisions, no-op updates, delete
-constraints, cascades, and lifecycle event occurrence. It does not claim
-PostgreSQL locking, trigger, computed-field materialization, permission-row, or
-temporal-history equivalence.
+class, object, and class-relation contracts. It models hierarchy, selector
+resolution, endpoint preparation, schema validation, bounded JSON Patch
+behavior, revisions, no-op updates, delete constraints, cascades, and lifecycle
+event occurrence. It does not claim PostgreSQL locking, trigger,
+computed-field materialization, permission-row, or temporal-history
+equivalence.
 
 ## Contract and performance gates
 
-The shared contract suite runs each migrated collection, class, and object
-behavior against both PostgreSQL and memory. Each test focuses on one behavior
-so backend differences cannot be hidden inside a large scenario.
+The shared contract suite runs each migrated collection, class, object, and
+class-relation behavior against both PostgreSQL and memory. Each test focuses
+on one behavior so backend differences cannot be hidden inside a large
+scenario.
 
 The PostgreSQL query-capture tests exercise both services and retain exact
 point-read and mutation budgets. The opt-in PostgreSQL Criterion benchmark also
@@ -91,11 +110,12 @@ application-side pagination.
 
 ## Current migration boundary
 
-This is an incremental migration. Collection, class, and object list/search,
-computed-field enrichment, permission management, relation lifecycles, graph
-traversal, history, and unrelated aggregates still use `BackendContext` and the
-existing model/database traits. Existing direct persistence APIs also remain
-for fixtures, imports, restore paths, and unmigrated callers.
+This is an incremental migration. Collection, class, object, and class-relation
+list/search, computed-field enrichment, permission management, object-relation
+lifecycles, graph traversal, history, and unrelated aggregates still use
+`BackendContext` and the existing model/database traits. Existing direct
+persistence APIs also remain for fixtures, imports, restore paths, and
+unmigrated callers.
 
 When expanding the boundary:
 

--- a/src/api/v1/handlers/classes/class_related.rs
+++ b/src/api/v1/handlers/classes/class_related.rs
@@ -126,7 +126,11 @@ async fn create_class_relation(
 
     let relation = partial_relation.into_relation(class_id);
 
-    let resource = relation.to_resource_ref(&pool).await?;
+    let prepared = pool
+        .class_relation_service()
+        .prepare_create(relation)
+        .await?;
+    let resource = prepared.authorization_resource();
     authorize_resources(
         pool.permission_backend(),
         &pool,
@@ -138,7 +142,11 @@ async fn create_class_relation(
     .await?;
 
     let event_context = requestor.event_context(&req);
-    let relation = relation.save(&pool, &event_context).await?;
+    let target = pool
+        .class_relation_service()
+        .create(&prepared, &event_context)
+        .await?;
+    let relation = target.relation().clone();
 
     let location = api_locations::class_relation(class_id.id(), relation.id())?;
     ApiResponse::created_revisioned(relation, location)
@@ -166,13 +174,11 @@ async fn get_class_relation(
     paths: web::Path<(HubuumClassID, HubuumClassRelationID)>,
 ) -> Result<impl Responder, ApiError> {
     let (class_id, relation_id) = paths.into_inner();
-    let relation = relation_id.instance(&pool).await?;
-    if relation.from_hubuum_class_id != class_id.id()
-        && relation.to_hubuum_class_id != class_id.id()
-    {
+    let target = pool.class_relation_service().resolve(relation_id).await?;
+    if !target.contains_class(class_id) {
         return Err(ApiError::NotFound("Class relation not found".to_string()));
     }
-    let resource = relation.to_resource_ref(&pool).await?;
+    let resource = target.authorization_resource();
     authorize_resources(
         pool.permission_backend(),
         &pool,
@@ -182,7 +188,7 @@ async fn get_class_relation(
         vec![resource],
     )
     .await?;
-    ApiResponse::ok_revisioned(relation)
+    ApiResponse::ok_revisioned(target.relation().clone())
 }
 
 #[utoipa::path(
@@ -218,9 +224,10 @@ async fn delete_class_relation(
         relation_id = relation_id.id()
     );
 
-    let relation = relation_id.instance(&pool).await?;
+    let target = pool.class_relation_service().resolve(relation_id).await?;
+    let relation = target.relation();
 
-    let resource = relation.to_resource_ref(&pool).await?;
+    let resource = target.authorization_resource();
     authorize_resources(
         pool.permission_backend(),
         &pool,
@@ -231,14 +238,16 @@ async fn delete_class_relation(
     )
     .await?;
 
-    if relation.from_hubuum_class_id == class_id.id()
-        || relation.to_hubuum_class_id == class_id.id()
-    {
+    if target.contains_class(class_id) {
         let etag = relation.entity_tag()?;
         let precondition = revision_precondition_for_tag(&req, &etag)?;
         let event_context = requestor.event_context(&req);
-        with_revision_precondition_scope(precondition, relation.delete(&pool, &event_context))
-            .await?;
+        with_revision_precondition_scope(
+            precondition,
+            pool.class_relation_service()
+                .delete(&target, &event_context),
+        )
+        .await?;
         Ok(ApiResponse::no_content_with_etag(etag))
     } else {
         info!(

--- a/src/api/v1/handlers/relations.rs
+++ b/src/api/v1/handlers/relations.rs
@@ -136,8 +136,8 @@ async fn get_class_relation(
         relation_id = ?relation_id,
     );
 
-    let relation = relation_id.instance(&pool).await?;
-    let resource = relation.to_resource_ref(&pool).await?;
+    let target = pool.class_relation_service().resolve(relation_id).await?;
+    let resource = target.authorization_resource();
     authorize_resources(
         pool.permission_backend(),
         &pool,
@@ -148,7 +148,7 @@ async fn get_class_relation(
     )
     .await?;
 
-    ApiResponse::ok_revisioned(relation)
+    ApiResponse::ok_revisioned(target.relation().clone())
 }
 
 #[utoipa::path(
@@ -183,7 +183,11 @@ async fn create_class_relation(
         to_class = relation.to_hubuum_class_id,
     );
 
-    let resource = relation.to_resource_ref(&pool).await?;
+    let prepared = pool
+        .class_relation_service()
+        .prepare_create(relation)
+        .await?;
+    let resource = prepared.authorization_resource();
     authorize_resources(
         pool.permission_backend(),
         &pool,
@@ -195,9 +199,12 @@ async fn create_class_relation(
     .await?;
 
     let event_context = requestor.event_context(&req);
-    let relation = relation.save(&pool, &event_context).await?;
+    let target = pool
+        .class_relation_service()
+        .create(&prepared, &event_context)
+        .await?;
 
-    ApiResponse::revisioned(relation, StatusCode::CREATED)
+    ApiResponse::revisioned(target.relation().clone(), StatusCode::CREATED)
 }
 
 #[utoipa::path(
@@ -230,8 +237,8 @@ async fn delete_class_relation(
         relation_id = ?relation_id,
     );
 
-    let relation = relation_id.instance(&pool).await?;
-    let resource = relation.to_resource_ref(&pool).await?;
+    let target = pool.class_relation_service().resolve(relation_id).await?;
+    let resource = target.authorization_resource();
     authorize_resources(
         pool.permission_backend(),
         &pool,
@@ -242,11 +249,15 @@ async fn delete_class_relation(
     )
     .await?;
 
-    let etag = relation.entity_tag()?;
+    let etag = target.relation().entity_tag()?;
     let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
-    with_revision_precondition_scope(precondition, relation_id.delete(&pool, &event_context))
-        .await?;
+    with_revision_precondition_scope(
+        precondition,
+        pool.class_relation_service()
+            .delete(&target, &event_context),
+    )
+    .await?;
 
     Ok(ApiResponse::no_content_with_etag(etag))
 }

--- a/src/db/traits/relations.rs
+++ b/src/db/traits/relations.rs
@@ -5,15 +5,15 @@ use crate::db::traits::ClassRelation;
 
 pub use crate::config::max_transitive_depth as max_transitive_depth_from_config;
 
-use crate::db::{DbPool, with_connection, with_transaction};
+use crate::db::{DbConnection, DbPool, with_connection, with_transaction};
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
 use crate::models::search::{FilterField, ParsedQueryParam, ParsedQueryParamExt, QueryOptions};
 use crate::models::{
     HubuumClass, HubuumClassRelation, HubuumClassRelationID, HubuumClassRelationTransitive,
     HubuumObject, HubuumObjectID, HubuumObjectRelation, HubuumObjectRelationID,
-    HubuumObjectTransitiveLink, NewHubuumClassRelation, NewHubuumObjectRelation, User,
-    user_can_on_any,
+    HubuumObjectTransitiveLink, NewHubuumClassRelation, NewHubuumObjectRelation,
+    PreparedClassRelation, ResolvedClassRelationTarget, User, user_can_on_any,
 };
 use crate::permissions::{ResourceAttrs, ResourceKind, ResourceRef};
 use crate::{
@@ -899,6 +899,86 @@ impl LoadClassRelationRecord for HubuumClassRelationID {
     }
 }
 
+async fn load_class_relation_endpoint_records(
+    conn: &mut DbConnection,
+    from_class_id: i32,
+    to_class_id: i32,
+) -> Result<(HubuumClass, HubuumClass), ApiError> {
+    use crate::schema::hubuumclass::dsl::{hubuumclass, id};
+
+    let classes = hubuumclass
+        .filter(id.eq_any([from_class_id, to_class_id]))
+        .load::<HubuumClass>(conn)
+        .await?;
+    let from_class = classes
+        .iter()
+        .find(|class| class.id == from_class_id)
+        .cloned()
+        .ok_or_else(|| ApiError::NotFound(format!("Class {from_class_id} was not found")))?;
+    let to_class = classes
+        .into_iter()
+        .find(|class| class.id == to_class_id)
+        .ok_or_else(|| ApiError::NotFound(format!("Class {to_class_id} was not found")))?;
+    Ok((from_class, to_class))
+}
+
+pub trait PrepareClassRelationRecord {
+    async fn prepare_class_relation_record(
+        &self,
+        pool: &DbPool,
+    ) -> Result<PreparedClassRelation, ApiError>;
+}
+
+impl PrepareClassRelationRecord for NewHubuumClassRelation {
+    async fn prepare_class_relation_record(
+        &self,
+        pool: &DbPool,
+    ) -> Result<PreparedClassRelation, ApiError> {
+        let command = self.clone().normalized()?;
+        with_connection(pool, async |conn| {
+            let (from_class, to_class) = load_class_relation_endpoint_records(
+                conn,
+                command.from_hubuum_class_id,
+                command.to_hubuum_class_id,
+            )
+            .await?;
+            PreparedClassRelation::new(command, from_class, to_class)
+        })
+        .await
+    }
+}
+
+pub trait ResolveClassRelationTargetRecord {
+    async fn resolve_class_relation_target_record(
+        &self,
+        pool: &DbPool,
+    ) -> Result<ResolvedClassRelationTarget, ApiError>;
+}
+
+impl ResolveClassRelationTargetRecord for HubuumClassRelationID {
+    async fn resolve_class_relation_target_record(
+        &self,
+        pool: &DbPool,
+    ) -> Result<ResolvedClassRelationTarget, ApiError> {
+        use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
+
+        with_connection(pool, async |conn| {
+            let relation = hubuumclass_relation
+                .filter(id.eq(self.id()))
+                .first::<HubuumClassRelation>(conn)
+                .await?;
+            let (from_class, to_class) = load_class_relation_endpoint_records(
+                conn,
+                relation.from_hubuum_class_id,
+                relation.to_hubuum_class_id,
+            )
+            .await?;
+            ResolvedClassRelationTarget::new(relation, from_class, to_class)
+        })
+        .await
+    }
+}
+
 pub trait DeleteClassRelationRecord {
     async fn delete_class_relation_record_without_events(
         &self,
@@ -1127,6 +1207,132 @@ impl SaveClassRelationRecord for NewHubuumClassRelation {
                 Ok(relation)
             },
         )
+        .await
+    }
+}
+
+pub trait CreatePreparedClassRelationRecord {
+    async fn create_prepared_class_relation_record(
+        &self,
+        pool: &DbPool,
+        context: &EventContext,
+    ) -> Result<HubuumClassRelation, ApiError>;
+}
+
+impl CreatePreparedClassRelationRecord for PreparedClassRelation {
+    async fn create_prepared_class_relation_record(
+        &self,
+        pool: &DbPool,
+        context: &EventContext,
+    ) -> Result<HubuumClassRelation, ApiError> {
+        use crate::schema::hubuumclass::dsl::{hubuumclass, id};
+        use crate::schema::hubuumclass_relation::dsl::hubuumclass_relation;
+
+        with_transaction(
+            pool,
+            async |conn| -> Result<HubuumClassRelation, ApiError> {
+                let from_class = hubuumclass
+                    .filter(id.eq(self.command().from_hubuum_class_id))
+                    .for_update()
+                    .first::<HubuumClass>(conn)
+                    .await?;
+                let to_class = hubuumclass
+                    .filter(id.eq(self.command().to_hubuum_class_id))
+                    .for_update()
+                    .first::<HubuumClass>(conn)
+                    .await?;
+                if &from_class != self.from_class() || &to_class != self.to_class() {
+                    return Err(ApiError::NotFound(
+                        "Class relation endpoints no longer match the prepared target".to_string(),
+                    ));
+                }
+
+                let relation = diesel::insert_into(hubuumclass_relation)
+                    .values(self.command())
+                    .get_result::<HubuumClassRelation>(conn)
+                    .await?;
+                let event = NewEvent::new(
+                    EntityType::ClassRelation,
+                    Action::Created,
+                    context.actor_kind(),
+                    format!(
+                        "Class relation {} -> {} created",
+                        relation.from_hubuum_class_id, relation.to_hubuum_class_id
+                    ),
+                )?
+                .with_context(context)
+                .with_entity_id(relation.id)
+                .with_after(class_relation_snapshot(&relation))
+                .with_metadata(class_relation_metadata(&from_class, &to_class));
+                emit_event(conn, &event).await?;
+                Ok(relation)
+            },
+        )
+        .await
+    }
+}
+
+pub trait DeleteResolvedClassRelationRecord {
+    async fn delete_resolved_class_relation_record(
+        &self,
+        pool: &DbPool,
+        context: &EventContext,
+    ) -> Result<(), ApiError>;
+}
+
+impl DeleteResolvedClassRelationRecord for ResolvedClassRelationTarget {
+    async fn delete_resolved_class_relation_record(
+        &self,
+        pool: &DbPool,
+        context: &EventContext,
+    ) -> Result<(), ApiError> {
+        use crate::schema::hubuumclass::dsl::{hubuumclass, id as class_id};
+        use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
+
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
+            let relation = hubuumclass_relation
+                .filter(id.eq(self.relation().id))
+                .for_update()
+                .first::<HubuumClassRelation>(conn)
+                .await?;
+            let from_class = hubuumclass
+                .filter(class_id.eq(relation.from_hubuum_class_id))
+                .for_update()
+                .first::<HubuumClass>(conn)
+                .await?;
+            let to_class = hubuumclass
+                .filter(class_id.eq(relation.to_hubuum_class_id))
+                .for_update()
+                .first::<HubuumClass>(conn)
+                .await?;
+            if &relation != self.relation()
+                || &from_class != self.from_class()
+                || &to_class != self.to_class()
+            {
+                return Err(ApiError::NotFound(
+                    "Class relation no longer matches the resolved target".to_string(),
+                ));
+            }
+
+            diesel::delete(hubuumclass_relation.filter(id.eq(relation.id)))
+                .execute(conn)
+                .await?;
+            let event = NewEvent::new(
+                EntityType::ClassRelation,
+                Action::Deleted,
+                context.actor_kind(),
+                format!(
+                    "Class relation {} -> {} deleted",
+                    relation.from_hubuum_class_id, relation.to_hubuum_class_id
+                ),
+            )?
+            .with_context(context)
+            .with_entity_id(relation.id)
+            .with_before(class_relation_snapshot(&relation))
+            .with_metadata(class_relation_metadata(&from_class, &to_class));
+            emit_event(conn, &event).await?;
+            Ok(())
+        })
         .await
     }
 }

--- a/src/models/relation.rs
+++ b/src/models/relation.rs
@@ -14,7 +14,8 @@ use utoipa::openapi::{KnownFormat, ObjectBuilder, RefOr, SchemaFormat};
 use crate::db::DbPool;
 use crate::errors::ApiError;
 use crate::models::{
-    HubuumClassID, HubuumClassWithPath, HubuumObjectID, HubuumObjectWithPath, ResourceRevision,
+    HubuumClass, HubuumClassID, HubuumClassWithPath, HubuumObjectID, HubuumObjectWithPath,
+    ResourceRevision,
 };
 use crate::permissions::{AuthzTarget, ResourceAttrs, ResourceKind, ResourceRef};
 use crate::traits::SelfAccessors;
@@ -189,6 +190,125 @@ impl NewHubuumClassRelationFromClass {
             from_max_relations: self.from_max_relations,
             to_max_relations: self.to_max_relations,
         }
+    }
+}
+
+fn class_relation_authorization_resource(
+    relation_id: i32,
+    from_class: &HubuumClass,
+    to_class: &HubuumClass,
+) -> ResourceRef {
+    ResourceRef {
+        kind: ResourceKind::ClassRelation,
+        id: relation_id,
+        attrs: ResourceAttrs {
+            collection_id: (from_class.collection_id == to_class.collection_id)
+                .then_some(from_class.collection_id),
+            from_collection_id: Some(from_class.collection_id),
+            to_collection_id: Some(to_class.collection_id),
+            from_class_id: Some(from_class.id),
+            to_class_id: Some(to_class.id),
+            ..Default::default()
+        },
+    }
+}
+
+/// A normalized prospective class relation together with both endpoint classes.
+///
+/// Carrying the endpoints keeps authorization independent of the persistence
+/// adapter and lets creation recheck the exact aggregate that was authorized.
+#[derive(Clone, Debug)]
+pub struct PreparedClassRelation {
+    command: NewHubuumClassRelation,
+    from_class: HubuumClass,
+    to_class: HubuumClass,
+}
+
+impl PreparedClassRelation {
+    pub(crate) fn new(
+        command: NewHubuumClassRelation,
+        from_class: HubuumClass,
+        to_class: HubuumClass,
+    ) -> Result<Self, ApiError> {
+        let command = command.normalized()?;
+        if command.from_hubuum_class_id != from_class.id
+            || command.to_hubuum_class_id != to_class.id
+        {
+            return Err(ApiError::InternalServerError(
+                "prepared class relation endpoints do not match its normalized command".to_string(),
+            ));
+        }
+        Ok(Self {
+            command,
+            from_class,
+            to_class,
+        })
+    }
+
+    pub(crate) fn command(&self) -> &NewHubuumClassRelation {
+        &self.command
+    }
+
+    pub fn from_class(&self) -> &HubuumClass {
+        &self.from_class
+    }
+
+    pub fn to_class(&self) -> &HubuumClass {
+        &self.to_class
+    }
+
+    pub(crate) fn authorization_resource(&self) -> ResourceRef {
+        class_relation_authorization_resource(0, &self.from_class, &self.to_class)
+    }
+}
+
+/// A persisted class relation resolved with both endpoint classes.
+#[derive(Clone, Debug)]
+pub struct ResolvedClassRelationTarget {
+    relation: HubuumClassRelation,
+    from_class: HubuumClass,
+    to_class: HubuumClass,
+}
+
+impl ResolvedClassRelationTarget {
+    pub(crate) fn new(
+        relation: HubuumClassRelation,
+        from_class: HubuumClass,
+        to_class: HubuumClass,
+    ) -> Result<Self, ApiError> {
+        if relation.from_hubuum_class_id != from_class.id
+            || relation.to_hubuum_class_id != to_class.id
+        {
+            return Err(ApiError::InternalServerError(format!(
+                "class relation {} endpoints do not match the resolved classes",
+                relation.id
+            )));
+        }
+        Ok(Self {
+            relation,
+            from_class,
+            to_class,
+        })
+    }
+
+    pub fn relation(&self) -> &HubuumClassRelation {
+        &self.relation
+    }
+
+    pub fn from_class(&self) -> &HubuumClass {
+        &self.from_class
+    }
+
+    pub fn to_class(&self) -> &HubuumClass {
+        &self.to_class
+    }
+
+    pub fn contains_class(&self, class_id: HubuumClassID) -> bool {
+        self.from_class.id == class_id.id() || self.to_class.id == class_id.id()
+    }
+
+    pub(crate) fn authorization_resource(&self) -> ResourceRef {
+        class_relation_authorization_resource(self.relation.id, &self.from_class, &self.to_class)
     }
 }
 

--- a/src/permissions/context.rs
+++ b/src/permissions/context.rs
@@ -8,7 +8,9 @@ use futures_util::future::{Ready, ready};
 use crate::config::get_config;
 use crate::db::DbPool;
 use crate::errors::ApiError;
-use crate::services::{ClassService, CollectionService, ObjectService, Services};
+use crate::services::{
+    ClassRelationService, ClassService, CollectionService, ObjectService, Services,
+};
 use crate::traits::BackendContext;
 
 use super::backend::PermissionBackend;
@@ -52,6 +54,10 @@ impl AppContext {
 
     pub fn class_service(&self) -> &ClassService {
         self.services.classes()
+    }
+
+    pub fn class_relation_service(&self) -> &ClassRelationService {
+        self.services.class_relations()
     }
 
     pub fn object_service(&self) -> &ObjectService {

--- a/src/services/class_relations.rs
+++ b/src/services/class_relations.rs
@@ -1,0 +1,511 @@
+use crate::errors::ApiError;
+use crate::events::EventContext;
+use crate::models::{
+    HubuumClassRelationID, NewHubuumClassRelation, PreparedClassRelation,
+    ResolvedClassRelationTarget,
+};
+use crate::storage::DynStorage;
+
+/// Application-facing class-relation lifecycle use cases.
+#[derive(Clone)]
+pub struct ClassRelationService {
+    storage: DynStorage,
+}
+
+impl ClassRelationService {
+    pub(crate) fn new(storage: DynStorage) -> Self {
+        Self { storage }
+    }
+
+    pub async fn prepare_create(
+        &self,
+        command: NewHubuumClassRelation,
+    ) -> Result<PreparedClassRelation, ApiError> {
+        self.storage
+            .inner()
+            .prepare_class_relation(command)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn resolve(
+        &self,
+        id: HubuumClassRelationID,
+    ) -> Result<ResolvedClassRelationTarget, ApiError> {
+        self.storage
+            .inner()
+            .resolve_class_relation(id)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn create(
+        &self,
+        prepared: &PreparedClassRelation,
+        context: &EventContext,
+    ) -> Result<ResolvedClassRelationTarget, ApiError> {
+        self.storage
+            .inner()
+            .create_class_relation(prepared, context)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn delete(
+        &self,
+        target: &ResolvedClassRelationTarget,
+        context: &EventContext,
+    ) -> Result<(), ApiError> {
+        self.storage
+            .inner()
+            .delete_class_relation(target, context)
+            .await
+            .map_err(ApiError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::errors::ApiError;
+    use crate::events::{Action, EventContext};
+    use crate::models::{
+        ClassSelector, GroupID, HubuumClass, HubuumClassID, HubuumClassRelationID,
+        NewCollectionWithAssignee, NewGroup, NewHubuumClass, NewHubuumClassRelation,
+        ObjectRelationLimit, ResourceRevision, UpdateHubuumClass,
+    };
+    use crate::services::{
+        Services, storage_contract_pool, storage_contract_postgres_permit, storage_contract_prefix,
+    };
+    use crate::storage::{DynStorage, MemoryStorage, PostgresStorage};
+    use crate::tests::CollectionFixture;
+    use crate::traits::CanSave;
+
+    #[derive(Clone, Copy, Debug)]
+    enum ContractBackend {
+        Memory,
+        Postgres,
+    }
+
+    struct ContractHarness {
+        services: Services,
+        storage: Option<MemoryStorage>,
+        collection_id: i32,
+        prefix: String,
+        postgres_cleanup: Option<CollectionFixture>,
+        _postgres_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    }
+
+    impl ContractHarness {
+        async fn new(backend: ContractBackend, label: &str) -> Self {
+            match backend {
+                ContractBackend::Memory => {
+                    let storage = MemoryStorage::new();
+                    let services = Services::from_storage(DynStorage::new(storage.clone()));
+                    Self {
+                        services,
+                        storage: Some(storage),
+                        collection_id: 1,
+                        prefix: format!("memory_{label}"),
+                        postgres_cleanup: None,
+                        _postgres_permit: None,
+                    }
+                }
+                ContractBackend::Postgres => {
+                    let permit = storage_contract_postgres_permit().await;
+                    let pool = storage_contract_pool();
+                    let prefix = storage_contract_prefix(label);
+                    let owner_group = NewGroup {
+                        identity_scope: None,
+                        groupname: format!("{prefix}_owner"),
+                        description: Some("class relation storage contract owner".to_string()),
+                    }
+                    .save_without_events(&pool)
+                    .await
+                    .expect("contract owner group should save");
+                    let collection = NewCollectionWithAssignee {
+                        name: format!("{prefix}_collection"),
+                        description: "class relation storage contract collection".to_string(),
+                        group_id: GroupID::new(owner_group.id).expect("valid owner group id"),
+                        parent_collection_id: None,
+                    }
+                    .save_without_events(&pool)
+                    .await
+                    .expect("contract collection should save");
+                    let collection_id = collection.id;
+                    let fixture = CollectionFixture {
+                        pool: pool.clone(),
+                        collection,
+                        owner_group,
+                        prefix: prefix.clone(),
+                    };
+                    Self {
+                        services: Services::from_storage(DynStorage::new(PostgresStorage::new(
+                            pool.get_ref().clone(),
+                        ))),
+                        storage: None,
+                        collection_id,
+                        prefix,
+                        postgres_cleanup: Some(fixture),
+                        _postgres_permit: Some(permit),
+                    }
+                }
+            }
+        }
+
+        async fn create_class(&self, label: &str) -> HubuumClass {
+            self.services
+                .classes()
+                .create(
+                    NewHubuumClass {
+                        name: format!("{}_{}", self.prefix, label),
+                        collection_id: self.collection_id,
+                        json_schema: None,
+                        validate_schema: None,
+                        description: format!("class relation contract {label}"),
+                    },
+                    &EventContext::system(),
+                )
+                .await
+                .expect("contract class should create")
+        }
+
+        fn command(
+            &self,
+            from_class: &HubuumClass,
+            to_class: &HubuumClass,
+        ) -> NewHubuumClassRelation {
+            NewHubuumClassRelation {
+                from_hubuum_class_id: from_class.id,
+                to_hubuum_class_id: to_class.id,
+                forward_template_alias: None,
+                reverse_template_alias: None,
+                from_max_relations: None,
+                to_max_relations: None,
+            }
+        }
+
+        async fn finish(self) {
+            if let Some(fixture) = self.postgres_cleanup {
+                fixture.cleanup().await.expect("contract fixture cleanup");
+            }
+        }
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_relation_contract_normalizes_directional_settings(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "normalize").await;
+        let lower = harness.create_class("lower").await;
+        let higher = harness.create_class("higher").await;
+        let prepared = harness
+            .services
+            .class_relations()
+            .prepare_create(NewHubuumClassRelation {
+                from_hubuum_class_id: higher.id,
+                to_hubuum_class_id: lower.id,
+                forward_template_alias: Some("Higher Links".to_string()),
+                reverse_template_alias: Some("Lower Links".to_string()),
+                from_max_relations: Some(ObjectRelationLimit::new(1).expect("valid limit")),
+                to_max_relations: Some(ObjectRelationLimit::new(2).expect("valid limit")),
+            })
+            .await
+            .expect("relation should prepare");
+
+        assert_eq!(prepared.from_class().id, lower.id);
+        assert_eq!(prepared.to_class().id, higher.id);
+        assert_eq!(
+            prepared.command().forward_template_alias.as_deref(),
+            Some("lower_links")
+        );
+        assert_eq!(
+            prepared.command().reverse_template_alias.as_deref(),
+            Some("higher_links")
+        );
+        assert_eq!(
+            prepared.command().from_max_relations,
+            Some(ObjectRelationLimit::new(2).expect("valid limit"))
+        );
+        assert_eq!(
+            prepared.command().to_max_relations,
+            Some(ObjectRelationLimit::new(1).expect("valid limit"))
+        );
+
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_relation_contract_rejects_self_relations(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "self_relation").await;
+        let class = harness.create_class("class").await;
+        let error = harness
+            .services
+            .class_relations()
+            .prepare_create(harness.command(&class, &class))
+            .await
+            .expect_err("self relation should fail");
+        assert!(matches!(error, ApiError::BadRequest(_)));
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_relation_contract_creates_and_resolves_the_endpoint_aggregate(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "create_resolve").await;
+        let from_class = harness.create_class("from").await;
+        let to_class = harness.create_class("to").await;
+        let prepared = harness
+            .services
+            .class_relations()
+            .prepare_create(harness.command(&from_class, &to_class))
+            .await
+            .expect("relation should prepare");
+        let created = harness
+            .services
+            .class_relations()
+            .create(&prepared, &EventContext::system())
+            .await
+            .expect("relation should create");
+        let resolved = harness
+            .services
+            .class_relations()
+            .resolve(
+                HubuumClassRelationID::new(created.relation().id).expect("valid class relation id"),
+            )
+            .await
+            .expect("relation should resolve");
+
+        assert_eq!(resolved.relation(), created.relation());
+        assert_eq!(resolved.relation().revision, ResourceRevision::INITIAL);
+        assert_eq!(resolved.from_class(), &from_class);
+        assert_eq!(resolved.to_class(), &to_class);
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_relation_contract_rejects_duplicate_endpoint_pairs(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "duplicate").await;
+        let from_class = harness.create_class("from").await;
+        let to_class = harness.create_class("to").await;
+        let prepared = harness
+            .services
+            .class_relations()
+            .prepare_create(harness.command(&from_class, &to_class))
+            .await
+            .expect("relation should prepare");
+        harness
+            .services
+            .class_relations()
+            .create(&prepared, &EventContext::system())
+            .await
+            .expect("first relation should create");
+        let error = harness
+            .services
+            .class_relations()
+            .create(&prepared, &EventContext::system())
+            .await
+            .expect_err("duplicate relation should fail");
+        assert!(matches!(error, ApiError::Conflict(_)));
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_relation_contract_rejects_a_stale_prepared_endpoint(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "stale_prepare").await;
+        let from_class = harness.create_class("from").await;
+        let to_class = harness.create_class("to").await;
+        let prepared = harness
+            .services
+            .class_relations()
+            .prepare_create(harness.command(&from_class, &to_class))
+            .await
+            .expect("relation should prepare");
+        let class_target = harness
+            .services
+            .classes()
+            .resolve(ClassSelector::by_id(
+                HubuumClassID::new(from_class.id).expect("valid class id"),
+            ))
+            .await
+            .expect("class should resolve");
+        harness
+            .services
+            .classes()
+            .update(
+                &class_target,
+                UpdateHubuumClass {
+                    name: None,
+                    collection_id: None,
+                    json_schema: None,
+                    validate_schema: None,
+                    description: Some("changed after authorization".to_string()),
+                },
+                &EventContext::system(),
+            )
+            .await
+            .expect("class should update");
+
+        let error = harness
+            .services
+            .class_relations()
+            .create(&prepared, &EventContext::system())
+            .await
+            .expect_err("stale prepared endpoint should fail");
+        assert!(matches!(error, ApiError::NotFound(_)));
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_relation_contract_deletes_the_resolved_relation(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "delete").await;
+        let from_class = harness.create_class("from").await;
+        let to_class = harness.create_class("to").await;
+        let prepared = harness
+            .services
+            .class_relations()
+            .prepare_create(harness.command(&from_class, &to_class))
+            .await
+            .expect("relation should prepare");
+        let created = harness
+            .services
+            .class_relations()
+            .create(&prepared, &EventContext::system())
+            .await
+            .expect("relation should create");
+        let relation_id =
+            HubuumClassRelationID::new(created.relation().id).expect("valid relation id");
+        harness
+            .services
+            .class_relations()
+            .delete(&created, &EventContext::system())
+            .await
+            .expect("relation should delete");
+        assert!(matches!(
+            harness
+                .services
+                .class_relations()
+                .resolve(relation_id)
+                .await,
+            Err(ApiError::NotFound(_))
+        ));
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn class_relation_contract_class_delete_cascades_the_relation(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "class_cascade").await;
+        let from_class = harness.create_class("from").await;
+        let to_class = harness.create_class("to").await;
+        let prepared = harness
+            .services
+            .class_relations()
+            .prepare_create(harness.command(&from_class, &to_class))
+            .await
+            .expect("relation should prepare");
+        let created = harness
+            .services
+            .class_relations()
+            .create(&prepared, &EventContext::system())
+            .await
+            .expect("relation should create");
+        let relation_id =
+            HubuumClassRelationID::new(created.relation().id).expect("valid relation id");
+        let class_target = harness
+            .services
+            .classes()
+            .resolve(ClassSelector::by_id(
+                HubuumClassID::new(from_class.id).expect("valid class id"),
+            ))
+            .await
+            .expect("class should resolve");
+        harness
+            .services
+            .classes()
+            .delete(&class_target, &EventContext::system())
+            .await
+            .expect("class should delete");
+
+        assert!(matches!(
+            harness
+                .services
+                .class_relations()
+                .resolve(relation_id)
+                .await,
+            Err(ApiError::NotFound(_))
+        ));
+        harness.finish().await;
+    }
+
+    #[actix_web::test]
+    async fn memory_class_relation_events_cover_explicit_lifecycle_writes() {
+        let harness = ContractHarness::new(ContractBackend::Memory, "events").await;
+        let from_class = harness.create_class("from").await;
+        let to_class = harness.create_class("to").await;
+        let context = EventContext::system();
+        let prepared = harness
+            .services
+            .class_relations()
+            .prepare_create(harness.command(&from_class, &to_class))
+            .await
+            .expect("relation should prepare");
+        let created = harness
+            .services
+            .class_relations()
+            .create(&prepared, &context)
+            .await
+            .expect("relation should create");
+        harness
+            .services
+            .class_relations()
+            .delete(&created, &context)
+            .await
+            .expect("relation should delete");
+
+        let events = harness
+            .storage
+            .as_ref()
+            .expect("memory harness should expose storage")
+            .class_relation_events()
+            .await;
+        assert_eq!(
+            events.iter().map(|event| event.action).collect::<Vec<_>>(),
+            vec![Action::Created, Action::Deleted]
+        );
+        assert!(events.iter().all(|event| {
+            event.class_relation_id == created.relation().id && event.context == context
+        }));
+        harness.finish().await;
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,7 +1,9 @@
+mod class_relations;
 mod classes;
 mod collections;
 mod objects;
 
+pub use class_relations::ClassRelationService;
 pub use classes::ClassService;
 pub use collections::CollectionService;
 pub use objects::ObjectService;
@@ -39,6 +41,7 @@ pub(crate) fn storage_contract_prefix(label: &str) -> String {
 #[derive(Clone)]
 pub struct Services {
     classes: ClassService,
+    class_relations: ClassRelationService,
     collections: CollectionService,
     objects: ObjectService,
 }
@@ -51,6 +54,7 @@ impl Services {
     pub(crate) fn from_storage(storage: DynStorage) -> Self {
         Self {
             classes: ClassService::new(storage.clone()),
+            class_relations: ClassRelationService::new(storage.clone()),
             collections: CollectionService::new(storage.clone()),
             objects: ObjectService::new(storage),
         }
@@ -58,6 +62,10 @@ impl Services {
 
     pub fn classes(&self) -> &ClassService {
         &self.classes
+    }
+
+    pub fn class_relations(&self) -> &ClassRelationService {
+        &self.class_relations
     }
 
     pub fn collections(&self) -> &CollectionService {

--- a/src/storage/class_relations.rs
+++ b/src/storage/class_relations.rs
@@ -1,0 +1,38 @@
+use async_trait::async_trait;
+
+use crate::events::EventContext;
+use crate::models::{
+    HubuumClassRelationID, NewHubuumClassRelation, PreparedClassRelation,
+    ResolvedClassRelationTarget,
+};
+
+use super::StorageError;
+
+/// Persistence capability for class-relation resolution and lifecycle writes.
+///
+/// Prepared and resolved aggregates include both endpoint classes so callers
+/// can authorize without depending on persistence-specific lookups.
+#[async_trait]
+pub trait ClassRelationStore: Send + Sync {
+    async fn prepare_class_relation(
+        &self,
+        command: NewHubuumClassRelation,
+    ) -> Result<PreparedClassRelation, StorageError>;
+
+    async fn resolve_class_relation(
+        &self,
+        id: HubuumClassRelationID,
+    ) -> Result<ResolvedClassRelationTarget, StorageError>;
+
+    async fn create_class_relation(
+        &self,
+        prepared: &PreparedClassRelation,
+        context: &EventContext,
+    ) -> Result<ResolvedClassRelationTarget, StorageError>;
+
+    async fn delete_class_relation(
+        &self,
+        target: &ResolvedClassRelationTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError>;
+}

--- a/src/storage/collections.rs
+++ b/src/storage/collections.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use crate::events::EventContext;
 use crate::models::{Collection, CollectionID, NewCollectionWithAssignee, UpdateCollection};
 
-use super::{ClassStore, ObjectStore, StorageError};
+use super::{ClassRelationStore, ClassStore, ObjectStore, StorageError};
 
 /// Persistence capability for the core collection lifecycle.
 ///
@@ -50,9 +50,9 @@ pub trait CollectionStore: Send + Sync {
 
 /// Umbrella storage boundary. New aggregate capabilities can be added here as
 /// vertical slices migrate without exposing a database pool to services.
-pub trait Storage: CollectionStore + ClassStore + ObjectStore {}
+pub trait Storage: CollectionStore + ClassStore + ObjectStore + ClassRelationStore {}
 
-impl<T> Storage for T where T: CollectionStore + ClassStore + ObjectStore {}
+impl<T> Storage for T where T: CollectionStore + ClassStore + ObjectStore + ClassRelationStore {}
 
 #[derive(Clone)]
 pub struct DynStorage {

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -7,13 +7,15 @@ use tokio::sync::RwLock;
 
 use crate::events::{Action, EventContext};
 use crate::models::{
-    ClassSelector, ClassSelectorKind, Collection, CollectionID, HubuumClass, HubuumObject,
-    NewCollectionWithAssignee, NewHubuumClass, NewHubuumObject, ObjectDataPatchDocument,
-    ObjectSelector, ObjectSelectorKind, ResolvedClassTarget, ResolvedObjectTarget,
-    ResourceRevision, UpdateCollection, UpdateHubuumClass, UpdateHubuumObject,
+    ClassSelector, ClassSelectorKind, Collection, CollectionID, HubuumClass, HubuumClassRelation,
+    HubuumClassRelationID, HubuumObject, NewCollectionWithAssignee, NewHubuumClass,
+    NewHubuumClassRelation, NewHubuumObject, ObjectDataPatchDocument, ObjectSelector,
+    ObjectSelectorKind, PreparedClassRelation, ResolvedClassRelationTarget, ResolvedClassTarget,
+    ResolvedObjectTarget, ResourceRevision, UpdateCollection, UpdateHubuumClass,
+    UpdateHubuumObject,
 };
 
-use super::{ClassStore, CollectionStore, ObjectStore, StorageError};
+use super::{ClassRelationStore, ClassStore, CollectionStore, ObjectStore, StorageError};
 
 const ROOT_COLLECTION_ID: i32 = 1;
 
@@ -38,16 +40,26 @@ pub(crate) struct MemoryObjectEvent {
     pub(crate) context: EventContext,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct MemoryClassRelationEvent {
+    pub(crate) class_relation_id: i32,
+    pub(crate) action: Action,
+    pub(crate) context: EventContext,
+}
+
 struct MemoryState {
     next_collection_id: i32,
     next_class_id: i32,
     next_object_id: i32,
+    next_class_relation_id: i32,
     collections: BTreeMap<i32, Collection>,
     classes: BTreeMap<i32, HubuumClass>,
     objects: BTreeMap<i32, HubuumObject>,
+    class_relations: BTreeMap<i32, HubuumClassRelation>,
     events: Vec<MemoryCollectionEvent>,
     class_events: Vec<MemoryClassEvent>,
     object_events: Vec<MemoryObjectEvent>,
+    class_relation_events: Vec<MemoryClassRelationEvent>,
 }
 
 impl MemoryState {
@@ -66,12 +78,15 @@ impl MemoryState {
             next_collection_id: ROOT_COLLECTION_ID + 1,
             next_class_id: 1,
             next_object_id: 1,
+            next_class_relation_id: 1,
             collections: BTreeMap::from([(root.id, root)]),
             classes: BTreeMap::new(),
             objects: BTreeMap::new(),
+            class_relations: BTreeMap::new(),
             events: Vec::new(),
             class_events: Vec::new(),
             object_events: Vec::new(),
+            class_relation_events: Vec::new(),
         }
     }
 
@@ -188,6 +203,69 @@ impl MemoryState {
         })
     }
 
+    fn class_relation(
+        &self,
+        id: HubuumClassRelationID,
+    ) -> Result<&HubuumClassRelation, StorageError> {
+        self.class_relations.get(&id.id()).ok_or_else(|| {
+            StorageError::not_found(format!("Class relation {} was not found", id.id()))
+        })
+    }
+
+    fn prepared_class_relation_endpoints(
+        &self,
+        prepared: &PreparedClassRelation,
+    ) -> Result<(&HubuumClass, &HubuumClass), StorageError> {
+        let command = prepared.command();
+        let from_class = self
+            .classes
+            .get(&command.from_hubuum_class_id)
+            .ok_or_else(|| StorageError::not_found("From class was not found"))?;
+        let to_class = self
+            .classes
+            .get(&command.to_hubuum_class_id)
+            .ok_or_else(|| StorageError::not_found("To class was not found"))?;
+        if from_class != prepared.from_class() || to_class != prepared.to_class() {
+            return Err(StorageError::not_found(
+                "Class relation endpoints no longer match the prepared target",
+            ));
+        }
+        Ok((from_class, to_class))
+    }
+
+    fn class_relation_target(
+        &self,
+        target: &ResolvedClassRelationTarget,
+    ) -> Result<&HubuumClassRelation, StorageError> {
+        let relation_id =
+            HubuumClassRelationID::new(target.relation().id).map_err(StorageError::from)?;
+        let current = self.class_relation(relation_id)?;
+        let from_class = self
+            .classes
+            .get(&current.from_hubuum_class_id)
+            .ok_or_else(|| StorageError::not_found("From class was not found"))?;
+        let to_class = self
+            .classes
+            .get(&current.to_hubuum_class_id)
+            .ok_or_else(|| StorageError::not_found("To class was not found"))?;
+        if current != target.relation()
+            || from_class != target.from_class()
+            || to_class != target.to_class()
+        {
+            return Err(StorageError::not_found(
+                "Class relation no longer matches the resolved target",
+            ));
+        }
+        Ok(current)
+    }
+
+    fn class_relation_pair_in_use(&self, from_class_id: i32, to_class_id: i32) -> bool {
+        self.class_relations.values().any(|relation| {
+            relation.from_hubuum_class_id == from_class_id
+                && relation.to_hubuum_class_id == to_class_id
+        })
+    }
+
     fn record_event(&mut self, collection_id: i32, action: Action, context: &EventContext) {
         self.events.push(MemoryCollectionEvent {
             collection_id,
@@ -207,6 +285,19 @@ impl MemoryState {
     fn record_object_event(&mut self, object_id: i32, action: Action, context: &EventContext) {
         self.object_events.push(MemoryObjectEvent {
             object_id,
+            action,
+            context: context.clone(),
+        });
+    }
+
+    fn record_class_relation_event(
+        &mut self,
+        class_relation_id: i32,
+        action: Action,
+        context: &EventContext,
+    ) {
+        self.class_relation_events.push(MemoryClassRelationEvent {
+            class_relation_id,
             action,
             context: context.clone(),
         });
@@ -236,6 +327,10 @@ impl MemoryStorage {
 
     pub(crate) async fn object_events(&self) -> Vec<MemoryObjectEvent> {
         self.state.read().await.object_events.clone()
+    }
+
+    pub(crate) async fn class_relation_events(&self) -> Vec<MemoryClassRelationEvent> {
+        self.state.read().await.class_relation_events.clone()
     }
 }
 
@@ -345,12 +440,22 @@ impl CollectionStore for MemoryStorage {
             ));
         }
         state.collections.remove(&id.id());
+        let deleted_class_ids = state
+            .classes
+            .values()
+            .filter(|class| class.collection_id == id.id())
+            .map(|class| class.id)
+            .collect::<Vec<_>>();
         state
             .classes
             .retain(|_, class| class.collection_id != id.id());
         state
             .objects
             .retain(|_, object| object.collection_id != id.id());
+        state.class_relations.retain(|_, relation| {
+            !deleted_class_ids.contains(&relation.from_hubuum_class_id)
+                && !deleted_class_ids.contains(&relation.to_hubuum_class_id)
+        });
         state.record_event(id.id(), Action::Deleted, context);
         Ok(())
     }
@@ -556,7 +661,105 @@ impl ClassStore for MemoryStorage {
         state
             .objects
             .retain(|_, object| object.hubuum_class_id != class.id);
+        state.class_relations.retain(|_, relation| {
+            relation.from_hubuum_class_id != class.id && relation.to_hubuum_class_id != class.id
+        });
         state.record_class_event(class.id, Action::Deleted, context);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ClassRelationStore for MemoryStorage {
+    async fn prepare_class_relation(
+        &self,
+        command: NewHubuumClassRelation,
+    ) -> Result<PreparedClassRelation, StorageError> {
+        let command = command.normalized().map_err(StorageError::from)?;
+        let state = self.state.read().await;
+        let from_class = state
+            .classes
+            .get(&command.from_hubuum_class_id)
+            .cloned()
+            .ok_or_else(|| StorageError::not_found("From class was not found"))?;
+        let to_class = state
+            .classes
+            .get(&command.to_hubuum_class_id)
+            .cloned()
+            .ok_or_else(|| StorageError::not_found("To class was not found"))?;
+        PreparedClassRelation::new(command, from_class, to_class).map_err(StorageError::from)
+    }
+
+    async fn resolve_class_relation(
+        &self,
+        id: HubuumClassRelationID,
+    ) -> Result<ResolvedClassRelationTarget, StorageError> {
+        let state = self.state.read().await;
+        let relation = state.class_relation(id)?.clone();
+        let from_class = state
+            .classes
+            .get(&relation.from_hubuum_class_id)
+            .cloned()
+            .ok_or_else(|| StorageError::not_found("From class was not found"))?;
+        let to_class = state
+            .classes
+            .get(&relation.to_hubuum_class_id)
+            .cloned()
+            .ok_or_else(|| StorageError::not_found("To class was not found"))?;
+        ResolvedClassRelationTarget::new(relation, from_class, to_class).map_err(StorageError::from)
+    }
+
+    async fn create_class_relation(
+        &self,
+        prepared: &PreparedClassRelation,
+        context: &EventContext,
+    ) -> Result<ResolvedClassRelationTarget, StorageError> {
+        let mut state = self.state.write().await;
+        state.prepared_class_relation_endpoints(prepared)?;
+        let command = prepared.command();
+        if state
+            .class_relation_pair_in_use(command.from_hubuum_class_id, command.to_hubuum_class_id)
+        {
+            return Err(StorageError::conflict(format!(
+                "A relation between classes {} and {} already exists",
+                command.from_hubuum_class_id, command.to_hubuum_class_id
+            )));
+        }
+
+        let id = state.next_class_relation_id;
+        state.next_class_relation_id += 1;
+        let now = Utc::now().naive_utc();
+        let relation = HubuumClassRelation {
+            id,
+            from_hubuum_class_id: command.from_hubuum_class_id,
+            to_hubuum_class_id: command.to_hubuum_class_id,
+            forward_template_alias: command.forward_template_alias.clone(),
+            reverse_template_alias: command.reverse_template_alias.clone(),
+            created_at: now,
+            updated_at: now,
+            from_max_relations: command.from_max_relations,
+            to_max_relations: command.to_max_relations,
+            revision: ResourceRevision::INITIAL,
+        };
+        state.class_relations.insert(id, relation.clone());
+        state.record_class_relation_event(id, Action::Created, context);
+        ResolvedClassRelationTarget::new(
+            relation,
+            prepared.from_class().clone(),
+            prepared.to_class().clone(),
+        )
+        .map_err(StorageError::from)
+    }
+
+    async fn delete_class_relation(
+        &self,
+        target: &ResolvedClassRelationTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        let mut state = self.state.write().await;
+        let relation_id = state.class_relation_target(target)?.id;
+        state.class_relations.remove(&relation_id);
+        state.record_class_relation_event(relation_id, Action::Deleted, context);
         Ok(())
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,3 +1,4 @@
+mod class_relations;
 mod classes;
 mod collections;
 mod error;
@@ -6,6 +7,7 @@ mod memory;
 mod objects;
 mod postgres;
 
+pub use class_relations::ClassRelationStore;
 pub use classes::ClassStore;
 pub use collections::{CollectionStore, DynStorage, Storage};
 pub use error::StorageError;

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -15,14 +15,20 @@ use crate::db::traits::object::{
     CreateObjectInResolvedClassRecord, DeleteResolvedObjectRecord, PatchObjectDataRecord,
     ResolveObjectSelectorRecord, UpdateResolvedObjectRecord,
 };
+use crate::db::traits::relations::{
+    CreatePreparedClassRelationRecord, DeleteResolvedClassRelationRecord,
+    PrepareClassRelationRecord, ResolveClassRelationTargetRecord,
+};
 use crate::events::EventContext;
 use crate::models::{
-    ClassSelector, Collection, CollectionID, HubuumClass, HubuumObject, NewCollectionWithAssignee,
-    NewHubuumClass, NewHubuumObject, ObjectDataPatchDocument, ObjectSelector, ResolvedClassTarget,
-    ResolvedObjectTarget, UpdateCollection, UpdateHubuumClass, UpdateHubuumObject,
+    ClassSelector, Collection, CollectionID, HubuumClass, HubuumClassRelationID, HubuumObject,
+    NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
+    ObjectDataPatchDocument, ObjectSelector, PreparedClassRelation, ResolvedClassRelationTarget,
+    ResolvedClassTarget, ResolvedObjectTarget, UpdateCollection, UpdateHubuumClass,
+    UpdateHubuumObject,
 };
 
-use super::{ClassStore, CollectionStore, ObjectStore, StorageError};
+use super::{ClassRelationStore, ClassStore, CollectionStore, ObjectStore, StorageError};
 
 /// Canonical production storage adapter.
 #[derive(Clone)]
@@ -148,6 +154,56 @@ impl ClassStore for PostgresStorage {
     ) -> Result<(), StorageError> {
         target
             .delete_resolved_class_record(&self.pool, context)
+            .await
+            .map_err(StorageError::from)
+    }
+}
+
+#[async_trait]
+impl ClassRelationStore for PostgresStorage {
+    async fn prepare_class_relation(
+        &self,
+        command: NewHubuumClassRelation,
+    ) -> Result<PreparedClassRelation, StorageError> {
+        command
+            .prepare_class_relation_record(&self.pool)
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn resolve_class_relation(
+        &self,
+        id: HubuumClassRelationID,
+    ) -> Result<ResolvedClassRelationTarget, StorageError> {
+        id.resolve_class_relation_target_record(&self.pool)
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn create_class_relation(
+        &self,
+        prepared: &PreparedClassRelation,
+        context: &EventContext,
+    ) -> Result<ResolvedClassRelationTarget, StorageError> {
+        let relation = prepared
+            .create_prepared_class_relation_record(&self.pool, context)
+            .await
+            .map_err(StorageError::from)?;
+        ResolvedClassRelationTarget::new(
+            relation,
+            prepared.from_class().clone(),
+            prepared.to_class().clone(),
+        )
+        .map_err(StorageError::from)
+    }
+
+    async fn delete_class_relation(
+        &self,
+        target: &ResolvedClassRelationTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        target
+            .delete_resolved_class_relation_record(&self.pool, context)
             .await
             .map_err(StorageError::from)
     }

--- a/src/tests/storage_performance.rs
+++ b/src/tests/storage_performance.rs
@@ -18,9 +18,10 @@ use crate::events::EventContext;
 use crate::models::collection::effective_group_on;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
-    ClassSelector, CollectionID, GroupID, HubuumClassID, HubuumObjectID, NewCollectionWithAssignee,
-    NewHubuumClass, NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation,
-    ObjectSelector, UpdateCollection, UpdateHubuumClass, UpdateHubuumObject, UserID,
+    ClassSelector, CollectionID, GroupID, HubuumClassID, HubuumClassRelationID, HubuumObjectID,
+    NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
+    NewHubuumObjectRelation, ObjectSelector, UpdateCollection, UpdateHubuumClass,
+    UpdateHubuumObject, UserID,
 };
 use crate::services::Services;
 use crate::tests::{TestScope, ensure_admin_user};
@@ -279,6 +280,190 @@ async fn class_storage_query_budget_no_op_avoids_writes_and_events() {
         .delete_without_events(&scope.pool)
         .await
         .expect("class cleanup");
+    fixture.cleanup().await.expect("collection fixture cleanup");
+}
+
+#[actix_web::test]
+async fn class_relation_storage_query_budget_point_resolution_is_fixed() {
+    let scope = TestScope::new();
+    let fixture = scope
+        .collection_fixture("query_budget_class_relation_point")
+        .await;
+    let services = Services::postgres(scope.pool.get_ref().clone());
+    let from_class = NewHubuumClass {
+        name: scope.scoped_name("query_budget_class_relation_point_from"),
+        collection_id: fixture.collection.id,
+        json_schema: None,
+        validate_schema: None,
+        description: "class relation point budget from class".to_string(),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("from class fixture should save");
+    let to_class = NewHubuumClass {
+        name: scope.scoped_name("query_budget_class_relation_point_to"),
+        collection_id: fixture.collection.id,
+        json_schema: None,
+        validate_schema: None,
+        description: "class relation point budget to class".to_string(),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("to class fixture should save");
+    let relation = NewHubuumClassRelation {
+        from_hubuum_class_id: from_class.id,
+        to_hubuum_class_id: to_class.id,
+        forward_template_alias: None,
+        reverse_template_alias: None,
+        from_max_relations: None,
+        to_max_relations: None,
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("relation fixture should save");
+
+    let (loaded, queries) = capture_queries(
+        services
+            .class_relations()
+            .resolve(HubuumClassRelationID::new(relation.id).expect("valid class relation id")),
+    )
+    .await;
+    assert_eq!(
+        loaded.expect("relation should resolve").relation(),
+        &relation
+    );
+    assert_eq!(queries.total_queries(), 2, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 2);
+    assert_eq!(queries.control_queries(), 0);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(queries.queries_matching("FROM \"hubuumclass_relation\""), 1);
+    assert_eq!(queries.queries_matching("FROM \"hubuumclass\""), 1);
+
+    fixture.cleanup().await.expect("collection fixture cleanup");
+}
+
+#[actix_web::test]
+async fn class_relation_storage_query_budget_create_with_event_is_fixed() {
+    let scope = TestScope::new();
+    let fixture = scope
+        .collection_fixture("query_budget_class_relation_create")
+        .await;
+    let services = Services::postgres(scope.pool.get_ref().clone());
+    let from_class = NewHubuumClass {
+        name: scope.scoped_name("query_budget_class_relation_create_from"),
+        collection_id: fixture.collection.id,
+        json_schema: None,
+        validate_schema: None,
+        description: "class relation create budget from class".to_string(),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("from class fixture should save");
+    let to_class = NewHubuumClass {
+        name: scope.scoped_name("query_budget_class_relation_create_to"),
+        collection_id: fixture.collection.id,
+        json_schema: None,
+        validate_schema: None,
+        description: "class relation create budget to class".to_string(),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("to class fixture should save");
+    let prepared = services
+        .class_relations()
+        .prepare_create(NewHubuumClassRelation {
+            from_hubuum_class_id: from_class.id,
+            to_hubuum_class_id: to_class.id,
+            forward_template_alias: None,
+            reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
+        })
+        .await
+        .expect("relation should prepare");
+
+    let (created, queries) = capture_queries(
+        services
+            .class_relations()
+            .create(&prepared, &EventContext::system()),
+    )
+    .await;
+    created.expect("relation should create with an event");
+    assert_eq!(queries.total_queries(), 6, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 4);
+    assert_eq!(queries.control_queries(), 2);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(
+        queries.queries_matching("INSERT INTO \"hubuumclass_relation\""),
+        1
+    );
+    assert_eq!(queries.queries_matching("INSERT INTO \"events\""), 1);
+
+    fixture.cleanup().await.expect("collection fixture cleanup");
+}
+
+#[actix_web::test]
+async fn class_relation_storage_query_budget_delete_with_event_is_fixed() {
+    let scope = TestScope::new();
+    let fixture = scope
+        .collection_fixture("query_budget_class_relation_delete")
+        .await;
+    let services = Services::postgres(scope.pool.get_ref().clone());
+    let from_class = NewHubuumClass {
+        name: scope.scoped_name("query_budget_class_relation_delete_from"),
+        collection_id: fixture.collection.id,
+        json_schema: None,
+        validate_schema: None,
+        description: "class relation delete budget from class".to_string(),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("from class fixture should save");
+    let to_class = NewHubuumClass {
+        name: scope.scoped_name("query_budget_class_relation_delete_to"),
+        collection_id: fixture.collection.id,
+        json_schema: None,
+        validate_schema: None,
+        description: "class relation delete budget to class".to_string(),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("to class fixture should save");
+    let prepared = services
+        .class_relations()
+        .prepare_create(NewHubuumClassRelation {
+            from_hubuum_class_id: from_class.id,
+            to_hubuum_class_id: to_class.id,
+            forward_template_alias: None,
+            reverse_template_alias: None,
+            from_max_relations: None,
+            to_max_relations: None,
+        })
+        .await
+        .expect("relation should prepare");
+    let target = services
+        .class_relations()
+        .create(&prepared, &EventContext::system())
+        .await
+        .expect("relation should create");
+
+    let (deleted, queries) = capture_queries(
+        services
+            .class_relations()
+            .delete(&target, &EventContext::system()),
+    )
+    .await;
+    deleted.expect("relation should delete with an event");
+    assert_eq!(queries.total_queries(), 7, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 5);
+    assert_eq!(queries.control_queries(), 2);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(
+        queries.queries_matching("DELETE FROM \"hubuumclass_relation\""),
+        1
+    );
+    assert_eq!(queries.queries_matching("INSERT INTO \"events\""), 1);
+
     fixture.cleanup().await.expect("collection fixture cleanup");
 }
 


### PR DESCRIPTION
## Stack

Depends on #287, which adds the object service/storage capability. GitHub tracks this as the fourth layer of stack #286; review this PR against `agent/object-storage-boundary`.

## Summary

- add an application-facing `ClassRelationService` and aggregate-shaped `ClassRelationStore` capability
- represent prospective and persisted relations with both endpoint classes, so authorization resources do not perform hidden database lookups
- normalize class IDs, directional template aliases, and object-relation limits during relation preparation
- route global and class-scoped class-relation point reads, creation, and deletion through the new boundary
- lock and recheck the exact endpoint snapshots authorized before PostgreSQL creation or deletion
- implement the logical lifecycle in the test-only memory adapter, including duplicate protection, cascades, revisions, and lifecycle events
- add shared PostgreSQL/memory contracts and exact PostgreSQL query budgets
- update the service/storage boundary documentation

## Why

Class relations connect the object model and define the valid shape and cardinality of object relations. Leaving their point lifecycle on direct `DbPool`/Diesel helpers would keep authorization-dependent endpoint loading outside the application boundary and make the subsequent object-relation layer depend on an incomplete abstraction.

## Behavior and design notes

Preparation returns a normalized prospective aggregate containing both endpoint classes. Resolution returns the persisted relation with the same endpoint aggregate. Handlers authorize those snapshots at the boundary; PostgreSQL writes then lock and compare them before inserting or deleting, rejecting stale authorization targets.

Production persistence, uniqueness constraints, revision preconditions, cascade behavior, and event atomicity remain PostgreSQL-backed. The memory adapter models the logical contract without claiming PostgreSQL locking, trigger, or temporal-history equivalence.

Class-relation list/search and transitive graph traversal remain on the PostgreSQL compatibility path. There are no HTTP API, OpenAPI, or database schema changes.

Part of #27.

## Changelog

No changelog entry: this is an internal architecture refactor with no user-facing behavior or API change.

## Verification

- `source .env && ./run_tests.sh`
- `source .env && ./run_tests.sh class_relation_contract_ -- --nocapture`
- `source .env && ./run_tests.sh class_relation_storage_query_budget_ -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `./scripts/test-classify-ci-changes.sh`
- `git diff --check`