### PR TITLE
Add object relation service and storage boundary

### DIFF
--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -6,7 +6,7 @@ is a compile-time dependency boundary and faster contract tests, not generic
 multi-database support.
 
 The first migrated capabilities cover the core collection, class, object, and
-class-relation lifecycles. Collections include:
+relation lifecycles. Collections include:
 
 - point reads;
 - create with an initial assignee grant and lifecycle event;
@@ -40,37 +40,51 @@ Class relations include:
 - directional alias and cardinality-limit preservation; and
 - class and collection delete cascades.
 
+Object relations include:
+
+- explicit point resolution by relation ID or a class/object endpoint pair;
+- endpoint and direct class-relation preparation before authorization;
+- normalized creation with duplicate and same-class rejection;
+- directional cardinality enforcement owned by the storage implementation;
+- create and delete with atomic lifecycle events; and
+- object, class, collection, and class-relation delete cascades.
+
 ## Dependency direction
 
 ```text
-collection/class/object/class-relation HTTP handlers
-                         |
-                         v
+collection/class/object/relation HTTP handlers
+                       |
+                       v
  CollectionService / ClassService / ObjectService
-               / ClassRelationService
-                         |
-                         v
+       / ClassRelationService / ObjectRelationService
+                       |
+                       v
  CollectionStore / ClassStore / ObjectStore
-               / ClassRelationStore
-                    /       \
-                   v         v
-             PostgreSQL    memory
-              adapter      adapter
-                   |
-                   v
-          Diesel transactions and queries
+       / ClassRelationStore / ObjectRelationStore
+                  /       \
+                 v         v
+           PostgreSQL    memory
+            adapter      adapter
+                 |
+                 v
+        Diesel transactions and queries
 ```
 
 `AppContext` constructs `Services` with `PostgresStorage` in production. Core
-collection, class, object, and class-relation point/lifecycle handlers call
-their services; they do not choose a Diesel query or transaction helper for
-migrated operations. Permission checks remain at the handler boundary.
+collection, class, object, and relation point/lifecycle handlers call their
+services; they do not choose a Diesel query or transaction helper for migrated
+operations. Permission checks remain at the handler boundary.
 
 Class-relation preparation and resolution return aggregates containing both
 endpoint classes. Handlers build permission resources from those aggregates,
 so authorization does not perform hidden PostgreSQL lookups. Transactional
 writes lock and recheck the same endpoint snapshots before inserting or
 deleting a relation.
+
+Object-relation preparation and resolution similarly carry both objects and
+the resolved class relation. The PostgreSQL adapter keeps cardinality
+serialization in the database trigger, where it locks only bounded endpoints;
+the service boundary does not introduce broader application-side locking.
 
 ## Responsibility split
 
@@ -88,19 +102,19 @@ and transaction implementation. `PostgresStorage` delegates to these existing
 operations without changing their query shape.
 
 `MemoryStorage` is compiled for tests and implements the logical collection,
-class, object, and class-relation contracts. It models hierarchy, selector
-resolution, endpoint preparation, schema validation, bounded JSON Patch
-behavior, revisions, no-op updates, delete constraints, cascades, and lifecycle
-event occurrence. It does not claim PostgreSQL locking, trigger,
-computed-field materialization, permission-row, or temporal-history
-equivalence.
+class, object, class-relation, and object-relation contracts. It models
+hierarchy, selector resolution, endpoint preparation, schema validation,
+bounded JSON Patch behavior, revisions, no-op updates, relation cardinality,
+delete constraints, cascades, and lifecycle event occurrence. It does not
+claim PostgreSQL locking, trigger, computed-field materialization,
+permission-row, or temporal-history equivalence.
 
 ## Contract and performance gates
 
 The shared contract suite runs each migrated collection, class, object, and
-class-relation behavior against both PostgreSQL and memory. Each test focuses
-on one behavior so backend differences cannot be hidden inside a large
-scenario.
+class-relation, and object-relation behavior against both PostgreSQL and
+memory. Each test focuses on one behavior so backend differences cannot be
+hidden inside a large scenario.
 
 The PostgreSQL query-capture tests exercise both services and retain exact
 point-read and mutation budgets. The opt-in PostgreSQL Criterion benchmark also
@@ -110,12 +124,11 @@ application-side pagination.
 
 ## Current migration boundary
 
-This is an incremental migration. Collection, class, object, and class-relation
-list/search, computed-field enrichment, permission management, object-relation
-lifecycles, graph traversal, history, and unrelated aggregates still use
-`BackendContext` and the existing model/database traits. Existing direct
-persistence APIs also remain for fixtures, imports, restore paths, and
-unmigrated callers.
+This is an incremental migration. Collection, class, object, and relation
+list/search, computed-field enrichment, permission management, graph traversal,
+history, and unrelated aggregates still use `BackendContext` and the existing
+model/database traits. Existing direct persistence APIs also remain for
+fixtures, imports, restore paths, and unmigrated callers.
 
 When expanding the boundary:
 

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -12,6 +12,7 @@ use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
 use crate::api::v1::handlers::history::HistoryResponse;
 use crate::can;
+use crate::db::traits::UserPermissions;
 use crate::db::traits::authz::scope_allows;
 use crate::db::traits::computed_field::enrich_objects_with_computed;
 use crate::db::traits::history::{
@@ -22,7 +23,6 @@ use crate::db::traits::relations::{
     class_relation_authorization_resources, object_relation_authorization_resources,
 };
 use crate::db::traits::user::UserSearchBackend;
-use crate::db::traits::{ClassRelation, ObjectRelationMemberships, UserPermissions};
 use crate::db::with_revision_precondition_scope;
 use crate::errors::ApiError;
 use crate::extractors::{AccessEventContext, Authenticated, ObjectDataPatchPayload};
@@ -43,12 +43,12 @@ use crate::models::{
     HubuumClass, HubuumClassExpanded, HubuumClassHistory, HubuumClassID, HubuumClassRelation,
     HubuumClassRelationID, HubuumClassWithPath, HubuumObject, HubuumObjectHistory, HubuumObjectID,
     HubuumObjectReadResponse, HubuumObjectRelation, HubuumObjectWithPath, NewHubuumClass,
-    NewHubuumClassRelationFromClass, NewHubuumObjectRelation, NewHubuumObjectRequest,
-    ObjectDataPatchDocument, ObjectSelector, Permissions, RelatedClassGraph, RelatedObjectGraph,
-    RelatedObjectGraphRow, ResolvedClassTarget, ResolvedObjectTarget, UpdateHubuumClass,
-    UpdateHubuumObject, UpdateHubuumObjectRequest,
+    NewHubuumClassRelationFromClass, NewHubuumObjectRequest, ObjectDataPatchDocument,
+    ObjectRelationCreateSelector, ObjectRelationSelector, ObjectSelector, Permissions,
+    RelatedClassGraph, RelatedObjectGraph, RelatedObjectGraphRow, ResolvedClassTarget,
+    ResolvedObjectTarget, UpdateHubuumClass, UpdateHubuumObject, UpdateHubuumObjectRequest,
 };
-use crate::traits::{BackendContext, CanDelete, CanSave, Search, SelfAccessors};
+use crate::traits::{BackendContext, Search, SelfAccessors};
 use crate::utilities::extensions::CustomStringExtensions;
 
 use crate::models::search::{

--- a/src/api/v1/handlers/classes/object_related.rs
+++ b/src/api/v1/handlers/classes/object_related.rs
@@ -421,11 +421,14 @@ async fn get_object_relation_from_class_and_objects(
         to_object_id = to_object.id()
     );
 
-    check_if_object_in_class(&pool, &from_class, &from_object).await?;
-    check_if_object_in_class(&pool, &to_class, &to_object).await?;
-
-    let relation = from_object
-        .object_relation(&pool, &from_class, &to_object)
+    let target = pool
+        .object_relation_service()
+        .resolve(ObjectRelationSelector::between(
+            from_class,
+            from_object,
+            to_class,
+            to_object,
+        ))
         .await
         .map_err(|_| {
             ApiError::NotFound(format!(
@@ -435,7 +438,7 @@ async fn get_object_relation_from_class_and_objects(
                 to_object.id()
             ))
         })?;
-    let resource = relation.to_resource_ref(&pool).await?;
+    let resource = target.authorization_resource();
     authorize_resources(
         pool.permission_backend(),
         &pool,
@@ -445,7 +448,7 @@ async fn get_object_relation_from_class_and_objects(
         vec![resource],
     )
     .await?;
-    ApiResponse::ok_revisioned(relation)
+    ApiResponse::ok_revisioned(*target.relation())
 }
 
 #[utoipa::path(
@@ -475,9 +478,6 @@ async fn delete_object_relation(
     let user = &requestor.principal;
     let (from_class, from_object, to_class, to_object) = paths.into_inner();
 
-    check_if_object_in_class(&pool, &from_class, &from_object).await?;
-    check_if_object_in_class(&pool, &to_class, &to_object).await?;
-
     debug!(
         message = "Deleting object relation",
         user_id = user.id(),
@@ -487,29 +487,24 @@ async fn delete_object_relation(
         to_object_id = to_object.id()
     );
 
-    let relation = from_object
-        .object_relation(&pool, &from_class, &to_object)
-        .await;
-
-    if relation.is_err() {
-        debug!(
-            message = "Relation does not exist",
-            user_id = user.id(),
-            from_class_id = from_class.id(),
-            from_object_id = from_object.id(),
-            to_class_id = to_class.id(),
-            to_object_id = to_object.id()
-        );
-        return Err(ApiError::NotFound(format!(
-            "Class {} is not related to class {}",
-            from_class.id(),
-            to_class.id()
-        )));
-    }
-
-    let relation = relation.expect("Relation should exist after is_err check");
-
-    let resource = relation.to_resource_ref(&pool).await?;
+    let target = pool
+        .object_relation_service()
+        .resolve(ObjectRelationSelector::between(
+            from_class,
+            from_object,
+            to_class,
+            to_object,
+        ))
+        .await
+        .map_err(|_| {
+            ApiError::NotFound(format!(
+                "Class {} is not related to class {}",
+                from_class.id(),
+                to_class.id()
+            ))
+        })?;
+    let relation = target.relation();
+    let resource = target.authorization_resource();
     authorize_resources(
         pool.permission_backend(),
         &pool,
@@ -532,7 +527,12 @@ async fn delete_object_relation(
     let etag = relation.entity_tag()?;
     let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
-    with_revision_precondition_scope(precondition, relation.delete(&pool, &event_context)).await?;
+    with_revision_precondition_scope(
+        precondition,
+        pool.object_relation_service()
+            .delete(&target, &event_context),
+    )
+    .await?;
     Ok(ApiResponse::no_content_with_etag(etag))
 }
 
@@ -574,31 +574,16 @@ async fn create_object_relation(
         to_object = to_object.id()
     );
 
-    let is_related = from_class.direct_relation_to(&pool, &to_class).await?;
-
-    if is_related.is_none() {
-        debug!(
-            message = "Relation does not exist",
-            user_id = user.id(),
-            from_class = from_class.id(),
-            to_class = to_class.id()
-        );
-        return Err(ApiError::NotFound(format!(
-            "Class {} is not related to class {}",
-            from_class.id(),
-            to_class.id()
-        )));
-    }
-
-    let relation = is_related.expect("Relation should exist after is_none check");
-
-    let relation = NewHubuumObjectRelation {
-        class_relation_id: relation.id,
-        from_hubuum_object_id: from_object.id(),
-        to_hubuum_object_id: to_object.id(),
-    };
-
-    let resource = relation.to_resource_ref(&pool).await?;
+    let prepared = pool
+        .object_relation_service()
+        .prepare_create(ObjectRelationCreateSelector::between(
+            from_class,
+            from_object,
+            to_class,
+            to_object,
+        ))
+        .await?;
+    let resource = prepared.authorization_resource();
     authorize_resources(
         pool.permission_backend(),
         &pool,
@@ -610,7 +595,11 @@ async fn create_object_relation(
     .await?;
 
     let event_context = requestor.event_context(&req);
-    let relation = relation.save(&pool, &event_context).await?;
+    let target = pool
+        .object_relation_service()
+        .create(&prepared, &event_context)
+        .await?;
+    let relation = *target.relation();
 
     let location = api_locations::object_relation(
         from_class.id(),

--- a/src/api/v1/handlers/relations.rs
+++ b/src/api/v1/handlers/relations.rs
@@ -14,12 +14,13 @@ use crate::extractors::{AccessEventContext, Authenticated};
 use crate::models::search::{QueryParamsExt, parse_query_parameter};
 use crate::models::{
     HubuumClassRelation, HubuumClassRelationID, HubuumObjectRelation, HubuumObjectRelationID,
-    NewHubuumClassRelation, NewHubuumObjectRelation, Permissions,
+    NewHubuumClassRelation, NewHubuumObjectRelation, ObjectRelationCreateSelector,
+    ObjectRelationSelector, Permissions,
 };
 use crate::pagination::{count_query_options, prepare_db_pagination};
 use crate::permissions::visibility::authorize_cursor_page;
-use crate::permissions::{AppContext, AuthzTarget, PrincipalRef, authorize_resources};
-use crate::traits::{CanDelete, CanSave, SelfAccessors};
+use crate::permissions::{AppContext, PrincipalRef, authorize_resources};
+use crate::traits::SelfAccessors;
 
 use actix_web::delete;
 use tracing::debug;
@@ -371,8 +372,11 @@ async fn get_object_relation(
         relation_id = ?relation_id,
     );
 
-    let relation = relation_id.instance(&pool).await?;
-    let resource = relation.to_resource_ref(&pool).await?;
+    let target = pool
+        .object_relation_service()
+        .resolve(ObjectRelationSelector::by_id(relation_id))
+        .await?;
+    let resource = target.authorization_resource();
     authorize_resources(
         pool.permission_backend(),
         &pool,
@@ -383,7 +387,7 @@ async fn get_object_relation(
     )
     .await?;
 
-    ApiResponse::ok_revisioned(relation)
+    ApiResponse::ok_revisioned(*target.relation())
 }
 
 #[utoipa::path(
@@ -418,7 +422,11 @@ async fn create_object_relation(
         to_object = relation.to_hubuum_object_id,
     );
 
-    let resource = relation.to_resource_ref(&pool).await?;
+    let prepared = pool
+        .object_relation_service()
+        .prepare_create(ObjectRelationCreateSelector::explicit(relation))
+        .await?;
+    let resource = prepared.authorization_resource();
     authorize_resources(
         pool.permission_backend(),
         &pool,
@@ -430,9 +438,12 @@ async fn create_object_relation(
     .await?;
 
     let event_context = requestor.event_context(&req);
-    let relation = relation.save(&pool, &event_context).await?;
+    let target = pool
+        .object_relation_service()
+        .create(&prepared, &event_context)
+        .await?;
 
-    ApiResponse::revisioned(relation, StatusCode::CREATED)
+    ApiResponse::revisioned(*target.relation(), StatusCode::CREATED)
 }
 
 #[utoipa::path(
@@ -465,8 +476,11 @@ async fn delete_object_relation(
         relation_id = ?relation_id,
     );
 
-    let relation = relation_id.instance(&pool).await?;
-    let resource = relation.to_resource_ref(&pool).await?;
+    let target = pool
+        .object_relation_service()
+        .resolve(ObjectRelationSelector::by_id(relation_id))
+        .await?;
+    let resource = target.authorization_resource();
     authorize_resources(
         pool.permission_backend(),
         &pool,
@@ -477,11 +491,15 @@ async fn delete_object_relation(
     )
     .await?;
 
-    let etag = relation.entity_tag()?;
+    let etag = target.relation().entity_tag()?;
     let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
-    with_revision_precondition_scope(precondition, relation_id.delete(&pool, &event_context))
-        .await?;
+    with_revision_precondition_scope(
+        precondition,
+        pool.object_relation_service()
+            .delete(&target, &event_context),
+    )
+    .await?;
 
     Ok(ApiResponse::no_content_with_etag(etag))
 }

--- a/src/db/traits/relations.rs
+++ b/src/db/traits/relations.rs
@@ -13,7 +13,9 @@ use crate::models::{
     HubuumClass, HubuumClassRelation, HubuumClassRelationID, HubuumClassRelationTransitive,
     HubuumObject, HubuumObjectID, HubuumObjectRelation, HubuumObjectRelationID,
     HubuumObjectTransitiveLink, NewHubuumClassRelation, NewHubuumObjectRelation,
-    PreparedClassRelation, ResolvedClassRelationTarget, User, user_can_on_any,
+    ObjectRelationCreateSelector, ObjectRelationCreateSelectorKind, ObjectRelationSelector,
+    ObjectRelationSelectorKind, PreparedClassRelation, PreparedObjectRelation,
+    ResolvedClassRelationTarget, ResolvedObjectRelationTarget, User, user_can_on_any,
 };
 use crate::permissions::{ResourceAttrs, ResourceKind, ResourceRef};
 use crate::{
@@ -955,25 +957,32 @@ pub trait ResolveClassRelationTargetRecord {
     ) -> Result<ResolvedClassRelationTarget, ApiError>;
 }
 
+async fn load_resolved_class_relation_target_on_connection(
+    conn: &mut DbConnection,
+    relation_id: i32,
+) -> Result<ResolvedClassRelationTarget, ApiError> {
+    use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
+
+    let relation = hubuumclass_relation
+        .filter(id.eq(relation_id))
+        .first::<HubuumClassRelation>(conn)
+        .await?;
+    let (from_class, to_class) = load_class_relation_endpoint_records(
+        conn,
+        relation.from_hubuum_class_id,
+        relation.to_hubuum_class_id,
+    )
+    .await?;
+    ResolvedClassRelationTarget::new(relation, from_class, to_class)
+}
+
 impl ResolveClassRelationTargetRecord for HubuumClassRelationID {
     async fn resolve_class_relation_target_record(
         &self,
         pool: &DbPool,
     ) -> Result<ResolvedClassRelationTarget, ApiError> {
-        use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
-
         with_connection(pool, async |conn| {
-            let relation = hubuumclass_relation
-                .filter(id.eq(self.id()))
-                .first::<HubuumClassRelation>(conn)
-                .await?;
-            let (from_class, to_class) = load_class_relation_endpoint_records(
-                conn,
-                relation.from_hubuum_class_id,
-                relation.to_hubuum_class_id,
-            )
-            .await?;
-            ResolvedClassRelationTarget::new(relation, from_class, to_class)
+            load_resolved_class_relation_target_on_connection(conn, self.id()).await
         })
         .await
     }
@@ -1330,6 +1339,373 @@ impl DeleteResolvedClassRelationRecord for ResolvedClassRelationTarget {
             .with_entity_id(relation.id)
             .with_before(class_relation_snapshot(&relation))
             .with_metadata(class_relation_metadata(&from_class, &to_class));
+            emit_event(conn, &event).await?;
+            Ok(())
+        })
+        .await
+    }
+}
+
+async fn load_object_relation_endpoint_records(
+    conn: &mut DbConnection,
+    from_object_id: i32,
+    to_object_id: i32,
+) -> Result<(HubuumObject, HubuumObject), ApiError> {
+    use crate::schema::hubuumobject::dsl::{hubuumobject, id};
+
+    let objects = hubuumobject
+        .filter(id.eq_any([from_object_id, to_object_id]))
+        .load::<HubuumObject>(conn)
+        .await?;
+    let from_object = objects
+        .iter()
+        .find(|object| object.id == from_object_id)
+        .cloned()
+        .ok_or_else(|| ApiError::NotFound(format!("Object {from_object_id} was not found")))?;
+    let to_object = objects
+        .into_iter()
+        .find(|object| object.id == to_object_id)
+        .ok_or_else(|| ApiError::NotFound(format!("Object {to_object_id} was not found")))?;
+    Ok((from_object, to_object))
+}
+
+async fn load_direct_class_relation_target_on_connection(
+    conn: &mut DbConnection,
+    first_class_id: i32,
+    second_class_id: i32,
+) -> Result<ResolvedClassRelationTarget, ApiError> {
+    use crate::schema::hubuumclass_relation::dsl::{
+        from_hubuum_class_id, hubuumclass_relation, to_hubuum_class_id,
+    };
+
+    let lower_class_id = first_class_id.min(second_class_id);
+    let higher_class_id = first_class_id.max(second_class_id);
+    let relation = hubuumclass_relation
+        .filter(from_hubuum_class_id.eq(lower_class_id))
+        .filter(to_hubuum_class_id.eq(higher_class_id))
+        .first::<HubuumClassRelation>(conn)
+        .await
+        .map_err(|error| match error {
+            diesel::result::Error::NotFound => ApiError::NotFound(format!(
+                "Class {first_class_id} is not related to class {second_class_id}"
+            )),
+            error => ApiError::from(error),
+        })?;
+    let (from_class, to_class) = load_class_relation_endpoint_records(
+        conn,
+        relation.from_hubuum_class_id,
+        relation.to_hubuum_class_id,
+    )
+    .await?;
+    ResolvedClassRelationTarget::new(relation, from_class, to_class)
+}
+
+fn order_object_relation_endpoints(
+    command: &NewHubuumObjectRelation,
+    first_object: HubuumObject,
+    second_object: HubuumObject,
+) -> Result<(HubuumObject, HubuumObject), ApiError> {
+    if first_object.id == command.from_hubuum_object_id
+        && second_object.id == command.to_hubuum_object_id
+    {
+        Ok((first_object, second_object))
+    } else if second_object.id == command.from_hubuum_object_id
+        && first_object.id == command.to_hubuum_object_id
+    {
+        Ok((second_object, first_object))
+    } else {
+        Err(ApiError::InternalServerError(
+            "loaded object relation endpoints do not match the command".to_string(),
+        ))
+    }
+}
+
+pub trait PrepareObjectRelationRecord {
+    async fn prepare_object_relation_record(
+        &self,
+        pool: &DbPool,
+    ) -> Result<PreparedObjectRelation, ApiError>;
+}
+
+impl PrepareObjectRelationRecord for ObjectRelationCreateSelector {
+    async fn prepare_object_relation_record(
+        &self,
+        pool: &DbPool,
+    ) -> Result<PreparedObjectRelation, ApiError> {
+        with_connection(pool, async |conn| match self.kind() {
+            ObjectRelationCreateSelectorKind::Explicit(command) => {
+                let command = command.clone().normalized()?;
+                let (from_object, to_object) = load_object_relation_endpoint_records(
+                    conn,
+                    command.from_hubuum_object_id,
+                    command.to_hubuum_object_id,
+                )
+                .await?;
+                let class_relation = load_resolved_class_relation_target_on_connection(
+                    conn,
+                    command.class_relation_id,
+                )
+                .await?;
+                PreparedObjectRelation::new(command, from_object, to_object, class_relation)
+            }
+            ObjectRelationCreateSelectorKind::Between {
+                from_class_id,
+                from_object_id,
+                to_class_id,
+                to_object_id,
+            } => {
+                let (route_from_object, route_to_object) = load_object_relation_endpoint_records(
+                    conn,
+                    from_object_id.id(),
+                    to_object_id.id(),
+                )
+                .await?;
+                if route_from_object.hubuum_class_id != from_class_id.id()
+                    || route_to_object.hubuum_class_id != to_class_id.id()
+                {
+                    return Err(ApiError::NotFound(
+                        "Object was not found in the selected class".to_string(),
+                    ));
+                }
+                let class_relation = load_direct_class_relation_target_on_connection(
+                    conn,
+                    from_class_id.id(),
+                    to_class_id.id(),
+                )
+                .await?;
+                let command = NewHubuumObjectRelation {
+                    from_hubuum_object_id: route_from_object.id,
+                    to_hubuum_object_id: route_to_object.id,
+                    class_relation_id: class_relation.relation().id,
+                }
+                .normalized()?;
+                let (from_object, to_object) =
+                    order_object_relation_endpoints(&command, route_from_object, route_to_object)?;
+                PreparedObjectRelation::new(command, from_object, to_object, class_relation)
+            }
+        })
+        .await
+    }
+}
+
+pub trait ResolveObjectRelationTargetRecord {
+    async fn resolve_object_relation_target_record(
+        &self,
+        pool: &DbPool,
+    ) -> Result<ResolvedObjectRelationTarget, ApiError>;
+}
+
+impl ResolveObjectRelationTargetRecord for ObjectRelationSelector {
+    async fn resolve_object_relation_target_record(
+        &self,
+        pool: &DbPool,
+    ) -> Result<ResolvedObjectRelationTarget, ApiError> {
+        use crate::schema::hubuumobject_relation::dsl::{
+            from_hubuum_object_id, hubuumobject_relation, id, to_hubuum_object_id,
+        };
+
+        with_connection(pool, async |conn| {
+            let (relation, from_object, to_object) = match self.kind() {
+                ObjectRelationSelectorKind::ById(relation_id) => {
+                    let relation = hubuumobject_relation
+                        .filter(id.eq(relation_id.id()))
+                        .first::<HubuumObjectRelation>(conn)
+                        .await?;
+                    let (from_object, to_object) = load_object_relation_endpoint_records(
+                        conn,
+                        relation.from_hubuum_object_id,
+                        relation.to_hubuum_object_id,
+                    )
+                    .await?;
+                    (relation, from_object, to_object)
+                }
+                ObjectRelationSelectorKind::Between {
+                    from_class_id,
+                    from_object_id,
+                    to_class_id,
+                    to_object_id,
+                } => {
+                    let (route_from_object, route_to_object) =
+                        load_object_relation_endpoint_records(
+                            conn,
+                            from_object_id.id(),
+                            to_object_id.id(),
+                        )
+                        .await?;
+                    if route_from_object.hubuum_class_id != from_class_id.id()
+                        || route_to_object.hubuum_class_id != to_class_id.id()
+                    {
+                        return Err(ApiError::NotFound(
+                            "Object relation was not found for the selected classes".to_string(),
+                        ));
+                    }
+                    let lower_object_id = from_object_id.id().min(to_object_id.id());
+                    let higher_object_id = from_object_id.id().max(to_object_id.id());
+                    let relation = hubuumobject_relation
+                        .filter(from_hubuum_object_id.eq(lower_object_id))
+                        .filter(to_hubuum_object_id.eq(higher_object_id))
+                        .first::<HubuumObjectRelation>(conn)
+                        .await?;
+                    let command = NewHubuumObjectRelation {
+                        from_hubuum_object_id: relation.from_hubuum_object_id,
+                        to_hubuum_object_id: relation.to_hubuum_object_id,
+                        class_relation_id: relation.class_relation_id,
+                    };
+                    let (from_object, to_object) = order_object_relation_endpoints(
+                        &command,
+                        route_from_object,
+                        route_to_object,
+                    )?;
+                    (relation, from_object, to_object)
+                }
+            };
+            let class_relation =
+                load_resolved_class_relation_target_on_connection(conn, relation.class_relation_id)
+                    .await?;
+            ResolvedObjectRelationTarget::new(relation, from_object, to_object, class_relation)
+        })
+        .await
+    }
+}
+
+fn object_relation_scope_matches(current: &HubuumObject, expected: &HubuumObject) -> bool {
+    current.id == expected.id
+        && current.collection_id == expected.collection_id
+        && current.hubuum_class_id == expected.hubuum_class_id
+}
+
+pub trait CreatePreparedObjectRelationRecord {
+    async fn create_prepared_object_relation_record(
+        &self,
+        pool: &DbPool,
+        context: &EventContext,
+    ) -> Result<HubuumObjectRelation, ApiError>;
+}
+
+impl CreatePreparedObjectRelationRecord for PreparedObjectRelation {
+    async fn create_prepared_object_relation_record(
+        &self,
+        pool: &DbPool,
+        context: &EventContext,
+    ) -> Result<HubuumObjectRelation, ApiError> {
+        use crate::schema::hubuumclass_relation::dsl::{
+            hubuumclass_relation, id as class_relation_id,
+        };
+        use crate::schema::hubuumobject_relation::dsl::hubuumobject_relation;
+
+        with_transaction(
+            pool,
+            async |conn| -> Result<HubuumObjectRelation, ApiError> {
+                let (from_object, to_object) = load_object_relation_endpoint_records(
+                    conn,
+                    self.command().from_hubuum_object_id,
+                    self.command().to_hubuum_object_id,
+                )
+                .await?;
+                if !object_relation_scope_matches(&from_object, self.from_object())
+                    || !object_relation_scope_matches(&to_object, self.to_object())
+                {
+                    return Err(ApiError::NotFound(
+                        "Object relation endpoints no longer match the prepared target".to_string(),
+                    ));
+                }
+                let class_relation = hubuumclass_relation
+                    .filter(class_relation_id.eq(self.command().class_relation_id))
+                    .for_share()
+                    .first::<HubuumClassRelation>(conn)
+                    .await?;
+                if &class_relation != self.class_relation().relation() {
+                    return Err(ApiError::NotFound(
+                        "Class relation no longer matches the prepared object relation".to_string(),
+                    ));
+                }
+
+                let relation = diesel::insert_into(hubuumobject_relation)
+                    .values(self.command())
+                    .get_result::<HubuumObjectRelation>(conn)
+                    .await?;
+                let event = NewEvent::new(
+                    EntityType::ObjectRelation,
+                    Action::Created,
+                    context.actor_kind(),
+                    format!(
+                        "Object relation {} -> {} created",
+                        relation.from_hubuum_object_id, relation.to_hubuum_object_id
+                    ),
+                )?
+                .with_context(context)
+                .with_entity_id(relation.id)
+                .with_after(object_relation_snapshot(&relation))
+                .with_metadata(object_relation_metadata(
+                    &relation,
+                    &from_object,
+                    &to_object,
+                ));
+                emit_event(conn, &event).await?;
+                Ok(relation)
+            },
+        )
+        .await
+    }
+}
+
+pub trait DeleteResolvedObjectRelationRecord {
+    async fn delete_resolved_object_relation_record(
+        &self,
+        pool: &DbPool,
+        context: &EventContext,
+    ) -> Result<(), ApiError>;
+}
+
+impl DeleteResolvedObjectRelationRecord for ResolvedObjectRelationTarget {
+    async fn delete_resolved_object_relation_record(
+        &self,
+        pool: &DbPool,
+        context: &EventContext,
+    ) -> Result<(), ApiError> {
+        use crate::schema::hubuumobject_relation::dsl::{hubuumobject_relation, id};
+
+        with_transaction(pool, async |conn| -> Result<(), ApiError> {
+            let relation = hubuumobject_relation
+                .filter(id.eq(self.relation().id))
+                .for_update()
+                .first::<HubuumObjectRelation>(conn)
+                .await?;
+            let (from_object, to_object) = load_object_relation_endpoint_records(
+                conn,
+                relation.from_hubuum_object_id,
+                relation.to_hubuum_object_id,
+            )
+            .await?;
+            if &relation != self.relation()
+                || !object_relation_scope_matches(&from_object, self.from_object())
+                || !object_relation_scope_matches(&to_object, self.to_object())
+            {
+                return Err(ApiError::NotFound(
+                    "Object relation no longer matches the resolved target".to_string(),
+                ));
+            }
+
+            diesel::delete(hubuumobject_relation.filter(id.eq(relation.id)))
+                .execute(conn)
+                .await?;
+            let event = NewEvent::new(
+                EntityType::ObjectRelation,
+                Action::Deleted,
+                context.actor_kind(),
+                format!(
+                    "Object relation {} -> {} deleted",
+                    relation.from_hubuum_object_id, relation.to_hubuum_object_id
+                ),
+            )?
+            .with_context(context)
+            .with_entity_id(relation.id)
+            .with_before(object_relation_snapshot(&relation))
+            .with_metadata(object_relation_metadata(
+                &relation,
+                &from_object,
+                &to_object,
+            ));
             emit_event(conn, &event).await?;
             Ok(())
         })

--- a/src/models/relation.rs
+++ b/src/models/relation.rs
@@ -14,8 +14,8 @@ use utoipa::openapi::{KnownFormat, ObjectBuilder, RefOr, SchemaFormat};
 use crate::db::DbPool;
 use crate::errors::ApiError;
 use crate::models::{
-    HubuumClass, HubuumClassID, HubuumClassWithPath, HubuumObjectID, HubuumObjectWithPath,
-    ResourceRevision,
+    HubuumClass, HubuumClassID, HubuumClassWithPath, HubuumObject, HubuumObjectID,
+    HubuumObjectWithPath, ResourceRevision,
 };
 use crate::permissions::{AuthzTarget, ResourceAttrs, ResourceKind, ResourceRef};
 use crate::traits::SelfAccessors;
@@ -330,13 +330,277 @@ pub struct HubuumObjectRelation {
     pub revision: ResourceRevision,
 }
 
-#[derive(Debug, Serialize, Deserialize, Insertable, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable, ToSchema)]
 #[schema(example = new_hubuum_object_relation_example)]
 #[diesel(table_name = hubuumobject_relation)]
 pub struct NewHubuumObjectRelation {
     pub from_hubuum_object_id: i32,
     pub to_hubuum_object_id: i32,
     pub class_relation_id: i32,
+}
+
+impl NewHubuumObjectRelation {
+    /// Validate and normalize an object relation before persistence.
+    pub(crate) fn normalized(mut self) -> Result<Self, ApiError> {
+        if self.from_hubuum_object_id == self.to_hubuum_object_id {
+            return Err(ApiError::BadRequest(
+                "from_hubuum_object_id and to_hubuum_object_id cannot be the same".to_string(),
+            ));
+        }
+        if self.from_hubuum_object_id > self.to_hubuum_object_id {
+            std::mem::swap(
+                &mut self.from_hubuum_object_id,
+                &mut self.to_hubuum_object_id,
+            );
+        }
+        Ok(self)
+    }
+}
+
+/// Explicit address for a persisted object relation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObjectRelationSelector(ObjectRelationSelectorKind);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ObjectRelationSelectorKind {
+    ById(HubuumObjectRelationID),
+    Between {
+        from_class_id: HubuumClassID,
+        from_object_id: HubuumObjectID,
+        to_class_id: HubuumClassID,
+        to_object_id: HubuumObjectID,
+    },
+}
+
+impl ObjectRelationSelector {
+    pub fn by_id(id: HubuumObjectRelationID) -> Self {
+        Self(ObjectRelationSelectorKind::ById(id))
+    }
+
+    pub fn between(
+        from_class_id: HubuumClassID,
+        from_object_id: HubuumObjectID,
+        to_class_id: HubuumClassID,
+        to_object_id: HubuumObjectID,
+    ) -> Self {
+        Self(ObjectRelationSelectorKind::Between {
+            from_class_id,
+            from_object_id,
+            to_class_id,
+            to_object_id,
+        })
+    }
+
+    pub(crate) fn kind(&self) -> &ObjectRelationSelectorKind {
+        &self.0
+    }
+}
+
+/// Explicit source for preparing a prospective object relation.
+#[derive(Clone, Debug)]
+pub struct ObjectRelationCreateSelector(ObjectRelationCreateSelectorKind);
+
+#[derive(Clone, Debug)]
+pub(crate) enum ObjectRelationCreateSelectorKind {
+    Explicit(NewHubuumObjectRelation),
+    Between {
+        from_class_id: HubuumClassID,
+        from_object_id: HubuumObjectID,
+        to_class_id: HubuumClassID,
+        to_object_id: HubuumObjectID,
+    },
+}
+
+impl ObjectRelationCreateSelector {
+    pub fn explicit(command: NewHubuumObjectRelation) -> Self {
+        Self(ObjectRelationCreateSelectorKind::Explicit(command))
+    }
+
+    pub fn between(
+        from_class_id: HubuumClassID,
+        from_object_id: HubuumObjectID,
+        to_class_id: HubuumClassID,
+        to_object_id: HubuumObjectID,
+    ) -> Self {
+        Self(ObjectRelationCreateSelectorKind::Between {
+            from_class_id,
+            from_object_id,
+            to_class_id,
+            to_object_id,
+        })
+    }
+
+    pub(crate) fn kind(&self) -> &ObjectRelationCreateSelectorKind {
+        &self.0
+    }
+}
+
+fn object_relation_authorization_resource(
+    relation_id: i32,
+    class_relation_id: i32,
+    from_object: &HubuumObject,
+    to_object: &HubuumObject,
+) -> ResourceRef {
+    ResourceRef {
+        kind: ResourceKind::ObjectRelation,
+        id: relation_id,
+        attrs: ResourceAttrs {
+            collection_id: (from_object.collection_id == to_object.collection_id)
+                .then_some(from_object.collection_id),
+            from_collection_id: Some(from_object.collection_id),
+            to_collection_id: Some(to_object.collection_id),
+            from_class_id: Some(from_object.hubuum_class_id),
+            to_class_id: Some(to_object.hubuum_class_id),
+            from_object_id: Some(from_object.id),
+            to_object_id: Some(to_object.id),
+            class_relation_id: Some(class_relation_id),
+            ..Default::default()
+        },
+    }
+}
+
+fn validate_object_relation_membership(
+    command: &NewHubuumObjectRelation,
+    from_object: &HubuumObject,
+    to_object: &HubuumObject,
+    class_relation: &ResolvedClassRelationTarget,
+) -> Result<(), ApiError> {
+    if command.from_hubuum_object_id != from_object.id
+        || command.to_hubuum_object_id != to_object.id
+        || command.class_relation_id != class_relation.relation().id
+    {
+        return Err(ApiError::InternalServerError(
+            "object relation aggregate does not match its command".to_string(),
+        ));
+    }
+    if from_object.hubuum_class_id == to_object.hubuum_class_id {
+        return Err(ApiError::BadRequest(
+            "from_hubuum_object_id and to_hubuum_object_id must not have the same class"
+                .to_string(),
+        ));
+    }
+    let matches_class_relation = (from_object.hubuum_class_id == class_relation.from_class().id
+        && to_object.hubuum_class_id == class_relation.to_class().id)
+        || (from_object.hubuum_class_id == class_relation.to_class().id
+            && to_object.hubuum_class_id == class_relation.from_class().id);
+    if !matches_class_relation {
+        return Err(ApiError::BadRequest(
+            "objects do not match the specified class relation".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// A prospective object relation with both objects and its class relation.
+#[derive(Clone, Debug)]
+pub struct PreparedObjectRelation {
+    command: NewHubuumObjectRelation,
+    from_object: HubuumObject,
+    to_object: HubuumObject,
+    class_relation: ResolvedClassRelationTarget,
+}
+
+impl PreparedObjectRelation {
+    pub(crate) fn new(
+        command: NewHubuumObjectRelation,
+        from_object: HubuumObject,
+        to_object: HubuumObject,
+        class_relation: ResolvedClassRelationTarget,
+    ) -> Result<Self, ApiError> {
+        let command = command.normalized()?;
+        validate_object_relation_membership(&command, &from_object, &to_object, &class_relation)?;
+        Ok(Self {
+            command,
+            from_object,
+            to_object,
+            class_relation,
+        })
+    }
+
+    pub(crate) fn command(&self) -> &NewHubuumObjectRelation {
+        &self.command
+    }
+
+    pub fn from_object(&self) -> &HubuumObject {
+        &self.from_object
+    }
+
+    pub fn to_object(&self) -> &HubuumObject {
+        &self.to_object
+    }
+
+    pub fn class_relation(&self) -> &ResolvedClassRelationTarget {
+        &self.class_relation
+    }
+
+    pub(crate) fn authorization_resource(&self) -> ResourceRef {
+        object_relation_authorization_resource(
+            0,
+            self.class_relation.relation().id,
+            &self.from_object,
+            &self.to_object,
+        )
+    }
+}
+
+/// A persisted object relation resolved with both objects and its class relation.
+#[derive(Clone, Debug)]
+pub struct ResolvedObjectRelationTarget {
+    relation: HubuumObjectRelation,
+    from_object: HubuumObject,
+    to_object: HubuumObject,
+    class_relation: ResolvedClassRelationTarget,
+}
+
+impl ResolvedObjectRelationTarget {
+    pub(crate) fn new(
+        relation: HubuumObjectRelation,
+        from_object: HubuumObject,
+        to_object: HubuumObject,
+        class_relation: ResolvedClassRelationTarget,
+    ) -> Result<Self, ApiError> {
+        validate_object_relation_membership(
+            &NewHubuumObjectRelation {
+                from_hubuum_object_id: relation.from_hubuum_object_id,
+                to_hubuum_object_id: relation.to_hubuum_object_id,
+                class_relation_id: relation.class_relation_id,
+            },
+            &from_object,
+            &to_object,
+            &class_relation,
+        )?;
+        Ok(Self {
+            relation,
+            from_object,
+            to_object,
+            class_relation,
+        })
+    }
+
+    pub fn relation(&self) -> &HubuumObjectRelation {
+        &self.relation
+    }
+
+    pub fn from_object(&self) -> &HubuumObject {
+        &self.from_object
+    }
+
+    pub fn to_object(&self) -> &HubuumObject {
+        &self.to_object
+    }
+
+    pub fn class_relation(&self) -> &ResolvedClassRelationTarget {
+        &self.class_relation
+    }
+
+    pub(crate) fn authorization_resource(&self) -> ResourceRef {
+        object_relation_authorization_resource(
+            self.relation.id,
+            self.relation.class_relation_id,
+            &self.from_object,
+            &self.to_object,
+        )
+    }
 }
 
 /// To create new relations between objects from within a

--- a/src/permissions/context.rs
+++ b/src/permissions/context.rs
@@ -9,7 +9,8 @@ use crate::config::get_config;
 use crate::db::DbPool;
 use crate::errors::ApiError;
 use crate::services::{
-    ClassRelationService, ClassService, CollectionService, ObjectService, Services,
+    ClassRelationService, ClassService, CollectionService, ObjectRelationService, ObjectService,
+    Services,
 };
 use crate::traits::BackendContext;
 
@@ -62,6 +63,10 @@ impl AppContext {
 
     pub fn object_service(&self) -> &ObjectService {
         self.services.objects()
+    }
+
+    pub fn object_relation_service(&self) -> &ObjectRelationService {
+        self.services.object_relations()
     }
 }
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,11 +1,13 @@
 mod class_relations;
 mod classes;
 mod collections;
+mod object_relations;
 mod objects;
 
 pub use class_relations::ClassRelationService;
 pub use classes::ClassService;
 pub use collections::CollectionService;
+pub use object_relations::ObjectRelationService;
 pub use objects::ObjectService;
 
 use crate::db::DbPool;
@@ -44,6 +46,7 @@ pub struct Services {
     class_relations: ClassRelationService,
     collections: CollectionService,
     objects: ObjectService,
+    object_relations: ObjectRelationService,
 }
 
 impl Services {
@@ -56,7 +59,8 @@ impl Services {
             classes: ClassService::new(storage.clone()),
             class_relations: ClassRelationService::new(storage.clone()),
             collections: CollectionService::new(storage.clone()),
-            objects: ObjectService::new(storage),
+            objects: ObjectService::new(storage.clone()),
+            object_relations: ObjectRelationService::new(storage),
         }
     }
 
@@ -74,5 +78,9 @@ impl Services {
 
     pub fn objects(&self) -> &ObjectService {
         &self.objects
+    }
+
+    pub fn object_relations(&self) -> &ObjectRelationService {
+        &self.object_relations
     }
 }

--- a/src/services/object_relations.rs
+++ b/src/services/object_relations.rs
@@ -1,0 +1,760 @@
+use crate::errors::ApiError;
+use crate::events::EventContext;
+use crate::models::{
+    ObjectRelationCreateSelector, ObjectRelationSelector, PreparedObjectRelation,
+    ResolvedObjectRelationTarget,
+};
+use crate::storage::DynStorage;
+
+/// Application-facing object-relation lifecycle use cases.
+#[derive(Clone)]
+pub struct ObjectRelationService {
+    storage: DynStorage,
+}
+
+impl ObjectRelationService {
+    pub(crate) fn new(storage: DynStorage) -> Self {
+        Self { storage }
+    }
+
+    pub async fn prepare_create(
+        &self,
+        selector: ObjectRelationCreateSelector,
+    ) -> Result<PreparedObjectRelation, ApiError> {
+        self.storage
+            .inner()
+            .prepare_object_relation(selector)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn resolve(
+        &self,
+        selector: ObjectRelationSelector,
+    ) -> Result<ResolvedObjectRelationTarget, ApiError> {
+        self.storage
+            .inner()
+            .resolve_object_relation(selector)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn create(
+        &self,
+        prepared: &PreparedObjectRelation,
+        context: &EventContext,
+    ) -> Result<ResolvedObjectRelationTarget, ApiError> {
+        self.storage
+            .inner()
+            .create_object_relation(prepared, context)
+            .await
+            .map_err(ApiError::from)
+    }
+
+    pub async fn delete(
+        &self,
+        target: &ResolvedObjectRelationTarget,
+        context: &EventContext,
+    ) -> Result<(), ApiError> {
+        self.storage
+            .inner()
+            .delete_object_relation(target, context)
+            .await
+            .map_err(ApiError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use serde_json::json;
+
+    use crate::errors::ApiError;
+    use crate::events::{Action, EventContext};
+    use crate::models::{
+        ClassSelector, GroupID, HubuumClass, HubuumClassID, HubuumObject, HubuumObjectID,
+        HubuumObjectRelationID, NewCollectionWithAssignee, NewGroup, NewHubuumClass,
+        NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation,
+        ObjectRelationCreateSelector, ObjectRelationLimit, ObjectRelationSelector,
+        ResolvedClassRelationTarget, ResourceRevision,
+    };
+    use crate::services::{
+        Services, storage_contract_pool, storage_contract_postgres_permit, storage_contract_prefix,
+    };
+    use crate::storage::{DynStorage, MemoryStorage, PostgresStorage};
+    use crate::tests::CollectionFixture;
+    use crate::traits::CanSave;
+
+    #[derive(Clone, Copy, Debug)]
+    enum ContractBackend {
+        Memory,
+        Postgres,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum RelationAddress {
+        Id,
+        Between,
+    }
+
+    struct RelationFixture {
+        from_class: HubuumClass,
+        to_class: HubuumClass,
+        class_relation: ResolvedClassRelationTarget,
+        from_object: HubuumObject,
+        to_object: HubuumObject,
+    }
+
+    struct ContractHarness {
+        services: Services,
+        storage: Option<MemoryStorage>,
+        collection_id: i32,
+        prefix: String,
+        postgres_cleanup: Option<CollectionFixture>,
+        _postgres_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    }
+
+    impl ContractHarness {
+        async fn new(backend: ContractBackend, label: &str) -> Self {
+            match backend {
+                ContractBackend::Memory => {
+                    let storage = MemoryStorage::new();
+                    let services = Services::from_storage(DynStorage::new(storage.clone()));
+                    Self {
+                        services,
+                        storage: Some(storage),
+                        collection_id: 1,
+                        prefix: format!("memory_{label}"),
+                        postgres_cleanup: None,
+                        _postgres_permit: None,
+                    }
+                }
+                ContractBackend::Postgres => {
+                    let permit = storage_contract_postgres_permit().await;
+                    let pool = storage_contract_pool();
+                    let prefix = storage_contract_prefix(label);
+                    let owner_group = NewGroup {
+                        identity_scope: None,
+                        groupname: format!("{prefix}_owner"),
+                        description: Some("object relation storage contract owner".to_string()),
+                    }
+                    .save_without_events(&pool)
+                    .await
+                    .expect("contract owner group should save");
+                    let collection = NewCollectionWithAssignee {
+                        name: format!("{prefix}_collection"),
+                        description: "object relation storage contract collection".to_string(),
+                        group_id: GroupID::new(owner_group.id).expect("valid owner group id"),
+                        parent_collection_id: None,
+                    }
+                    .save_without_events(&pool)
+                    .await
+                    .expect("contract collection should save");
+                    let collection_id = collection.id;
+                    let fixture = CollectionFixture {
+                        pool: pool.clone(),
+                        collection,
+                        owner_group,
+                        prefix: prefix.clone(),
+                    };
+                    Self {
+                        services: Services::from_storage(DynStorage::new(PostgresStorage::new(
+                            pool.get_ref().clone(),
+                        ))),
+                        storage: None,
+                        collection_id,
+                        prefix,
+                        postgres_cleanup: Some(fixture),
+                        _postgres_permit: Some(permit),
+                    }
+                }
+            }
+        }
+
+        async fn create_class(&self, label: &str) -> HubuumClass {
+            self.services
+                .classes()
+                .create(
+                    NewHubuumClass {
+                        name: format!("{}_{}", self.prefix, label),
+                        collection_id: self.collection_id,
+                        json_schema: None,
+                        validate_schema: None,
+                        description: format!("object relation contract {label}"),
+                    },
+                    &EventContext::system(),
+                )
+                .await
+                .expect("contract class should create")
+        }
+
+        async fn create_object(&self, class: &HubuumClass, label: &str) -> HubuumObject {
+            let class_target = self
+                .services
+                .classes()
+                .resolve(ClassSelector::by_id(
+                    HubuumClassID::new(class.id).expect("valid class id"),
+                ))
+                .await
+                .expect("class should resolve");
+            self.services
+                .objects()
+                .create(
+                    &class_target,
+                    NewHubuumObject {
+                        name: format!("{}_{}", self.prefix, label),
+                        collection_id: class.collection_id,
+                        hubuum_class_id: class.id,
+                        data: json!({"label": label}),
+                        description: format!("object relation contract {label}"),
+                    },
+                    &EventContext::system(),
+                )
+                .await
+                .expect("contract object should create")
+        }
+
+        async fn create_class_relation(
+            &self,
+            from_class: &HubuumClass,
+            to_class: &HubuumClass,
+            from_limit: Option<ObjectRelationLimit>,
+            to_limit: Option<ObjectRelationLimit>,
+        ) -> ResolvedClassRelationTarget {
+            let prepared = self
+                .services
+                .class_relations()
+                .prepare_create(NewHubuumClassRelation {
+                    from_hubuum_class_id: from_class.id,
+                    to_hubuum_class_id: to_class.id,
+                    forward_template_alias: None,
+                    reverse_template_alias: None,
+                    from_max_relations: from_limit,
+                    to_max_relations: to_limit,
+                })
+                .await
+                .expect("class relation should prepare");
+            self.services
+                .class_relations()
+                .create(&prepared, &EventContext::system())
+                .await
+                .expect("class relation should create")
+        }
+
+        async fn fixture(&self, label: &str) -> RelationFixture {
+            let from_class = self.create_class(&format!("{label}_from_class")).await;
+            let to_class = self.create_class(&format!("{label}_to_class")).await;
+            let class_relation = self
+                .create_class_relation(&from_class, &to_class, None, None)
+                .await;
+            let from_object = self
+                .create_object(&from_class, &format!("{label}_from_object"))
+                .await;
+            let to_object = self
+                .create_object(&to_class, &format!("{label}_to_object"))
+                .await;
+            RelationFixture {
+                from_class,
+                to_class,
+                class_relation,
+                from_object,
+                to_object,
+            }
+        }
+
+        fn explicit_selector(&self, fixture: &RelationFixture) -> ObjectRelationCreateSelector {
+            ObjectRelationCreateSelector::explicit(NewHubuumObjectRelation {
+                from_hubuum_object_id: fixture.from_object.id,
+                to_hubuum_object_id: fixture.to_object.id,
+                class_relation_id: fixture.class_relation.relation().id,
+            })
+        }
+
+        fn between_create_selector(
+            &self,
+            fixture: &RelationFixture,
+        ) -> ObjectRelationCreateSelector {
+            ObjectRelationCreateSelector::between(
+                HubuumClassID::new(fixture.from_class.id).expect("valid from class id"),
+                HubuumObjectID::new(fixture.from_object.id).expect("valid from object id"),
+                HubuumClassID::new(fixture.to_class.id).expect("valid to class id"),
+                HubuumObjectID::new(fixture.to_object.id).expect("valid to object id"),
+            )
+        }
+
+        fn selector(
+            &self,
+            address: RelationAddress,
+            fixture: &RelationFixture,
+            relation_id: i32,
+        ) -> ObjectRelationSelector {
+            match address {
+                RelationAddress::Id => ObjectRelationSelector::by_id(
+                    HubuumObjectRelationID::new(relation_id).expect("valid object relation id"),
+                ),
+                RelationAddress::Between => ObjectRelationSelector::between(
+                    HubuumClassID::new(fixture.from_class.id).expect("valid from class id"),
+                    HubuumObjectID::new(fixture.from_object.id).expect("valid from object id"),
+                    HubuumClassID::new(fixture.to_class.id).expect("valid to class id"),
+                    HubuumObjectID::new(fixture.to_object.id).expect("valid to object id"),
+                ),
+            }
+        }
+
+        async fn finish(self) {
+            if let Some(fixture) = self.postgres_cleanup {
+                fixture.cleanup().await.expect("contract fixture cleanup");
+            }
+        }
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_relation_contract_prepares_a_normalized_endpoint_aggregate(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "normalize").await;
+        let fixture = harness.fixture("normalize").await;
+        let prepared = harness
+            .services
+            .object_relations()
+            .prepare_create(ObjectRelationCreateSelector::explicit(
+                NewHubuumObjectRelation {
+                    from_hubuum_object_id: fixture.to_object.id,
+                    to_hubuum_object_id: fixture.from_object.id,
+                    class_relation_id: fixture.class_relation.relation().id,
+                },
+            ))
+            .await
+            .expect("relation should prepare");
+
+        assert!(prepared.from_object().id < prepared.to_object().id);
+        assert_eq!(
+            prepared.command().from_hubuum_object_id,
+            prepared.from_object().id
+        );
+        assert_eq!(
+            prepared.command().to_hubuum_object_id,
+            prepared.to_object().id
+        );
+        assert_eq!(
+            prepared.class_relation().relation(),
+            fixture.class_relation.relation()
+        );
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres_id(ContractBackend::Postgres, RelationAddress::Id)]
+    #[case::postgres_between(ContractBackend::Postgres, RelationAddress::Between)]
+    #[case::memory_id(ContractBackend::Memory, RelationAddress::Id)]
+    #[case::memory_between(ContractBackend::Memory, RelationAddress::Between)]
+    #[actix_web::test]
+    async fn object_relation_contract_resolves_explicit_addresses(
+        #[case] backend: ContractBackend,
+        #[case] address: RelationAddress,
+    ) {
+        let harness = ContractHarness::new(backend, "resolve").await;
+        let fixture = harness.fixture("resolve").await;
+        let prepared = harness
+            .services
+            .object_relations()
+            .prepare_create(harness.explicit_selector(&fixture))
+            .await
+            .expect("relation should prepare");
+        let created = harness
+            .services
+            .object_relations()
+            .create(&prepared, &EventContext::system())
+            .await
+            .expect("relation should create");
+        let resolved = harness
+            .services
+            .object_relations()
+            .resolve(harness.selector(address, &fixture, created.relation().id))
+            .await
+            .expect("relation should resolve");
+
+        assert_eq!(resolved.relation(), created.relation());
+        assert_eq!(resolved.relation().revision, ResourceRevision::INITIAL);
+        assert_eq!(resolved.from_object(), prepared.from_object());
+        assert_eq!(resolved.to_object(), prepared.to_object());
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_relation_contract_between_preparation_validates_path_membership(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "path_membership").await;
+        let fixture = harness.fixture("path_membership").await;
+        let error = harness
+            .services
+            .object_relations()
+            .prepare_create(ObjectRelationCreateSelector::between(
+                HubuumClassID::new(fixture.to_class.id).expect("valid wrong class id"),
+                HubuumObjectID::new(fixture.from_object.id).expect("valid object id"),
+                HubuumClassID::new(fixture.from_class.id).expect("valid wrong class id"),
+                HubuumObjectID::new(fixture.to_object.id).expect("valid object id"),
+            ))
+            .await
+            .expect_err("path membership mismatch should fail");
+        assert!(matches!(error, ApiError::NotFound(_)));
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_relation_contract_rejects_self_relations(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "self_relation").await;
+        let fixture = harness.fixture("self_relation").await;
+        let error = harness
+            .services
+            .object_relations()
+            .prepare_create(ObjectRelationCreateSelector::explicit(
+                NewHubuumObjectRelation {
+                    from_hubuum_object_id: fixture.from_object.id,
+                    to_hubuum_object_id: fixture.from_object.id,
+                    class_relation_id: fixture.class_relation.relation().id,
+                },
+            ))
+            .await
+            .expect_err("self relation should fail");
+        assert!(matches!(error, ApiError::BadRequest(_)));
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_relation_contract_rejects_objects_from_the_same_class(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "same_class").await;
+        let fixture = harness.fixture("same_class").await;
+        let sibling = harness
+            .create_object(&fixture.from_class, "same_class_sibling")
+            .await;
+        let error = harness
+            .services
+            .object_relations()
+            .prepare_create(ObjectRelationCreateSelector::explicit(
+                NewHubuumObjectRelation {
+                    from_hubuum_object_id: fixture.from_object.id,
+                    to_hubuum_object_id: sibling.id,
+                    class_relation_id: fixture.class_relation.relation().id,
+                },
+            ))
+            .await
+            .expect_err("same-class objects should fail");
+        assert!(matches!(error, ApiError::BadRequest(_)));
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_relation_contract_rejects_a_mismatched_class_relation(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "class_mismatch").await;
+        let fixture = harness.fixture("class_mismatch").await;
+        let third_class = harness.create_class("class_mismatch_third").await;
+        let mismatched = harness
+            .create_class_relation(&fixture.from_class, &third_class, None, None)
+            .await;
+        let error = harness
+            .services
+            .object_relations()
+            .prepare_create(ObjectRelationCreateSelector::explicit(
+                NewHubuumObjectRelation {
+                    from_hubuum_object_id: fixture.from_object.id,
+                    to_hubuum_object_id: fixture.to_object.id,
+                    class_relation_id: mismatched.relation().id,
+                },
+            ))
+            .await
+            .expect_err("mismatched class relation should fail");
+        assert!(matches!(error, ApiError::BadRequest(_)));
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_relation_contract_rejects_reverse_duplicates(#[case] backend: ContractBackend) {
+        let harness = ContractHarness::new(backend, "duplicate").await;
+        let fixture = harness.fixture("duplicate").await;
+        let prepared = harness
+            .services
+            .object_relations()
+            .prepare_create(harness.explicit_selector(&fixture))
+            .await
+            .expect("relation should prepare");
+        harness
+            .services
+            .object_relations()
+            .create(&prepared, &EventContext::system())
+            .await
+            .expect("first relation should create");
+        let reverse = harness
+            .services
+            .object_relations()
+            .prepare_create(ObjectRelationCreateSelector::explicit(
+                NewHubuumObjectRelation {
+                    from_hubuum_object_id: fixture.to_object.id,
+                    to_hubuum_object_id: fixture.from_object.id,
+                    class_relation_id: fixture.class_relation.relation().id,
+                },
+            ))
+            .await
+            .expect("reverse relation should prepare");
+        let error = harness
+            .services
+            .object_relations()
+            .create(&reverse, &EventContext::system())
+            .await
+            .expect_err("reverse duplicate should fail");
+        assert!(matches!(error, ApiError::Conflict(_)));
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_relation_contract_enforces_directional_cardinality(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "cardinality").await;
+        let from_class = harness.create_class("cardinality_from_class").await;
+        let to_class = harness.create_class("cardinality_to_class").await;
+        let class_relation = harness
+            .create_class_relation(
+                &from_class,
+                &to_class,
+                Some(ObjectRelationLimit::new(1).expect("valid limit")),
+                None,
+            )
+            .await;
+        let from_object = harness.create_object(&from_class, "cardinality_from").await;
+        let first_to = harness
+            .create_object(&to_class, "cardinality_first_to")
+            .await;
+        let second_to = harness
+            .create_object(&to_class, "cardinality_second_to")
+            .await;
+        let command = |to_object: &HubuumObject| {
+            ObjectRelationCreateSelector::explicit(NewHubuumObjectRelation {
+                from_hubuum_object_id: from_object.id,
+                to_hubuum_object_id: to_object.id,
+                class_relation_id: class_relation.relation().id,
+            })
+        };
+        let first = harness
+            .services
+            .object_relations()
+            .prepare_create(command(&first_to))
+            .await
+            .expect("first relation should prepare");
+        harness
+            .services
+            .object_relations()
+            .create(&first, &EventContext::system())
+            .await
+            .expect("first relation should create");
+        let second = harness
+            .services
+            .object_relations()
+            .prepare_create(command(&second_to))
+            .await
+            .expect("second relation should prepare");
+        let error = harness
+            .services
+            .object_relations()
+            .create(&second, &EventContext::system())
+            .await
+            .expect_err("cardinality should reject second relation");
+        assert!(matches!(error, ApiError::Conflict(_)));
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_relation_contract_deletes_the_resolved_relation(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "delete").await;
+        let fixture = harness.fixture("delete").await;
+        let prepared = harness
+            .services
+            .object_relations()
+            .prepare_create(harness.explicit_selector(&fixture))
+            .await
+            .expect("relation should prepare");
+        let created = harness
+            .services
+            .object_relations()
+            .create(&prepared, &EventContext::system())
+            .await
+            .expect("relation should create");
+        let relation_id =
+            HubuumObjectRelationID::new(created.relation().id).expect("valid object relation id");
+        harness
+            .services
+            .object_relations()
+            .delete(&created, &EventContext::system())
+            .await
+            .expect("relation should delete");
+        assert!(matches!(
+            harness
+                .services
+                .object_relations()
+                .resolve(ObjectRelationSelector::by_id(relation_id))
+                .await,
+            Err(ApiError::NotFound(_))
+        ));
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_relation_contract_object_delete_cascades_the_relation(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "object_cascade").await;
+        let fixture = harness.fixture("object_cascade").await;
+        let prepared = harness
+            .services
+            .object_relations()
+            .prepare_create(harness.explicit_selector(&fixture))
+            .await
+            .expect("relation should prepare");
+        let created = harness
+            .services
+            .object_relations()
+            .create(&prepared, &EventContext::system())
+            .await
+            .expect("relation should create");
+        let relation_id =
+            HubuumObjectRelationID::new(created.relation().id).expect("valid object relation id");
+        let object_target = harness
+            .services
+            .objects()
+            .resolve(crate::models::ObjectSelector::by_id(
+                HubuumClassID::new(fixture.from_class.id).expect("valid class id"),
+                HubuumObjectID::new(fixture.from_object.id).expect("valid object id"),
+            ))
+            .await
+            .expect("object should resolve");
+        harness
+            .services
+            .objects()
+            .delete(&object_target, &EventContext::system())
+            .await
+            .expect("object should delete");
+        assert!(matches!(
+            harness
+                .services
+                .object_relations()
+                .resolve(ObjectRelationSelector::by_id(relation_id))
+                .await,
+            Err(ApiError::NotFound(_))
+        ));
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractBackend::Postgres)]
+    #[case::memory(ContractBackend::Memory)]
+    #[actix_web::test]
+    async fn object_relation_contract_class_relation_delete_cascades_the_relation(
+        #[case] backend: ContractBackend,
+    ) {
+        let harness = ContractHarness::new(backend, "class_relation_cascade").await;
+        let fixture = harness.fixture("class_relation_cascade").await;
+        let prepared = harness
+            .services
+            .object_relations()
+            .prepare_create(harness.explicit_selector(&fixture))
+            .await
+            .expect("relation should prepare");
+        let created = harness
+            .services
+            .object_relations()
+            .create(&prepared, &EventContext::system())
+            .await
+            .expect("relation should create");
+        let relation_id =
+            HubuumObjectRelationID::new(created.relation().id).expect("valid object relation id");
+        harness
+            .services
+            .class_relations()
+            .delete(&fixture.class_relation, &EventContext::system())
+            .await
+            .expect("class relation should delete");
+        assert!(matches!(
+            harness
+                .services
+                .object_relations()
+                .resolve(ObjectRelationSelector::by_id(relation_id))
+                .await,
+            Err(ApiError::NotFound(_))
+        ));
+        harness.finish().await;
+    }
+
+    #[actix_web::test]
+    async fn memory_object_relation_events_cover_explicit_lifecycle_writes() {
+        let harness = ContractHarness::new(ContractBackend::Memory, "events").await;
+        let fixture = harness.fixture("events").await;
+        let context = EventContext::system();
+        let prepared = harness
+            .services
+            .object_relations()
+            .prepare_create(harness.between_create_selector(&fixture))
+            .await
+            .expect("relation should prepare");
+        let created = harness
+            .services
+            .object_relations()
+            .create(&prepared, &context)
+            .await
+            .expect("relation should create");
+        harness
+            .services
+            .object_relations()
+            .delete(&created, &context)
+            .await
+            .expect("relation should delete");
+
+        let events = harness
+            .storage
+            .as_ref()
+            .expect("memory harness should expose storage")
+            .object_relation_events()
+            .await;
+        assert_eq!(
+            events.iter().map(|event| event.action).collect::<Vec<_>>(),
+            vec![Action::Created, Action::Deleted]
+        );
+        assert!(events.iter().all(|event| {
+            event.object_relation_id == created.relation().id && event.context == context
+        }));
+        harness.finish().await;
+    }
+}

--- a/src/storage/collections.rs
+++ b/src/storage/collections.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use crate::events::EventContext;
 use crate::models::{Collection, CollectionID, NewCollectionWithAssignee, UpdateCollection};
 
-use super::{ClassRelationStore, ClassStore, ObjectStore, StorageError};
+use super::{ClassRelationStore, ClassStore, ObjectRelationStore, ObjectStore, StorageError};
 
 /// Persistence capability for the core collection lifecycle.
 ///
@@ -50,9 +50,15 @@ pub trait CollectionStore: Send + Sync {
 
 /// Umbrella storage boundary. New aggregate capabilities can be added here as
 /// vertical slices migrate without exposing a database pool to services.
-pub trait Storage: CollectionStore + ClassStore + ObjectStore + ClassRelationStore {}
+pub trait Storage:
+    CollectionStore + ClassStore + ObjectStore + ClassRelationStore + ObjectRelationStore
+{
+}
 
-impl<T> Storage for T where T: CollectionStore + ClassStore + ObjectStore + ClassRelationStore {}
+impl<T> Storage for T where
+    T: CollectionStore + ClassStore + ObjectStore + ClassRelationStore + ObjectRelationStore
+{
+}
 
 #[derive(Clone)]
 pub struct DynStorage {

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -8,14 +8,19 @@ use tokio::sync::RwLock;
 use crate::events::{Action, EventContext};
 use crate::models::{
     ClassSelector, ClassSelectorKind, Collection, CollectionID, HubuumClass, HubuumClassRelation,
-    HubuumClassRelationID, HubuumObject, NewCollectionWithAssignee, NewHubuumClass,
-    NewHubuumClassRelation, NewHubuumObject, ObjectDataPatchDocument, ObjectSelector,
-    ObjectSelectorKind, PreparedClassRelation, ResolvedClassRelationTarget, ResolvedClassTarget,
+    HubuumClassRelationID, HubuumObject, HubuumObjectRelation, HubuumObjectRelationID,
+    NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
+    NewHubuumObjectRelation, ObjectDataPatchDocument, ObjectRelationCreateSelector,
+    ObjectRelationCreateSelectorKind, ObjectRelationSelector, ObjectRelationSelectorKind,
+    ObjectSelector, ObjectSelectorKind, PreparedClassRelation, PreparedObjectRelation,
+    ResolvedClassRelationTarget, ResolvedClassTarget, ResolvedObjectRelationTarget,
     ResolvedObjectTarget, ResourceRevision, UpdateCollection, UpdateHubuumClass,
     UpdateHubuumObject,
 };
 
-use super::{ClassRelationStore, ClassStore, CollectionStore, ObjectStore, StorageError};
+use super::{
+    ClassRelationStore, ClassStore, CollectionStore, ObjectRelationStore, ObjectStore, StorageError,
+};
 
 const ROOT_COLLECTION_ID: i32 = 1;
 
@@ -47,19 +52,29 @@ pub(crate) struct MemoryClassRelationEvent {
     pub(crate) context: EventContext,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct MemoryObjectRelationEvent {
+    pub(crate) object_relation_id: i32,
+    pub(crate) action: Action,
+    pub(crate) context: EventContext,
+}
+
 struct MemoryState {
     next_collection_id: i32,
     next_class_id: i32,
     next_object_id: i32,
     next_class_relation_id: i32,
+    next_object_relation_id: i32,
     collections: BTreeMap<i32, Collection>,
     classes: BTreeMap<i32, HubuumClass>,
     objects: BTreeMap<i32, HubuumObject>,
     class_relations: BTreeMap<i32, HubuumClassRelation>,
+    object_relations: BTreeMap<i32, HubuumObjectRelation>,
     events: Vec<MemoryCollectionEvent>,
     class_events: Vec<MemoryClassEvent>,
     object_events: Vec<MemoryObjectEvent>,
     class_relation_events: Vec<MemoryClassRelationEvent>,
+    object_relation_events: Vec<MemoryObjectRelationEvent>,
 }
 
 impl MemoryState {
@@ -79,14 +94,17 @@ impl MemoryState {
             next_class_id: 1,
             next_object_id: 1,
             next_class_relation_id: 1,
+            next_object_relation_id: 1,
             collections: BTreeMap::from([(root.id, root)]),
             classes: BTreeMap::new(),
             objects: BTreeMap::new(),
             class_relations: BTreeMap::new(),
+            object_relations: BTreeMap::new(),
             events: Vec::new(),
             class_events: Vec::new(),
             object_events: Vec::new(),
             class_relation_events: Vec::new(),
+            object_relation_events: Vec::new(),
         }
     }
 
@@ -266,6 +284,148 @@ impl MemoryState {
         })
     }
 
+    fn resolved_class_relation(
+        &self,
+        relation: &HubuumClassRelation,
+    ) -> Result<ResolvedClassRelationTarget, StorageError> {
+        let from_class = self
+            .classes
+            .get(&relation.from_hubuum_class_id)
+            .cloned()
+            .ok_or_else(|| StorageError::not_found("From class was not found"))?;
+        let to_class = self
+            .classes
+            .get(&relation.to_hubuum_class_id)
+            .cloned()
+            .ok_or_else(|| StorageError::not_found("To class was not found"))?;
+        ResolvedClassRelationTarget::new(relation.clone(), from_class, to_class)
+            .map_err(StorageError::from)
+    }
+
+    fn direct_class_relation(
+        &self,
+        first_class_id: i32,
+        second_class_id: i32,
+    ) -> Result<&HubuumClassRelation, StorageError> {
+        let lower_class_id = first_class_id.min(second_class_id);
+        let higher_class_id = first_class_id.max(second_class_id);
+        self.class_relations
+            .values()
+            .find(|relation| {
+                relation.from_hubuum_class_id == lower_class_id
+                    && relation.to_hubuum_class_id == higher_class_id
+            })
+            .ok_or_else(|| {
+                StorageError::not_found(format!(
+                    "Class {first_class_id} is not related to class {second_class_id}"
+                ))
+            })
+    }
+
+    fn object_relation(
+        &self,
+        id: HubuumObjectRelationID,
+    ) -> Result<&HubuumObjectRelation, StorageError> {
+        self.object_relations.get(&id.id()).ok_or_else(|| {
+            StorageError::not_found(format!("Object relation {} was not found", id.id()))
+        })
+    }
+
+    fn object_relation_by_pair(
+        &self,
+        first_object_id: i32,
+        second_object_id: i32,
+    ) -> Result<&HubuumObjectRelation, StorageError> {
+        let lower_object_id = first_object_id.min(second_object_id);
+        let higher_object_id = first_object_id.max(second_object_id);
+        self.object_relations
+            .values()
+            .find(|relation| {
+                relation.from_hubuum_object_id == lower_object_id
+                    && relation.to_hubuum_object_id == higher_object_id
+            })
+            .ok_or_else(|| StorageError::not_found("Object relation was not found"))
+    }
+
+    fn object_relation_endpoints(
+        &self,
+        command: &NewHubuumObjectRelation,
+    ) -> Result<(&HubuumObject, &HubuumObject), StorageError> {
+        let from_object = self
+            .objects
+            .get(&command.from_hubuum_object_id)
+            .ok_or_else(|| StorageError::not_found("From object was not found"))?;
+        let to_object = self
+            .objects
+            .get(&command.to_hubuum_object_id)
+            .ok_or_else(|| StorageError::not_found("To object was not found"))?;
+        Ok((from_object, to_object))
+    }
+
+    fn object_relation_scope_matches(current: &HubuumObject, expected: &HubuumObject) -> bool {
+        current.id == expected.id
+            && current.collection_id == expected.collection_id
+            && current.hubuum_class_id == expected.hubuum_class_id
+    }
+
+    fn validate_prepared_object_relation(
+        &self,
+        prepared: &PreparedObjectRelation,
+    ) -> Result<(), StorageError> {
+        let (from_object, to_object) = self.object_relation_endpoints(prepared.command())?;
+        if !Self::object_relation_scope_matches(from_object, prepared.from_object())
+            || !Self::object_relation_scope_matches(to_object, prepared.to_object())
+        {
+            return Err(StorageError::not_found(
+                "Object relation endpoints no longer match the prepared target",
+            ));
+        }
+        let class_relation_id = HubuumClassRelationID::new(prepared.command().class_relation_id)
+            .map_err(StorageError::from)?;
+        let class_relation = self.class_relation(class_relation_id)?;
+        if class_relation != prepared.class_relation().relation() {
+            return Err(StorageError::not_found(
+                "Class relation no longer matches the prepared object relation",
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_resolved_object_relation(
+        &self,
+        target: &ResolvedObjectRelationTarget,
+    ) -> Result<(), StorageError> {
+        let relation_id =
+            HubuumObjectRelationID::new(target.relation().id).map_err(StorageError::from)?;
+        let relation = self.object_relation(relation_id)?;
+        let command = NewHubuumObjectRelation {
+            from_hubuum_object_id: relation.from_hubuum_object_id,
+            to_hubuum_object_id: relation.to_hubuum_object_id,
+            class_relation_id: relation.class_relation_id,
+        };
+        let (from_object, to_object) = self.object_relation_endpoints(&command)?;
+        if relation != target.relation()
+            || !Self::object_relation_scope_matches(from_object, target.from_object())
+            || !Self::object_relation_scope_matches(to_object, target.to_object())
+        {
+            return Err(StorageError::not_found(
+                "Object relation no longer matches the resolved target",
+            ));
+        }
+        Ok(())
+    }
+
+    fn object_relation_count(&self, class_relation_id: i32, object_id: i32) -> usize {
+        self.object_relations
+            .values()
+            .filter(|relation| {
+                relation.class_relation_id == class_relation_id
+                    && (relation.from_hubuum_object_id == object_id
+                        || relation.to_hubuum_object_id == object_id)
+            })
+            .count()
+    }
+
     fn record_event(&mut self, collection_id: i32, action: Action, context: &EventContext) {
         self.events.push(MemoryCollectionEvent {
             collection_id,
@@ -302,6 +462,19 @@ impl MemoryState {
             context: context.clone(),
         });
     }
+
+    fn record_object_relation_event(
+        &mut self,
+        object_relation_id: i32,
+        action: Action,
+        context: &EventContext,
+    ) {
+        self.object_relation_events.push(MemoryObjectRelationEvent {
+            object_relation_id,
+            action,
+            context: context.clone(),
+        });
+    }
 }
 
 /// Deterministic collection adapter used by shared storage contract tests.
@@ -331,6 +504,10 @@ impl MemoryStorage {
 
     pub(crate) async fn class_relation_events(&self) -> Vec<MemoryClassRelationEvent> {
         self.state.read().await.class_relation_events.clone()
+    }
+
+    pub(crate) async fn object_relation_events(&self) -> Vec<MemoryObjectRelationEvent> {
+        self.state.read().await.object_relation_events.clone()
     }
 }
 
@@ -455,6 +632,14 @@ impl CollectionStore for MemoryStorage {
         state.class_relations.retain(|_, relation| {
             !deleted_class_ids.contains(&relation.from_hubuum_class_id)
                 && !deleted_class_ids.contains(&relation.to_hubuum_class_id)
+        });
+        let remaining_object_ids = state.objects.keys().copied().collect::<Vec<_>>();
+        let remaining_class_relation_ids =
+            state.class_relations.keys().copied().collect::<Vec<_>>();
+        state.object_relations.retain(|_, relation| {
+            remaining_object_ids.contains(&relation.from_hubuum_object_id)
+                && remaining_object_ids.contains(&relation.to_hubuum_object_id)
+                && remaining_class_relation_ids.contains(&relation.class_relation_id)
         });
         state.record_event(id.id(), Action::Deleted, context);
         Ok(())
@@ -664,6 +849,14 @@ impl ClassStore for MemoryStorage {
         state.class_relations.retain(|_, relation| {
             relation.from_hubuum_class_id != class.id && relation.to_hubuum_class_id != class.id
         });
+        let remaining_object_ids = state.objects.keys().copied().collect::<Vec<_>>();
+        let remaining_class_relation_ids =
+            state.class_relations.keys().copied().collect::<Vec<_>>();
+        state.object_relations.retain(|_, relation| {
+            remaining_object_ids.contains(&relation.from_hubuum_object_id)
+                && remaining_object_ids.contains(&relation.to_hubuum_object_id)
+                && remaining_class_relation_ids.contains(&relation.class_relation_id)
+        });
         state.record_class_event(class.id, Action::Deleted, context);
         Ok(())
     }
@@ -759,7 +952,205 @@ impl ClassRelationStore for MemoryStorage {
         let mut state = self.state.write().await;
         let relation_id = state.class_relation_target(target)?.id;
         state.class_relations.remove(&relation_id);
+        state
+            .object_relations
+            .retain(|_, relation| relation.class_relation_id != relation_id);
         state.record_class_relation_event(relation_id, Action::Deleted, context);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ObjectRelationStore for MemoryStorage {
+    async fn prepare_object_relation(
+        &self,
+        selector: ObjectRelationCreateSelector,
+    ) -> Result<PreparedObjectRelation, StorageError> {
+        let state = self.state.read().await;
+        match selector.kind() {
+            ObjectRelationCreateSelectorKind::Explicit(command) => {
+                let command = command.clone().normalized().map_err(StorageError::from)?;
+                let (from_object, to_object) = state.object_relation_endpoints(&command)?;
+                let class_relation_id = HubuumClassRelationID::new(command.class_relation_id)
+                    .map_err(StorageError::from)?;
+                let class_relation = state.class_relation(class_relation_id)?;
+                let class_relation = state.resolved_class_relation(class_relation)?;
+                PreparedObjectRelation::new(
+                    command,
+                    from_object.clone(),
+                    to_object.clone(),
+                    class_relation,
+                )
+                .map_err(StorageError::from)
+            }
+            ObjectRelationCreateSelectorKind::Between {
+                from_class_id,
+                from_object_id,
+                to_class_id,
+                to_object_id,
+            } => {
+                let route_from_object = state
+                    .objects
+                    .get(&from_object_id.id())
+                    .ok_or_else(|| StorageError::not_found("From object was not found"))?;
+                let route_to_object = state
+                    .objects
+                    .get(&to_object_id.id())
+                    .ok_or_else(|| StorageError::not_found("To object was not found"))?;
+                if route_from_object.hubuum_class_id != from_class_id.id()
+                    || route_to_object.hubuum_class_id != to_class_id.id()
+                {
+                    return Err(StorageError::not_found(
+                        "Object was not found in the selected class",
+                    ));
+                }
+                let class_relation =
+                    state.direct_class_relation(from_class_id.id(), to_class_id.id())?;
+                let class_relation = state.resolved_class_relation(class_relation)?;
+                let command = NewHubuumObjectRelation {
+                    from_hubuum_object_id: route_from_object.id,
+                    to_hubuum_object_id: route_to_object.id,
+                    class_relation_id: class_relation.relation().id,
+                }
+                .normalized()
+                .map_err(StorageError::from)?;
+                let (from_object, to_object) =
+                    if route_from_object.id == command.from_hubuum_object_id {
+                        (route_from_object.clone(), route_to_object.clone())
+                    } else {
+                        (route_to_object.clone(), route_from_object.clone())
+                    };
+                PreparedObjectRelation::new(command, from_object, to_object, class_relation)
+                    .map_err(StorageError::from)
+            }
+        }
+    }
+
+    async fn resolve_object_relation(
+        &self,
+        selector: ObjectRelationSelector,
+    ) -> Result<ResolvedObjectRelationTarget, StorageError> {
+        let state = self.state.read().await;
+        let relation = match selector.kind() {
+            ObjectRelationSelectorKind::ById(relation_id) => {
+                state.object_relation(*relation_id)?.to_owned()
+            }
+            ObjectRelationSelectorKind::Between {
+                from_class_id,
+                from_object_id,
+                to_class_id,
+                to_object_id,
+            } => {
+                let route_from_object = state
+                    .objects
+                    .get(&from_object_id.id())
+                    .ok_or_else(|| StorageError::not_found("From object was not found"))?;
+                let route_to_object = state
+                    .objects
+                    .get(&to_object_id.id())
+                    .ok_or_else(|| StorageError::not_found("To object was not found"))?;
+                if route_from_object.hubuum_class_id != from_class_id.id()
+                    || route_to_object.hubuum_class_id != to_class_id.id()
+                {
+                    return Err(StorageError::not_found(
+                        "Object relation was not found for the selected classes",
+                    ));
+                }
+                state
+                    .object_relation_by_pair(from_object_id.id(), to_object_id.id())?
+                    .to_owned()
+            }
+        };
+        let command = NewHubuumObjectRelation {
+            from_hubuum_object_id: relation.from_hubuum_object_id,
+            to_hubuum_object_id: relation.to_hubuum_object_id,
+            class_relation_id: relation.class_relation_id,
+        };
+        let (from_object, to_object) = state.object_relation_endpoints(&command)?;
+        let class_relation_id =
+            HubuumClassRelationID::new(relation.class_relation_id).map_err(StorageError::from)?;
+        let class_relation =
+            state.resolved_class_relation(state.class_relation(class_relation_id)?)?;
+        ResolvedObjectRelationTarget::new(
+            relation,
+            from_object.clone(),
+            to_object.clone(),
+            class_relation,
+        )
+        .map_err(StorageError::from)
+    }
+
+    async fn create_object_relation(
+        &self,
+        prepared: &PreparedObjectRelation,
+        context: &EventContext,
+    ) -> Result<ResolvedObjectRelationTarget, StorageError> {
+        let mut state = self.state.write().await;
+        state.validate_prepared_object_relation(prepared)?;
+        let command = prepared.command();
+        if state
+            .object_relation_by_pair(command.from_hubuum_object_id, command.to_hubuum_object_id)
+            .is_ok()
+        {
+            return Err(StorageError::conflict(format!(
+                "A relation between objects {} and {} already exists",
+                command.from_hubuum_object_id, command.to_hubuum_object_id
+            )));
+        }
+
+        let class_relation = prepared.class_relation().relation();
+        for object in [prepared.from_object(), prepared.to_object()] {
+            let limit = if object.hubuum_class_id == class_relation.from_hubuum_class_id {
+                class_relation.from_max_relations
+            } else {
+                class_relation.to_max_relations
+            };
+            if let Some(limit) = limit
+                && state.object_relation_count(class_relation.id, object.id)
+                    >= limit.value() as usize
+            {
+                return Err(StorageError::conflict(format!(
+                    "Object relation cardinality exceeded: object {} is limited to {} relations by class relation {}",
+                    object.id,
+                    limit.value(),
+                    class_relation.id
+                )));
+            }
+        }
+
+        let id = state.next_object_relation_id;
+        state.next_object_relation_id += 1;
+        let now = Utc::now().naive_utc();
+        let relation = HubuumObjectRelation {
+            id,
+            from_hubuum_object_id: command.from_hubuum_object_id,
+            to_hubuum_object_id: command.to_hubuum_object_id,
+            class_relation_id: command.class_relation_id,
+            created_at: now,
+            updated_at: now,
+            revision: ResourceRevision::INITIAL,
+        };
+        state.object_relations.insert(id, relation);
+        state.record_object_relation_event(id, Action::Created, context);
+        ResolvedObjectRelationTarget::new(
+            relation,
+            prepared.from_object().clone(),
+            prepared.to_object().clone(),
+            prepared.class_relation().clone(),
+        )
+        .map_err(StorageError::from)
+    }
+
+    async fn delete_object_relation(
+        &self,
+        target: &ResolvedObjectRelationTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        let mut state = self.state.write().await;
+        state.validate_resolved_object_relation(target)?;
+        let relation_id = target.relation().id;
+        state.object_relations.remove(&relation_id);
+        state.record_object_relation_event(relation_id, Action::Deleted, context);
         Ok(())
     }
 }
@@ -894,6 +1285,9 @@ impl ObjectStore for MemoryStorage {
         let (_, object) = state.object_target(target)?;
         let object_id = object.id;
         state.objects.remove(&object_id);
+        state.object_relations.retain(|_, relation| {
+            relation.from_hubuum_object_id != object_id && relation.to_hubuum_object_id != object_id
+        });
         state.record_object_event(object_id, Action::Deleted, context);
         Ok(())
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,6 +4,7 @@ mod collections;
 mod error;
 #[cfg(test)]
 mod memory;
+mod object_relations;
 mod objects;
 mod postgres;
 
@@ -13,5 +14,6 @@ pub use collections::{CollectionStore, DynStorage, Storage};
 pub use error::StorageError;
 #[cfg(test)]
 pub(crate) use memory::MemoryStorage;
+pub use object_relations::ObjectRelationStore;
 pub use objects::ObjectStore;
 pub use postgres::PostgresStorage;

--- a/src/storage/object_relations.rs
+++ b/src/storage/object_relations.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+
+use crate::events::EventContext;
+use crate::models::{
+    ObjectRelationCreateSelector, ObjectRelationSelector, PreparedObjectRelation,
+    ResolvedObjectRelationTarget,
+};
+
+use super::StorageError;
+
+/// Persistence capability for object-relation resolution and lifecycle writes.
+#[async_trait]
+pub trait ObjectRelationStore: Send + Sync {
+    async fn prepare_object_relation(
+        &self,
+        selector: ObjectRelationCreateSelector,
+    ) -> Result<PreparedObjectRelation, StorageError>;
+
+    async fn resolve_object_relation(
+        &self,
+        selector: ObjectRelationSelector,
+    ) -> Result<ResolvedObjectRelationTarget, StorageError>;
+
+    async fn create_object_relation(
+        &self,
+        prepared: &PreparedObjectRelation,
+        context: &EventContext,
+    ) -> Result<ResolvedObjectRelationTarget, StorageError>;
+
+    async fn delete_object_relation(
+        &self,
+        target: &ResolvedObjectRelationTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError>;
+}

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -16,19 +16,24 @@ use crate::db::traits::object::{
     ResolveObjectSelectorRecord, UpdateResolvedObjectRecord,
 };
 use crate::db::traits::relations::{
-    CreatePreparedClassRelationRecord, DeleteResolvedClassRelationRecord,
-    PrepareClassRelationRecord, ResolveClassRelationTargetRecord,
+    CreatePreparedClassRelationRecord, CreatePreparedObjectRelationRecord,
+    DeleteResolvedClassRelationRecord, DeleteResolvedObjectRelationRecord,
+    PrepareClassRelationRecord, PrepareObjectRelationRecord, ResolveClassRelationTargetRecord,
+    ResolveObjectRelationTargetRecord,
 };
 use crate::events::EventContext;
 use crate::models::{
     ClassSelector, Collection, CollectionID, HubuumClass, HubuumClassRelationID, HubuumObject,
     NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
-    ObjectDataPatchDocument, ObjectSelector, PreparedClassRelation, ResolvedClassRelationTarget,
-    ResolvedClassTarget, ResolvedObjectTarget, UpdateCollection, UpdateHubuumClass,
-    UpdateHubuumObject,
+    ObjectDataPatchDocument, ObjectRelationCreateSelector, ObjectRelationSelector, ObjectSelector,
+    PreparedClassRelation, PreparedObjectRelation, ResolvedClassRelationTarget,
+    ResolvedClassTarget, ResolvedObjectRelationTarget, ResolvedObjectTarget, UpdateCollection,
+    UpdateHubuumClass, UpdateHubuumObject,
 };
 
-use super::{ClassRelationStore, ClassStore, CollectionStore, ObjectStore, StorageError};
+use super::{
+    ClassRelationStore, ClassStore, CollectionStore, ObjectRelationStore, ObjectStore, StorageError,
+};
 
 /// Canonical production storage adapter.
 #[derive(Clone)]
@@ -204,6 +209,58 @@ impl ClassRelationStore for PostgresStorage {
     ) -> Result<(), StorageError> {
         target
             .delete_resolved_class_relation_record(&self.pool, context)
+            .await
+            .map_err(StorageError::from)
+    }
+}
+
+#[async_trait]
+impl ObjectRelationStore for PostgresStorage {
+    async fn prepare_object_relation(
+        &self,
+        selector: ObjectRelationCreateSelector,
+    ) -> Result<PreparedObjectRelation, StorageError> {
+        selector
+            .prepare_object_relation_record(&self.pool)
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn resolve_object_relation(
+        &self,
+        selector: ObjectRelationSelector,
+    ) -> Result<ResolvedObjectRelationTarget, StorageError> {
+        selector
+            .resolve_object_relation_target_record(&self.pool)
+            .await
+            .map_err(StorageError::from)
+    }
+
+    async fn create_object_relation(
+        &self,
+        prepared: &PreparedObjectRelation,
+        context: &EventContext,
+    ) -> Result<ResolvedObjectRelationTarget, StorageError> {
+        let relation = prepared
+            .create_prepared_object_relation_record(&self.pool, context)
+            .await
+            .map_err(StorageError::from)?;
+        ResolvedObjectRelationTarget::new(
+            relation,
+            prepared.from_object().clone(),
+            prepared.to_object().clone(),
+            prepared.class_relation().clone(),
+        )
+        .map_err(StorageError::from)
+    }
+
+    async fn delete_object_relation(
+        &self,
+        target: &ResolvedObjectRelationTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        target
+            .delete_resolved_object_relation_record(&self.pool, context)
             .await
             .map_err(StorageError::from)
     }

--- a/src/tests/storage_performance.rs
+++ b/src/tests/storage_performance.rs
@@ -19,15 +19,80 @@ use crate::models::collection::effective_group_on;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
     ClassSelector, CollectionID, GroupID, HubuumClassID, HubuumClassRelationID, HubuumObjectID,
-    NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
-    NewHubuumObjectRelation, ObjectSelector, UpdateCollection, UpdateHubuumClass,
-    UpdateHubuumObject, UserID,
+    HubuumObjectRelationID, NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation,
+    NewHubuumObject, NewHubuumObjectRelation, ObjectRelationCreateSelector, ObjectRelationSelector,
+    ObjectSelector, UpdateCollection, UpdateHubuumClass, UpdateHubuumObject, UserID,
 };
 use crate::services::Services;
-use crate::tests::{TestScope, ensure_admin_user};
+use crate::tests::{CollectionFixture, TestScope, ensure_admin_user};
 use crate::traits::{CanDelete, CanSave, CanUpdate};
 
 const REPRESENTATIVE_COLLECTION_ROWS: i32 = 2_000;
+
+async fn object_relation_budget_fixture(
+    scope: &TestScope,
+    label: &str,
+) -> (CollectionFixture, Services, ObjectRelationCreateSelector) {
+    let fixture = scope.collection_fixture(label).await;
+    let services = Services::postgres(scope.pool.get_ref().clone());
+    let class_one = NewHubuumClass {
+        collection_id: fixture.collection.id,
+        name: scope.scoped_name(&format!("{label}_class_one")),
+        description: "object relation budget class one".to_string(),
+        json_schema: None,
+        validate_schema: None,
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("first class should save");
+    let class_two = NewHubuumClass {
+        collection_id: fixture.collection.id,
+        name: scope.scoped_name(&format!("{label}_class_two")),
+        description: "object relation budget class two".to_string(),
+        json_schema: None,
+        validate_schema: None,
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("second class should save");
+    let class_relation = NewHubuumClassRelation {
+        from_hubuum_class_id: class_one.id,
+        to_hubuum_class_id: class_two.id,
+        forward_template_alias: None,
+        reverse_template_alias: None,
+        from_max_relations: None,
+        to_max_relations: None,
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("class relation should save");
+    let object_one = NewHubuumObject {
+        collection_id: fixture.collection.id,
+        hubuum_class_id: class_one.id,
+        name: scope.scoped_name(&format!("{label}_object_one")),
+        description: "object relation budget object one".to_string(),
+        data: serde_json::json!({}),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("first object should save");
+    let object_two = NewHubuumObject {
+        collection_id: fixture.collection.id,
+        hubuum_class_id: class_two.id,
+        name: scope.scoped_name(&format!("{label}_object_two")),
+        description: "object relation budget object two".to_string(),
+        data: serde_json::json!({}),
+    }
+    .save_without_events(&scope.pool)
+    .await
+    .expect("second object should save");
+    let selector = ObjectRelationCreateSelector::explicit(NewHubuumObjectRelation {
+        from_hubuum_object_id: object_one.id,
+        to_hubuum_object_id: object_two.id,
+        class_relation_id: class_relation.id,
+    });
+    (fixture, services, selector)
+}
 
 #[derive(QueryableByName)]
 struct ExplainPlanRow {
@@ -1082,6 +1147,132 @@ async fn object_relation_create_has_a_fixed_query_and_checkout_budget() {
     assert_eq!(queries.queries_matching("FROM \"hubuumobject\""), 2);
     assert_eq!(
         queries.queries_matching("INSERT INTO \"hubuumobject_relation\""),
+        1
+    );
+    assert_eq!(queries.queries_matching("INSERT INTO \"events\""), 1);
+
+    fixture.cleanup().await.expect("fixture cleanup");
+}
+
+#[actix_web::test]
+async fn object_relation_storage_query_budget_preparation_is_fixed() {
+    let scope = TestScope::new();
+    let (fixture, services, selector) =
+        object_relation_budget_fixture(&scope, "query_budget_object_relation_prepare").await;
+
+    let (prepared, queries) =
+        capture_queries(services.object_relations().prepare_create(selector)).await;
+    prepared.expect("object relation should prepare");
+    assert_eq!(queries.total_queries(), 3, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 3);
+    assert_eq!(queries.control_queries(), 0);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(queries.queries_matching("FROM \"hubuumobject\""), 1);
+    assert_eq!(queries.queries_matching("FROM \"hubuumclass_relation\""), 1);
+    assert_eq!(queries.queries_matching("FROM \"hubuumclass\""), 1);
+
+    fixture.cleanup().await.expect("fixture cleanup");
+}
+
+#[actix_web::test]
+async fn object_relation_storage_query_budget_point_resolution_is_fixed() {
+    let scope = TestScope::new();
+    let (fixture, services, selector) =
+        object_relation_budget_fixture(&scope, "query_budget_object_relation_resolve").await;
+    let prepared = services
+        .object_relations()
+        .prepare_create(selector)
+        .await
+        .expect("object relation should prepare");
+    let created = services
+        .object_relations()
+        .create(&prepared, &EventContext::system())
+        .await
+        .expect("object relation should create");
+
+    let (resolved, queries) = capture_queries(services.object_relations().resolve(
+        ObjectRelationSelector::by_id(
+            HubuumObjectRelationID::new(created.relation().id).expect("valid object relation id"),
+        ),
+    ))
+    .await;
+    assert_eq!(
+        resolved.expect("object relation should resolve").relation(),
+        created.relation()
+    );
+    assert_eq!(queries.total_queries(), 4, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 4);
+    assert_eq!(queries.control_queries(), 0);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(
+        queries.queries_matching("FROM \"hubuumobject_relation\""),
+        1
+    );
+    assert_eq!(queries.queries_matching("FROM \"hubuumobject\""), 1);
+
+    fixture.cleanup().await.expect("fixture cleanup");
+}
+
+#[actix_web::test]
+async fn object_relation_storage_query_budget_create_with_event_is_fixed() {
+    let scope = TestScope::new();
+    let (fixture, services, selector) =
+        object_relation_budget_fixture(&scope, "query_budget_object_relation_service_create").await;
+    let prepared = services
+        .object_relations()
+        .prepare_create(selector)
+        .await
+        .expect("object relation should prepare");
+
+    let (created, queries) = capture_queries(
+        services
+            .object_relations()
+            .create(&prepared, &EventContext::system()),
+    )
+    .await;
+    created.expect("object relation should create with an event");
+    assert_eq!(queries.total_queries(), 6, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 4);
+    assert_eq!(queries.control_queries(), 2);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(
+        queries.queries_matching("INSERT INTO \"hubuumobject_relation\""),
+        1
+    );
+    assert_eq!(queries.queries_matching("INSERT INTO \"events\""), 1);
+
+    fixture.cleanup().await.expect("fixture cleanup");
+}
+
+#[actix_web::test]
+async fn object_relation_storage_query_budget_delete_with_event_is_fixed() {
+    let scope = TestScope::new();
+    let (fixture, services, selector) =
+        object_relation_budget_fixture(&scope, "query_budget_object_relation_service_delete").await;
+    let prepared = services
+        .object_relations()
+        .prepare_create(selector)
+        .await
+        .expect("object relation should prepare");
+    let target = services
+        .object_relations()
+        .create(&prepared, &EventContext::system())
+        .await
+        .expect("object relation should create");
+
+    let (deleted, queries) = capture_queries(
+        services
+            .object_relations()
+            .delete(&target, &EventContext::system()),
+    )
+    .await;
+    deleted.expect("object relation should delete with an event");
+    assert_eq!(queries.total_queries(), 6, "{:#?}", queries.query_counts());
+    assert_eq!(queries.domain_queries(), 4);
+    assert_eq!(queries.control_queries(), 2);
+    assert_eq!(queries.connection_checkouts(), 1);
+    assert_eq!(
+        queries.queries_matching("DELETE FROM \"hubuumobject_relation\""),
         1
     );
     assert_eq!(queries.queries_matching("INSERT INTO \"events\""), 1);


### PR DESCRIPTION
## Summary

- introduce backend-neutral object-relation selectors, prepared commands, resolved authorization targets, and an `ObjectRelationService`
- add PostgreSQL and in-memory implementations for object-relation preparation, point resolution, creation, deletion, cardinality enforcement, cascading cleanup, and lifecycle events
- route global and class/object-scoped object-relation lifecycle handlers through the service boundary
- preserve PostgreSQL trigger serialization for bounded directional cardinality while keeping unrelated creates concurrent
- document the completed object-relation lifecycle boundary and its intentionally PostgreSQL-specific list/search/graph compatibility paths
- add 24 shared PostgreSQL/in-memory contract cases and exact query-budget regressions

## Stack

This is the fifth layer of stack #286 and targets #288:

1. #284 collection service and query baselines
2. #285 class storage boundary
3. #287 object storage boundary
4. #288 class-relation storage boundary
5. **#289 object-relation storage boundary**

The lower relation layer supplies the class-relation aggregate used to validate object-relation commands.

## Behavior notes

- endpoint order is normalized before persistence, so reverse duplicates remain conflicts
- object endpoints must belong to different classes covered by the direct class relation
- create/delete authorization uses complete object, collection, and class-relation context
- PostgreSQL creation rechecks authorization scope and class-relation membership atomically, then relies on the existing trigger-owned conditional object locks for cardinality
- HTTP and OpenAPI request/response shapes are unchanged

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `./scripts/test-classify-ci-changes.sh`
- `git diff --check`

## Changelog

No changelog entry: this is an internal application storage-boundary refactor with unchanged public API behavior.

Closes #27 only when the complete stack is merged; this layer does not close the issue by itself.