### PR TITLE
Enforce a complete application storage boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,17 +31,26 @@
   backend-neutral persistence capabilities in `src/storage/*`.
 - Keep Diesel/Postgres query construction and backend details in `src/db/traits/*`.
 - Model methods should stay thin and delegate persistence-heavy work to backend traits.
-- Route migrated high-level callers through services rather than adding new
-  direct `DbPool` dependencies. Use `BackendContext` as the compatibility
-  boundary for APIs that have not migrated and still need to accept either
-  `DbPool` or wrappers such as `web::Data<DbPool>`.
+- Route high-level callers through services or operation-shaped backend
+  capabilities. Application consumers may pass `AppContext` or the opaque
+  `BackendContext`, but must not acquire, name, or select a `DbPool`.
+  Backend implementations may recover their configured connection pool behind
+  that sealed boundary; direct `DbPool` compatibility is internal migration
+  machinery, not an application-layer escape hatch.
 - Keep storage capabilities aggregate- or query-shaped rather than table-shaped.
-  Shared memory/Postgres contract tests cover logical behavior; PostgreSQL-only
-  tests must retain transaction, locking, trigger, concurrency, and query-budget
-  coverage.
+  Every selectable backend must implement the complete storage contract; focused
+  in-memory models may exercise shared logical contracts but must not be exposed
+  as partially supported backends. PostgreSQL-only tests must retain transaction,
+  locking, trigger, concurrency, migration, recovery, and query-budget coverage.
+- Give each storage adapter an implementation-owned error type and convert it to
+  the backend-neutral `StorageError` at the adapter boundary. Only the application
+  error layer converts `StorageError` to `ApiError`.
+- Apply backend-neutral tracing and metrics outside individual adapters so a new
+  backend cannot silently omit common diagnostics. Report the selected backend
+  and non-secret effective settings through the administrator configuration.
 - Put multi-step database writes in `with_transaction`; use `with_connection` for single reads, single writes, and non-atomic database work.
 - Workspace crates should expose small, explicit interfaces with private fields. Prefer typed request/builder APIs over long positional argument lists when callers must provide several settings.
-- Keep workspace crate boundaries clean of app-specific errors, global config, Actix, Diesel, and task persistence unless the crate explicitly owns that layer.
+- Keep workspace crate boundaries clean of app-specific errors, global config, Actix, Diesel, and task persistence unless the crate explicitly owns that layer. A dedicated PostgreSQL storage crate may own Diesel, its generated schema, migrations, pool/TLS setup, transaction helpers, and adapter errors; those types must not leak through the backend-neutral storage contract.
 - Avoid leaking third-party implementation types from workspace crate APIs unless they are the intentional integration surface. Use crate-owned structs, builders, traits, and errors at boundaries where practical.
 - Use typestate builders when they prevent meaningful invalid call order or missing required data; otherwise prefer a simpler builder with validating terminal methods.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- The redacted administrator configuration now reports the selected complete
+  storage backend, storage contract version, required capability families, and
+  effective non-secret pool settings. Startup logs and Prometheus metrics expose
+  the same backend identity, and lifecycle storage calls have uniform bounded
+  tracing plus duration and failure metrics.
 - Class object lists now accept up to four named `related.<alias>` filter
   groups. Each group selects one target class, normal target-object fields, and
   an optional bidirectional depth up to 10; groups are combined with `AND`, and

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,23 +56,28 @@ for package classifications, publishing policy, and promotion requirements.
   choosing persistence helpers directly.
 - `src/storage/*`:
   Backend-neutral capability traits plus PostgreSQL adapters. The test-only
-  memory adapter implements selected logical contracts without claiming
-  PostgreSQL concurrency equivalence.
+  memory contract model exercises focused logical behavior. It is not a
+  selectable backend and does not represent partial application support.
 - `src/models/*`:
   Application domain models and high-level operations.
   These should not contain Diesel query construction for non-trivial backend logic.
 - `src/traits/*`:
   Behavioral interfaces used by handlers and models inside the application.
-  `BackendContext` remains the compatibility boundary for unmigrated APIs that
-  accept either `DbPool` or wrappers such as `web::Data<DbPool>`.
+  `BackendContext` is a sealed, opaque persistence capability. Consumers pass
+  it to operations but cannot extract or select the database implementation.
+- `src/backend.rs`:
+  Application-facing capability facade for query, workflow, and operational
+  contracts that do not yet have multiple storage implementations.
 - `src/db/traits/*`:
   Diesel/Postgres-backed implementations behind model and storage adapters.
   This is where query details, joins, filters, and transactions belong.
 
-The collection lifecycle and class resolution/lifecycle are the first
-service/storage capabilities. See
-[Service and Storage Boundary](storage_boundary.md) for responsibilities,
-contract testing, performance gates, and current migration limits.
+The collection, class, object, class-relation, and object-relation point and
+lifecycle operations are the first backend-neutral service/storage ports. A
+selectable backend must nevertheless satisfy the complete application storage
+contract. See [Application and Storage Boundary](storage_boundary.md) for the
+required families, compatibility tests, performance gates, and opaque backend
+boundary.
 
 ### Practical layering rule
 
@@ -86,7 +91,9 @@ When adding a feature:
    PostgreSQL storage implementation.
 4. Keep model methods thin while they remain in unmigrated paths.
 5. Add shared logical contract tests and retain PostgreSQL-specific query,
-   transaction, and concurrency tests.
+   transaction, migration, recovery, and concurrency tests.
+6. Do not register the implementation as selectable until it satisfies every
+   storage capability family and the available-backend compatibility suite.
 
 ### Module layout notes
 
@@ -111,9 +118,10 @@ permission reads in `src/db/traits/collection/permissions.rs` or
 Normal collection and class lifecycle handlers enter this implementation
 through their service and storage capabilities. Do not bypass those services
 from a migrated handler. Imports, restore code, fixtures, list/search,
-permissions, and history remain explicitly outside the pilot until their
-complete use cases can move without weakening transaction, authorization, or
-performance behavior.
+permissions, and history still use operation-shaped PostgreSQL adapters during
+the internal migration. That location does not make them optional backend
+features: a selectable backend must supply equivalent capabilities before it
+can be registered.
 
 When adding a collection creation path, use the shared collection insert helper
 from the collection backend so `collections` and `collection_closure` stay in

--- a/docs/distributed_deployment.md
+++ b/docs/distributed_deployment.md
@@ -228,7 +228,10 @@ identity or behavior. In particular:
 
 The effective non-secret configuration is available through the existing
 running-configuration endpoint. Secret fields report only whether they are
-configured.
+configured. Its database section also reports the selected complete storage
+backend, storage contract version, required capability families, and effective
+pool settings. Every replica in one deployment must report the same backend and
+contract version.
 
 ## Shared Login Throttling
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -20,7 +20,10 @@ Every log record includes:
 
 Request-scoped records also include `request_id` and, when accepted from the client, `correlation_id`. Authenticated requests record `principal_id` on the request span after bearer token resolution.
 
-The server emits one `server startup` record at `INFO` after binding succeeds. It includes the package version, build Git SHA, bind address, TLS state, worker counts, database and authorization backends, log format and level, and the number of enabled event sinks. Release and container builds populate `git_sha`; local builds report `unknown` unless `HUBUUM_BUILD_GIT_SHA` is set while compiling.
+The server emits one `server startup` record at `INFO` after binding succeeds. It includes the package version, build Git SHA, bind address, TLS state, worker counts, storage and authorization backends, storage contract version, log format and level, and the number of enabled event sinks. Release and container builds populate `git_sha`; local builds report `unknown` unless `HUBUUM_BUILD_GIT_SHA` is set while compiling.
+
+`db_backend` remains as a compatibility alias for `storage_backend` while the
+only selectable implementation is PostgreSQL.
 
 ## Request Logs
 
@@ -74,6 +77,24 @@ Authorization decision logs use:
 | Denial | `WARN` |
 
 Authorization records include `event_type=authorization`, `decision`, `principal_id`, requested `permissions` as a JSON array, derived `action` and `entity_type` when the requested permissions share them, nullable `collection_id` and `collection_count`, and a short `reason`.
+
+## Storage Diagnostics
+
+Lifecycle storage calls run inside a `storage_operation` debug span with the
+bounded fields `backend`, `capability`, and `operation`. Successful calls emit
+`storage operation complete` at `DEBUG`. Expected domain outcomes such as not
+found, conflict, validation, and stale preconditions emit
+`storage operation rejected` at `DEBUG`. Database, unavailable, and internal
+failures emit `storage operation failed` at `WARN`.
+
+PostgreSQL pool checkout and helper boundaries use the corresponding
+`storage backend connection acquired`, `storage backend operation complete`,
+and failure events. These include the bounded `caller` and `operation` fields,
+plus elapsed milliseconds. They do not include SQL text or arguments.
+
+Use the lifecycle events to debug application use cases and the PostgreSQL
+events to debug connection or transaction behavior. A lifecycle call may
+contain more than one implementation-level operation.
 
 ## Sensitive Data Rules
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -32,6 +32,7 @@ Use these metrics to identify a target:
 
 - `hubuum_build_info{version,git_sha}`
 - `hubuum_runtime_info{role}`
+- `hubuum_storage_backend_info{backend,contract_version}`
 - `hubuum_process_start_time_seconds`
 
 Check the target mix before interpreting process-local worker metrics:
@@ -201,6 +202,9 @@ max by (template_id, template_name) (
 | `hubuum_db_connection_acquire_failures_total` | `caller` | Pool connection acquisition failures |
 | `hubuum_db_operation_duration_seconds` | `caller`, `operation`, `result` | `with_connection` and `with_transaction` helper duration |
 | `hubuum_db_operation_errors_total` | `caller`, `operation`, `result` | Database helper failures by broad public error class |
+| `hubuum_storage_backend_info` | `backend`, `contract_version` | Complete storage backend selected for the process |
+| `hubuum_storage_operation_duration_seconds` | `backend`, `capability`, `operation`, `result` | Backend-neutral lifecycle storage duration |
+| `hubuum_storage_operation_errors_total` | `backend`, `capability`, `operation`, `result` | Backend-neutral lifecycle storage failures |
 | `hubuum_metrics_refresh_duration_seconds` | `source` | Duration of the latest refresh attempt |
 | `hubuum_metrics_refresh_last_success_timestamp_seconds` | `source` | Unix timestamp of the latest successful refresh |
 | `hubuum_metrics_refresh_failures_total` | `source` | Best-effort refresh failures |
@@ -213,6 +217,14 @@ The bounded database `caller` values are `event_delivery`, `event_fanout`,
 `event_retention`, `http_request`, `metrics_refresh`, `readiness`,
 `request_maintenance`, `restore_coordinator`, `task_lease`, `task_worker`,
 `token_retention`, and `unattributed`.
+
+Storage `capability`, `operation`, and `result` values come from closed Rust
+enums or fixed call sites. Expected domain failures are included in
+`hubuum_storage_operation_errors_total`; use the `result` label to distinguish
+them from `database`, `unavailable`, and `internal` backend failures. Storage
+metrics describe logical use cases, while `hubuum_db_*` metrics describe the
+PostgreSQL implementation. Do not sum the two as though they were the same
+operation count.
 
 The standard unprefixed `process_*` families are available on Linux, macOS, and
 Windows. The names intentionally match the Prometheus ecosystem so existing

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -20253,12 +20253,32 @@
       "DatabaseConfig": {
         "type": "object",
         "required": [
+          "backend",
+          "contract_version",
+          "capabilities",
           "url",
           "pool_size",
           "pool_acquire_timeout_ms",
           "statement_timeout_ms"
         ],
         "properties": {
+          "backend": {
+            "type": "string",
+            "description": "Complete storage backend selected by the application composition root."
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Required capability families. Selectable backends always report the complete set."
+          },
+          "contract_version": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Version of the all-or-nothing storage contract implemented by the backend.",
+            "minimum": 0
+          },
           "pool_acquire_timeout_ms": {
             "type": "integer",
             "format": "int64",
@@ -20370,7 +20390,7 @@
           "connections_created": {
             "type": "integer",
             "format": "int64",
-            "description": "Cumulative connections established by the pool.",
+            "description": "Cumulative connections established by the context.",
             "minimum": 0
           },
           "db_size": {
@@ -20381,13 +20401,13 @@
           "idle_connections": {
             "type": "integer",
             "format": "int32",
-            "description": "Established connections currently waiting in the pool.",
+            "description": "Established connections currently waiting in the context.",
             "minimum": 0
           },
           "in_use_connections": {
             "type": "integer",
             "format": "int32",
-            "description": "Established connections currently checked out of the pool.",
+            "description": "Established connections currently checked out of the context.",
             "minimum": 0
           },
           "last_vacuum_time": {
@@ -20400,7 +20420,7 @@
           "max_connections": {
             "type": "integer",
             "format": "int32",
-            "description": "Configured maximum number of connections in this process-local pool.",
+            "description": "Configured maximum number of connections in this process-local context.",
             "minimum": 0
           },
           "pending_acquisitions": {
@@ -20412,7 +20432,7 @@
           "total_connections": {
             "type": "integer",
             "format": "int32",
-            "description": "Connections currently managed by this process-local pool.",
+            "description": "Connections currently managed by this process-local context.",
             "minimum": 0
           }
         }

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -79,6 +79,13 @@ examples.
 See [Database Pool Tuning and Load Testing](performance.md) for connection
 budgeting, pool observability, and a repeatable k6 scenario.
 
+Administrators can inspect the selected storage backend, storage contract
+version, complete capability-family list, and these effective pool settings at
+`GET /api/v1/admin/config`. The endpoint reports only whether the database URL
+is configured; it never returns the URL or credentials. See
+[Application and Storage Boundary](storage_boundary.md) for the all-or-nothing
+backend contract.
+
 ### Task System Configuration
 
 | Variable | Default | Description |

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -1,148 +1,310 @@
-# Service and Storage Boundary
+# Application and Storage Boundary
 
-Hubuum is incrementally separating application use cases from PostgreSQL and
-Diesel details. PostgreSQL remains the production semantic reference; the goal
-is a compile-time dependency boundary and faster contract tests, not generic
-multi-database support.
+Hubuum has one application-facing storage boundary. A storage backend is a
+complete implementation of that boundary, not a collection of optional
+features. PostgreSQL is currently the only selectable backend.
 
-The first migrated capabilities cover the core collection, class, object, and
-relation lifecycles. Collections include:
+The in-memory implementation used by lifecycle tests is deliberately named a
+contract model. It is not selectable, is not advertised to administrators, and
+does not satisfy the complete `StorageBackend` trait. It may become a backend
+only after it implements every required capability family and passes the full
+compatibility suite.
 
-- point reads;
-- create with an initial assignee grant and lifecycle event;
-- update, including no-op behavior;
-- delete constraints;
-- direct children and ordered ancestors; and
-- hierarchy moves.
+The immediate goal is a hard dependency boundary around PostgreSQL and Diesel,
+not support for additional production databases.
 
-Classes include:
-
-- explicit point resolution by ID or name;
-- create with schema validation and a lifecycle event;
-- update, including no-op behavior and collection moves;
-- selector-aware mutations that reject stale name targets; and
-- delete with a lifecycle event.
-
-Objects include:
-
-- explicit point resolution by class/object ID or class/object name;
-- create within a resolved class, including JSON Schema validation;
-- update and atomic JSON Patch, including revision-preserving no-ops;
-- selector-aware mutations that reject stale class or object names; and
-- delete with a lifecycle event.
-
-Class relations include:
-
-- normalization and endpoint preparation before authorization;
-- point resolution with both endpoint classes;
-- create and delete with atomic lifecycle events;
-- stale endpoint rejection between authorization and a transactional write;
-- directional alias and cardinality-limit preservation; and
-- class and collection delete cascades.
-
-Object relations include:
-
-- explicit point resolution by relation ID or a class/object endpoint pair;
-- endpoint and direct class-relation preparation before authorization;
-- normalized creation with duplicate and same-class rejection;
-- directional cardinality enforcement owned by the storage implementation;
-- create and delete with atomic lifecycle events; and
-- object, class, collection, and class-relation delete cascades.
-
-## Dependency direction
+## Dependency Direction
 
 ```text
-collection/class/object/relation HTTP handlers
-                       |
-                       v
- CollectionService / ClassService / ObjectService
-       / ClassRelationService / ObjectRelationService
-                       |
-                       v
- CollectionStore / ClassStore / ObjectStore
-       / ClassRelationStore / ObjectRelationStore
-                  /       \
-                 v         v
-           PostgreSQL    memory
-            adapter      adapter
-                 |
-                 v
-        Diesel transactions and queries
+HTTP / workers / administration
+              |
+              v
+     application use cases
+              |
+              v
+      opaque BackendContext
+              |
+              v
+ complete StorageBackend contract
+              |
+              v
+      PostgreSQL adapter
+              |
+              v
+ Diesel, SQL, pools, transactions
 ```
 
-`AppContext` constructs `Services` with `PostgresStorage` in production. Core
-collection, class, object, and relation point/lifecycle handlers call their
-services; they do not choose a Diesel query or transaction helper for migrated
-operations. Permission checks remain at the handler boundary.
+Lifecycle services use a narrower internal `LifecycleStorage` view of the
+selected complete backend:
 
-Class-relation preparation and resolution return aggregates containing both
-endpoint classes. Handlers build permission resources from those aggregates,
-so authorization does not perform hidden PostgreSQL lookups. Transactional
-writes lock and recheck the same endpoint snapshots before inserting or
-deleting a relation.
+```text
+CollectionService / ClassService / ObjectService
+       / ClassRelationService / ObjectRelationService
+                           |
+                           v
+                    LifecycleStorage
+                      /          \
+                     v            v
+          selected PostgreSQL   memory contract model
+                backend             (tests only)
+```
 
-Object-relation preparation and resolution similarly carry both objects and
-the resolved class relation. The PostgreSQL adapter keeps cardinality
-serialization in the database trigger, where it locks only bounded endpoints;
-the service boundary does not introduce broader application-side locking.
+This narrower view exists so domain behavior can be tested without pretending
+that the test model is a complete application backend. Production composition
+uses `DynLifecycleStorage::from_backend`, which requires `StorageBackend`.
+`DynLifecycleStorage::new` is reserved for focused contract harnesses.
 
-## Responsibility split
+## Complete Backend Contract
 
-`src/services/*` owns application-facing use-case entrypoints. Services accept
-domain request types and return application errors after translating the
-backend-neutral storage error taxonomy.
+`StorageBackend` is a sealed aggregate trait. A selectable implementation must
+satisfy every capability family below before `BackendHandle` can compose it:
 
-`src/storage/*` owns capability traits and adapters. Capability methods are
-aggregate-shaped rather than table-shaped so implementations retain control of
-transactions, batching, hierarchy maintenance, initial permission grants, and
-atomic lifecycle events.
+| Required family | Contract responsibility |
+| --- | --- |
+| Domain lifecycle | Collection, class, object, class-relation, and object-relation resolution and lifecycle behavior |
+| Identity and authorization data | Principals, credentials, memberships, grants, and data needed by configured authorization providers |
+| Queries and history | Lists, filtering, stable pagination, search, aggregates, computed enrichment, graphs, and temporal history |
+| Workflows | Imports, restores, tasks, backups, exports, remote calls, and their atomic state transitions |
+| Operations | Probes, metrics snapshots, retention, event delivery, leases, locking, and worker coordination |
 
-`src/db/traits/*` continues to own Diesel expressions, PostgreSQL SQL, locks,
-and transaction implementation. `PostgresStorage` delegates to these existing
-operations without changing their query shape.
+The families are not feature flags and the admin configuration does not report
+optional support. Every selectable backend implements the entire list. The
+central certification implementations in `src/storage/contract.rs` make adding
+a backend an explicit architecture change rather than an incidental trait impl.
 
-`MemoryStorage` is compiled for tests and implements the logical collection,
-class, object, class-relation, and object-relation contracts. It models
-hierarchy, selector resolution, endpoint preparation, schema validation,
-bounded JSON Patch behavior, revisions, no-op updates, relation cardinality,
-delete constraints, cascades, and lifecycle event occurrence. It does not
-claim PostgreSQL locking, trigger, computed-field materialization,
-permission-row, or temporal-history equivalence.
+Some PostgreSQL capability implementations remain in `src/db/traits/*` while
+the internal migration continues. That is an implementation-location detail,
+not partial backend support. `BackendHandle` selects one certified PostgreSQL
+adapter, and compatibility helpers may recover its pool only behind the sealed
+boundary. No second backend can be added to composition while those adapters
+remain PostgreSQL-only without completing their backend-neutral ports.
 
-## Contract and performance gates
+The storage contract version changes when a required family is added or when
+observable semantics change. The selected backend and contract version are
+reported in startup logs, process metrics, and the redacted admin configuration.
 
-The shared contract suite runs each migrated collection, class, object, and
-class-relation, and object-relation behavior against both PostgreSQL and
-memory. Each test focuses on one behavior so backend differences cannot be
-hidden inside a large scenario.
+## Lifecycle Semantics
 
-The PostgreSQL query-capture tests exercise both services and retain exact
-point-read and mutation budgets. The opt-in PostgreSQL Criterion benchmark also
-times the collection service path. Trait dispatch or service composition must
-therefore not introduce extra pool checkouts, SQL statements, or
-application-side pagination.
+The currently shared lifecycle contract covers the following behavior.
 
-## Current migration boundary
+Collections provide:
 
-This is an incremental migration. Collection, class, object, and relation
-list/search, computed-field enrichment, permission management, graph traversal,
-history, and unrelated aggregates still use `BackendContext` and the existing
-model/database traits. Existing direct persistence APIs also remain for
-fixtures, imports, restore paths, and unmigrated callers.
+- point reads;
+- create with an initial assignee grant and atomic lifecycle event;
+- update and revision-preserving no-op behavior;
+- delete constraints;
+- direct children and ordered ancestors; and
+- hierarchy moves with sibling-scoped name uniqueness.
 
-When expanding the boundary:
+Classes provide:
 
-1. Add a use-case-shaped storage capability rather than a generic repository.
-2. Preserve set-based SQL, batching, transactions, and event atomicity in the
-   PostgreSQL adapter.
-3. Add focused shared logical contract tests.
-4. Keep PostgreSQL-only query-budget, locking, rollback, trigger, and
-   concurrency tests.
-5. Route the selected high-level caller through a service before removing its
-   direct `DbPool` dependency.
-6. Remove old model/database entrypoints only after every production,
-   administrative, worker, import, restore, and test caller has migrated.
+- point resolution by ID or name;
+- create with schema validation and an atomic lifecycle event;
+- update, no-op behavior, and collection moves;
+- stale selector rejection; and
+- delete with lifecycle and cascade semantics.
 
-Search and cursor pagination remain PostgreSQL-oriented until a concrete
-backend-neutral query contract can preserve filtering, stable ordering, count
-behavior, authorization, and query budgets without leaking SQL types.
+Objects provide:
+
+- point resolution by ID or name within a class;
+- create and update with JSON Schema validation;
+- bounded, atomic JSON Patch and revision-preserving no-ops;
+- stale selector rejection; and
+- delete with lifecycle and cascade semantics.
+
+Class and object relations provide:
+
+- endpoint preparation before authorization;
+- resolution with the endpoint aggregates required by policy checks;
+- stale endpoint rejection between authorization and mutation;
+- normalized direction, aliases, duplicates, and cardinality semantics;
+- atomic lifecycle events; and
+- the documented object, class, collection, and relation cascades.
+
+Capability methods are use-case or aggregate shaped. Implementations own
+transactions, batching, locking, hierarchy maintenance, initial grants,
+cardinality enforcement, and atomic event persistence. The contract must not
+devolve into table repositories or expose query builders.
+
+## Error Direction
+
+Errors cross the boundary in one direction:
+
+```text
+PostgresStorageError / contract-model error
+                    |
+                    v
+              StorageError
+                    |
+                    v
+                 ApiError
+```
+
+Each adapter owns its implementation error and converts it to the bounded
+`StorageErrorKind` taxonomy at the adapter edge. Backend-neutral storage code
+does not import `ApiError`. The application error layer alone converts
+`StorageError` into the public `ApiError` response surface. There is no reverse
+application-error-to-storage-error conversion.
+
+Expected domain outcomes such as not found, conflict, validation, and stale
+preconditions retain their useful public classification. Database, unavailable,
+and internal failures retain diagnostic detail for logs while public HTTP
+responses use the existing safe generic messages.
+
+## Observability Contract
+
+Every lifecycle call is wrapped outside the implementation, so backends cannot
+silently omit common diagnostics. The wrapper provides:
+
+- a `storage_operation` tracing span with bounded `backend`, `capability`, and
+  `operation` fields;
+- a `storage operation complete` debug event on success;
+- a debug rejection event for expected domain failures;
+- a warning event for database, unavailable, and internal failures; and
+- backend-neutral duration and error metrics with the same bounded labels.
+
+The PostgreSQL connection and transaction helpers provide the equivalent
+completion and failure logs for capability families still backed by legacy
+operation-shaped adapters. Their existing low-cardinality database metrics
+remain the implementation-level view. Storage metrics describe logical calls;
+database metrics describe pool and transaction behavior. Operators should use
+both rather than deriving one from the other.
+
+Logs and metric labels must never contain entity IDs, user-controlled names,
+queries, URLs, credentials, or payloads. Detailed mutation audit logs remain
+commit-aware and separate from diagnostic backend events.
+
+## Administrator Configuration
+
+`GET /api/v1/admin/config` reports the effective non-secret storage selection:
+
+- backend name;
+- storage contract version;
+- the complete required capability-family list;
+- whether a connection URL is configured;
+- pool size;
+- pool acquisition timeout; and
+- statement timeout.
+
+The connection URL and credentials are never returned. Startup metadata and
+`hubuum_storage_backend_info` report the same backend identity and contract
+version so configuration, logs, and metrics cannot disagree about composition.
+
+## Compatibility and Backend-Specific Tests
+
+There are two complementary test layers:
+
+1. Shared lifecycle contract tests run the same focused behaviors against the
+   PostgreSQL adapter and the in-memory contract model.
+2. The available-backend compatibility registry iterates every selectable
+   `StorageBackendKind`, composes it through `BackendHandle`, verifies its
+   contract descriptor, and exercises the service boundary.
+
+PostgreSQL-specific tests remain responsible for behavior a logical model
+cannot reproduce: transactions, rollbacks, isolation, row locks, trigger
+serialization, migrations, temporal history, recovery, concurrency, query
+budgets, and production feature combinations. The complete repository test
+suite is therefore part of PostgreSQL backend certification, not a substitute
+for the shared logical contracts.
+
+Adding another selectable backend requires all of the following in one change:
+
+1. Implement every capability family in `StorageBackend`.
+2. Add the backend to the sealed certification module and
+   `StorageBackendKind::ALL`.
+3. Add an exhaustive `BackendHandle` composition variant without a fallback.
+4. Run every shared compatibility contract against the implementation.
+5. Add backend-specific unit and integration coverage for its native failure,
+   consistency, concurrency, and recovery behavior.
+6. Provide adapter-owned error conversion into `StorageError`.
+7. Verify the common tracing and metric wrapper labels.
+8. Add a redacted administrator configuration projection for its settings.
+9. Preserve the PostgreSQL integration and query-budget suite unless
+   PostgreSQL is deliberately removed as an available backend.
+
+If any item is absent, the implementation is a test model or internal adapter,
+not an available storage backend.
+
+## Workspace Extraction Path
+
+The boundary is intended to become a set of workspace crates. The target
+dependency graph is:
+
+```text
+root hubuum application
+|-- depends on --> hubuum-domain
+|-- depends on --> hubuum-storage-core
+|                    `-- depends on --> hubuum-domain
+`-- depends on --> hubuum-storage-postgres
+                     |-- depends on --> hubuum-storage-core
+                     `-- depends on --> hubuum-domain
+
+hubuum-storage-contract-tests
+|-- depends on --> hubuum-storage-core
+`-- exercised with --> each backend adapter
+```
+
+No workspace crate depends on the root application package.
+
+The crates have deliberately different responsibilities:
+
+- `hubuum-domain` owns validated identifiers, commands, aggregates, and result
+  types without Diesel, Actix, global configuration, or `ApiError`.
+- `hubuum-storage-core` owns the complete traits, `StorageError`, backend
+  descriptors, and the adapter-independent observation contract.
+- `hubuum-storage-postgres` intentionally owns Diesel, generated schema,
+  migrations, pool and TLS setup, transaction helpers, persistence rows,
+  PostgreSQL queries, and `PostgresStorageError`.
+- `hubuum-storage-contract-tests` supplies the reusable compatibility suite and
+  focused logical model. Every available adapter runs that suite; each adapter
+  also retains native unit and integration tests.
+- The root package owns application services and composition, administrator
+  configuration projection, Actix/OpenAPI types, and `StorageError` to
+  `ApiError` conversion.
+
+Moving Diesel first without separating types would either make the adapter
+depend on the root package or move application and HTTP concerns into the
+adapter. Both create the wrong dependency direction. Existing structs that
+combine domain behavior with `Queryable`, `Insertable`, schema references, or
+SQL methods therefore need to split into backend-neutral types and private
+PostgreSQL row types at the adapter edge.
+
+A safe extraction stack is:
+
+1. Introduce backend-neutral domain command/result types and explicit
+   conversions to private PostgreSQL rows.
+2. Move the contract, errors, descriptors, and compatibility harness into
+   `hubuum-storage-core` and `hubuum-storage-contract-tests`.
+3. Move the pool/TLS runtime and transaction boundary, then queries and adapter
+   errors, into `hubuum-storage-postgres`.
+4. Move `src/schema.rs` and `migrations/` together so generated schema,
+   embedded migrations, and production queries stay owned by one crate.
+5. Forward root package features such as embedded migrations and TLS to the
+   adapter crate, and update the CLI migration entrypoint to call its narrow
+   migration API.
+6. Update the Docker manifest-copy stage, CI change classifier, Rust API policy,
+   and production container build in the same stack layers that add the crates.
+
+The pool/TLS/transaction runtime can be extracted before all queries if its API
+uses crate-owned configuration and errors. It should not expose Diesel pool or
+connection types to the root application; closures or adapter-owned operation
+APIs keep those implementation details on the PostgreSQL side.
+
+## Boundary Enforcement
+
+Architecture tests enforce that:
+
+- handlers, extractors, middleware, and metrics scraping do not import Diesel,
+  `DbPool`, transaction helpers, or database implementation modules;
+- backend-neutral services and storage contracts do not import PostgreSQL or
+  application API errors;
+- only adapter modules translate implementation errors to `StorageError`;
+- the application error layer owns `StorageError` to `ApiError` conversion;
+- `AppContext` owns an opaque `BackendHandle` and composes services from a
+  complete backend;
+- the complete backend trait contains every required capability family; and
+- the memory contract model cannot be certified or selected as a full backend.
+
+Direct persistence APIs remain internal implementation machinery for adapters,
+administrative workflows, and fixtures. They are not an application-facing
+escape hatch.

--- a/src/api/handlers/auth.rs
+++ b/src/api/handlers/auth.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 use crate::api::openapi::{ApiErrorResponse, LoginResponse, MessageResponse};
 use crate::api::response::ApiResponse;
-use crate::db::DbPool;
 use crate::errors::ApiError;
 use crate::extractors::{AdminAccess, Authenticated, ManagementAccess};
 use crate::middlewares::rate_limit::{
@@ -10,6 +9,7 @@ use crate::middlewares::rate_limit::{
 };
 use crate::models::{LOCAL_IDENTITY_SCOPE, LoginUser, REDACTED_DEBUG_VALUE, Token, UserID};
 use crate::observability::metrics;
+use crate::permissions::AppContext;
 use actix_web::{HttpRequest, Responder, get, post, web};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
@@ -69,7 +69,7 @@ pub async fn get_auth_providers() -> Result<impl Responder, ApiError> {
 )]
 #[post("/login")]
 pub async fn login(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     req: HttpRequest,
     req_input: web::Json<LoginUser>,
 ) -> Result<impl Responder, ApiError> {
@@ -97,7 +97,7 @@ pub async fn login(
     };
 
     debug!(message = "Login started", user = name);
-    let user = match crate::auth::login(&pool, login).await {
+    let user = match crate::auth::login(&context, login).await {
         Ok(user) => user,
         Err(e) => {
             let (outcome, metric_outcome) = if matches!(e, ApiError::Unauthorized(_)) {
@@ -113,7 +113,7 @@ pub async fn login(
 
     finish_login_attempt(login_permit, LoginAttemptOutcome::Succeeded).await?;
 
-    let token_generation_result = user.create_issued_token(&pool).await;
+    let token_generation_result = user.create_issued_token(&context).await;
 
     let token = match token_generation_result {
         Ok(token) => token,
@@ -149,14 +149,14 @@ pub async fn login(
 )]
 #[post("/logout")]
 pub async fn logout(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: Authenticated,
 ) -> Result<impl Responder, ApiError> {
     let token = requestor.token;
 
     debug!(message = "token logout requested");
 
-    let result = token.delete(&pool).await;
+    let result = token.delete(&context).await;
 
     match result {
         Ok(_) => Ok(ApiResponse::message("Logout successful.")),
@@ -182,7 +182,7 @@ pub async fn logout(
 )]
 #[post("/logout_all")]
 pub async fn logout_all(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     user_access: ManagementAccess,
 ) -> Result<impl Responder, ApiError> {
     debug!(
@@ -190,7 +190,7 @@ pub async fn logout_all(
         user_access.user.id
     );
 
-    let delete_result = user_access.user.delete_all_tokens(&pool).await;
+    let delete_result = user_access.user.delete_all_tokens(&context).await;
 
     match delete_result {
         Ok(_) => Ok(ApiResponse::message("Logout of all tokens successful.")),
@@ -221,14 +221,14 @@ pub async fn logout_all(
 )]
 #[post("/logout/token")]
 pub async fn logout_token(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     user_access: AdminAccess,
     token: web::Json<LogoutTokenRequest>,
 ) -> Result<impl Responder, ApiError> {
     let token = Token(token.into_inner().token);
     debug!(message = "administrative token logout requested");
 
-    let result = token.delete(&pool).await;
+    let result = token.delete(&context).await;
 
     match result {
         Ok(_) => Ok(ApiResponse::message("Logout of token successful.")),
@@ -261,7 +261,7 @@ pub async fn logout_token(
 )]
 #[post("/logout/uid/{user_id}")]
 pub async fn logout_other(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     admin_access: AdminAccess,
     user_id: web::Path<UserID>,
 ) -> Result<impl Responder, ApiError> {
@@ -274,9 +274,9 @@ pub async fn logout_other(
     );
 
     let delete_result = user_id
-        .instance(&pool)
+        .instance(&context)
         .await?
-        .delete_all_tokens(&pool)
+        .delete_all_tokens(&context)
         .await;
 
     match delete_result {

--- a/src/api/handlers/meta.rs
+++ b/src/api/handlers/meta.rs
@@ -1,14 +1,16 @@
 use crate::api::openapi::{ApiErrorResponse, CountsResponse};
 use crate::api::response::ApiResponse;
+use crate::backend::capabilities::meta::{
+    load_database_pool_state, load_database_state, load_task_queue_state,
+};
 use crate::config::{get_config, login_rate_limit_config};
-use crate::db::DbPool;
-use crate::db::traits::meta::{load_database_state, load_task_queue_state};
 use crate::errors::ApiError;
 use crate::extractors::AdminAccess;
 use crate::middlewares::rate_limit;
 use crate::models::class::total_class_count;
 use crate::models::collection::total_collection_count;
 use crate::models::object::{objects_per_class_count, total_object_count};
+use crate::permissions::AppContext;
 use actix_web::{Responder, delete, get, http::StatusCode, web};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -18,15 +20,15 @@ use utoipa::ToSchema;
 
 #[derive(Serialize, Debug, ToSchema)]
 pub struct DbStateResponse {
-    /// Configured maximum number of connections in this process-local pool.
+    /// Configured maximum number of connections in this process-local context.
     max_connections: u32,
-    /// Connections currently managed by this process-local pool.
+    /// Connections currently managed by this process-local context.
     total_connections: u32,
     /// Remaining capacity: idle connections plus capacity to create connections.
     available_connections: u32,
-    /// Established connections currently waiting in the pool.
+    /// Established connections currently waiting in the context.
     idle_connections: u32,
-    /// Established connections currently checked out of the pool.
+    /// Established connections currently checked out of the context.
     in_use_connections: u32,
     /// Connection acquisitions currently waiting to complete.
     pending_acquisitions: u64,
@@ -40,7 +42,7 @@ pub struct DbStateResponse {
     acquisitions_timed_out: u64,
     /// Cumulative time spent waiting for connections, in milliseconds.
     acquisition_wait_time_ms: u64,
-    /// Cumulative connections established by the pool.
+    /// Cumulative connections established by the context.
     connections_created: u64,
     /// Cumulative connections discarded because they were broken.
     connections_closed_broken: u64,
@@ -94,38 +96,33 @@ pub struct TaskQueueStateResponse {
 )]
 #[get("db")]
 pub async fn get_db_state(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: AdminAccess,
 ) -> Result<impl Responder, ApiError> {
-    let row = load_database_state(&pool).await?;
-    let state = pool.state();
-    let max_connections = pool.config().max_size;
-    let in_use_connections = state.connections.saturating_sub(state.idle_connections);
-    let available_connections = max_connections.saturating_sub(in_use_connections);
-    let acquisition_wait_time_ms =
-        u64::try_from(state.statistics.get_wait_time.as_millis()).unwrap_or(u64::MAX);
+    let row = load_database_state(&context).await?;
+    let state = load_database_pool_state(&context);
     debug!(
         message = "DB state requested",
         requestor = requestor.user.id
     );
 
     let response = DbStateResponse {
-        max_connections,
-        total_connections: state.connections,
-        available_connections,
+        max_connections: state.max_connections,
+        total_connections: state.total_connections,
+        available_connections: state.available_connections,
         idle_connections: state.idle_connections,
-        in_use_connections,
-        pending_acquisitions: state.statistics.pending_gets(),
-        acquisitions_started: state.statistics.get_started,
-        acquisitions_direct: state.statistics.get_direct,
-        acquisitions_waited: state.statistics.get_waited,
-        acquisitions_timed_out: state.statistics.get_timed_out,
-        acquisition_wait_time_ms,
-        connections_created: state.statistics.connections_created,
-        connections_closed_broken: state.statistics.connections_closed_broken,
-        connections_closed_invalid: state.statistics.connections_closed_invalid,
-        connections_closed_max_lifetime: state.statistics.connections_closed_max_lifetime,
-        connections_closed_idle_timeout: state.statistics.connections_closed_idle_timeout,
+        in_use_connections: state.in_use_connections,
+        pending_acquisitions: state.pending_acquisitions,
+        acquisitions_started: state.acquisitions_started,
+        acquisitions_direct: state.acquisitions_direct,
+        acquisitions_waited: state.acquisitions_waited,
+        acquisitions_timed_out: state.acquisitions_timed_out,
+        acquisition_wait_time_ms: state.acquisition_wait_time_ms,
+        connections_created: state.connections_created,
+        connections_closed_broken: state.connections_closed_broken,
+        connections_closed_invalid: state.connections_closed_invalid,
+        connections_closed_max_lifetime: state.connections_closed_max_lifetime,
+        connections_closed_idle_timeout: state.connections_closed_idle_timeout,
         active_connections: row.active_connections,
         db_size: row.db_size,
         last_vacuum_time: row.last_vacuum_time.map(|dt| dt.to_string()),
@@ -146,7 +143,7 @@ pub async fn get_db_state(
 )]
 #[get("counts")]
 pub async fn get_object_and_class_count(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: AdminAccess,
 ) -> Result<impl Responder, ApiError> {
     debug!(
@@ -155,10 +152,10 @@ pub async fn get_object_and_class_count(
     );
 
     let response = CountsResponse {
-        total_objects: total_object_count(&pool).await?,
-        total_classes: total_class_count(&pool).await?,
-        total_collections: total_collection_count(&pool).await?,
-        objects_per_class: objects_per_class_count(&pool).await?,
+        total_objects: total_object_count(&context).await?,
+        total_classes: total_class_count(&context).await?,
+        total_collections: total_collection_count(&context).await?,
+        objects_per_class: objects_per_class_count(&context).await?,
     };
 
     Ok(ApiResponse::new(response, StatusCode::OK))
@@ -177,11 +174,11 @@ pub async fn get_object_and_class_count(
 )]
 #[get("tasks")]
 pub async fn get_task_queue_state(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: AdminAccess,
 ) -> Result<impl Responder, ApiError> {
     let config = get_config()?.clone();
-    let state = load_task_queue_state(&pool).await?;
+    let state = load_task_queue_state(&context).await?;
 
     debug!(
         message = "Task queue state requested",

--- a/src/api/handlers/probes.rs
+++ b/src/api/handlers/probes.rs
@@ -1,12 +1,13 @@
-use actix_web::{Responder, get, http::StatusCode, web};
+use actix_web::{Responder, get, http::StatusCode};
 use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::db::traits::probe::ProbeBackend;
-use crate::db::{DbCallSite, DbPool, with_db_call_site};
+use crate::backend::capabilities::probe::ProbeBackend;
+use crate::backend::{DbCallSite, with_db_call_site};
 use crate::errors::ApiError;
+use crate::permissions::AppContext;
 
 #[derive(Serialize, ToSchema)]
 pub struct ProbeResponse {
@@ -44,8 +45,8 @@ pub async fn healthz() -> impl Responder {
     )
 )]
 #[get("/readyz")]
-pub async fn readyz(pool: web::Data<DbPool>) -> Result<impl Responder, ApiError> {
-    let snapshot = with_db_call_site(DbCallSite::Readiness, pool.readiness_snapshot())
+pub async fn readyz(context: AppContext) -> Result<impl Responder, ApiError> {
+    let snapshot = with_db_call_site(DbCallSite::Readiness, context.readiness_snapshot())
         .await
         .map_err(|_| ApiError::ServiceUnavailable("Database is not ready".to_string()))?;
     if !snapshot.schema_is_ready() {

--- a/src/api/v1/handlers/backups.rs
+++ b/src/api/v1/handlers/backups.rs
@@ -4,8 +4,8 @@ use base64::Engine;
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
+use crate::backend::capabilities::task::{TaskBackend, TaskCreateRequest, TaskScopeSnapshot};
 use crate::backups::{BackupSettings, authorize_backup_request};
-use crate::db::traits::task::{TaskBackend, TaskCreateRequest, TaskScopeSnapshot};
 use crate::errors::ApiError;
 use crate::extractors::Authenticated;
 use crate::models::{

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -11,19 +11,19 @@ use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
 use crate::api::v1::handlers::history::HistoryResponse;
-use crate::can;
-use crate::db::traits::UserPermissions;
-use crate::db::traits::authz::scope_allows;
-use crate::db::traits::computed_field::enrich_objects_with_computed;
-use crate::db::traits::history::{
+use crate::backend::capabilities::UserPermissions;
+use crate::backend::capabilities::authz::scope_allows;
+use crate::backend::capabilities::computed_field::enrich_objects_with_computed;
+use crate::backend::capabilities::history::{
     HistoryCollectionFilter, class_as_of, class_history_paginated_with_total_count, object_as_of,
     object_history_paginated_with_total_count,
 };
-use crate::db::traits::relations::{
+use crate::backend::capabilities::relations::{
     class_relation_authorization_resources, object_relation_authorization_resources,
 };
-use crate::db::traits::user::UserSearchBackend;
-use crate::db::with_revision_precondition_scope;
+use crate::backend::capabilities::user::UserSearchBackend;
+use crate::backend::with_revision_precondition_scope;
+use crate::can;
 use crate::errors::ApiError;
 use crate::extractors::{AccessEventContext, Authenticated, ObjectDataPatchPayload};
 use crate::models::collection as collection_model;
@@ -44,11 +44,11 @@ use crate::models::{
     HubuumClassRelationID, HubuumClassWithPath, HubuumObject, HubuumObjectHistory, HubuumObjectID,
     HubuumObjectReadResponse, HubuumObjectRelation, HubuumObjectWithPath, NewHubuumClass,
     NewHubuumClassRelationFromClass, NewHubuumObjectRequest, ObjectDataPatchDocument,
-    ObjectRelationCreateSelector, ObjectRelationSelector, ObjectSelector, Permissions,
-    RelatedClassGraph, RelatedObjectGraph, RelatedObjectGraphRow, ResolvedClassTarget,
+    ObjectRelationCreateSelector, ObjectRelationEndpoint, ObjectRelationSelector, ObjectSelector,
+    Permissions, RelatedClassGraph, RelatedObjectGraph, RelatedObjectGraphRow, ResolvedClassTarget,
     ResolvedObjectTarget, UpdateHubuumClass, UpdateHubuumObject, UpdateHubuumObjectRequest,
 };
-use crate::traits::{BackendContext, Search, SelfAccessors};
+use crate::traits::{Search, SelfAccessors};
 use crate::utilities::extensions::CustomStringExtensions;
 
 use crate::models::search::{
@@ -127,17 +127,17 @@ fn scope_object_query_to_class(params: &mut QueryOptions, class: &HubuumClassID)
 }
 
 async fn computed_personal_owner(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     class: &HubuumClass,
 ) -> Result<Option<i32>, ApiError> {
     if !requestor.principal.is_human() {
         return Ok(None);
     }
-    let resource = class.to_resource_ref(pool.db_pool()).await?;
+    let resource = class.to_resource_ref(&context).await?;
     match authorize_resources(
-        pool.permission_backend(),
-        pool,
+        context.permission_backend(),
+        &context,
         &requestor.principal,
         requestor.scopes(),
         vec![Permissions::ReadClass],
@@ -307,7 +307,7 @@ fn ensure_graph_result_within_limit<T>(
 #[get("")]
 #[get("/")]
 async fn get_classes(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
@@ -321,16 +321,19 @@ async fn get_classes(
 
     debug!(message = "Listing classes", user_id = user.id());
 
-    let (classes, total_count) = if pool.permission_backend().supports_sql_visibility_pushdown() {
+    let (classes, total_count) = if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
         let total_count = if params.include_total {
-            user.count_classes(&pool, count_query_options(&params), requestor.scopes())
+            user.count_classes(&context, count_query_options(&params), requestor.scopes())
                 .await?
         } else {
             SKIPPED_TOTAL_COUNT
         };
         let search_params = prepare_db_pagination::<HubuumClassExpanded>(&params)?;
         let classes = user
-            .search_classes(&pool, search_params, requestor.scopes())
+            .search_classes(&context, search_params, requestor.scopes())
             .await?;
         (classes, total_count)
     } else {
@@ -339,16 +342,16 @@ async fn get_classes(
         }
         let candidates = user
             .search_classes_from_backend_with_admin_status(
-                &pool,
+                &context,
                 count_query_options(&params),
                 true,
                 None,
             )
             .await?;
-        let principal = PrincipalRef::load(&pool, user).await?;
+        let principal = PrincipalRef::load(&context, user).await?;
         let search_params = prepare_db_pagination::<HubuumClassExpanded>(&params)?;
         let page = authorize_cursor_page(
-            pool.permission_backend(),
+            context.permission_backend(),
             &principal,
             candidates,
             requestor.scopes(),
@@ -388,7 +391,7 @@ async fn get_classes(
 #[post("")]
 #[post("/")]
 async fn create_class(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_data: web::Json<NewHubuumClass>,
     req: HttpRequest,
@@ -404,7 +407,7 @@ async fn create_class(
 
     let collection = CollectionID::new(class_data.collection_id)?;
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::CreateClass],
@@ -412,23 +415,23 @@ async fn create_class(
     );
 
     let event_context = requestor.event_context(&req);
-    let class = pool
+    let class = context
         .class_service()
         .create(class_data, &event_context)
         .await?;
-    let expanded = class.expand_collection(&pool).await?;
+    let expanded = class.expand_collection(&context).await?;
 
     let location = api_locations::class(class.id)?;
     Ok(ApiResponse::created(expanded, location))
 }
 
 async fn read_resolved_class(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     target: ResolvedClassTarget,
 ) -> Result<HubuumClass, ApiError> {
     can!(
-        pool,
+        context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadClass],
@@ -453,7 +456,7 @@ async fn read_resolved_class(
 )]
 #[get("/{class_id}")]
 async fn get_class(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
@@ -467,13 +470,13 @@ async fn get_class(
         class_id = class_id.id()
     );
 
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_id(class_id))
         .await?;
-    let class = read_resolved_class(&pool, &requestor, target).await?;
+    let class = read_resolved_class(&context, &requestor, target).await?;
     if parse_collection_include(req.query_string())? {
-        let expanded = class.expand_collection(&pool).await?;
+        let expanded = class.expand_collection(&context).await?;
         return Ok(Either::Right(ApiResponse::ok(expanded)));
     }
     Ok(Either::Left(ApiResponse::ok_revisioned(class)?))
@@ -495,32 +498,32 @@ async fn get_class(
 )]
 #[get("/by-name/{class_name}")]
 async fn get_class_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
-    let class = read_resolved_class(&pool, &requestor, target).await?;
+    let class = read_resolved_class(&context, &requestor, target).await?;
     if parse_collection_include(req.query_string())? {
-        let expanded = class.expand_collection(&pool).await?;
+        let expanded = class.expand_collection(&context).await?;
         return Ok(Either::Right(ApiResponse::ok(expanded)));
     }
     Ok(Either::Left(ApiResponse::ok_revisioned(class)?))
 }
 
 async fn apply_resolved_class_update(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     req: &HttpRequest,
     target: ResolvedClassTarget,
     update: UpdateHubuumClass,
 ) -> Result<HubuumClass, ApiError> {
     can!(
-        pool,
+        context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::UpdateClass],
@@ -531,7 +534,7 @@ async fn apply_resolved_class_update(
         && target_collection_id != target.class().collection_id
     {
         can!(
-            pool,
+            context,
             &requestor.principal,
             requestor.scopes(),
             [Permissions::CreateClass],
@@ -543,7 +546,9 @@ async fn apply_resolved_class_update(
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,
-        pool.class_service().update(&target, update, &event_context),
+        context
+            .class_service()
+            .update(&target, update, &event_context),
     )
     .await
 }
@@ -566,7 +571,7 @@ async fn apply_resolved_class_update(
 )]
 #[patch("/{class_id}")]
 async fn update_class(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     class_data: web::Json<UpdateHubuumClass>,
@@ -582,12 +587,12 @@ async fn update_class(
         class_id = class_id.id()
     );
 
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_id(class_id))
         .await?;
-    let class = apply_resolved_class_update(&pool, &requestor, &req, target, class_data).await?;
-    let expanded = class.expand_collection(&pool).await?;
+    let class = apply_resolved_class_update(&context, &requestor, &req, target, class_data).await?;
+    let expanded = class.expand_collection(&context).await?;
     Ok(ApiResponse::ok(expanded))
 }
 
@@ -610,31 +615,31 @@ async fn update_class(
 )]
 #[patch("/by-name/{class_name}")]
 async fn update_class_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_name: web::Path<String>,
     class_data: web::Json<UpdateHubuumClass>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
     let class =
-        apply_resolved_class_update(&pool, &requestor, &req, target, class_data.into_inner())
+        apply_resolved_class_update(&context, &requestor, &req, target, class_data.into_inner())
             .await?;
-    let expanded = class.expand_collection(&pool).await?;
+    let expanded = class.expand_collection(&context).await?;
     Ok(ApiResponse::ok(expanded))
 }
 
 async fn delete_resolved_class(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     req: &HttpRequest,
     target: ResolvedClassTarget,
 ) -> Result<crate::api::etag::EntityTag, ApiError> {
     can!(
-        pool,
+        context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::DeleteClass],
@@ -646,7 +651,7 @@ async fn delete_resolved_class(
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,
-        pool.class_service().delete(&target, &event_context),
+        context.class_service().delete(&target, &event_context),
     )
     .await?;
     Ok(etag)
@@ -668,7 +673,7 @@ async fn delete_resolved_class(
 )]
 #[delete("/{class_id}")]
 async fn delete_class(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
@@ -682,11 +687,11 @@ async fn delete_class(
         class_id = class_id.id()
     );
 
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_id(class_id))
         .await?;
-    let etag = delete_resolved_class(&pool, &requestor, &req, target).await?;
+    let etag = delete_resolved_class(&context, &requestor, &req, target).await?;
     Ok(ApiResponse::no_content_with_etag(etag))
 }
 
@@ -707,16 +712,16 @@ async fn delete_class(
 )]
 #[delete("/by-name/{class_name}")]
 async fn delete_class_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
-    let etag = delete_resolved_class(&pool, &requestor, &req, target).await?;
+    let etag = delete_resolved_class(&context, &requestor, &req, target).await?;
     Ok(ApiResponse::no_content_with_etag(etag))
 }
 
@@ -736,16 +741,16 @@ async fn delete_class_by_name(
 )]
 #[get("/{class_id}/permissions")]
 async fn get_class_permissions(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_id(class_id.into_inner()))
         .await?;
-    read_resolved_class_permissions(pool, requestor, target, req).await
+    read_resolved_class_permissions(context, requestor, target, req).await
 }
 
 #[utoipa::path(
@@ -763,20 +768,20 @@ async fn get_class_permissions(
 )]
 #[get("/by-name/{class_name}/permissions")]
 async fn get_class_permissions_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
-    read_resolved_class_permissions(pool, requestor, target, req).await
+    read_resolved_class_permissions(context, requestor, target, req).await
 }
 
 async fn read_resolved_class_permissions(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     target: ResolvedClassTarget,
     req: HttpRequest,
@@ -792,7 +797,7 @@ async fn read_resolved_class_permissions(
     );
 
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::ReadClass],
@@ -807,10 +812,10 @@ async fn read_resolved_class_permissions(
         Permissions::DeleteClass,
     ];
     let search_params = prepare_db_pagination::<GroupPermission>(&params)?;
-    let (permissions, total_count) = if pool.permission_backend().uses_sql_permission_store() {
+    let (permissions, total_count) = if context.permission_backend().uses_sql_permission_store() {
         let total_count = if params.include_total {
             collection_model::count_groups_on_paginated(
-                &pool,
+                &context,
                 target_collection_id,
                 class_permissions.to_vec(),
                 &count_query_options(&params),
@@ -820,7 +825,7 @@ async fn read_resolved_class_permissions(
             SKIPPED_TOTAL_COUNT
         };
         let permissions = collection_model::groups_on_paginated(
-            &pool,
+            &context,
             target_collection_id,
             class_permissions.to_vec(),
             &search_params,
@@ -828,7 +833,8 @@ async fn read_resolved_class_permissions(
         .await?;
         (permissions, total_count)
     } else {
-        pool.permission_backend()
+        context
+            .permission_backend()
             .groups_with_permissions_on(target_collection_id, &class_permissions, &search_params)
             .await?
     };

--- a/src/api/v1/handlers/classes/class_objects.rs
+++ b/src/api/v1/handlers/classes/class_objects.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::db::traits::user::search::{
+use crate::backend::capabilities::user::search::{
     ExternalRelatedFilterAuthorization, externally_authorized_related_object_ids,
 };
 
@@ -30,12 +30,12 @@ use crate::db::traits::user::search::{
 )]
 #[get("/{class_id}/")]
 async fn get_objects_in_class(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    list_objects_in_class(pool, requestor, class_id.into_inner(), None, req).await
+    list_objects_in_class(context, requestor, class_id.into_inner(), None, req).await
 }
 
 #[utoipa::path(
@@ -62,33 +62,33 @@ async fn get_objects_in_class(
 )]
 #[get("/by-name/{class_name}/objects")]
 async fn get_objects_in_class_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
     let class_id = HubuumClassID::new(target.class().id)?;
     let class = target.class().clone();
-    list_objects_in_class(pool, requestor, class_id, Some(class), req).await
+    list_objects_in_class(context, requestor, class_id, Some(class), req).await
 }
 
 async fn class_for_object_list(
-    pool: &AppContext,
+    context: &AppContext,
     class_id: &HubuumClassID,
     resolved_class: Option<&HubuumClass>,
 ) -> Result<HubuumClass, ApiError> {
     match resolved_class {
         Some(class) => Ok(class.clone()),
-        None => class_id.instance(pool).await,
+        None => class_id.instance(context).await,
     }
 }
 
 async fn list_objects_in_class(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: HubuumClassID,
     resolved_class: Option<HubuumClass>,
@@ -118,20 +118,26 @@ async fn list_objects_in_class(
             .any(|filter| filter.field.computed_query().is_some());
 
     if computed_querying {
-        let class = class_for_object_list(&pool, &class_id, resolved_class.as_ref()).await?;
-        return computed_objects::list_objects(&pool, &requestor, &class, params, include_computed)
-            .await;
+        let class = class_for_object_list(&context, &class_id, resolved_class.as_ref()).await?;
+        return computed_objects::list_objects(
+            &context,
+            &requestor,
+            &class,
+            params,
+            include_computed,
+        )
+        .await;
     }
 
-    let (page, total_count) = load_raw_object_page(&pool, &requestor, &params).await?;
+    let (page, total_count) = load_raw_object_page(&context, &requestor, &params).await?;
     if !include_computed {
         return object_read_page(page, total_count, effective_page_limit(&params)?, false);
     }
 
-    let class = class_for_object_list(&pool, &class_id, resolved_class.as_ref()).await?;
-    let personal_owner = computed_personal_owner(&pool, &requestor, &class).await?;
+    let class = class_for_object_list(&context, &class_id, resolved_class.as_ref()).await?;
+    let personal_owner = computed_personal_owner(&context, &requestor, &class).await?;
     let next_cursor = page.next_cursor;
-    let enriched = enrich_objects_with_computed(&pool, page.items, personal_owner).await?;
+    let enriched = enrich_objects_with_computed(&context, page.items, personal_owner).await?;
     object_read_page(
         Page {
             items: enriched,
@@ -144,21 +150,24 @@ async fn list_objects_in_class(
 }
 
 async fn load_raw_object_page(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     params: &QueryOptions,
 ) -> Result<(Page<HubuumObject>, i64), ApiError> {
     let user = &requestor.principal;
-    let (objects, total_count) = if pool.permission_backend().supports_sql_visibility_pushdown() {
+    let (objects, total_count) = if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
         let total_count = if params.include_total {
-            user.count_objects(pool, count_query_options(params), requestor.scopes())
+            user.count_objects(context, count_query_options(params), requestor.scopes())
                 .await?
         } else {
             SKIPPED_TOTAL_COUNT
         };
         let objects = user
             .search_objects(
-                pool,
+                context,
                 prepare_db_pagination::<HubuumObject>(params)?,
                 requestor.scopes(),
             )
@@ -167,13 +176,13 @@ async fn load_raw_object_page(
     } else if !scope_allows(requestor.scopes(), &[Permissions::ReadObject]) {
         (Vec::new(), 0)
     } else {
-        let principal = PrincipalRef::load(pool, user).await?;
+        let principal = PrincipalRef::load(&context, user).await?;
         let related_ids = externally_authorized_related_object_ids(
             user,
             &params.filters,
             ExternalRelatedFilterAuthorization::new(
-                pool.db_pool(),
-                pool.permission_backend(),
+                &context,
+                context.permission_backend(),
                 &principal,
                 requestor.scopes(),
             ),
@@ -186,15 +195,20 @@ async fn load_raw_object_page(
         let mut candidates = if related_ids.as_ref().is_some_and(|ids| ids.is_empty()) {
             Vec::new()
         } else {
-            user.search_objects_from_backend_with_admin_status(pool, candidate_options, true, None)
-                .await?
+            user.search_objects_from_backend_with_admin_status(
+                &context,
+                candidate_options,
+                true,
+                None,
+            )
+            .await?
         };
         if let Some(related_ids) = &related_ids {
             candidates.retain(|object| related_ids.contains(object.id));
         }
         let search_params = prepare_db_pagination::<HubuumObject>(params)?;
         let page = authorize_cursor_page(
-            pool.permission_backend(),
+            context.permission_backend(),
             &principal,
             candidates,
             requestor.scopes(),
@@ -226,19 +240,24 @@ async fn load_raw_object_page(
 )]
 #[post("/{class_id}/")]
 async fn create_object_in_class(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     object_data: web::Json<NewHubuumObjectRequest>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_id(class_id.into_inner()))
         .await?;
-    let object =
-        create_object_in_resolved_class(&pool, &requestor, &req, target, object_data.into_inner())
-            .await?;
+    let object = create_object_in_resolved_class(
+        &context,
+        &requestor,
+        &req,
+        target,
+        object_data.into_inner(),
+    )
+    .await?;
     let location = api_locations::class_object(object.hubuum_class_id, object.id())?;
     ApiResponse::created_revisioned(object, location)
 }
@@ -263,25 +282,30 @@ async fn create_object_in_class(
 )]
 #[post("/by-name/{class_name}/objects")]
 async fn create_object_in_class_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_name: web::Path<String>,
     object_data: web::Json<NewHubuumObjectRequest>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
-    let object =
-        create_object_in_resolved_class(&pool, &requestor, &req, target, object_data.into_inner())
-            .await?;
+    let object = create_object_in_resolved_class(
+        &context,
+        &requestor,
+        &req,
+        target,
+        object_data.into_inner(),
+    )
+    .await?;
     let location = api_locations::class_object(object.hubuum_class_id, object.id())?;
     ApiResponse::created_revisioned(object, location)
 }
 
 async fn create_object_in_resolved_class(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     req: &HttpRequest,
     target: ResolvedClassTarget,
@@ -296,26 +320,27 @@ async fn create_object_in_resolved_class(
     );
 
     can!(
-        pool,
+        context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::CreateObject],
         target.class()
     );
     let event_context = requestor.event_context(req);
-    pool.object_service()
+    context
+        .object_service()
         .create(&target, object, &event_context)
         .await
 }
 
 async fn read_resolved_object(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     req: &HttpRequest,
     target: ResolvedObjectTarget,
 ) -> Result<ApiResponse<HubuumObjectReadResponse>, ApiError> {
     can!(
-        pool,
+        context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadObject],
@@ -324,9 +349,9 @@ async fn read_resolved_object(
 
     let (_, include_computed) = parse_computed_include(req.query_string())?;
     if include_computed {
-        let personal_owner = computed_personal_owner(pool, requestor, target.class()).await?;
+        let personal_owner = computed_personal_owner(context, requestor, target.class()).await?;
         let enriched =
-            enrich_objects_with_computed(pool, vec![target.object().clone()], personal_owner)
+            enrich_objects_with_computed(&context, vec![target.object().clone()], personal_owner)
                 .await?
                 .pop()
                 .ok_or_else(|| {
@@ -365,7 +390,7 @@ async fn read_resolved_object(
 )]
 #[get("/{class_id}/{object_id}")]
 async fn get_object_in_class(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumObjectID)>,
     req: HttpRequest,
@@ -380,11 +405,11 @@ async fn get_object_in_class(
         object_id = object_id.id()
     );
 
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
-    read_resolved_object(&pool, &requestor, &req, target).await
+    read_resolved_object(&context, &requestor, &req, target).await
 }
 
 #[utoipa::path(
@@ -408,28 +433,28 @@ async fn get_object_in_class(
 )]
 #[get("/by-name/{class_name}/objects/by-name/{object_name}")]
 async fn get_object_in_class_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(String, String)>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_name, object_name) = paths.into_inner();
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
-    read_resolved_object(&pool, &requestor, &req, target).await
+    read_resolved_object(&context, &requestor, &req, target).await
 }
 
 async fn apply_resolved_object_update(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     req: &HttpRequest,
     target: ResolvedObjectTarget,
     update: UpdateHubuumObject,
 ) -> Result<HubuumObject, ApiError> {
     can!(
-        pool,
+        context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::UpdateObject],
@@ -441,7 +466,8 @@ async fn apply_resolved_object_update(
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,
-        pool.object_service()
+        context
+            .object_service()
             .update(&target, update, &event_context),
     )
     .await
@@ -466,7 +492,7 @@ async fn apply_resolved_object_update(
 )]
 #[patch("/{class_id}/{object_id}")]
 async fn patch_object_in_class(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumObjectID)>,
     object_data: web::Json<UpdateHubuumObjectRequest>,
@@ -483,11 +509,12 @@ async fn patch_object_in_class(
         object_id = object_id.id()
     );
 
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
-    let object = apply_resolved_object_update(&pool, &requestor, &req, target, object_data).await?;
+    let object =
+        apply_resolved_object_update(&context, &requestor, &req, target, object_data).await?;
     ApiResponse::ok_revisioned(object)
 }
 
@@ -513,19 +540,19 @@ async fn patch_object_in_class(
 )]
 #[patch("/by-name/{class_name}/objects/by-name/{object_name}")]
 async fn patch_object_in_class_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(String, String)>,
     object_data: web::Json<UpdateHubuumObjectRequest>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_name, object_name) = paths.into_inner();
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
     let object = apply_resolved_object_update(
-        &pool,
+        &context,
         &requestor,
         &req,
         target,
@@ -536,14 +563,14 @@ async fn patch_object_in_class_by_name(
 }
 
 async fn apply_object_data_patch(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     req: &HttpRequest,
     target: ResolvedObjectTarget,
     patch: ObjectDataPatchDocument,
 ) -> Result<HubuumObject, ApiError> {
     can!(
-        pool,
+        context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::UpdateObject],
@@ -557,7 +584,8 @@ async fn apply_object_data_patch(
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,
-        pool.object_service()
+        context
+            .object_service()
             .patch_data(&target, patch, &event_context),
     )
     .await
@@ -594,7 +622,7 @@ async fn apply_object_data_patch(
 )]
 #[patch("/{class_id}/{object_id}/data")]
 async fn patch_object_data_in_class(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumObjectID)>,
     patch: ObjectDataPatchPayload,
@@ -610,12 +638,12 @@ async fn patch_object_data_in_class(
         object_id = object_id.id()
     );
 
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
     let object =
-        apply_object_data_patch(&pool, &requestor, &req, target, patch.into_inner()).await?;
+        apply_object_data_patch(&context, &requestor, &req, target, patch.into_inner()).await?;
     ApiResponse::ok_revisioned(object)
 }
 
@@ -650,7 +678,7 @@ async fn patch_object_data_in_class(
 )]
 #[patch("/by-name/{class_name}/objects/by-name/{object_name}/data")]
 async fn patch_object_data_by_name_in_class(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(String, String)>,
     patch: ObjectDataPatchPayload,
@@ -658,7 +686,7 @@ async fn patch_object_data_by_name_in_class(
 ) -> Result<impl Responder, ApiError> {
     let user = &requestor.principal;
     let (class_name, object_name) = paths.into_inner();
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
@@ -671,18 +699,18 @@ async fn patch_object_data_by_name_in_class(
     );
 
     let object =
-        apply_object_data_patch(&pool, &requestor, &req, target, patch.into_inner()).await?;
+        apply_object_data_patch(&context, &requestor, &req, target, patch.into_inner()).await?;
     ApiResponse::ok_revisioned(object)
 }
 
 async fn delete_resolved_object(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     req: &HttpRequest,
     target: ResolvedObjectTarget,
 ) -> Result<crate::api::etag::EntityTag, ApiError> {
     can!(
-        pool,
+        context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::DeleteObject],
@@ -694,7 +722,7 @@ async fn delete_resolved_object(
     let event_context = requestor.event_context(req);
     with_revision_precondition_scope(
         precondition,
-        pool.object_service().delete(&target, &event_context),
+        context.object_service().delete(&target, &event_context),
     )
     .await?;
     Ok(etag)
@@ -717,7 +745,7 @@ async fn delete_resolved_object(
 )]
 #[delete("/{class_id}/{object_id}")]
 async fn delete_object_in_class(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumObjectID)>,
     req: HttpRequest,
@@ -732,11 +760,11 @@ async fn delete_object_in_class(
         object_id = object_id.id()
     );
 
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
-    let etag = delete_resolved_object(&pool, &requestor, &req, target).await?;
+    let etag = delete_resolved_object(&context, &requestor, &req, target).await?;
     Ok(ApiResponse::no_content_with_etag(etag))
 }
 
@@ -760,16 +788,16 @@ async fn delete_object_in_class(
 )]
 #[delete("/by-name/{class_name}/objects/by-name/{object_name}")]
 async fn delete_object_in_class_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(String, String)>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_name, object_name) = paths.into_inner();
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
-    let etag = delete_resolved_object(&pool, &requestor, &req, target).await?;
+    let etag = delete_resolved_object(&context, &requestor, &req, target).await?;
     Ok(ApiResponse::no_content_with_etag(etag))
 }

--- a/src/api/v1/handlers/classes/class_related.rs
+++ b/src/api/v1/handlers/classes/class_related.rs
@@ -19,16 +19,16 @@ use super::*;
 #[get("/{class_id}/related/classes")]
 #[get("/{class_id}/related/classes/")]
 async fn get_related_classes(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_id(class_id.into_inner()))
         .await?;
-    read_related_classes(pool, requestor, target, req).await
+    read_related_classes(context, requestor, target, req).await
 }
 
 #[utoipa::path(
@@ -47,20 +47,20 @@ async fn get_related_classes(
 )]
 #[get("/by-name/{class_name}/related/classes")]
 async fn get_related_classes_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
-    read_related_classes(pool, requestor, target, req).await
+    read_related_classes(context, requestor, target, req).await
 }
 
 async fn read_related_classes(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     target: ResolvedClassTarget,
     req: HttpRequest,
@@ -69,7 +69,7 @@ async fn read_related_classes(
     let params = parse_query_parameter(req.query_string())?;
     let class = target.class();
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::ReadClass],
@@ -78,7 +78,7 @@ async fn read_related_classes(
 
     let search_params = prepare_db_pagination::<ClassGraphRow>(&params)?;
     let (classes, total_count) = user
-        .classes_related_to_page(&pool, class.clone(), search_params, requestor.scopes())
+        .classes_related_to_page(&context, class.clone(), search_params, requestor.scopes())
         .await?;
 
     ApiResponse::mapped_paginated(classes, total_count, &params, |page| {
@@ -107,7 +107,7 @@ async fn read_related_classes(
 #[post("/{class_id}/relations")]
 #[post("/{class_id}/relations/")]
 async fn create_class_relation(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     relation_data: web::Json<NewHubuumClassRelationFromClass>,
@@ -126,14 +126,14 @@ async fn create_class_relation(
 
     let relation = partial_relation.into_relation(class_id);
 
-    let prepared = pool
+    let prepared = context
         .class_relation_service()
         .prepare_create(relation)
         .await?;
     let resource = prepared.authorization_resource();
     authorize_resources(
-        pool.permission_backend(),
-        &pool,
+        context.permission_backend(),
+        &context,
         user,
         requestor.scopes(),
         vec![Permissions::CreateClassRelation],
@@ -142,7 +142,7 @@ async fn create_class_relation(
     .await?;
 
     let event_context = requestor.event_context(&req);
-    let target = pool
+    let target = context
         .class_relation_service()
         .create(&prepared, &event_context)
         .await?;
@@ -169,19 +169,22 @@ async fn create_class_relation(
 )]
 #[get("/{class_id}/relations/{relation_id}")]
 async fn get_class_relation(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumClassRelationID)>,
 ) -> Result<impl Responder, ApiError> {
     let (class_id, relation_id) = paths.into_inner();
-    let target = pool.class_relation_service().resolve(relation_id).await?;
+    let target = context
+        .class_relation_service()
+        .resolve(relation_id)
+        .await?;
     if !target.contains_class(class_id) {
         return Err(ApiError::NotFound("Class relation not found".to_string()));
     }
     let resource = target.authorization_resource();
     authorize_resources(
-        pool.permission_backend(),
-        &pool,
+        context.permission_backend(),
+        &context,
         &requestor.principal,
         requestor.scopes(),
         vec![Permissions::ReadClassRelation],
@@ -209,7 +212,7 @@ async fn get_class_relation(
 )]
 #[delete("/{class_id}/relations/{relation_id}")]
 async fn delete_class_relation(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumClassRelationID)>,
     req: HttpRequest,
@@ -224,13 +227,16 @@ async fn delete_class_relation(
         relation_id = relation_id.id()
     );
 
-    let target = pool.class_relation_service().resolve(relation_id).await?;
+    let target = context
+        .class_relation_service()
+        .resolve(relation_id)
+        .await?;
     let relation = target.relation();
 
     let resource = target.authorization_resource();
     authorize_resources(
-        pool.permission_backend(),
-        &pool,
+        context.permission_backend(),
+        &context,
         user,
         requestor.scopes(),
         vec![Permissions::DeleteClassRelation],
@@ -244,7 +250,8 @@ async fn delete_class_relation(
         let event_context = requestor.event_context(&req);
         with_revision_precondition_scope(
             precondition,
-            pool.class_relation_service()
+            context
+                .class_relation_service()
                 .delete(&target, &event_context),
         )
         .await?;
@@ -285,16 +292,16 @@ async fn delete_class_relation(
 #[get("/{class_id}/related/relations")]
 #[get("/{class_id}/related/relations/")]
 async fn get_related_class_relations(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_id(class_id.into_inner()))
         .await?;
-    read_related_class_relations(pool, requestor, target, req).await
+    read_related_class_relations(context, requestor, target, req).await
 }
 
 #[utoipa::path(
@@ -313,20 +320,20 @@ async fn get_related_class_relations(
 )]
 #[get("/by-name/{class_name}/related/relations")]
 async fn get_related_class_relations_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
-    read_related_class_relations(pool, requestor, target, req).await
+    read_related_class_relations(context, requestor, target, req).await
 }
 
 async fn read_related_class_relations(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     target: ResolvedClassTarget,
     req: HttpRequest,
@@ -335,7 +342,7 @@ async fn read_related_class_relations(
     let params = parse_query_parameter(req.query_string())?;
     let class = target.class();
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::ReadClass],
@@ -348,10 +355,18 @@ async fn read_related_class_relations(
         class_id = class.id
     );
 
-    let (relations, total_count) = if pool.permission_backend().supports_sql_visibility_pushdown() {
+    let (relations, total_count) = if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
         let search_params = prepare_db_pagination::<HubuumClassRelation>(&params)?;
-        user.class_relations_touching_page(&pool, class.clone(), search_params, requestor.scopes())
-            .await?
+        user.class_relations_touching_page(
+            &context,
+            class.clone(),
+            search_params,
+            requestor.scopes(),
+        )
+        .await?
     } else {
         let mut required = params.filters.permissions()?;
         required.ensure_contains(&[Permissions::ReadClassRelation]);
@@ -363,22 +378,22 @@ async fn read_related_class_relations(
         candidate_options.include_total = false;
         let (candidates, _) = user
             .class_relations_touching_page_from_backend_with_admin_status(
-                &pool,
+                &context,
                 class.clone(),
                 candidate_options,
                 true,
                 None,
             )
             .await?;
-        let resources = class_relation_authorization_resources(&pool, &candidates)
+        let resources = class_relation_authorization_resources(&context, &candidates)
             .await?
             .into_iter()
             .map(|resource| (resource.id, resource))
             .collect::<HashMap<_, _>>();
-        let principal = PrincipalRef::load(&pool, user).await?;
+        let principal = PrincipalRef::load(&context, user).await?;
         let search_params = prepare_db_pagination::<HubuumClassRelation>(&params)?;
         let page = authorize_cursor_page(
-            pool.permission_backend(),
+            context.permission_backend(),
             &principal,
             candidates,
             requestor.scopes(),
@@ -416,16 +431,16 @@ async fn read_related_class_relations(
 #[get("/{class_id}/related/graph")]
 #[get("/{class_id}/related/graph/")]
 async fn get_related_class_graph(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_id(class_id.into_inner()))
         .await?;
-    read_related_class_graph(pool, requestor, target, req).await
+    read_related_class_graph(context, requestor, target, req).await
 }
 
 #[utoipa::path(
@@ -444,20 +459,20 @@ async fn get_related_class_graph(
 )]
 #[get("/by-name/{class_name}/related/graph")]
 async fn get_related_class_graph_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
-    read_related_class_graph(pool, requestor, target, req).await
+    read_related_class_graph(context, requestor, target, req).await
 }
 
 async fn read_related_class_graph(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     target: ResolvedClassTarget,
     req: HttpRequest,
@@ -467,7 +482,7 @@ async fn read_related_class_graph(
         prepare_graph_query_options(parse_query_parameter(req.query_string())?)?;
     let class = target.class();
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::ReadClass],
@@ -476,7 +491,7 @@ async fn read_related_class_graph(
 
     let root_class = class_with_root_path(class);
     let connected_classes = user
-        .search_classes_related_to(&pool, class.clone(), params, requestor.scopes())
+        .search_classes_related_to(&context, class.clone(), params, requestor.scopes())
         .await?;
     ensure_graph_result_within_limit(&connected_classes, graph_limit, "classes")?;
     let mut classes = Vec::with_capacity(connected_classes.len() + 1);
@@ -485,7 +500,7 @@ async fn read_related_class_graph(
 
     let class_ids = classes.iter().map(|item| item.id).collect::<Vec<_>>();
     let relations = user
-        .search_class_relations_between_ids(&pool, &class_ids, requestor.scopes())
+        .search_class_relations_between_ids(&context, &class_ids, requestor.scopes())
         .await?;
 
     Ok(ApiResponse::new(

--- a/src/api/v1/handlers/classes/computed_objects.rs
+++ b/src/api/v1/handlers/classes/computed_objects.rs
@@ -2,13 +2,13 @@ use crate::api::response::ApiResponse;
 use crate::api::v1::handlers::classes::{
     computed_personal_owner, object_read_page, scope_object_query_to_class,
 };
-use crate::db::traits::authz::scope_allows;
-use crate::db::traits::computed_field::{
+use crate::backend::capabilities::authz::scope_allows;
+use crate::backend::capabilities::computed_field::{
     ComputedQuerySnapshot, enrich_objects_with_computed_query_snapshot,
     resolve_computed_query_fields,
 };
-use crate::db::traits::user::UserSearchBackend;
-use crate::db::traits::user::search::{
+use crate::backend::capabilities::user::UserSearchBackend;
+use crate::backend::capabilities::user::search::{
     ExternalRelatedFilterAuthorization, count_computed_objects_with_authorized_ids,
     externally_authorized_related_object_ids, search_computed_objects_with_authorized_ids,
 };
@@ -25,7 +25,6 @@ use crate::pagination::{
 };
 use crate::permissions::visibility::{AuthorizedObjectIds, authorize_all_candidates};
 use crate::permissions::{AppContext, PrincipalRef, authorize_resources};
-use crate::traits::BackendContext;
 
 enum ComputedListVisibility {
     SqlPushdown,
@@ -33,7 +32,7 @@ enum ComputedListVisibility {
 }
 
 struct ResolvedComputedObjectQuery<'a> {
-    pool: &'a AppContext,
+    context: &'a AppContext,
     requestor: &'a Authenticated,
     params: &'a QueryOptions,
     personal_owner: Option<i32>,
@@ -67,7 +66,7 @@ impl ResolvedComputedObjectQuery<'_> {
             self.requestor
                 .principal
                 .count_objects_with_computed_query_from_backend(
-                    self.pool.db_pool(),
+                    &self.context,
                     count_query_options(self.params),
                     self.requestor.scopes(),
                     self.snapshot,
@@ -80,7 +79,7 @@ impl ResolvedComputedObjectQuery<'_> {
             .requestor
             .principal
             .search_objects_with_computed_query_from_backend(
-                self.pool.db_pool(),
+                &self.context,
                 self.search_options()?,
                 self.requestor.scopes(),
                 self.snapshot,
@@ -96,7 +95,7 @@ impl ResolvedComputedObjectQuery<'_> {
         let total_count = if self.params.include_total {
             count_computed_objects_with_authorized_ids(
                 &self.requestor.principal,
-                self.pool.db_pool(),
+                &self.context,
                 count_query_options(self.params),
                 self.snapshot,
                 authorized_ids,
@@ -107,7 +106,7 @@ impl ResolvedComputedObjectQuery<'_> {
         };
         let objects = search_computed_objects_with_authorized_ids(
             &self.requestor.principal,
-            self.pool.db_pool(),
+            &self.context,
             self.search_options()?,
             self.snapshot,
             authorized_ids,
@@ -124,7 +123,7 @@ impl ResolvedComputedObjectQuery<'_> {
     ) -> Result<ApiResponse<Vec<HubuumObjectReadResponse>>, ApiError> {
         if include_computed {
             let enriched = enrich_objects_with_computed_query_snapshot(
-                self.pool.db_pool(),
+                &self.context,
                 objects,
                 self.personal_owner,
                 self.snapshot,
@@ -151,7 +150,7 @@ impl ResolvedComputedObjectQuery<'_> {
         let (objects, cursor_boundary) = page_items_and_cursor_boundary(objects, request.limit);
         let next_cursor = if let Some(boundary) = cursor_boundary {
             let mut enriched = enrich_objects_with_computed_query_snapshot(
-                self.pool.db_pool(),
+                &self.context,
                 vec![boundary],
                 self.personal_owner,
                 self.snapshot,
@@ -181,7 +180,7 @@ impl ResolvedComputedObjectQuery<'_> {
 }
 
 async fn can_list_objects_in_class(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     class: &HubuumClass,
 ) -> Result<bool, ApiError> {
@@ -196,8 +195,8 @@ async fn can_list_objects_in_class(
         .is_some_and(|ids| ids.has_collection_or_class_entries());
     if has_class_or_collection_scope || requestor.scopes().is_none() {
         return Ok(authorize_resources(
-            pool.permission_backend(),
-            pool.db_pool(),
+            context.permission_backend(),
+            &context,
             &requestor.principal,
             requestor.scopes(),
             vec![Permissions::ReadObject, Permissions::ReadCollection],
@@ -217,13 +216,13 @@ async fn can_list_objects_in_class(
     scope_object_query_to_class(&mut visibility_query, &HubuumClassID::new(class.id)?);
     let visible_objects = requestor
         .principal
-        .search_objects_from_backend(pool.db_pool(), visibility_query, requestor.scopes())
+        .search_objects_from_backend(&context, visibility_query, requestor.scopes())
         .await?;
     Ok(!visible_objects.is_empty())
 }
 
 async fn authorized_object_ids_in_class(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     class: &HubuumClassID,
 ) -> Result<AuthorizedObjectIds, ApiError> {
@@ -237,11 +236,11 @@ async fn authorized_object_ids_in_class(
     scope_object_query_to_class(&mut visibility_query, class);
     let candidates = requestor
         .principal
-        .search_objects_from_backend_with_admin_status(pool, visibility_query, true, None)
+        .search_objects_from_backend_with_admin_status(&context, visibility_query, true, None)
         .await?;
-    let principal = PrincipalRef::load(pool, &requestor.principal).await?;
+    let principal = PrincipalRef::load(&context, &requestor.principal).await?;
     let authorized = authorize_all_candidates(
-        pool.permission_backend(),
+        context.permission_backend(),
         &principal,
         candidates,
         requestor.scopes(),
@@ -253,26 +252,29 @@ async fn authorized_object_ids_in_class(
 }
 
 async fn computed_list_visibility(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     class: &HubuumClass,
     class_id: &HubuumClassID,
     params: &QueryOptions,
 ) -> Result<Option<ComputedListVisibility>, ApiError> {
-    if pool.permission_backend().supports_sql_visibility_pushdown() {
-        return can_list_objects_in_class(pool, requestor, class)
+    if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
+        return can_list_objects_in_class(context, requestor, class)
             .await
             .map(|allowed| allowed.then_some(ComputedListVisibility::SqlPushdown));
     }
 
-    let authorized_ids = authorized_object_ids_in_class(pool, requestor, class_id).await?;
-    let principal = PrincipalRef::load(pool, &requestor.principal).await?;
+    let authorized_ids = authorized_object_ids_in_class(context, requestor, class_id).await?;
+    let principal = PrincipalRef::load(&context, &requestor.principal).await?;
     let related_ids = externally_authorized_related_object_ids(
         &requestor.principal,
         &params.filters,
         ExternalRelatedFilterAuthorization::new(
-            pool.db_pool(),
-            pool.permission_backend(),
+            &context,
+            context.permission_backend(),
             &principal,
             requestor.scopes(),
         ),
@@ -300,7 +302,7 @@ fn empty_computed_page(
 }
 
 pub(super) async fn list_objects(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     class: &HubuumClass,
     mut params: QueryOptions,
@@ -312,18 +314,18 @@ pub(super) async fn list_objects(
 
     let class_id = HubuumClassID::new(class.id)?;
     let Some(visibility) =
-        computed_list_visibility(pool, requestor, class, &class_id, &params).await?
+        computed_list_visibility(context, requestor, class, &class_id, &params).await?
     else {
         return empty_computed_page(&params);
     };
 
-    let personal_owner = computed_personal_owner(pool, requestor, class).await?;
+    let personal_owner = computed_personal_owner(context, requestor, class).await?;
     let computed_sorting = params
         .sort
         .iter()
         .any(|sort| sort.field.computed_query().is_some());
     let computed_query_snapshot = resolve_computed_query_fields(
-        pool.db_pool(),
+        &context,
         class.id,
         personal_owner,
         &mut params.filters,
@@ -332,7 +334,7 @@ pub(super) async fn list_objects(
     .await?;
 
     let query = ResolvedComputedObjectQuery {
-        pool,
+        context,
         requestor,
         params: &params,
         personal_owner,

--- a/src/api/v1/handlers/classes/history_endpoints.rs
+++ b/src/api/v1/handlers/classes/history_endpoints.rs
@@ -15,7 +15,7 @@ use super::*;
 )]
 #[get("/{class_id}/history")]
 async fn get_class_history(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
@@ -28,10 +28,10 @@ async fn get_class_history(
 
     let user = &requestor.principal;
     let class_id = class_id.into_inner();
-    let (entity_id, require_history) = match class_id.instance(&pool).await {
+    let (entity_id, require_history) = match class_id.instance(&context).await {
         Ok(instance) => {
             can!(
-                &pool,
+                &context,
                 user,
                 requestor.scopes(),
                 [Permissions::ReadClass],
@@ -41,7 +41,7 @@ async fn get_class_history(
         }
         Err(ApiError::NotFound(_))
             if can_read_deleted_history(
-                &pool,
+                &context,
                 &requestor.principal,
                 requestor.scopes().is_some(),
             )
@@ -57,14 +57,17 @@ async fn get_class_history(
     let (rows, total_count) = if require_history {
         class_history_paginated_with_total_count(
             entity_id,
-            &pool,
+            &context,
             &search_params,
             HistoryCollectionFilter::All,
         )
         .await?
-    } else if pool.permission_backend().supports_sql_visibility_pushdown() {
+    } else if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
         let collection_ids = readable_history_collection_ids(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadClass,
@@ -72,7 +75,7 @@ async fn get_class_history(
         .await?;
         class_history_paginated_with_total_count(
             entity_id,
-            &pool,
+            &context,
             &search_params,
             HistoryCollectionFilter::Visible(&collection_ids),
         )
@@ -81,13 +84,13 @@ async fn get_class_history(
         let candidate_params = history_candidate_query_options(&params);
         let (candidates, _) = class_history_paginated_with_total_count(
             entity_id,
-            &pool,
+            &context,
             &candidate_params,
             HistoryCollectionFilter::All,
         )
         .await?;
         authorize_history_page(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadClass,
@@ -101,7 +104,7 @@ async fn get_class_history(
         return Err(ApiError::NotFound(format!("class {entity_id} not found")));
     }
 
-    let principal_names = resolve_history_principal_names(&pool, &rows).await?;
+    let principal_names = resolve_history_principal_names(&context, &rows).await?;
 
     ApiResponse::mapped_paginated(rows, total_count, &params, move |rows| {
         rows.into_iter()
@@ -129,7 +132,7 @@ async fn get_class_history(
 )]
 #[get("/{class_id}/history/as-of")]
 async fn get_class_as_of(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
@@ -141,10 +144,10 @@ async fn get_class_as_of(
 
     let user = &requestor.principal;
     let class_id = class_id.into_inner();
-    let (entity_id, deleted) = match class_id.instance(&pool).await {
+    let (entity_id, deleted) = match class_id.instance(&context).await {
         Ok(instance) => {
             can!(
-                &pool,
+                &context,
                 user,
                 requestor.scopes(),
                 [Permissions::ReadClass],
@@ -154,7 +157,7 @@ async fn get_class_as_of(
         }
         Err(ApiError::NotFound(_))
             if can_read_deleted_history(
-                &pool,
+                &context,
                 &requestor.principal,
                 requestor.scopes().is_some(),
             )
@@ -166,13 +169,13 @@ async fn get_class_as_of(
     };
 
     let at = parse_as_of(req.query_string())?;
-    let row = class_as_of(entity_id, at, &pool)
+    let row = class_as_of(entity_id, at, &context)
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("no version of class {entity_id} at {at}")))?;
 
     if !deleted {
         authorize_history_snapshot(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadClass,
@@ -182,7 +185,7 @@ async fn get_class_as_of(
     }
 
     let principal_names =
-        resolve_history_principal_names(&pool, std::slice::from_ref(&row)).await?;
+        resolve_history_principal_names(&context, std::slice::from_ref(&row)).await?;
     Ok(ApiResponse::new(
         HistoryResponse::new(row, &principal_names),
         StatusCode::OK,
@@ -207,7 +210,7 @@ async fn get_class_as_of(
 )]
 #[get("/{class_id}/{object_id}/history")]
 async fn get_object_history(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumObjectID)>,
     req: HttpRequest,
@@ -222,11 +225,11 @@ async fn get_object_history(
     let (class_id, object_id) = paths.into_inner();
 
     let (entity_id, require_history) =
-        match check_if_object_in_class(&pool, &class_id, &object_id).await {
+        match check_if_object_in_class(&context, &class_id, &object_id).await {
             Ok(()) => {
-                let object = object_id.instance(&pool).await?;
+                let object = object_id.instance(&context).await?;
                 can!(
-                    &pool,
+                    &context,
                     user,
                     requestor.scopes(),
                     [Permissions::ReadObject],
@@ -236,7 +239,7 @@ async fn get_object_history(
             }
             Err(ApiError::NotFound(_))
                 if can_read_deleted_history(
-                    &pool,
+                    &context,
                     &requestor.principal,
                     requestor.scopes().is_some(),
                 )
@@ -253,14 +256,17 @@ async fn get_object_history(
         object_history_paginated_with_total_count(
             entity_id,
             class_id.id(),
-            &pool,
+            &context,
             &search_params,
             HistoryCollectionFilter::All,
         )
         .await?
-    } else if pool.permission_backend().supports_sql_visibility_pushdown() {
+    } else if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
         let collection_ids = readable_history_collection_ids(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadObject,
@@ -269,7 +275,7 @@ async fn get_object_history(
         object_history_paginated_with_total_count(
             entity_id,
             class_id.id(),
-            &pool,
+            &context,
             &search_params,
             HistoryCollectionFilter::Visible(&collection_ids),
         )
@@ -279,13 +285,13 @@ async fn get_object_history(
         let (candidates, _) = object_history_paginated_with_total_count(
             entity_id,
             class_id.id(),
-            &pool,
+            &context,
             &candidate_params,
             HistoryCollectionFilter::All,
         )
         .await?;
         authorize_history_page(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadObject,
@@ -299,7 +305,7 @@ async fn get_object_history(
         return Err(ApiError::NotFound(format!("object {entity_id} not found")));
     }
 
-    let principal_names = resolve_history_principal_names(&pool, &rows).await?;
+    let principal_names = resolve_history_principal_names(&context, &rows).await?;
 
     ApiResponse::mapped_paginated(rows, total_count, &params, move |rows| {
         rows.into_iter()
@@ -328,7 +334,7 @@ async fn get_object_history(
 )]
 #[get("/{class_id}/{object_id}/history/as-of")]
 async fn get_object_as_of(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumObjectID)>,
     req: HttpRequest,
@@ -341,11 +347,12 @@ async fn get_object_as_of(
     let user = &requestor.principal;
     let (class_id, object_id) = paths.into_inner();
 
-    let (entity_id, deleted) = match check_if_object_in_class(&pool, &class_id, &object_id).await {
+    let (entity_id, deleted) = match check_if_object_in_class(&context, &class_id, &object_id).await
+    {
         Ok(()) => {
-            let object = object_id.instance(&pool).await?;
+            let object = object_id.instance(&context).await?;
             can!(
-                &pool,
+                &context,
                 user,
                 requestor.scopes(),
                 [Permissions::ReadObject],
@@ -355,7 +362,7 @@ async fn get_object_as_of(
         }
         Err(ApiError::NotFound(_))
             if can_read_deleted_history(
-                &pool,
+                &context,
                 &requestor.principal,
                 requestor.scopes().is_some(),
             )
@@ -367,13 +374,13 @@ async fn get_object_as_of(
     };
 
     let at = parse_as_of(req.query_string())?;
-    let row = object_as_of(entity_id, class_id.id(), at, &pool)
+    let row = object_as_of(entity_id, class_id.id(), at, &context)
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("no version of object {entity_id} at {at}")))?;
 
     if !deleted {
         authorize_history_snapshot(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadObject,
@@ -383,7 +390,7 @@ async fn get_object_as_of(
     }
 
     let principal_names =
-        resolve_history_principal_names(&pool, std::slice::from_ref(&row)).await?;
+        resolve_history_principal_names(&context, std::slice::from_ref(&row)).await?;
     Ok(ApiResponse::new(
         HistoryResponse::new(row, &principal_names),
         StatusCode::OK,

--- a/src/api/v1/handlers/classes/object_aggregates.rs
+++ b/src/api/v1/handlers/classes/object_aggregates.rs
@@ -44,16 +44,16 @@ use crate::traits::{Search, SelfAccessors};
 #[get("/{class_id}/object-aggregates")]
 #[get("/{class_id}/object-aggregates/")]
 pub(crate) async fn get_object_aggregates(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_id(class_id.into_inner()))
         .await?;
-    read_object_aggregates(pool, requestor, target, req).await
+    read_object_aggregates(context, requestor, target, req).await
 }
 
 #[utoipa::path(
@@ -79,20 +79,20 @@ pub(crate) async fn get_object_aggregates(
 )]
 #[get("/by-name/{class_name}/object-aggregates")]
 pub(crate) async fn get_object_aggregates_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_name: web::Path<String>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let target = pool
+    let target = context
         .class_service()
         .resolve(ClassSelector::by_name(class_name.into_inner()))
         .await?;
-    read_object_aggregates(pool, requestor, target, req).await
+    read_object_aggregates(context, requestor, target, req).await
 }
 
 async fn read_object_aggregates(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_target: ResolvedClassTarget,
     req: HttpRequest,
@@ -113,7 +113,7 @@ async fn read_object_aggregates(
             ));
         }
         Some(UserID::new(
-            computed_personal_owner(&pool, &requestor, class)
+            computed_personal_owner(&context, &requestor, class)
                 .await?
                 .ok_or_else(|| {
                     ApiError::BadRequest(
@@ -145,7 +145,7 @@ async fn read_object_aggregates(
     if let Some(owner_id) = personal_owner_id {
         request = request.personal_owner(owner_id);
     }
-    let page = user.aggregate_objects(&pool, request.build()?).await?;
+    let page = user.aggregate_objects(&context, request.build()?).await?;
     let (rows, total_count, next_cursor) = page.into_parts();
     Ok(ApiResponse::paginated_items(
         rows,

--- a/src/api/v1/handlers/classes/object_related.rs
+++ b/src/api/v1/handlers/classes/object_related.rs
@@ -22,17 +22,17 @@ use super::*;
 #[get("/{class_id}/objects/{object_id}/related/objects")]
 #[get("/{class_id}/objects/{object_id}/related/objects/")]
 async fn get_related_objects(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumObjectID)>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_id, object_id) = paths.into_inner();
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
-    read_related_objects(pool, requestor, target, req).await
+    read_related_objects(context, requestor, target, req).await
 }
 
 #[utoipa::path(
@@ -56,21 +56,21 @@ async fn get_related_objects(
 )]
 #[get("/by-name/{class_name}/objects/by-name/{object_name}/related/objects")]
 async fn get_related_objects_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(String, String)>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_name, object_name) = paths.into_inner();
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
-    read_related_objects(pool, requestor, target, req).await
+    read_related_objects(context, requestor, target, req).await
 }
 
 async fn read_related_objects(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     target: ResolvedObjectTarget,
     req: HttpRequest,
@@ -82,7 +82,7 @@ async fn read_related_objects(
     let (mut params, related_options) = parse_related_objects_query(query_string)?;
 
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::ReadObject],
@@ -122,7 +122,7 @@ async fn read_related_objects(
 
     let search_params = prepare_db_pagination::<RelatedObjectGraphRow>(&params)?;
     let (hits, total_count) = user
-        .objects_related_to_page(&pool, object.clone(), search_params, requestor.scopes())
+        .objects_related_to_page(&context, object.clone(), search_params, requestor.scopes())
         .await?;
 
     ApiResponse::mapped_paginated(hits, total_count, &params, |page| {
@@ -150,17 +150,17 @@ async fn read_related_objects(
 #[get("/{class_id}/objects/{object_id}/related/relations")]
 #[get("/{class_id}/objects/{object_id}/related/relations/")]
 async fn get_related_object_relations(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumObjectID)>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_id, object_id) = paths.into_inner();
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
-    read_related_object_relations(pool, requestor, target, req).await
+    read_related_object_relations(context, requestor, target, req).await
 }
 
 #[utoipa::path(
@@ -182,21 +182,21 @@ async fn get_related_object_relations(
 )]
 #[get("/by-name/{class_name}/objects/by-name/{object_name}/related/relations")]
 async fn get_related_object_relations_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(String, String)>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_name, object_name) = paths.into_inner();
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
-    read_related_object_relations(pool, requestor, target, req).await
+    read_related_object_relations(context, requestor, target, req).await
 }
 
 async fn read_related_object_relations(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     target: ResolvedObjectTarget,
     req: HttpRequest,
@@ -205,7 +205,7 @@ async fn read_related_object_relations(
     let params = parse_query_parameter(req.query_string())?;
     let object = target.object();
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::ReadObject],
@@ -220,10 +220,13 @@ async fn read_related_object_relations(
         query = req.query_string(),
     );
 
-    let (relations, total_count) = if pool.permission_backend().supports_sql_visibility_pushdown() {
+    let (relations, total_count) = if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
         let search_params = prepare_db_pagination::<HubuumObjectRelation>(&params)?;
         user.object_relations_touching_page(
-            &pool,
+            &context,
             object.clone(),
             search_params,
             requestor.scopes(),
@@ -240,22 +243,22 @@ async fn read_related_object_relations(
         candidate_options.include_total = false;
         let (candidates, _) = user
             .object_relations_touching_page_from_backend_with_admin_status(
-                &pool,
+                &context,
                 object.clone(),
                 candidate_options,
                 true,
                 None,
             )
             .await?;
-        let resources = object_relation_authorization_resources(&pool, &candidates)
+        let resources = object_relation_authorization_resources(&context, &candidates)
             .await?
             .into_iter()
             .map(|resource| (resource.id, resource))
             .collect::<HashMap<_, _>>();
-        let principal = PrincipalRef::load(&pool, user).await?;
+        let principal = PrincipalRef::load(&context, user).await?;
         let search_params = prepare_db_pagination::<HubuumObjectRelation>(&params)?;
         let page = authorize_cursor_page(
-            pool.permission_backend(),
+            context.permission_backend(),
             &principal,
             candidates,
             requestor.scopes(),
@@ -295,17 +298,17 @@ async fn read_related_object_relations(
 #[get("/{class_id}/objects/{object_id}/related/graph")]
 #[get("/{class_id}/objects/{object_id}/related/graph/")]
 async fn get_related_object_graph(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumObjectID)>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_id, object_id) = paths.into_inner();
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_id(class_id, object_id))
         .await?;
-    read_related_object_graph(pool, requestor, target, req).await
+    read_related_object_graph(context, requestor, target, req).await
 }
 
 #[utoipa::path(
@@ -327,21 +330,21 @@ async fn get_related_object_graph(
 )]
 #[get("/by-name/{class_name}/objects/by-name/{object_name}/related/graph")]
 async fn get_related_object_graph_by_name(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(String, String)>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_name, object_name) = paths.into_inner();
-    let target = pool
+    let target = context
         .object_service()
         .resolve(ObjectSelector::by_name(class_name, object_name))
         .await?;
-    read_related_object_graph(pool, requestor, target, req).await
+    read_related_object_graph(context, requestor, target, req).await
 }
 
 async fn read_related_object_graph(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     target: ResolvedObjectTarget,
     req: HttpRequest,
@@ -352,7 +355,7 @@ async fn read_related_object_graph(
         prepare_graph_query_options(parse_query_parameter(req.query_string())?)?;
 
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::ReadObject],
@@ -369,7 +372,7 @@ async fn read_related_object_graph(
 
     let root_object = object_with_root_path(object);
     let connected_objects = user
-        .search_objects_related_to(&pool, object.clone(), params, requestor.scopes())
+        .search_objects_related_to(&context, object.clone(), params, requestor.scopes())
         .await?;
     ensure_graph_result_within_limit(&connected_objects, graph_limit, "objects")?;
     let mut objects = Vec::with_capacity(connected_objects.len() + 1);
@@ -378,7 +381,7 @@ async fn read_related_object_graph(
 
     let object_ids = objects.iter().map(|item| item.id).collect::<Vec<_>>();
     let relations = user
-        .search_object_relations_between_ids(&pool, &object_ids, requestor.scopes())
+        .search_object_relations_between_ids(&context, &object_ids, requestor.scopes())
         .await?;
 
     Ok(ApiResponse::new(
@@ -406,7 +409,7 @@ async fn read_related_object_graph(
 )]
 #[get("/{class_id}/{from_object_id}/relations/{to_class_id}/{to_object_id}")]
 async fn get_object_relation_from_class_and_objects(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumObjectID, HubuumClassID, HubuumObjectID)>,
 ) -> Result<impl Responder, ApiError> {
@@ -421,13 +424,11 @@ async fn get_object_relation_from_class_and_objects(
         to_object_id = to_object.id()
     );
 
-    let target = pool
+    let target = context
         .object_relation_service()
         .resolve(ObjectRelationSelector::between(
-            from_class,
-            from_object,
-            to_class,
-            to_object,
+            ObjectRelationEndpoint::new(from_class, from_object),
+            ObjectRelationEndpoint::new(to_class, to_object),
         ))
         .await
         .map_err(|_| {
@@ -440,8 +441,8 @@ async fn get_object_relation_from_class_and_objects(
         })?;
     let resource = target.authorization_resource();
     authorize_resources(
-        pool.permission_backend(),
-        &pool,
+        context.permission_backend(),
+        &context,
         user,
         requestor.scopes(),
         vec![Permissions::ReadObjectRelation],
@@ -470,7 +471,7 @@ async fn get_object_relation_from_class_and_objects(
 )]
 #[delete("/{class_id}/{from_object_id}/relations/{to_class_id}/{to_object_id}")]
 async fn delete_object_relation(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumObjectID, HubuumClassID, HubuumObjectID)>,
     req: HttpRequest,
@@ -487,13 +488,11 @@ async fn delete_object_relation(
         to_object_id = to_object.id()
     );
 
-    let target = pool
+    let target = context
         .object_relation_service()
         .resolve(ObjectRelationSelector::between(
-            from_class,
-            from_object,
-            to_class,
-            to_object,
+            ObjectRelationEndpoint::new(from_class, from_object),
+            ObjectRelationEndpoint::new(to_class, to_object),
         ))
         .await
         .map_err(|_| {
@@ -506,8 +505,8 @@ async fn delete_object_relation(
     let relation = target.relation();
     let resource = target.authorization_resource();
     authorize_resources(
-        pool.permission_backend(),
-        &pool,
+        context.permission_backend(),
+        &context,
         user,
         requestor.scopes(),
         vec![Permissions::DeleteObjectRelation],
@@ -529,7 +528,8 @@ async fn delete_object_relation(
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(
         precondition,
-        pool.object_relation_service()
+        context
+            .object_relation_service()
             .delete(&target, &event_context),
     )
     .await?;
@@ -557,7 +557,7 @@ async fn delete_object_relation(
 )]
 #[post("/{class_id}/{from_object_id}/relations/{to_class_id}/{to_object_id}")]
 async fn create_object_relation(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     paths: web::Path<(HubuumClassID, HubuumObjectID, HubuumClassID, HubuumObjectID)>,
     req: HttpRequest,
@@ -574,19 +574,17 @@ async fn create_object_relation(
         to_object = to_object.id()
     );
 
-    let prepared = pool
+    let prepared = context
         .object_relation_service()
         .prepare_create(ObjectRelationCreateSelector::between(
-            from_class,
-            from_object,
-            to_class,
-            to_object,
+            ObjectRelationEndpoint::new(from_class, from_object),
+            ObjectRelationEndpoint::new(to_class, to_object),
         ))
         .await?;
     let resource = prepared.authorization_resource();
     authorize_resources(
-        pool.permission_backend(),
-        &pool,
+        context.permission_backend(),
+        &context,
         user,
         requestor.scopes(),
         vec![Permissions::CreateObjectRelation],
@@ -595,7 +593,7 @@ async fn create_object_relation(
     .await?;
 
     let event_context = requestor.event_context(&req);
-    let target = pool
+    let target = context
         .object_relation_service()
         .create(&prepared, &event_context)
         .await?;

--- a/src/api/v1/handlers/collections.rs
+++ b/src/api/v1/handlers/collections.rs
@@ -3,14 +3,14 @@ use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
 use crate::api::v1::handlers::history::HistoryResponse;
-use crate::can;
-use crate::db::traits::UserPermissions;
-use crate::db::traits::authz::scope_allows;
-use crate::db::traits::history::{
+use crate::backend::capabilities::UserPermissions;
+use crate::backend::capabilities::authz::scope_allows;
+use crate::backend::capabilities::history::{
     HistoryCollectionFilter, collection_as_of, collection_history_paginated_with_total_count,
 };
-use crate::db::traits::user::UserSearchBackend;
-use crate::db::with_revision_precondition_scope;
+use crate::backend::capabilities::user::UserSearchBackend;
+use crate::backend::with_revision_precondition_scope;
+use crate::can;
 use crate::errors::ApiError;
 use crate::extractors::{AccessEventContext, AdminAccess, Authenticated};
 use crate::models::collection as collection_model;
@@ -29,14 +29,14 @@ use actix_web::{
 };
 use tracing::{debug, info};
 
-use crate::traits::{BackendContext, PermissionController, Search};
+use crate::traits::{PermissionController, Search};
 
 async fn sql_collection_permission_set(
-    pool: &AppContext,
+    context: &AppContext,
     collection: &Collection,
 ) -> Result<CollectionPermissionSet, ApiError> {
-    crate::db::traits::collection::collection_permission_set_from_backend(
-        pool.db_pool(),
+    crate::backend::capabilities::collection::collection_permission_set_from_backend(
+        &context,
         collection.id,
         None,
     )
@@ -65,7 +65,7 @@ fn collection_precondition(
 #[get("")]
 #[get("/")]
 pub async fn get_collections(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
@@ -79,16 +79,19 @@ pub async fn get_collections(
         Err(e) => return Err(e),
     };
 
-    let (result, total_count) = if pool.permission_backend().supports_sql_visibility_pushdown() {
+    let (result, total_count) = if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
         let total_count = if params.include_total {
-            user.count_collections(&pool, count_query_options(&params), requestor.scopes())
+            user.count_collections(&context, count_query_options(&params), requestor.scopes())
                 .await?
         } else {
             SKIPPED_TOTAL_COUNT
         };
         let search_params = prepare_db_pagination::<Collection>(&params)?;
         let result = user
-            .search_collections(&pool, search_params, requestor.scopes())
+            .search_collections(&context, search_params, requestor.scopes())
             .await?;
         (result, total_count)
     } else {
@@ -97,16 +100,16 @@ pub async fn get_collections(
         }
         let candidates = user
             .search_collections_from_backend_with_admin_status(
-                &pool,
+                &context,
                 count_query_options(&params),
                 true,
                 None,
             )
             .await?;
-        let principal = PrincipalRef::load(&pool, user).await?;
+        let principal = PrincipalRef::load(&context, user).await?;
         let search_params = prepare_db_pagination::<Collection>(&params)?;
         let page = authorize_cursor_page(
-            pool.permission_backend(),
+            context.permission_backend(),
             &principal,
             candidates,
             requestor.scopes(),
@@ -137,7 +140,7 @@ pub async fn get_collections(
 #[post("")]
 #[post("/")]
 pub async fn create_collection(
-    pool: AppContext,
+    context: AppContext,
     new_collection_request: web::Json<NewCollectionWithAssignee>,
     requestor: AdminAccess,
     req: HttpRequest,
@@ -150,7 +153,7 @@ pub async fn create_collection(
     );
 
     let event_context = requestor.event_context(&req);
-    let created_collection = pool
+    let created_collection = context
         .collection_service()
         .create(new_collection_request, &event_context)
         .await?;
@@ -175,7 +178,7 @@ pub async fn create_collection(
 )]
 #[get("/{collection_id}")]
 pub async fn get_collection(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     collection_id: web::Path<CollectionID>,
 ) -> Result<impl Responder, ApiError> {
@@ -185,10 +188,10 @@ pub async fn get_collection(
         collection_id = collection_id.id()
     );
 
-    let collection = pool.collection_service().get(*collection_id).await?;
+    let collection = context.collection_service().get(*collection_id).await?;
 
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadCollection],
@@ -216,7 +219,7 @@ pub async fn get_collection(
 )]
 #[patch("/{collection_id}")]
 pub async fn update_collection(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     collection_id: web::Path<CollectionID>,
     update_data: web::Json<UpdateCollection>,
@@ -229,10 +232,10 @@ pub async fn update_collection(
         collection_id = collection_id.id()
     );
 
-    let collection = pool.collection_service().get(collection_id).await?;
+    let collection = context.collection_service().get(collection_id).await?;
 
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::UpdateCollection],
@@ -243,8 +246,11 @@ pub async fn update_collection(
     let event_context = requestor.event_context(&req);
     let updated_collection = with_revision_precondition_scope(
         precondition,
-        pool.collection_service()
-            .update(collection_id, update_data.into_inner(), &event_context),
+        context.collection_service().update(
+            collection_id,
+            update_data.into_inner(),
+            &event_context,
+        ),
     )
     .await?;
     ApiResponse::accepted_revisioned(updated_collection)
@@ -266,7 +272,7 @@ pub async fn update_collection(
 )]
 #[delete("/{collection_id}")]
 pub async fn delete_collection(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     collection_id: web::Path<CollectionID>,
     req: HttpRequest,
@@ -277,9 +283,9 @@ pub async fn delete_collection(
         collection_id = collection_id.id()
     );
 
-    let collection = pool.collection_service().get(*collection_id).await?;
+    let collection = context.collection_service().get(*collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::DeleteCollection],
@@ -291,7 +297,8 @@ pub async fn delete_collection(
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(
         precondition,
-        pool.collection_service()
+        context
+            .collection_service()
             .delete(*collection_id, &event_context),
     )
     .await?;
@@ -314,20 +321,23 @@ pub async fn delete_collection(
 )]
 #[get("/{collection_id}/children")]
 pub async fn get_collection_children(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     collection_id: web::Path<CollectionID>,
 ) -> Result<impl Responder, ApiError> {
-    let collection = pool.collection_service().get(*collection_id).await?;
+    let collection = context.collection_service().get(*collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadCollection],
         collection.clone()
     );
 
-    let children = pool.collection_service().children(*collection_id).await?;
+    let children = context
+        .collection_service()
+        .children(*collection_id)
+        .await?;
     Ok(ApiResponse::new(children, StatusCode::OK))
 }
 
@@ -347,20 +357,23 @@ pub async fn get_collection_children(
 )]
 #[get("/{collection_id}/ancestors")]
 pub async fn get_collection_ancestors(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     collection_id: web::Path<CollectionID>,
 ) -> Result<impl Responder, ApiError> {
-    let collection = pool.collection_service().get(*collection_id).await?;
+    let collection = context.collection_service().get(*collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadCollection],
         collection.clone()
     );
 
-    let ancestors = pool.collection_service().ancestors(*collection_id).await?;
+    let ancestors = context
+        .collection_service()
+        .ancestors(*collection_id)
+        .await?;
     Ok(ApiResponse::new(ancestors, StatusCode::OK))
 }
 
@@ -384,18 +397,18 @@ pub async fn get_collection_ancestors(
 )]
 #[put("/{collection_id}/parent")]
 pub async fn move_collection_parent(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     collection_id: web::Path<CollectionID>,
     update_parent: web::Json<UpdateCollectionParent>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let collection = pool.collection_service().get(*collection_id).await?;
+    let collection = context.collection_service().get(*collection_id).await?;
     let new_parent_id = update_parent.into_inner().parent_collection_id;
-    let new_parent = pool.collection_service().get(new_parent_id).await?;
+    let new_parent = context.collection_service().get(new_parent_id).await?;
 
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::UpdateCollection],
@@ -403,12 +416,12 @@ pub async fn move_collection_parent(
     );
 
     if let Some(old_parent_id) = collection.parent_collection_id {
-        let old_parent = pool
+        let old_parent = context
             .collection_service()
             .get(CollectionID::new(old_parent_id)?)
             .await?;
         can!(
-            &pool,
+            &context,
             &requestor.principal,
             requestor.scopes(),
             [Permissions::DelegateCollection],
@@ -417,7 +430,7 @@ pub async fn move_collection_parent(
     }
 
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::DelegateCollection],
@@ -428,7 +441,8 @@ pub async fn move_collection_parent(
     let event_context = requestor.event_context(&req);
     let updated = with_revision_precondition_scope(
         precondition,
-        pool.collection_service()
+        context
+            .collection_service()
             .move_to(*collection_id, new_parent_id, &event_context),
     )
     .await?;
@@ -453,7 +467,7 @@ pub async fn move_collection_parent(
 )]
 #[get("/{collection_id}/permissions")]
 pub async fn get_collection_permissions(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     collection_id: web::Path<CollectionID>,
     req: HttpRequest,
@@ -466,22 +480,22 @@ pub async fn get_collection_permissions(
 
     let params = parse_query_parameter(req.query_string())?;
 
-    let collection = pool.collection_service().get(*collection_id).await?;
+    let collection = context.collection_service().get(*collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadCollection],
         collection
     );
 
-    if pool.permission_backend().uses_sql_permission_store() {
-        let permission_set = sql_collection_permission_set(&pool, &collection).await?;
+    if context.permission_backend().uses_sql_permission_store() {
+        let permission_set = sql_collection_permission_set(&context, &collection).await?;
         return Ok(Either::Left(ApiResponse::ok_revisioned(permission_set)?));
     }
 
     let search_params = prepare_db_pagination::<GroupPermission>(&params)?;
-    let (permissions, total_count) = pool
+    let (permissions, total_count) = context
         .permission_backend()
         .groups_with_permissions_on(*collection_id, &[], &search_params)
         .await?;
@@ -510,7 +524,7 @@ pub async fn get_collection_permissions(
 )]
 #[get("/{collection_id}/permissions/group/{group_id}")]
 pub async fn get_collection_group_permissions(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     params: web::Path<(CollectionID, GroupID)>,
 ) -> Result<impl Responder, ApiError> {
@@ -525,22 +539,23 @@ pub async fn get_collection_group_permissions(
         group_id = group_id.id()
     );
 
-    let collection = pool.collection_service().get(collection_id).await?;
+    let collection = context.collection_service().get(collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadCollection],
         collection
     );
 
-    if pool.permission_backend().uses_sql_permission_store() {
-        let permission_set = crate::db::traits::collection::collection_permission_set_from_backend(
-            pool.db_pool(),
-            collection.id,
-            Some(group_id.id()),
-        )
-        .await?;
+    if context.permission_backend().uses_sql_permission_store() {
+        let permission_set =
+            crate::backend::capabilities::collection::collection_permission_set_from_backend(
+                &context,
+                collection.id,
+                Some(group_id.id()),
+            )
+            .await?;
         if permission_set.permissions.is_empty() {
             return Err(ApiError::NotFound(
                 "Permission record not found".to_string(),
@@ -549,7 +564,7 @@ pub async fn get_collection_group_permissions(
         return Ok(Either::Left(ApiResponse::ok_revisioned(permission_set)?));
     }
 
-    let permission = pool
+    let permission = context
         .permission_backend()
         .group_permission_on(collection_id, group_id)
         .await?
@@ -574,19 +589,22 @@ pub async fn get_collection_group_permissions(
 )]
 #[get("/{collection_id}/permissions/effective/group/{group_id}")]
 pub async fn get_collection_effective_group_permissions(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     params: web::Path<(CollectionID, GroupID)>,
 ) -> Result<impl Responder, ApiError> {
-    if !pool.permission_backend().supports_permission_provenance() {
+    if !context
+        .permission_backend()
+        .supports_permission_provenance()
+    {
         return Err(ApiError::NotImplemented(
             "effective permission provenance is unavailable for the treetop backend".to_string(),
         ));
     }
     let (collection_id, group_id) = params.into_inner();
-    let collection = pool.collection_service().get(collection_id).await?;
+    let collection = context.collection_service().get(collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadCollection],
@@ -594,7 +612,7 @@ pub async fn get_collection_effective_group_permissions(
     );
 
     let permissions =
-        collection_model::effective_group_on(&pool, collection_id.id(), group_id.id()).await?;
+        collection_model::effective_group_on(&context, collection_id.id(), group_id.id()).await?;
 
     Ok(ApiResponse::new(permissions, StatusCode::OK))
 }
@@ -628,7 +646,7 @@ pub async fn get_collection_effective_group_permissions(
 )]
 #[post("/{collection_id}/permissions/group/{group_id}")]
 pub async fn grant_collection_group_permissions(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     params: web::Path<(CollectionID, GroupID)>,
     permissions: web::Json<Vec<Permissions>>,
@@ -645,32 +663,33 @@ pub async fn grant_collection_group_permissions(
         permissions = ?permissions
     );
 
-    let collection = pool.collection_service().get(collection_id).await?;
+    let collection = context.collection_service().get(collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::DelegateCollection],
         collection
     );
 
-    if pool.permission_backend().uses_sql_permission_store() {
-        let current = sql_collection_permission_set(&pool, &collection).await?;
+    if context.permission_backend().uses_sql_permission_store() {
+        let current = sql_collection_permission_set(&context, &collection).await?;
         let precondition = collection_precondition(&req, &current)?;
         let event_context = requestor.event_context(&req);
         with_revision_precondition_scope(
             precondition,
-            collection.grant(&pool, group_id, permissions, Some(&event_context)),
+            collection.grant(&context, group_id, permissions, Some(&event_context)),
         )
         .await?;
-        let updated = sql_collection_permission_set(&pool, &collection).await?;
+        let updated = sql_collection_permission_set(&context, &collection).await?;
         return Ok(Either::Left(ApiResponse::revisioned(
             updated,
             StatusCode::CREATED,
         )?));
     }
 
-    pool.permission_backend()
+    context
+        .permission_backend()
         .apply_permissions(collection_id, group_id, permissions, false)
         .await?;
     Ok(Either::Right(ApiResponse::created_empty()))
@@ -697,7 +716,7 @@ pub async fn grant_collection_group_permissions(
 )]
 #[put("/{collection_id}/permissions/group/{group_id}")]
 pub async fn replace_collection_group_permissions(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     params: web::Path<(CollectionID, GroupID)>,
     permissions: web::Json<Vec<Permissions>>,
@@ -714,9 +733,9 @@ pub async fn replace_collection_group_permissions(
         permissions = ?permissions
     );
 
-    let collection = pool.collection_service().get(collection_id).await?;
+    let collection = context.collection_service().get(collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::DelegateCollection],
@@ -730,20 +749,21 @@ pub async fn replace_collection_group_permissions(
         ));
     }
 
-    if pool.permission_backend().uses_sql_permission_store() {
-        let current = sql_collection_permission_set(&pool, &collection).await?;
+    if context.permission_backend().uses_sql_permission_store() {
+        let current = sql_collection_permission_set(&context, &collection).await?;
         let precondition = collection_precondition(&req, &current)?;
         let event_context = requestor.event_context(&req);
         with_revision_precondition_scope(
             precondition,
-            collection.set_permissions(&pool, group_id, permissions, Some(&event_context)),
+            collection.set_permissions(&context, group_id, permissions, Some(&event_context)),
         )
         .await?;
-        let updated = sql_collection_permission_set(&pool, &collection).await?;
+        let updated = sql_collection_permission_set(&context, &collection).await?;
         return Ok(Either::Left(ApiResponse::ok_revisioned(updated)?));
     }
 
-    pool.permission_backend()
+    context
+        .permission_backend()
         .apply_permissions(collection_id, group_id, permissions, true)
         .await?;
     Ok(Either::Right(ApiResponse::ok_empty()))
@@ -767,7 +787,7 @@ pub async fn replace_collection_group_permissions(
 )]
 #[delete("/{collection_id}/permissions/group/{group_id}")]
 pub async fn revoke_collection_group_permissions(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     params: web::Path<(CollectionID, GroupID)>,
     req: HttpRequest,
@@ -781,29 +801,30 @@ pub async fn revoke_collection_group_permissions(
         group_id = group_id.id()
     );
 
-    let collection = pool.collection_service().get(collection_id).await?;
+    let collection = context.collection_service().get(collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::DelegateCollection],
         collection
     );
 
-    if pool.permission_backend().uses_sql_permission_store() {
-        let current = sql_collection_permission_set(&pool, &collection).await?;
+    if context.permission_backend().uses_sql_permission_store() {
+        let current = sql_collection_permission_set(&context, &collection).await?;
         let precondition = collection_precondition(&req, &current)?;
         let event_context = requestor.event_context(&req);
         with_revision_precondition_scope(
             precondition,
-            collection.revoke_all(&pool, group_id, Some(&event_context)),
+            collection.revoke_all(&context, group_id, Some(&event_context)),
         )
         .await?;
-        let updated = sql_collection_permission_set(&pool, &collection).await?;
+        let updated = sql_collection_permission_set(&context, &collection).await?;
         return Ok(Either::Left(ApiResponse::ok_revisioned(updated)?));
     }
 
-    pool.permission_backend()
+    context
+        .permission_backend()
         .revoke_all(collection_id, group_id)
         .await?;
     Ok(Either::Right(ApiResponse::no_content()))
@@ -827,7 +848,7 @@ pub async fn revoke_collection_group_permissions(
 )]
 #[get("/{collection_id}/permissions/group/{group_id}/{permission}")]
 pub async fn get_collection_group_permission(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     params: web::Path<(CollectionID, GroupID, Permissions)>,
 ) -> Result<impl Responder, ApiError> {
@@ -843,19 +864,20 @@ pub async fn get_collection_group_permission(
         permission = ?permission
     );
 
-    let collection = pool.collection_service().get(collection_id).await?;
+    let collection = context.collection_service().get(collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadCollection],
         collection
     );
 
-    let allowed = if pool.permission_backend().uses_sql_permission_store() {
-        group_can_on(&pool, group_id.id(), collection, permission).await?
+    let allowed = if context.permission_backend().uses_sql_permission_store() {
+        group_can_on(&context, group_id.id(), collection, permission).await?
     } else {
-        pool.permission_backend()
+        context
+            .permission_backend()
             .group_permission_on(collection_id, group_id)
             .await?
             .is_some_and(|row| row.granted().contains(&permission))
@@ -886,7 +908,7 @@ pub async fn get_collection_group_permission(
 )]
 #[post("/{collection_id}/permissions/group/{group_id}/{permission}")]
 pub async fn grant_collection_group_permission(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     params: web::Path<(CollectionID, GroupID, Permissions)>,
     req: HttpRequest,
@@ -901,9 +923,9 @@ pub async fn grant_collection_group_permission(
         permission = ?permission
     );
 
-    let collection = pool.collection_service().get(collection_id).await?;
+    let collection = context.collection_service().get(collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::DelegateCollection],
@@ -911,23 +933,24 @@ pub async fn grant_collection_group_permission(
     );
 
     let permissions = PermissionsList::new([permission]);
-    if pool.permission_backend().uses_sql_permission_store() {
-        let current = sql_collection_permission_set(&pool, &collection).await?;
+    if context.permission_backend().uses_sql_permission_store() {
+        let current = sql_collection_permission_set(&context, &collection).await?;
         let precondition = collection_precondition(&req, &current)?;
         let event_context = requestor.event_context(&req);
         with_revision_precondition_scope(
             precondition,
-            collection.grant(&pool, group_id, permissions, Some(&event_context)),
+            collection.grant(&context, group_id, permissions, Some(&event_context)),
         )
         .await?;
-        let updated = sql_collection_permission_set(&pool, &collection).await?;
+        let updated = sql_collection_permission_set(&context, &collection).await?;
         return Ok(Either::Left(ApiResponse::revisioned(
             updated,
             StatusCode::CREATED,
         )?));
     }
 
-    pool.permission_backend()
+    context
+        .permission_backend()
         .apply_permissions(collection_id, group_id, permissions, false)
         .await?;
     Ok(Either::Right(ApiResponse::created_empty()))
@@ -952,7 +975,7 @@ pub async fn grant_collection_group_permission(
 )]
 #[delete("/{collection_id}/permissions/group/{group_id}/{permission}")]
 pub async fn revoke_collection_group_permission(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     params: web::Path<(CollectionID, GroupID, Permissions)>,
     req: HttpRequest,
@@ -967,9 +990,9 @@ pub async fn revoke_collection_group_permission(
         permission = ?permission
     );
 
-    let collection = pool.collection_service().get(collection_id).await?;
+    let collection = context.collection_service().get(collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::DelegateCollection],
@@ -977,20 +1000,21 @@ pub async fn revoke_collection_group_permission(
     );
 
     let permissions = PermissionsList::new([permission]);
-    if pool.permission_backend().uses_sql_permission_store() {
-        let current = sql_collection_permission_set(&pool, &collection).await?;
+    if context.permission_backend().uses_sql_permission_store() {
+        let current = sql_collection_permission_set(&context, &collection).await?;
         let precondition = collection_precondition(&req, &current)?;
         let event_context = requestor.event_context(&req);
         with_revision_precondition_scope(
             precondition,
-            collection.revoke(&pool, group_id, permissions, Some(&event_context)),
+            collection.revoke(&context, group_id, permissions, Some(&event_context)),
         )
         .await?;
-        let updated = sql_collection_permission_set(&pool, &collection).await?;
+        let updated = sql_collection_permission_set(&context, &collection).await?;
         return Ok(Either::Left(ApiResponse::ok_revisioned(updated)?));
     }
 
-    pool.permission_backend()
+    context
+        .permission_backend()
         .revoke_permissions(collection_id, group_id, permissions)
         .await?;
     Ok(Either::Right(ApiResponse::no_content()))
@@ -1014,12 +1038,15 @@ pub async fn revoke_collection_group_permission(
 )]
 #[get("/{collection_id}/permissions/principal/{principal_id}")]
 pub async fn get_collection_principal_permissions(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     params: web::Path<(CollectionID, PrincipalID)>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    if !pool.permission_backend().supports_permission_provenance() {
+    if !context
+        .permission_backend()
+        .supports_permission_provenance()
+    {
         return Err(ApiError::NotImplemented(
             "principal permission provenance is unavailable for the treetop backend".to_string(),
         ));
@@ -1034,9 +1061,9 @@ pub async fn get_collection_principal_permissions(
         principal_id = principal_id.id()
     );
 
-    let collection = pool.collection_service().get(collection_id).await?;
+    let collection = context.collection_service().get(collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadCollection],
@@ -1045,7 +1072,7 @@ pub async fn get_collection_principal_permissions(
 
     let search_params = prepare_db_pagination::<GroupPermission>(&query_options)?;
     let (permissions, total_count) = collection_model::principal_on_paginated_with_total_count(
-        &pool,
+        &context,
         principal_id,
         collection.clone(),
         &search_params,
@@ -1076,19 +1103,22 @@ pub async fn get_collection_principal_permissions(
 )]
 #[get("/{collection_id}/permissions/effective/principal/{principal_id}")]
 pub async fn get_collection_effective_principal_permissions(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     params: web::Path<(CollectionID, PrincipalID)>,
 ) -> Result<impl Responder, ApiError> {
-    if !pool.permission_backend().supports_permission_provenance() {
+    if !context
+        .permission_backend()
+        .supports_permission_provenance()
+    {
         return Err(ApiError::NotImplemented(
             "effective permission provenance is unavailable for the treetop backend".to_string(),
         ));
     }
     let (collection_id, principal_id) = params.into_inner();
-    let collection = pool.collection_service().get(collection_id).await?;
+    let collection = context.collection_service().get(collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadCollection],
@@ -1096,7 +1126,7 @@ pub async fn get_collection_effective_principal_permissions(
     );
 
     let permissions =
-        collection_model::effective_principal_on(&pool, principal_id, collection).await?;
+        collection_model::effective_principal_on(&context, principal_id, collection).await?;
 
     Ok(ApiResponse::new(permissions, StatusCode::OK))
 }
@@ -1119,7 +1149,7 @@ pub async fn get_collection_effective_principal_permissions(
 )]
 #[get("/{collection_id}/has_permissions/{permission}")]
 pub async fn get_collection_groups_with_permission(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     params: web::Path<(CollectionID, Permissions)>,
     req: HttpRequest,
@@ -1134,9 +1164,9 @@ pub async fn get_collection_groups_with_permission(
         permission = ?permission
     );
 
-    let collection = pool.collection_service().get(collection_id).await?;
+    let collection = context.collection_service().get(collection_id).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadCollection],
@@ -1144,16 +1174,16 @@ pub async fn get_collection_groups_with_permission(
     );
 
     let search_params = prepare_db_pagination::<Group>(&query_options)?;
-    let (groups, total_count) = if pool.permission_backend().uses_sql_permission_store() {
+    let (groups, total_count) = if context.permission_backend().uses_sql_permission_store() {
         collection_model::groups_can_on_paginated_with_total_count(
-            &pool,
+            &context,
             collection.id,
             permission,
             &search_params,
         )
         .await?
     } else {
-        let (permissions, total_count) = pool
+        let (permissions, total_count) = context
             .permission_backend()
             .groups_with_permissions_on(collection_id, &[permission], &search_params)
             .await?;
@@ -1163,7 +1193,7 @@ pub async fn get_collection_groups_with_permission(
         )
     };
 
-    let response = GroupResponse::from_groups(&pool, groups).await?;
+    let response = GroupResponse::from_groups(&context, groups).await?;
 
     ApiResponse::paginated(response, total_count, &query_options)
 }
@@ -1183,7 +1213,7 @@ pub async fn get_collection_groups_with_permission(
 )]
 #[get("/{collection_id}/history")]
 pub async fn get_collection_history(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     collection_id: web::Path<CollectionID>,
     req: HttpRequest,
@@ -1196,10 +1226,10 @@ pub async fn get_collection_history(
 
     let user = &requestor.principal;
     let collection_id = collection_id.into_inner();
-    let (entity_id, require_history) = match pool.collection_service().get(collection_id).await {
+    let (entity_id, require_history) = match context.collection_service().get(collection_id).await {
         Ok(instance) => {
             can!(
-                &pool,
+                &context,
                 user,
                 requestor.scopes(),
                 [Permissions::ReadCollection],
@@ -1209,7 +1239,7 @@ pub async fn get_collection_history(
         }
         Err(ApiError::NotFound(_))
             if can_read_deleted_history(
-                &pool,
+                &context,
                 &requestor.principal,
                 requestor.scopes().is_some(),
             )
@@ -1225,14 +1255,17 @@ pub async fn get_collection_history(
     let (rows, total_count) = if require_history {
         collection_history_paginated_with_total_count(
             entity_id,
-            &pool,
+            &context,
             &search_params,
             HistoryCollectionFilter::All,
         )
         .await?
-    } else if pool.permission_backend().supports_sql_visibility_pushdown() {
+    } else if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
         let collection_ids = readable_history_collection_ids(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadCollection,
@@ -1240,7 +1273,7 @@ pub async fn get_collection_history(
         .await?;
         collection_history_paginated_with_total_count(
             entity_id,
-            &pool,
+            &context,
             &search_params,
             HistoryCollectionFilter::Visible(&collection_ids),
         )
@@ -1249,13 +1282,13 @@ pub async fn get_collection_history(
         let candidate_params = history_candidate_query_options(&params);
         let (candidates, _) = collection_history_paginated_with_total_count(
             entity_id,
-            &pool,
+            &context,
             &candidate_params,
             HistoryCollectionFilter::All,
         )
         .await?;
         authorize_history_page(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadCollection,
@@ -1271,7 +1304,7 @@ pub async fn get_collection_history(
         )));
     }
 
-    let principal_names = resolve_history_principal_names(&pool, &rows).await?;
+    let principal_names = resolve_history_principal_names(&context, &rows).await?;
 
     ApiResponse::mapped_paginated(rows, total_count, &params, move |rows| {
         rows.into_iter()
@@ -1299,7 +1332,7 @@ pub async fn get_collection_history(
 )]
 #[get("/{collection_id}/history/as-of")]
 pub async fn get_collection_as_of(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     collection_id: web::Path<CollectionID>,
     req: HttpRequest,
@@ -1311,10 +1344,10 @@ pub async fn get_collection_as_of(
 
     let user = &requestor.principal;
     let collection_id = collection_id.into_inner();
-    let (entity_id, deleted) = match pool.collection_service().get(collection_id).await {
+    let (entity_id, deleted) = match context.collection_service().get(collection_id).await {
         Ok(instance) => {
             can!(
-                &pool,
+                &context,
                 user,
                 requestor.scopes(),
                 [Permissions::ReadCollection],
@@ -1324,7 +1357,7 @@ pub async fn get_collection_as_of(
         }
         Err(ApiError::NotFound(_))
             if can_read_deleted_history(
-                &pool,
+                &context,
                 &requestor.principal,
                 requestor.scopes().is_some(),
             )
@@ -1336,7 +1369,7 @@ pub async fn get_collection_as_of(
     };
 
     let at = parse_as_of(req.query_string())?;
-    let row = collection_as_of(entity_id, at, &pool)
+    let row = collection_as_of(entity_id, at, &context)
         .await?
         .ok_or_else(|| {
             ApiError::NotFound(format!("no version of collection {entity_id} at {at}"))
@@ -1344,7 +1377,7 @@ pub async fn get_collection_as_of(
 
     if !deleted {
         authorize_history_snapshot(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadCollection,
@@ -1354,7 +1387,7 @@ pub async fn get_collection_as_of(
     }
 
     let principal_names =
-        resolve_history_principal_names(&pool, std::slice::from_ref(&row)).await?;
+        resolve_history_principal_names(&context, std::slice::from_ref(&row)).await?;
     Ok(ApiResponse::new(
         HistoryResponse::new(row, &principal_names),
         StatusCode::OK,

--- a/src/api/v1/handlers/computed_fields.rs
+++ b/src/api/v1/handlers/computed_fields.rs
@@ -3,15 +3,15 @@ use actix_web::{HttpRequest, Responder, delete, get, http::StatusCode, patch, po
 use crate::api::etag::{RevisionedResource, revision_precondition};
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::can;
-use crate::db::traits::UserPermissions;
-use crate::db::traits::computed_field::{
+use crate::backend::capabilities::UserPermissions;
+use crate::backend::capabilities::computed_field::{
     class_computation_state_for, create_personal_definition, create_shared_definition,
     delete_personal_definition, delete_shared_definition, get_computed_definition,
     list_personal_definitions_page, list_shared_definitions, preview_computed_definition,
     request_class_rebuild, update_personal_definition, update_shared_definition,
 };
-use crate::db::with_revision_precondition_scope;
+use crate::backend::with_revision_precondition_scope;
+use crate::can;
 use crate::errors::ApiError;
 use crate::extractors::{AccessEventContext, Authenticated};
 use crate::models::search::parse_query_parameter_with_passthrough;
@@ -56,21 +56,21 @@ fn computed_field_precondition(
 )]
 #[get("/{class_id}/computed-fields")]
 pub async fn get_shared_computed_fields(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
 ) -> Result<impl Responder, ApiError> {
     let class_id = class_id.into_inner();
-    let class = class_id.instance(&pool).await?;
+    let class = class_id.instance(&context).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadClass],
         class
     );
-    let definitions = list_shared_definitions(&pool, class.id).await?;
-    let state = class_computation_state_for(&pool, class.id).await?;
+    let definitions = list_shared_definitions(&context, class.id).await?;
+    let state = class_computation_state_for(&context, class.id).await?;
     Ok(ApiResponse::ok(ComputedFieldListResponse {
         definitions,
         state,
@@ -94,20 +94,20 @@ pub async fn get_shared_computed_fields(
 )]
 #[get("/{class_id}/computed-fields/{field_id}")]
 pub async fn get_shared_computed_field(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     path: web::Path<(HubuumClassID, ComputedFieldDefinitionID)>,
 ) -> Result<impl Responder, ApiError> {
     let (class_id, field_id) = path.into_inner();
-    let class = class_id.instance(&pool).await?;
+    let class = class_id.instance(&context).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadClass],
         class
     );
-    let definition = get_computed_definition(&pool, field_id.id()).await?;
+    let definition = get_computed_definition(&context, field_id.id()).await?;
     if definition.class_id != class.id || !definition.is_shared() {
         return Err(ApiError::NotFound(format!(
             "Shared computed field {} was not found in class {}",
@@ -135,19 +135,19 @@ pub async fn get_shared_computed_field(
 )]
 #[post("/{class_id}/computed-fields")]
 pub async fn create_shared_computed_field(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     request: web::Json<ComputedFieldDefinitionRequest>,
     http_request: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let class_id = class_id.into_inner();
-    let class = class_id.instance(&pool).await?;
+    let class = class_id.instance(&context).await?;
     let collection = CollectionID::new(class.collection_id)?
-        .instance(&pool)
+        .instance(&context)
         .await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::UpdateCollection],
@@ -155,7 +155,7 @@ pub async fn create_shared_computed_field(
     );
     let event_context = requestor.event_context(&http_request);
     let response = create_shared_definition(
-        &pool,
+        &context,
         class.id,
         class.collection_id,
         requestor.principal.id,
@@ -184,25 +184,25 @@ pub async fn create_shared_computed_field(
 )]
 #[patch("/{class_id}/computed-fields/{field_id}")]
 pub async fn patch_shared_computed_field(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     path: web::Path<(HubuumClassID, ComputedFieldDefinitionID)>,
     request: web::Json<ComputedFieldDefinitionPatch>,
     http_request: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_id, field_id) = path.into_inner();
-    let class = class_id.instance(&pool).await?;
+    let class = class_id.instance(&context).await?;
     let collection = CollectionID::new(class.collection_id)?
-        .instance(&pool)
+        .instance(&context)
         .await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::UpdateCollection],
         collection
     );
-    let definition = get_computed_definition(&pool, field_id.id()).await?;
+    let definition = get_computed_definition(&context, field_id.id()).await?;
     if definition.class_id != class.id || !definition.is_shared() {
         return Err(ApiError::NotFound(format!(
             "Shared computed field {} was not found in class {}",
@@ -215,7 +215,7 @@ pub async fn patch_shared_computed_field(
     let response = with_revision_precondition_scope(
         precondition,
         update_shared_definition(
-            &pool,
+            &context,
             class.id,
             class.collection_id,
             field_id.id(),
@@ -244,24 +244,24 @@ pub async fn patch_shared_computed_field(
 )]
 #[delete("/{class_id}/computed-fields/{field_id}")]
 pub async fn delete_shared_computed_field(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     path: web::Path<(HubuumClassID, ComputedFieldDefinitionID)>,
     http_request: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let (class_id, field_id) = path.into_inner();
-    let class = class_id.instance(&pool).await?;
+    let class = class_id.instance(&context).await?;
     let collection = CollectionID::new(class.collection_id)?
-        .instance(&pool)
+        .instance(&context)
         .await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::UpdateCollection],
         collection
     );
-    let definition = get_computed_definition(&pool, field_id.id()).await?;
+    let definition = get_computed_definition(&context, field_id.id()).await?;
     if definition.class_id != class.id || !definition.is_shared() {
         return Err(ApiError::NotFound(format!(
             "Shared computed field {} was not found in class {}",
@@ -274,7 +274,7 @@ pub async fn delete_shared_computed_field(
     let state = with_revision_precondition_scope(
         precondition,
         delete_shared_definition(
-            &pool,
+            &context,
             class.id,
             class.collection_id,
             field_id.id(),
@@ -293,7 +293,7 @@ pub async fn delete_shared_computed_field(
 }
 
 async fn preview_source(
-    pool: &AppContext,
+    context: &AppContext,
     requestor: &Authenticated,
     request: &ComputedFieldPreviewRequest,
     target_class_id: i32,
@@ -307,7 +307,7 @@ async fn preview_source(
         return Ok(data.clone());
     }
     let object_id = HubuumObjectID::new(request.object_id.expect("source count checked"))?;
-    let object = object_id.instance(pool).await?;
+    let object = object_id.instance(context).await?;
     if object.hubuum_class_id != target_class_id {
         return Err(ApiError::BadRequest(format!(
             "Object {} is not in class {target_class_id}",
@@ -315,7 +315,7 @@ async fn preview_source(
         )));
     }
     can!(
-        pool,
+        context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadObject],
@@ -338,25 +338,25 @@ async fn preview_source(
 )]
 #[post("/{class_id}/computed-fields/preview")]
 pub async fn preview_shared_computed_field(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
     request: web::Json<ComputedFieldPreviewRequest>,
 ) -> Result<impl Responder, ApiError> {
     let class_id = class_id.into_inner();
-    let class = class_id.instance(&pool).await?;
+    let class = class_id.instance(&context).await?;
     let collection = CollectionID::new(class.collection_id)?
-        .instance(&pool)
+        .instance(&context)
         .await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::UpdateCollection],
         collection
     );
     let request = request.into_inner();
-    let data = preview_source(&pool, &requestor, &request, class.id).await?;
+    let data = preview_source(&context, &requestor, &request, class.id).await?;
     Ok(ApiResponse::ok(preview_computed_definition(
         &data,
         &request.definition,
@@ -376,17 +376,17 @@ pub async fn preview_shared_computed_field(
 )]
 #[post("/{class_id}/computed-fields/rebuild")]
 pub async fn rebuild_shared_computed_fields(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     class_id: web::Path<HubuumClassID>,
 ) -> Result<impl Responder, ApiError> {
     let class_id = class_id.into_inner();
-    let class = class_id.instance(&pool).await?;
+    let class = class_id.instance(&context).await?;
     let collection = CollectionID::new(class.collection_id)?
-        .instance(&pool)
+        .instance(&context)
         .await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::UpdateCollection],
@@ -394,7 +394,7 @@ pub async fn rebuild_shared_computed_fields(
     );
     Ok(ApiResponse::accepted(
         request_class_rebuild(
-            &pool,
+            &context,
             class.id,
             class.collection_id,
             Some(requestor.principal.id),
@@ -416,7 +416,7 @@ pub async fn rebuild_shared_computed_fields(
 )]
 #[get("/computed-fields")]
 pub async fn get_personal_computed_fields(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     request: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
@@ -438,7 +438,7 @@ pub async fn get_personal_computed_fields(
     };
     let search_params = prepare_db_pagination::<ComputedFieldDefinition>(&params)?;
     let (definitions, total_count) =
-        list_personal_definitions_page(&pool, owner_id, class_filter, &search_params).await?;
+        list_personal_definitions_page(&context, owner_id, class_filter, &search_params).await?;
     ApiResponse::paginated(definitions, total_count, &params)
 }
 
@@ -457,13 +457,13 @@ pub async fn get_personal_computed_fields(
 )]
 #[get("/computed-fields/{field_id}")]
 pub async fn get_personal_computed_field(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     field_id: web::Path<ComputedFieldDefinitionID>,
 ) -> Result<impl Responder, ApiError> {
     let owner_id = require_human(&requestor)?;
     let field_id = field_id.into_inner();
-    let definition = get_computed_definition(&pool, field_id.id()).await?;
+    let definition = get_computed_definition(&context, field_id.id()).await?;
     if !definition.is_personal_for(owner_id) {
         return Err(ApiError::NotFound(format!(
             "Personal computed field {} was not found",
@@ -471,10 +471,10 @@ pub async fn get_personal_computed_field(
         )));
     }
     let class = HubuumClassID::new(definition.class_id)?
-        .instance(&pool)
+        .instance(&context)
         .await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadClass],
@@ -496,23 +496,23 @@ pub async fn get_personal_computed_field(
 )]
 #[post("/computed-fields")]
 pub async fn create_personal_computed_field(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     request: web::Json<PersonalComputedFieldDefinitionRequest>,
 ) -> Result<impl Responder, ApiError> {
     let owner_id = require_human(&requestor)?;
     let request = request.into_inner();
     let class_id = HubuumClassID::new(request.class_id)?;
-    let class = class_id.instance(&pool).await?;
+    let class = class_id.instance(&context).await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadClass],
         class
     );
     ApiResponse::revisioned(
-        create_personal_definition(&pool, class.id, owner_id, request.definition).await?,
+        create_personal_definition(&context, class.id, owner_id, request.definition).await?,
         StatusCode::CREATED,
     )
 }
@@ -531,7 +531,7 @@ pub async fn create_personal_computed_field(
 )]
 #[patch("/computed-fields/{field_id}")]
 pub async fn patch_personal_computed_field(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     field_id: web::Path<ComputedFieldDefinitionID>,
     request: web::Json<ComputedFieldDefinitionPatch>,
@@ -539,7 +539,7 @@ pub async fn patch_personal_computed_field(
 ) -> Result<impl Responder, ApiError> {
     let owner_id = require_human(&requestor)?;
     let field_id = field_id.into_inner();
-    let definition = get_computed_definition(&pool, field_id.id()).await?;
+    let definition = get_computed_definition(&context, field_id.id()).await?;
     if !definition.is_personal_for(owner_id) {
         return Err(ApiError::NotFound(format!(
             "Personal computed field {} was not found",
@@ -547,10 +547,10 @@ pub async fn patch_personal_computed_field(
         )));
     }
     let class = HubuumClassID::new(definition.class_id)?
-        .instance(&pool)
+        .instance(&context)
         .await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadClass],
@@ -559,7 +559,7 @@ pub async fn patch_personal_computed_field(
     let precondition = computed_field_precondition(&http_request, &definition)?;
     let updated = with_revision_precondition_scope(
         precondition,
-        update_personal_definition(&pool, owner_id, field_id.id(), request.into_inner()),
+        update_personal_definition(&context, owner_id, field_id.id(), request.into_inner()),
     )
     .await?;
     ApiResponse::ok_revisioned(updated)
@@ -580,14 +580,14 @@ pub async fn patch_personal_computed_field(
 )]
 #[delete("/computed-fields/{field_id}")]
 pub async fn delete_personal_computed_field(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     field_id: web::Path<ComputedFieldDefinitionID>,
     http_request: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let owner_id = require_human(&requestor)?;
     let field_id = field_id.into_inner();
-    let definition = get_computed_definition(&pool, field_id.id()).await?;
+    let definition = get_computed_definition(&context, field_id.id()).await?;
     if !definition.is_personal_for(owner_id) {
         return Err(ApiError::NotFound(format!(
             "Personal computed field {} was not found",
@@ -595,10 +595,10 @@ pub async fn delete_personal_computed_field(
         )));
     }
     let class = HubuumClassID::new(definition.class_id)?
-        .instance(&pool)
+        .instance(&context)
         .await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadClass],
@@ -607,7 +607,7 @@ pub async fn delete_personal_computed_field(
     let precondition = computed_field_precondition(&http_request, &definition)?;
     with_revision_precondition_scope(
         precondition,
-        delete_personal_definition(&pool, owner_id, field_id.id()),
+        delete_personal_definition(&context, owner_id, field_id.id()),
     )
     .await?;
     Ok(ApiResponse::no_content_with_etag(definition.entity_tag()?))
@@ -626,7 +626,7 @@ pub async fn delete_personal_computed_field(
 )]
 #[post("/computed-fields/preview")]
 pub async fn preview_personal_computed_field(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     request: web::Json<ComputedFieldPreviewRequest>,
 ) -> Result<impl Responder, ApiError> {
@@ -635,15 +635,17 @@ pub async fn preview_personal_computed_field(
     let target_class_id = request.class_id.ok_or_else(|| {
         ApiError::BadRequest("class_id is required for a personal preview".to_string())
     })?;
-    let class = HubuumClassID::new(target_class_id)?.instance(&pool).await?;
+    let class = HubuumClassID::new(target_class_id)?
+        .instance(&context)
+        .await?;
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ReadClass],
         class
     );
-    let data = preview_source(&pool, &requestor, &request, target_class_id).await?;
+    let data = preview_source(&context, &requestor, &request, target_class_id).await?;
     Ok(ApiResponse::ok(preview_computed_definition(
         &data,
         &request.definition,

--- a/src/api/v1/handlers/event_deliveries.rs
+++ b/src/api/v1/handlers/event_deliveries.rs
@@ -2,12 +2,11 @@ use actix_web::{Responder, get, http::StatusCode, post, routes, web};
 
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::db::DbPool;
-use crate::db::traits::event_delivery::{
+use crate::backend::capabilities::event_delivery::{
     list_event_deliveries_with_total_count, load_event_delivery, mark_event_delivery_dead,
     release_event_delivery_for_retry,
 };
-use crate::db::traits::event_observability::load_event_delivery_health;
+use crate::backend::capabilities::event_observability::load_event_delivery_health;
 use crate::errors::ApiError;
 use crate::events::kick_event_delivery_worker;
 use crate::extractors::AdminAccess;
@@ -17,6 +16,7 @@ use crate::models::{
     EventDeliveryUpdateResponse,
 };
 use crate::pagination::prepare_db_pagination;
+use crate::permissions::AppContext;
 
 #[utoipa::path(
     get,
@@ -39,14 +39,14 @@ use crate::pagination::prepare_db_pagination;
 #[get("")]
 #[get("/")]
 pub async fn get_event_deliveries(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     _admin: AdminAccess,
     req: actix_web::HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let params = parse_query_parameter(req.query_string())?;
     let query_options = prepare_db_pagination::<EventDelivery>(&params)?;
     let (deliveries, total_count) =
-        list_event_deliveries_with_total_count(&pool, &query_options).await?;
+        list_event_deliveries_with_total_count(&context, &query_options).await?;
     ApiResponse::mapped_paginated(deliveries, total_count, &params, |deliveries| {
         deliveries
             .into_iter()
@@ -68,11 +68,11 @@ pub async fn get_event_deliveries(
 )]
 #[get("/health")]
 pub async fn get_event_delivery_health(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     _admin: AdminAccess,
 ) -> Result<impl Responder, ApiError> {
     Ok(ApiResponse::new(
-        load_event_delivery_health(&pool).await?,
+        load_event_delivery_health(&context).await?,
         StatusCode::OK,
     ))
 }
@@ -92,12 +92,12 @@ pub async fn get_event_delivery_health(
 )]
 #[get("/{delivery_id}")]
 pub async fn get_event_delivery(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     _admin: AdminAccess,
     delivery_id: web::Path<EventDeliveryID>,
 ) -> Result<impl Responder, ApiError> {
     Ok(ApiResponse::new(
-        EventDeliveryResponse::from(load_event_delivery(&pool, delivery_id.into_inner()).await?),
+        EventDeliveryResponse::from(load_event_delivery(&context, delivery_id.into_inner()).await?),
         StatusCode::OK,
     ))
 }
@@ -118,12 +118,12 @@ pub async fn get_event_delivery(
 )]
 #[post("/{delivery_id}/retry")]
 pub async fn retry_event_delivery(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     _admin: AdminAccess,
     delivery_id: web::Path<EventDeliveryID>,
 ) -> Result<impl Responder, ApiError> {
-    let delivery = release_event_delivery_for_retry(&pool, delivery_id.into_inner()).await?;
-    kick_event_delivery_worker(pool.get_ref().clone());
+    let delivery = release_event_delivery_for_retry(&context, delivery_id.into_inner()).await?;
+    kick_event_delivery_worker(context.clone());
     Ok(ApiResponse::new(
         EventDeliveryUpdateResponse::from(delivery),
         StatusCode::OK,
@@ -145,11 +145,11 @@ pub async fn retry_event_delivery(
 )]
 #[post("/{delivery_id}/dead")]
 pub async fn dead_letter_event_delivery(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     _admin: AdminAccess,
     delivery_id: web::Path<EventDeliveryID>,
 ) -> Result<impl Responder, ApiError> {
-    let delivery = mark_event_delivery_dead(&pool, delivery_id.into_inner()).await?;
+    let delivery = mark_event_delivery_dead(&context, delivery_id.into_inner()).await?;
     Ok(ApiResponse::new(
         EventDeliveryUpdateResponse::from(delivery),
         StatusCode::OK,

--- a/src/api/v1/handlers/event_sinks.rs
+++ b/src/api/v1/handlers/event_sinks.rs
@@ -3,15 +3,16 @@ use actix_web::{HttpRequest, Responder, delete, get, patch, routes, web};
 use crate::api::etag::{RevisionedResource, revision_precondition, revision_precondition_for_tag};
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::{ApiResponse, ResponseLocation};
-use crate::db::traits::event_subscription::{
+use crate::backend::capabilities::event_subscription::{
     DeleteEventSinkRecord, SaveEventSinkRecord, UpdateEventSinkRecord,
 };
-use crate::db::{DbPool, with_revision_precondition_scope};
+use crate::backend::with_revision_precondition_scope;
 use crate::errors::ApiError;
 use crate::extractors::{AccessEventContext, AdminAccess};
 use crate::models::search::parse_query_parameter;
 use crate::models::{EventSink, EventSinkID, NewEventSink, UpdateEventSink};
 use crate::pagination::prepare_db_pagination;
+use crate::permissions::AppContext;
 
 #[utoipa::path(
     post,
@@ -31,7 +32,7 @@ use crate::pagination::prepare_db_pagination;
 #[post("")]
 #[post("/")]
 pub async fn create_event_sink(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     admin: AdminAccess,
     req: HttpRequest,
     sink: web::Json<NewEventSink>,
@@ -40,7 +41,7 @@ pub async fn create_event_sink(
     let created: EventSink = sink
         .into_inner()
         .into_row()?
-        .save_event_sink_record(&pool, &event_context)
+        .save_event_sink_record(&context, &event_context)
         .await?
         .try_into()?;
     let location = ResponseLocation::new(format!("/api/v1/event-sinks/{}", created.id))?;
@@ -63,13 +64,13 @@ pub async fn create_event_sink(
 #[get("")]
 #[get("/")]
 pub async fn get_event_sinks(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     _admin: AdminAccess,
     req: actix_web::HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let params = parse_query_parameter(req.query_string())?;
     let query_options = prepare_db_pagination::<EventSink>(&params)?;
-    let (sinks, total_count) = EventSink::list_with_total_count(&pool, &query_options).await?;
+    let (sinks, total_count) = EventSink::list_with_total_count(&context, &query_options).await?;
     ApiResponse::paginated(sinks, total_count, &params)
 }
 
@@ -88,11 +89,11 @@ pub async fn get_event_sinks(
 )]
 #[get("/{sink_id}")]
 pub async fn get_event_sink(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     _admin: AdminAccess,
     sink_id: web::Path<EventSinkID>,
 ) -> Result<impl Responder, ApiError> {
-    ApiResponse::ok_revisioned(sink_id.into_inner().instance(&pool).await?)
+    ApiResponse::ok_revisioned(sink_id.into_inner().instance(&context).await?)
 }
 
 #[utoipa::path(
@@ -113,7 +114,7 @@ pub async fn get_event_sink(
 )]
 #[patch("/{sink_id}")]
 pub async fn patch_event_sink(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     admin: AdminAccess,
     req: HttpRequest,
     sink_id: web::Path<EventSinkID>,
@@ -126,14 +127,14 @@ pub async fn patch_event_sink(
             "Event sink update must include at least one field".to_string(),
         ));
     }
-    let existing = sink_id.instance(&pool).await?;
+    let existing = sink_id.instance(&context).await?;
     let precondition = revision_precondition(&req, &existing)?;
     let event_context = admin.event_context(&req);
     let updated: EventSink = with_revision_precondition_scope(
         precondition,
         update
             .into_row(&existing)?
-            .update_event_sink_record(&pool, existing.id, &event_context),
+            .update_event_sink_record(&context, existing.id, &event_context),
     )
     .await?
     .try_into()?;
@@ -155,19 +156,19 @@ pub async fn patch_event_sink(
 )]
 #[delete("/{sink_id}")]
 pub async fn delete_event_sink(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     admin: AdminAccess,
     req: HttpRequest,
     sink_id: web::Path<EventSinkID>,
 ) -> Result<impl Responder, ApiError> {
     let sink_id = sink_id.into_inner();
-    let existing = sink_id.instance(&pool).await?;
+    let existing = sink_id.instance(&context).await?;
     let etag = existing.entity_tag()?;
     let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = admin.event_context(&req);
     with_revision_precondition_scope(
         precondition,
-        sink_id.delete_event_sink_record(&pool, &event_context),
+        sink_id.delete_event_sink_record(&context, &event_context),
     )
     .await?;
     Ok(ApiResponse::no_content_with_etag(etag))

--- a/src/api/v1/handlers/event_subscriptions.rs
+++ b/src/api/v1/handlers/event_subscriptions.rs
@@ -3,12 +3,12 @@ use actix_web::{HttpRequest, Responder, delete, get, patch, routes, web};
 use crate::api::etag::{RevisionedResource, revision_precondition, revision_precondition_for_tag};
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::{ApiResponse, ResponseLocation};
-use crate::can;
-use crate::db::traits::UserPermissions;
-use crate::db::traits::event_subscription::{
+use crate::backend::capabilities::UserPermissions;
+use crate::backend::capabilities::event_subscription::{
     DeleteEventSubscriptionRecord, SaveEventSubscriptionRecord, UpdateEventSubscriptionRecord,
 };
-use crate::db::with_revision_precondition_scope;
+use crate::backend::with_revision_precondition_scope;
+use crate::can;
 use crate::errors::ApiError;
 use crate::extractors::{AccessEventContext, Authenticated};
 use crate::models::search::parse_query_parameter;
@@ -39,7 +39,7 @@ use crate::permissions::AppContext;
 #[post("/{collection_id}/event-subscriptions")]
 #[post("/{collection_id}/event-subscriptions/")]
 pub async fn create_event_subscription(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     collection_id: web::Path<CollectionID>,
@@ -47,18 +47,18 @@ pub async fn create_event_subscription(
 ) -> Result<impl Responder, ApiError> {
     let collection_id = collection_id.into_inner();
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ManageEventSubscription],
         collection_id
     );
-    subscription.sink_id.instance(&pool).await?;
+    subscription.sink_id.instance(&context).await?;
     let event_context = requestor.event_context(&req);
     let created: EventSubscription = subscription
         .into_inner()
         .into_row(collection_id)?
-        .save_event_subscription_record(&pool, &event_context)
+        .save_event_subscription_record(&context, &event_context)
         .await?
         .try_into()?;
     let location = ResponseLocation::new(format!(
@@ -85,14 +85,14 @@ pub async fn create_event_subscription(
 #[get("/{collection_id}/event-subscriptions")]
 #[get("/{collection_id}/event-subscriptions/")]
 pub async fn get_event_subscriptions(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     collection_id: web::Path<CollectionID>,
     req: actix_web::HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let collection_id = collection_id.into_inner();
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ManageEventSubscription],
@@ -101,7 +101,8 @@ pub async fn get_event_subscriptions(
     let params = parse_query_parameter(req.query_string())?;
     let query_options = prepare_db_pagination::<EventSubscription>(&params)?;
     let (subscriptions, total_count) =
-        EventSubscription::list_with_total_count(&pool, collection_id.id(), &query_options).await?;
+        EventSubscription::list_with_total_count(&context, collection_id.id(), &query_options)
+            .await?;
     ApiResponse::paginated(subscriptions, total_count, &params)
 }
 
@@ -123,19 +124,19 @@ pub async fn get_event_subscriptions(
 )]
 #[get("/{collection_id}/event-subscriptions/{subscription_id}")]
 pub async fn get_event_subscription(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     path: web::Path<(CollectionID, EventSubscriptionID)>,
 ) -> Result<impl Responder, ApiError> {
     let (collection_id, subscription_id) = path.into_inner();
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ManageEventSubscription],
         collection_id
     );
-    let subscription = subscription_id.instance(&pool).await?;
+    let subscription = subscription_id.instance(&context).await?;
     ensure_subscription_collection(&subscription, collection_id)?;
     ApiResponse::ok_revisioned(subscription)
 }
@@ -161,7 +162,7 @@ pub async fn get_event_subscription(
 )]
 #[patch("/{collection_id}/event-subscriptions/{subscription_id}")]
 pub async fn patch_event_subscription(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     path: web::Path<(CollectionID, EventSubscriptionID)>,
@@ -169,7 +170,7 @@ pub async fn patch_event_subscription(
 ) -> Result<impl Responder, ApiError> {
     let (collection_id, subscription_id) = path.into_inner();
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ManageEventSubscription],
@@ -182,9 +183,9 @@ pub async fn patch_event_subscription(
         ));
     }
     if let Some(sink_id) = update.sink_id {
-        sink_id.instance(&pool).await?;
+        sink_id.instance(&context).await?;
     }
-    let existing = subscription_id.instance(&pool).await?;
+    let existing = subscription_id.instance(&context).await?;
     ensure_subscription_collection(&existing, collection_id)?;
     let precondition = revision_precondition(&req, &existing)?;
     let event_context = requestor.event_context(&req);
@@ -192,7 +193,7 @@ pub async fn patch_event_subscription(
         precondition,
         update
             .into_row(&existing)?
-            .update_event_subscription_record(&pool, existing.id, &event_context),
+            .update_event_subscription_record(&context, existing.id, &event_context),
     )
     .await?
     .try_into()?;
@@ -217,27 +218,27 @@ pub async fn patch_event_subscription(
 )]
 #[delete("/{collection_id}/event-subscriptions/{subscription_id}")]
 pub async fn delete_event_subscription(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     path: web::Path<(CollectionID, EventSubscriptionID)>,
 ) -> Result<impl Responder, ApiError> {
     let (collection_id, subscription_id) = path.into_inner();
     can!(
-        &pool,
+        &context,
         &requestor.principal,
         requestor.scopes(),
         [Permissions::ManageEventSubscription],
         collection_id
     );
-    let existing = subscription_id.instance(&pool).await?;
+    let existing = subscription_id.instance(&context).await?;
     ensure_subscription_collection(&existing, collection_id)?;
     let etag = existing.entity_tag()?;
     let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(
         precondition,
-        subscription_id.delete_event_subscription_record(&pool, &event_context),
+        subscription_id.delete_event_subscription_record(&context, &event_context),
     )
     .await?;
     Ok(ApiResponse::no_content_with_etag(etag))

--- a/src/api/v1/handlers/events.rs
+++ b/src/api/v1/handlers/events.rs
@@ -2,8 +2,8 @@ use actix_web::{HttpRequest, Responder, get, web};
 
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::db::traits::authz::scope_allows;
-use crate::db::traits::events::{list_events_with_total_count, parse_event_filters};
+use crate::backend::capabilities::authz::scope_allows;
+use crate::backend::capabilities::events::{list_events_with_total_count, parse_event_filters};
 use crate::errors::ApiError;
 use crate::events::{EntityType, EventResponse};
 use crate::extractors::Authenticated;
@@ -45,15 +45,15 @@ use crate::traits::AuthzSubject;
 )]
 #[get("")]
 pub async fn get_events(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    list_visible_events(pool, requestor, req, None).await
+    list_visible_events(context, requestor, req, None).await
 }
 
 async fn list_visible_events(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     entity_filter: Option<(EntityType, i32)>,
@@ -88,30 +88,32 @@ async fn list_visible_events(
         filters.entity_id = Some(entity_id);
     }
     let search_params = prepare_db_pagination::<EventResponse>(&params)?;
-    let (visible_collections, include_collection_less) =
-        if pool.permission_backend().supports_sql_visibility_pushdown() {
-            let collections = user_can_on_any(
-                &pool,
-                &requestor.principal,
-                Permissions::ReadAudit,
-                requestor.scopes(),
-            )
+    let (visible_collections, include_collection_less) = if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
+        let collections = user_can_on_any(
+            &context,
+            &requestor.principal,
+            Permissions::ReadAudit,
+            requestor.scopes(),
+        )
+        .await?;
+        let include_collection_less =
+            requestor.scopes().is_none() && requestor.principal.is_admin(&context).await?;
+        (collections, include_collection_less)
+    } else if scope_allows(requestor.scopes(), &[Permissions::ReadAudit]) {
+        let principal = PrincipalRef::load(&context, &requestor.principal).await?;
+        let collections = context
+            .permission_backend()
+            .collections_user_can(&principal, &[Permissions::ReadAudit])
             .await?;
-            let include_collection_less =
-                requestor.scopes().is_none() && requestor.principal.is_admin(&pool).await?;
-            (collections, include_collection_less)
-        } else if scope_allows(requestor.scopes(), &[Permissions::ReadAudit]) {
-            let principal = PrincipalRef::load(&pool, &requestor.principal).await?;
-            let collections = pool
-                .permission_backend()
-                .collections_user_can(&principal, &[Permissions::ReadAudit])
-                .await?;
-            let include_collection_less = requestor.scopes().is_none()
-                && pool.permission_backend().is_admin(&principal).await?;
-            (collections, include_collection_less)
-        } else {
-            (Vec::new(), false)
-        };
+        let include_collection_less = requestor.scopes().is_none()
+            && context.permission_backend().is_admin(&principal).await?;
+        (collections, include_collection_less)
+    } else {
+        (Vec::new(), false)
+    };
     let mut accessible_collection_ids = visible_collections
         .iter()
         .map(|collection| collection.id)
@@ -120,7 +122,7 @@ async fn list_visible_events(
         scope.retain_allowed_collection_ids(&mut accessible_collection_ids);
     }
     let (events, total_count) = list_events_with_total_count(
-        &pool,
+        &context,
         &accessible_collection_ids,
         include_collection_less,
         &filters,
@@ -155,13 +157,13 @@ async fn list_visible_events(
 )]
 #[get("/{collection_id}/events")]
 pub async fn get_collection_events(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     collection_id: web::Path<CollectionID>,
 ) -> Result<impl Responder, ApiError> {
     list_visible_events(
-        pool,
+        context,
         requestor,
         req,
         Some((EntityType::Collection, collection_id.into_inner().id())),
@@ -195,13 +197,13 @@ pub async fn get_collection_events(
 )]
 #[get("/{class_id}/events")]
 pub async fn get_class_events(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     class_id: web::Path<HubuumClassID>,
 ) -> Result<impl Responder, ApiError> {
     list_visible_events(
-        pool,
+        context,
         requestor,
         req,
         Some((EntityType::Class, class_id.into_inner().id())),
@@ -237,15 +239,15 @@ pub async fn get_class_events(
 )]
 #[get("/{class_id}/{object_id}/events")]
 pub async fn get_object_events(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     path: web::Path<(HubuumClassID, HubuumObjectID)>,
 ) -> Result<impl Responder, ApiError> {
     let (class_id, object_id) = path.into_inner();
-    check_if_object_in_class(&pool, &class_id, &object_id).await?;
+    check_if_object_in_class(&context, &class_id, &object_id).await?;
     list_visible_events(
-        pool,
+        context,
         requestor,
         req,
         Some((EntityType::Object, object_id.id())),
@@ -279,13 +281,13 @@ pub async fn get_object_events(
 )]
 #[get("/{user_id}/events")]
 pub async fn get_user_events(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     user_id: web::Path<UserID>,
 ) -> Result<impl Responder, ApiError> {
     list_visible_events(
-        pool,
+        context,
         requestor,
         req,
         Some((EntityType::User, user_id.into_inner().id())),
@@ -319,13 +321,13 @@ pub async fn get_user_events(
 )]
 #[get("/{group_id}/events")]
 pub async fn get_group_events(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     group_id: web::Path<GroupID>,
 ) -> Result<impl Responder, ApiError> {
     list_visible_events(
-        pool,
+        context,
         requestor,
         req,
         Some((EntityType::Group, group_id.into_inner().id())),
@@ -359,13 +361,13 @@ pub async fn get_group_events(
 )]
 #[get("/{template_id}/events")]
 pub async fn get_export_template_events(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     template_id: web::Path<ExportTemplateID>,
 ) -> Result<impl Responder, ApiError> {
     list_visible_events(
-        pool,
+        context,
         requestor,
         req,
         Some((EntityType::ExportTemplate, template_id.into_inner().id())),
@@ -399,13 +401,13 @@ pub async fn get_export_template_events(
 )]
 #[get("/{target_id}/events")]
 pub async fn get_remote_target_events(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     target_id: web::Path<RemoteTargetID>,
 ) -> Result<impl Responder, ApiError> {
     list_visible_events(
-        pool,
+        context,
         requestor,
         req,
         Some((EntityType::RemoteTarget, target_id.into_inner().id())),

--- a/src/api/v1/handlers/export_templates.rs
+++ b/src/api/v1/handlers/export_templates.rs
@@ -6,14 +6,14 @@ use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
 use crate::api::v1::handlers::history::HistoryResponse;
-use crate::can;
-use crate::db::traits::UserPermissions;
-use crate::db::traits::authz::scope_allows;
-use crate::db::traits::history::{
+use crate::backend::capabilities::UserPermissions;
+use crate::backend::capabilities::authz::scope_allows;
+use crate::backend::capabilities::history::{
     HistoryCollectionFilter, export_template_as_of,
     export_template_history_paginated_with_total_count,
 };
-use crate::db::with_revision_precondition_scope;
+use crate::backend::with_revision_precondition_scope;
+use crate::can;
 use crate::errors::ApiError;
 use crate::exports::{ExportTaskSubmission, submit_export_task};
 use crate::extractors::{AccessEventContext, Authenticated};
@@ -50,7 +50,7 @@ use crate::traits::{CanDelete, CanSave, CanUpdate, SelfAccessors};
 #[post("")]
 #[post("/")]
 pub async fn create_template(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     template: web::Json<NewExportTemplate>,
     req: HttpRequest,
@@ -65,9 +65,9 @@ pub async fn create_template(
         template_name = template.name
     );
 
-    if pool.permission_backend().uses_sql_permission_store() {
+    if context.permission_backend().uses_sql_permission_store() {
         can!(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             [Permissions::CreateTemplate],
@@ -75,8 +75,8 @@ pub async fn create_template(
         );
     } else {
         authorize_resources(
-            pool.permission_backend(),
-            &pool,
+            context.permission_backend(),
+            &context,
             user,
             requestor.scopes(),
             vec![Permissions::CreateTemplate],
@@ -94,7 +94,7 @@ pub async fn create_template(
     }
 
     let event_context = requestor.event_context(&req);
-    let created = template.save(&pool, &event_context).await?;
+    let created = template.save(&context, &event_context).await?;
 
     let location = api_locations::template(created.id)?;
     ApiResponse::created_revisioned(created, location)
@@ -115,7 +115,7 @@ pub async fn create_template(
 #[get("")]
 #[get("/")]
 pub async fn get_templates(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
@@ -127,18 +127,25 @@ pub async fn get_templates(
         user_id = user.id
     );
 
-    let (templates, total_count) = if pool.permission_backend().supports_sql_visibility_pushdown() {
+    let (templates, total_count) = if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
         let search_params = prepare_db_pagination::<ExportTemplate>(&params)?;
-        let mut allowed_collection_ids =
-            user_can_on_any(&pool, user, Permissions::ReadTemplate, requestor.scopes())
-                .await?
-                .into_iter()
-                .map(|collection| collection.id)
-                .collect::<Vec<_>>();
+        let mut allowed_collection_ids = user_can_on_any(
+            &context,
+            user,
+            Permissions::ReadTemplate,
+            requestor.scopes(),
+        )
+        .await?
+        .into_iter()
+        .map(|collection| collection.id)
+        .collect::<Vec<_>>();
         if let Some(scope) = requestor.scopes() {
             scope.retain_allowed_collection_ids(&mut allowed_collection_ids);
         }
-        ExportTemplate::list_with_total_count(&pool, &allowed_collection_ids, &search_params)
+        ExportTemplate::list_with_total_count(&context, &allowed_collection_ids, &search_params)
             .await?
     } else {
         if !scope_allows(requestor.scopes(), &[Permissions::ReadTemplate]) {
@@ -146,11 +153,11 @@ pub async fn get_templates(
         }
         let mut candidate_options = count_query_options(&params);
         candidate_options.include_total = false;
-        let candidates = ExportTemplate::list_candidates(&pool, &candidate_options).await?;
-        let principal = PrincipalRef::load(&pool, user).await?;
+        let candidates = ExportTemplate::list_candidates(&context, &candidate_options).await?;
+        let principal = PrincipalRef::load(&context, user).await?;
         let search_params = prepare_db_pagination::<ExportTemplate>(&params)?;
         let page = authorize_cursor_page(
-            pool.permission_backend(),
+            context.permission_backend(),
             &principal,
             candidates,
             requestor.scopes(),
@@ -190,7 +197,7 @@ pub async fn get_templates(
 )]
 #[get("/{template_id}")]
 pub async fn get_template(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     template_id: web::Path<ExportTemplateID>,
 ) -> Result<impl Responder, ApiError> {
@@ -203,10 +210,10 @@ pub async fn get_template(
         template_id = template_id.id()
     );
 
-    let template = template_id.instance(&pool).await?;
+    let template = template_id.instance(&context).await?;
 
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::ReadTemplate],
@@ -237,7 +244,7 @@ pub async fn get_template(
 )]
 #[post("/{template_id}/exports")]
 pub async fn run_template_export(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     template_id: web::Path<ExportTemplateID>,
@@ -253,10 +260,10 @@ pub async fn run_template_export(
         template_id = template_id.id()
     );
 
-    let template = template_id.instance(&pool).await?;
+    let template = template_id.instance(&context).await?;
 
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::ReadTemplate],
@@ -272,8 +279,8 @@ pub async fn run_template_export(
     )
     .template(template)
     .idempotency_key(idempotency_key);
-    let task = submit_export_task(&pool, user, submission).await?;
-    kick_task_worker(pool.clone());
+    let task = submit_export_task(&context, user, submission).await?;
+    kick_task_worker(context.clone());
     let response = task.to_response()?;
 
     Ok(ApiResponse::accepted_at(
@@ -302,7 +309,7 @@ pub async fn run_template_export(
 )]
 #[patch("/{template_id}")]
 pub async fn patch_template(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     template_id: web::Path<ExportTemplateID>,
     update: web::Json<UpdateExportTemplate>,
@@ -318,10 +325,10 @@ pub async fn patch_template(
         template_id = template_id.id()
     );
 
-    let existing = template_id.instance(&pool).await?;
+    let existing = template_id.instance(&context).await?;
 
     can!(
-        &pool,
+        &context,
         user.clone(),
         requestor.scopes(),
         [Permissions::UpdateTemplate],
@@ -332,7 +339,7 @@ pub async fn patch_template(
         && target_collection != existing.collection_id
     {
         can!(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             [Permissions::CreateTemplate],
@@ -344,7 +351,7 @@ pub async fn patch_template(
     let event_context = requestor.event_context(&req);
     let updated = with_revision_precondition_scope(
         precondition,
-        update.update(&pool, template_id, &event_context),
+        update.update(&context, template_id, &event_context),
     )
     .await?;
 
@@ -368,7 +375,7 @@ pub async fn patch_template(
 )]
 #[delete("/{template_id}")]
 pub async fn delete_template(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     template_id: web::Path<ExportTemplateID>,
     req: HttpRequest,
@@ -382,10 +389,10 @@ pub async fn delete_template(
         template_id = template_id.id()
     );
 
-    let template = template_id.instance(&pool).await?;
+    let template = template_id.instance(&context).await?;
 
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::DeleteTemplate],
@@ -395,7 +402,7 @@ pub async fn delete_template(
     let etag = template.entity_tag()?;
     let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
-    with_revision_precondition_scope(precondition, template_id.delete(&pool, &event_context))
+    with_revision_precondition_scope(precondition, template_id.delete(&context, &event_context))
         .await?;
 
     Ok(ApiResponse::no_content_with_etag(etag))
@@ -416,7 +423,7 @@ pub async fn delete_template(
 )]
 #[get("/{template_id}/history")]
 pub async fn get_template_history(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     template_id: web::Path<ExportTemplateID>,
     req: HttpRequest,
@@ -431,10 +438,10 @@ pub async fn get_template_history(
 
     let user = &requestor.principal;
     let template_id = template_id.into_inner();
-    let (entity_id, require_history) = match template_id.instance(&pool).await {
+    let (entity_id, require_history) = match template_id.instance(&context).await {
         Ok(instance) => {
             can!(
-                &pool,
+                &context,
                 user,
                 requestor.scopes(),
                 [Permissions::ReadTemplate],
@@ -444,7 +451,7 @@ pub async fn get_template_history(
         }
         Err(ApiError::NotFound(_))
             if can_read_deleted_history(
-                &pool,
+                &context,
                 &requestor.principal,
                 requestor.scopes().is_some(),
             )
@@ -460,14 +467,17 @@ pub async fn get_template_history(
     let (rows, total_count) = if require_history {
         export_template_history_paginated_with_total_count(
             entity_id,
-            &pool,
+            &context,
             &search_params,
             HistoryCollectionFilter::All,
         )
         .await?
-    } else if pool.permission_backend().supports_sql_visibility_pushdown() {
+    } else if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
         let collection_ids = readable_history_collection_ids(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadTemplate,
@@ -475,7 +485,7 @@ pub async fn get_template_history(
         .await?;
         export_template_history_paginated_with_total_count(
             entity_id,
-            &pool,
+            &context,
             &search_params,
             HistoryCollectionFilter::Visible(&collection_ids),
         )
@@ -484,13 +494,13 @@ pub async fn get_template_history(
         let candidate_params = history_candidate_query_options(&params);
         let (candidates, _) = export_template_history_paginated_with_total_count(
             entity_id,
-            &pool,
+            &context,
             &candidate_params,
             HistoryCollectionFilter::All,
         )
         .await?;
         authorize_history_page(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadTemplate,
@@ -506,7 +516,7 @@ pub async fn get_template_history(
         )));
     }
 
-    let principal_names = resolve_history_principal_names(&pool, &rows).await?;
+    let principal_names = resolve_history_principal_names(&context, &rows).await?;
 
     ApiResponse::mapped_paginated(rows, total_count, &params, move |rows| {
         rows.into_iter()
@@ -534,7 +544,7 @@ pub async fn get_template_history(
 )]
 #[get("/{template_id}/history/as-of")]
 pub async fn get_template_as_of(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     template_id: web::Path<ExportTemplateID>,
     req: HttpRequest,
@@ -546,10 +556,10 @@ pub async fn get_template_as_of(
 
     let user = &requestor.principal;
     let template_id = template_id.into_inner();
-    let (entity_id, deleted) = match template_id.instance(&pool).await {
+    let (entity_id, deleted) = match template_id.instance(&context).await {
         Ok(instance) => {
             can!(
-                &pool,
+                &context,
                 user,
                 requestor.scopes(),
                 [Permissions::ReadTemplate],
@@ -559,7 +569,7 @@ pub async fn get_template_as_of(
         }
         Err(ApiError::NotFound(_))
             if can_read_deleted_history(
-                &pool,
+                &context,
                 &requestor.principal,
                 requestor.scopes().is_some(),
             )
@@ -571,13 +581,13 @@ pub async fn get_template_as_of(
     };
 
     let at = parse_as_of(req.query_string())?;
-    let row = export_template_as_of(entity_id, at, &pool)
+    let row = export_template_as_of(entity_id, at, &context)
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("no version of template {entity_id} at {at}")))?;
 
     if !deleted {
         authorize_history_snapshot(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadTemplate,
@@ -587,7 +597,7 @@ pub async fn get_template_as_of(
     }
 
     let principal_names =
-        resolve_history_principal_names(&pool, std::slice::from_ref(&row)).await?;
+        resolve_history_principal_names(&context, std::slice::from_ref(&row)).await?;
     Ok(ApiResponse::new(
         HistoryResponse::new(row, &principal_names),
         StatusCode::OK,

--- a/src/api/v1/handlers/exports.rs
+++ b/src/api/v1/handlers/exports.rs
@@ -3,7 +3,7 @@ use actix_web::{HttpRequest, HttpResponse, Responder, get, http::StatusCode, pos
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::db::traits::task::TaskBackend;
+use crate::backend::capabilities::task::TaskBackend;
 use crate::errors::ApiError;
 use crate::exports::{ExportTaskSubmission, submit_export_task};
 use crate::extractors::Authenticated;
@@ -61,7 +61,7 @@ fn render_export_task_output(output: ExportTaskOutputRecord) -> Result<HttpRespo
 )]
 #[post("")]
 pub async fn run_export(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     export: web::Json<ExportRequest>,
@@ -73,10 +73,10 @@ pub async fn run_export(
         requestor.scopes(),
     )
     .idempotency_key(idempotency_key_from_headers(req.headers())?);
-    let task = submit_export_task(&pool, &requestor.principal, submission).await?;
+    let task = submit_export_task(&context, &requestor.principal, submission).await?;
 
     let response = task.to_response()?;
-    kick_task_worker(pool.clone());
+    kick_task_worker(context.clone());
 
     Ok(ApiResponse::accepted_at(
         response,
@@ -100,16 +100,16 @@ pub async fn run_export(
 )]
 #[get("/{task_id}")]
 pub async fn get_export(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.clone());
+    ensure_task_worker_running(context.clone());
     let task = task_id
         .into_inner()
-        .load_authorized_export(&pool, &requestor.principal)
+        .load_authorized_export(&context, &requestor.principal)
         .await?;
-    let output = task.find_export_output_summary(&pool).await?;
+    let output = task.find_export_output_summary(&context).await?;
     Ok(ApiResponse::new(
         task.to_response_with_export_output(output.as_ref())?,
         StatusCode::OK,
@@ -142,16 +142,16 @@ pub async fn get_export(
 )]
 #[get("/{task_id}/output")]
 pub async fn get_export_output(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.clone());
+    ensure_task_worker_running(context.clone());
     let task_id = task_id.into_inner();
     task_id
-        .load_authorized_export(&pool, &requestor.principal)
+        .load_authorized_export(&context, &requestor.principal)
         .await?;
-    match task_id.find_export_output(&pool).await? {
+    match task_id.find_export_output(&context).await? {
         ExportOutputLookup::Available(output) => render_export_task_output(output),
         ExportOutputLookup::Expired { expires_at } => Err(ApiError::Gone(format!(
             "Export output expired at {expires_at} UTC"

--- a/src/api/v1/handlers/groups.rs
+++ b/src/api/v1/handlers/groups.rs
@@ -4,7 +4,7 @@ use crate::api::etag::{
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::db::{DbPool, with_revision_precondition_scope};
+use crate::backend::with_revision_precondition_scope;
 use crate::errors::ApiError;
 use crate::extractors::{AccessEventContext, AdminAccess, UserAccess};
 use crate::models::group::{GroupID, NewGroup, UpdateGroup};
@@ -13,6 +13,7 @@ use crate::models::{
     Group, GroupPointResponse, GroupResponse, Principal, PrincipalID, PrincipalMemberResponse,
 };
 use crate::pagination::{count_query_options, prepare_db_pagination};
+use crate::permissions::AppContext;
 use actix_web::{HttpRequest, Responder, delete, get, http::StatusCode, patch, post, routes, web};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
@@ -38,7 +39,7 @@ struct GroupMember {
 #[get("")]
 #[get("/")]
 pub async fn get_groups(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: UserAccess,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
@@ -57,14 +58,14 @@ pub async fn get_groups(
     );
 
     let total_count = if params.include_total {
-        user.count_groups(&pool, count_query_options(&params))
+        user.count_groups(&context, count_query_options(&params))
             .await?
     } else {
         crate::pagination::SKIPPED_TOTAL_COUNT
     };
     let search_params = prepare_db_pagination::<Group>(&params)?;
-    let groups = user.search_groups(&pool, search_params).await?;
-    let result = GroupResponse::from_groups(&pool, groups).await?;
+    let groups = user.search_groups(&context, search_params).await?;
+    let result = GroupResponse::from_groups(&context, groups).await?;
 
     ApiResponse::paginated(result, total_count, &params)
 }
@@ -86,7 +87,7 @@ pub async fn get_groups(
 #[post("")]
 #[post("/")]
 pub async fn create_group(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     new_group: web::Json<NewGroup>,
     requestor: AdminAccess,
     req: HttpRequest,
@@ -98,10 +99,10 @@ pub async fn create_group(
     );
 
     let event_context = requestor.event_context(&req);
-    let group = new_group.save(&pool, Some(&event_context)).await?;
+    let group = new_group.save(&context, Some(&event_context)).await?;
 
     let location = api_locations::group(group.id)?;
-    ApiResponse::created_revisioned(group.to_point_response(&pool).await?, location)
+    ApiResponse::created_revisioned(group.to_point_response(&context).await?, location)
 }
 
 #[utoipa::path(
@@ -120,11 +121,11 @@ pub async fn create_group(
 )]
 #[get("/{group_id}")]
 pub async fn get_group(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     group_id: web::Path<GroupID>,
     requestor: UserAccess,
 ) -> Result<impl Responder, ApiError> {
-    let group = group_id.group(&pool).await?;
+    let group = group_id.group(&context).await?;
 
     debug!(
         message = "Group get requested",
@@ -132,7 +133,7 @@ pub async fn get_group(
         requestor = requestor.user.id
     );
 
-    ApiResponse::ok_revisioned(group.to_point_response(&pool).await?)
+    ApiResponse::ok_revisioned(group.to_point_response(&context).await?)
 }
 
 #[utoipa::path(
@@ -154,7 +155,7 @@ pub async fn get_group(
 )]
 #[patch("/{group_id}")]
 pub async fn update_group(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     group_id: web::Path<GroupID>,
     updated_group: web::Json<UpdateGroup>,
     requestor: AdminAccess,
@@ -169,17 +170,17 @@ pub async fn update_group(
         requestor = requestor.user.id
     );
 
-    let current = group_id.group(&pool).await?;
+    let current = group_id.group(&context).await?;
     let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let updated = with_revision_precondition_scope(
         precondition,
         updated_group
             .into_inner()
-            .save(group_id, &pool, Some(&event_context)),
+            .save(group_id, &context, Some(&event_context)),
     )
     .await?;
-    ApiResponse::ok_revisioned(updated.to_point_response(&pool).await?)
+    ApiResponse::ok_revisioned(updated.to_point_response(&context).await?)
 }
 
 #[utoipa::path(
@@ -200,7 +201,7 @@ pub async fn update_group(
 )]
 #[delete("/{group_id}")]
 pub async fn delete_group(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     group_id: web::Path<GroupID>,
     requestor: AdminAccess,
     req: HttpRequest,
@@ -211,12 +212,15 @@ pub async fn delete_group(
         requestor = requestor.user.id
     );
 
-    let group = group_id.group(&pool).await?;
+    let group = group_id.group(&context).await?;
     let etag = group.entity_tag()?;
     let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
-    with_revision_precondition_scope(precondition, group_id.delete(&pool, Some(&event_context)))
-        .await?;
+    with_revision_precondition_scope(
+        precondition,
+        group_id.delete(&context, Some(&event_context)),
+    )
+    .await?;
     Ok(ApiResponse::no_content_with_etag(etag))
 }
 
@@ -236,14 +240,14 @@ pub async fn delete_group(
 )]
 #[get("/{group_id}/members")]
 pub async fn get_group_members(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     group_id: web::Path<GroupID>,
     requestor: UserAccess,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let params = parse_query_parameter(req.query_string())?;
 
-    let group = group_id.group(&pool).await?;
+    let group = group_id.group(&context).await?;
 
     debug!(
         message = "Group members requested",
@@ -253,14 +257,16 @@ pub async fn get_group_members(
 
     let total_count = if params.include_total {
         let count_params = count_query_options(&params);
-        group.count_members_paginated(&pool, &count_params).await?
+        group
+            .count_members_paginated(&context, &count_params)
+            .await?
     } else {
         crate::pagination::SKIPPED_TOTAL_COUNT
     };
     let search_params = prepare_db_pagination::<Principal>(&params)?;
-    let members = group.members_paginated(&pool, &search_params).await?;
+    let members = group.members_paginated(&context, &search_params).await?;
 
-    let response = PrincipalMemberResponse::from_memberships(&pool, members).await?;
+    let response = PrincipalMemberResponse::from_memberships(&context, members).await?;
     ApiResponse::paginated(response, total_count, &params)
 }
 
@@ -281,14 +287,18 @@ pub async fn get_group_members(
 )]
 #[get("/{group_id}/members/{principal_id}")]
 pub async fn get_group_member(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     user_group_ids: web::Path<GroupMember>,
     requestor: UserAccess,
 ) -> Result<impl Responder, ApiError> {
-    let group = user_group_ids.group_id.group(&pool).await?;
-    let principal = user_group_ids.principal_id.principal(&pool).await?;
-    let membership =
-        crate::db::traits::group::principal_group_by_ids(&pool, principal.id, group.id).await?;
+    let group = user_group_ids.group_id.group(&context).await?;
+    let principal = user_group_ids.principal_id.principal(&context).await?;
+    let membership = crate::backend::capabilities::group::principal_group_by_ids(
+        &context,
+        principal.id,
+        group.id,
+    )
+    .await?;
 
     debug!(
         message = "Group membership requested",
@@ -318,14 +328,14 @@ pub async fn get_group_member(
 )]
 #[post("/{group_id}/members/{principal_id}")]
 pub async fn add_group_member(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     user_group_ids: web::Path<GroupMember>,
     requestor: AdminAccess,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let group = user_group_ids.group_id.group(&pool).await?;
+    let group = user_group_ids.group_id.group(&context).await?;
     group.ensure_local_writes_allowed()?;
-    let principal = user_group_ids.principal_id.principal(&pool).await?;
+    let principal = user_group_ids.principal_id.principal(&context).await?;
 
     debug!(
         message = "Adding principal to group",
@@ -335,8 +345,12 @@ pub async fn add_group_member(
     );
 
     let condition = IfMatchCondition::from_request(&req)?;
-    let current =
-        crate::db::traits::group::principal_group_by_ids(&pool, principal.id, group.id).await;
+    let current = crate::backend::capabilities::group::principal_group_by_ids(
+        &context,
+        principal.id,
+        group.id,
+    )
+    .await;
     let precondition = match current {
         Ok(current) => condition.database_precondition(&current.entity_tag()?)?,
         Err(ApiError::NotFound(_)) if matches!(condition, IfMatchCondition::Missing) => None,
@@ -352,7 +366,7 @@ pub async fn add_group_member(
     let event_context = requestor.event_context(&req);
     let membership = with_revision_precondition_scope(
         precondition,
-        group.add_member(&pool, &principal, Some(&event_context)),
+        group.add_member(&context, &principal, Some(&event_context)),
     )
     .await?;
     let response = PrincipalMemberResponse::point(membership);
@@ -376,14 +390,14 @@ pub async fn add_group_member(
 )]
 #[delete("/{group_id}/members/{principal_id}")]
 pub async fn delete_group_member(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     user_group_ids: web::Path<GroupMember>,
     requestor: AdminAccess,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let group = user_group_ids.group_id.group(&pool).await?;
+    let group = user_group_ids.group_id.group(&context).await?;
     group.ensure_local_writes_allowed()?;
-    let principal = user_group_ids.principal_id.principal(&pool).await?;
+    let principal = user_group_ids.principal_id.principal(&context).await?;
 
     debug!(
         message = "Deleting principal from group",
@@ -392,16 +406,26 @@ pub async fn delete_group_member(
         requestor = requestor.user.id
     );
 
-    let membership =
-        crate::db::traits::group::principal_group_by_ids(&pool, principal.id, group.id).await?;
+    let membership = crate::backend::capabilities::group::principal_group_by_ids(
+        &context,
+        principal.id,
+        group.id,
+    )
+    .await?;
     let precondition = revision_precondition(&req, &membership)?;
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(
         precondition,
-        group.remove_member(&principal, &pool, Some(&event_context)),
+        group.remove_member(&principal, &context, Some(&event_context)),
     )
     .await?;
-    match crate::db::traits::group::principal_group_by_ids(&pool, principal.id, group.id).await {
+    match crate::backend::capabilities::group::principal_group_by_ids(
+        &context,
+        principal.id,
+        group.id,
+    )
+    .await
+    {
         Ok(surviving) => Ok(ApiResponse::no_content_with_etag(surviving.entity_tag()?)),
         Err(ApiError::NotFound(_)) => Ok(ApiResponse::no_content()),
         Err(error) => Err(error),

--- a/src/api/v1/handlers/history.rs
+++ b/src/api/v1/handlers/history.rs
@@ -5,9 +5,8 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::db::DbPool;
-use crate::db::traits::authz::scope_allows;
-use crate::db::traits::history::resolve_principal_names;
+use crate::backend::capabilities::authz::scope_allows;
+use crate::backend::capabilities::history::resolve_principal_names;
 use crate::errors::ApiError;
 use crate::events::{PrincipalNames, Provenance, StoredProvenance};
 use crate::models::collection::user_can_on_any;
@@ -52,7 +51,7 @@ where
 
 /// Resolve the union of actor and initiator ids with one principal query.
 pub(crate) async fn resolve_history_principal_names<T>(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     rows: &[T],
 ) -> Result<PrincipalNames, ApiError>
 where

--- a/src/api/v1/handlers/imports.rs
+++ b/src/api/v1/handlers/imports.rs
@@ -4,9 +4,8 @@ use hubuum_task_core::IdempotencyKey;
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
+use crate::backend::capabilities::task::{TaskBackend, TaskCreateRequest, TaskScopeSnapshot};
 use crate::config::{DEFAULT_IMPORT_MAX_ACTIVE_TASKS_PER_USER, get_config};
-use crate::db::DbPool;
-use crate::db::traits::task::{TaskBackend, TaskCreateRequest, TaskScopeSnapshot};
 use crate::errors::ApiError;
 use crate::extractors::Authenticated;
 use crate::models::search::parse_query_parameter;
@@ -21,7 +20,7 @@ use crate::tasks::{
 };
 
 async fn find_or_create_import_task(
-    pool: &DbPool,
+    context: &impl crate::traits::BackendContext,
     submitted_by: PrincipalID,
     snapshot: TaskScopeSnapshot,
     idempotency_key: Option<IdempotencyKey>,
@@ -34,7 +33,7 @@ async fn find_or_create_import_task(
         .request_hash(Some(request_hash))
         .scope_snapshot(snapshot)
         .build()
-        .create_idempotently_with_active_limit(pool, max_active_import_tasks_per_user())
+        .create_idempotently_with_active_limit(context, max_active_import_tasks_per_user())
         .await
 }
 
@@ -55,12 +54,12 @@ async fn find_or_create_import_task(
 )]
 #[post("")]
 pub async fn create_import(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     import_request: web::Json<ImportRequest>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.clone());
+    ensure_task_worker_running(context.clone());
 
     let import_request = import_request.into_inner();
     import_request.validate()?;
@@ -73,7 +72,7 @@ pub async fn create_import(
     );
 
     let task = find_or_create_import_task(
-        &pool,
+        &context,
         PrincipalID::new(requestor.principal.id)?,
         snapshot,
         idempotency_key,
@@ -84,7 +83,7 @@ pub async fn create_import(
     .await?;
 
     let response = task.to_response()?;
-    kick_task_worker(pool.clone());
+    kick_task_worker(context.clone());
 
     Ok(ApiResponse::accepted_at(
         response,
@@ -115,14 +114,14 @@ fn max_active_import_tasks_per_user() -> usize {
 )]
 #[get("/{task_id}")]
 pub async fn get_import(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.clone());
+    ensure_task_worker_running(context.clone());
     let task = task_id
         .into_inner()
-        .load_authorized_import(&pool, &requestor.principal)
+        .load_authorized_import(&context, &requestor.principal)
         .await?;
     Ok(ApiResponse::new(task.to_response()?, StatusCode::OK))
 }
@@ -144,20 +143,20 @@ pub async fn get_import(
 )]
 #[get("/{task_id}/results")]
 pub async fn get_import_results(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.clone());
+    ensure_task_worker_running(context.clone());
     let task_id = task_id.into_inner();
     task_id
-        .load_authorized_import(&pool, &requestor.principal)
+        .load_authorized_import(&context, &requestor.principal)
         .await?;
     let params = parse_query_parameter(req.query_string())?;
     let search_params = prepare_db_pagination::<ImportTaskResultResponse>(&params)?;
     let (results, total_count) = task_id
-        .list_import_results_with_total_count(&pool, &search_params)
+        .list_import_results_with_total_count(&context, &search_params)
         .await?;
     let results = results
         .into_iter()

--- a/src/api/v1/handlers/me.rs
+++ b/src/api/v1/handlers/me.rs
@@ -8,8 +8,8 @@ use crate::api::response::ApiResponse;
 use crate::api::v1::handlers::principals::{
     PrincipalCollectionPermissions, parse_token_list_query, principal_permissions_response,
 };
-use crate::db::traits::active_tokens::retained_token_metadata_by_principal_id_paginated_with_total_count;
-use crate::db::{DbPool, with_revision_precondition_scope};
+use crate::backend::capabilities::active_tokens::retained_token_metadata_by_principal_id_paginated_with_total_count;
+use crate::backend::with_revision_precondition_scope;
 use crate::errors::ApiError;
 use crate::extractors::{
     AccessEventContext, Authenticated, ManagementAccess, PrincipalSettingsPatchPayload,
@@ -20,6 +20,7 @@ use crate::models::{
     PrincipalToken, TokenListState,
 };
 use crate::pagination::{effective_page_limit, finalize_page, prepare_db_pagination};
+use crate::permissions::AppContext;
 use crate::traits::GroupAccessors;
 
 pub use crate::models::CurrentTokenMetadata;
@@ -61,7 +62,7 @@ pub struct MeResponse {
 #[get("")]
 #[get("/")]
 pub async fn get_me(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: Authenticated,
 ) -> Result<impl Responder, ApiError> {
     let token = CurrentTokenMetadata::from_token_and_scope(&requestor.token_meta, requestor.scope)?;
@@ -69,7 +70,7 @@ pub async fn get_me(
     Ok(ApiResponse::new(
         MeResponse {
             principal: crate::models::MembershipPrincipalResponse::from_principal(
-                &pool,
+                &context,
                 requestor.principal,
             )
             .await?,
@@ -95,7 +96,7 @@ pub async fn get_me(
 )]
 #[get("/tokens")]
 pub async fn list_my_tokens(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
@@ -104,7 +105,7 @@ pub async fn list_my_tokens(
     let (metadata, total_count) =
         retained_token_metadata_by_principal_id_paginated_with_total_count(
             PrincipalID::new(requestor.user.id)?,
-            &pool,
+            &context,
             &search_params,
             state,
         )
@@ -132,7 +133,7 @@ pub async fn list_my_tokens(
 )]
 #[get("/groups")]
 pub async fn list_my_groups(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
@@ -140,9 +141,9 @@ pub async fn list_my_groups(
     let search_params = prepare_db_pagination::<Group>(&params)?;
     let (groups, total_count) = requestor
         .principal
-        .groups_paginated_with_total_count(&pool, &search_params)
+        .groups_paginated_with_total_count(&context, &search_params)
         .await?;
-    let response = GroupResponse::from_groups(&pool, groups).await?;
+    let response = GroupResponse::from_groups(&context, groups).await?;
     ApiResponse::paginated(response, total_count, &params)
 }
 
@@ -158,10 +159,10 @@ pub async fn list_my_groups(
 )]
 #[get("/permissions")]
 pub async fn list_my_permissions(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: Authenticated,
 ) -> Result<impl Responder, ApiError> {
-    let export = principal_permissions_response(&pool, &requestor.principal).await?;
+    let export = principal_permissions_response(&context, &requestor.principal).await?;
     Ok(ApiResponse::new(export, StatusCode::OK))
 }
 
@@ -177,11 +178,11 @@ pub async fn list_my_permissions(
 )]
 #[get("/settings")]
 pub async fn get_my_settings(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: Authenticated,
 ) -> Result<impl Responder, ApiError> {
     let principal_id = PrincipalID::new(requestor.principal.id)?;
-    ApiResponse::ok_revisioned(principal_id.settings(&pool).await?)
+    ApiResponse::ok_revisioned(principal_id.settings(&context).await?)
 }
 
 #[utoipa::path(
@@ -198,18 +199,18 @@ pub async fn get_my_settings(
 )]
 #[put("/settings")]
 pub async fn put_my_settings(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: Authenticated,
     settings: web::Json<PrincipalSettings>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let principal_id = PrincipalID::new(requestor.principal.id)?;
-    let current = principal_id.settings(&pool).await?;
+    let current = principal_id.settings(&context).await?;
     let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let settings = with_revision_precondition_scope(
         precondition,
-        principal_id.replace_settings(&pool, settings.into_inner(), &event_context),
+        principal_id.replace_settings(&context, settings.into_inner(), &event_context),
     )
     .await?;
     ApiResponse::ok_revisioned(settings)
@@ -251,18 +252,18 @@ pub async fn put_my_settings(
 )]
 #[patch("/settings")]
 pub async fn patch_my_settings(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: Authenticated,
     patch: PrincipalSettingsPatchPayload,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let principal_id = PrincipalID::new(requestor.principal.id)?;
-    let current = principal_id.settings(&pool).await?;
+    let current = principal_id.settings(&context).await?;
     let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let settings = with_revision_precondition_scope(
         precondition,
-        principal_id.apply_settings_patch(&pool, patch.into_inner(), &event_context),
+        principal_id.apply_settings_patch(&context, patch.into_inner(), &event_context),
     )
     .await?;
     ApiResponse::ok_revisioned(settings)
@@ -280,17 +281,17 @@ pub async fn patch_my_settings(
 )]
 #[delete("/settings")]
 pub async fn delete_my_settings(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let principal_id = PrincipalID::new(requestor.principal.id)?;
-    let current = principal_id.settings(&pool).await?;
+    let current = principal_id.settings(&context).await?;
     let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let reset = with_revision_precondition_scope(
         precondition,
-        principal_id.reset_settings(&pool, &event_context),
+        principal_id.reset_settings(&context, &event_context),
     )
     .await?;
     Ok(ApiResponse::no_content_with_etag(reset.entity_tag()?))

--- a/src/api/v1/handlers/principals.rs
+++ b/src/api/v1/handlers/principals.rs
@@ -6,11 +6,11 @@ use utoipa::ToSchema;
 use crate::api::etag::{RevisionedResource, revision_precondition};
 use crate::api::openapi::{ApiErrorResponse, LoginResponse};
 use crate::api::response::ApiResponse;
-use crate::db::traits::active_tokens::retained_token_metadata_by_principal_id_paginated_with_total_count;
-use crate::db::traits::service_account::{
+use crate::backend::capabilities::active_tokens::retained_token_metadata_by_principal_id_paginated_with_total_count;
+use crate::backend::capabilities::service_account::{
     is_human_owner_group_member, load_service_account_by_id, principal_is_disabled,
 };
-use crate::db::{DbPool, with_revision_precondition_scope};
+use crate::backend::with_revision_precondition_scope;
 use crate::errors::ApiError;
 use crate::extractors::{
     AccessEventContext, Authenticated, ManagementAccess, PrincipalSettingsPatchPayload,
@@ -29,6 +29,8 @@ use crate::models::{
     TokenScopeDetails,
 };
 use crate::pagination::{effective_page_limit, finalize_page, prepare_db_pagination};
+use crate::permissions::AppContext;
+use crate::traits::BackendContext;
 use crate::traits::{AuthzSubject, GroupAccessors};
 use std::collections::BTreeMap;
 
@@ -47,7 +49,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
 }
 
 async fn ensure_can_manage_principal_settings(
-    pool: &DbPool,
+    context: &impl BackendContext,
     requestor: &Authenticated,
     target_principal_id: i32,
 ) -> Result<(), ApiError> {
@@ -57,7 +59,7 @@ async fn ensure_can_manage_principal_settings(
 
     if requestor.scopes().is_none()
         && requestor.principal.is_human()
-        && requestor.principal.is_admin(pool).await?
+        && requestor.principal.is_admin(context).await?
     {
         return Ok(());
     }
@@ -132,18 +134,18 @@ pub(crate) fn parse_token_list_query(
 /// * human principal — self or admin;
 /// * service account — admin or a **human** member of its owner group.
 async fn ensure_can_manage_principal(
-    pool: &DbPool,
+    context: &impl BackendContext,
     requestor: &ManagementAccess,
     principal: &Principal,
 ) -> Result<(), ApiError> {
-    if requestor.user.is_admin(pool).await? {
+    if requestor.user.is_admin(context).await? {
         return Ok(());
     }
     let permitted = match principal.principal_kind()? {
         PrincipalKind::Human => requestor.user.id == principal.id,
         PrincipalKind::ServiceAccount => {
-            let sa = load_service_account_by_id(pool, principal.id).await?;
-            is_human_owner_group_member(pool, requestor.user.id, sa.owner_group_id).await?
+            let sa = load_service_account_by_id(context, principal.id).await?;
+            is_human_owner_group_member(context, requestor.user.id, sa.owner_group_id).await?
         }
     };
     if permitted {
@@ -155,10 +157,10 @@ async fn ensure_can_manage_principal(
 }
 
 pub(crate) async fn principal_permissions_response(
-    pool: &DbPool,
+    context: &impl BackendContext,
     principal: &impl AuthzSubject,
 ) -> Result<Vec<PrincipalCollectionPermissions>, ApiError> {
-    let rows = principal_all_permissions(pool, principal).await?;
+    let rows = principal_all_permissions(context, principal).await?;
 
     // Fold (collection, group, permission-row) tuples into a per-collection,
     // per-group export. BTreeMap keeps collections in a stable id order; groups
@@ -204,18 +206,18 @@ pub(crate) async fn principal_permissions_response(
 )]
 #[post("/{principal_id}/tokens")]
 pub async fn create_token(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     principal_id: web::Path<PrincipalID>,
     body: web::Json<NewTokenRequest>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let principal_id = principal_id.into_inner();
-    let principal = principal_id.principal(&pool).await?;
-    ensure_can_manage_principal(&pool, &requestor, &principal).await?;
+    let principal = principal_id.principal(&context).await?;
+    ensure_can_manage_principal(&context, &requestor, &principal).await?;
 
     // A disabled service account cannot mint credentials.
-    if principal_is_disabled(&pool, &principal).await? {
+    if principal_is_disabled(&context, &principal).await? {
         return Err(ApiError::Conflict(
             "Service account is disabled".to_string(),
         ));
@@ -232,7 +234,7 @@ pub async fn create_token(
 
     let event_context = requestor.event_context(&req);
     let issued = token_request
-        .create_issued(&pool, Some(&event_context))
+        .create_issued(&context, Some(&event_context))
         .await?;
 
     Ok(ApiResponse::new(
@@ -258,21 +260,21 @@ pub async fn create_token(
 )]
 #[get("/{principal_id}/tokens")]
 pub async fn list_tokens(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     principal_id: web::Path<PrincipalID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let pid = principal_id.into_inner();
-    let principal = pid.principal(&pool).await?;
-    ensure_can_manage_principal(&pool, &requestor, &principal).await?;
+    let principal = pid.principal(&context).await?;
+    ensure_can_manage_principal(&context, &requestor, &principal).await?;
 
     let (params, state) = parse_token_list_query(req.query_string())?;
     let search_params = prepare_db_pagination::<PrincipalToken>(&params)?;
     let (metadata, total_count) =
         retained_token_metadata_by_principal_id_paginated_with_total_count(
             pid,
-            &pool,
+            &context,
             &search_params,
             state,
         )
@@ -306,16 +308,19 @@ pub async fn list_tokens(
 )]
 #[get("/{principal_id}/tokens/{token_id}")]
 pub async fn get_token(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     path: web::Path<TokenPath>,
 ) -> Result<impl Responder, ApiError> {
     let path = path.into_inner();
-    let principal = path.principal_id.principal(&pool).await?;
-    ensure_can_manage_principal(&pool, &requestor, &principal).await?;
-    let token =
-        PrincipalTokenMetadata::load_for_principal_token(&pool, path.principal_id, path.token_id)
-            .await?;
+    let principal = path.principal_id.principal(&context).await?;
+    ensure_can_manage_principal(&context, &requestor, &principal).await?;
+    let token = PrincipalTokenMetadata::load_for_principal_token(
+        &context,
+        path.principal_id,
+        path.token_id,
+    )
+    .await?;
     ApiResponse::ok_revisioned(PrincipalTokenPointResponse::from(token))
 }
 
@@ -340,19 +345,19 @@ pub async fn get_token(
 )]
 #[post("/{principal_id}/tokens/{token_id}/renew")]
 pub async fn renew_token(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     path: web::Path<TokenPath>,
     body: web::Json<RenewTokenRequest>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let path = path.into_inner();
-    let principal = path.principal_id.principal(&pool).await?;
-    ensure_can_manage_principal(&pool, &requestor, &principal).await?;
+    let principal = path.principal_id.principal(&context).await?;
+    ensure_can_manage_principal(&context, &requestor, &principal).await?;
 
     let event_context = requestor.event_context(&req);
     let issued = renew_token_by_id_for_principal(
-        &pool,
+        &context,
         path.token_id,
         path.principal_id,
         body.into_inner().expires_at,
@@ -384,18 +389,21 @@ pub async fn renew_token(
 )]
 #[post("/{principal_id}/tokens/{token_id}/revoke")]
 pub async fn revoke_token(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     path: web::Path<TokenPath>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let path = path.into_inner();
-    let principal = path.principal_id.principal(&pool).await?;
-    ensure_can_manage_principal(&pool, &requestor, &principal).await?;
+    let principal = path.principal_id.principal(&context).await?;
+    ensure_can_manage_principal(&context, &requestor, &principal).await?;
 
-    let current =
-        PrincipalTokenMetadata::load_for_principal_token(&pool, path.principal_id, path.token_id)
-            .await?;
+    let current = PrincipalTokenMetadata::load_for_principal_token(
+        &context,
+        path.principal_id,
+        path.token_id,
+    )
+    .await?;
     let current = PrincipalTokenPointResponse::from(current);
     let precondition = revision_precondition(&req, &current)?;
 
@@ -403,7 +411,7 @@ pub async fn revoke_token(
     let revoked = with_revision_precondition_scope(
         precondition,
         revoke_token_by_id_for_principal(
-            &pool,
+            &context,
             path.token_id,
             path.principal_id,
             Some(&event_context),
@@ -415,9 +423,12 @@ pub async fn revoke_token(
             "Token not found for this principal".to_string(),
         ));
     }
-    let updated =
-        PrincipalTokenMetadata::load_for_principal_token(&pool, path.principal_id, path.token_id)
-            .await?;
+    let updated = PrincipalTokenMetadata::load_for_principal_token(
+        &context,
+        path.principal_id,
+        path.token_id,
+    )
+    .await?;
     Ok(ApiResponse::no_content_with_etag(
         PrincipalTokenPointResponse::from(updated).entity_tag()?,
     ))
@@ -437,21 +448,21 @@ pub async fn revoke_token(
 )]
 #[get("/{principal_id}/groups")]
 pub async fn list_principal_groups(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     principal_id: web::Path<PrincipalID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let pid = principal_id.into_inner();
-    let principal = pid.principal(&pool).await?;
-    ensure_can_manage_principal(&pool, &requestor, &principal).await?;
+    let principal = pid.principal(&context).await?;
+    ensure_can_manage_principal(&context, &requestor, &principal).await?;
 
     let params = parse_query_parameter(req.query_string())?;
     let search_params = prepare_db_pagination::<Group>(&params)?;
     let (groups, total_count) = pid
-        .groups_paginated_with_total_count(&pool, &search_params)
+        .groups_paginated_with_total_count(&context, &search_params)
         .await?;
-    let response = GroupResponse::from_groups(&pool, groups).await?;
+    let response = GroupResponse::from_groups(&context, groups).await?;
     ApiResponse::paginated(response, total_count, &params)
 }
 
@@ -486,15 +497,15 @@ pub struct PrincipalCollectionPermissions {
 )]
 #[get("/{principal_id}/permissions")]
 pub async fn list_principal_permissions(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     principal_id: web::Path<PrincipalID>,
 ) -> Result<impl Responder, ApiError> {
     let pid = principal_id.into_inner();
-    let principal = pid.principal(&pool).await?;
-    ensure_can_manage_principal(&pool, &requestor, &principal).await?;
+    let principal = pid.principal(&context).await?;
+    ensure_can_manage_principal(&context, &requestor, &principal).await?;
 
-    let export = principal_permissions_response(&pool, &pid).await?;
+    let export = principal_permissions_response(&context, &pid).await?;
     Ok(ApiResponse::new(export, StatusCode::OK))
 }
 
@@ -512,13 +523,13 @@ pub async fn list_principal_permissions(
 )]
 #[get("/{principal_id}/settings")]
 pub async fn get_principal_settings(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: Authenticated,
     principal_id: web::Path<PrincipalID>,
 ) -> Result<impl Responder, ApiError> {
     let principal_id = principal_id.into_inner();
-    ensure_can_manage_principal_settings(&pool, &requestor, principal_id.id()).await?;
-    ApiResponse::ok_revisioned(principal_id.settings(&pool).await?)
+    ensure_can_manage_principal_settings(&context, &requestor, principal_id.id()).await?;
+    ApiResponse::ok_revisioned(principal_id.settings(&context).await?)
 }
 
 #[utoipa::path(
@@ -537,20 +548,20 @@ pub async fn get_principal_settings(
 )]
 #[put("/{principal_id}/settings")]
 pub async fn put_principal_settings(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: Authenticated,
     principal_id: web::Path<PrincipalID>,
     settings: web::Json<PrincipalSettings>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let principal_id = principal_id.into_inner();
-    ensure_can_manage_principal_settings(&pool, &requestor, principal_id.id()).await?;
-    let current = principal_id.settings(&pool).await?;
+    ensure_can_manage_principal_settings(&context, &requestor, principal_id.id()).await?;
+    let current = principal_id.settings(&context).await?;
     let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let settings = with_revision_precondition_scope(
         precondition,
-        principal_id.replace_settings(&pool, settings.into_inner(), &event_context),
+        principal_id.replace_settings(&context, settings.into_inner(), &event_context),
     )
     .await?;
     ApiResponse::ok_revisioned(settings)
@@ -594,20 +605,20 @@ pub async fn put_principal_settings(
 )]
 #[patch("/{principal_id}/settings")]
 pub async fn patch_principal_settings(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: Authenticated,
     principal_id: web::Path<PrincipalID>,
     patch: PrincipalSettingsPatchPayload,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let principal_id = principal_id.into_inner();
-    ensure_can_manage_principal_settings(&pool, &requestor, principal_id.id()).await?;
-    let current = principal_id.settings(&pool).await?;
+    ensure_can_manage_principal_settings(&context, &requestor, principal_id.id()).await?;
+    let current = principal_id.settings(&context).await?;
     let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let settings = with_revision_precondition_scope(
         precondition,
-        principal_id.apply_settings_patch(&pool, patch.into_inner(), &event_context),
+        principal_id.apply_settings_patch(&context, patch.into_inner(), &event_context),
     )
     .await?;
     ApiResponse::ok_revisioned(settings)
@@ -627,19 +638,19 @@ pub async fn patch_principal_settings(
 )]
 #[delete("/{principal_id}/settings")]
 pub async fn delete_principal_settings(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: Authenticated,
     principal_id: web::Path<PrincipalID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let principal_id = principal_id.into_inner();
-    ensure_can_manage_principal_settings(&pool, &requestor, principal_id.id()).await?;
-    let current = principal_id.settings(&pool).await?;
+    ensure_can_manage_principal_settings(&context, &requestor, principal_id.id()).await?;
+    let current = principal_id.settings(&context).await?;
     let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let reset = with_revision_precondition_scope(
         precondition,
-        principal_id.reset_settings(&pool, &event_context),
+        principal_id.reset_settings(&context, &event_context),
     )
     .await?;
     Ok(ApiResponse::no_content_with_etag(reset.entity_tag()?))

--- a/src/api/v1/handlers/relations.rs
+++ b/src/api/v1/handlers/relations.rs
@@ -3,12 +3,12 @@ use std::collections::HashMap;
 use crate::api::etag::{RevisionedResource, revision_precondition_for_tag};
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::db::traits::authz::scope_allows;
-use crate::db::traits::relations::{
+use crate::backend::capabilities::authz::scope_allows;
+use crate::backend::capabilities::relations::{
     class_relation_authorization_resources, object_relation_authorization_resources,
 };
-use crate::db::traits::user::UserSearchBackend;
-use crate::db::with_revision_precondition_scope;
+use crate::backend::capabilities::user::UserSearchBackend;
+use crate::backend::with_revision_precondition_scope;
 use crate::errors::ApiError;
 use crate::extractors::{AccessEventContext, Authenticated};
 use crate::models::search::{QueryParamsExt, parse_query_parameter};
@@ -44,7 +44,7 @@ use actix_web::{HttpRequest, Responder, get, http::StatusCode, routes, web};
 #[get("classes")]
 #[get("classes/")]
 async fn get_class_relations(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
@@ -58,9 +58,12 @@ async fn get_class_relations(
 
     debug!(message = "Listing class relations", user_id = user.id());
 
-    let (classes, total_count) = if pool.permission_backend().supports_sql_visibility_pushdown() {
+    let (classes, total_count) = if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
         let search_params = prepare_db_pagination::<HubuumClassRelation>(&params)?;
-        user.class_relations_page(&pool, search_params, requestor.scopes())
+        user.class_relations_page(&context, search_params, requestor.scopes())
             .await?
     } else {
         let mut required = params.filters.permissions()?;
@@ -74,21 +77,21 @@ async fn get_class_relations(
         candidate_options.include_total = false;
         let candidates = user
             .search_class_relations_from_backend_with_admin_status(
-                &pool,
+                &context,
                 candidate_options,
                 true,
                 None,
             )
             .await?;
-        let resources = class_relation_authorization_resources(&pool, &candidates).await?;
+        let resources = class_relation_authorization_resources(&context, &candidates).await?;
         let resources = resources
             .into_iter()
             .map(|resource| (resource.id, resource))
             .collect::<HashMap<_, _>>();
-        let principal = PrincipalRef::load(&pool, user).await?;
+        let principal = PrincipalRef::load(&context, user).await?;
         let search_params = prepare_db_pagination::<HubuumClassRelation>(&params)?;
         let page = authorize_cursor_page(
-            pool.permission_backend(),
+            context.permission_backend(),
             &principal,
             candidates,
             requestor.scopes(),
@@ -124,7 +127,7 @@ async fn get_class_relations(
 )]
 #[get("classes/{relation_id}")]
 async fn get_class_relation(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     relation_id: web::Path<HubuumClassRelationID>,
 ) -> Result<impl Responder, ApiError> {
@@ -137,11 +140,14 @@ async fn get_class_relation(
         relation_id = ?relation_id,
     );
 
-    let target = pool.class_relation_service().resolve(relation_id).await?;
+    let target = context
+        .class_relation_service()
+        .resolve(relation_id)
+        .await?;
     let resource = target.authorization_resource();
     authorize_resources(
-        pool.permission_backend(),
-        &pool,
+        context.permission_backend(),
+        &context,
         user,
         requestor.scopes(),
         vec![Permissions::ReadClassRelation],
@@ -169,7 +175,7 @@ async fn get_class_relation(
 #[post("classes")]
 #[post("classes/")]
 async fn create_class_relation(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     relation: web::Json<NewHubuumClassRelation>,
     req: HttpRequest,
@@ -184,14 +190,14 @@ async fn create_class_relation(
         to_class = relation.to_hubuum_class_id,
     );
 
-    let prepared = pool
+    let prepared = context
         .class_relation_service()
         .prepare_create(relation)
         .await?;
     let resource = prepared.authorization_resource();
     authorize_resources(
-        pool.permission_backend(),
-        &pool,
+        context.permission_backend(),
+        &context,
         user,
         requestor.scopes(),
         vec![Permissions::CreateClassRelation],
@@ -200,7 +206,7 @@ async fn create_class_relation(
     .await?;
 
     let event_context = requestor.event_context(&req);
-    let target = pool
+    let target = context
         .class_relation_service()
         .create(&prepared, &event_context)
         .await?;
@@ -224,7 +230,7 @@ async fn create_class_relation(
 )]
 #[delete("classes/{relation_id}")]
 async fn delete_class_relation(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     relation_id: web::Path<HubuumClassRelationID>,
     req: HttpRequest,
@@ -238,11 +244,14 @@ async fn delete_class_relation(
         relation_id = ?relation_id,
     );
 
-    let target = pool.class_relation_service().resolve(relation_id).await?;
+    let target = context
+        .class_relation_service()
+        .resolve(relation_id)
+        .await?;
     let resource = target.authorization_resource();
     authorize_resources(
-        pool.permission_backend(),
-        &pool,
+        context.permission_backend(),
+        &context,
         user,
         requestor.scopes(),
         vec![Permissions::DeleteClassRelation],
@@ -255,7 +264,8 @@ async fn delete_class_relation(
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(
         precondition,
-        pool.class_relation_service()
+        context
+            .class_relation_service()
             .delete(&target, &event_context),
     )
     .await?;
@@ -278,7 +288,7 @@ async fn delete_class_relation(
 #[get("objects")]
 #[get("objects/")]
 async fn get_object_relations(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
@@ -292,53 +302,55 @@ async fn get_object_relations(
 
     debug!(message = "Listing object relations", user_id = user.id());
 
-    let (object_relations, total_count) =
-        if pool.permission_backend().supports_sql_visibility_pushdown() {
-            let search_params = prepare_db_pagination::<HubuumObjectRelation>(&params)?;
-            user.object_relations_page(&pool, search_params, requestor.scopes())
-                .await?
-        } else {
-            let mut required = params.filters.permissions()?;
-            required.ensure_contains(&[Permissions::ReadObjectRelation]);
-            let required = required.iter().copied().collect::<Vec<_>>();
-            if !scope_allows(requestor.scopes(), &required) {
-                return ApiResponse::paginated(Vec::new(), 0, &params);
-            }
+    let (object_relations, total_count) = if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
+        let search_params = prepare_db_pagination::<HubuumObjectRelation>(&params)?;
+        user.object_relations_page(&context, search_params, requestor.scopes())
+            .await?
+    } else {
+        let mut required = params.filters.permissions()?;
+        required.ensure_contains(&[Permissions::ReadObjectRelation]);
+        let required = required.iter().copied().collect::<Vec<_>>();
+        if !scope_allows(requestor.scopes(), &required) {
+            return ApiResponse::paginated(Vec::new(), 0, &params);
+        }
 
-            let mut candidate_options = count_query_options(&params);
-            candidate_options.include_total = false;
-            let candidates = user
-                .search_object_relations_from_backend_with_admin_status(
-                    &pool,
-                    candidate_options,
-                    true,
-                    None,
-                )
-                .await?;
-            let resources = object_relation_authorization_resources(&pool, &candidates).await?;
-            let resources = resources
-                .into_iter()
-                .map(|resource| (resource.id, resource))
-                .collect::<HashMap<_, _>>();
-            let principal = PrincipalRef::load(&pool, user).await?;
-            let search_params = prepare_db_pagination::<HubuumObjectRelation>(&params)?;
-            let page = authorize_cursor_page(
-                pool.permission_backend(),
-                &principal,
-                candidates,
-                requestor.scopes(),
-                required,
-                &search_params,
-                |relation| {
-                    resources
-                        .get(&relation.id)
-                        .expect("every relation candidate has an authorization resource")
-                        .clone()
-                },
+        let mut candidate_options = count_query_options(&params);
+        candidate_options.include_total = false;
+        let candidates = user
+            .search_object_relations_from_backend_with_admin_status(
+                &context,
+                candidate_options,
+                true,
+                None,
             )
             .await?;
-            (page.rows, page.total_count)
-        };
+        let resources = object_relation_authorization_resources(&context, &candidates).await?;
+        let resources = resources
+            .into_iter()
+            .map(|resource| (resource.id, resource))
+            .collect::<HashMap<_, _>>();
+        let principal = PrincipalRef::load(&context, user).await?;
+        let search_params = prepare_db_pagination::<HubuumObjectRelation>(&params)?;
+        let page = authorize_cursor_page(
+            context.permission_backend(),
+            &principal,
+            candidates,
+            requestor.scopes(),
+            required,
+            &search_params,
+            |relation| {
+                resources
+                    .get(&relation.id)
+                    .expect("every relation candidate has an authorization resource")
+                    .clone()
+            },
+        )
+        .await?;
+        (page.rows, page.total_count)
+    };
 
     ApiResponse::paginated(object_relations, total_count, &params)
 }
@@ -359,7 +371,7 @@ async fn get_object_relations(
 )]
 #[get("objects/{relation_id}")]
 async fn get_object_relation(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     relation_id: web::Path<HubuumObjectRelationID>,
 ) -> Result<impl Responder, ApiError> {
@@ -372,14 +384,14 @@ async fn get_object_relation(
         relation_id = ?relation_id,
     );
 
-    let target = pool
+    let target = context
         .object_relation_service()
         .resolve(ObjectRelationSelector::by_id(relation_id))
         .await?;
     let resource = target.authorization_resource();
     authorize_resources(
-        pool.permission_backend(),
-        &pool,
+        context.permission_backend(),
+        &context,
         user,
         requestor.scopes(),
         vec![Permissions::ReadObjectRelation],
@@ -407,7 +419,7 @@ async fn get_object_relation(
 #[post("objects")]
 #[post("objects/")]
 async fn create_object_relation(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     relation: web::Json<NewHubuumObjectRelation>,
     req: HttpRequest,
@@ -422,14 +434,14 @@ async fn create_object_relation(
         to_object = relation.to_hubuum_object_id,
     );
 
-    let prepared = pool
+    let prepared = context
         .object_relation_service()
         .prepare_create(ObjectRelationCreateSelector::explicit(relation))
         .await?;
     let resource = prepared.authorization_resource();
     authorize_resources(
-        pool.permission_backend(),
-        &pool,
+        context.permission_backend(),
+        &context,
         user,
         requestor.scopes(),
         vec![Permissions::CreateObjectRelation],
@@ -438,7 +450,7 @@ async fn create_object_relation(
     .await?;
 
     let event_context = requestor.event_context(&req);
-    let target = pool
+    let target = context
         .object_relation_service()
         .create(&prepared, &event_context)
         .await?;
@@ -462,7 +474,7 @@ async fn create_object_relation(
 )]
 #[delete("objects/{relation_id}")]
 async fn delete_object_relation(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     relation_id: web::Path<HubuumObjectRelationID>,
     req: HttpRequest,
@@ -476,14 +488,14 @@ async fn delete_object_relation(
         relation_id = ?relation_id,
     );
 
-    let target = pool
+    let target = context
         .object_relation_service()
         .resolve(ObjectRelationSelector::by_id(relation_id))
         .await?;
     let resource = target.authorization_resource();
     authorize_resources(
-        pool.permission_backend(),
-        &pool,
+        context.permission_backend(),
+        &context,
         user,
         requestor.scopes(),
         vec![Permissions::DeleteObjectRelation],
@@ -496,7 +508,8 @@ async fn delete_object_relation(
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(
         precondition,
-        pool.object_relation_service()
+        context
+            .object_relation_service()
             .delete(&target, &event_context),
     )
     .await?;

--- a/src/api/v1/handlers/remote_targets.rs
+++ b/src/api/v1/handlers/remote_targets.rs
@@ -7,19 +7,19 @@ use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
 use crate::api::v1::handlers::history::HistoryResponse;
-use crate::can;
-use crate::config::{DEFAULT_REMOTE_CALL_MAX_ACTIVE_TASKS_PER_USER, get_config};
-use crate::db::traits::UserPermissions;
-use crate::db::traits::authz::scope_allows;
-use crate::db::traits::history::{
+use crate::backend::capabilities::UserPermissions;
+use crate::backend::capabilities::authz::scope_allows;
+use crate::backend::capabilities::history::{
     HistoryCollectionFilter, remote_target_as_of, remote_target_history_paginated_with_total_count,
 };
-use crate::db::traits::remote_target::{
+use crate::backend::capabilities::remote_target::{
     DeleteRemoteTargetRecord, SaveRemoteTargetRecord, UpdateRemoteTargetRecord,
     emit_remote_target_invoked_event,
 };
-use crate::db::traits::task::{TaskCreateRequest, TaskScopeSnapshot};
-use crate::db::{DbPool, with_revision_precondition_scope};
+use crate::backend::capabilities::task::{TaskCreateRequest, TaskScopeSnapshot};
+use crate::backend::with_revision_precondition_scope;
+use crate::can;
+use crate::config::{DEFAULT_REMOTE_CALL_MAX_ACTIVE_TASKS_PER_USER, get_config};
 use crate::errors::ApiError;
 use crate::extractors::{AccessEventContext, Authenticated};
 use crate::models::collection::user_can_on_any;
@@ -55,7 +55,7 @@ use crate::traits::ClassAccessors;
 #[post("")]
 #[post("/")]
 pub async fn create_remote_target(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     target: web::Json<NewRemoteTarget>,
     req: HttpRequest,
@@ -63,14 +63,14 @@ pub async fn create_remote_target(
     let user = &requestor.principal;
     let target = target.into_inner();
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::CreateRemoteTarget],
         target.collection_id
     );
     validate_remote_target_class_scope(
-        &pool,
+        &context,
         target.collection_id.id(),
         target.class_id.map(HubuumClassID::id),
     )
@@ -79,7 +79,7 @@ pub async fn create_remote_target(
     let event_context = requestor.event_context(&req);
     let created: RemoteTarget = target
         .into_row()?
-        .save_remote_target_record(&pool, Some(&event_context))
+        .save_remote_target_record(&context, Some(&event_context))
         .await?
         .try_into()?;
     let location = api_locations::remote_target(created.id)?;
@@ -101,24 +101,28 @@ pub async fn create_remote_target(
 #[get("")]
 #[get("/")]
 pub async fn get_remote_targets(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let user = &requestor.principal;
     let params = parse_query_parameter(req.query_string())?;
     let query_options = prepare_db_pagination::<RemoteTarget>(&params)?;
-    let visible_collections = if pool.permission_backend().supports_sql_visibility_pushdown() {
+    let visible_collections = if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
         user_can_on_any(
-            &pool,
+            &context,
             user,
             Permissions::ReadRemoteTarget,
             requestor.scopes(),
         )
         .await?
     } else if scope_allows(requestor.scopes(), &[Permissions::ReadRemoteTarget]) {
-        let principal = PrincipalRef::load(&pool, user).await?;
-        pool.permission_backend()
+        let principal = PrincipalRef::load(&context, user).await?;
+        context
+            .permission_backend()
             .collections_user_can(&principal, &[Permissions::ReadRemoteTarget])
             .await?
     } else {
@@ -132,7 +136,8 @@ pub async fn get_remote_targets(
         scope.retain_allowed_collection_ids(&mut allowed_collection_ids);
     }
     let (targets, total_count) =
-        RemoteTarget::list_with_total_count(&pool, &allowed_collection_ids, &query_options).await?;
+        RemoteTarget::list_with_total_count(&context, &allowed_collection_ids, &query_options)
+            .await?;
 
     ApiResponse::paginated(targets, total_count, &params)
 }
@@ -152,14 +157,14 @@ pub async fn get_remote_targets(
 )]
 #[get("/{target_id}")]
 pub async fn get_remote_target(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     target_id: web::Path<RemoteTargetID>,
 ) -> Result<impl Responder, ApiError> {
     let user = &requestor.principal;
-    let target = target_id.into_inner().instance(&pool).await?;
+    let target = target_id.into_inner().instance(&context).await?;
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::ReadRemoteTarget],
@@ -186,7 +191,7 @@ pub async fn get_remote_target(
 )]
 #[patch("/{target_id}")]
 pub async fn patch_remote_target(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     target_id: web::Path<RemoteTargetID>,
     update: web::Json<UpdateRemoteTarget>,
@@ -201,9 +206,9 @@ pub async fn patch_remote_target(
         ));
     }
 
-    let existing = target_id.instance(&pool).await?;
+    let existing = target_id.instance(&context).await?;
     can!(
-        &pool,
+        &context,
         user.clone(),
         requestor.scopes(),
         [Permissions::UpdateRemoteTarget],
@@ -211,7 +216,7 @@ pub async fn patch_remote_target(
     );
     if let Some(collection_id) = update.collection_id {
         can!(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             [Permissions::CreateRemoteTarget],
@@ -227,14 +232,15 @@ pub async fn patch_remote_target(
         Some(None) => None,
         None => existing.class_id,
     };
-    validate_remote_target_class_scope(&pool, effective_collection_id, effective_class_id).await?;
+    validate_remote_target_class_scope(&context, effective_collection_id, effective_class_id)
+        .await?;
 
     let precondition = revision_precondition(&req, &existing)?;
     let row = update.into_row(&existing)?;
     let event_context = requestor.event_context(&req);
     let updated: RemoteTarget = with_revision_precondition_scope(
         precondition,
-        row.update_remote_target_record(&pool, existing.id, Some(&event_context)),
+        row.update_remote_target_record(&context, existing.id, Some(&event_context)),
     )
     .await?
     .try_into()?;
@@ -242,14 +248,14 @@ pub async fn patch_remote_target(
 }
 
 async fn validate_remote_target_class_scope(
-    pool: &DbPool,
+    context: &impl crate::traits::BackendContext,
     collection_id: i32,
     class_id: Option<i32>,
 ) -> Result<(), ApiError> {
     let Some(class_id) = class_id else {
         return Ok(());
     };
-    let class = HubuumClassID::new(class_id)?.class(pool).await?;
+    let class = HubuumClassID::new(class_id)?.class(context).await?;
     class.ensure_in_collection(collection_id, "Remote target")
 }
 
@@ -268,16 +274,16 @@ async fn validate_remote_target_class_scope(
 )]
 #[delete("/{target_id}")]
 pub async fn delete_remote_target(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     target_id: web::Path<RemoteTargetID>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let user = &requestor.principal;
     let target_id = target_id.into_inner();
-    let existing = target_id.instance(&pool).await?;
+    let existing = target_id.instance(&context).await?;
     can!(
-        &pool,
+        &context,
         user,
         requestor.scopes(),
         [Permissions::DeleteRemoteTarget],
@@ -288,7 +294,7 @@ pub async fn delete_remote_target(
     let event_context = requestor.event_context(&req);
     with_revision_precondition_scope(
         precondition,
-        target_id.delete_remote_target_record(&pool, Some(&event_context)),
+        target_id.delete_remote_target_record(&context, Some(&event_context)),
     )
     .await?;
     Ok(ApiResponse::no_content_with_etag(etag))
@@ -314,19 +320,19 @@ pub async fn delete_remote_target(
 )]
 #[post("/{target_id}/invoke")]
 pub async fn invoke_remote_target(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     target_id: web::Path<RemoteTargetID>,
     body: web::Json<RemoteTargetInvokeRequest>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.clone());
+    ensure_task_worker_running(context.clone());
     let user = &requestor.principal;
     let target_id = target_id.into_inner();
     let invoke = body.into_inner();
-    let target = target_id.instance(&pool).await?;
+    let target = target_id.instance(&context).await?;
     let resolved =
-        authorize_remote_invocation(&pool, user, requestor.scopes(), &target, &invoke.subject)
+        authorize_remote_invocation(&context, user, requestor.scopes(), &target, &invoke.subject)
             .await?;
 
     let payload = serde_json::to_value(StoredRemoteCallTaskPayload {
@@ -340,7 +346,7 @@ pub async fn invoke_remote_target(
         requestor.scopes(),
     );
     let task = find_or_create_remote_call_task(
-        &pool,
+        &context,
         PrincipalID::new(user.id)?,
         snapshot,
         idempotency_key_from_headers(req.headers())?,
@@ -349,7 +355,7 @@ pub async fn invoke_remote_target(
     .await?;
     let event_context = requestor.event_context(&req);
     emit_remote_target_invoked_event(
-        &pool,
+        &context,
         &target,
         &event_context,
         task.id,
@@ -357,7 +363,7 @@ pub async fn invoke_remote_target(
         resolved.subject_id,
     )
     .await?;
-    kick_task_worker(pool.clone());
+    kick_task_worker(context.clone());
 
     debug!(
         message = "Remote target invocation queued",
@@ -374,7 +380,7 @@ pub async fn invoke_remote_target(
 }
 
 async fn find_or_create_remote_call_task(
-    pool: &DbPool,
+    context: &impl crate::traits::BackendContext,
     submitted_by: PrincipalID,
     snapshot: TaskScopeSnapshot,
     idempotency_key: Option<IdempotencyKey>,
@@ -391,7 +397,7 @@ async fn find_or_create_remote_call_task(
         .request_hash(Some(hash))
         .scope_snapshot(snapshot)
         .build()
-        .create_idempotently_with_active_limit(pool, max_active_remote_call_tasks_per_user())
+        .create_idempotently_with_active_limit(context, max_active_remote_call_tasks_per_user())
         .await
 }
 
@@ -416,7 +422,7 @@ fn max_active_remote_call_tasks_per_user() -> usize {
 )]
 #[get("/{remote_target_id}/history")]
 pub async fn get_remote_target_history(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     remote_target_id: web::Path<RemoteTargetID>,
     req: HttpRequest,
@@ -431,10 +437,10 @@ pub async fn get_remote_target_history(
 
     let user = &requestor.principal;
     let remote_target_id = remote_target_id.into_inner();
-    let (entity_id, require_history) = match remote_target_id.instance(&pool).await {
+    let (entity_id, require_history) = match remote_target_id.instance(&context).await {
         Ok(instance) => {
             can!(
-                &pool,
+                &context,
                 user,
                 requestor.scopes(),
                 [Permissions::ReadRemoteTarget],
@@ -444,7 +450,7 @@ pub async fn get_remote_target_history(
         }
         Err(ApiError::NotFound(_))
             if can_read_deleted_history(
-                &pool,
+                &context,
                 &requestor.principal,
                 requestor.scopes().is_some(),
             )
@@ -460,14 +466,17 @@ pub async fn get_remote_target_history(
     let (rows, total_count) = if require_history {
         remote_target_history_paginated_with_total_count(
             entity_id,
-            &pool,
+            &context,
             &search_params,
             HistoryCollectionFilter::All,
         )
         .await?
-    } else if pool.permission_backend().supports_sql_visibility_pushdown() {
+    } else if context
+        .permission_backend()
+        .supports_sql_visibility_pushdown()
+    {
         let collection_ids = readable_history_collection_ids(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadRemoteTarget,
@@ -475,7 +484,7 @@ pub async fn get_remote_target_history(
         .await?;
         remote_target_history_paginated_with_total_count(
             entity_id,
-            &pool,
+            &context,
             &search_params,
             HistoryCollectionFilter::Visible(&collection_ids),
         )
@@ -484,13 +493,13 @@ pub async fn get_remote_target_history(
         let candidate_params = history_candidate_query_options(&params);
         let (candidates, _) = remote_target_history_paginated_with_total_count(
             entity_id,
-            &pool,
+            &context,
             &candidate_params,
             HistoryCollectionFilter::All,
         )
         .await?;
         authorize_history_page(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadRemoteTarget,
@@ -506,7 +515,7 @@ pub async fn get_remote_target_history(
         )));
     }
 
-    let principal_names = resolve_history_principal_names(&pool, &rows).await?;
+    let principal_names = resolve_history_principal_names(&context, &rows).await?;
 
     ApiResponse::mapped_paginated(rows, total_count, &params, move |rows| {
         rows.into_iter()
@@ -534,7 +543,7 @@ pub async fn get_remote_target_history(
 )]
 #[get("/{remote_target_id}/history/as-of")]
 pub async fn get_remote_target_as_of(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     remote_target_id: web::Path<RemoteTargetID>,
     req: HttpRequest,
@@ -546,10 +555,10 @@ pub async fn get_remote_target_as_of(
 
     let user = &requestor.principal;
     let remote_target_id = remote_target_id.into_inner();
-    let (entity_id, deleted) = match remote_target_id.instance(&pool).await {
+    let (entity_id, deleted) = match remote_target_id.instance(&context).await {
         Ok(instance) => {
             can!(
-                &pool,
+                &context,
                 user,
                 requestor.scopes(),
                 [Permissions::ReadRemoteTarget],
@@ -559,7 +568,7 @@ pub async fn get_remote_target_as_of(
         }
         Err(ApiError::NotFound(_))
             if can_read_deleted_history(
-                &pool,
+                &context,
                 &requestor.principal,
                 requestor.scopes().is_some(),
             )
@@ -571,7 +580,7 @@ pub async fn get_remote_target_as_of(
     };
 
     let at = parse_as_of(req.query_string())?;
-    let row = remote_target_as_of(entity_id, at, &pool)
+    let row = remote_target_as_of(entity_id, at, &context)
         .await?
         .ok_or_else(|| {
             ApiError::NotFound(format!("no version of remote target {entity_id} at {at}"))
@@ -579,7 +588,7 @@ pub async fn get_remote_target_as_of(
 
     if !deleted {
         authorize_history_snapshot(
-            &pool,
+            &context,
             user,
             requestor.scopes(),
             Permissions::ReadRemoteTarget,
@@ -589,7 +598,7 @@ pub async fn get_remote_target_as_of(
     }
 
     let principal_names =
-        resolve_history_principal_names(&pool, std::slice::from_ref(&row)).await?;
+        resolve_history_principal_names(&context, std::slice::from_ref(&row)).await?;
     Ok(ApiResponse::new(
         HistoryResponse::new(row, &principal_names),
         StatusCode::OK,

--- a/src/api/v1/handlers/restores.rs
+++ b/src/api/v1/handlers/restores.rs
@@ -4,7 +4,6 @@ use futures_util::StreamExt;
 
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::db::DbPool;
 use crate::errors::ApiError;
 use crate::extractors::AdminAccess;
 use crate::models::principal::load_principal_by_id;
@@ -12,6 +11,7 @@ use crate::models::{
     BackupDocument, RestoreConfirmRequest, RestoreInitiator, RestoreJobID, RestoreStageRequest,
     RestoreStageResponse,
 };
+use crate::permissions::AppContext;
 use crate::restores::{
     RestoreSettings, confirm_restore, identity_scope_name, restore_status, stage_restore,
 };
@@ -36,7 +36,7 @@ const RESTORE_CAPABILITY_HEADER: &str = "X-Hubuum-Restore-Capability";
 )]
 #[post("")]
 pub async fn create_restore_stage(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     settings: web::Data<RestoreSettings>,
     admin: AdminAccess,
     mut payload: web::Payload,
@@ -59,11 +59,11 @@ pub async fn create_restore_stage(
             "Restore upload must contain a backup document".to_string(),
         ));
     }
-    let principal = load_principal_by_id(&pool, admin.user.id).await?;
-    let scope_name = identity_scope_name(&pool, principal.identity_scope_id).await?;
+    let principal = load_principal_by_id(&context, admin.user.id).await?;
+    let scope_name = identity_scope_name(&context, principal.identity_scope_id).await?;
     let initiator = RestoreInitiator::principal(&principal, scope_name)?;
     let request = RestoreStageRequest::new(initiator, document.to_vec())?;
-    let staged = stage_restore(&pool, &settings, request).await?;
+    let staged = stage_restore(&context, &settings, request).await?;
     Ok(ApiResponse::new_no_store(staged, StatusCode::CREATED))
 }
 
@@ -87,12 +87,12 @@ pub async fn create_restore_stage(
 )]
 #[post("/{restore_id}/confirm")]
 pub async fn confirm_restore_stage(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     _admin: AdminAccess,
     restore_id: web::Path<RestoreJobID>,
     confirmation: web::Json<RestoreConfirmRequest>,
 ) -> Result<impl Responder, ApiError> {
-    let response = confirm_restore(&pool, restore_id.into_inner(), &confirmation).await?;
+    let response = confirm_restore(&context, restore_id.into_inner(), &confirmation).await?;
     Ok(ApiResponse::new_no_store(response, StatusCode::OK))
 }
 
@@ -112,7 +112,7 @@ pub async fn confirm_restore_stage(
 )]
 #[get("/{restore_id}/status")]
 pub async fn get_restore_status(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     restore_id: web::Path<RestoreJobID>,
     request: HttpRequest,
 ) -> Result<HttpResponse, ApiError> {
@@ -126,7 +126,7 @@ pub async fn get_restore_status(
                 "{RESTORE_CAPABILITY_HEADER} header is not valid text"
             ))
         })?;
-    let response = restore_status(&pool, restore_id.into_inner(), capability).await?;
+    let response = restore_status(&context, restore_id.into_inner(), capability).await?;
     Ok(HttpResponse::Ok()
         .insert_header(("Cache-Control", "no-store"))
         .json(response))

--- a/src/api/v1/handlers/search.rs
+++ b/src/api/v1/handlers/search.rs
@@ -46,13 +46,13 @@ fn sse_event<T: Serialize>(event: &str, payload: &T) -> Result<Bytes, ApiError> 
 )]
 #[get("")]
 pub async fn get_search(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let params = parse_unified_search_query(req.query_string())?;
     let response =
-        execute_unified_search(&requestor.principal, &pool, &params, requestor.scopes()).await?;
+        execute_unified_search(&requestor.principal, &context, &params, requestor.scopes()).await?;
     Ok(ApiResponse::new_with_headers(
         response,
         StatusCode::OK,
@@ -86,7 +86,7 @@ pub async fn get_search(
 )]
 #[get("/stream")]
 pub async fn stream_search(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<HttpResponse, ApiError> {
@@ -109,7 +109,7 @@ pub async fn stream_search(
 
         match execute_unified_search_batch(
             &requestor.principal,
-            &pool,
+            &context,
             &params,
             kind,
             requestor.scopes(),

--- a/src/api/v1/handlers/service_accounts.rs
+++ b/src/api/v1/handlers/service_accounts.rs
@@ -5,11 +5,11 @@ use crate::api::etag::{RevisionedResource, revision_precondition, revision_preco
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::db::traits::service_account::{
+use crate::backend::capabilities::service_account::{
     DisableServiceAccount, SaveServiceAccount, count_manageable_service_accounts,
     is_human_owner_group_member, search_manageable_service_accounts,
 };
-use crate::db::{DbPool, with_revision_precondition_scope};
+use crate::backend::with_revision_precondition_scope;
 use crate::errors::ApiError;
 use crate::extractors::{AccessEventContext, ManagementAccess};
 use crate::models::search::parse_query_parameter;
@@ -18,7 +18,8 @@ use crate::models::{
     ServiceAccountResponse, ServiceAccountWithName, UpdateServiceAccount,
 };
 use crate::pagination::{count_query_options, prepare_db_pagination};
-use crate::traits::{AuthzSubject, CanDelete, CanUpdate, SelfAccessors};
+use crate::permissions::AppContext;
+use crate::traits::{AuthzSubject, BackendContext, CanDelete, CanUpdate, SelfAccessors};
 
 pub fn config(cfg: &mut web::ServiceConfig) {
     cfg.service(create_service_account)
@@ -32,12 +33,12 @@ pub fn config(cfg: &mut web::ServiceConfig) {
 /// A caller may manage an SA iff they are an admin or a **human** member of the
 /// SA's owner group (a service account never manages itself; see token routes).
 async fn ensure_can_manage(
-    pool: &DbPool,
+    context: &impl BackendContext,
     requestor: &ManagementAccess,
     sa: &ServiceAccount,
 ) -> Result<(), ApiError> {
-    if requestor.user.is_admin(pool).await?
-        || is_human_owner_group_member(pool, requestor.user.id, sa.owner_group_id).await?
+    if requestor.user.is_admin(context).await?
+        || is_human_owner_group_member(context, requestor.user.id, sa.owner_group_id).await?
     {
         Ok(())
     } else {
@@ -64,7 +65,7 @@ async fn ensure_can_manage(
 #[post("")]
 #[post("/")]
 pub async fn create_service_account(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     req: HttpRequest,
     new_sa: web::Json<NewServiceAccount>,
@@ -73,8 +74,8 @@ pub async fn create_service_account(
 
     // Create authz: admin may create for any group; a non-admin human may create
     // only for a group they already belong to.
-    if !requestor.user.is_admin(&pool).await?
-        && !is_human_owner_group_member(&pool, requestor.user.id, new_sa.owner_group_id.id())
+    if !requestor.user.is_admin(&context).await?
+        && !is_human_owner_group_member(&context, requestor.user.id, new_sa.owner_group_id.id())
             .await?
     {
         return Err(ApiError::Forbidden(
@@ -91,9 +92,9 @@ pub async fn create_service_account(
 
     let event_context = requestor.event_context(&req);
     let sa = new_sa
-        .save(&pool, Some(requestor.user.id), &event_context)
+        .save(&context, Some(requestor.user.id), &event_context)
         .await?;
-    let response = sa.to_point_response(&pool).await?;
+    let response = sa.to_point_response(&context).await?;
 
     let location = api_locations::service_account(sa.id)?;
     ApiResponse::created_revisioned(response, location)
@@ -113,18 +114,18 @@ pub async fn create_service_account(
 #[get("")]
 #[get("/")]
 pub async fn list_service_accounts(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let is_admin = requestor.user.is_admin(&pool).await?;
+    let is_admin = requestor.user.is_admin(&context).await?;
     let params = parse_query_parameter(req.query_string())?;
 
     // Authorization is applied in SQL (admin sees all; otherwise owner-group
     // membership), so this is a single paginated query, not a per-row scan.
     let total_count = if params.include_total {
         count_manageable_service_accounts(
-            &pool,
+            &context,
             &requestor.user,
             is_admin,
             count_query_options(&params),
@@ -135,7 +136,8 @@ pub async fn list_service_accounts(
     };
     let search_params = prepare_db_pagination::<ServiceAccountWithName>(&params)?;
     let accounts =
-        search_manageable_service_accounts(&pool, &requestor.user, is_admin, search_params).await?;
+        search_manageable_service_accounts(&context, &requestor.user, is_admin, search_params)
+            .await?;
 
     ApiResponse::mapped_paginated(accounts, total_count, &params, |accounts| {
         accounts
@@ -160,13 +162,13 @@ pub async fn list_service_accounts(
 )]
 #[get("/{service_account_id}")]
 pub async fn get_service_account(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     service_account_id: web::Path<ServiceAccountID>,
 ) -> Result<impl Responder, ApiError> {
-    let sa = service_account_id.into_inner().instance(&pool).await?;
-    ensure_can_manage(&pool, &requestor, &sa).await?;
-    ApiResponse::ok_revisioned(sa.to_point_response(&pool).await?)
+    let sa = service_account_id.into_inner().instance(&context).await?;
+    ensure_can_manage(&context, &requestor, &sa).await?;
+    ApiResponse::ok_revisioned(sa.to_point_response(&context).await?)
 }
 
 #[utoipa::path(
@@ -185,15 +187,15 @@ pub async fn get_service_account(
 )]
 #[patch("/{service_account_id}")]
 pub async fn update_service_account(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     req: HttpRequest,
     service_account_id: web::Path<ServiceAccountID>,
     update: web::Json<UpdateServiceAccount>,
 ) -> Result<impl Responder, ApiError> {
     let id = service_account_id.into_inner();
-    let sa = id.instance(&pool).await?;
-    ensure_can_manage(&pool, &requestor, &sa).await?;
+    let sa = id.instance(&context).await?;
+    ensure_can_manage(&context, &requestor, &sa).await?;
 
     let update = update.into_inner();
 
@@ -203,21 +205,21 @@ pub async fn update_service_account(
     // rights to.
     if let Some(new_group) = update.owner_group_id
         && new_group != sa.owner_group_id
-        && !requestor.user.is_admin(&pool).await?
-        && !is_human_owner_group_member(&pool, requestor.user.id, new_group).await?
+        && !requestor.user.is_admin(&context).await?
+        && !is_human_owner_group_member(&context, requestor.user.id, new_group).await?
     {
         return Err(ApiError::Forbidden(
             "May only reassign a service account to a group you belong to".to_string(),
         ));
     }
 
-    let current = sa.to_point_response(&pool).await?;
+    let current = sa.to_point_response(&context).await?;
     let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let updated =
-        with_revision_precondition_scope(precondition, update.update(&pool, id, &event_context))
+        with_revision_precondition_scope(precondition, update.update(&context, id, &event_context))
             .await?;
-    ApiResponse::ok_revisioned(updated.to_point_response(&pool).await?)
+    ApiResponse::ok_revisioned(updated.to_point_response(&context).await?)
 }
 
 #[utoipa::path(
@@ -235,20 +237,21 @@ pub async fn update_service_account(
 )]
 #[post("/{service_account_id}/disable")]
 pub async fn disable_service_account(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     req: HttpRequest,
     service_account_id: web::Path<ServiceAccountID>,
 ) -> Result<impl Responder, ApiError> {
     let id = service_account_id.into_inner();
-    let sa = id.instance(&pool).await?;
-    ensure_can_manage(&pool, &requestor, &sa).await?;
+    let sa = id.instance(&context).await?;
+    ensure_can_manage(&context, &requestor, &sa).await?;
 
-    let current = sa.to_point_response(&pool).await?;
+    let current = sa.to_point_response(&context).await?;
     let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let disabled =
-        with_revision_precondition_scope(precondition, id.disable(&pool, &event_context)).await?;
+        with_revision_precondition_scope(precondition, id.disable(&context, &event_context))
+            .await?;
 
     debug!(
         message = "Service account disabled",
@@ -256,7 +259,7 @@ pub async fn disable_service_account(
         requestor = requestor.user.id
     );
 
-    ApiResponse::ok_revisioned(disabled.to_point_response(&pool).await?)
+    ApiResponse::ok_revisioned(disabled.to_point_response(&context).await?)
 }
 
 #[utoipa::path(
@@ -274,18 +277,18 @@ pub async fn disable_service_account(
 )]
 #[delete("/{service_account_id}")]
 pub async fn delete_service_account(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: ManagementAccess,
     req: HttpRequest,
     service_account_id: web::Path<ServiceAccountID>,
 ) -> Result<impl Responder, ApiError> {
     let id = service_account_id.into_inner();
-    let sa = id.instance(&pool).await?;
-    ensure_can_manage(&pool, &requestor, &sa).await?;
-    let current = sa.to_point_response(&pool).await?;
+    let sa = id.instance(&context).await?;
+    ensure_can_manage(&context, &requestor, &sa).await?;
+    let current = sa.to_point_response(&context).await?;
     let etag = current.entity_tag()?;
     let precondition = revision_precondition_for_tag(&req, &etag)?;
     let event_context = requestor.event_context(&req);
-    with_revision_precondition_scope(precondition, id.delete(&pool, &event_context)).await?;
+    with_revision_precondition_scope(precondition, id.delete(&context, &event_context)).await?;
     Ok(ApiResponse::no_content_with_etag(etag))
 }

--- a/src/api/v1/handlers/tasks.rs
+++ b/src/api/v1/handlers/tasks.rs
@@ -2,7 +2,7 @@ use actix_web::{HttpRequest, Responder, get, http::StatusCode, routes, web};
 
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::db::traits::task::{
+use crate::backend::capabilities::task::{
     TaskBackend, list_backup_task_output_summaries, list_export_task_output_summaries,
     list_tasks_with_total_count, task_event_responses,
 };
@@ -100,15 +100,15 @@ fn parse_task_list_query(query_string: &str) -> Result<(QueryOptions, TaskListFi
 #[get("")]
 #[get("/")]
 pub async fn get_tasks(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.clone());
+    ensure_task_worker_running(context.clone());
     let (params, filters) = parse_task_list_query(req.query_string())?;
     let search_params = prepare_db_pagination::<TaskResponse>(&params)?;
-    let backend = pool.permission_backend();
-    let principal = PrincipalRef::load(&pool, &requestor.principal).await?;
+    let backend = context.permission_backend();
+    let principal = PrincipalRef::load(&context, &requestor.principal).await?;
     let is_admin = backend.is_admin(&principal).await?;
     let submitted_by_filter = if is_admin {
         filters.submitted_by
@@ -119,7 +119,7 @@ pub async fn get_tasks(
     };
     let (tasks, total_count) = if backend.supports_sql_visibility_pushdown() {
         list_tasks_with_total_count(
-            &pool,
+            &context,
             submitted_by_filter,
             filters.kind.map(TaskKind::as_str),
             filters.status.map(TaskStatus::as_str),
@@ -130,7 +130,7 @@ pub async fn get_tasks(
         let mut candidate_options = count_query_options(&params);
         candidate_options.include_total = false;
         let (candidates, _) = list_tasks_with_total_count(
-            &pool,
+            &context,
             submitted_by_filter,
             filters.kind.map(TaskKind::as_str),
             filters.status.map(TaskStatus::as_str),
@@ -139,7 +139,7 @@ pub async fn get_tasks(
         .await?;
         let resources = candidates
             .iter()
-            .map(|task| task.to_resource_ref(&pool))
+            .map(|task| task.to_resource_ref(&context))
             .collect::<Vec<_>>();
         let mut task_resources = Vec::with_capacity(resources.len());
         for resource in resources {
@@ -159,7 +159,7 @@ pub async fn get_tasks(
         .filter(|task| task.kind == TaskKind::Export.as_str())
         .map(|task| task.id)
         .collect::<Vec<_>>();
-    let export_outputs = list_export_task_output_summaries(&pool, &export_task_ids)
+    let export_outputs = list_export_task_output_summaries(&context, &export_task_ids)
         .await?
         .into_iter()
         .map(|output| (output.task_id, output))
@@ -169,7 +169,7 @@ pub async fn get_tasks(
         .filter(|task| task.kind == TaskKind::Backup.as_str())
         .map(|task| task.id)
         .collect::<Vec<_>>();
-    let backup_outputs = list_backup_task_output_summaries(&pool, &backup_task_ids)
+    let backup_outputs = list_backup_task_output_summaries(&context, &backup_task_ids)
         .await?
         .into_iter()
         .map(|output| (output.task_id, output))
@@ -222,19 +222,21 @@ pub async fn get_tasks(
 )]
 #[get("/{task_id}")]
 pub async fn get_task(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.clone());
+    ensure_task_worker_running(context.clone());
     let task_id = task_id.into_inner();
-    let task = if pool.permission_backend().uses_sql_permission_store() {
-        task_id.load_authorized(&pool, &requestor.principal).await?
+    let task = if context.permission_backend().uses_sql_permission_store() {
+        task_id
+            .load_authorized(&context, &requestor.principal)
+            .await?
     } else {
-        let task = task_id.find_record(&pool).await?;
-        let principal = PrincipalRef::load(&pool, &requestor.principal).await?;
-        let resource = task.to_resource_ref(&pool).await?;
-        if pool
+        let task = task_id.find_record(&context).await?;
+        let principal = PrincipalRef::load(&context, &requestor.principal).await?;
+        let resource = task.to_resource_ref(&context).await?;
+        if context
             .permission_backend()
             .authorize_task(&principal, &resource)
             .await?
@@ -245,12 +247,12 @@ pub async fn get_task(
         task
     };
     let export_output = if task.kind == TaskKind::Export.as_str() {
-        task.find_export_output_summary(&pool).await?
+        task.find_export_output_summary(&context).await?
     } else {
         ExportOutputLookup::Missing
     };
     let backup_output = if task.kind == TaskKind::Backup.as_str() {
-        task.find_backup_output_summary(&pool).await?
+        task.find_backup_output_summary(&context).await?
     } else {
         BackupOutputLookup::Missing
     };
@@ -277,20 +279,22 @@ pub async fn get_task(
 )]
 #[get("/{task_id}/events")]
 pub async fn get_task_events(
-    pool: AppContext,
+    context: AppContext,
     requestor: Authenticated,
     req: HttpRequest,
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
-    ensure_task_worker_running(pool.clone());
+    ensure_task_worker_running(context.clone());
     let task_id = task_id.into_inner();
-    if pool.permission_backend().uses_sql_permission_store() {
-        task_id.load_authorized(&pool, &requestor.principal).await?;
+    if context.permission_backend().uses_sql_permission_store() {
+        task_id
+            .load_authorized(&context, &requestor.principal)
+            .await?;
     } else {
-        let task = task_id.find_record(&pool).await?;
-        let principal = PrincipalRef::load(&pool, &requestor.principal).await?;
-        let resource = task.to_resource_ref(&pool).await?;
-        if pool
+        let task = task_id.find_record(&context).await?;
+        let principal = PrincipalRef::load(&context, &requestor.principal).await?;
+        let resource = task.to_resource_ref(&context).await?;
+        if context
             .permission_backend()
             .authorize_task(&principal, &resource)
             .await?
@@ -302,8 +306,8 @@ pub async fn get_task_events(
     let (params, _) = parse_query_parameter_with_passthrough(req.query_string(), &[])?;
     let search_params = prepare_db_pagination::<TaskEventResponse>(&params)?;
     let (events, total_count) = task_id
-        .list_events_with_total_count(&pool, &search_params)
+        .list_events_with_total_count(&context, &search_params)
         .await?;
-    let events = task_event_responses(&pool, events).await?;
+    let events = task_event_responses(&context, events).await?;
     ApiResponse::paginated(events, total_count, &params)
 }

--- a/src/api/v1/handlers/users.rs
+++ b/src/api/v1/handlers/users.rs
@@ -2,7 +2,7 @@ use crate::api::etag::{RevisionedResource, revision_precondition, revision_preco
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
 use crate::api::response::ApiResponse;
-use crate::db::{DbPool, with_revision_precondition_scope};
+use crate::backend::with_revision_precondition_scope;
 use crate::errors::ApiError;
 use crate::extractors::{AccessEventContext, AdminAccess, AdminOrSelfAccess};
 use crate::models::search::parse_query_parameter;
@@ -10,6 +10,7 @@ use crate::models::user::{
     NewUser, UpdateUser, UserID, UserPointResponse, UserResponse, UserWithName,
 };
 use crate::pagination::{count_query_options, prepare_db_pagination};
+use crate::permissions::AppContext;
 use actix_web::{HttpRequest, Responder, delete, get, patch, post, routes, web};
 use tracing::debug;
 
@@ -29,7 +30,7 @@ use tracing::debug;
 #[get("")]
 #[get("/")]
 pub async fn get_users(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     requestor: AdminAccess,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
@@ -44,13 +45,13 @@ pub async fn get_users(
     debug!(message = "User list requested", requestor = user.id);
 
     let total_count = if params.include_total {
-        user.count_users(&pool, count_query_options(&params))
+        user.count_users(&context, count_query_options(&params))
             .await?
     } else {
         crate::pagination::SKIPPED_TOTAL_COUNT
     };
     let search_params = prepare_db_pagination::<UserWithName>(&params)?;
-    let result = user.search_users(&pool, search_params).await?;
+    let result = user.search_users(&context, search_params).await?;
 
     ApiResponse::mapped_paginated(result, total_count, &params, |users| {
         users.into_iter().map(UserResponse::from).collect()
@@ -74,7 +75,7 @@ pub async fn get_users(
 #[post("")]
 #[post("/")]
 pub async fn create_user(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     new_user: web::Json<NewUser>,
     requestor: AdminAccess,
     req: HttpRequest,
@@ -88,9 +89,9 @@ pub async fn create_user(
     let event_context = requestor.event_context(&req);
     let user = new_user
         .into_inner()
-        .save(&pool, Some(&event_context))
+        .save(&context, Some(&event_context))
         .await?;
-    let response = user.to_point_response(&pool).await?;
+    let response = user.to_point_response(&context).await?;
 
     let location = api_locations::user(user.id)?;
     ApiResponse::created_revisioned(response, location)
@@ -113,18 +114,18 @@ pub async fn create_user(
 )]
 #[get("/{user_id}")]
 pub async fn get_user(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     user_id: web::Path<UserID>,
     requestor: AdminOrSelfAccess,
 ) -> Result<impl Responder, ApiError> {
-    let user = user_id.into_inner().user(&pool).await?;
+    let user = user_id.into_inner().user(&context).await?;
     debug!(
         message = "User get requested",
         target = user.id,
         requestor = requestor.user.id
     );
 
-    ApiResponse::ok_revisioned(user.to_point_response(&pool).await?)
+    ApiResponse::ok_revisioned(user.to_point_response(&context).await?)
 }
 
 #[utoipa::path(
@@ -146,7 +147,7 @@ pub async fn get_user(
 )]
 #[patch("/{user_id}")]
 pub async fn update_user(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     user_id: web::Path<UserID>,
     updated_user: web::Json<UpdateUser>,
     requestor: AdminAccess,
@@ -160,17 +161,21 @@ pub async fn update_user(
         requestor = requestor.user.id
     );
 
-    let current = user_id.user(&pool).await?.to_point_response(&pool).await?;
+    let current = user_id
+        .user(&context)
+        .await?
+        .to_point_response(&context)
+        .await?;
     let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
     let user = with_revision_precondition_scope(
         precondition,
         updated_user
             .into_inner()
-            .save(user_id, &pool, Some(&event_context)),
+            .save(user_id, &context, Some(&event_context)),
     )
     .await?;
-    ApiResponse::ok_revisioned(user.to_point_response(&pool).await?)
+    ApiResponse::ok_revisioned(user.to_point_response(&context).await?)
 }
 
 #[utoipa::path(
@@ -190,7 +195,7 @@ pub async fn update_user(
 )]
 #[delete("/{user_id}")]
 pub async fn delete_user(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     user_id: web::Path<UserID>,
     requestor: AdminAccess,
     req: HttpRequest,
@@ -202,14 +207,20 @@ pub async fn delete_user(
     );
 
     let user_id = user_id.into_inner();
-    let current = user_id.user(&pool).await?.to_point_response(&pool).await?;
+    let current = user_id
+        .user(&context)
+        .await?
+        .to_point_response(&context)
+        .await?;
     let etag = current.entity_tag()?;
     let precondition = revision_precondition_for_tag(&req, &etag)?;
 
     let event_context = requestor.event_context(&req);
-    let delete_result =
-        with_revision_precondition_scope(precondition, user_id.delete(&pool, Some(&event_context)))
-            .await;
+    let delete_result = with_revision_precondition_scope(
+        precondition,
+        user_id.delete(&context, Some(&event_context)),
+    )
+    .await;
 
     match delete_result {
         Ok(_) => Ok(ApiResponse::no_content_with_etag(etag)),
@@ -232,7 +243,7 @@ pub async fn delete_user(
 )]
 #[post("/{user_id}/anonymize")]
 pub async fn anonymize_user(
-    pool: web::Data<DbPool>,
+    context: AppContext,
     user_id: web::Path<UserID>,
     requestor: AdminAccess,
     req: HttpRequest,
@@ -244,9 +255,17 @@ pub async fn anonymize_user(
         target = target_id,
         requestor = requestor.user.id
     );
-    let current = user_id.user(&pool).await?.to_point_response(&pool).await?;
+    let current = user_id
+        .user(&context)
+        .await?
+        .to_point_response(&context)
+        .await?;
     let precondition = revision_precondition(&req, &current)?;
-    with_revision_precondition_scope(precondition, user_id.anonymize(&pool)).await?;
-    let updated = user_id.user(&pool).await?.to_point_response(&pool).await?;
+    with_revision_precondition_scope(precondition, user_id.anonymize(&context)).await?;
+    let updated = user_id
+        .user(&context)
+        .await?
+        .to_point_response(&context)
+        .await?;
     Ok(ApiResponse::no_content_with_etag(updated.entity_tag()?))
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use tracing::{error, info, warn};
 
 use crate::api::openapi::openapi_json as openapi_json_handler;
+use crate::backend::capabilities::event_subscription::enabled_event_sink_count;
 use crate::backups::BackupSettings;
 #[cfg(test)]
 use crate::config::get_config;
@@ -153,27 +154,33 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
             )
         });
     let app_context = AppContext::new(pool.clone(), permission_backend);
+    let storage_backend = app_context.storage_backend_descriptor();
+    if config.metrics_enabled {
+        observability::metrics::storage_backend_identity(
+            storage_backend.kind().as_str(),
+            storage_backend.contract_version(),
+        );
+    }
     let authorization_backend = app_context.permission_backend().kind();
 
     // Every process that can serve or originate work must participate in the
     // restore drain barrier. In particular, API-only replicas need their own
     // heartbeat even though they do not run task or event workers.
-    ensure_restore_coordinator_running(app_context.db_pool.clone());
+    ensure_restore_coordinator_running(app_context.clone_backend());
 
-    let active_event_sinks =
-        match db::traits::event_subscription::enabled_event_sink_count(&pool).await {
-            Ok(count) => Some(count),
-            Err(error) => {
-                warn!(
-                    message = "failed to count active event sinks for startup metadata",
-                    error = %error,
-                );
-                None
-            }
-        };
+    let active_event_sinks = match enabled_event_sink_count(&app_context).await {
+        Ok(count) => Some(count),
+        Err(error) => {
+            warn!(
+                message = "failed to count active event sinks for startup metadata",
+                error = %error,
+            );
+            None
+        }
+    };
 
     if !config.runtime_role.serves_http() {
-        let metrics_server = start_worker_metrics_server(&config, pool.clone())?;
+        let metrics_server = start_worker_metrics_server(&config, app_context.clone())?;
         start_background_workers(&app_context, &backup_settings);
         info!(
             message = "worker startup",
@@ -183,7 +190,9 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
             task_workers = config.task_workers,
             event_fanout_workers = config.event_fanout_workers,
             event_delivery_workers = config.event_delivery_workers,
-            db_backend = "postgresql",
+            db_backend = storage_backend.kind().as_str(),
+            storage_backend = storage_backend.kind().as_str(),
+            storage_contract_version = storage_backend.contract_version(),
             authorization_backend,
             active_event_sinks,
             metrics_listener = metrics_server.is_some(),
@@ -219,10 +228,9 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
         config.trusted_proxies.nets().to_vec(),
         config.trusted_proxy_hops,
     );
-    let running_config = RunningConfig::from(&config);
+    let running_config = RunningConfig::from_app_config_and_storage(&config, storage_backend);
     let metrics_enabled = config.metrics_enabled;
     let metrics_path = config.metrics_path.clone();
-    let app_pool = pool.clone();
     let server_app_context = app_context.clone();
     let background_worker_context = app_context.clone();
     let app_backup_settings = backup_settings.clone();
@@ -245,7 +253,6 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
             .app_data(Data::new(running_config.clone()))
             .app_data(Data::new(app_backup_settings.clone()))
             .app_data(Data::new(app_restore_settings.clone()))
-            .app_data(Data::new(app_pool.clone()))
             .app_data(Data::new(server_app_context.clone()))
             .app_data(JsonConfig::default().error_handler(json_error_handler))
             .route("/api-doc/openapi.json", web::get().to(openapi_json_handler));
@@ -313,7 +320,9 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
         task_workers = config.task_workers,
         event_fanout_workers = config.event_fanout_workers,
         event_delivery_workers = config.event_delivery_workers,
-        db_backend = "postgresql",
+        db_backend = storage_backend.kind().as_str(),
+        storage_backend = storage_backend.kind().as_str(),
+        storage_contract_version = storage_backend.contract_version(),
         authorization_backend,
         login_rate_limit_backend = config.login_rate_limit_backend.as_str(),
         active_event_sinks,
@@ -342,10 +351,10 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
 
 fn start_background_workers(context: &AppContext, backup_settings: &BackupSettings) {
     ensure_task_worker_running_with_settings(context.clone(), backup_settings.clone());
-    ensure_event_fanout_worker_running(context.db_pool.clone());
-    ensure_event_delivery_worker_running(context.db_pool.clone());
-    ensure_event_retention_worker_running(context.db_pool.clone());
-    ensure_token_retention_worker_running(context.db_pool.clone());
+    ensure_event_fanout_worker_running(context.clone_backend());
+    ensure_event_delivery_worker_running(context.clone_backend());
+    ensure_event_retention_worker_running(context.clone_backend());
+    ensure_token_retention_worker_running(context.clone_backend());
 }
 
 async fn wait_for_background_worker_failure() -> std::io::Error {
@@ -380,7 +389,7 @@ fn worker_metrics_service(
     client_allowlist: ClientAllowlist,
     proxy_trust: middlewares::ProxyTrust,
     metrics_path: MetricsPath,
-    pool: db::DbPool,
+    context: AppContext,
 ) -> impl HttpServiceFactory {
     web::scope("")
         .wrap(middlewares::ClientAllowlistMiddleware::new_with_trust(
@@ -388,7 +397,7 @@ fn worker_metrics_service(
             proxy_trust.clone(),
         ))
         .wrap(middlewares::TracingMiddleware::new_with_trust(proxy_trust))
-        .app_data(Data::new(pool))
+        .app_data(Data::new(context))
         .route(
             metrics_path.as_str(),
             web::get().to(observability::metrics::scrape),
@@ -397,7 +406,7 @@ fn worker_metrics_service(
 
 fn start_worker_metrics_server(
     config: &AppConfig,
-    pool: db::DbPool,
+    context: AppContext,
 ) -> std::io::Result<Option<Server>> {
     if !config.metrics_enabled {
         return Ok(None);
@@ -415,7 +424,7 @@ fn start_worker_metrics_server(
             client_allowlist.clone(),
             proxy_trust.clone(),
             metrics_path.clone(),
-            pool.clone(),
+            context.clone(),
         ))
     });
     let bind_address = format!("{}:{}", config.bind_ip, config.port);
@@ -491,7 +500,11 @@ async fn wait_for_shutdown_signal() -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use actix_web::{http::StatusCode, test as actix_test};
+
+    use crate::permissions::LocalPermissionBackend;
 
     use super::*;
 
@@ -507,6 +520,14 @@ mod tests {
         init_pool_with_settings(&settings)
     }
 
+    fn unreachable_context() -> AppContext {
+        let pool = unreachable_pool();
+        AppContext::new(
+            pool.clone(),
+            Arc::new(LocalPermissionBackend::new(pool, "admin".to_string())),
+        )
+    }
+
     #[actix_web::test]
     async fn worker_metrics_service_instruments_scrape_requests() {
         observability::metrics::init().expect("metrics should initialize");
@@ -514,7 +535,7 @@ mod tests {
             ClientAllowlist::Any,
             middlewares::ProxyTrust::peer_only(),
             MetricsPath::new("/metrics").expect("metrics path should be valid"),
-            unreachable_pool(),
+            unreachable_context(),
         )))
         .await;
         let metrics_request = || {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -374,7 +374,11 @@ impl AuthProviderBackend for LdapAuthProvider {
     }
 }
 
-pub async fn login(pool: &DbPool, login: LoginUser) -> Result<User, ApiError> {
+pub async fn login(
+    pool: &impl crate::traits::BackendContext,
+    login: LoginUser,
+) -> Result<User, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     login.validate()?;
     let scope = login
         .identity_scope
@@ -388,7 +392,11 @@ pub async fn login(pool: &DbPool, login: LoginUser) -> Result<User, ApiError> {
         .await
 }
 
-pub async fn refresh_principal_if_needed(pool: &DbPool, principal_id: i32) -> Result<(), ApiError> {
+pub async fn refresh_principal_if_needed(
+    pool: &impl crate::traits::BackendContext,
+    principal_id: i32,
+) -> Result<(), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let Some(state) = external_user_state(pool, principal_id).await? else {
         return Ok(());
     };

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,422 @@
+//! Application-facing persistence capabilities.
+//!
+//! Consumers depend on operation-shaped contracts from this module and pass a
+//! [`crate::traits::BackendContext`]. PostgreSQL adapters remain behind the
+//! boundary in `crate::db`.
+
+/// Operation-shaped persistence capabilities still used directly by the
+/// application layer.
+///
+/// Keep this list explicit: adding a database module wholesale would make the
+/// boundary cosmetic and allow consumers to select arbitrary SQL adapters.
+pub(crate) mod capabilities {
+    pub(crate) use crate::db::traits::{Status, UserPermissions};
+
+    pub(crate) mod active_tokens {
+        pub(crate) use crate::db::traits::active_tokens::retained_token_metadata_by_principal_id_paginated_with_total_count;
+    }
+
+    pub(crate) mod authz {
+        pub(crate) use crate::db::traits::authz::{load_token_scope, scope_allows};
+    }
+
+    pub(crate) mod collection {
+        pub(crate) use crate::db::traits::collection::collection_permission_set_from_backend;
+    }
+
+    pub(crate) mod computed_field {
+        pub(crate) use crate::db::traits::computed_field::{
+            ComputedQuerySnapshot, class_computation_state_for, create_personal_definition,
+            create_shared_definition, delete_personal_definition, delete_shared_definition,
+            enrich_objects_with_computed, enrich_objects_with_computed_query_snapshot,
+            get_computed_definition, list_personal_definitions_page, list_shared_definitions,
+            preview_computed_definition, request_class_rebuild, resolve_computed_query_fields,
+            update_personal_definition, update_shared_definition,
+        };
+    }
+
+    pub(crate) mod event_delivery {
+        pub(crate) use crate::db::traits::event_delivery::{
+            list_event_deliveries_with_total_count, load_event_delivery, mark_event_delivery_dead,
+            release_event_delivery_for_retry,
+        };
+    }
+
+    pub(crate) mod event_observability {
+        pub(crate) use crate::db::traits::event_observability::load_event_delivery_health;
+    }
+
+    pub(crate) mod event_subscription {
+        pub(crate) use crate::db::traits::event_subscription::{
+            DeleteEventSinkRecord, DeleteEventSubscriptionRecord, SaveEventSinkRecord,
+            SaveEventSubscriptionRecord, UpdateEventSinkRecord, UpdateEventSubscriptionRecord,
+            enabled_event_sink_count,
+        };
+    }
+
+    pub(crate) mod events {
+        pub(crate) use crate::db::traits::events::{
+            list_events_with_total_count, parse_event_filters,
+        };
+    }
+
+    pub(crate) mod group {
+        pub(crate) use crate::db::traits::group::principal_group_by_ids;
+    }
+
+    pub(crate) mod history {
+        pub(crate) use crate::db::traits::history::{
+            HistoryCollectionFilter, class_as_of, class_history_paginated_with_total_count,
+            collection_as_of, collection_history_paginated_with_total_count, export_template_as_of,
+            export_template_history_paginated_with_total_count, object_as_of,
+            object_history_paginated_with_total_count, remote_target_as_of,
+            remote_target_history_paginated_with_total_count, resolve_principal_names,
+        };
+    }
+
+    pub(crate) mod meta {
+        pub(crate) use crate::db::traits::meta::{
+            load_database_pool_state, load_database_state, load_task_queue_state,
+        };
+    }
+
+    pub(crate) mod principal {
+        pub(crate) use crate::db::traits::principal::load_principal_with_user;
+    }
+
+    pub(crate) mod probe {
+        pub(crate) use crate::db::traits::probe::ProbeBackend;
+    }
+
+    pub(crate) mod relations {
+        pub(crate) use crate::db::traits::relations::{
+            class_relation_authorization_resources, object_relation_authorization_resources,
+        };
+    }
+
+    pub(crate) mod remote_target {
+        pub(crate) use crate::db::traits::remote_target::{
+            DeleteRemoteTargetRecord, SaveRemoteTargetRecord, UpdateRemoteTargetRecord,
+            emit_remote_target_invoked_event,
+        };
+    }
+
+    pub(crate) mod service_account {
+        pub(crate) use crate::db::traits::service_account::{
+            DisableServiceAccount, SaveServiceAccount, count_manageable_service_accounts,
+            is_human_owner_group_member, load_service_account_by_id, principal_is_disabled,
+            search_manageable_service_accounts,
+        };
+    }
+
+    pub(crate) mod task {
+        pub(crate) use crate::db::traits::task::{
+            TaskBackend, TaskCreateRequest, TaskScopeSnapshot, list_backup_task_output_summaries,
+            list_export_task_output_summaries, list_tasks_with_total_count, task_event_responses,
+        };
+    }
+
+    pub(crate) mod user {
+        use crate::errors::ApiError;
+        use crate::models::search::QueryOptions;
+        use crate::models::{
+            HubuumClass, HubuumClassExpanded, HubuumClassRelation, HubuumObject,
+            HubuumObjectRelation, TokenScope,
+        };
+        use crate::traits::{BackendContext, SelfAccessors};
+
+        use super::computed_field::ComputedQuerySnapshot;
+
+        /// The search operations required by application consumers.
+        ///
+        /// The underlying PostgreSQL trait also contains connection-pool
+        /// helpers for adapter composition. Keeping those methods out of this
+        /// facade prevents method resolution from becoming a pool escape hatch.
+        pub(crate) trait UserSearchBackend {
+            async fn search_collections_from_backend_with_admin_status<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<Vec<crate::models::Collection>, ApiError>
+            where
+                C: BackendContext;
+
+            async fn search_classes_from_backend_with_admin_status<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<Vec<HubuumClassExpanded>, ApiError>
+            where
+                C: BackendContext;
+
+            async fn search_objects_from_backend<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                scopes: Option<&TokenScope>,
+            ) -> Result<Vec<HubuumObject>, ApiError>
+            where
+                C: BackendContext;
+
+            async fn search_objects_from_backend_with_admin_status<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<Vec<HubuumObject>, ApiError>
+            where
+                C: BackendContext;
+
+            async fn search_objects_with_computed_query_from_backend<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                scopes: Option<&TokenScope>,
+                snapshot: &ComputedQuerySnapshot,
+            ) -> Result<Vec<HubuumObject>, ApiError>
+            where
+                C: BackendContext;
+
+            async fn count_objects_with_computed_query_from_backend<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                scopes: Option<&TokenScope>,
+                snapshot: &ComputedQuerySnapshot,
+            ) -> Result<i64, ApiError>
+            where
+                C: BackendContext;
+
+            async fn search_class_relations_from_backend_with_admin_status<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<Vec<HubuumClassRelation>, ApiError>
+            where
+                C: BackendContext;
+
+            async fn class_relations_touching_page_from_backend_with_admin_status<C, K>(
+                &self,
+                context: &C,
+                class: K,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<(Vec<HubuumClassRelation>, i64), ApiError>
+            where
+                C: BackendContext,
+                K: SelfAccessors<HubuumClass>;
+
+            async fn search_object_relations_from_backend_with_admin_status<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<Vec<HubuumObjectRelation>, ApiError>
+            where
+                C: BackendContext;
+
+            async fn object_relations_touching_page_from_backend_with_admin_status<C, O>(
+                &self,
+                context: &C,
+                object: O,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<(Vec<HubuumObjectRelation>, i64), ApiError>
+            where
+                C: BackendContext,
+                O: SelfAccessors<HubuumObject>;
+        }
+
+        impl<T> UserSearchBackend for T
+        where
+            T: crate::db::traits::user::UserSearchBackend + Sync + ?Sized,
+        {
+            async fn search_collections_from_backend_with_admin_status<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<Vec<crate::models::Collection>, ApiError>
+            where
+                C: BackendContext,
+            {
+                crate::db::traits::user::UserSearchBackend::search_collections_from_backend_with_admin_status(
+                    self, context, query_options, is_admin, scopes,
+                )
+                .await
+            }
+
+            async fn search_classes_from_backend_with_admin_status<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<Vec<HubuumClassExpanded>, ApiError>
+            where
+                C: BackendContext,
+            {
+                crate::db::traits::user::UserSearchBackend::search_classes_from_backend_with_admin_status(
+                    self, context, query_options, is_admin, scopes,
+                )
+                .await
+            }
+
+            async fn search_objects_from_backend<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                scopes: Option<&TokenScope>,
+            ) -> Result<Vec<HubuumObject>, ApiError>
+            where
+                C: BackendContext,
+            {
+                crate::db::traits::user::UserSearchBackend::search_objects_from_backend(
+                    self,
+                    context,
+                    query_options,
+                    scopes,
+                )
+                .await
+            }
+
+            async fn search_objects_from_backend_with_admin_status<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<Vec<HubuumObject>, ApiError>
+            where
+                C: BackendContext,
+            {
+                crate::db::traits::user::UserSearchBackend::search_objects_from_backend_with_admin_status(
+                    self, context, query_options, is_admin, scopes,
+                )
+                .await
+            }
+
+            async fn search_objects_with_computed_query_from_backend<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                scopes: Option<&TokenScope>,
+                snapshot: &ComputedQuerySnapshot,
+            ) -> Result<Vec<HubuumObject>, ApiError>
+            where
+                C: BackendContext,
+            {
+                crate::db::traits::user::UserSearchBackend::search_objects_with_computed_query_from_backend(
+                    self, context, query_options, scopes, snapshot,
+                )
+                .await
+            }
+
+            async fn count_objects_with_computed_query_from_backend<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                scopes: Option<&TokenScope>,
+                snapshot: &ComputedQuerySnapshot,
+            ) -> Result<i64, ApiError>
+            where
+                C: BackendContext,
+            {
+                crate::db::traits::user::UserSearchBackend::count_objects_with_computed_query_from_backend(
+                    self, context, query_options, scopes, snapshot,
+                )
+                .await
+            }
+
+            async fn search_class_relations_from_backend_with_admin_status<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<Vec<HubuumClassRelation>, ApiError>
+            where
+                C: BackendContext,
+            {
+                crate::db::traits::user::UserSearchBackend::search_class_relations_from_backend_with_admin_status(
+                    self, context, query_options, is_admin, scopes,
+                )
+                .await
+            }
+
+            async fn class_relations_touching_page_from_backend_with_admin_status<C, K>(
+                &self,
+                context: &C,
+                class: K,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<(Vec<HubuumClassRelation>, i64), ApiError>
+            where
+                C: BackendContext,
+                K: SelfAccessors<HubuumClass>,
+            {
+                crate::db::traits::user::UserSearchBackend::class_relations_touching_page_from_backend_with_admin_status(
+                    self, context, class, query_options, is_admin, scopes,
+                )
+                .await
+            }
+
+            async fn search_object_relations_from_backend_with_admin_status<C>(
+                &self,
+                context: &C,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<Vec<HubuumObjectRelation>, ApiError>
+            where
+                C: BackendContext,
+            {
+                crate::db::traits::user::UserSearchBackend::search_object_relations_from_backend_with_admin_status(
+                    self, context, query_options, is_admin, scopes,
+                )
+                .await
+            }
+
+            async fn object_relations_touching_page_from_backend_with_admin_status<C, O>(
+                &self,
+                context: &C,
+                object: O,
+                query_options: QueryOptions,
+                is_admin: bool,
+                scopes: Option<&TokenScope>,
+            ) -> Result<(Vec<HubuumObjectRelation>, i64), ApiError>
+            where
+                C: BackendContext,
+                O: SelfAccessors<HubuumObject>,
+            {
+                crate::db::traits::user::UserSearchBackend::object_relations_touching_page_from_backend_with_admin_status(
+                    self, context, object, query_options, is_admin, scopes,
+                )
+                .await
+            }
+        }
+
+        pub(crate) mod search {
+            pub(crate) use crate::db::traits::user::search::{
+                ExternalRelatedFilterAuthorization, count_computed_objects_with_authorized_ids,
+                externally_authorized_related_object_ids,
+                search_computed_objects_with_authorized_ids,
+            };
+        }
+    }
+}
+pub(crate) use crate::db::{
+    DbCallSite, with_db_call_site, with_mutation_provenance_scope, with_revision_precondition_scope,
+};

--- a/src/backups/mod.rs
+++ b/src/backups/mod.rs
@@ -4,7 +4,6 @@ use std::collections::BTreeMap;
 use chrono::Utc;
 use sha2::{Digest, Sha256};
 
-use crate::db::DbPool;
 use crate::db::traits::backup::snapshot_backup_db;
 use crate::db::traits::task::{TaskBackend, TaskStateUpdate};
 use crate::errors::ApiError;
@@ -94,9 +93,10 @@ fn build_manifest(state: &BackupState, history: Option<&BackupHistory>) -> Backu
 }
 
 pub async fn create_backup_document(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     request: &BackupRequest,
 ) -> Result<BackupDocument, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let include_history = request.include_history;
     let (state, history) = snapshot_backup_db(pool, include_history).await?;
     let manifest = build_manifest(&state, history.as_ref());

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -84,6 +84,12 @@ pub struct TlsConfig {
 
 #[derive(Clone, Debug, Serialize, ToSchema)]
 pub struct DatabaseConfig {
+    /// Complete storage backend selected by the application composition root.
+    pub backend: String,
+    /// Version of the all-or-nothing storage contract implemented by the backend.
+    pub contract_version: u16,
+    /// Required capability families. Selectable backends always report the complete set.
+    pub capabilities: Vec<String>,
     pub url: SecretStatus,
     pub pool_size: u32,
     pub pool_acquire_timeout_ms: u64,
@@ -237,8 +243,11 @@ impl From<&RunningConfig> for ClientConfig {
     }
 }
 
-impl From<&AppConfig> for RunningConfig {
-    fn from(config: &AppConfig) -> Self {
+impl RunningConfig {
+    pub(crate) fn from_app_config_and_storage(
+        config: &AppConfig,
+        storage: crate::storage::StorageBackendDescriptor,
+    ) -> Self {
         let client_allowlist = match &config.client_allowlist {
             ClientAllowlist::Any => ClientAllowlistStatus {
                 allows_any: true,
@@ -275,6 +284,12 @@ impl From<&AppConfig> for RunningConfig {
                 },
             },
             database: DatabaseConfig {
+                backend: storage.kind().as_str().to_string(),
+                contract_version: storage.contract_version(),
+                capabilities: storage
+                    .capabilities()
+                    .map(|capability| capability.as_str().to_string())
+                    .collect(),
                 url: SecretStatus {
                     configured: !config.database_url.trim().is_empty(),
                 },
@@ -398,6 +413,17 @@ impl From<&AppConfig> for RunningConfig {
     }
 }
 
+impl From<&AppConfig> for RunningConfig {
+    fn from(config: &AppConfig) -> Self {
+        Self::from_app_config_and_storage(
+            config,
+            crate::storage::StorageBackendDescriptor::new(
+                crate::storage::StorageBackendKind::Postgresql,
+            ),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use clap::Parser;
@@ -426,6 +452,9 @@ mod tests {
         assert!(!json.contains("valkey.example"));
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
+        assert!(json.contains("\"backend\":\"postgresql\""));
+        assert!(json.contains("\"contract_version\":1"));
+        assert!(json.contains("\"queries_and_history\""));
         assert!(!debug.contains("secret-password"));
         assert!(!debug.contains("correct horse battery staple"));
     }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -46,7 +46,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::api::etag::RevisionPrecondition;
 use crate::errors::{ApiError, EXIT_CODE_CONFIG_ERROR, fatal_error};
@@ -348,13 +348,79 @@ async fn acquire_connection(pool: &DbPool) -> Result<PooledConnection<'_, DbConn
             let mut conn = conn;
             #[cfg(any(test, feature = "query-capture", feature = "integration-test-support"))]
             query_capture::configure_connection(&mut conn);
-            metrics::db_connection_acquired(call_site.as_str(), start.elapsed());
+            let duration = start.elapsed();
+            metrics::db_connection_acquired(call_site.as_str(), duration);
+            debug!(
+                message = "storage backend connection acquired",
+                backend = "postgresql",
+                caller = call_site.as_str(),
+                elapsed_ms = duration.as_millis(),
+            );
             Ok(conn)
         }
         Err(error) => {
-            metrics::db_connection_acquire_failed(call_site.as_str(), start.elapsed());
+            let duration = start.elapsed();
+            metrics::db_connection_acquire_failed(call_site.as_str(), duration);
+            warn!(
+                message = "storage backend connection acquisition failed",
+                backend = "postgresql",
+                caller = call_site.as_str(),
+                elapsed_ms = duration.as_millis(),
+                error = %error,
+            );
             Err(ApiError::from(error))
         }
+    }
+}
+
+fn record_database_operation<R>(
+    call_site: DbCallSite,
+    operation: &'static str,
+    duration: Duration,
+    result: &Result<R, ApiError>,
+) {
+    let result_kind = match result {
+        Ok(_) => ResultKind::Ok,
+        Err(error) => ResultKind::Error(error.class()),
+    };
+    metrics::db_operation_finished(call_site.as_str(), operation, duration, &result_kind);
+
+    match result {
+        Ok(_) => debug!(
+            message = "storage backend operation complete",
+            backend = "postgresql",
+            caller = call_site.as_str(),
+            operation,
+            elapsed_ms = duration.as_millis(),
+        ),
+        Err(error)
+            if matches!(
+                error,
+                ApiError::DatabaseError(_)
+                    | ApiError::DbConnectionError(_)
+                    | ApiError::InternalServerError(_)
+                    | ApiError::ServiceUnavailable(_)
+            ) =>
+        {
+            warn!(
+                message = "storage backend operation failed",
+                backend = "postgresql",
+                caller = call_site.as_str(),
+                operation,
+                error_class = error.class(),
+                elapsed_ms = duration.as_millis(),
+                error = %error,
+            )
+        }
+        Err(error) => debug!(
+            message = "storage backend operation rejected",
+            backend = "postgresql",
+            caller = call_site.as_str(),
+            operation,
+            error_class = error.class(),
+            elapsed_ms = duration.as_millis(),
+            error = %error,
+        ),
     }
 }
 
@@ -707,16 +773,7 @@ where
         })
         .await
     };
-    let result_kind = match &result {
-        Ok(_) => ResultKind::Ok,
-        Err(error) => ResultKind::Error(error.class()),
-    };
-    metrics::db_operation_finished(
-        call_site.as_str(),
-        "connection",
-        start.elapsed(),
-        &result_kind,
-    );
+    record_database_operation(call_site, "connection", start.elapsed(), &result);
     result
 }
 
@@ -819,16 +876,7 @@ where
         }),
     )
     .await;
-    let result_kind = match &result {
-        Ok(_) => ResultKind::Ok,
-        Err(error) => ResultKind::Error(error.class()),
-    };
-    metrics::db_operation_finished(
-        call_site.as_str(),
-        "transaction",
-        start.elapsed(),
-        &result_kind,
-    );
+    record_database_operation(call_site, "transaction", start.elapsed(), &result);
     result
 }
 

--- a/src/db/traits/active_tokens.rs
+++ b/src/db/traits/active_tokens.rs
@@ -187,10 +187,11 @@ async fn tokens_by_principal_id_paginated_with_total_count(
 
 pub(crate) async fn retained_token_metadata_by_principal_id_paginated_with_total_count(
     principal: crate::models::PrincipalID,
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     query_options: &QueryOptions,
     state: TokenListState,
 ) -> Result<(Vec<PrincipalTokenMetadata>, i64), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let active_after = active_tokens_cutoff()?;
     let now = chrono::Utc::now().naive_utc();
 

--- a/src/db/traits/authz.rs
+++ b/src/db/traits/authz.rs
@@ -138,7 +138,8 @@ pub trait AuthzSubject: PrincipalIdAccessor {
     /// Note: this is a pure group-membership fact. It does NOT make a service
     /// account a *human IAM* administrator — that separation is enforced by the
     /// `kind = 'human'` gate on the human/IAM extractors, not here.
-    async fn is_admin(&self, pool: &DbPool) -> Result<bool, ApiError> {
+    async fn is_admin(&self, pool: &impl crate::traits::BackendContext) -> Result<bool, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let groupname = self.admin_groupname().await?;
         self.is_in_group_by_name(&groupname, pool).await
     }
@@ -450,9 +451,10 @@ pub(crate) async fn load_token_scopes_for_tokens_conn(
 /// flags are the source of truth, so a flagged dimension with no rows becomes a
 /// present-but-empty deny-all dimension.
 pub async fn load_token_scope(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     token: &PrincipalToken,
 ) -> Result<Option<TokenScope>, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     Ok(
         load_token_scopes_for_tokens(pool, std::slice::from_ref(token))
             .await?

--- a/src/db/traits/collection/permissions.rs
+++ b/src/db/traits/collection/permissions.rs
@@ -9,10 +9,11 @@ use std::collections::HashMap;
 /// database snapshot. When `group_id` is present, only that group's row is
 /// included while the aggregate revision still describes the complete ACL.
 pub(crate) async fn collection_permission_set_from_backend(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     collection_id: i32,
     group_id: Option<i32>,
 ) -> Result<CollectionPermissionSet, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::{collection_authorization_state, permissions};
 
     let rows = with_connection(pool, async |conn| {

--- a/src/db/traits/computed_field.rs
+++ b/src/db/traits/computed_field.rs
@@ -181,9 +181,10 @@ async fn ensure_computation_state(
 }
 
 pub async fn class_computation_state_for(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     target_class_id: i32,
 ) -> Result<ClassComputationState, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::class_computation_state::dsl::{class_computation_state, class_id};
 
     Ok(with_connection(pool, async |conn| {
@@ -199,9 +200,10 @@ pub async fn class_computation_state_for(
 }
 
 pub async fn list_shared_definitions(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     target_class_id: i32,
 ) -> Result<Vec<ComputedFieldDefinition>, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::computed_field_definitions::dsl::{
         class_id, computed_field_definitions, id, visibility,
     };
@@ -219,11 +221,12 @@ pub async fn list_shared_definitions(
 }
 
 pub async fn list_personal_definitions_page(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     owner_id: i32,
     class_filter: Option<i32>,
     query_options: &QueryOptions,
 ) -> Result<(Vec<ComputedFieldDefinition>, i64), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::computed_field_definitions::dsl::{
         class_id, computed_field_definitions, owner_user_id, visibility,
     };
@@ -262,9 +265,10 @@ pub async fn list_personal_definitions_page(
 }
 
 pub async fn get_computed_definition(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     definition_id: i32,
 ) -> Result<ComputedFieldDefinition, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::computed_field_definitions::dsl::{computed_field_definitions, id};
     with_connection(pool, async |conn| {
         computed_field_definitions
@@ -424,13 +428,14 @@ pub(crate) async fn advance_revision_and_enqueue(
 }
 
 pub async fn create_shared_definition(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     target_class_id: i32,
     authorized_collection_id: i32,
     actor_id: i32,
     request: ComputedFieldDefinitionRequest,
     context: &EventContext,
 ) -> Result<ComputedFieldMutationResponse, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let input = request.into_new_shared(target_class_id, actor_id)?;
     with_transaction(pool, async |conn| -> Result<_, ApiError> {
         acquire_computed_class_exclusive_lock(conn, target_class_id).await?;
@@ -514,7 +519,7 @@ async fn apply_definition_patch(
 }
 
 pub async fn update_shared_definition(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     target_class_id: i32,
     authorized_collection_id: i32,
     definition_id: i32,
@@ -522,6 +527,7 @@ pub async fn update_shared_definition(
     patch: ComputedFieldDefinitionPatch,
     context: &EventContext,
 ) -> Result<ComputedFieldMutationResponse, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     with_transaction(pool, async |conn| -> Result<_, ApiError> {
         acquire_computed_class_exclusive_lock(conn, target_class_id).await?;
         let class =
@@ -574,13 +580,14 @@ pub async fn update_shared_definition(
 }
 
 pub async fn delete_shared_definition(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     target_class_id: i32,
     authorized_collection_id: i32,
     definition_id: i32,
     actor_id: i32,
     context: &EventContext,
 ) -> Result<ClassComputationState, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     with_transaction(pool, async |conn| -> Result<_, ApiError> {
         acquire_computed_class_exclusive_lock(conn, target_class_id).await?;
         let class =
@@ -612,11 +619,12 @@ pub async fn delete_shared_definition(
 }
 
 pub async fn create_personal_definition(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     target_class_id: i32,
     owner_id: i32,
     request: ComputedFieldDefinitionRequest,
 ) -> Result<ComputedFieldDefinition, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let input = request.into_new_personal(target_class_id, owner_id)?;
     with_transaction(pool, async |conn| -> Result<_, ApiError> {
         acquire_personal_definition_scope_lock(conn, target_class_id, owner_id).await?;
@@ -646,11 +654,12 @@ pub async fn create_personal_definition(
 }
 
 pub async fn update_personal_definition(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     owner_id: i32,
     definition_id: i32,
     patch: ComputedFieldDefinitionPatch,
 ) -> Result<ComputedFieldDefinition, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     with_transaction(pool, async |conn| -> Result<_, ApiError> {
         let current = locked_definition(conn, definition_id).await?;
         crate::db::assert_locked_revision_precondition(
@@ -680,10 +689,11 @@ pub async fn update_personal_definition(
 }
 
 pub async fn delete_personal_definition(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     owner_id: i32,
     definition_id: i32,
 ) -> Result<(), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     with_transaction(pool, async |conn| -> Result<_, ApiError> {
         let current = locked_definition(conn, definition_id).await?;
         if !current.is_personal_for(owner_id) {

--- a/src/db/traits/computed_field/materialization.rs
+++ b/src/db/traits/computed_field/materialization.rs
@@ -254,10 +254,11 @@ fn computed_value_matches_result_type(
 }
 
 pub async fn enrich_objects_with_computed(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     objects: Vec<HubuumObject>,
     personal_owner_id: Option<i32>,
 ) -> Result<Vec<HubuumObjectComputedResponse>, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     if objects.is_empty() {
         return Ok(Vec::new());
     }
@@ -322,11 +323,12 @@ pub async fn enrich_objects_with_computed(
 }
 
 pub async fn enrich_objects_with_computed_query_snapshot(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     objects: Vec<HubuumObject>,
     personal_owner_id: Option<i32>,
     snapshot: &ComputedQuerySnapshot,
 ) -> Result<Vec<HubuumObjectComputedResponse>, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     if objects.is_empty() {
         return Ok(Vec::new());
     }

--- a/src/db/traits/computed_field/query.rs
+++ b/src/db/traits/computed_field/query.rs
@@ -1,12 +1,13 @@
 use super::*;
 
 pub async fn resolve_computed_query_fields(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     target_class_id: i32,
     personal_owner_id: Option<i32>,
     filters: &mut [ParsedQueryParam],
     sorts: &mut [SortParam],
 ) -> Result<ComputedQuerySnapshot, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     validate_computed_filter_count(
         filters
             .iter()

--- a/src/db/traits/computed_field/rebuild.rs
+++ b/src/db/traits/computed_field/rebuild.rs
@@ -1,11 +1,12 @@
 use super::*;
 
 pub async fn request_class_rebuild(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     target_class_id: i32,
     authorized_collection_id: i32,
     actor_id: Option<i32>,
 ) -> Result<ClassComputationState, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     with_transaction(pool, async |conn| -> Result<_, ApiError> {
         acquire_computed_class_exclusive_lock(conn, target_class_id).await?;
         let _ = locked_class_record_in_collection(conn, target_class_id, authorized_collection_id)
@@ -115,9 +116,10 @@ async fn process_reindex_batch(
 }
 
 pub async fn execute_computed_reindex_task(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     task: &TaskRecord,
 ) -> Result<(), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let started = Instant::now();
     let payload: ComputedReindexPayload = serde_json::from_value(
         task.request_payload

--- a/src/db/traits/event_delivery.rs
+++ b/src/db/traits/event_delivery.rs
@@ -388,9 +388,10 @@ fn truncate_delivery_error(error: &str) -> String {
 }
 
 pub async fn load_event_delivery(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     delivery_id: EventDeliveryID,
 ) -> Result<EventDelivery, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::event_deliveries::dsl::{event_deliveries, id};
 
     with_connection(pool, async |conn| {
@@ -403,9 +404,10 @@ pub async fn load_event_delivery(
 }
 
 pub async fn list_event_deliveries_with_total_count(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     query_options: &QueryOptions,
 ) -> Result<(Vec<EventDelivery>, i64), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let query = build_event_delivery_query(query_options)?;
     let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
         with_connection(pool, async |conn| {
@@ -472,9 +474,10 @@ fn build_event_delivery_query(
 }
 
 pub async fn release_event_delivery_for_retry(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     delivery_id: EventDeliveryID,
 ) -> Result<EventDelivery, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::event_deliveries::dsl::{
         claim_token, event_deliveries, id, last_error, locked_until, next_attempt_at, status,
     };
@@ -505,9 +508,10 @@ pub async fn release_event_delivery_for_retry(
 }
 
 pub async fn mark_event_delivery_dead(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     delivery_id: EventDeliveryID,
 ) -> Result<EventDelivery, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::event_deliveries::dsl::{
         claim_token, event_deliveries, id, last_error, locked_until, status,
     };

--- a/src/db/traits/event_observability.rs
+++ b/src/db/traits/event_observability.rs
@@ -8,7 +8,7 @@ use crate::config::{
     DEFAULT_EVENT_FANOUT_POLL_INTERVAL_MS, DEFAULT_EVENT_FANOUT_WORKERS, get_config,
 };
 use crate::db::traits::metrics::EventMetricsSnapshot;
-use crate::db::{DbPool, with_connection};
+use crate::db::with_connection;
 use crate::errors::ApiError;
 use crate::events::{event_delivery_wakeup_stats, event_fanout_wakeup_stats};
 use crate::models::{
@@ -121,8 +121,9 @@ struct SubscriptionHealthRow {
 }
 
 pub async fn load_event_delivery_health(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
 ) -> Result<EventDeliveryHealthResponse, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     with_connection(pool, async |conn| {
         let fanout = load_fanout_health(conn).await?;
         let delivery = load_delivery_queue_health(conn).await?;
@@ -139,7 +140,10 @@ pub async fn load_event_delivery_health(
     .await
 }
 
-pub async fn load_event_metrics_snapshot(pool: &DbPool) -> Result<EventMetricsSnapshot, ApiError> {
+pub async fn load_event_metrics_snapshot(
+    pool: &impl crate::traits::BackendContext,
+) -> Result<EventMetricsSnapshot, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     with_connection(pool, async |conn| {
         Ok::<EventMetricsSnapshot, ApiError>(EventMetricsSnapshot {
             fanout: load_fanout_health(conn).await?,

--- a/src/db/traits/event_subscription.rs
+++ b/src/db/traits/event_subscription.rs
@@ -32,33 +32,45 @@ impl LoadEventSinkRecord for EventSinkID {
 }
 
 pub(crate) trait SaveEventSinkRecord {
-    async fn save_event_sink_record(
+    async fn save_event_sink_record<C>(
         &self,
-        pool: &DbPool,
+        pool: &C,
         event_context: &EventContext,
-    ) -> Result<EventSinkRow, ApiError>;
+    ) -> Result<EventSinkRow, ApiError>
+    where
+        C: crate::traits::BackendContext + ?Sized;
 
     #[cfg(any(test, feature = "integration-test-support"))]
-    async fn save_event_sink_record_without_events(
+    async fn save_event_sink_record_without_events<C>(
         &self,
-        pool: &DbPool,
-    ) -> Result<EventSinkRow, ApiError>;
+        pool: &C,
+    ) -> Result<EventSinkRow, ApiError>
+    where
+        C: crate::traits::BackendContext + ?Sized;
 }
 
 impl SaveEventSinkRecord for NewEventSinkRow {
-    async fn save_event_sink_record(
+    async fn save_event_sink_record<C>(
         &self,
-        pool: &DbPool,
+        pool: &C,
         event_context: &EventContext,
-    ) -> Result<EventSinkRow, ApiError> {
+    ) -> Result<EventSinkRow, ApiError>
+    where
+        C: crate::traits::BackendContext + ?Sized,
+    {
+        let pool = crate::traits::backend_pool(pool);
         insert_event_sink_record(self, pool, Some(event_context)).await
     }
 
     #[cfg(any(test, feature = "integration-test-support"))]
-    async fn save_event_sink_record_without_events(
+    async fn save_event_sink_record_without_events<C>(
         &self,
-        pool: &DbPool,
-    ) -> Result<EventSinkRow, ApiError> {
+        pool: &C,
+    ) -> Result<EventSinkRow, ApiError>
+    where
+        C: crate::traits::BackendContext + ?Sized,
+    {
+        let pool = crate::traits::backend_pool(pool);
         insert_event_sink_record(self, pool, None).await
     }
 }
@@ -82,21 +94,27 @@ async fn insert_event_sink_record(
 }
 
 pub(crate) trait UpdateEventSinkRecord {
-    async fn update_event_sink_record(
+    async fn update_event_sink_record<C>(
         &self,
-        pool: &DbPool,
+        pool: &C,
         sink_id: i32,
         event_context: &EventContext,
-    ) -> Result<EventSinkRow, ApiError>;
+    ) -> Result<EventSinkRow, ApiError>
+    where
+        C: crate::traits::BackendContext + ?Sized;
 }
 
 impl UpdateEventSinkRecord for UpdateEventSinkRow {
-    async fn update_event_sink_record(
+    async fn update_event_sink_record<C>(
         &self,
-        pool: &DbPool,
+        pool: &C,
         sink_id: i32,
         event_context: &EventContext,
-    ) -> Result<EventSinkRow, ApiError> {
+    ) -> Result<EventSinkRow, ApiError>
+    where
+        C: crate::traits::BackendContext + ?Sized,
+    {
+        let pool = crate::traits::backend_pool(pool);
         update_event_sink_record_impl(self, pool, sink_id, Some(event_context)).await
     }
 }
@@ -142,19 +160,25 @@ async fn update_event_sink_record_impl(
 }
 
 pub(crate) trait DeleteEventSinkRecord {
-    async fn delete_event_sink_record(
+    async fn delete_event_sink_record<C>(
         &self,
-        pool: &DbPool,
+        pool: &C,
         event_context: &EventContext,
-    ) -> Result<(), ApiError>;
+    ) -> Result<(), ApiError>
+    where
+        C: crate::traits::BackendContext + ?Sized;
 }
 
 impl DeleteEventSinkRecord for EventSinkID {
-    async fn delete_event_sink_record(
+    async fn delete_event_sink_record<C>(
         &self,
-        pool: &DbPool,
+        pool: &C,
         event_context: &EventContext,
-    ) -> Result<(), ApiError> {
+    ) -> Result<(), ApiError>
+    where
+        C: crate::traits::BackendContext + ?Sized,
+    {
+        let pool = crate::traits::backend_pool(pool);
         delete_event_sink_record_impl(self, pool, Some(event_context)).await
     }
 }
@@ -210,7 +234,7 @@ impl LoadEventSubscriptionRecord for EventSubscriptionID {
 pub(crate) trait SaveEventSubscriptionRecord {
     async fn save_event_subscription_record(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         event_context: &EventContext,
     ) -> Result<EventSubscriptionRow, ApiError>;
 
@@ -224,9 +248,10 @@ pub(crate) trait SaveEventSubscriptionRecord {
 impl SaveEventSubscriptionRecord for NewEventSubscriptionRow {
     async fn save_event_subscription_record(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         event_context: &EventContext,
     ) -> Result<EventSubscriptionRow, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         insert_event_subscription_record(self, pool, Some(event_context)).await
     }
 
@@ -264,7 +289,7 @@ async fn insert_event_subscription_record(
 pub(crate) trait UpdateEventSubscriptionRecord {
     async fn update_event_subscription_record(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         subscription_id: i32,
         event_context: &EventContext,
     ) -> Result<EventSubscriptionRow, ApiError>;
@@ -273,10 +298,11 @@ pub(crate) trait UpdateEventSubscriptionRecord {
 impl UpdateEventSubscriptionRecord for UpdateEventSubscriptionRow {
     async fn update_event_subscription_record(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         subscription_id: i32,
         event_context: &EventContext,
     ) -> Result<EventSubscriptionRow, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         update_event_subscription_record_impl(self, pool, subscription_id, Some(event_context))
             .await
     }
@@ -328,7 +354,7 @@ async fn update_event_subscription_record_impl(
 pub(crate) trait DeleteEventSubscriptionRecord {
     async fn delete_event_subscription_record(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         event_context: &EventContext,
     ) -> Result<(), ApiError>;
 }
@@ -336,9 +362,10 @@ pub(crate) trait DeleteEventSubscriptionRecord {
 impl DeleteEventSubscriptionRecord for EventSubscriptionID {
     async fn delete_event_subscription_record(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         event_context: &EventContext,
     ) -> Result<(), ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         delete_event_subscription_record_impl(self, pool, Some(event_context)).await
     }
 }
@@ -478,11 +505,15 @@ pub(crate) async fn list_event_sink_rows_with_total_count(
     Ok((rows, total_count))
 }
 
-pub async fn enabled_event_sink_count(pool: &DbPool) -> Result<i64, ApiError> {
+pub async fn enabled_event_sink_count<C>(backend: &C) -> Result<i64, ApiError>
+where
+    C: crate::traits::BackendContext + ?Sized,
+{
     use diesel::dsl::count_star;
 
     use crate::schema::event_sinks::dsl::{enabled, event_sinks};
 
+    let pool = crate::traits::backend_pool(backend);
     with_connection(pool, async |conn| {
         event_sinks
             .filter(enabled.eq(true))
@@ -570,22 +601,31 @@ fn build_event_subscription_query(
 }
 
 impl EventSinkID {
-    pub async fn instance(&self, pool: &DbPool) -> Result<EventSink, ApiError> {
+    pub async fn instance(
+        &self,
+        pool: &impl crate::traits::BackendContext,
+    ) -> Result<EventSink, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         self.load_event_sink_record(pool).await?.try_into()
     }
 }
 
 impl EventSubscriptionID {
-    pub async fn instance(&self, pool: &DbPool) -> Result<EventSubscription, ApiError> {
+    pub async fn instance(
+        &self,
+        pool: &impl crate::traits::BackendContext,
+    ) -> Result<EventSubscription, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         self.load_event_subscription_record(pool).await?.try_into()
     }
 }
 
 impl EventSink {
     pub async fn list_with_total_count(
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: &QueryOptions,
     ) -> Result<(Vec<EventSink>, i64), ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let (rows, total) = list_event_sink_rows_with_total_count(pool, query_options).await?;
         let sinks = rows
             .into_iter()
@@ -597,10 +637,11 @@ impl EventSink {
 
 impl EventSubscription {
     pub async fn list_with_total_count(
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         collection_id: i32,
         query_options: &QueryOptions,
     ) -> Result<(Vec<EventSubscription>, i64), ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let (rows, total) =
             list_event_subscription_rows_with_total_count(pool, collection_id, query_options)
                 .await?;

--- a/src/db/traits/events.rs
+++ b/src/db/traits/events.rs
@@ -23,12 +23,13 @@ pub struct EventListFilters {
 }
 
 pub async fn list_events_with_total_count(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     accessible_collection_ids: &[i32],
     include_collection_less: bool,
     filters: &EventListFilters,
     query_options: &QueryOptions,
 ) -> Result<(Vec<EventResponse>, i64), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     crate::logger::log_operation_read(filters.entity_type, filters.action, filters.entity_id);
 
     let query = build_event_query(

--- a/src/db/traits/group.rs
+++ b/src/db/traits/group.rs
@@ -869,10 +869,11 @@ async fn load_principal_group(
 }
 
 pub async fn principal_group_by_ids(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     principal: i32,
     group: i32,
 ) -> Result<PrincipalGroup, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     with_connection(pool, async |conn| {
         load_principal_group(conn, principal, group).await
     })

--- a/src/db/traits/history.rs
+++ b/src/db/traits/history.rs
@@ -1,5 +1,5 @@
 use crate::db::prelude::*;
-use crate::db::{DbPool, with_connection};
+use crate::db::with_connection;
 use crate::errors::ApiError;
 use crate::events::PrincipalNames;
 use crate::models::search::QueryOptions;
@@ -15,9 +15,10 @@ pub enum HistoryCollectionFilter<'a> {
 /// Batch-resolve principal ids for provenance responses (anonymized users keep
 /// their tombstoned principal name; ids with no matching principal are absent).
 pub(crate) async fn resolve_principal_names(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     mut principal_ids: Vec<i32>,
 ) -> Result<PrincipalNames, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::principals::dsl::{id, name, principals};
     principal_ids.sort_unstable();
     principal_ids.dedup();
@@ -45,10 +46,11 @@ macro_rules! history_db_fns {
     ) => {
         pub async fn $paginate_fn(
             entity_id: i32,
-            pool: &$crate::db::DbPool,
+            pool: &impl $crate::traits::BackendContext,
             query_options: &$crate::models::search::QueryOptions,
             collection_filter: $crate::db::traits::history::HistoryCollectionFilter<'_>,
         ) -> Result<(Vec<$ty>, i64), $crate::errors::ApiError> {
+            let pool = $crate::traits::backend_pool(pool);
             use $crate::db::prelude::*;
             use $($schema)::+::dsl::*;
             let total = $crate::pagination::exact_count_or_skipped(query_options, async || {
@@ -109,8 +111,9 @@ macro_rules! history_db_fns {
         pub async fn $as_of_fn(
             entity_id: i32,
             at: chrono::DateTime<chrono::Utc>,
-            pool: &$crate::db::DbPool,
+            pool: &impl $crate::traits::BackendContext,
         ) -> Result<Option<$ty>, $crate::errors::ApiError> {
+            let pool = $crate::traits::backend_pool(pool);
             use $crate::db::prelude::*;
             use $($schema)::+::dsl::*;
             $crate::db::with_connection(pool, async |conn| {
@@ -164,10 +167,11 @@ history_db_fns!(
 pub async fn object_history_paginated_with_total_count(
     object_id: i32,
     class_id: i32,
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     query_options: &QueryOptions,
     collection_filter: HistoryCollectionFilter<'_>,
 ) -> Result<(Vec<crate::models::HubuumObjectHistory>, i64), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::hubuumobject_history::dsl as history;
 
     let total = crate::pagination::exact_count_or_skipped(query_options, async || {
@@ -231,8 +235,9 @@ pub async fn object_as_of(
     object_id: i32,
     class_id: i32,
     at: DateTime<Utc>,
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
 ) -> Result<Option<crate::models::HubuumObjectHistory>, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::hubuumobject_history::dsl as history;
 
     with_connection(pool, async |conn| {

--- a/src/db/traits/is_active.rs
+++ b/src/db/traits/is_active.rs
@@ -4,7 +4,7 @@ use tracing::warn;
 
 use crate::db::traits::Status;
 use crate::db::traits::active_tokens::{active_token_predicate, active_tokens_cutoff};
-use crate::db::{DbPool, with_connection_async};
+use crate::db::with_connection_async;
 use crate::errors::ApiError;
 use crate::models::{PrincipalToken, Token};
 
@@ -22,7 +22,11 @@ impl Status<PrincipalToken> for Token {
     /// `last_used_at` is advanced best-effort and only when stale (see
     /// [`LAST_USED_AT_THROTTLE_SECS`]); the telemetry write is intentionally
     /// decoupled from the validity check so the common case touches no rows.
-    async fn is_valid(&self, pool: &DbPool) -> Result<PrincipalToken, ApiError> {
+    async fn is_valid<C>(&self, backend: &C) -> Result<PrincipalToken, ApiError>
+    where
+        C: crate::traits::BackendContext + ?Sized,
+    {
+        let pool = crate::traits::backend_pool(backend);
         use crate::schema::service_accounts;
         use crate::schema::tokens::dsl::{
             id as token_id, last_used_at, principal_id, token, tokens,

--- a/src/db/traits/meta.rs
+++ b/src/db/traits/meta.rs
@@ -1,7 +1,7 @@
 use crate::db::prelude::*;
 use diesel::sql_types::{BigInt, Nullable, Timestamp};
 
-use crate::db::{DbPool, with_connection};
+use crate::db::with_connection;
 use crate::errors::ApiError;
 
 #[derive(QueryableByName, Debug)]
@@ -12,6 +12,26 @@ pub struct DatabaseState {
     pub db_size: i64,
     #[diesel(sql_type = Nullable<Timestamp>)]
     pub last_vacuum_time: Option<chrono::NaiveDateTime>,
+}
+
+#[derive(Debug)]
+pub struct DatabasePoolState {
+    pub max_connections: u32,
+    pub total_connections: u32,
+    pub available_connections: u32,
+    pub idle_connections: u32,
+    pub in_use_connections: u32,
+    pub pending_acquisitions: u64,
+    pub acquisitions_started: u64,
+    pub acquisitions_direct: u64,
+    pub acquisitions_waited: u64,
+    pub acquisitions_timed_out: u64,
+    pub acquisition_wait_time_ms: u64,
+    pub connections_created: u64,
+    pub connections_closed_broken: u64,
+    pub connections_closed_invalid: u64,
+    pub connections_closed_max_lifetime: u64,
+    pub connections_closed_idle_timeout: u64,
 }
 
 #[derive(QueryableByName, Debug)]
@@ -48,7 +68,10 @@ pub struct TaskQueueState {
     pub oldest_active_at: Option<chrono::NaiveDateTime>,
 }
 
-pub async fn load_database_state(pool: &DbPool) -> Result<DatabaseState, ApiError> {
+pub async fn load_database_state(
+    pool: &impl crate::traits::BackendContext,
+) -> Result<DatabaseState, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     const QUERY: &str = r#"
         SELECT
           (SELECT count(*) FROM pg_stat_activity WHERE state = 'active') AS active_connections,
@@ -68,7 +91,36 @@ pub async fn load_database_state(pool: &DbPool) -> Result<DatabaseState, ApiErro
     })
 }
 
-pub async fn load_task_queue_state(pool: &DbPool) -> Result<TaskQueueState, ApiError> {
+pub fn load_database_pool_state(backend: &impl crate::traits::BackendContext) -> DatabasePoolState {
+    let pool = crate::traits::backend_pool(backend);
+    let state = pool.state();
+    let max_connections = pool.config().max_size;
+    let in_use_connections = state.connections.saturating_sub(state.idle_connections);
+    DatabasePoolState {
+        max_connections,
+        total_connections: state.connections,
+        available_connections: max_connections.saturating_sub(in_use_connections),
+        idle_connections: state.idle_connections,
+        in_use_connections,
+        pending_acquisitions: state.statistics.pending_gets(),
+        acquisitions_started: state.statistics.get_started,
+        acquisitions_direct: state.statistics.get_direct,
+        acquisitions_waited: state.statistics.get_waited,
+        acquisitions_timed_out: state.statistics.get_timed_out,
+        acquisition_wait_time_ms: u64::try_from(state.statistics.get_wait_time.as_millis())
+            .unwrap_or(u64::MAX),
+        connections_created: state.statistics.connections_created,
+        connections_closed_broken: state.statistics.connections_closed_broken,
+        connections_closed_invalid: state.statistics.connections_closed_invalid,
+        connections_closed_max_lifetime: state.statistics.connections_closed_max_lifetime,
+        connections_closed_idle_timeout: state.statistics.connections_closed_idle_timeout,
+    }
+}
+
+pub async fn load_task_queue_state(
+    pool: &impl crate::traits::BackendContext,
+) -> Result<TaskQueueState, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     const QUERY: &str = r#"
         SELECT
           COUNT(*)::bigint AS total_tasks,

--- a/src/db/traits/metrics.rs
+++ b/src/db/traits/metrics.rs
@@ -106,11 +106,11 @@ where
     T: BackendContext + Sync + ?Sized,
 {
     async fn metrics_inventory_snapshot(&self) -> Result<InventoryMetricsSnapshot, ApiError> {
-        with_connection(self.db_pool(), load_inventory_counts).await
+        with_connection(crate::traits::backend_pool(self), load_inventory_counts).await
     }
 
     async fn metrics_task_snapshot(&self) -> Result<TaskMetricsSnapshot, ApiError> {
-        with_connection(self.db_pool(), async |conn| {
+        with_connection(crate::traits::backend_pool(self), async |conn| {
             let counts = load_task_count_rows(conn)
                 .await?
                 .into_iter()
@@ -146,7 +146,7 @@ where
     T: BackendContext + Sync + ?Sized,
 {
     async fn metrics_inventory_gauge_snapshot(&self) -> Result<InventoryGaugeSnapshot, ApiError> {
-        with_connection(self.db_pool(), async |conn| {
+        with_connection(crate::traits::backend_pool(self), async |conn| {
             let counts = load_inventory_counts(conn).await?;
             let export_templates = export_templates::table
                 .select((export_templates::id, export_templates::name))
@@ -171,7 +171,7 @@ where
     }
 
     async fn metrics_task_gauge_snapshot(&self) -> Result<TaskGaugeSnapshot, ApiError> {
-        with_connection(self.db_pool(), async |conn| {
+        with_connection(crate::traits::backend_pool(self), async |conn| {
             let counts = load_task_count_rows(conn)
                 .await?
                 .into_iter()

--- a/src/db/traits/mod.rs
+++ b/src/db/traits/mod.rs
@@ -62,7 +62,9 @@ pub trait Status<T> {
     ///
     /// Validity implies that the structure exists in the database and that it is not expired, disabled,
     /// or otherwise inactive.
-    async fn is_valid(&self, pool: &DbPool) -> Result<T, ApiError>;
+    async fn is_valid<C>(&self, backend: &C) -> Result<T, ApiError>
+    where
+        C: crate::traits::BackendContext + ?Sized;
 }
 
 /// Trait for getting all active tokens for a given structure.

--- a/src/db/traits/principal.rs
+++ b/src/db/traits/principal.rs
@@ -246,9 +246,10 @@ fn stored_principal_settings(
 /// Load a principal and, when it is human, its `users` row in one left-joined
 /// query. A service account simply has no `users` row, so the user is `None`.
 pub async fn load_principal_with_user(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     principal_id_value: i32,
 ) -> Result<(Principal, Option<User>), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::{principals, users};
 
     with_connection(pool, async |conn| {

--- a/src/db/traits/probe.rs
+++ b/src/db/traits/probe.rs
@@ -28,7 +28,7 @@ where
     T: BackendContext + Sync + ?Sized,
 {
     async fn readiness_snapshot(&self) -> Result<ReadinessSnapshot, ApiError> {
-        with_connection(self.db_pool(), async |conn| {
+        with_connection(crate::traits::backend_pool(self), async |conn| {
             use crate::schema::system_maintenance::dsl::{id, state, system_maintenance};
 
             let schema_ready = database_schema_is_ready(conn).await?;

--- a/src/db/traits/relations.rs
+++ b/src/db/traits/relations.rs
@@ -32,9 +32,10 @@ use super::{ObjectRelationsFromUser, Relations, SelfRelations};
 /// queries per relation that `AuthzTarget::to_resource_ref` would otherwise
 /// require on list paths.
 pub async fn class_relation_authorization_resources(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     relations: &[HubuumClassRelation],
 ) -> Result<Vec<ResourceRef>, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::hubuumclass::dsl::{hubuumclass, id};
 
     let class_ids = relations
@@ -135,9 +136,10 @@ async fn load_objects_by_id(
 /// Build Cedar authorization resources for object relations with one bulk
 /// object lookup, rather than issuing endpoint lookups for every row.
 pub async fn object_relation_authorization_resources(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     relations: &[HubuumObjectRelation],
 ) -> Result<Vec<ResourceRef>, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let object_ids = relations
         .iter()
         .flat_map(|relation| [relation.from_hubuum_object_id, relation.to_hubuum_object_id])
@@ -924,7 +926,7 @@ async fn load_class_relation_endpoint_records(
     Ok((from_class, to_class))
 }
 
-pub trait PrepareClassRelationRecord {
+pub(crate) trait PrepareClassRelationRecord {
     async fn prepare_class_relation_record(
         &self,
         pool: &DbPool,
@@ -950,7 +952,7 @@ impl PrepareClassRelationRecord for NewHubuumClassRelation {
     }
 }
 
-pub trait ResolveClassRelationTargetRecord {
+pub(crate) trait ResolveClassRelationTargetRecord {
     async fn resolve_class_relation_target_record(
         &self,
         pool: &DbPool,
@@ -1220,7 +1222,7 @@ impl SaveClassRelationRecord for NewHubuumClassRelation {
     }
 }
 
-pub trait CreatePreparedClassRelationRecord {
+pub(crate) trait CreatePreparedClassRelationRecord {
     async fn create_prepared_class_relation_record(
         &self,
         pool: &DbPool,
@@ -1281,7 +1283,7 @@ impl CreatePreparedClassRelationRecord for PreparedClassRelation {
     }
 }
 
-pub trait DeleteResolvedClassRelationRecord {
+pub(crate) trait DeleteResolvedClassRelationRecord {
     async fn delete_resolved_class_relation_record(
         &self,
         pool: &DbPool,
@@ -1420,7 +1422,7 @@ fn order_object_relation_endpoints(
     }
 }
 
-pub trait PrepareObjectRelationRecord {
+pub(crate) trait PrepareObjectRelationRecord {
     async fn prepare_object_relation_record(
         &self,
         pool: &DbPool,
@@ -1448,20 +1450,15 @@ impl PrepareObjectRelationRecord for ObjectRelationCreateSelector {
                 .await?;
                 PreparedObjectRelation::new(command, from_object, to_object, class_relation)
             }
-            ObjectRelationCreateSelectorKind::Between {
-                from_class_id,
-                from_object_id,
-                to_class_id,
-                to_object_id,
-            } => {
+            ObjectRelationCreateSelectorKind::Between { from, to } => {
                 let (route_from_object, route_to_object) = load_object_relation_endpoint_records(
                     conn,
-                    from_object_id.id(),
-                    to_object_id.id(),
+                    from.object_id().id(),
+                    to.object_id().id(),
                 )
                 .await?;
-                if route_from_object.hubuum_class_id != from_class_id.id()
-                    || route_to_object.hubuum_class_id != to_class_id.id()
+                if route_from_object.hubuum_class_id != from.class_id().id()
+                    || route_to_object.hubuum_class_id != to.class_id().id()
                 {
                     return Err(ApiError::NotFound(
                         "Object was not found in the selected class".to_string(),
@@ -1469,8 +1466,8 @@ impl PrepareObjectRelationRecord for ObjectRelationCreateSelector {
                 }
                 let class_relation = load_direct_class_relation_target_on_connection(
                     conn,
-                    from_class_id.id(),
-                    to_class_id.id(),
+                    from.class_id().id(),
+                    to.class_id().id(),
                 )
                 .await?;
                 let command = NewHubuumObjectRelation {
@@ -1488,7 +1485,7 @@ impl PrepareObjectRelationRecord for ObjectRelationCreateSelector {
     }
 }
 
-pub trait ResolveObjectRelationTargetRecord {
+pub(crate) trait ResolveObjectRelationTargetRecord {
     async fn resolve_object_relation_target_record(
         &self,
         pool: &DbPool,
@@ -1519,28 +1516,23 @@ impl ResolveObjectRelationTargetRecord for ObjectRelationSelector {
                     .await?;
                     (relation, from_object, to_object)
                 }
-                ObjectRelationSelectorKind::Between {
-                    from_class_id,
-                    from_object_id,
-                    to_class_id,
-                    to_object_id,
-                } => {
+                ObjectRelationSelectorKind::Between { from, to } => {
                     let (route_from_object, route_to_object) =
                         load_object_relation_endpoint_records(
                             conn,
-                            from_object_id.id(),
-                            to_object_id.id(),
+                            from.object_id().id(),
+                            to.object_id().id(),
                         )
                         .await?;
-                    if route_from_object.hubuum_class_id != from_class_id.id()
-                        || route_to_object.hubuum_class_id != to_class_id.id()
+                    if route_from_object.hubuum_class_id != from.class_id().id()
+                        || route_to_object.hubuum_class_id != to.class_id().id()
                     {
                         return Err(ApiError::NotFound(
                             "Object relation was not found for the selected classes".to_string(),
                         ));
                     }
-                    let lower_object_id = from_object_id.id().min(to_object_id.id());
-                    let higher_object_id = from_object_id.id().max(to_object_id.id());
+                    let lower_object_id = from.object_id().id().min(to.object_id().id());
+                    let higher_object_id = from.object_id().id().max(to.object_id().id());
                     let relation = hubuumobject_relation
                         .filter(from_hubuum_object_id.eq(lower_object_id))
                         .filter(to_hubuum_object_id.eq(higher_object_id))
@@ -1574,7 +1566,7 @@ fn object_relation_scope_matches(current: &HubuumObject, expected: &HubuumObject
         && current.hubuum_class_id == expected.hubuum_class_id
 }
 
-pub trait CreatePreparedObjectRelationRecord {
+pub(crate) trait CreatePreparedObjectRelationRecord {
     async fn create_prepared_object_relation_record(
         &self,
         pool: &DbPool,
@@ -1649,7 +1641,7 @@ impl CreatePreparedObjectRelationRecord for PreparedObjectRelation {
     }
 }
 
-pub trait DeleteResolvedObjectRelationRecord {
+pub(crate) trait DeleteResolvedObjectRelationRecord {
     async fn delete_resolved_object_relation_record(
         &self,
         pool: &DbPool,

--- a/src/db/traits/remote_target.rs
+++ b/src/db/traits/remote_target.rs
@@ -56,9 +56,10 @@ pub(crate) trait SaveRemoteTargetRecord {
 
     async fn save_remote_target_record(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         context: Option<&EventContext>,
     ) -> Result<RemoteTargetRow, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let _ = context;
         self.save_remote_target_record_without_events(pool).await
     }
@@ -82,9 +83,10 @@ impl SaveRemoteTargetRecord for NewRemoteTargetRow {
 
     async fn save_remote_target_record(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         context: Option<&EventContext>,
     ) -> Result<RemoteTargetRow, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let Some(context) = context else {
             return self.save_remote_target_record_without_events(pool).await;
         };
@@ -119,10 +121,11 @@ pub(crate) trait UpdateRemoteTargetRecord {
 
     async fn update_remote_target_record(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         target_id: i32,
         context: Option<&EventContext>,
     ) -> Result<RemoteTargetRow, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let _ = context;
         self.update_remote_target_record_without_events(pool, target_id)
             .await
@@ -153,10 +156,11 @@ impl UpdateRemoteTargetRecord for UpdateRemoteTargetRow {
 
     async fn update_remote_target_record(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         target_id: i32,
         context: Option<&EventContext>,
     ) -> Result<RemoteTargetRow, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let Some(context) = context else {
             return self
                 .update_remote_target_record_without_events(pool, target_id)
@@ -207,9 +211,10 @@ pub(crate) trait DeleteRemoteTargetRecord {
 
     async fn delete_remote_target_record(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         context: Option<&EventContext>,
     ) -> Result<(), ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let _ = context;
         self.delete_remote_target_record_without_events(pool).await
     }
@@ -233,9 +238,10 @@ impl DeleteRemoteTargetRecord for RemoteTargetID {
 
     async fn delete_remote_target_record(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         context: Option<&EventContext>,
     ) -> Result<(), ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let Some(context) = context else {
             return self.delete_remote_target_record_without_events(pool).await;
         };
@@ -266,13 +272,14 @@ impl DeleteRemoteTargetRecord for RemoteTargetID {
 }
 
 pub(crate) async fn emit_remote_target_invoked_event(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     target: &RemoteTarget,
     context: &EventContext,
     task_id: i32,
     subject_type: &str,
     subject_id: i32,
 ) -> Result<(), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     with_connection(pool, async |conn| -> Result<(), ApiError> {
         let event = NewEvent::new(
             EntityType::RemoteTarget,
@@ -389,17 +396,22 @@ pub async fn insert_remote_call_result(
 }
 
 impl RemoteTargetID {
-    pub async fn instance(&self, pool: &DbPool) -> Result<RemoteTarget, ApiError> {
+    pub async fn instance(
+        &self,
+        pool: &impl crate::traits::BackendContext,
+    ) -> Result<RemoteTarget, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         self.load_remote_target_record(pool).await?.try_into()
     }
 }
 
 impl RemoteTarget {
     pub async fn list_with_total_count(
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         allowed_collection_ids: &[i32],
         query_options: &QueryOptions,
     ) -> Result<(Vec<RemoteTarget>, i64), ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let (rows, total) =
             list_rows_with_total_count(pool, allowed_collection_ids, query_options).await?;
         let targets = rows

--- a/src/db/traits/service_account.rs
+++ b/src/db/traits/service_account.rs
@@ -90,10 +90,11 @@ where
                 .to_string(),
         ));
     }
-    let local_scope = identity_scope_by_name(backend.db_pool(), LOCAL_IDENTITY_SCOPE).await?;
+    let local_scope =
+        identity_scope_by_name(crate::traits::backend_pool(backend), LOCAL_IDENTITY_SCOPE).await?;
 
     with_transaction(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         async |conn| -> Result<ServiceAccount, ApiError> {
             let principal = NewPrincipal {
                 identity_scope_id: local_scope.id,
@@ -274,10 +275,11 @@ where
     C: BackendContext + ?Sized,
 {
     let sa_id = account_id.id();
-    let (disabled, cancelled_tasks) = with_transaction(backend.db_pool(), async |conn| {
-        disable_service_account_conn(conn, sa_id, event_context).await
-    })
-    .await?;
+    let (disabled, cancelled_tasks) =
+        with_transaction(crate::traits::backend_pool(backend), async |conn| {
+            disable_service_account_conn(conn, sa_id, event_context).await
+        })
+        .await?;
 
     record_cancelled_task_metrics(&cancelled_tasks);
     Ok(disabled)
@@ -419,10 +421,11 @@ fn service_account_snapshot(
 
 /// Is `principal_id` a **human** member of `owner_group_id`?
 pub async fn is_human_owner_group_member(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     principal_id: i32,
     owner_group_id: i32,
 ) -> Result<bool, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::group_memberships;
     use crate::schema::principals;
     use diesel::dsl::{exists, select};
@@ -443,7 +446,11 @@ pub async fn is_human_owner_group_member(
     .await
 }
 
-pub async fn principal_is_disabled(pool: &DbPool, principal: &Principal) -> Result<bool, ApiError> {
+pub async fn principal_is_disabled(
+    pool: &impl crate::traits::BackendContext,
+    principal: &Principal,
+) -> Result<bool, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     if !principal.is_service_account() {
         return Ok(false);
     }
@@ -526,9 +533,10 @@ pub async fn service_accounts_owned_by_group(
 }
 
 pub async fn load_service_account_by_id(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     service_account_id: i32,
 ) -> Result<ServiceAccount, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::service_accounts::dsl::{id, service_accounts as sa_table};
     with_connection(pool, async |conn| {
         sa_table
@@ -540,7 +548,7 @@ pub async fn load_service_account_by_id(
 }
 
 pub async fn search_manageable_service_accounts<S>(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     requestor: &S,
     is_admin: bool,
     query_options: QueryOptions,
@@ -548,6 +556,7 @@ pub async fn search_manageable_service_accounts<S>(
 where
     S: AuthzSubject + ?Sized,
 {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::identity_scopes;
     use crate::schema::principals;
     use crate::schema::service_accounts::dsl::{
@@ -616,7 +625,7 @@ where
 }
 
 pub async fn count_manageable_service_accounts<S>(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     requestor: &S,
     is_admin: bool,
     query_options: QueryOptions,
@@ -624,6 +633,7 @@ pub async fn count_manageable_service_accounts<S>(
 where
     S: AuthzSubject + ?Sized,
 {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::identity_scopes;
     use crate::schema::principals;
     use crate::schema::service_accounts::dsl::{

--- a/src/db/traits/task.rs
+++ b/src/db/traits/task.rs
@@ -343,7 +343,11 @@ impl<T: TaskIdentifier + ?Sized> TaskIdentifier for &T {
 /// `task.find_record(pool)` / `task.update_state(pool, ..)` rather than passing a bare id to a free
 /// function; all Diesel query construction stays here in the backend layer.
 pub trait TaskBackend: TaskIdentifier {
-    async fn find_record(&self, pool: &DbPool) -> Result<TaskRecord, ApiError> {
+    async fn find_record(
+        &self,
+        pool: &impl crate::traits::BackendContext,
+    ) -> Result<TaskRecord, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::tasks::dsl::{id, tasks};
 
         let task_id_value = self.task_id();
@@ -358,9 +362,10 @@ pub trait TaskBackend: TaskIdentifier {
 
     async fn list_events_with_total_count(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: &QueryOptions,
     ) -> Result<(Vec<TaskEventRecord>, i64), ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::events::dsl::{entity_id, entity_type, events, id};
 
         let task_id_value = self.task_id();
@@ -425,9 +430,10 @@ pub trait TaskBackend: TaskIdentifier {
 
     async fn list_import_results_with_total_count(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: &QueryOptions,
     ) -> Result<(Vec<ImportTaskResultRecord>, i64), ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::import_task_results::dsl::{id, import_task_results, task_id};
 
         let task_id_value = self.task_id();
@@ -487,8 +493,9 @@ pub trait TaskBackend: TaskIdentifier {
 
     async fn find_export_output(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
     ) -> Result<ExportOutputLookup<ExportTaskOutputRecord>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::export_task_outputs::dsl::{export_task_outputs, task_id};
 
         let task_id_value = self.task_id();
@@ -515,8 +522,9 @@ pub trait TaskBackend: TaskIdentifier {
 
     async fn find_export_output_summary(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
     ) -> Result<ExportOutputLookup<ExportTaskOutputSummaryRecord>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::export_task_outputs::dsl::{export_task_outputs, task_id};
 
         let task_id_value = self.task_id();
@@ -542,8 +550,9 @@ pub trait TaskBackend: TaskIdentifier {
 
     async fn find_backup_output(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
     ) -> Result<BackupOutputLookup<BackupTaskOutputRecord>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::backup_task_outputs::dsl::{backup_task_outputs, task_id};
 
         let task_id_value = self.task_id();
@@ -568,8 +577,9 @@ pub trait TaskBackend: TaskIdentifier {
 
     async fn find_backup_output_summary(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
     ) -> Result<BackupOutputLookup<BackupTaskOutputSummaryRecord>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::backup_task_outputs::dsl::{backup_task_outputs, task_id};
 
         let task_id_value = self.task_id();
@@ -813,11 +823,12 @@ pub trait TaskBackend: TaskIdentifier {
 
     async fn finalize_backup_with_output(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         update: TaskStateUpdate,
         event: NewTaskEventRecord,
         output: NewBackupTaskOutputRecord,
     ) -> Result<TaskRecord, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::backup_task_outputs::dsl::{
             backup_task_outputs, task_id as backup_output_task_id,
         };
@@ -960,12 +971,13 @@ fn build_task_query<'a>(
 }
 
 pub async fn list_tasks_with_total_count(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     submitted_by_filter: Option<i32>,
     kind_filter: Option<&str>,
     status_filter: Option<&str>,
     query_options: &QueryOptions,
 ) -> Result<(Vec<TaskRecord>, i64), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
         with_connection(pool, async |conn| {
             build_task_query(submitted_by_filter, kind_filter, status_filter)
@@ -990,9 +1002,10 @@ pub async fn list_tasks_with_total_count(
 /// Enrich one task-event page with legacy queued-event initiators and one
 /// batched principal-name lookup.
 pub(crate) async fn task_event_responses(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     mut records: Vec<TaskEventRecord>,
 ) -> Result<Vec<crate::models::TaskEventResponse>, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::events::dsl as stored;
 
     let legacy_task_ids = records
@@ -1045,9 +1058,10 @@ pub(crate) async fn task_event_responses(
 }
 
 pub async fn list_export_task_output_summaries(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     task_ids: &[i32],
 ) -> Result<Vec<ExportTaskOutputSummaryRecord>, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::export_task_outputs::dsl::{export_task_outputs, task_id};
 
     if task_ids.is_empty() {
@@ -1068,9 +1082,10 @@ pub async fn list_export_task_output_summaries(
 }
 
 pub async fn list_backup_task_output_summaries(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     task_ids: &[i32],
 ) -> Result<Vec<BackupTaskOutputSummaryRecord>, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::backup_task_outputs::dsl::{backup_task_outputs, task_id};
 
     if task_ids.is_empty() {
@@ -1324,9 +1339,10 @@ fn task_kind_claim_order(start: usize) -> [&'static str; TaskKind::ALL.len()] {
 }
 
 pub(crate) async fn claim_next_queued_task(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     lease_duration: TaskLeaseDuration,
 ) -> Result<Option<TaskRecord>, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     use crate::schema::tasks::dsl::{
         attempt_count, id, lease_expires_at, lease_token, started_at, status, tasks, updated_at,
     };
@@ -1594,9 +1610,10 @@ impl TaskCreateRequest {
     /// closes the race between concurrent requests carrying the same key.
     pub async fn create_idempotently_with_active_limit(
         self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         max_active_tasks: usize,
     ) -> Result<TaskRecord, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let kind = self.kind;
         let submitted_by = self.submitted_by;
         let idempotency_key = self.idempotency_key.clone();

--- a/src/db/traits/user/object_aggregate/mod.rs
+++ b/src/db/traits/user/object_aggregate/mod.rs
@@ -142,7 +142,7 @@ pub trait ObjectAggregateBackend: UserCollectionAccessors {
         );
 
         let execution = ObjectAggregateExecution {
-            pool: context.db_pool(),
+            pool: crate::traits::backend_pool(context),
             target: ObjectAggregateRouteTarget {
                 class_id: class_id.id(),
                 class_name,

--- a/src/db/traits/user/permissions.rs
+++ b/src/db/traits/user/permissions.rs
@@ -17,14 +17,15 @@ pub trait UserPermissions: AuthzSubject {
     /// ### Returns
     ///
     /// * Nothing if the subject has the required permissions, or an ApiError::Forbidden if they do not.
-    async fn can<P, N, I>(
+    async fn can<C, P, N, I>(
         &self,
-        pool: &DbPool,
+        backend: &C,
         permissions: P,
         collections: I,
         scopes: Option<&TokenScope>,
     ) -> Result<(), ApiError>
     where
+        C: crate::traits::BackendContext + ?Sized,
         P: IntoIterator<Item = Permissions>,
         I: IntoIterator<Item = N>,
         N: CollectionAccessors,
@@ -35,6 +36,7 @@ pub trait UserPermissions: AuthzSubject {
 
         let requested: Vec<Permissions> = permissions.into_iter().collect();
         let principal_id = self.principal_id();
+        let pool = crate::traits::backend_pool(backend);
 
         // Fail-closed scope pre-filter, before the admin bypass.
         if !scope_allows(scopes, &requested) {

--- a/src/db/traits/user/search.rs
+++ b/src/db/traits/user/search.rs
@@ -286,11 +286,12 @@ pub(crate) struct ExternalRelatedFilterAuthorization<'a> {
 
 impl<'a> ExternalRelatedFilterAuthorization<'a> {
     pub(crate) fn new(
-        pool: &'a DbPool,
+        pool: &'a impl crate::traits::BackendContext,
         permission_backend: &'a dyn PermissionBackend,
         principal: &'a PrincipalRef,
         scopes: Option<&'a TokenScope>,
     ) -> Self {
+        let pool = crate::traits::backend_pool(pool);
         Self {
             pool,
             permission_backend,
@@ -713,7 +714,7 @@ async fn externally_authorized_related_group_ids(
 
 pub(crate) async fn search_computed_objects_with_authorized_ids<U>(
     user: &U,
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     query_options: QueryOptions,
     snapshot: &ComputedQuerySnapshot,
     authorized_object_ids: &AuthorizedObjectIds,
@@ -721,6 +722,7 @@ pub(crate) async fn search_computed_objects_with_authorized_ids<U>(
 where
     U: UserSearchBackend + ?Sized,
 {
+    let pool = crate::traits::backend_pool(pool);
     let plan = ObjectQueryPlan::computed_for_authorized_objects(
         query_options,
         snapshot,
@@ -732,7 +734,7 @@ where
 
 pub(crate) async fn count_computed_objects_with_authorized_ids<U>(
     user: &U,
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     query_options: QueryOptions,
     snapshot: &ComputedQuerySnapshot,
     authorized_object_ids: &AuthorizedObjectIds,
@@ -740,6 +742,7 @@ pub(crate) async fn count_computed_objects_with_authorized_ids<U>(
 where
     U: UserSearchBackend + ?Sized,
 {
+    let pool = crate::traits::backend_pool(pool);
     let plan = ObjectQueryPlan::computed_for_authorized_objects(
         query_options,
         snapshot,
@@ -796,11 +799,12 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
     async fn search_collections_from_backend_with_admin_status(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: QueryOptions,
         is_admin: bool,
         scopes: Option<&TokenScope>,
     ) -> Result<Vec<Collection>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         // Fail-closed: a scoped token must carry the resource read permission.
         if !scope_allows(scopes, &[Permissions::ReadCollection]) {
             return Ok(Vec::new());
@@ -1029,11 +1033,12 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
     async fn search_classes_from_backend_with_admin_status(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: QueryOptions,
         is_admin: bool,
         scopes: Option<&TokenScope>,
     ) -> Result<Vec<HubuumClassExpanded>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::hubuumclass::dsl::{
             collection_id as class_collection_id, created_at as class_created_at,
             description as class_description, hubuumclass, id as class_id, name as class_name,
@@ -1240,10 +1245,11 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
     async fn search_objects_from_backend(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: QueryOptions,
         scopes: Option<&TokenScope>,
     ) -> Result<Vec<HubuumObject>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let is_admin = self.is_admin(pool).await?;
         self.search_objects_from_backend_with_admin_status(pool, query_options, is_admin, scopes)
             .await
@@ -1251,10 +1257,11 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
     async fn count_objects_from_backend(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: QueryOptions,
         scopes: Option<&TokenScope>,
     ) -> Result<i64, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let is_admin = self.is_admin(pool).await?;
         self.count_objects_from_backend_with_admin_status(pool, query_options, is_admin, scopes)
             .await
@@ -1262,11 +1269,12 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
     async fn search_objects_from_backend_with_admin_status(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: QueryOptions,
         is_admin: bool,
         scopes: Option<&TokenScope>,
     ) -> Result<Vec<HubuumObject>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let plan = ObjectQueryPlan::ordinary(query_options)?;
         self.search_objects_from_backend_with_query_plan(pool, plan, is_admin, scopes)
             .await
@@ -1274,11 +1282,12 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
     async fn search_objects_with_computed_query_from_backend(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: QueryOptions,
         scopes: Option<&TokenScope>,
         snapshot: &ComputedQuerySnapshot,
     ) -> Result<Vec<HubuumObject>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let is_admin = self.is_admin(pool).await?;
         let plan = ObjectQueryPlan::computed(query_options, snapshot);
         self.search_objects_from_backend_with_query_plan(pool, plan, is_admin, scopes)
@@ -1453,11 +1462,12 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
     async fn count_objects_with_computed_query_from_backend(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: QueryOptions,
         scopes: Option<&TokenScope>,
         snapshot: &ComputedQuerySnapshot,
     ) -> Result<i64, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let is_admin = self.is_admin(pool).await?;
         let plan = ObjectQueryPlan::computed(query_options, snapshot);
         self.count_objects_from_backend_with_query_plan(pool, plan, is_admin, scopes)
@@ -1608,11 +1618,12 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
     async fn search_class_relations_from_backend_with_admin_status(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: QueryOptions,
         is_admin: bool,
         scopes: Option<&TokenScope>,
     ) -> Result<Vec<HubuumClassRelation>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let (items, _) = self
             .class_relations_page_from_backend_with_admin_status(
                 pool,
@@ -1853,7 +1864,7 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
     async fn class_relations_touching_page_from_backend_with_admin_status<K>(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         class: K,
         query_options: QueryOptions,
         is_admin: bool,
@@ -1862,6 +1873,7 @@ pub trait UserSearchBackend: UserCollectionAccessors {
     where
         K: SelfAccessors<HubuumClass>,
     {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::hubuumclass::dsl::{
             collection_id as class_collection_id, hubuumclass, id as class_id,
         };
@@ -2315,11 +2327,12 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
     async fn search_object_relations_from_backend_with_admin_status(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: QueryOptions,
         is_admin: bool,
         scopes: Option<&TokenScope>,
     ) -> Result<Vec<HubuumObjectRelation>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let (items, _) = self
             .object_relations_page_from_backend_with_admin_status(
                 pool,
@@ -2495,7 +2508,7 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
     async fn object_relations_touching_page_from_backend_with_admin_status<O>(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         object: O,
         query_options: QueryOptions,
         is_admin: bool,
@@ -2504,6 +2517,7 @@ pub trait UserSearchBackend: UserCollectionAccessors {
     where
         O: SelfAccessors<HubuumObject>,
     {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::hubuumobject::dsl::{
             collection_id as object_collection_id, hubuumobject, id as object_id_column,
         };
@@ -4874,9 +4888,10 @@ impl<T: ?Sized> UserSearchBackend for T where T: UserCollectionAccessors {}
 impl User {
     pub async fn search_users(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: QueryOptions,
     ) -> Result<Vec<crate::models::UserWithName>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::identity_scopes;
         use crate::schema::principals;
         use crate::schema::users::dsl::{created_at, email, id, proper_name, updated_at, users};
@@ -4964,9 +4979,10 @@ impl User {
 
     pub async fn count_users(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: QueryOptions,
     ) -> Result<i64, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::identity_scopes;
         use crate::schema::principals;
         use crate::schema::users::dsl::{created_at, email, id, proper_name, updated_at, users};
@@ -5020,9 +5036,10 @@ impl User {
 
     pub async fn search_groups(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: QueryOptions,
     ) -> Result<Vec<Group>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::groups::dsl::{
             created_at, description, groupname, groups, id, revision, updated_at,
         };
@@ -5081,9 +5098,10 @@ impl User {
 
     pub async fn count_groups(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: QueryOptions,
     ) -> Result<i64, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         use crate::schema::groups::dsl::{
             created_at, description, groupname, groups, id, revision, updated_at,
         };

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,6 +11,7 @@ use std::num::ParseIntError;
 use tracing::{debug, error};
 
 use crate::observability::metrics;
+use crate::storage::{StorageError, StorageErrorKind};
 
 const PUBLIC_INTERNAL_ERROR: &str = "An internal error occurred";
 const PUBLIC_SERVICE_UNAVAILABLE: &str = "Service temporarily unavailable";
@@ -156,6 +157,24 @@ impl ApiError {
             | ApiError::OperatorMismatch(message)
             | ApiError::InvalidIntegerRange(message)
             | ApiError::ValidationError(message) => message,
+        }
+    }
+}
+
+impl From<StorageError> for ApiError {
+    fn from(error: StorageError) -> Self {
+        let (kind, message, current_etag) = error.into_parts();
+        match kind {
+            StorageErrorKind::BadRequest => Self::BadRequest(message),
+            StorageErrorKind::Conflict => Self::Conflict(message),
+            StorageErrorKind::Database => Self::DatabaseError(message),
+            StorageErrorKind::Internal => Self::InternalServerError(message),
+            StorageErrorKind::NotFound => Self::NotFound(message),
+            StorageErrorKind::NotAcceptable => Self::NotAcceptable(message),
+            StorageErrorKind::PayloadTooLarge => Self::PayloadTooLarge(message),
+            StorageErrorKind::PreconditionFailed => Self::PreconditionFailed(message, current_etag),
+            StorageErrorKind::Unavailable => Self::ServiceUnavailable(message),
+            StorageErrorKind::Validation => Self::ValidationError(message),
         }
     }
 }
@@ -428,6 +447,46 @@ mod tests {
 
         let generic_error = ApiError::InternalServerError("internal error".to_string());
         assert_eq!(generic_error.exit_code(), EXIT_CODE_GENERIC_ERROR);
+    }
+
+    #[test]
+    fn storage_errors_preserve_public_failure_categories() {
+        for (error, expected_class) in [
+            (
+                StorageError::new(StorageErrorKind::BadRequest, "invalid move", None),
+                "bad_request",
+            ),
+            (
+                StorageError::new(StorageErrorKind::Conflict, "collection has children", None),
+                "conflict",
+            ),
+            (
+                StorageError::new(StorageErrorKind::NotFound, "collection missing", None),
+                "not_found",
+            ),
+            (
+                StorageError::new(StorageErrorKind::Validation, "object schema mismatch", None),
+                "validation_error",
+            ),
+            (
+                StorageError::new(
+                    StorageErrorKind::PayloadTooLarge,
+                    "object data exceeds its limit",
+                    None,
+                ),
+                "payload_too_large",
+            ),
+            (
+                StorageError::new(
+                    StorageErrorKind::PreconditionFailed,
+                    "stale collection",
+                    Some("\"collection-1-r2\"".to_string()),
+                ),
+                "precondition_failed",
+            ),
+        ] {
+            assert_eq!(ApiError::from(error).class(), expected_class);
+        }
     }
 
     #[test]

--- a/src/events/delivery.rs
+++ b/src/events/delivery.rs
@@ -29,6 +29,7 @@ use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::{EventSink, EventSubscription, EventWorkerWakeupStats};
 use crate::observability::metrics;
 use crate::restores::MaintenanceActivityGuard;
+use crate::traits::{BackendContext, backend_pool};
 
 static EVENT_DELIVERY_WORKER: Once = Once::new();
 static EVENT_DELIVERY_LISTENER: Once = Once::new();
@@ -344,7 +345,11 @@ fn spawn_event_delivery_worker_loop(
     );
 }
 
-pub fn ensure_event_delivery_worker_running(pool: DbPool) {
+pub fn ensure_event_delivery_worker_running<C>(backend: C)
+where
+    C: BackendContext,
+{
+    let pool = backend_pool(&backend).clone();
     let worker_count = configured_event_delivery_worker_count();
     if worker_count == 0 {
         return;
@@ -387,8 +392,11 @@ pub fn ensure_event_delivery_worker_running(pool: DbPool) {
     });
 }
 
-pub fn kick_event_delivery_worker(pool: DbPool) {
-    ensure_event_delivery_worker_running(pool);
+pub fn kick_event_delivery_worker<C>(backend: C)
+where
+    C: BackendContext,
+{
+    ensure_event_delivery_worker_running(backend);
     EVENT_DELIVERY_NOTIFICATIONS_SENT.fetch_add(1, Ordering::Relaxed);
     metrics::event_worker_wakeup("delivery", "notifications_sent");
     get_event_delivery_notify().notify_one();

--- a/src/events/fanout.rs
+++ b/src/events/fanout.rs
@@ -18,6 +18,7 @@ use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::EventWorkerWakeupStats;
 use crate::observability::metrics;
 use crate::restores::MaintenanceActivityGuard;
+use crate::traits::{BackendContext, backend_pool};
 
 static EVENT_FANOUT_WORKER: Once = Once::new();
 static EVENT_FANOUT_LISTENER: Once = Once::new();
@@ -142,7 +143,11 @@ fn spawn_event_fanout_worker_loop(
     );
 }
 
-pub fn ensure_event_fanout_worker_running(pool: DbPool) {
+pub fn ensure_event_fanout_worker_running<C>(backend: C)
+where
+    C: BackendContext,
+{
+    let pool = backend_pool(&backend).clone();
     let worker_count = configured_event_fanout_worker_count();
     if worker_count == 0 {
         return;
@@ -179,8 +184,11 @@ pub fn ensure_event_fanout_worker_running(pool: DbPool) {
     });
 }
 
-pub fn kick_event_fanout_worker(pool: DbPool) {
-    ensure_event_fanout_worker_running(pool);
+pub fn kick_event_fanout_worker<C>(backend: C)
+where
+    C: BackendContext,
+{
+    ensure_event_fanout_worker_running(backend);
     EVENT_FANOUT_NOTIFICATIONS_SENT.fetch_add(1, Ordering::Relaxed);
     metrics::event_worker_wakeup("fanout", "notifications_sent");
     get_event_fanout_notify().notify_one();

--- a/src/events/retention.rs
+++ b/src/events/retention.rs
@@ -26,6 +26,7 @@ use crate::errors::ApiError;
 use crate::events::{Event, EventRetentionSettings};
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::restores::MaintenanceActivityGuard;
+use crate::traits::{BackendContext, backend_pool};
 
 static EVENT_RETENTION_WORKER: std::sync::Once = std::sync::Once::new();
 
@@ -157,7 +158,11 @@ fn spawn_event_retention_worker_loop(pool: DbPool, config: EventRetentionWorkerC
     });
 }
 
-pub fn ensure_event_retention_worker_running(pool: DbPool) {
+pub fn ensure_event_retention_worker_running<C>(backend: C)
+where
+    C: BackendContext,
+{
+    let pool = backend_pool(&backend).clone();
     if get_config().is_ok_and(|config| !config.runtime_role.runs_background_workers()) {
         return;
     }

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -480,11 +480,14 @@ where
         {
             ExportAuthorization::External {
                 backend: permission_backend,
-                principal: PrincipalRef::load(backend.db_pool(), subject).await?,
+                principal: PrincipalRef::load(crate::traits::backend_pool(backend), subject)
+                    .await?,
             }
         } else {
             ExportAuthorization::LocalSql {
-                is_admin: subject.is_admin(backend.db_pool()).await?,
+                is_admin: subject
+                    .is_admin(crate::traits::backend_pool(backend))
+                    .await?,
             }
         };
         Ok(Self {
@@ -496,7 +499,7 @@ where
     }
 
     fn pool(&self) -> &DbPool {
-        self.backend.db_pool()
+        crate::traits::backend_pool(self.backend)
     }
 
     fn external_backend(
@@ -974,10 +977,11 @@ impl ExportTaskSubmission {
 }
 
 pub(crate) async fn submit_export_task<S: AuthzSubject>(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     subject: &S,
     submission: ExportTaskSubmission,
 ) -> Result<TaskRecord, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let ExportTaskSubmission {
         export,
         template,
@@ -1106,7 +1110,7 @@ pub(crate) async fn execute_export_task<C>(
 where
     C: BackendContext + ?Sized,
 {
-    let pool = backend.db_pool();
+    let pool = crate::traits::backend_pool(backend);
     let payload = task
         .request_payload
         .clone()

--- a/src/extractors/mod.rs
+++ b/src/extractors/mod.rs
@@ -1,7 +1,6 @@
-use crate::db::DbPool;
-use crate::db::traits::Status;
-use crate::db::traits::authz::{AuthzSubject, load_token_scope};
-use crate::db::traits::principal::load_principal_with_user;
+use crate::backend::capabilities::Status;
+use crate::backend::capabilities::authz::load_token_scope;
+use crate::backend::capabilities::principal::load_principal_with_user;
 use crate::errors::ApiError;
 use crate::events::{EventContext, RequestProvenance};
 use crate::models::principal::{Principal, load_principal_by_id};
@@ -12,12 +11,10 @@ use crate::models::{
     PrincipalSettings, PrincipalSettingsPatch, PrincipalSettingsPatchDocument, TokenScope,
 };
 use crate::permissions::{AppContext, PrincipalRef};
+use crate::traits::BackendContext;
 
 use actix_web::{
-    FromRequest, HttpMessage, HttpRequest,
-    dev::Payload,
-    error::JsonPayloadError,
-    web::{Data, JsonBody},
+    FromRequest, HttpMessage, HttpRequest, dev::Payload, error::JsonPayloadError, web::JsonBody,
 };
 use futures_util::future::{self, FutureExt};
 use std::pin::Pin;
@@ -277,42 +274,32 @@ fn extract_token(req: &HttpRequest) -> Result<Token, ApiError> {
         .ok_or_else(|| ApiError::Unauthorized("No token provided".to_string()))
 }
 
-fn pool_from_req(req: &HttpRequest) -> Result<Data<DbPool>, ApiError> {
-    req.app_data::<Data<DbPool>>()
-        .cloned()
-        .ok_or_else(|| ApiError::InternalServerError("Pool not found".to_string()))
+fn backend_from_req(req: &HttpRequest) -> Result<AppContext, ApiError> {
+    AppContext::from_http_request(req)
 }
 
-fn permission_context_from_req(req: &HttpRequest) -> Option<Data<AppContext>> {
-    req.app_data::<Data<AppContext>>().cloned()
-}
-
-async fn selected_backend_is_admin(
-    context: Option<&AppContext>,
-    pool: &DbPool,
-    user: &User,
-) -> Result<bool, ApiError> {
-    let Some(context) = context else {
-        return user.is_admin(pool).await;
-    };
-    let principal = PrincipalRef::load(pool, user).await?;
+async fn selected_backend_is_admin(context: &AppContext, user: &User) -> Result<bool, ApiError> {
+    let principal = PrincipalRef::load(context, user).await?;
     context.permission_backend().is_admin(&principal).await
 }
 
 /// Build the full authenticated context (accepts scoped tokens).
-async fn build_authenticated(pool: &DbPool, token: Token) -> Result<Authenticated, ApiError> {
-    let token_meta = token.is_valid(pool).await?;
-    build_authenticated_from_meta(pool, token, token_meta).await
+async fn build_authenticated(
+    backend: &impl BackendContext,
+    token: Token,
+) -> Result<Authenticated, ApiError> {
+    let token_meta = token.is_valid(backend).await?;
+    build_authenticated_from_meta(backend, token, token_meta).await
 }
 
 async fn build_authenticated_from_meta(
-    pool: &DbPool,
+    backend: &impl BackendContext,
     token: Token,
     token_meta: PrincipalToken,
 ) -> Result<Authenticated, ApiError> {
-    crate::auth::refresh_principal_if_needed(pool, token_meta.principal_id).await?;
-    let principal = load_principal_by_id(pool, token_meta.principal_id).await?;
-    let scope = load_token_scope(pool, &token_meta).await?;
+    crate::auth::refresh_principal_if_needed(backend, token_meta.principal_id).await?;
+    let principal = load_principal_by_id(backend, token_meta.principal_id).await?;
+    let scope = load_token_scope(backend, &token_meta).await?;
     Ok(Authenticated {
         token,
         token_meta,
@@ -338,7 +325,7 @@ fn resolved_auth(req: &HttpRequest, token: &Token) -> Option<PrincipalToken> {
 /// decision, so a service account (even one in the admin group, even with an
 /// unscoped token) can never act through a human/IAM extractor.
 async fn human_unscoped_user_from_meta(
-    pool: &DbPool,
+    backend: &impl BackendContext,
     token_meta: PrincipalToken,
 ) -> Result<User, ApiError> {
     if token_meta.is_scoped() {
@@ -347,11 +334,11 @@ async fn human_unscoped_user_from_meta(
         ));
     }
 
-    crate::auth::refresh_principal_if_needed(pool, token_meta.principal_id).await?;
+    crate::auth::refresh_principal_if_needed(backend, token_meta.principal_id).await?;
 
     // Single round trip: fetch the principal and (when human) its `users` row
     // together, rather than a separate principal load followed by a user load.
-    let (principal, user) = load_principal_with_user(pool, token_meta.principal_id).await?;
+    let (principal, user) = load_principal_with_user(backend, token_meta.principal_id).await?;
     if !principal.is_human() {
         return Err(ApiError::Forbidden(
             "Service accounts cannot use human/management endpoints".to_string(),
@@ -361,9 +348,12 @@ async fn human_unscoped_user_from_meta(
     user.ok_or_else(|| ApiError::Unauthorized("Invalid token".to_string()))
 }
 
-async fn human_unscoped_user(pool: &DbPool, token: &Token) -> Result<User, ApiError> {
-    let token_meta = token.is_valid(pool).await?;
-    human_unscoped_user_from_meta(pool, token_meta).await
+async fn human_unscoped_user(
+    backend: &impl BackendContext,
+    token: &Token,
+) -> Result<User, ApiError> {
+    let token_meta = token.is_valid(backend).await?;
+    human_unscoped_user_from_meta(backend, token_meta).await
 }
 
 /// Resolve the self-target principal id from the path (`principal_id` preferred,
@@ -382,18 +372,20 @@ impl FromRequest for Authenticated {
     type Future = Pin<Box<dyn future::Future<Output = Result<Self, Self::Error>>>>;
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
-        let pool = pool_from_req(req);
+        let backend = backend_from_req(req);
         let token_result = extract_token(req);
         let token_meta = token_result
             .as_ref()
             .ok()
             .and_then(|token| resolved_auth(req, token));
         async move {
-            let pool = pool?;
+            let backend = backend?;
             let token = token_result?;
             match token_meta {
-                Some(token_meta) => build_authenticated_from_meta(&pool, token, token_meta).await,
-                None => build_authenticated(&pool, token).await,
+                Some(token_meta) => {
+                    build_authenticated_from_meta(&backend, token, token_meta).await
+                }
+                None => build_authenticated(&backend, token).await,
             }
         }
         .boxed_local()
@@ -405,18 +397,18 @@ impl FromRequest for UserAccess {
     type Future = Pin<Box<dyn future::Future<Output = Result<Self, Self::Error>>>>;
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
-        let pool = pool_from_req(req);
+        let backend = backend_from_req(req);
         let token_result = extract_token(req);
         let token_meta = token_result
             .as_ref()
             .ok()
             .and_then(|token| resolved_auth(req, token));
         async move {
-            let pool = pool?;
+            let backend = backend?;
             let token = token_result?;
             let user = match token_meta {
-                Some(token_meta) => human_unscoped_user_from_meta(&pool, token_meta).await?,
-                None => human_unscoped_user(&pool, &token).await?,
+                Some(token_meta) => human_unscoped_user_from_meta(&backend, token_meta).await?,
+                None => human_unscoped_user(&backend, &token).await?,
             };
             Ok(UserAccess { user })
         }
@@ -429,18 +421,18 @@ impl FromRequest for ManagementAccess {
     type Future = Pin<Box<dyn future::Future<Output = Result<Self, Self::Error>>>>;
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
-        let pool = pool_from_req(req);
+        let backend = backend_from_req(req);
         let token_result = extract_token(req);
         let token_meta = token_result
             .as_ref()
             .ok()
             .and_then(|token| resolved_auth(req, token));
         async move {
-            let pool = pool?;
+            let backend = backend?;
             let token = token_result?;
             let user = match token_meta {
-                Some(token_meta) => human_unscoped_user_from_meta(&pool, token_meta).await?,
-                None => human_unscoped_user(&pool, &token).await?,
+                Some(token_meta) => human_unscoped_user_from_meta(&backend, token_meta).await?,
+                None => human_unscoped_user(&backend, &token).await?,
             };
             Ok(ManagementAccess { user })
         }
@@ -453,28 +445,21 @@ impl FromRequest for AdminAccess {
     type Future = Pin<Box<dyn future::Future<Output = Result<Self, Self::Error>>>>;
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
-        let pool = pool_from_req(req);
-        let permission_context = permission_context_from_req(req);
+        let backend = backend_from_req(req);
         let token_result = extract_token(req);
         let token_meta = token_result
             .as_ref()
             .ok()
             .and_then(|token| resolved_auth(req, token));
         async move {
-            let pool = pool?;
+            let backend = backend?;
             let token = token_result?;
             let user = match token_meta {
-                Some(token_meta) => human_unscoped_user_from_meta(&pool, token_meta).await?,
-                None => human_unscoped_user(&pool, &token).await?,
+                Some(token_meta) => human_unscoped_user_from_meta(&backend, token_meta).await?,
+                None => human_unscoped_user(&backend, &token).await?,
             };
 
-            if selected_backend_is_admin(
-                permission_context.as_ref().map(|context| context.get_ref()),
-                &pool,
-                &user,
-            )
-            .await?
-            {
+            if selected_backend_is_admin(&backend, &user).await? {
                 Ok(AdminAccess { user })
             } else {
                 Err(ApiError::Forbidden("Permission denied".to_string()))
@@ -489,8 +474,7 @@ impl FromRequest for AdminOrSelfAccess {
     type Future = Pin<Box<dyn future::Future<Output = Result<Self, Self::Error>>>>;
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
-        let pool = pool_from_req(req);
-        let permission_context = permission_context_from_req(req);
+        let backend = backend_from_req(req);
         let token_result = extract_token(req);
         let token_meta = token_result
             .as_ref()
@@ -499,22 +483,15 @@ impl FromRequest for AdminOrSelfAccess {
         let path_info = req.match_info().clone();
 
         async move {
-            let pool = pool?;
+            let backend = backend?;
             let token = token_result?;
             let user = match token_meta {
-                Some(token_meta) => human_unscoped_user_from_meta(&pool, token_meta).await?,
-                None => human_unscoped_user(&pool, &token).await?,
+                Some(token_meta) => human_unscoped_user_from_meta(&backend, token_meta).await?,
+                None => human_unscoped_user(&backend, &token).await?,
             };
             let target_id = self_target_id(&path_info)?;
 
-            if selected_backend_is_admin(
-                permission_context.as_ref().map(|context| context.get_ref()),
-                &pool,
-                &user,
-            )
-            .await?
-                || user.id == target_id
-            {
+            if selected_backend_is_admin(&backend, &user).await? || user.id == target_id {
                 Ok(AdminOrSelfAccess { user })
             } else {
                 debug! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 mod administration;
 mod application;
+mod backend;
 
 pub use administration::run_admin_from_environment;
 pub use application::run_runtime_from_environment;
@@ -35,7 +36,7 @@ pub mod permissions;
 pub mod restores;
 pub mod schema;
 pub mod services;
-pub mod storage;
+mod storage;
 pub mod tasks;
 #[cfg(feature = "integration-test-support")]
 #[doc(hidden)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -86,22 +86,21 @@ macro_rules! can {
         #[allow(unused_imports)]
         use $crate::permissions::AuthzTarget as _;
         #[allow(unused_imports)]
-        use $crate::traits::BackendContext as _;
-        #[allow(unused_imports)]
         use $crate::traits::CollectionAccessors as _;
 
+        let backend = &$pool;
         let resources = vec![
-            $($collection.to_resource_ref($pool.db_pool()).await?),+
+            $($collection.to_resource_ref(backend).await?),+
         ];
         if !$crate::db::traits::authz::scope_allows_resources($scopes, &resources) {
             return Err($crate::errors::ApiError::Forbidden("Permission denied".to_string()));
         }
 
-        match $crate::traits::BackendContext::permission_backend($pool) {
+        match $crate::traits::BackendContext::permission_backend(backend) {
             Some(permission_backend) if !permission_backend.uses_sql_permission_store() => {
                 $crate::permissions::authorize_resources(
                     permission_backend,
-                    $pool.db_pool(),
+                    backend,
                     $subject,
                     $scopes,
                     vec![$($perm),+],
@@ -110,10 +109,10 @@ macro_rules! can {
             }
             _ => {
                 $subject.can(
-                    $pool.db_pool(),
+                    backend,
                     vec![$($perm),+],
                     vec![
-                        $($collection.collection_id($pool.db_pool()).await?),+
+                        $($collection.collection_id(backend).await?),+
                     ],
                     $scopes,
                 ).await?

--- a/src/middlewares/actor_context.rs
+++ b/src/middlewares/actor_context.rs
@@ -1,14 +1,14 @@
 use actix_web::body::{BoxBody, MessageBody};
 use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::middleware::Next;
-use actix_web::web::Data;
 use actix_web::{Error, HttpMessage};
 
-use crate::db::traits::Status;
-use crate::db::{DbPool, with_mutation_provenance_scope};
+use crate::backend::capabilities::Status;
+use crate::backend::with_mutation_provenance_scope;
 use crate::events::MutationProvenance;
 use crate::middlewares::tracing::record_principal_on_current_span;
 use crate::models::token::{PrincipalToken, Token};
+use crate::permissions::AppContext;
 
 /// Outcome of resolving the bearer token once per request. Stored in request
 /// extensions and consumed by the auth extractors so they never re-query.
@@ -40,11 +40,11 @@ async fn resolve_auth(req: &ServiceRequest) -> ResolvedAuth {
         Some(token) => token,
         None => return ResolvedAuth::Missing,
     };
-    let pool = match req.app_data::<Data<DbPool>>() {
-        Some(pool) => pool.clone(),
-        None => return ResolvedAuth::Invalid,
+    let backend = match AppContext::from_http_request(req.request()) {
+        Ok(backend) => backend,
+        Err(_) => return ResolvedAuth::Invalid,
     };
-    match token.is_valid(&pool).await {
+    match token.is_valid(&backend).await {
         Ok(token_meta) => ResolvedAuth::Authenticated { token, token_meta },
         Err(_) => ResolvedAuth::Invalid,
     }

--- a/src/middlewares/maintenance.rs
+++ b/src/middlewares/maintenance.rs
@@ -4,10 +4,11 @@ use actix_web::middleware::Next;
 use actix_web::web::Data;
 use actix_web::{Error, ResponseError};
 
+use crate::backend::{DbCallSite, with_db_call_site};
 use crate::config::DEFAULT_METRICS_PATH;
 use crate::config::running::RunningConfig;
-use crate::db::{DbCallSite, DbPool, with_db_call_site};
 use crate::errors::ApiError;
+use crate::permissions::AppContext;
 use crate::restores::{MaintenanceActivityGuard, current_maintenance_state};
 
 fn allowed_during_maintenance(path: &str, metrics_path: Option<&str>) -> bool {
@@ -37,12 +38,10 @@ pub async fn reject_during_maintenance(
             // cannot wait on itself. Its transactional state transition and
             // advisory lock serialize concurrent confirmations.
             let _activity = (!initiates_restore(req.path())).then(MaintenanceActivityGuard::begin);
-            let pool = req.app_data::<Data<DbPool>>().cloned().ok_or_else(|| {
-                ApiError::InternalServerError("Database pool is unavailable".to_string())
-            })?;
+            let backend = AppContext::from_http_request(req.request())?;
             let state = with_db_call_site(
                 DbCallSite::RequestMaintenance,
-                current_maintenance_state(&pool),
+                current_maintenance_state(&backend),
             )
             .await?;
             if !state.is_normal() {

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -3,7 +3,6 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::db::DbPool;
 use crate::db::traits::class::total_class_count_from_backend;
 use crate::errors::ApiError;
 use crate::models::ResourceRevision;
@@ -233,7 +232,7 @@ pub async fn total_class_count<C>(backend: &C) -> Result<i64, ApiError>
 where
     C: BackendContext + ?Sized,
 {
-    total_class_count_from_backend(backend.db_pool()).await
+    total_class_count_from_backend(crate::traits::backend_pool(backend)).await
 }
 
 fn new_hubuum_class_example() -> NewHubuumClass {
@@ -282,14 +281,20 @@ crate::impl_history_pagination!(HubuumClassHistory, "hubuumclass_history");
 
 #[async_trait]
 impl AuthzTarget for HubuumClass {
-    async fn to_resource_ref(&self, _pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        _pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         Ok(self.authorization_resource())
     }
 }
 
 #[async_trait]
 impl AuthzTarget for HubuumClassID {
-    async fn to_resource_ref(&self, pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         self.instance(pool).await?.to_resource_ref(pool).await
     }
 }

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::db::DbPool;
 use crate::db::traits::authz::AuthzSubject;
 use crate::db::traits::collection as collection_backend;
 use crate::errors::ApiError;
@@ -118,7 +117,8 @@ pub async fn total_collection_count<C>(backend: &C) -> Result<i64, ApiError>
 where
     C: BackendContext + ?Sized,
 {
-    collection_backend::total_collection_count_from_backend(backend.db_pool()).await
+    collection_backend::total_collection_count_from_backend(crate::traits::backend_pool(backend))
+        .await
 }
 
 /// Check what permissions a user has to a given collection
@@ -141,8 +141,12 @@ where
     S: AuthzSubject,
     T: CollectionAccessors,
 {
-    collection_backend::principal_on_from_backend(backend.db_pool(), principal, collection_ref)
-        .await
+    collection_backend::principal_on_from_backend(
+        crate::traits::backend_pool(backend),
+        principal,
+        collection_ref,
+    )
+    .await
 }
 
 /// All of a principal's direct permission rows across every collection, as
@@ -155,7 +159,11 @@ where
     C: BackendContext + ?Sized,
     S: AuthzSubject,
 {
-    collection_backend::principal_all_permissions_from_backend(backend.db_pool(), principal).await
+    collection_backend::principal_all_permissions_from_backend(
+        crate::traits::backend_pool(backend),
+        principal,
+    )
+    .await
 }
 
 pub async fn principal_on_paginated_with_total_count<C, S, T>(
@@ -170,7 +178,7 @@ where
     T: CollectionAccessors,
 {
     collection_backend::principal_on_paginated_with_total_count_from_backend(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         principal,
         collection_ref,
         query_options,
@@ -189,7 +197,7 @@ where
     T: CollectionAccessors,
 {
     collection_backend::effective_principal_on_from_backend(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         principal,
         collection_ref,
     )
@@ -218,7 +226,7 @@ where
     U: GroupAccessors + AuthzSubject,
 {
     collection_backend::user_can_on_any_from_backend(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         user_id,
         permission_type,
         scopes,
@@ -248,7 +256,7 @@ where
     T: CollectionAccessors,
 {
     collection_backend::group_can_on_from_backend(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         gid,
         collection_ref,
         permission_type,
@@ -265,7 +273,7 @@ where
     C: BackendContext + ?Sized,
 {
     collection_backend::effective_group_on_from_backend(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         target_collection_id,
         gid,
     )
@@ -291,7 +299,7 @@ where
     C: BackendContext + ?Sized,
 {
     collection_backend::groups_can_on_from_backend(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         target_collection_id,
         permission_type,
     )
@@ -308,7 +316,7 @@ where
     C: BackendContext + ?Sized,
 {
     collection_backend::groups_can_on_paginated_with_total_count_from_backend(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         target_collection_id,
         permission_type,
         query_options,
@@ -336,7 +344,7 @@ where
     T: CollectionAccessors,
 {
     collection_backend::groups_on_from_backend(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         collection_ref,
         permissions_filter,
         query_options,
@@ -355,7 +363,7 @@ where
     T: CollectionAccessors,
 {
     collection_backend::groups_on_paginated_from_backend(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         collection_ref,
         permissions_filter,
         query_options,
@@ -374,7 +382,7 @@ where
     T: CollectionAccessors,
 {
     collection_backend::groups_on_paginated_with_total_count_from_backend(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         collection_ref,
         permissions_filter,
         query_options,
@@ -393,7 +401,7 @@ where
     T: CollectionAccessors,
 {
     collection_backend::count_groups_on_paginated_from_backend(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         collection_ref,
         permissions_filter,
         query_options,
@@ -410,7 +418,12 @@ pub async fn group_on<C>(
 where
     C: BackendContext + ?Sized,
 {
-    collection_backend::group_on_from_backend(backend.db_pool(), target_collection_id, gid).await
+    collection_backend::group_on_from_backend(
+        crate::traits::backend_pool(backend),
+        target_collection_id,
+        gid,
+    )
+    .await
 }
 
 pub async fn collection_children<C, T>(
@@ -421,7 +434,11 @@ where
     C: BackendContext + ?Sized,
     T: CollectionAccessors,
 {
-    collection_backend::collection_children_from_backend(backend.db_pool(), collection_ref).await
+    collection_backend::collection_children_from_backend(
+        crate::traits::backend_pool(backend),
+        collection_ref,
+    )
+    .await
 }
 
 pub async fn collection_ancestors<C, T>(
@@ -432,7 +449,11 @@ where
     C: BackendContext + ?Sized,
     T: CollectionAccessors,
 {
-    collection_backend::collection_ancestors_from_backend(backend.db_pool(), collection_ref).await
+    collection_backend::collection_ancestors_from_backend(
+        crate::traits::backend_pool(backend),
+        collection_ref,
+    )
+    .await
 }
 
 pub async fn move_collection<C>(
@@ -445,7 +466,7 @@ where
     C: BackendContext + ?Sized,
 {
     collection_backend::move_collection_record_from_backend(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         collection_id,
         new_parent_collection_id,
         context,
@@ -477,7 +498,10 @@ crate::impl_history_pagination!(CollectionHistory, "collections_history");
 
 #[async_trait]
 impl AuthzTarget for Collection {
-    async fn to_resource_ref(&self, _pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        _pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         Ok(ResourceRef {
             kind: ResourceKind::Collection,
             id: self.id,
@@ -492,7 +516,10 @@ impl AuthzTarget for Collection {
 
 #[async_trait]
 impl AuthzTarget for CollectionID {
-    async fn to_resource_ref(&self, pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         self.instance(pool).await?.to_resource_ref(pool).await
     }
 }

--- a/src/models/export_template.rs
+++ b/src/models/export_template.rs
@@ -483,10 +483,11 @@ impl ExportTemplate {
     /// List export templates (sorted/paginated per `query_options`) together with the total count
     /// matching the filters, scoped to the collections the caller may see.
     pub async fn list_with_total_count(
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         allowed_collection_ids: &[i32],
         query_options: &QueryOptions,
     ) -> Result<(Vec<ExportTemplate>, i64), ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         if allowed_collection_ids.is_empty() {
             return Ok((
                 Vec::new(),
@@ -510,9 +511,10 @@ impl ExportTemplate {
     /// External authorization backends use this before filtering the rows
     /// against their own policy decisions.
     pub async fn list_candidates(
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         query_options: &QueryOptions,
     ) -> Result<Vec<ExportTemplate>, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         let (rows, _) = backend::list_all_rows_with_total_count(pool, query_options).await?;
         rows.into_iter().map(TryInto::try_into).collect()
     }
@@ -538,7 +540,7 @@ pub trait CollectionExportTemplates: CollectionAccessors {
     {
         let collection_id = self.collection_id(backend).await?.id();
         let rows = crate::db::traits::export_template::load_rows_in_collection(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             collection_id,
             exclude_template_id,
         )
@@ -1339,7 +1341,10 @@ crate::impl_history_pagination!(ExportTemplateHistory, "export_templates_history
 
 #[async_trait]
 impl AuthzTarget for ExportTemplate {
-    async fn to_resource_ref(&self, _pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        _pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         Ok(ResourceRef {
             kind: ResourceKind::Template,
             id: self.id,
@@ -1354,7 +1359,10 @@ impl AuthzTarget for ExportTemplate {
 
 #[async_trait]
 impl AuthzTarget for ExportTemplateID {
-    async fn to_resource_ref(&self, pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         self.instance(pool).await?.to_resource_ref(pool).await
     }
 }

--- a/src/models/group.rs
+++ b/src/models/group.rs
@@ -47,7 +47,8 @@ impl GroupID {
     where
         C: BackendContext + ?Sized,
     {
-        self.load_group_record(backend.db_pool()).await
+        self.load_group_record(crate::traits::backend_pool(backend))
+            .await
     }
 
     /// Delete this group without emitting domain events.
@@ -59,7 +60,7 @@ impl GroupID {
     where
         C: BackendContext + ?Sized,
     {
-        self.delete_group_record_without_events(backend.db_pool())
+        self.delete_group_record_without_events(crate::traits::backend_pool(backend))
             .await
     }
 
@@ -71,7 +72,8 @@ impl GroupID {
     where
         C: BackendContext + ?Sized,
     {
-        self.delete_group_record(backend.db_pool(), context).await
+        self.delete_group_record(crate::traits::backend_pool(backend), context)
+            .await
     }
 }
 
@@ -177,9 +179,11 @@ impl GroupResponse {
             .iter()
             .map(|group| group.identity_scope_id)
             .collect::<Vec<_>>();
-        let scope_names =
-            crate::db::traits::identity::identity_scope_names_by_ids(backend.db_pool(), &scope_ids)
-                .await?;
+        let scope_names = crate::db::traits::identity::identity_scope_names_by_ids(
+            crate::traits::backend_pool(backend),
+            &scope_ids,
+        )
+        .await?;
 
         groups
             .into_iter()
@@ -249,7 +253,8 @@ impl Group {
     where
         C: BackendContext + ?Sized,
     {
-        let identity_scope = group_identity_scope_name(backend.db_pool(), self.id).await?;
+        let identity_scope =
+            group_identity_scope_name(crate::traits::backend_pool(backend), self.id).await?;
         Ok(GroupResponse::from_parts(self, identity_scope))
     }
 
@@ -264,7 +269,8 @@ impl Group {
     where
         C: BackendContext + ?Sized,
     {
-        self.load_group_members(backend.db_pool()).await
+        self.load_group_members(crate::traits::backend_pool(backend))
+            .await
     }
 
     pub async fn members_paginated<C>(
@@ -275,7 +281,7 @@ impl Group {
     where
         C: BackendContext + ?Sized,
     {
-        self.load_group_members_paginated(backend.db_pool(), query_options)
+        self.load_group_members_paginated(crate::traits::backend_pool(backend), query_options)
             .await
     }
 
@@ -287,7 +293,7 @@ impl Group {
     where
         C: BackendContext + ?Sized,
     {
-        self.count_group_members_paginated(backend.db_pool(), query_options)
+        self.count_group_members_paginated(crate::traits::backend_pool(backend), query_options)
             .await
     }
 
@@ -320,7 +326,7 @@ impl Group {
             principal_id: member.principal_id(),
             group_id: self.id,
         }
-        .save_principal_group_record_without_events(backend.db_pool())
+        .save_principal_group_record_without_events(crate::traits::backend_pool(backend))
         .await?;
 
         Ok(())
@@ -340,7 +346,7 @@ impl Group {
             principal_id: member.principal_id(),
             group_id: self.id,
         }
-        .save_principal_group_record(backend.db_pool(), context)
+        .save_principal_group_record(crate::traits::backend_pool(backend), context)
         .await
     }
 
@@ -360,7 +366,7 @@ impl Group {
     {
         self.remove_group_member_from_backend_without_events(
             member.principal_id(),
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
         )
         .await
     }
@@ -375,8 +381,12 @@ impl Group {
         C: BackendContext + ?Sized,
         P: PrincipalIdAccessor,
     {
-        self.remove_group_member_from_backend(member.principal_id(), backend.db_pool(), context)
-            .await
+        self.remove_group_member_from_backend(
+            member.principal_id(),
+            crate::traits::backend_pool(backend),
+            context,
+        )
+        .await
     }
 
     /// Delete this group without emitting domain events.
@@ -388,7 +398,7 @@ impl Group {
     where
         C: BackendContext + ?Sized,
     {
-        self.delete_group_record_without_events(backend.db_pool())
+        self.delete_group_record_without_events(crate::traits::backend_pool(backend))
             .await
     }
 }
@@ -411,7 +421,7 @@ impl NewGroup {
     where
         C: BackendContext + ?Sized,
     {
-        self.save_group_record_without_events(backend.db_pool())
+        self.save_group_record_without_events(crate::traits::backend_pool(backend))
             .await
     }
 
@@ -423,7 +433,8 @@ impl NewGroup {
     where
         C: BackendContext + ?Sized,
     {
-        self.save_group_record(backend.db_pool(), context).await
+        self.save_group_record(crate::traits::backend_pool(backend), context)
+            .await
     }
 }
 
@@ -457,7 +468,7 @@ impl UpdateGroup {
     where
         C: BackendContext + ?Sized,
     {
-        self.update_group_record_without_events(group_id.id(), backend.db_pool())
+        self.update_group_record_without_events(group_id.id(), crate::traits::backend_pool(backend))
             .await
     }
 
@@ -470,7 +481,7 @@ impl UpdateGroup {
     where
         C: BackendContext + ?Sized,
     {
-        self.update_group_record(group_id.id(), backend.db_pool(), context)
+        self.update_group_record(group_id.id(), crate::traits::backend_pool(backend), context)
             .await
     }
 }

--- a/src/models/object.rs
+++ b/src/models/object.rs
@@ -4,7 +4,6 @@ use diesel::sql_types::{BigInt, Integer, Jsonb, Text, Timestamp};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::db::DbPool;
 use crate::db::traits::object::{
     objects_per_class_count_from_backend, total_object_count_from_backend,
 };
@@ -365,14 +364,14 @@ pub async fn total_object_count<C>(backend: &C) -> Result<i64, ApiError>
 where
     C: BackendContext + ?Sized,
 {
-    total_object_count_from_backend(backend.db_pool()).await
+    total_object_count_from_backend(crate::traits::backend_pool(backend)).await
 }
 
 pub async fn objects_per_class_count<C>(backend: &C) -> Result<Vec<ObjectsByClass>, ApiError>
 where
     C: BackendContext + ?Sized,
 {
-    objects_per_class_count_from_backend(backend.db_pool()).await
+    objects_per_class_count_from_backend(crate::traits::backend_pool(backend)).await
 }
 
 fn new_hubuum_object_example() -> NewHubuumObject {
@@ -421,14 +420,20 @@ crate::impl_history_pagination!(HubuumObjectHistory, "hubuumobject_history");
 
 #[async_trait]
 impl AuthzTarget for HubuumObject {
-    async fn to_resource_ref(&self, _pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        _pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         Ok(self.authorization_resource())
     }
 }
 
 #[async_trait]
 impl AuthzTarget for HubuumObjectID {
-    async fn to_resource_ref(&self, pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         self.instance(pool).await?.to_resource_ref(pool).await
     }
 }

--- a/src/models/principal.rs
+++ b/src/models/principal.rs
@@ -310,7 +310,7 @@ impl MembershipPrincipalResponse {
         C: BackendContext + ?Sized,
     {
         let identity_scope = crate::db::traits::identity::identity_scope_name_by_id(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             principal.identity_scope_id,
         )
         .await?;
@@ -364,9 +364,11 @@ impl PrincipalMemberResponse {
             .iter()
             .map(|(_, principal)| principal.identity_scope_id)
             .collect::<Vec<_>>();
-        let scope_names =
-            crate::db::traits::identity::identity_scope_names_by_ids(backend.db_pool(), &scope_ids)
-                .await?;
+        let scope_names = crate::db::traits::identity::identity_scope_names_by_ids(
+            crate::traits::backend_pool(backend),
+            &scope_ids,
+        )
+        .await?;
 
         memberships
             .into_iter()
@@ -530,14 +532,18 @@ impl PrincipalID {
     where
         C: BackendContext + ?Sized,
     {
-        load_principal_by_id(backend.db_pool(), self.id()).await
+        load_principal_by_id(crate::traits::backend_pool(backend), self.id()).await
     }
 
     pub async fn settings<C>(&self, backend: &C) -> Result<PrincipalSettingsResponse, ApiError>
     where
         C: BackendContext + ?Sized,
     {
-        crate::db::traits::principal::load_principal_settings(backend.db_pool(), self.id()).await
+        crate::db::traits::principal::load_principal_settings(
+            crate::traits::backend_pool(backend),
+            self.id(),
+        )
+        .await
     }
 
     pub async fn replace_settings<C>(
@@ -550,7 +556,7 @@ impl PrincipalID {
         C: BackendContext + ?Sized,
     {
         crate::db::traits::principal::mutate_principal_settings(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             self.id(),
             PrincipalSettingsMutation::Replace,
             settings,
@@ -569,7 +575,7 @@ impl PrincipalID {
         C: BackendContext + ?Sized,
     {
         crate::db::traits::principal::mutate_principal_settings(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             self.id(),
             PrincipalSettingsMutation::Patch,
             patch,
@@ -588,7 +594,7 @@ impl PrincipalID {
         C: BackendContext + ?Sized,
     {
         crate::db::traits::principal::apply_principal_settings_patch(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             self.id(),
             patch,
             event_context,
@@ -605,7 +611,7 @@ impl PrincipalID {
         C: BackendContext + ?Sized,
     {
         crate::db::traits::principal::mutate_principal_settings(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             self.id(),
             PrincipalSettingsMutation::Reset,
             PrincipalSettings::default(),
@@ -616,7 +622,11 @@ impl PrincipalID {
 }
 
 /// Load a principal by id.
-pub async fn load_principal_by_id(pool: &DbPool, principal_id: i32) -> Result<Principal, ApiError> {
+pub async fn load_principal_by_id(
+    pool: &impl crate::traits::BackendContext,
+    principal_id: i32,
+) -> Result<Principal, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     crate::db::traits::principal::load_principal_by_id(pool, principal_id).await
 }
 

--- a/src/models/principal_group.rs
+++ b/src/models/principal_group.rs
@@ -50,21 +50,23 @@ impl PrincipalGroup {
     where
         C: BackendContext + ?Sized,
     {
-        self.load_principal_group_principal(backend.db_pool()).await
+        self.load_principal_group_principal(crate::traits::backend_pool(backend))
+            .await
     }
 
     pub async fn group<C>(&self, backend: &C) -> Result<Group, ApiError>
     where
         C: BackendContext + ?Sized,
     {
-        self.load_principal_group_group(backend.db_pool()).await
+        self.load_principal_group_group(crate::traits::backend_pool(backend))
+            .await
     }
 
     pub async fn save<C>(&self, backend: &C) -> Result<PrincipalGroup, ApiError>
     where
         C: BackendContext + ?Sized,
     {
-        self.save_principal_group_record_without_events(backend.db_pool())
+        self.save_principal_group_record_without_events(crate::traits::backend_pool(backend))
             .await
     }
 
@@ -72,6 +74,7 @@ impl PrincipalGroup {
     where
         C: BackendContext + ?Sized,
     {
-        self.delete_principal_group_record(backend.db_pool()).await
+        self.delete_principal_group_record(crate::traits::backend_pool(backend))
+            .await
     }
 }

--- a/src/models/relation.rs
+++ b/src/models/relation.rs
@@ -11,7 +11,6 @@ use utoipa::ToSchema;
 use utoipa::openapi::schema::{Schema, Type};
 use utoipa::openapi::{KnownFormat, ObjectBuilder, RefOr, SchemaFormat};
 
-use crate::db::DbPool;
 use crate::errors::ApiError;
 use crate::models::{
     HubuumClass, HubuumClassID, HubuumClassWithPath, HubuumObject, HubuumObjectID,
@@ -357,6 +356,30 @@ impl NewHubuumObjectRelation {
     }
 }
 
+/// One typed endpoint of an object relation route.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ObjectRelationEndpoint {
+    class_id: HubuumClassID,
+    object_id: HubuumObjectID,
+}
+
+impl ObjectRelationEndpoint {
+    pub fn new(class_id: HubuumClassID, object_id: HubuumObjectID) -> Self {
+        Self {
+            class_id,
+            object_id,
+        }
+    }
+
+    pub fn class_id(self) -> HubuumClassID {
+        self.class_id
+    }
+
+    pub fn object_id(self) -> HubuumObjectID {
+        self.object_id
+    }
+}
+
 /// Explicit address for a persisted object relation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ObjectRelationSelector(ObjectRelationSelectorKind);
@@ -365,10 +388,8 @@ pub struct ObjectRelationSelector(ObjectRelationSelectorKind);
 pub(crate) enum ObjectRelationSelectorKind {
     ById(HubuumObjectRelationID),
     Between {
-        from_class_id: HubuumClassID,
-        from_object_id: HubuumObjectID,
-        to_class_id: HubuumClassID,
-        to_object_id: HubuumObjectID,
+        from: ObjectRelationEndpoint,
+        to: ObjectRelationEndpoint,
     },
 }
 
@@ -377,18 +398,8 @@ impl ObjectRelationSelector {
         Self(ObjectRelationSelectorKind::ById(id))
     }
 
-    pub fn between(
-        from_class_id: HubuumClassID,
-        from_object_id: HubuumObjectID,
-        to_class_id: HubuumClassID,
-        to_object_id: HubuumObjectID,
-    ) -> Self {
-        Self(ObjectRelationSelectorKind::Between {
-            from_class_id,
-            from_object_id,
-            to_class_id,
-            to_object_id,
-        })
+    pub fn between(from: ObjectRelationEndpoint, to: ObjectRelationEndpoint) -> Self {
+        Self(ObjectRelationSelectorKind::Between { from, to })
     }
 
     pub(crate) fn kind(&self) -> &ObjectRelationSelectorKind {
@@ -404,10 +415,8 @@ pub struct ObjectRelationCreateSelector(ObjectRelationCreateSelectorKind);
 pub(crate) enum ObjectRelationCreateSelectorKind {
     Explicit(NewHubuumObjectRelation),
     Between {
-        from_class_id: HubuumClassID,
-        from_object_id: HubuumObjectID,
-        to_class_id: HubuumClassID,
-        to_object_id: HubuumObjectID,
+        from: ObjectRelationEndpoint,
+        to: ObjectRelationEndpoint,
     },
 }
 
@@ -416,18 +425,8 @@ impl ObjectRelationCreateSelector {
         Self(ObjectRelationCreateSelectorKind::Explicit(command))
     }
 
-    pub fn between(
-        from_class_id: HubuumClassID,
-        from_object_id: HubuumObjectID,
-        to_class_id: HubuumClassID,
-        to_object_id: HubuumObjectID,
-    ) -> Self {
-        Self(ObjectRelationCreateSelectorKind::Between {
-            from_class_id,
-            from_object_id,
-            to_class_id,
-            to_object_id,
-        })
+    pub fn between(from: ObjectRelationEndpoint, to: ObjectRelationEndpoint) -> Self {
+        Self(ObjectRelationCreateSelectorKind::Between { from, to })
     }
 
     pub(crate) fn kind(&self) -> &ObjectRelationCreateSelectorKind {
@@ -861,7 +860,10 @@ fn new_hubuum_object_relation_example() -> NewHubuumObjectRelation {
 
 #[async_trait]
 impl AuthzTarget for HubuumClassRelation {
-    async fn to_resource_ref(&self, pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         let from_class = HubuumClassID::new(self.from_hubuum_class_id)?
             .instance(pool)
             .await?;
@@ -887,7 +889,10 @@ impl AuthzTarget for HubuumClassRelation {
 
 #[async_trait]
 impl AuthzTarget for NewHubuumClassRelation {
-    async fn to_resource_ref(&self, pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         let from_class = HubuumClassID::new(self.from_hubuum_class_id)?
             .instance(pool)
             .await?;
@@ -912,14 +917,20 @@ impl AuthzTarget for NewHubuumClassRelation {
 
 #[async_trait]
 impl AuthzTarget for HubuumClassRelationID {
-    async fn to_resource_ref(&self, pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         self.instance(pool).await?.to_resource_ref(pool).await
     }
 }
 
 #[async_trait]
 impl AuthzTarget for HubuumObjectRelation {
-    async fn to_resource_ref(&self, pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         let from_object = HubuumObjectID::new(self.from_hubuum_object_id)?
             .instance(pool)
             .await?;
@@ -948,7 +959,10 @@ impl AuthzTarget for HubuumObjectRelation {
 
 #[async_trait]
 impl AuthzTarget for NewHubuumObjectRelation {
-    async fn to_resource_ref(&self, pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         let from_object = HubuumObjectID::new(self.from_hubuum_object_id)?
             .instance(pool)
             .await?;
@@ -976,7 +990,10 @@ impl AuthzTarget for NewHubuumObjectRelation {
 
 #[async_trait]
 impl AuthzTarget for HubuumObjectRelationID {
-    async fn to_resource_ref(&self, pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         self.instance(pool).await?.to_resource_ref(pool).await
     }
 }

--- a/src/models/remote_target.rs
+++ b/src/models/remote_target.rs
@@ -925,7 +925,7 @@ pub async fn authorize_remote_invocation<C>(
 where
     C: crate::traits::BackendContext + ?Sized,
 {
-    let pool = backend.db_pool();
+    let pool = crate::traits::backend_pool(backend);
     let target_collection_id = CollectionID::new(target.collection_id)?;
     crate::can!(
         backend,

--- a/src/models/service_account.rs
+++ b/src/models/service_account.rs
@@ -44,7 +44,7 @@ impl ServiceAccount {
         C: BackendContext + ?Sized,
     {
         crate::db::traits::principal::load_service_account_point_response(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             self.id,
         )
         .await

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -1006,7 +1006,10 @@ impl InstanceAdapter<TaskRecord> for TaskID {
 
 #[async_trait]
 impl AuthzTarget for TaskRecord {
-    async fn to_resource_ref(&self, _pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        _pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         Ok(ResourceRef {
             kind: ResourceKind::Task,
             id: self.id,
@@ -1020,7 +1023,10 @@ impl AuthzTarget for TaskRecord {
 
 #[async_trait]
 impl AuthzTarget for TaskID {
-    async fn to_resource_ref(&self, pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         self.instance(pool).await?.to_resource_ref(pool).await
     }
 }

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -150,7 +150,7 @@ impl PrincipalTokenCreateRequest {
     {
         let issuance_policy = configured_token_issuance_policy()?;
         let (token, persisted) = crate::db::traits::token::create_principal_token_request_db(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             self,
             issuance_policy,
             context,
@@ -259,7 +259,11 @@ impl PrincipalTokenMetadata {
     where
         C: BackendContext + ?Sized,
     {
-        crate::db::traits::token::principal_token_metadata_db(backend.db_pool(), tokens).await
+        crate::db::traits::token::principal_token_metadata_db(
+            crate::traits::backend_pool(backend),
+            tokens,
+        )
+        .await
     }
 
     /// Load one retained token by id, constrained to its owning principal.
@@ -276,7 +280,7 @@ impl PrincipalTokenMetadata {
         C: BackendContext + ?Sized,
     {
         crate::db::traits::token::principal_token_metadata_by_id_for_principal_db(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             token_id.id(),
             principal_id.id(),
         )
@@ -466,7 +470,8 @@ impl Token {
     where
         C: BackendContext + ?Sized,
     {
-        self.delete_token_record(backend.db_pool()).await
+        self.delete_token_record(crate::traits::backend_pool(backend))
+            .await
     }
 
     pub fn storage_hash(&self) -> String {
@@ -499,7 +504,7 @@ where
     C: BackendContext + ?Sized,
 {
     crate::db::traits::token::revoke_token_by_id_for_principal_without_events_db(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         token_id.id(),
         principal_id.id(),
     )
@@ -516,7 +521,7 @@ where
     C: BackendContext + ?Sized,
 {
     crate::db::traits::token::revoke_token_by_id_for_principal_db(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         token_id.id(),
         principal_id.id(),
         context,
@@ -541,7 +546,7 @@ where
 {
     let issuance_policy = configured_token_issuance_policy()?;
     let (token, persisted) = crate::db::traits::token::renew_principal_token_db(
-        backend.db_pool(),
+        crate::traits::backend_pool(backend),
         token_id.id(),
         principal_id.id(),
         expires_at,

--- a/src/models/traits/class.rs
+++ b/src/models/traits/class.rs
@@ -27,7 +27,7 @@ impl ResolveClassTarget for ClassSelector {
         C: crate::traits::BackendContext + ?Sized,
     {
         let class = self
-            .resolve_class_selector_record(backend.db_pool())
+            .resolve_class_selector_record(crate::traits::backend_pool(backend))
             .await?;
         Ok(ResolvedClassTarget::new(self.clone(), class))
     }
@@ -54,7 +54,7 @@ impl UpdateResolvedClass for UpdateHubuumClass {
     where
         C: crate::traits::BackendContext + ?Sized,
     {
-        self.update_resolved_class_record(backend.db_pool(), target, context)
+        self.update_resolved_class_record(crate::traits::backend_pool(backend), target, context)
             .await
     }
 }
@@ -78,7 +78,7 @@ impl DeleteResolvedClass for ResolvedClassTarget {
     where
         C: crate::traits::BackendContext + ?Sized,
     {
-        self.delete_resolved_class_record(backend.db_pool(), context)
+        self.delete_resolved_class_record(crate::traits::backend_pool(backend), context)
             .await
     }
 }

--- a/src/models/traits/collection.rs
+++ b/src/models/traits/collection.rs
@@ -168,8 +168,11 @@ impl NewCollection {
     where
         C: BackendContext + ?Sized,
     {
-        self.save_collection_for_group_record_without_events(backend.db_pool(), assignee.id())
-            .await
+        self.save_collection_for_group_record_without_events(
+            crate::traits::backend_pool(backend),
+            assignee.id(),
+        )
+        .await
     }
 
     /// Persist the collection and apply permissions using the assignee embedded in the supplied
@@ -186,7 +189,7 @@ impl NewCollection {
         C: BackendContext + ?Sized,
     {
         self.save_collection_for_group_record_without_events(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             collection_with_assignee.group_id.id(),
         )
         .await

--- a/src/models/traits/object.rs
+++ b/src/models/traits/object.rs
@@ -26,7 +26,7 @@ use crate::traits::{
 use tracing::debug;
 
 pub async fn check_if_object_in_class<C, O>(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     class: &C,
     object: &O,
 ) -> Result<(), ApiError>
@@ -34,6 +34,7 @@ where
     C: crate::traits::SelfAccessors<HubuumClass>,
     O: crate::traits::SelfAccessors<HubuumObject> + ClassAccessors<HubuumClass>,
 {
+    let pool = crate::traits::backend_pool(pool);
     let object_class_id = object.class_id(pool).await?.id();
 
     if object_class_id != class.id() {
@@ -90,7 +91,8 @@ impl Validate for HubuumObject {
     where
         C: BackendContext + ?Sized,
     {
-        self.validate_object_record(backend.db_pool()).await
+        self.validate_object_record(crate::traits::backend_pool(backend))
+            .await
     }
 }
 
@@ -105,7 +107,8 @@ impl Validate for NewHubuumObject {
     where
         C: BackendContext + ?Sized,
     {
-        self.validate_object_record(backend.db_pool()).await
+        self.validate_object_record(crate::traits::backend_pool(backend))
+            .await
     }
 }
 
@@ -120,7 +123,8 @@ impl Validate for (&UpdateHubuumObject, i32) {
     where
         C: BackendContext + ?Sized,
     {
-        self.validate_object_record(backend.db_pool()).await
+        self.validate_object_record(crate::traits::backend_pool(backend))
+            .await
     }
 }
 
@@ -204,7 +208,7 @@ impl PatchObjectData for ObjectDataPatchDocument {
     where
         C: BackendContext + ?Sized,
     {
-        self.patch_object_data_record(backend.db_pool(), target, context)
+        self.patch_object_data_record(crate::traits::backend_pool(backend), target, context)
             .await
     }
 }
@@ -236,8 +240,12 @@ impl CreateObjectInResolvedClass for NewHubuumObject {
     where
         C: BackendContext + ?Sized,
     {
-        self.create_object_in_resolved_class_record(backend.db_pool(), target, context)
-            .await
+        self.create_object_in_resolved_class_record(
+            crate::traits::backend_pool(backend),
+            target,
+            context,
+        )
+        .await
     }
 }
 
@@ -247,7 +255,7 @@ impl ResolveObjectTarget for ObjectSelector {
         C: BackendContext + ?Sized,
     {
         let (class, object) = self
-            .resolve_object_selector_record(backend.db_pool())
+            .resolve_object_selector_record(crate::traits::backend_pool(backend))
             .await?;
         Ok(ResolvedObjectTarget::new(self.clone(), class, object))
     }
@@ -274,7 +282,7 @@ impl UpdateResolvedObject for UpdateHubuumObject {
     where
         C: BackendContext + ?Sized,
     {
-        self.update_resolved_object_record(backend.db_pool(), target, context)
+        self.update_resolved_object_record(crate::traits::backend_pool(backend), target, context)
             .await
     }
 }
@@ -298,7 +306,7 @@ impl DeleteResolvedObject for ResolvedObjectTarget {
     where
         C: BackendContext + ?Sized,
     {
-        self.delete_resolved_object_record(backend.db_pool(), context)
+        self.delete_resolved_object_record(crate::traits::backend_pool(backend), context)
             .await
     }
 }

--- a/src/models/traits/task.rs
+++ b/src/models/traits/task.rs
@@ -16,9 +16,10 @@ impl TaskID {
     /// Load this task for `requestor`, enforcing principal-centric authorization.
     pub async fn load_authorized(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         requestor: &impl AuthzSubject,
     ) -> Result<TaskRecord, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         self.load_authorized_of_kind(pool, requestor, None, "Task")
             .await
     }
@@ -26,18 +27,20 @@ impl TaskID {
     /// Load this task, additionally requiring it to be an export task.
     pub async fn load_authorized_export(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         requestor: &impl AuthzSubject,
     ) -> Result<TaskRecord, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         self.load_authorized_of_kind(pool, requestor, Some(TaskKind::Export), "Export task")
             .await
     }
 
     pub async fn load_authorized_backup(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         requestor: &impl crate::db::traits::authz::AuthzSubject,
     ) -> Result<TaskRecord, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         self.load_authorized_of_kind(pool, requestor, Some(TaskKind::Backup), "Backup task")
             .await
     }
@@ -45,9 +48,10 @@ impl TaskID {
     /// Load this task, additionally requiring it to be an import task.
     pub async fn load_authorized_import(
         &self,
-        pool: &DbPool,
+        pool: &impl crate::traits::BackendContext,
         requestor: &impl AuthzSubject,
     ) -> Result<TaskRecord, ApiError> {
+        let pool = crate::traits::backend_pool(pool);
         self.load_authorized_of_kind(pool, requestor, Some(TaskKind::Import), "Import task")
             .await
     }

--- a/src/models/traits/user.rs
+++ b/src/models/traits/user.rs
@@ -43,8 +43,12 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.search_collections_from_backend(backend.db_pool(), query_options, scopes)
-            .await
+        self.search_collections_from_backend(
+            crate::traits::backend_pool(backend),
+            query_options,
+            scopes,
+        )
+        .await
     }
 
     async fn count_collections<C>(
@@ -56,8 +60,12 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.count_collections_from_backend(backend.db_pool(), query_options, scopes)
-            .await
+        self.count_collections_from_backend(
+            crate::traits::backend_pool(backend),
+            query_options,
+            scopes,
+        )
+        .await
     }
 
     async fn search_classes<C>(
@@ -69,8 +77,12 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.search_classes_from_backend(backend.db_pool(), query_options, scopes)
-            .await
+        self.search_classes_from_backend(
+            crate::traits::backend_pool(backend),
+            query_options,
+            scopes,
+        )
+        .await
     }
 
     async fn count_classes<C>(
@@ -82,7 +94,7 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.count_classes_from_backend(backend.db_pool(), query_options, scopes)
+        self.count_classes_from_backend(crate::traits::backend_pool(backend), query_options, scopes)
             .await
     }
 
@@ -95,8 +107,12 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.search_objects_from_backend(backend.db_pool(), query_options, scopes)
-            .await
+        self.search_objects_from_backend(
+            crate::traits::backend_pool(backend),
+            query_options,
+            scopes,
+        )
+        .await
     }
 
     async fn count_objects<C>(
@@ -108,7 +124,7 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.count_objects_from_backend(backend.db_pool(), query_options, scopes)
+        self.count_objects_from_backend(crate::traits::backend_pool(backend), query_options, scopes)
             .await
     }
 
@@ -121,8 +137,12 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.search_class_relations_from_backend(backend.db_pool(), query_options, scopes)
-            .await
+        self.search_class_relations_from_backend(
+            crate::traits::backend_pool(backend),
+            query_options,
+            scopes,
+        )
+        .await
     }
 
     async fn class_relations_page<C>(
@@ -134,8 +154,12 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.class_relations_page_from_backend(backend.db_pool(), query_options, scopes)
-            .await
+        self.class_relations_page_from_backend(
+            crate::traits::backend_pool(backend),
+            query_options,
+            scopes,
+        )
+        .await
     }
 
     async fn search_classes_related_to<C, K>(
@@ -149,8 +173,13 @@ pub trait Search: UserCollectionAccessors {
         C: BackendContext + ?Sized,
         K: SelfAccessors<HubuumClass>,
     {
-        self.search_classes_related_to_from_backend(backend.db_pool(), class, query_options, scopes)
-            .await
+        self.search_classes_related_to_from_backend(
+            crate::traits::backend_pool(backend),
+            class,
+            query_options,
+            scopes,
+        )
+        .await
     }
 
     async fn classes_related_to_page<C, K>(
@@ -164,8 +193,13 @@ pub trait Search: UserCollectionAccessors {
         C: BackendContext + ?Sized,
         K: SelfAccessors<HubuumClass>,
     {
-        self.classes_related_to_page_from_backend(backend.db_pool(), class, query_options, scopes)
-            .await
+        self.classes_related_to_page_from_backend(
+            crate::traits::backend_pool(backend),
+            class,
+            query_options,
+            scopes,
+        )
+        .await
     }
 
     async fn class_relations_touching_page<C, K>(
@@ -180,7 +214,7 @@ pub trait Search: UserCollectionAccessors {
         K: SelfAccessors<HubuumClass>,
     {
         self.class_relations_touching_page_from_backend(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             class,
             query_options,
             scopes,
@@ -197,8 +231,12 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.search_class_relations_between_ids_from_backend(backend.db_pool(), class_ids, scopes)
-            .await
+        self.search_class_relations_between_ids_from_backend(
+            crate::traits::backend_pool(backend),
+            class_ids,
+            scopes,
+        )
+        .await
     }
 
     async fn search_object_relations<C>(
@@ -210,8 +248,12 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.search_object_relations_from_backend(backend.db_pool(), query_options, scopes)
-            .await
+        self.search_object_relations_from_backend(
+            crate::traits::backend_pool(backend),
+            query_options,
+            scopes,
+        )
+        .await
     }
 
     async fn object_relations_page<C>(
@@ -223,8 +265,12 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.object_relations_page_from_backend(backend.db_pool(), query_options, scopes)
-            .await
+        self.object_relations_page_from_backend(
+            crate::traits::backend_pool(backend),
+            query_options,
+            scopes,
+        )
+        .await
     }
 
     async fn search_objects_related_to<C, O>(
@@ -239,7 +285,7 @@ pub trait Search: UserCollectionAccessors {
         O: SelfAccessors<HubuumObject> + ClassAccessors,
     {
         self.search_objects_related_to_from_backend(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             object,
             query_options,
             scopes,
@@ -258,8 +304,13 @@ pub trait Search: UserCollectionAccessors {
         C: BackendContext + ?Sized,
         O: SelfAccessors<HubuumObject> + ClassAccessors,
     {
-        self.objects_related_to_page_from_backend(backend.db_pool(), object, query_options, scopes)
-            .await
+        self.objects_related_to_page_from_backend(
+            crate::traits::backend_pool(backend),
+            object,
+            query_options,
+            scopes,
+        )
+        .await
     }
 
     async fn related_objects_for_roots<C>(
@@ -273,7 +324,7 @@ pub trait Search: UserCollectionAccessors {
         C: BackendContext + ?Sized,
     {
         self.related_objects_for_roots_from_backend(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             root_object_ids,
             include,
             scopes,
@@ -293,7 +344,7 @@ pub trait Search: UserCollectionAccessors {
         C: BackendContext + ?Sized,
     {
         self.bidirectionally_related_objects_for_roots_from_backend(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             root_object_ids,
             max_depth,
             per_root_cap,
@@ -314,7 +365,7 @@ pub trait Search: UserCollectionAccessors {
         O: SelfAccessors<HubuumObject>,
     {
         self.object_relations_touching_page_from_backend(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             object,
             query_options,
             scopes,
@@ -331,8 +382,12 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.search_object_relations_between_ids_from_backend(backend.db_pool(), object_ids, scopes)
-            .await
+        self.search_object_relations_between_ids_from_backend(
+            crate::traits::backend_pool(backend),
+            object_ids,
+            scopes,
+        )
+        .await
     }
 
     async fn search_unified_collections<C>(
@@ -344,8 +399,12 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.search_unified_collections_from_backend(backend.db_pool(), query, scopes)
-            .await
+        self.search_unified_collections_from_backend(
+            crate::traits::backend_pool(backend),
+            query,
+            scopes,
+        )
+        .await
     }
 
     async fn search_unified_classes<C>(
@@ -357,8 +416,12 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.search_unified_classes_from_backend(backend.db_pool(), query, scopes)
-            .await
+        self.search_unified_classes_from_backend(
+            crate::traits::backend_pool(backend),
+            query,
+            scopes,
+        )
+        .await
     }
 
     async fn search_unified_objects<C>(
@@ -370,8 +433,12 @@ pub trait Search: UserCollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.search_unified_objects_from_backend(backend.db_pool(), query, scopes)
-            .await
+        self.search_unified_objects_from_backend(
+            crate::traits::backend_pool(backend),
+            query,
+            scopes,
+        )
+        .await
     }
 }
 
@@ -383,7 +450,8 @@ pub trait GroupAccessors: AuthzSubject {
     where
         C: BackendContext + ?Sized,
     {
-        self.load_user_groups(backend.db_pool()).await
+        self.load_user_groups(crate::traits::backend_pool(backend))
+            .await
     }
 
     #[allow(async_fn_in_trait)]
@@ -395,8 +463,11 @@ pub trait GroupAccessors: AuthzSubject {
     where
         C: BackendContext + ?Sized,
     {
-        self.load_user_groups_paginated_with_total_count(backend.db_pool(), query_options)
-            .await
+        self.load_user_groups_paginated_with_total_count(
+            crate::traits::backend_pool(backend),
+            query_options,
+        )
+        .await
     }
 }
 
@@ -425,8 +496,12 @@ pub trait UserCollectionAccessors: GroupAccessors + AuthzSubject {
         // threading through the collection/search visibility helpers is wired in
         // the handler/search-scope pass; the admin fast path stays correct for
         // the `None` case.
-        self.load_collections_with_permissions(backend.db_pool(), permissions_list, None)
-            .await
+        self.load_collections_with_permissions(
+            crate::traits::backend_pool(backend),
+            permissions_list,
+            None,
+        )
+        .await
     }
 }
 

--- a/src/models/unified_search.rs
+++ b/src/models/unified_search.rs
@@ -466,7 +466,7 @@ where
             candidate_spec.limit_per_kind = usize::MAX;
             let candidates = user
                 .search_unified_collections_from_backend_with_admin_status(
-                    backend.db_pool(),
+                    crate::traits::backend_pool(backend),
                     &candidate_spec,
                     None,
                     true,
@@ -538,7 +538,7 @@ where
             candidate_spec.limit_per_kind = usize::MAX;
             let candidates = user
                 .search_unified_classes_from_backend_with_admin_status(
-                    backend.db_pool(),
+                    crate::traits::backend_pool(backend),
                     &candidate_spec,
                     None,
                     true,
@@ -616,7 +616,7 @@ where
             candidate_spec.limit_per_kind = usize::MAX;
             let candidates = user
                 .search_unified_objects_from_backend_with_admin_status(
-                    backend.db_pool(),
+                    crate::traits::backend_pool(backend),
                     &candidate_spec,
                     None,
                     true,
@@ -686,7 +686,7 @@ where
         .permission_backend()
         .filter(|permission_backend| !permission_backend.supports_sql_visibility_pushdown());
     let principal = if external_backend.is_some() {
-        Some(PrincipalRef::load(backend.db_pool(), user).await?)
+        Some(PrincipalRef::load(crate::traits::backend_pool(backend), user).await?)
     } else {
         None
     };
@@ -755,7 +755,7 @@ where
         .permission_backend()
         .filter(|permission_backend| !permission_backend.supports_sql_visibility_pushdown());
     let principal = if external_backend.is_some() {
-        Some(PrincipalRef::load(backend.db_pool(), user).await?)
+        Some(PrincipalRef::load(crate::traits::backend_pool(backend), user).await?)
     } else {
         None
     };

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -290,7 +290,11 @@ impl User {
     where
         C: BackendContext + ?Sized,
     {
-        Ok(load_principal_by_id(backend.db_pool(), self.id).await?.name)
+        Ok(
+            load_principal_by_id(crate::traits::backend_pool(backend), self.id)
+                .await?
+                .name,
+        )
     }
 
     /// Build a [`UserResponse`], resolving the name from the principal.
@@ -298,7 +302,11 @@ impl User {
     where
         C: BackendContext + ?Sized,
     {
-        crate::db::traits::principal::load_user_response(backend.db_pool(), self.id).await
+        crate::db::traits::principal::load_user_response(
+            crate::traits::backend_pool(backend),
+            self.id,
+        )
+        .await
     }
 
     /// Build the strongly tagged point representation in one database snapshot.
@@ -306,7 +314,11 @@ impl User {
     where
         C: BackendContext + ?Sized,
     {
-        crate::db::traits::principal::load_user_point_response(backend.db_pool(), self.id).await
+        crate::db::traits::principal::load_user_point_response(
+            crate::traits::backend_pool(backend),
+            self.id,
+        )
+        .await
     }
 
     /// Set a new local password and revoke every active bearer token for this
@@ -320,7 +332,7 @@ impl User {
             .await
             .map_err(|error| ApiError::HashError(format!("Failed to hash password: {error}")))?;
         let revoked_tokens = self
-            .set_password_record(backend.db_pool(), &password_hash)
+            .set_password_record(crate::traits::backend_pool(backend), &password_hash)
             .await?;
         debug!(
             message = "Password changed and active tokens revoked",
@@ -354,7 +366,7 @@ impl User {
     where
         C: BackendContext + ?Sized,
     {
-        self.load_owned_user_token_record(&token_param, backend.db_pool())
+        self.load_owned_user_token_record(&token_param, crate::traits::backend_pool(backend))
             .await
     }
 
@@ -362,7 +374,7 @@ impl User {
     where
         C: BackendContext + ?Sized,
     {
-        self.delete_owned_user_token_record(&token_param, backend.db_pool())
+        self.delete_owned_user_token_record(&token_param, crate::traits::backend_pool(backend))
             .await
     }
 
@@ -370,7 +382,8 @@ impl User {
     where
         C: BackendContext + ?Sized,
     {
-        self.delete_all_user_tokens_record(backend.db_pool()).await
+        self.delete_all_user_tokens_record(crate::traits::backend_pool(backend))
+            .await
     }
 
     /// Delete this user without emitting domain events.
@@ -382,7 +395,7 @@ impl User {
     where
         C: BackendContext + ?Sized,
     {
-        self.delete_user_record_without_events(backend.db_pool())
+        self.delete_user_record_without_events(crate::traits::backend_pool(backend))
             .await
     }
 
@@ -394,14 +407,16 @@ impl User {
     where
         C: BackendContext + ?Sized,
     {
-        self.delete_user_record(backend.db_pool(), context).await
+        self.delete_user_record(crate::traits::backend_pool(backend), context)
+            .await
     }
 
     pub async fn anonymize<C>(&self, backend: &C) -> Result<(), ApiError>
     where
         C: BackendContext + ?Sized,
     {
-        self.anonymize_user_record(backend.db_pool()).await
+        self.anonymize_user_record(crate::traits::backend_pool(backend))
+            .await
     }
 }
 
@@ -460,7 +475,7 @@ impl UpdateUser {
     {
         let hashed = self.hash_password().await?;
         hashed
-            .update_user_record_without_events(user_id.id(), backend.db_pool())
+            .update_user_record_without_events(user_id.id(), crate::traits::backend_pool(backend))
             .await
     }
 
@@ -475,7 +490,7 @@ impl UpdateUser {
     {
         let hashed = self.hash_password().await?;
         hashed
-            .update_user_record(user_id.id(), backend.db_pool(), context)
+            .update_user_record(user_id.id(), crate::traits::backend_pool(backend), context)
             .await
     }
 }
@@ -518,7 +533,7 @@ impl NewUser {
     {
         let hashed = self.hash_password().await?;
         hashed
-            .create_user_record_without_events(backend.db_pool())
+            .create_user_record_without_events(crate::traits::backend_pool(backend))
             .await
     }
 
@@ -531,7 +546,9 @@ impl NewUser {
         C: BackendContext + ?Sized,
     {
         let hashed = self.hash_password().await?;
-        hashed.create_user_record(backend.db_pool(), context).await
+        hashed
+            .create_user_record(crate::traits::backend_pool(backend), context)
+            .await
     }
 
     pub async fn hash_password(mut self) -> Result<Self, ApiError> {
@@ -554,7 +571,8 @@ impl UserID {
         C: BackendContext + ?Sized,
     {
         use crate::db::traits::user::LoadUserRecord;
-        self.load_user_record(backend.db_pool()).await
+        self.load_user_record(crate::traits::backend_pool(backend))
+            .await
     }
 
     pub async fn delete<C>(
@@ -565,14 +583,16 @@ impl UserID {
     where
         C: BackendContext + ?Sized,
     {
-        self.delete_user_record(backend.db_pool(), context).await
+        self.delete_user_record(crate::traits::backend_pool(backend), context)
+            .await
     }
 
     pub async fn anonymize<C>(&self, backend: &C) -> Result<(), ApiError>
     where
         C: BackendContext + ?Sized,
     {
-        self.anonymize_user_record(backend.db_pool()).await
+        self.anonymize_user_record(crate::traits::backend_pool(backend))
+            .await
     }
 }
 
@@ -615,8 +635,12 @@ impl LoginUser {
             .identity_scope
             .as_deref()
             .unwrap_or(LOCAL_IDENTITY_SCOPE);
-        let user = match User::get_by_name_in_scope(backend.db_pool(), identity_scope, &self.name)
-            .await
+        let user = match User::get_by_name_in_scope(
+            crate::traits::backend_pool(backend),
+            identity_scope,
+            &self.name,
+        )
+        .await
         {
             Ok(user) => user,
             Err(_) => {

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -12,6 +12,7 @@ mod registry;
 mod remote_call;
 mod scrape;
 mod security;
+mod storage;
 mod task;
 mod timer;
 
@@ -53,6 +54,7 @@ pub use self::registry::{init, runtime_identity};
 pub use self::remote_call::remote_call_finished;
 pub use self::scrape::scrape;
 pub use self::security::{client_allowlist_rejected, revision_condition};
+pub use self::storage::{storage_backend_identity, storage_operation_finished};
 pub use self::task::{
     TaskOutputKind, task_claimed, task_completed, task_lease_recovered,
     task_output_cleanup_deleted, task_output_cleanup_failed, task_output_cleanup_run,
@@ -98,6 +100,9 @@ struct Metrics {
     db_connection_acquire_failures: Counter<u64>,
     db_operation_duration: Histogram<f64>,
     db_operation_errors: Counter<u64>,
+    storage_backend_info: Gauge<u64>,
+    storage_operation_duration: Histogram<f64>,
+    storage_operation_errors: Counter<u64>,
     task_worker_iterations: Counter<u64>,
     task_claims: Counter<u64>,
     task_lease_recoveries: Counter<u64>,

--- a/src/observability/metrics/db.rs
+++ b/src/observability/metrics/db.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use opentelemetry::KeyValue;
 
-use crate::db::DbPool;
+use crate::db::traits::meta::load_database_pool_state;
 
 use super::{Metrics, current};
 
@@ -62,23 +62,22 @@ pub(crate) fn db_operation_finished(
     }
 }
 
-pub(super) fn refresh_pool_gauges(metrics: &Metrics, pool: &DbPool) {
-    let state = pool.state();
+pub(super) fn refresh_pool_gauges(metrics: &Metrics, backend: &impl crate::traits::BackendContext) {
+    let state = load_database_pool_state(backend);
     metrics.db_pool_connections.record(
-        u64::from(pool.config().max_size),
+        u64::from(state.max_connections),
         &[KeyValue::new("state", "configured")],
     );
     metrics.db_pool_connections.record(
-        u64::from(state.connections),
+        u64::from(state.total_connections),
         &[KeyValue::new("state", "open")],
     );
     metrics.db_pool_connections.record(
         u64::from(state.idle_connections),
         &[KeyValue::new("state", "idle")],
     );
-    let checked_out = state.connections.saturating_sub(state.idle_connections);
     metrics.db_pool_connections.record(
-        u64::from(checked_out),
+        u64::from(state.in_use_connections),
         &[KeyValue::new("state", "checked_out")],
     );
 }

--- a/src/observability/metrics/event.rs
+++ b/src/observability/metrics/event.rs
@@ -2,7 +2,6 @@ use std::time::{Duration, Instant};
 
 use opentelemetry::KeyValue;
 
-use crate::db::DbPool;
 use crate::db::traits::event_observability::load_event_metrics_snapshot;
 use crate::db::traits::metrics::EventMetricsSnapshot;
 use crate::models::{EventDeliveryStatusCounts, EventWorkerHealth};
@@ -19,14 +18,17 @@ pub fn event_worker_wakeup(worker: &'static str, kind: &'static str) {
     }
 }
 
-pub(super) async fn refresh_event_gauges(metrics: &Metrics, pool: &DbPool) {
+pub(super) async fn refresh_event_gauges(
+    metrics: &Metrics,
+    backend: &impl crate::traits::BackendContext,
+) {
     if let Some(snapshot) = cached_event_snapshot(metrics) {
         record_event_snapshot(metrics, &snapshot);
         return;
     }
 
     let refresh_started_at = Instant::now();
-    match load_event_metrics_snapshot(pool).await {
+    match load_event_metrics_snapshot(backend).await {
         Ok(snapshot) => {
             record_refresh_attempt(
                 metrics,

--- a/src/observability/metrics/inventory.rs
+++ b/src/observability/metrics/inventory.rs
@@ -2,20 +2,22 @@ use std::time::Instant;
 
 use opentelemetry::KeyValue;
 
-use crate::db::DbPool;
 use crate::db::traits::metrics::{InventoryGaugeSnapshot, MetricsRefreshBackend};
 
 use super::Metrics;
 use super::scrape::{RefreshOutcome, RefreshSource, record_refresh_attempt};
 
-pub(super) async fn refresh_inventory_gauges(metrics: &Metrics, pool: &DbPool) {
+pub(super) async fn refresh_inventory_gauges(
+    metrics: &Metrics,
+    backend: &impl crate::traits::BackendContext,
+) {
     if let Some(row) = cached_inventory_snapshot(metrics) {
         record_inventory_snapshot(metrics, &row);
         return;
     }
 
     let refresh_started_at = Instant::now();
-    match pool.metrics_inventory_gauge_snapshot().await {
+    match backend.metrics_inventory_gauge_snapshot().await {
         Ok(row) => {
             record_refresh_attempt(
                 metrics,

--- a/src/observability/metrics/registry.rs
+++ b/src/observability/metrics/registry.rs
@@ -28,6 +28,7 @@ const BACKGROUND_BUCKETS_SECONDS: &[f64] = &[
 const HTTP_REQUEST_DURATION: &str = "hubuum_http_request_duration";
 const DB_CONNECTION_ACQUIRE_DURATION: &str = "hubuum_db_connection_acquire_duration";
 const DB_OPERATION_DURATION: &str = "hubuum_db_operation_duration";
+const STORAGE_OPERATION_DURATION: &str = "hubuum_storage_operation_duration";
 const REMOTE_CALL_DURATION: &str = "hubuum_remote_call_duration";
 const TASK_QUEUE_WAIT_DURATION: &str = "hubuum_task_queue_wait_duration";
 const TASK_EXECUTION_DURATION: &str = "hubuum_task_execution_duration";
@@ -38,9 +39,10 @@ const IMPORT_PHASE_DURATION: &str = "hubuum_import_phase_duration";
 
 fn duration_histogram_view(instrument: &Instrument) -> Option<Stream> {
     let boundaries = match instrument.name() {
-        HTTP_REQUEST_DURATION | DB_CONNECTION_ACQUIRE_DURATION | DB_OPERATION_DURATION => {
-            LATENCY_BUCKETS_SECONDS
-        }
+        HTTP_REQUEST_DURATION
+        | DB_CONNECTION_ACQUIRE_DURATION
+        | DB_OPERATION_DURATION
+        | STORAGE_OPERATION_DURATION => LATENCY_BUCKETS_SECONDS,
         REMOTE_CALL_DURATION => OUTBOUND_BUCKETS_SECONDS,
         TASK_QUEUE_WAIT_DURATION
         | TASK_EXECUTION_DURATION
@@ -180,6 +182,19 @@ pub fn init() -> Result<(), ApiError> {
         db_operation_errors: meter
             .u64_counter("hubuum_db_operation_errors")
             .with_description("Database helper operation failures")
+            .build(),
+        storage_backend_info: meter
+            .u64_gauge("hubuum_storage_backend_info")
+            .with_description("Selected complete storage backend and contract version")
+            .build(),
+        storage_operation_duration: duration_histogram(
+            &meter,
+            STORAGE_OPERATION_DURATION,
+            "Backend-neutral lifecycle storage operation duration",
+        ),
+        storage_operation_errors: meter
+            .u64_counter("hubuum_storage_operation_errors")
+            .with_description("Backend-neutral lifecycle storage operation failures")
             .build(),
         task_worker_iterations: meter
             .u64_counter("hubuum_task_worker_iterations")
@@ -471,6 +486,19 @@ mod tests {
     #[test]
     fn request_histograms_use_subsecond_latency_buckets() {
         let bounds = histogram_bucket_bounds(HTTP_REQUEST_DURATION, 0.004);
+
+        assert_eq!(
+            bounds,
+            [
+                "0.0005", "0.001", "0.0025", "0.005", "0.01", "0.025", "0.05", "0.1", "0.25",
+                "0.5", "1", "2.5", "5", "10", "30", "+Inf",
+            ]
+        );
+    }
+
+    #[test]
+    fn storage_histograms_use_subsecond_latency_buckets() {
+        let bounds = histogram_bucket_bounds(STORAGE_OPERATION_DURATION, 0.004);
 
         assert_eq!(
             bounds,

--- a/src/observability/metrics/scrape.rs
+++ b/src/observability/metrics/scrape.rs
@@ -1,11 +1,12 @@
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
-use actix_web::{HttpResponse, Responder, http::header, web};
+use actix_web::{HttpResponse, Responder, http::header};
 use opentelemetry::KeyValue;
 use prometheus::{Encoder, TextEncoder};
 
-use crate::db::{DbCallSite, DbPool, with_db_call_site};
+use crate::backend::{DbCallSite, with_db_call_site};
 use crate::errors::ApiError;
+use crate::permissions::AppContext;
 
 use super::Metrics;
 use super::{db, event, get, inventory, login, task};
@@ -39,7 +40,7 @@ impl RefreshSource {
     }
 }
 
-pub async fn scrape(pool: web::Data<DbPool>) -> Result<impl Responder, ApiError> {
+pub async fn scrape(context: AppContext) -> Result<impl Responder, ApiError> {
     let metrics = get()?;
     let process_refresh_started_at = Instant::now();
     let process_refresh_outcome = if metrics.process_metrics.refresh() {
@@ -55,7 +56,7 @@ pub async fn scrape(pool: web::Data<DbPool>) -> Result<impl Responder, ApiError>
     );
     with_db_call_site(
         DbCallSite::MetricsRefresh,
-        refresh_scrape_gauges(metrics, &pool),
+        refresh_scrape_gauges(metrics, &context),
     )
     .await;
 
@@ -73,13 +74,13 @@ pub async fn scrape(pool: web::Data<DbPool>) -> Result<impl Responder, ApiError>
         .body(body))
 }
 
-async fn refresh_scrape_gauges(metrics: &Metrics, pool: &DbPool) {
-    db::refresh_pool_gauges(metrics, pool);
+async fn refresh_scrape_gauges(metrics: &Metrics, backend: &impl crate::traits::BackendContext) {
+    db::refresh_pool_gauges(metrics, backend);
     login::refresh_login_limiter_gauges(metrics).await;
     if let Ok(_refresh_guard) = metrics.db_refresh_lock.try_lock() {
-        inventory::refresh_inventory_gauges(metrics, pool).await;
-        task::refresh_task_gauges(metrics, pool).await;
-        event::refresh_event_gauges(metrics, pool).await;
+        inventory::refresh_inventory_gauges(metrics, backend).await;
+        task::refresh_task_gauges(metrics, backend).await;
+        event::refresh_event_gauges(metrics, backend).await;
     } else {
         metrics.refresh_skipped.add(
             1,

--- a/src/observability/metrics/storage.rs
+++ b/src/observability/metrics/storage.rs
@@ -1,0 +1,42 @@
+use std::time::Duration;
+
+use opentelemetry::KeyValue;
+
+use super::current;
+
+/// Publish the one complete storage backend selected for this process.
+pub fn storage_backend_identity(backend: &'static str, contract_version: u16) {
+    if let Some(metrics) = current() {
+        metrics.storage_backend_info.record(
+            1,
+            &[
+                KeyValue::new("backend", backend),
+                KeyValue::new("contract_version", i64::from(contract_version)),
+            ],
+        );
+    }
+}
+
+/// Record one backend-neutral lifecycle storage operation.
+pub fn storage_operation_finished(
+    backend: &'static str,
+    capability: &'static str,
+    operation: &'static str,
+    result: &'static str,
+    duration: Duration,
+) {
+    if let Some(metrics) = current() {
+        let attributes = [
+            KeyValue::new("backend", backend),
+            KeyValue::new("capability", capability),
+            KeyValue::new("operation", operation),
+            KeyValue::new("result", result),
+        ];
+        metrics
+            .storage_operation_duration
+            .record(duration.as_secs_f64(), &attributes);
+        if result != "ok" {
+            metrics.storage_operation_errors.add(1, &attributes);
+        }
+    }
+}

--- a/src/observability/metrics/task.rs
+++ b/src/observability/metrics/task.rs
@@ -3,7 +3,6 @@ use std::time::{Duration, Instant};
 
 use opentelemetry::KeyValue;
 
-use crate::db::DbPool;
 use crate::db::traits::metrics::{MetricsRefreshBackend, TaskGaugeSnapshot};
 use crate::models::{TaskKind, TaskStatus};
 
@@ -119,14 +118,17 @@ pub fn task_output_cleanup_deleted(kind: TaskOutputKind, count: usize) {
     }
 }
 
-pub(super) async fn refresh_task_gauges(metrics: &Metrics, pool: &DbPool) {
+pub(super) async fn refresh_task_gauges(
+    metrics: &Metrics,
+    backend: &impl crate::traits::BackendContext,
+) {
     if let Some(snapshot) = cached_task_snapshot(metrics) {
         record_task_snapshot(metrics, &snapshot);
         return;
     }
 
     let refresh_started_at = Instant::now();
-    match pool.metrics_task_gauge_snapshot().await {
+    match backend.metrics_task_gauge_snapshot().await {
         Ok(snapshot) => {
             record_refresh_attempt(
                 metrics,

--- a/src/permissions/context.rs
+++ b/src/permissions/context.rs
@@ -1,10 +1,9 @@
-use std::ops::Deref;
 use std::sync::Arc;
 
 use actix_web::{FromRequest, HttpRequest, dev::Payload, web::Data};
 use futures_util::future::{Ready, ready};
 
-#[cfg(test)]
+#[cfg(any(test, feature = "integration-test-support"))]
 use crate::config::get_config;
 use crate::db::DbPool;
 use crate::errors::ApiError;
@@ -12,39 +11,68 @@ use crate::services::{
     ClassRelationService, ClassService, CollectionService, ObjectRelationService, ObjectService,
     Services,
 };
-use crate::traits::BackendContext;
+use crate::traits::{BackendContext, BackendHandle};
 
 use super::backend::PermissionBackend;
-#[cfg(test)]
+#[cfg(any(test, feature = "integration-test-support"))]
 use super::local::LocalPermissionBackend;
 
 #[derive(Clone)]
 pub struct AppContext {
-    pub db_pool: DbPool,
-    pub permissions: Arc<dyn PermissionBackend>,
+    backend: BackendHandle,
+    permissions: Arc<dyn PermissionBackend>,
     services: Services,
 }
 
 impl AppContext {
     pub fn new(db_pool: DbPool, permissions: Arc<dyn PermissionBackend>) -> Self {
-        let services = Services::postgres(db_pool.clone());
+        let backend = BackendHandle::postgres(db_pool);
+        let services = Services::from_lifecycle_storage(backend.lifecycle_storage());
         Self {
-            db_pool,
+            backend,
             permissions,
             services,
         }
     }
-}
 
-impl Deref for AppContext {
-    type Target = DbPool;
+    pub(crate) fn from_http_request(req: &HttpRequest) -> Result<Self, ApiError> {
+        if let Some(context) = req.app_data::<Data<Self>>() {
+            return Ok(context.get_ref().clone());
+        }
 
-    fn deref(&self) -> &Self::Target {
-        &self.db_pool
+        #[cfg(any(test, feature = "integration-test-support"))]
+        if let Some(pool) = req.app_data::<Data<DbPool>>() {
+            let admin_groupname = get_config()
+                .map(|config| config.admin_groupname.clone())
+                .unwrap_or_else(|_| "admin".to_string());
+            return Ok(Self::new(
+                pool.get_ref().clone(),
+                Arc::new(LocalPermissionBackend::new(
+                    pool.get_ref().clone(),
+                    admin_groupname,
+                )),
+            ));
+        }
+
+        Err(ApiError::InternalServerError(
+            "Application context not found".to_string(),
+        ))
     }
 }
 
 impl AppContext {
+    pub(crate) fn backend(&self) -> &BackendHandle {
+        &self.backend
+    }
+
+    pub(crate) fn clone_backend(&self) -> BackendHandle {
+        self.backend.clone()
+    }
+
+    pub(crate) fn storage_backend_descriptor(&self) -> crate::storage::StorageBackendDescriptor {
+        self.backend.descriptor()
+    }
+
     pub fn permission_backend(&self) -> &dyn PermissionBackend {
         self.permissions.as_ref()
     }
@@ -71,10 +99,6 @@ impl AppContext {
 }
 
 impl BackendContext for AppContext {
-    fn db_pool(&self) -> &DbPool {
-        &self.db_pool
-    }
-
     fn permission_backend(&self) -> Option<&dyn PermissionBackend> {
         Some(self.permissions.as_ref())
     }
@@ -85,26 +109,6 @@ impl FromRequest for AppContext {
     type Future = Ready<Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
-        if let Some(context) = req.app_data::<Data<Self>>() {
-            return ready(Ok(context.get_ref().clone()));
-        }
-
-        #[cfg(test)]
-        if let Some(pool) = req.app_data::<Data<DbPool>>() {
-            let admin_groupname = get_config()
-                .map(|config| config.admin_groupname.clone())
-                .unwrap_or_else(|_| "admin".to_string());
-            return ready(Ok(Self::new(
-                pool.get_ref().clone(),
-                Arc::new(LocalPermissionBackend::new(
-                    pool.get_ref().clone(),
-                    admin_groupname,
-                )),
-            )));
-        }
-
-        ready(Err(ApiError::InternalServerError(
-            "Application permission context not found".to_string(),
-        )))
+        ready(Self::from_http_request(req))
     }
 }

--- a/src/permissions/mod.rs
+++ b/src/permissions/mod.rs
@@ -35,7 +35,7 @@ use crate::traits::{AuthzSubject, BackendContext, PrincipalIdAccessor};
 
 pub async fn authorize_resources<S>(
     backend: &dyn PermissionBackend,
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     subject: S,
     scopes: Option<&TokenScope>,
     permissions: Vec<Permissions>,
@@ -44,6 +44,7 @@ pub async fn authorize_resources<S>(
 where
     S: PrincipalIdAccessor,
 {
+    let pool = crate::traits::backend_pool(pool);
     if !scope_allows(scopes, &permissions) {
         return Err(ApiError::Forbidden("Permission denied".to_string()));
     }
@@ -91,7 +92,7 @@ where
         ));
     }
 
-    let pool = context.db_pool();
+    let pool = crate::traits::backend_pool(context);
     let is_admin = match context.permission_backend() {
         Some(backend) => {
             let principal = PrincipalRef::load(pool, subject).await?;

--- a/src/permissions/types.rs
+++ b/src/permissions/types.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use crate::db::{DbPool, with_connection};
+use crate::db::with_connection;
 use crate::errors::ApiError;
 use crate::models::Permissions;
 use crate::traits::PrincipalIdAccessor;
@@ -23,10 +23,14 @@ impl PrincipalRef {
         Self { user_id, group_ids }
     }
 
-    pub async fn load<S>(pool: &DbPool, subject: &S) -> Result<Self, ApiError>
+    pub async fn load<S>(
+        pool: &impl crate::traits::BackendContext,
+        subject: &S,
+    ) -> Result<Self, ApiError>
     where
         S: PrincipalIdAccessor + ?Sized,
     {
+        let pool = crate::traits::backend_pool(pool);
         use crate::db::prelude::*;
         use crate::schema::group_memberships::dsl::{group_id, group_memberships, principal_id};
 
@@ -258,7 +262,10 @@ pub struct AuthorizationResult {
 /// HubuumObject, …).
 #[async_trait]
 pub trait AuthzTarget: Send + Sync {
-    async fn to_resource_ref(&self, pool: &DbPool) -> Result<ResourceRef, ApiError>;
+    async fn to_resource_ref(
+        &self,
+        backend: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError>;
 }
 
 #[async_trait]
@@ -266,7 +273,10 @@ impl<T> AuthzTarget for &T
 where
     T: AuthzTarget + ?Sized + Sync,
 {
-    async fn to_resource_ref(&self, pool: &DbPool) -> Result<ResourceRef, ApiError> {
+    async fn to_resource_ref(
+        &self,
+        pool: &dyn crate::traits::BackendContext,
+    ) -> Result<ResourceRef, ApiError> {
         (*self).to_resource_ref(pool).await
     }
 }

--- a/src/restores/mod.rs
+++ b/src/restores/mod.rs
@@ -33,6 +33,7 @@ use crate::models::{
     RESTORE_CONFIRMATION_PHRASE, RestoreConfirmRequest, RestoreJobID, RestoreJobRecord,
     RestoreJobStatus, RestoreStageRequest, RestoreStageResponse, RestoreValidationSummary,
 };
+use crate::traits::{BackendContext, backend_pool};
 
 static RESTORE_COORDINATOR: Once = Once::new();
 static ACTIVE_MAINTENANCE_WORK: AtomicUsize = AtomicUsize::new(0);
@@ -627,10 +628,11 @@ fn validate_required_seed_rows(document: &BackupDocument) -> Result<(), ApiError
 }
 
 pub async fn stage_restore(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     settings: &RestoreSettings,
     request: RestoreStageRequest,
 ) -> Result<RestoreStageResponse, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let (initiator, document_bytes) = request.into_parts();
     if document_bytes.len() > settings.max_upload_bytes() {
         return Err(ApiError::PayloadTooLarge(format!(
@@ -697,10 +699,11 @@ pub async fn load_restore_job(
 }
 
 pub async fn restore_status(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     job_id: RestoreJobID,
     capability: &str,
 ) -> Result<RestoreStageResponse, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let job = match load_restore_status_job_db(pool, job_id.id()).await {
         Ok(job) => Some(job),
         Err(ApiError::NotFound(_)) => None,
@@ -791,10 +794,11 @@ fn restore_error_for_storage(error: &ApiError) -> String {
 }
 
 pub async fn confirm_restore(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     job_id: RestoreJobID,
     confirmation: &RestoreConfirmRequest,
 ) -> Result<RestoreStageResponse, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let job = match load_restore_job(pool, job_id).await {
         Ok(job) => Some(job),
         Err(ApiError::NotFound(_)) => None,
@@ -1031,7 +1035,11 @@ async fn reconcile_interrupted_restore_with_heartbeat(
     }
 }
 
-pub fn ensure_restore_coordinator_running(pool: DbPool) {
+pub fn ensure_restore_coordinator_running<C>(backend: C)
+where
+    C: BackendContext,
+{
+    let pool = backend_pool(&backend).clone();
     RESTORE_COORDINATOR.call_once(move || {
         spawn_background_worker("restore-coordinator", move |shutdown| {
             let system = actix_rt::System::new();
@@ -1089,7 +1097,10 @@ pub fn ensure_restore_coordinator_running(pool: DbPool) {
     });
 }
 
-pub(crate) async fn current_maintenance_state(pool: &DbPool) -> Result<MaintenanceState, ApiError> {
+pub(crate) async fn current_maintenance_state(
+    pool: &impl crate::traits::BackendContext,
+) -> Result<MaintenanceState, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     maintenance_state_db(pool).await
 }
 
@@ -1100,9 +1111,10 @@ pub async fn maintenance_state(pool: &DbPool) -> Result<String, ApiError> {
 }
 
 pub async fn identity_scope_name(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     identity_scope_id: i32,
 ) -> Result<String, ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     identity_scope_name_by_id(pool, identity_scope_id).await
 }
 

--- a/src/services/class_relations.rs
+++ b/src/services/class_relations.rs
@@ -4,16 +4,16 @@ use crate::models::{
     HubuumClassRelationID, NewHubuumClassRelation, PreparedClassRelation,
     ResolvedClassRelationTarget,
 };
-use crate::storage::DynStorage;
+use crate::storage::DynLifecycleStorage;
 
 /// Application-facing class-relation lifecycle use cases.
 #[derive(Clone)]
 pub struct ClassRelationService {
-    storage: DynStorage,
+    storage: DynLifecycleStorage,
 }
 
 impl ClassRelationService {
-    pub(crate) fn new(storage: DynStorage) -> Self {
+    pub(crate) fn new(storage: DynLifecycleStorage) -> Self {
         Self { storage }
     }
 
@@ -75,22 +75,18 @@ mod tests {
         NewCollectionWithAssignee, NewGroup, NewHubuumClass, NewHubuumClassRelation,
         ObjectRelationLimit, ResourceRevision, UpdateHubuumClass,
     };
-    use crate::services::{
-        Services, storage_contract_pool, storage_contract_postgres_permit, storage_contract_prefix,
-    };
-    use crate::storage::{DynStorage, MemoryStorage, PostgresStorage};
+    use crate::services::Services;
+    use crate::storage::{DynLifecycleStorage, MemoryStorageModel, PostgresStorage};
     use crate::tests::CollectionFixture;
+    use crate::tests::storage_contract::{
+        LifecycleContractImplementation as ContractImplementation, pool as storage_contract_pool,
+        postgres_permit as storage_contract_postgres_permit, prefix as storage_contract_prefix,
+    };
     use crate::traits::CanSave;
-
-    #[derive(Clone, Copy, Debug)]
-    enum ContractBackend {
-        Memory,
-        Postgres,
-    }
 
     struct ContractHarness {
         services: Services,
-        storage: Option<MemoryStorage>,
+        storage: Option<MemoryStorageModel>,
         collection_id: i32,
         prefix: String,
         postgres_cleanup: Option<CollectionFixture>,
@@ -98,11 +94,12 @@ mod tests {
     }
 
     impl ContractHarness {
-        async fn new(backend: ContractBackend, label: &str) -> Self {
+        async fn new(backend: ContractImplementation, label: &str) -> Self {
             match backend {
-                ContractBackend::Memory => {
-                    let storage = MemoryStorage::new();
-                    let services = Services::from_storage(DynStorage::new(storage.clone()));
+                ContractImplementation::MemoryModel => {
+                    let storage = MemoryStorageModel::new();
+                    let services =
+                        Services::from_lifecycle_storage(DynLifecycleStorage::new(storage.clone()));
                     Self {
                         services,
                         storage: Some(storage),
@@ -112,7 +109,7 @@ mod tests {
                         _postgres_permit: None,
                     }
                 }
-                ContractBackend::Postgres => {
+                ContractImplementation::PostgresAdapter => {
                     let permit = storage_contract_postgres_permit().await;
                     let pool = storage_contract_pool();
                     let prefix = storage_contract_prefix(label);
@@ -141,9 +138,9 @@ mod tests {
                         prefix: prefix.clone(),
                     };
                     Self {
-                        services: Services::from_storage(DynStorage::new(PostgresStorage::new(
-                            pool.get_ref().clone(),
-                        ))),
+                        services: Services::from_lifecycle_storage(DynLifecycleStorage::new(
+                            PostgresStorage::new(pool.get_ref().clone()),
+                        )),
                         storage: None,
                         collection_id,
                         prefix,
@@ -194,11 +191,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn class_relation_contract_normalizes_directional_settings(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "normalize").await;
         let lower = harness.create_class("lower").await;
@@ -240,10 +237,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn class_relation_contract_rejects_self_relations(#[case] backend: ContractBackend) {
+    async fn class_relation_contract_rejects_self_relations(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "self_relation").await;
         let class = harness.create_class("class").await;
         let error = harness
@@ -257,11 +256,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn class_relation_contract_creates_and_resolves_the_endpoint_aggregate(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "create_resolve").await;
         let from_class = harness.create_class("from").await;
@@ -295,11 +294,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn class_relation_contract_rejects_duplicate_endpoint_pairs(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "duplicate").await;
         let from_class = harness.create_class("from").await;
@@ -327,11 +326,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn class_relation_contract_rejects_a_stale_prepared_endpoint(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "stale_prepare").await;
         let from_class = harness.create_class("from").await;
@@ -378,11 +377,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn class_relation_contract_deletes_the_resolved_relation(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "delete").await;
         let from_class = harness.create_class("from").await;
@@ -419,11 +418,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn class_relation_contract_class_delete_cascades_the_relation(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "class_cascade").await;
         let from_class = harness.create_class("from").await;
@@ -470,7 +469,7 @@ mod tests {
 
     #[actix_web::test]
     async fn memory_class_relation_events_cover_explicit_lifecycle_writes() {
-        let harness = ContractHarness::new(ContractBackend::Memory, "events").await;
+        let harness = ContractHarness::new(ContractImplementation::MemoryModel, "events").await;
         let from_class = harness.create_class("from").await;
         let to_class = harness.create_class("to").await;
         let context = EventContext::system();

--- a/src/services/classes.rs
+++ b/src/services/classes.rs
@@ -3,16 +3,16 @@ use crate::events::EventContext;
 use crate::models::{
     ClassSelector, HubuumClass, NewHubuumClass, ResolvedClassTarget, UpdateHubuumClass,
 };
-use crate::storage::DynStorage;
+use crate::storage::DynLifecycleStorage;
 
 /// Application-facing class resolution and lifecycle use cases.
 #[derive(Clone)]
 pub struct ClassService {
-    storage: DynStorage,
+    storage: DynLifecycleStorage,
 }
 
 impl ClassService {
-    pub(crate) fn new(storage: DynStorage) -> Self {
+    pub(crate) fn new(storage: DynLifecycleStorage) -> Self {
         Self { storage }
     }
 
@@ -73,21 +73,16 @@ mod tests {
         ClassSelector, Collection, CollectionID, GroupID, HubuumClass, HubuumClassID,
         NewCollectionWithAssignee, NewGroup, NewHubuumClass, UpdateHubuumClass,
     };
-    use crate::services::{
-        CollectionService, Services, storage_contract_pool, storage_contract_postgres_permit,
-        storage_contract_prefix,
-    };
-    use crate::storage::{DynStorage, MemoryStorage, PostgresStorage};
+    use crate::services::{CollectionService, Services};
+    use crate::storage::{DynLifecycleStorage, MemoryStorageModel, PostgresStorage};
     use crate::tests::CollectionFixture;
+    use crate::tests::storage_contract::{
+        LifecycleContractImplementation as ContractImplementation, pool as storage_contract_pool,
+        postgres_permit as storage_contract_postgres_permit, prefix as storage_contract_prefix,
+    };
     use crate::traits::CanSave;
 
     use super::ClassService;
-
-    #[derive(Clone, Copy, Debug)]
-    enum ContractBackend {
-        Memory,
-        Postgres,
-    }
 
     #[derive(Clone, Copy, Debug)]
     enum ClassAddress {
@@ -106,10 +101,12 @@ mod tests {
     }
 
     impl ContractHarness {
-        async fn new(backend: ContractBackend, label: &str) -> Self {
+        async fn new(backend: ContractImplementation, label: &str) -> Self {
             match backend {
-                ContractBackend::Memory => {
-                    let services = Services::from_storage(DynStorage::new(MemoryStorage::new()));
+                ContractImplementation::MemoryModel => {
+                    let services = Services::from_lifecycle_storage(DynLifecycleStorage::new(
+                        MemoryStorageModel::new(),
+                    ));
                     Self {
                         service: services.classes().clone(),
                         collections: services.collections().clone(),
@@ -120,7 +117,7 @@ mod tests {
                         _postgres_permit: None,
                     }
                 }
-                ContractBackend::Postgres => {
+                ContractImplementation::PostgresAdapter => {
                     let permit = storage_contract_postgres_permit().await;
                     let pool = storage_contract_pool();
                     let prefix = storage_contract_prefix(label);
@@ -147,9 +144,9 @@ mod tests {
                         owner_group,
                         prefix: prefix.clone(),
                     };
-                    let services = Services::from_storage(DynStorage::new(PostgresStorage::new(
-                        pool.get_ref().clone(),
-                    )));
+                    let services = Services::from_lifecycle_storage(DynLifecycleStorage::new(
+                        PostgresStorage::new(pool.get_ref().clone()),
+                    ));
                     Self {
                         service: services.classes().clone(),
                         collections: services.collections().clone(),
@@ -226,13 +223,13 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres_id(ContractBackend::Postgres, ClassAddress::Id)]
-    #[case::postgres_name(ContractBackend::Postgres, ClassAddress::Name)]
-    #[case::memory_id(ContractBackend::Memory, ClassAddress::Id)]
-    #[case::memory_name(ContractBackend::Memory, ClassAddress::Name)]
+    #[case::postgres_id(ContractImplementation::PostgresAdapter, ClassAddress::Id)]
+    #[case::postgres_name(ContractImplementation::PostgresAdapter, ClassAddress::Name)]
+    #[case::memory_id(ContractImplementation::MemoryModel, ClassAddress::Id)]
+    #[case::memory_name(ContractImplementation::MemoryModel, ClassAddress::Name)]
     #[actix_web::test]
     async fn class_contract_resolves_explicit_addresses(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
         #[case] address: ClassAddress,
     ) {
         let harness = ContractHarness::new(backend, "resolve").await;
@@ -250,10 +247,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn class_contract_changed_update_advances_revision(#[case] backend: ContractBackend) {
+    async fn class_contract_changed_update_advances_revision(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "changed_update").await;
         let class = harness.create("class").await;
         let target = harness
@@ -284,10 +283,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn class_contract_no_op_update_preserves_revision(#[case] backend: ContractBackend) {
+    async fn class_contract_no_op_update_preserves_revision(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "no_op_update").await;
         let class = harness.create("class").await;
         let target = harness
@@ -318,11 +319,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn class_contract_update_moves_the_class_between_collections(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "move_collection").await;
         let target_collection = harness.create_collection("target").await;
@@ -363,10 +364,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn class_contract_collection_delete_cascades_the_class(#[case] backend: ContractBackend) {
+    async fn class_contract_collection_delete_cascades_the_class(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "collection_cascade").await;
         let collection = harness.create_collection("target").await;
         let class = harness
@@ -404,10 +407,10 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn class_contract_rejects_a_stale_name_target(#[case] backend: ContractBackend) {
+    async fn class_contract_rejects_a_stale_name_target(#[case] backend: ContractImplementation) {
         let harness = ContractHarness::new(backend, "stale_name").await;
         let class = harness.create("class").await;
         let name_target = harness
@@ -459,10 +462,10 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn class_contract_rejects_invalid_json_schema(#[case] backend: ContractBackend) {
+    async fn class_contract_rejects_invalid_json_schema(#[case] backend: ContractImplementation) {
         let harness = ContractHarness::new(backend, "invalid_schema").await;
 
         assert!(matches!(
@@ -486,10 +489,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn class_contract_delete_removes_the_resolved_class(#[case] backend: ContractBackend) {
+    async fn class_contract_delete_removes_the_resolved_class(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "delete").await;
         let class = harness.create("class").await;
         let target = harness
@@ -516,8 +521,8 @@ mod tests {
 
     #[actix_web::test]
     async fn memory_class_events_exclude_no_op_updates() {
-        let storage = MemoryStorage::new();
-        let service = Services::from_storage(DynStorage::new(storage.clone()))
+        let storage = MemoryStorageModel::new();
+        let service = Services::from_lifecycle_storage(DynLifecycleStorage::new(storage.clone()))
             .classes()
             .clone();
         let context = EventContext::system();

--- a/src/services/collections.rs
+++ b/src/services/collections.rs
@@ -1,7 +1,7 @@
 use crate::errors::ApiError;
 use crate::events::EventContext;
 use crate::models::{Collection, CollectionID, NewCollectionWithAssignee, UpdateCollection};
-use crate::storage::DynStorage;
+use crate::storage::DynLifecycleStorage;
 
 /// Application-facing collection use cases.
 ///
@@ -10,11 +10,11 @@ use crate::storage::DynStorage;
 /// while persistence invariants stay behind the storage capability.
 #[derive(Clone)]
 pub struct CollectionService {
-    storage: DynStorage,
+    storage: DynLifecycleStorage,
 }
 
 impl CollectionService {
-    pub(crate) fn new(storage: DynStorage) -> Self {
+    pub(crate) fn new(storage: DynLifecycleStorage) -> Self {
         Self { storage }
     }
 
@@ -101,18 +101,14 @@ mod tests {
         Collection, CollectionID, Group, GroupID, NewCollectionWithAssignee, NewGroup,
         UpdateCollection,
     };
-    use crate::services::{
-        Services, storage_contract_pool, storage_contract_postgres_permit, storage_contract_prefix,
+    use crate::services::Services;
+    use crate::storage::{DynLifecycleStorage, MemoryStorageModel, PostgresStorage};
+    use crate::tests::storage_contract::{
+        LifecycleContractImplementation as ContractImplementation, pool as storage_contract_pool,
+        postgres_permit as storage_contract_postgres_permit, prefix as storage_contract_prefix,
     };
-    use crate::storage::{DynStorage, MemoryStorage, PostgresStorage};
 
     use super::CollectionService;
-
-    #[derive(Clone, Copy, Debug)]
-    enum ContractBackend {
-        Memory,
-        Postgres,
-    }
 
     struct ContractHarness {
         service: CollectionService,
@@ -123,18 +119,20 @@ mod tests {
     }
 
     impl ContractHarness {
-        async fn new(backend: ContractBackend, label: &str) -> Self {
+        async fn new(backend: ContractImplementation, label: &str) -> Self {
             match backend {
-                ContractBackend::Memory => Self {
-                    service: Services::from_storage(DynStorage::new(MemoryStorage::new()))
-                        .collections()
-                        .clone(),
+                ContractImplementation::MemoryModel => Self {
+                    service: Services::from_lifecycle_storage(DynLifecycleStorage::new(
+                        MemoryStorageModel::new(),
+                    ))
+                    .collections()
+                    .clone(),
                     group_id: GroupID::new(1).expect("valid memory group id"),
                     prefix: format!("memory_{label}"),
                     postgres_cleanup: None,
                     _postgres_permit: None,
                 },
-                ContractBackend::Postgres => {
+                ContractImplementation::PostgresAdapter => {
                     let permit = storage_contract_postgres_permit().await;
                     let pool = storage_contract_pool();
                     let prefix = storage_contract_prefix(label);
@@ -147,9 +145,9 @@ mod tests {
                     .await
                     .expect("contract owner group should save");
                     Self {
-                        service: Services::from_storage(DynStorage::new(PostgresStorage::new(
-                            pool.get_ref().clone(),
-                        )))
+                        service: Services::from_lifecycle_storage(DynLifecycleStorage::new(
+                            PostgresStorage::new(pool.get_ref().clone()),
+                        ))
                         .collections()
                         .clone(),
                         group_id: GroupID::new(owner_group.id).expect("valid owner group id"),
@@ -191,11 +189,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn collection_contract_create_is_visible_to_point_reads(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "create_read").await;
         let created = harness.create("collection", None).await;
@@ -214,10 +212,10 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn collection_contract_lists_direct_children(#[case] backend: ContractBackend) {
+    async fn collection_contract_lists_direct_children(#[case] backend: ContractImplementation) {
         let harness = ContractHarness::new(backend, "children").await;
         let parent = harness.create("parent", None).await;
         let child = harness.create("child", Some(id(&parent))).await;
@@ -245,10 +243,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn collection_contract_orders_ancestors_nearest_first(#[case] backend: ContractBackend) {
+    async fn collection_contract_orders_ancestors_nearest_first(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "ancestors").await;
         let parent = harness.create("parent", None).await;
         let child = harness.create("child", Some(id(&parent))).await;
@@ -275,11 +275,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn collection_contract_changed_update_advances_revision(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "changed_update").await;
         let collection = harness.create("collection", None).await;
@@ -307,10 +307,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn collection_contract_no_op_update_preserves_revision(#[case] backend: ContractBackend) {
+    async fn collection_contract_no_op_update_preserves_revision(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "no_op_update").await;
         let collection = harness.create("collection", None).await;
 
@@ -337,10 +339,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn collection_contract_move_reparents_the_subtree(#[case] backend: ContractBackend) {
+    async fn collection_contract_move_reparents_the_subtree(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "move").await;
         let old_parent = harness.create("old_parent", None).await;
         let new_parent = harness.create("new_parent", None).await;
@@ -370,11 +374,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn collection_contract_rejects_deleting_a_parent_with_children(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "delete_parent").await;
         let parent = harness.create("parent", None).await;
@@ -401,10 +405,124 @@ mod tests {
         harness.finish().await;
     }
 
+    #[rstest]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
+    #[actix_web::test]
+    async fn collection_contract_allows_matching_names_under_different_parents(
+        #[case] backend: ContractImplementation,
+    ) {
+        let harness = ContractHarness::new(backend, "scoped_name").await;
+        let first_parent = harness.create("first_parent", None).await;
+        let second_parent = harness.create("second_parent", None).await;
+        let first_child = harness.create("child", Some(id(&first_parent))).await;
+        let second_child = harness.create("child", Some(id(&second_parent))).await;
+
+        assert_eq!(first_child.name, second_child.name);
+
+        for child in [first_child, second_child] {
+            harness
+                .service
+                .delete(id(&child), &EventContext::system())
+                .await
+                .expect("child cleanup");
+        }
+        for parent in [first_parent, second_parent] {
+            harness
+                .service
+                .delete(id(&parent), &EventContext::system())
+                .await
+                .expect("parent cleanup");
+        }
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
+    #[actix_web::test]
+    async fn collection_contract_rejects_matching_sibling_names(
+        #[case] backend: ContractImplementation,
+    ) {
+        let harness = ContractHarness::new(backend, "sibling_name").await;
+        let parent = harness.create("parent", None).await;
+        let child = harness.create("child", Some(id(&parent))).await;
+
+        assert!(matches!(
+            harness
+                .service
+                .create(
+                    NewCollectionWithAssignee {
+                        name: child.name.clone(),
+                        description: "duplicate sibling".to_string(),
+                        group_id: harness.group_id,
+                        parent_collection_id: Some(id(&parent)),
+                    },
+                    &EventContext::system(),
+                )
+                .await,
+            Err(ApiError::Conflict(_))
+        ));
+
+        harness
+            .service
+            .delete(id(&child), &EventContext::system())
+            .await
+            .expect("child cleanup");
+        harness
+            .service
+            .delete(id(&parent), &EventContext::system())
+            .await
+            .expect("parent cleanup");
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
+    #[actix_web::test]
+    async fn collection_contract_rejects_move_into_matching_sibling_name(
+        #[case] backend: ContractImplementation,
+    ) {
+        let harness = ContractHarness::new(backend, "move_name").await;
+        let first_parent = harness.create("first_parent", None).await;
+        let second_parent = harness.create("second_parent", None).await;
+        let first_child = harness.create("child", Some(id(&first_parent))).await;
+        let second_child = harness.create("child", Some(id(&second_parent))).await;
+
+        assert!(matches!(
+            harness
+                .service
+                .move_to(
+                    id(&first_child),
+                    id(&second_parent),
+                    &EventContext::system(),
+                )
+                .await,
+            Err(ApiError::Conflict(_))
+        ));
+
+        for child in [first_child, second_child] {
+            harness
+                .service
+                .delete(id(&child), &EventContext::system())
+                .await
+                .expect("child cleanup");
+        }
+        for parent in [first_parent, second_parent] {
+            harness
+                .service
+                .delete(id(&parent), &EventContext::system())
+                .await
+                .expect("parent cleanup");
+        }
+        harness.finish().await;
+    }
+
     #[actix_web::test]
     async fn memory_collection_events_exclude_no_op_updates() {
-        let storage = MemoryStorage::new();
-        let service = Services::from_storage(DynStorage::new(storage.clone()))
+        let storage = MemoryStorageModel::new();
+        let service = Services::from_lifecycle_storage(DynLifecycleStorage::new(storage.clone()))
             .collections()
             .clone();
         let context = EventContext::system();

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -11,33 +11,7 @@ pub use object_relations::ObjectRelationService;
 pub use objects::ObjectService;
 
 use crate::db::DbPool;
-use crate::storage::{DynStorage, PostgresStorage};
-
-#[cfg(test)]
-pub(crate) async fn storage_contract_postgres_permit() -> tokio::sync::OwnedSemaphorePermit {
-    use std::sync::{Arc, LazyLock};
-    use tokio::sync::Semaphore;
-
-    static LIMITER: LazyLock<Arc<Semaphore>> = LazyLock::new(|| Arc::new(Semaphore::new(4)));
-    LIMITER
-        .clone()
-        .acquire_owned()
-        .await
-        .expect("storage contract semaphore should remain open")
-}
-
-#[cfg(test)]
-pub(crate) fn storage_contract_pool() -> actix_web::web::Data<DbPool> {
-    let config = crate::tests::integration_test_config()
-        .expect("integration test config should be initialized");
-    actix_web::web::Data::new(crate::db::init_pool(&config.database_url, 2))
-}
-
-#[cfg(test)]
-pub(crate) fn storage_contract_prefix(label: &str) -> String {
-    let suffix = crate::utilities::auth::generate_random_password(12).to_ascii_lowercase();
-    format!("storage_contract_{label}_{suffix}")
-}
+use crate::storage::{DynLifecycleStorage, PostgresStorage};
 
 /// Application use-case facade.
 #[derive(Clone)]
@@ -51,10 +25,12 @@ pub struct Services {
 
 impl Services {
     pub fn postgres(pool: DbPool) -> Self {
-        Self::from_storage(DynStorage::new(PostgresStorage::new(pool)))
+        Self::from_lifecycle_storage(DynLifecycleStorage::from_backend(PostgresStorage::new(
+            pool,
+        )))
     }
 
-    pub(crate) fn from_storage(storage: DynStorage) -> Self {
+    pub(crate) fn from_lifecycle_storage(storage: DynLifecycleStorage) -> Self {
         Self {
             classes: ClassService::new(storage.clone()),
             class_relations: ClassRelationService::new(storage.clone()),

--- a/src/services/object_relations.rs
+++ b/src/services/object_relations.rs
@@ -4,16 +4,16 @@ use crate::models::{
     ObjectRelationCreateSelector, ObjectRelationSelector, PreparedObjectRelation,
     ResolvedObjectRelationTarget,
 };
-use crate::storage::DynStorage;
+use crate::storage::DynLifecycleStorage;
 
 /// Application-facing object-relation lifecycle use cases.
 #[derive(Clone)]
 pub struct ObjectRelationService {
-    storage: DynStorage,
+    storage: DynLifecycleStorage,
 }
 
 impl ObjectRelationService {
-    pub(crate) fn new(storage: DynStorage) -> Self {
+    pub(crate) fn new(storage: DynLifecycleStorage) -> Self {
         Self { storage }
     }
 
@@ -75,21 +75,17 @@ mod tests {
         ClassSelector, GroupID, HubuumClass, HubuumClassID, HubuumObject, HubuumObjectID,
         HubuumObjectRelationID, NewCollectionWithAssignee, NewGroup, NewHubuumClass,
         NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation,
-        ObjectRelationCreateSelector, ObjectRelationLimit, ObjectRelationSelector,
-        ResolvedClassRelationTarget, ResourceRevision,
+        ObjectRelationCreateSelector, ObjectRelationEndpoint, ObjectRelationLimit,
+        ObjectRelationSelector, ResolvedClassRelationTarget, ResourceRevision,
     };
-    use crate::services::{
-        Services, storage_contract_pool, storage_contract_postgres_permit, storage_contract_prefix,
-    };
-    use crate::storage::{DynStorage, MemoryStorage, PostgresStorage};
+    use crate::services::Services;
+    use crate::storage::{DynLifecycleStorage, MemoryStorageModel, PostgresStorage};
     use crate::tests::CollectionFixture;
+    use crate::tests::storage_contract::{
+        LifecycleContractImplementation as ContractImplementation, pool as storage_contract_pool,
+        postgres_permit as storage_contract_postgres_permit, prefix as storage_contract_prefix,
+    };
     use crate::traits::CanSave;
-
-    #[derive(Clone, Copy, Debug)]
-    enum ContractBackend {
-        Memory,
-        Postgres,
-    }
 
     #[derive(Clone, Copy, Debug)]
     enum RelationAddress {
@@ -107,7 +103,7 @@ mod tests {
 
     struct ContractHarness {
         services: Services,
-        storage: Option<MemoryStorage>,
+        storage: Option<MemoryStorageModel>,
         collection_id: i32,
         prefix: String,
         postgres_cleanup: Option<CollectionFixture>,
@@ -115,11 +111,12 @@ mod tests {
     }
 
     impl ContractHarness {
-        async fn new(backend: ContractBackend, label: &str) -> Self {
+        async fn new(backend: ContractImplementation, label: &str) -> Self {
             match backend {
-                ContractBackend::Memory => {
-                    let storage = MemoryStorage::new();
-                    let services = Services::from_storage(DynStorage::new(storage.clone()));
+                ContractImplementation::MemoryModel => {
+                    let storage = MemoryStorageModel::new();
+                    let services =
+                        Services::from_lifecycle_storage(DynLifecycleStorage::new(storage.clone()));
                     Self {
                         services,
                         storage: Some(storage),
@@ -129,7 +126,7 @@ mod tests {
                         _postgres_permit: None,
                     }
                 }
-                ContractBackend::Postgres => {
+                ContractImplementation::PostgresAdapter => {
                     let permit = storage_contract_postgres_permit().await;
                     let pool = storage_contract_pool();
                     let prefix = storage_contract_prefix(label);
@@ -158,9 +155,9 @@ mod tests {
                         prefix: prefix.clone(),
                     };
                     Self {
-                        services: Services::from_storage(DynStorage::new(PostgresStorage::new(
-                            pool.get_ref().clone(),
-                        ))),
+                        services: Services::from_lifecycle_storage(DynLifecycleStorage::new(
+                            PostgresStorage::new(pool.get_ref().clone()),
+                        )),
                         storage: None,
                         collection_id,
                         prefix,
@@ -275,10 +272,14 @@ mod tests {
             fixture: &RelationFixture,
         ) -> ObjectRelationCreateSelector {
             ObjectRelationCreateSelector::between(
-                HubuumClassID::new(fixture.from_class.id).expect("valid from class id"),
-                HubuumObjectID::new(fixture.from_object.id).expect("valid from object id"),
-                HubuumClassID::new(fixture.to_class.id).expect("valid to class id"),
-                HubuumObjectID::new(fixture.to_object.id).expect("valid to object id"),
+                ObjectRelationEndpoint::new(
+                    HubuumClassID::new(fixture.from_class.id).expect("valid from class id"),
+                    HubuumObjectID::new(fixture.from_object.id).expect("valid from object id"),
+                ),
+                ObjectRelationEndpoint::new(
+                    HubuumClassID::new(fixture.to_class.id).expect("valid to class id"),
+                    HubuumObjectID::new(fixture.to_object.id).expect("valid to object id"),
+                ),
             )
         }
 
@@ -293,10 +294,14 @@ mod tests {
                     HubuumObjectRelationID::new(relation_id).expect("valid object relation id"),
                 ),
                 RelationAddress::Between => ObjectRelationSelector::between(
-                    HubuumClassID::new(fixture.from_class.id).expect("valid from class id"),
-                    HubuumObjectID::new(fixture.from_object.id).expect("valid from object id"),
-                    HubuumClassID::new(fixture.to_class.id).expect("valid to class id"),
-                    HubuumObjectID::new(fixture.to_object.id).expect("valid to object id"),
+                    ObjectRelationEndpoint::new(
+                        HubuumClassID::new(fixture.from_class.id).expect("valid from class id"),
+                        HubuumObjectID::new(fixture.from_object.id).expect("valid from object id"),
+                    ),
+                    ObjectRelationEndpoint::new(
+                        HubuumClassID::new(fixture.to_class.id).expect("valid to class id"),
+                        HubuumObjectID::new(fixture.to_object.id).expect("valid to object id"),
+                    ),
                 ),
             }
         }
@@ -309,11 +314,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn object_relation_contract_prepares_a_normalized_endpoint_aggregate(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "normalize").await;
         let fixture = harness.fixture("normalize").await;
@@ -347,13 +352,13 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres_id(ContractBackend::Postgres, RelationAddress::Id)]
-    #[case::postgres_between(ContractBackend::Postgres, RelationAddress::Between)]
-    #[case::memory_id(ContractBackend::Memory, RelationAddress::Id)]
-    #[case::memory_between(ContractBackend::Memory, RelationAddress::Between)]
+    #[case::postgres_id(ContractImplementation::PostgresAdapter, RelationAddress::Id)]
+    #[case::postgres_between(ContractImplementation::PostgresAdapter, RelationAddress::Between)]
+    #[case::memory_id(ContractImplementation::MemoryModel, RelationAddress::Id)]
+    #[case::memory_between(ContractImplementation::MemoryModel, RelationAddress::Between)]
     #[actix_web::test]
     async fn object_relation_contract_resolves_explicit_addresses(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
         #[case] address: RelationAddress,
     ) {
         let harness = ContractHarness::new(backend, "resolve").await;
@@ -385,11 +390,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn object_relation_contract_between_preparation_validates_path_membership(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "path_membership").await;
         let fixture = harness.fixture("path_membership").await;
@@ -397,10 +402,14 @@ mod tests {
             .services
             .object_relations()
             .prepare_create(ObjectRelationCreateSelector::between(
-                HubuumClassID::new(fixture.to_class.id).expect("valid wrong class id"),
-                HubuumObjectID::new(fixture.from_object.id).expect("valid object id"),
-                HubuumClassID::new(fixture.from_class.id).expect("valid wrong class id"),
-                HubuumObjectID::new(fixture.to_object.id).expect("valid object id"),
+                ObjectRelationEndpoint::new(
+                    HubuumClassID::new(fixture.to_class.id).expect("valid wrong class id"),
+                    HubuumObjectID::new(fixture.from_object.id).expect("valid object id"),
+                ),
+                ObjectRelationEndpoint::new(
+                    HubuumClassID::new(fixture.from_class.id).expect("valid wrong class id"),
+                    HubuumObjectID::new(fixture.to_object.id).expect("valid object id"),
+                ),
             ))
             .await
             .expect_err("path membership mismatch should fail");
@@ -409,10 +418,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn object_relation_contract_rejects_self_relations(#[case] backend: ContractBackend) {
+    async fn object_relation_contract_rejects_self_relations(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "self_relation").await;
         let fixture = harness.fixture("self_relation").await;
         let error = harness
@@ -432,11 +443,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn object_relation_contract_rejects_objects_from_the_same_class(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "same_class").await;
         let fixture = harness.fixture("same_class").await;
@@ -460,11 +471,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn object_relation_contract_rejects_a_mismatched_class_relation(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "class_mismatch").await;
         let fixture = harness.fixture("class_mismatch").await;
@@ -489,10 +500,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn object_relation_contract_rejects_reverse_duplicates(#[case] backend: ContractBackend) {
+    async fn object_relation_contract_rejects_reverse_duplicates(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "duplicate").await;
         let fixture = harness.fixture("duplicate").await;
         let prepared = harness
@@ -530,11 +543,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn object_relation_contract_enforces_directional_cardinality(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "cardinality").await;
         let from_class = harness.create_class("cardinality_from_class").await;
@@ -590,11 +603,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn object_relation_contract_deletes_the_resolved_relation(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "delete").await;
         let fixture = harness.fixture("delete").await;
@@ -630,11 +643,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn object_relation_contract_object_delete_cascades_the_relation(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "object_cascade").await;
         let fixture = harness.fixture("object_cascade").await;
@@ -679,11 +692,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn object_relation_contract_class_relation_delete_cascades_the_relation(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let harness = ContractHarness::new(backend, "class_relation_cascade").await;
         let fixture = harness.fixture("class_relation_cascade").await;
@@ -720,7 +733,7 @@ mod tests {
 
     #[actix_web::test]
     async fn memory_object_relation_events_cover_explicit_lifecycle_writes() {
-        let harness = ContractHarness::new(ContractBackend::Memory, "events").await;
+        let harness = ContractHarness::new(ContractImplementation::MemoryModel, "events").await;
         let fixture = harness.fixture("events").await;
         let context = EventContext::system();
         let prepared = harness

--- a/src/services/objects.rs
+++ b/src/services/objects.rs
@@ -4,16 +4,16 @@ use crate::models::{
     HubuumObject, NewHubuumObject, ObjectDataPatchDocument, ObjectSelector, ResolvedClassTarget,
     ResolvedObjectTarget, UpdateHubuumObject,
 };
-use crate::storage::DynStorage;
+use crate::storage::DynLifecycleStorage;
 
 /// Application-facing object resolution and lifecycle use cases.
 #[derive(Clone)]
 pub struct ObjectService {
-    storage: DynStorage,
+    storage: DynLifecycleStorage,
 }
 
 impl ObjectService {
-    pub(crate) fn new(storage: DynStorage) -> Self {
+    pub(crate) fn new(storage: DynLifecycleStorage) -> Self {
         Self { storage }
     }
 
@@ -92,21 +92,16 @@ mod tests {
         HubuumObjectID, NewCollectionWithAssignee, NewGroup, NewHubuumClass, NewHubuumObject,
         ObjectDataPatchDocument, ObjectSelector, UpdateHubuumObject,
     };
-    use crate::services::{
-        ClassService, Services, storage_contract_pool, storage_contract_postgres_permit,
-        storage_contract_prefix,
-    };
-    use crate::storage::{DynStorage, MemoryStorage, PostgresStorage};
+    use crate::services::{ClassService, Services};
+    use crate::storage::{DynLifecycleStorage, MemoryStorageModel, PostgresStorage};
     use crate::tests::CollectionFixture;
+    use crate::tests::storage_contract::{
+        LifecycleContractImplementation as ContractImplementation, pool as storage_contract_pool,
+        postgres_permit as storage_contract_postgres_permit, prefix as storage_contract_prefix,
+    };
     use crate::traits::CanSave;
 
     use super::ObjectService;
-
-    #[derive(Clone, Copy, Debug)]
-    enum ContractBackend {
-        Memory,
-        Postgres,
-    }
 
     #[derive(Clone, Copy, Debug)]
     enum ObjectAddress {
@@ -124,10 +119,12 @@ mod tests {
     }
 
     impl ContractHarness {
-        async fn new(backend: ContractBackend, label: &str) -> Self {
+        async fn new(backend: ContractImplementation, label: &str) -> Self {
             match backend {
-                ContractBackend::Memory => {
-                    let services = Services::from_storage(DynStorage::new(MemoryStorage::new()));
+                ContractImplementation::MemoryModel => {
+                    let services = Services::from_lifecycle_storage(DynLifecycleStorage::new(
+                        MemoryStorageModel::new(),
+                    ));
                     let prefix = format!("memory_{label}");
                     let class = create_class(
                         services.classes(),
@@ -145,7 +142,7 @@ mod tests {
                         _postgres_permit: None,
                     }
                 }
-                ContractBackend::Postgres => {
+                ContractImplementation::PostgresAdapter => {
                     let permit = storage_contract_postgres_permit().await;
                     let pool = storage_contract_pool();
                     let prefix = storage_contract_prefix(label);
@@ -172,9 +169,9 @@ mod tests {
                         owner_group,
                         prefix: prefix.clone(),
                     };
-                    let services = Services::from_storage(DynStorage::new(PostgresStorage::new(
-                        pool.get_ref().clone(),
-                    )));
+                    let services = Services::from_lifecycle_storage(DynLifecycleStorage::new(
+                        PostgresStorage::new(pool.get_ref().clone()),
+                    ));
                     let class =
                         create_class(services.classes(), &prefix, fixture.collection.id, None)
                             .await;
@@ -261,13 +258,13 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres_id(ContractBackend::Postgres, ObjectAddress::Id)]
-    #[case::postgres_name(ContractBackend::Postgres, ObjectAddress::Name)]
-    #[case::memory_id(ContractBackend::Memory, ObjectAddress::Id)]
-    #[case::memory_name(ContractBackend::Memory, ObjectAddress::Name)]
+    #[case::postgres_id(ContractImplementation::PostgresAdapter, ObjectAddress::Id)]
+    #[case::postgres_name(ContractImplementation::PostgresAdapter, ObjectAddress::Name)]
+    #[case::memory_id(ContractImplementation::MemoryModel, ObjectAddress::Id)]
+    #[case::memory_name(ContractImplementation::MemoryModel, ObjectAddress::Name)]
     #[actix_web::test]
     async fn object_contract_resolves_explicit_addresses(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
         #[case] address: ObjectAddress,
     ) {
         let harness = ContractHarness::new(backend, "resolve").await;
@@ -285,10 +282,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn object_contract_changed_update_advances_revision(#[case] backend: ContractBackend) {
+    async fn object_contract_changed_update_advances_revision(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "changed_update").await;
         let object = harness.create("object", json!({"value": 1})).await;
         let target = harness
@@ -318,10 +317,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn object_contract_no_op_update_preserves_revision(#[case] backend: ContractBackend) {
+    async fn object_contract_no_op_update_preserves_revision(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "no_op_update").await;
         let object = harness.create("object", json!({"value": 1})).await;
         let target = harness
@@ -351,10 +352,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn object_contract_patch_updates_data_and_revision(#[case] backend: ContractBackend) {
+    async fn object_contract_patch_updates_data_and_revision(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "patch").await;
         let object = harness.create("object", json!({"value": 1})).await;
         let target = harness
@@ -379,10 +382,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn object_contract_no_op_patch_preserves_revision(#[case] backend: ContractBackend) {
+    async fn object_contract_no_op_patch_preserves_revision(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "no_op_patch").await;
         let object = harness.create("object", json!({"value": 1})).await;
         let target = harness
@@ -406,11 +411,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
     async fn object_contract_rejects_data_outside_the_class_schema(
-        #[case] backend: ContractBackend,
+        #[case] backend: ContractImplementation,
     ) {
         let mut harness = ContractHarness::new(backend, "schema").await;
         let schema_class = create_class(
@@ -455,10 +460,10 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn object_contract_rejects_a_stale_name_target(#[case] backend: ContractBackend) {
+    async fn object_contract_rejects_a_stale_name_target(#[case] backend: ContractImplementation) {
         let harness = ContractHarness::new(backend, "stale_name").await;
         let object = harness.create("object", json!({"value": 1})).await;
         let name_target = harness
@@ -510,10 +515,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn object_contract_delete_removes_the_resolved_object(#[case] backend: ContractBackend) {
+    async fn object_contract_delete_removes_the_resolved_object(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "delete").await;
         let object = harness.create("object", json!({"value": 1})).await;
         let selector = selector(ObjectAddress::Id, &harness.class, &object);
@@ -537,10 +544,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case::postgres(ContractBackend::Postgres)]
-    #[case::memory(ContractBackend::Memory)]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
     #[actix_web::test]
-    async fn object_contract_class_delete_cascades_the_object(#[case] backend: ContractBackend) {
+    async fn object_contract_class_delete_cascades_the_object(
+        #[case] backend: ContractImplementation,
+    ) {
         let harness = ContractHarness::new(backend, "class_cascade").await;
         let object = harness.create("object", json!({"value": 1})).await;
         let object_selector = selector(ObjectAddress::Id, &harness.class, &object);
@@ -567,8 +576,8 @@ mod tests {
 
     #[actix_web::test]
     async fn memory_object_events_exclude_no_op_mutations() {
-        let storage = MemoryStorage::new();
-        let services = Services::from_storage(DynStorage::new(storage.clone()));
+        let storage = MemoryStorageModel::new();
+        let services = Services::from_lifecycle_storage(DynLifecycleStorage::new(storage.clone()));
         let class = create_class(services.classes(), "memory_object_events", 1, None).await;
         let class_target = services
             .classes()

--- a/src/storage/class_relations.rs
+++ b/src/storage/class_relations.rs
@@ -13,7 +13,7 @@ use super::StorageError;
 /// Prepared and resolved aggregates include both endpoint classes so callers
 /// can authorize without depending on persistence-specific lookups.
 #[async_trait]
-pub trait ClassRelationStore: Send + Sync {
+pub(crate) trait ClassRelationStore: Send + Sync {
     async fn prepare_class_relation(
         &self,
         command: NewHubuumClassRelation,

--- a/src/storage/classes.rs
+++ b/src/storage/classes.rs
@@ -12,7 +12,7 @@ use super::StorageError;
 /// Resolved targets preserve the route-selected address so implementations can
 /// recheck ID- and name-based mutations atomically before writing.
 #[async_trait]
-pub trait ClassStore: Send + Sync {
+pub(crate) trait ClassStore: Send + Sync {
     async fn resolve_class(
         &self,
         selector: ClassSelector,

--- a/src/storage/collections.rs
+++ b/src/storage/collections.rs
@@ -1,11 +1,9 @@
-use std::sync::Arc;
-
 use async_trait::async_trait;
 
 use crate::events::EventContext;
 use crate::models::{Collection, CollectionID, NewCollectionWithAssignee, UpdateCollection};
 
-use super::{ClassRelationStore, ClassStore, ObjectRelationStore, ObjectStore, StorageError};
+use super::StorageError;
 
 /// Persistence capability for the core collection lifecycle.
 ///
@@ -13,7 +11,7 @@ use super::{ClassRelationStore, ClassStore, ObjectRelationStore, ObjectStore, St
 /// over transactions, hierarchy maintenance, initial permission grants, and
 /// atomic event persistence.
 #[async_trait]
-pub trait CollectionStore: Send + Sync {
+pub(crate) trait CollectionStore: Send + Sync {
     async fn get_collection(&self, id: CollectionID) -> Result<Collection, StorageError>;
 
     async fn create_collection(
@@ -46,33 +44,4 @@ pub trait CollectionStore: Send + Sync {
         new_parent_id: CollectionID,
         context: &EventContext,
     ) -> Result<Collection, StorageError>;
-}
-
-/// Umbrella storage boundary. New aggregate capabilities can be added here as
-/// vertical slices migrate without exposing a database pool to services.
-pub trait Storage:
-    CollectionStore + ClassStore + ObjectStore + ClassRelationStore + ObjectRelationStore
-{
-}
-
-impl<T> Storage for T where
-    T: CollectionStore + ClassStore + ObjectStore + ClassRelationStore + ObjectRelationStore
-{
-}
-
-#[derive(Clone)]
-pub struct DynStorage {
-    inner: Arc<dyn Storage>,
-}
-
-impl DynStorage {
-    pub fn new(storage: impl Storage + 'static) -> Self {
-        Self {
-            inner: Arc::new(storage),
-        }
-    }
-
-    pub(crate) fn inner(&self) -> &dyn Storage {
-        self.inner.as_ref()
-    }
 }

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -1,0 +1,211 @@
+use std::sync::Arc;
+
+use super::{
+    ClassRelationStore, ClassStore, CollectionStore, ObjectRelationStore, ObjectStore,
+    PostgresStorage, observed::ObservedLifecycleStorage,
+};
+
+/// Version of the complete application storage contract.
+///
+/// Increment this when a selectable backend must implement a new capability
+/// family or when an existing family's externally observable semantics change.
+pub(crate) const STORAGE_CONTRACT_VERSION: u16 = 1;
+
+/// Stable identity of a selectable storage backend.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StorageBackendKind {
+    Postgresql,
+}
+
+impl StorageBackendKind {
+    #[cfg(test)]
+    pub(crate) const ALL: [Self; 1] = [Self::Postgresql];
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Postgresql => "postgresql",
+        }
+    }
+}
+
+/// Stable, bounded capability families required of every selectable backend.
+///
+/// This is deliberately not a feature bitmap. A backend either satisfies the
+/// complete [`StorageBackend`] trait or cannot be selected by `AppContext`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StorageCapability {
+    DomainLifecycle,
+    IdentityAndAuthorizationData,
+    QueriesAndHistory,
+    Workflows,
+    Operations,
+}
+
+impl StorageCapability {
+    pub(crate) const ALL: [Self; 5] = [
+        Self::DomainLifecycle,
+        Self::IdentityAndAuthorizationData,
+        Self::QueriesAndHistory,
+        Self::Workflows,
+        Self::Operations,
+    ];
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::DomainLifecycle => "domain_lifecycle",
+            Self::IdentityAndAuthorizationData => "identity_and_authorization_data",
+            Self::QueriesAndHistory => "queries_and_history",
+            Self::Workflows => "workflows",
+            Self::Operations => "operations",
+        }
+    }
+}
+
+/// Non-secret metadata for the backend selected at application composition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct StorageBackendDescriptor {
+    kind: StorageBackendKind,
+}
+
+impl StorageBackendDescriptor {
+    pub(crate) const fn new(kind: StorageBackendKind) -> Self {
+        Self { kind }
+    }
+
+    pub(crate) const fn kind(self) -> StorageBackendKind {
+        self.kind
+    }
+
+    pub(crate) const fn contract_version(self) -> u16 {
+        STORAGE_CONTRACT_VERSION
+    }
+
+    pub(crate) fn capabilities(self) -> impl Iterator<Item = StorageCapability> {
+        StorageCapability::ALL.into_iter()
+    }
+}
+
+/// Identifies a lifecycle implementation for diagnostics and contract tests.
+///
+/// Focused models may implement this and [`LifecycleStorage`] without becoming
+/// selectable application backends.
+pub(crate) trait StorageIdentity: Send + Sync {
+    fn storage_name(&self) -> &'static str;
+}
+
+/// Complete lifecycle contract shared by services and focused test models.
+pub(crate) trait LifecycleStorage:
+    StorageIdentity
+    + CollectionStore
+    + ClassStore
+    + ObjectStore
+    + ClassRelationStore
+    + ObjectRelationStore
+{
+}
+
+impl<T> LifecycleStorage for T where
+    T: StorageIdentity
+        + CollectionStore
+        + ClassStore
+        + ObjectStore
+        + ClassRelationStore
+        + ObjectRelationStore
+{
+}
+
+/// Certification gates for capability families that are still implemented by
+/// operation-shaped adapters outside `src/storage`.
+///
+/// These traits are intentionally sealed and implemented in this central
+/// contract module. They make the composition checklist compile-time visible:
+/// adding a selectable backend requires an explicit implementation for every
+/// family here, followed by the shared compatibility suite.
+pub(crate) trait IdentityAndAuthorizationStorage: Send + Sync {}
+pub(crate) trait QueryAndHistoryStorage: Send + Sync {}
+pub(crate) trait WorkflowStorage: Send + Sync {}
+pub(crate) trait OperationalStorage: Send + Sync {}
+
+mod sealed {
+    pub trait CertifiedStorageBackend {}
+}
+
+/// All-or-nothing storage backend accepted by the application composition root.
+///
+/// Partial lifecycle models cannot implement the private certification trait
+/// and therefore cannot be selected by `AppContext`.
+pub(crate) trait StorageBackend:
+    LifecycleStorage
+    + IdentityAndAuthorizationStorage
+    + QueryAndHistoryStorage
+    + WorkflowStorage
+    + OperationalStorage
+    + sealed::CertifiedStorageBackend
+{
+    fn descriptor(&self) -> StorageBackendDescriptor;
+}
+
+impl IdentityAndAuthorizationStorage for PostgresStorage {}
+impl QueryAndHistoryStorage for PostgresStorage {}
+impl WorkflowStorage for PostgresStorage {}
+impl OperationalStorage for PostgresStorage {}
+impl sealed::CertifiedStorageBackend for PostgresStorage {}
+
+impl StorageBackend for PostgresStorage {
+    fn descriptor(&self) -> StorageBackendDescriptor {
+        StorageBackendDescriptor::new(StorageBackendKind::Postgresql)
+    }
+}
+
+/// Type-erased lifecycle capability used by application services.
+#[derive(Clone)]
+pub(crate) struct DynLifecycleStorage {
+    inner: Arc<dyn LifecycleStorage>,
+}
+
+impl DynLifecycleStorage {
+    pub(crate) fn from_backend(storage: impl StorageBackend + 'static) -> Self {
+        Self::new(storage)
+    }
+
+    /// Construct a focused lifecycle contract harness.
+    ///
+    /// Production composition must use [`Self::from_backend`], whose stronger
+    /// bound rejects partial implementations.
+    pub(crate) fn new(storage: impl LifecycleStorage + 'static) -> Self {
+        let inner: Arc<dyn LifecycleStorage> = Arc::new(storage);
+        Self {
+            inner: Arc::new(ObservedLifecycleStorage::new(inner)),
+        }
+    }
+
+    pub(crate) fn inner(&self) -> &dyn LifecycleStorage {
+        self.inner.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_complete_backend<T: StorageBackend>() {}
+
+    #[test]
+    fn postgres_satisfies_the_complete_storage_backend_contract() {
+        assert_complete_backend::<PostgresStorage>();
+    }
+
+    #[test]
+    fn required_capabilities_are_stable_and_complete() {
+        assert_eq!(
+            StorageCapability::ALL.map(StorageCapability::as_str),
+            [
+                "domain_lifecycle",
+                "identity_and_authorization_data",
+                "queries_and_history",
+                "workflows",
+                "operations",
+            ]
+        );
+    }
+}

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -1,9 +1,7 @@
 use std::fmt;
 
-use crate::errors::ApiError;
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum StorageErrorKind {
+pub(crate) enum StorageErrorKind {
     BadRequest,
     Conflict,
     Database,
@@ -16,31 +14,55 @@ enum StorageErrorKind {
     Validation,
 }
 
+impl StorageErrorKind {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::BadRequest => "bad_request",
+            Self::Conflict => "conflict",
+            Self::Database => "database",
+            Self::Internal => "internal",
+            Self::NotFound => "not_found",
+            Self::NotAcceptable => "not_acceptable",
+            Self::PayloadTooLarge => "payload_too_large",
+            Self::PreconditionFailed => "precondition_failed",
+            Self::Unavailable => "unavailable",
+            Self::Validation => "validation",
+        }
+    }
+
+    pub(crate) const fn is_backend_failure(self) -> bool {
+        matches!(self, Self::Database | Self::Internal | Self::Unavailable)
+    }
+}
+
 /// Backend-neutral failure returned by storage capabilities.
 ///
-/// The representation deliberately carries no Diesel or Actix types. API
-/// adapters translate it into [`ApiError`] only at the application boundary.
+/// The representation deliberately carries no Diesel, Actix, or application
+/// error types. The application error layer owns transport-facing translation.
 #[derive(Debug, PartialEq, Eq)]
-pub struct StorageError {
+pub(crate) struct StorageError {
     kind: StorageErrorKind,
     message: String,
     current_etag: Option<String>,
 }
 
 impl StorageError {
-    pub fn bad_request(message: impl Into<String>) -> Self {
+    #[cfg(test)]
+    pub(crate) fn bad_request(message: impl Into<String>) -> Self {
         Self::new(StorageErrorKind::BadRequest, message, None)
     }
 
-    pub fn conflict(message: impl Into<String>) -> Self {
+    #[cfg(test)]
+    pub(crate) fn conflict(message: impl Into<String>) -> Self {
         Self::new(StorageErrorKind::Conflict, message, None)
     }
 
-    pub fn not_found(message: impl Into<String>) -> Self {
+    #[cfg(test)]
+    pub(crate) fn not_found(message: impl Into<String>) -> Self {
         Self::new(StorageErrorKind::NotFound, message, None)
     }
 
-    fn new(
+    pub(crate) fn new(
         kind: StorageErrorKind,
         message: impl Into<String>,
         current_etag: Option<String>,
@@ -51,6 +73,14 @@ impl StorageError {
             current_etag,
         }
     }
+
+    pub(crate) fn into_parts(self) -> (StorageErrorKind, String, Option<String>) {
+        (self.kind, self.message, self.current_etag)
+    }
+
+    pub(crate) const fn kind(&self) -> StorageErrorKind {
+        self.kind
+    }
 }
 
 impl fmt::Display for StorageError {
@@ -60,92 +90,3 @@ impl fmt::Display for StorageError {
 }
 
 impl std::error::Error for StorageError {}
-
-impl From<ApiError> for StorageError {
-    fn from(error: ApiError) -> Self {
-        match error {
-            ApiError::BadRequest(message)
-            | ApiError::InvalidIntegerRange(message)
-            | ApiError::OperatorMismatch(message) => {
-                Self::new(StorageErrorKind::BadRequest, message, None)
-            }
-            ApiError::NotAcceptable(message) => {
-                Self::new(StorageErrorKind::NotAcceptable, message, None)
-            }
-            ApiError::ValidationError(message) => {
-                Self::new(StorageErrorKind::Validation, message, None)
-            }
-            ApiError::PayloadTooLarge(message) => {
-                Self::new(StorageErrorKind::PayloadTooLarge, message, None)
-            }
-            ApiError::Conflict(message) => Self::new(StorageErrorKind::Conflict, message, None),
-            ApiError::DatabaseError(message) | ApiError::DbConnectionError(message) => {
-                Self::new(StorageErrorKind::Database, message, None)
-            }
-            ApiError::NotFound(message) | ApiError::Gone(message) => {
-                Self::new(StorageErrorKind::NotFound, message, None)
-            }
-            ApiError::PreconditionFailed(message, current_etag) => {
-                Self::new(StorageErrorKind::PreconditionFailed, message, current_etag)
-            }
-            ApiError::ServiceUnavailable(message) => {
-                Self::new(StorageErrorKind::Unavailable, message, None)
-            }
-            error => Self::new(
-                StorageErrorKind::Internal,
-                format!(
-                    "unexpected storage adapter error ({}): {error}",
-                    error.class()
-                ),
-                None,
-            ),
-        }
-    }
-}
-
-impl From<StorageError> for ApiError {
-    fn from(error: StorageError) -> Self {
-        match error.kind {
-            StorageErrorKind::BadRequest => Self::BadRequest(error.message),
-            StorageErrorKind::Conflict => Self::Conflict(error.message),
-            StorageErrorKind::Database => Self::DatabaseError(error.message),
-            StorageErrorKind::Internal => Self::InternalServerError(error.message),
-            StorageErrorKind::NotFound => Self::NotFound(error.message),
-            StorageErrorKind::NotAcceptable => Self::NotAcceptable(error.message),
-            StorageErrorKind::PayloadTooLarge => Self::PayloadTooLarge(error.message),
-            StorageErrorKind::PreconditionFailed => {
-                Self::PreconditionFailed(error.message, error.current_etag)
-            }
-            StorageErrorKind::Unavailable => Self::ServiceUnavailable(error.message),
-            StorageErrorKind::Validation => Self::ValidationError(error.message),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::errors::ApiError;
-
-    use super::StorageError;
-
-    #[test]
-    fn storage_errors_preserve_public_failure_categories() {
-        for error in [
-            ApiError::BadRequest("invalid move".to_string()),
-            ApiError::Conflict("collection has children".to_string()),
-            ApiError::NotFound("collection missing".to_string()),
-            ApiError::ValidationError("object schema mismatch".to_string()),
-            ApiError::PayloadTooLarge("object data exceeds its limit".to_string()),
-            ApiError::PreconditionFailed(
-                "stale collection".to_string(),
-                Some("\"collection-1-r2\"".to_string()),
-            ),
-        ] {
-            let expected_class = error.class();
-            let expected_message = error.public_message().to_string();
-            let round_trip = ApiError::from(StorageError::from(error));
-            assert_eq!(round_trip.class(), expected_class);
-            assert_eq!(round_trip.public_message(), expected_message);
-        }
-    }
-}

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -1,3 +1,5 @@
+mod error;
+
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -19,8 +21,10 @@ use crate::models::{
 };
 
 use super::{
-    ClassRelationStore, ClassStore, CollectionStore, ObjectRelationStore, ObjectStore, StorageError,
+    ClassRelationStore, ClassStore, CollectionStore, ObjectRelationStore, ObjectStore,
+    StorageError, StorageIdentity,
 };
+use error::map_memory_error;
 
 const ROOT_COLLECTION_ID: i32 = 1;
 
@@ -114,10 +118,17 @@ impl MemoryState {
             .ok_or_else(|| StorageError::not_found(format!("Collection {} was not found", id.id())))
     }
 
-    fn name_in_use(&self, name: &str, except_id: Option<i32>) -> bool {
-        self.collections
-            .values()
-            .any(|collection| collection.name == name && Some(collection.id) != except_id)
+    fn collection_name_in_use(
+        &self,
+        parent_collection_id: i32,
+        name: &str,
+        except_id: Option<i32>,
+    ) -> bool {
+        self.collections.values().any(|collection| {
+            collection.parent_collection_id == Some(parent_collection_id)
+                && collection.name == name
+                && Some(collection.id) != except_id
+        })
     }
 
     fn class_name_in_use(&self, name: &str, except_id: Option<i32>) -> bool {
@@ -256,7 +267,7 @@ impl MemoryState {
         target: &ResolvedClassRelationTarget,
     ) -> Result<&HubuumClassRelation, StorageError> {
         let relation_id =
-            HubuumClassRelationID::new(target.relation().id).map_err(StorageError::from)?;
+            HubuumClassRelationID::new(target.relation().id).map_err(map_memory_error)?;
         let current = self.class_relation(relation_id)?;
         let from_class = self
             .classes
@@ -299,7 +310,7 @@ impl MemoryState {
             .cloned()
             .ok_or_else(|| StorageError::not_found("To class was not found"))?;
         ResolvedClassRelationTarget::new(relation.clone(), from_class, to_class)
-            .map_err(StorageError::from)
+            .map_err(map_memory_error)
     }
 
     fn direct_class_relation(
@@ -381,7 +392,7 @@ impl MemoryState {
             ));
         }
         let class_relation_id = HubuumClassRelationID::new(prepared.command().class_relation_id)
-            .map_err(StorageError::from)?;
+            .map_err(map_memory_error)?;
         let class_relation = self.class_relation(class_relation_id)?;
         if class_relation != prepared.class_relation().relation() {
             return Err(StorageError::not_found(
@@ -396,7 +407,7 @@ impl MemoryState {
         target: &ResolvedObjectRelationTarget,
     ) -> Result<(), StorageError> {
         let relation_id =
-            HubuumObjectRelationID::new(target.relation().id).map_err(StorageError::from)?;
+            HubuumObjectRelationID::new(target.relation().id).map_err(map_memory_error)?;
         let relation = self.object_relation(relation_id)?;
         let command = NewHubuumObjectRelation {
             from_hubuum_object_id: relation.from_hubuum_object_id,
@@ -479,11 +490,11 @@ impl MemoryState {
 
 /// Deterministic collection adapter used by shared storage contract tests.
 #[derive(Clone)]
-pub(crate) struct MemoryStorage {
+pub(crate) struct MemoryStorageModel {
     state: Arc<RwLock<MemoryState>>,
 }
 
-impl MemoryStorage {
+impl MemoryStorageModel {
     pub(crate) fn new() -> Self {
         Self {
             state: Arc::new(RwLock::new(MemoryState::new())),
@@ -511,8 +522,14 @@ impl MemoryStorage {
     }
 }
 
+impl StorageIdentity for MemoryStorageModel {
+    fn storage_name(&self) -> &'static str {
+        "memory_contract_model"
+    }
+}
+
 #[async_trait]
-impl CollectionStore for MemoryStorage {
+impl CollectionStore for MemoryStorageModel {
     async fn get_collection(&self, id: CollectionID) -> Result<Collection, StorageError> {
         self.state.read().await.collection(id).cloned()
     }
@@ -523,12 +540,6 @@ impl CollectionStore for MemoryStorage {
         context: &EventContext,
     ) -> Result<Collection, StorageError> {
         let mut state = self.state.write().await;
-        if state.name_in_use(&command.name, None) {
-            return Err(StorageError::conflict(format!(
-                "A collection named '{}' already exists",
-                command.name
-            )));
-        }
         let parent_id = command
             .parent_collection_id
             .map(CollectionID::id)
@@ -536,6 +547,12 @@ impl CollectionStore for MemoryStorage {
         if !state.collections.contains_key(&parent_id) {
             return Err(StorageError::not_found(format!(
                 "Parent collection {parent_id} was not found"
+            )));
+        }
+        if state.collection_name_in_use(parent_id, &command.name, None) {
+            return Err(StorageError::conflict(format!(
+                "A collection named '{}' already exists under parent {parent_id}",
+                command.name
             )));
         }
 
@@ -567,11 +584,12 @@ impl CollectionStore for MemoryStorage {
         if !changes.has_changes(&current) {
             return Ok(current);
         }
-        if let Some(name) = changes.name.as_deref()
-            && state.name_in_use(name, Some(id.id()))
+        if let (Some(name), Some(parent_id)) =
+            (changes.name.as_deref(), current.parent_collection_id)
+            && state.collection_name_in_use(parent_id, name, Some(id.id()))
         {
             return Err(StorageError::conflict(format!(
-                "A collection named '{name}' already exists"
+                "A collection named '{name}' already exists under the same parent"
             )));
         }
 
@@ -589,7 +607,7 @@ impl CollectionStore for MemoryStorage {
         collection.revision = collection
             .revision
             .checked_advance()
-            .map_err(StorageError::from)?;
+            .map_err(map_memory_error)?;
         let updated = collection.clone();
         state.record_event(id.id(), Action::Updated, context);
         Ok(updated)
@@ -710,6 +728,13 @@ impl CollectionStore for MemoryStorage {
                 .get(&current_id)
                 .and_then(|current| current.parent_collection_id);
         }
+        if state.collection_name_in_use(new_parent_id.id(), &collection.name, Some(id.id())) {
+            return Err(StorageError::conflict(format!(
+                "A collection named '{}' already exists under parent {}",
+                collection.name,
+                new_parent_id.id()
+            )));
+        }
 
         let collection = state
             .collections
@@ -720,7 +745,7 @@ impl CollectionStore for MemoryStorage {
         collection.revision = collection
             .revision
             .checked_advance()
-            .map_err(StorageError::from)?;
+            .map_err(map_memory_error)?;
         let moved = collection.clone();
         state.record_event(id.id(), Action::Updated, context);
         Ok(moved)
@@ -728,7 +753,7 @@ impl CollectionStore for MemoryStorage {
 }
 
 #[async_trait]
-impl ClassStore for MemoryStorage {
+impl ClassStore for MemoryStorageModel {
     async fn resolve_class(
         &self,
         selector: ClassSelector,
@@ -743,7 +768,7 @@ impl ClassStore for MemoryStorage {
         command: NewHubuumClass,
         context: &EventContext,
     ) -> Result<HubuumClass, StorageError> {
-        command.validate_schema().map_err(StorageError::from)?;
+        command.validate_schema().map_err(map_memory_error)?;
         let mut state = self.state.write().await;
         if state.class_name_in_use(&command.name, None) {
             return Err(StorageError::conflict(format!(
@@ -787,7 +812,7 @@ impl ClassStore for MemoryStorage {
         let current = state.class_target(target)?.clone();
         changes
             .validate_schema_update(&current)
-            .map_err(StorageError::from)?;
+            .map_err(map_memory_error)?;
         if !changes.has_changes(&current) {
             return Ok(current);
         }
@@ -826,10 +851,7 @@ impl ClassStore for MemoryStorage {
             class.description = description;
         }
         class.updated_at = Utc::now().naive_utc();
-        class.revision = class
-            .revision
-            .checked_advance()
-            .map_err(StorageError::from)?;
+        class.revision = class.revision.checked_advance().map_err(map_memory_error)?;
         let updated = class.clone();
         state.record_class_event(updated.id, Action::Updated, context);
         Ok(updated)
@@ -863,12 +885,12 @@ impl ClassStore for MemoryStorage {
 }
 
 #[async_trait]
-impl ClassRelationStore for MemoryStorage {
+impl ClassRelationStore for MemoryStorageModel {
     async fn prepare_class_relation(
         &self,
         command: NewHubuumClassRelation,
     ) -> Result<PreparedClassRelation, StorageError> {
-        let command = command.normalized().map_err(StorageError::from)?;
+        let command = command.normalized().map_err(map_memory_error)?;
         let state = self.state.read().await;
         let from_class = state
             .classes
@@ -880,7 +902,7 @@ impl ClassRelationStore for MemoryStorage {
             .get(&command.to_hubuum_class_id)
             .cloned()
             .ok_or_else(|| StorageError::not_found("To class was not found"))?;
-        PreparedClassRelation::new(command, from_class, to_class).map_err(StorageError::from)
+        PreparedClassRelation::new(command, from_class, to_class).map_err(map_memory_error)
     }
 
     async fn resolve_class_relation(
@@ -899,7 +921,7 @@ impl ClassRelationStore for MemoryStorage {
             .get(&relation.to_hubuum_class_id)
             .cloned()
             .ok_or_else(|| StorageError::not_found("To class was not found"))?;
-        ResolvedClassRelationTarget::new(relation, from_class, to_class).map_err(StorageError::from)
+        ResolvedClassRelationTarget::new(relation, from_class, to_class).map_err(map_memory_error)
     }
 
     async fn create_class_relation(
@@ -941,7 +963,7 @@ impl ClassRelationStore for MemoryStorage {
             prepared.from_class().clone(),
             prepared.to_class().clone(),
         )
-        .map_err(StorageError::from)
+        .map_err(map_memory_error)
     }
 
     async fn delete_class_relation(
@@ -961,7 +983,7 @@ impl ClassRelationStore for MemoryStorage {
 }
 
 #[async_trait]
-impl ObjectRelationStore for MemoryStorage {
+impl ObjectRelationStore for MemoryStorageModel {
     async fn prepare_object_relation(
         &self,
         selector: ObjectRelationCreateSelector,
@@ -969,10 +991,10 @@ impl ObjectRelationStore for MemoryStorage {
         let state = self.state.read().await;
         match selector.kind() {
             ObjectRelationCreateSelectorKind::Explicit(command) => {
-                let command = command.clone().normalized().map_err(StorageError::from)?;
+                let command = command.clone().normalized().map_err(map_memory_error)?;
                 let (from_object, to_object) = state.object_relation_endpoints(&command)?;
                 let class_relation_id = HubuumClassRelationID::new(command.class_relation_id)
-                    .map_err(StorageError::from)?;
+                    .map_err(map_memory_error)?;
                 let class_relation = state.class_relation(class_relation_id)?;
                 let class_relation = state.resolved_class_relation(class_relation)?;
                 PreparedObjectRelation::new(
@@ -981,31 +1003,26 @@ impl ObjectRelationStore for MemoryStorage {
                     to_object.clone(),
                     class_relation,
                 )
-                .map_err(StorageError::from)
+                .map_err(map_memory_error)
             }
-            ObjectRelationCreateSelectorKind::Between {
-                from_class_id,
-                from_object_id,
-                to_class_id,
-                to_object_id,
-            } => {
+            ObjectRelationCreateSelectorKind::Between { from, to } => {
                 let route_from_object = state
                     .objects
-                    .get(&from_object_id.id())
+                    .get(&from.object_id().id())
                     .ok_or_else(|| StorageError::not_found("From object was not found"))?;
                 let route_to_object = state
                     .objects
-                    .get(&to_object_id.id())
+                    .get(&to.object_id().id())
                     .ok_or_else(|| StorageError::not_found("To object was not found"))?;
-                if route_from_object.hubuum_class_id != from_class_id.id()
-                    || route_to_object.hubuum_class_id != to_class_id.id()
+                if route_from_object.hubuum_class_id != from.class_id().id()
+                    || route_to_object.hubuum_class_id != to.class_id().id()
                 {
                     return Err(StorageError::not_found(
                         "Object was not found in the selected class",
                     ));
                 }
                 let class_relation =
-                    state.direct_class_relation(from_class_id.id(), to_class_id.id())?;
+                    state.direct_class_relation(from.class_id().id(), to.class_id().id())?;
                 let class_relation = state.resolved_class_relation(class_relation)?;
                 let command = NewHubuumObjectRelation {
                     from_hubuum_object_id: route_from_object.id,
@@ -1013,7 +1030,7 @@ impl ObjectRelationStore for MemoryStorage {
                     class_relation_id: class_relation.relation().id,
                 }
                 .normalized()
-                .map_err(StorageError::from)?;
+                .map_err(map_memory_error)?;
                 let (from_object, to_object) =
                     if route_from_object.id == command.from_hubuum_object_id {
                         (route_from_object.clone(), route_to_object.clone())
@@ -1021,7 +1038,7 @@ impl ObjectRelationStore for MemoryStorage {
                         (route_to_object.clone(), route_from_object.clone())
                     };
                 PreparedObjectRelation::new(command, from_object, to_object, class_relation)
-                    .map_err(StorageError::from)
+                    .map_err(map_memory_error)
             }
         }
     }
@@ -1035,29 +1052,24 @@ impl ObjectRelationStore for MemoryStorage {
             ObjectRelationSelectorKind::ById(relation_id) => {
                 state.object_relation(*relation_id)?.to_owned()
             }
-            ObjectRelationSelectorKind::Between {
-                from_class_id,
-                from_object_id,
-                to_class_id,
-                to_object_id,
-            } => {
+            ObjectRelationSelectorKind::Between { from, to } => {
                 let route_from_object = state
                     .objects
-                    .get(&from_object_id.id())
+                    .get(&from.object_id().id())
                     .ok_or_else(|| StorageError::not_found("From object was not found"))?;
                 let route_to_object = state
                     .objects
-                    .get(&to_object_id.id())
+                    .get(&to.object_id().id())
                     .ok_or_else(|| StorageError::not_found("To object was not found"))?;
-                if route_from_object.hubuum_class_id != from_class_id.id()
-                    || route_to_object.hubuum_class_id != to_class_id.id()
+                if route_from_object.hubuum_class_id != from.class_id().id()
+                    || route_to_object.hubuum_class_id != to.class_id().id()
                 {
                     return Err(StorageError::not_found(
                         "Object relation was not found for the selected classes",
                     ));
                 }
                 state
-                    .object_relation_by_pair(from_object_id.id(), to_object_id.id())?
+                    .object_relation_by_pair(from.object_id().id(), to.object_id().id())?
                     .to_owned()
             }
         };
@@ -1068,7 +1080,7 @@ impl ObjectRelationStore for MemoryStorage {
         };
         let (from_object, to_object) = state.object_relation_endpoints(&command)?;
         let class_relation_id =
-            HubuumClassRelationID::new(relation.class_relation_id).map_err(StorageError::from)?;
+            HubuumClassRelationID::new(relation.class_relation_id).map_err(map_memory_error)?;
         let class_relation =
             state.resolved_class_relation(state.class_relation(class_relation_id)?)?;
         ResolvedObjectRelationTarget::new(
@@ -1077,7 +1089,7 @@ impl ObjectRelationStore for MemoryStorage {
             to_object.clone(),
             class_relation,
         )
-        .map_err(StorageError::from)
+        .map_err(map_memory_error)
     }
 
     async fn create_object_relation(
@@ -1138,7 +1150,7 @@ impl ObjectRelationStore for MemoryStorage {
             prepared.to_object().clone(),
             prepared.class_relation().clone(),
         )
-        .map_err(StorageError::from)
+        .map_err(map_memory_error)
     }
 
     async fn delete_object_relation(
@@ -1156,7 +1168,7 @@ impl ObjectRelationStore for MemoryStorage {
 }
 
 #[async_trait]
-impl ObjectStore for MemoryStorage {
+impl ObjectStore for MemoryStorageModel {
     async fn resolve_object(
         &self,
         selector: ObjectSelector,
@@ -1180,7 +1192,7 @@ impl ObjectStore for MemoryStorage {
         let current_class = state.class_target(class)?.clone();
         command
             .validate_for_class(&current_class)
-            .map_err(StorageError::from)?;
+            .map_err(map_memory_error)?;
         if state.object_name_in_use(current_class.id, &command.name, None) {
             return Err(StorageError::conflict(format!(
                 "An object named '{}' already exists in class {}",
@@ -1219,7 +1231,7 @@ impl ObjectStore for MemoryStorage {
         let current = current.clone();
         changes
             .validate_for_class(&current, &class)
-            .map_err(StorageError::from)?;
+            .map_err(map_memory_error)?;
         if !changes.has_changes(&current) {
             return Ok(current);
         }
@@ -1237,7 +1249,7 @@ impl ObjectStore for MemoryStorage {
         updated.revision = current
             .revision
             .checked_advance()
-            .map_err(StorageError::from)?;
+            .map_err(map_memory_error)?;
         state.objects.insert(updated.id, updated.clone());
         state.record_object_event(updated.id, Action::Updated, context);
         Ok(updated)
@@ -1253,12 +1265,12 @@ impl ObjectStore for MemoryStorage {
         let (class, current) = state.object_target(target)?;
         let class = class.clone();
         let current = current.clone();
-        let patched_data = patch.apply(&current.data).map_err(StorageError::from)?;
+        let patched_data = patch.apply(&current.data).map_err(map_memory_error)?;
         if class.validate_schema
             && let Some(schema) = class.json_schema.as_ref()
         {
             crate::utilities::json_schema::validate_json_value(schema, &patched_data)
-                .map_err(StorageError::from)?;
+                .map_err(map_memory_error)?;
         }
         if patched_data == current.data {
             return Ok(current);
@@ -1270,7 +1282,7 @@ impl ObjectStore for MemoryStorage {
         updated.revision = current
             .revision
             .checked_advance()
-            .map_err(StorageError::from)?;
+            .map_err(map_memory_error)?;
         state.objects.insert(updated.id, updated.clone());
         state.record_object_event(updated.id, Action::Updated, context);
         Ok(updated)

--- a/src/storage/memory/error.rs
+++ b/src/storage/memory/error.rs
@@ -1,0 +1,89 @@
+use std::fmt;
+
+use crate::errors::ApiError;
+
+use super::super::{StorageError, StorageErrorKind};
+
+/// Failure produced by the focused in-memory lifecycle contract model.
+#[derive(Debug)]
+pub(super) struct MemoryStorageModelError {
+    source: ApiError,
+}
+
+impl From<ApiError> for MemoryStorageModelError {
+    fn from(source: ApiError) -> Self {
+        Self { source }
+    }
+}
+
+impl fmt::Display for MemoryStorageModelError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.source)
+    }
+}
+
+impl std::error::Error for MemoryStorageModelError {}
+
+impl From<MemoryStorageModelError> for StorageError {
+    fn from(error: MemoryStorageModelError) -> Self {
+        let source = error.source;
+        match source {
+            ApiError::BadRequest(message)
+            | ApiError::InvalidIntegerRange(message)
+            | ApiError::OperatorMismatch(message) => {
+                Self::new(StorageErrorKind::BadRequest, message, None)
+            }
+            ApiError::NotAcceptable(message) => {
+                Self::new(StorageErrorKind::NotAcceptable, message, None)
+            }
+            ApiError::ValidationError(message) => {
+                Self::new(StorageErrorKind::Validation, message, None)
+            }
+            ApiError::PayloadTooLarge(message) => {
+                Self::new(StorageErrorKind::PayloadTooLarge, message, None)
+            }
+            ApiError::Conflict(message) => Self::new(StorageErrorKind::Conflict, message, None),
+            ApiError::DatabaseError(message) | ApiError::DbConnectionError(message) => {
+                Self::new(StorageErrorKind::Database, message, None)
+            }
+            ApiError::NotFound(message) | ApiError::Gone(message) => {
+                Self::new(StorageErrorKind::NotFound, message, None)
+            }
+            ApiError::PreconditionFailed(message, current_etag) => {
+                Self::new(StorageErrorKind::PreconditionFailed, message, current_etag)
+            }
+            ApiError::ServiceUnavailable(message) => {
+                Self::new(StorageErrorKind::Unavailable, message, None)
+            }
+            error => Self::new(
+                StorageErrorKind::Internal,
+                format!(
+                    "unexpected memory storage model error ({}): {error}",
+                    error.class()
+                ),
+                None,
+            ),
+        }
+    }
+}
+
+pub(super) fn map_memory_error(error: ApiError) -> StorageError {
+    MemoryStorageModelError::from(error).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_model_errors_are_classified_before_crossing_the_storage_boundary() {
+        assert_eq!(
+            map_memory_error(ApiError::ValidationError("invalid value".to_string())).kind(),
+            StorageErrorKind::Validation
+        );
+        assert_eq!(
+            map_memory_error(ApiError::Conflict("duplicate".to_string())).kind(),
+            StorageErrorKind::Conflict
+        );
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,19 +1,27 @@
 mod class_relations;
 mod classes;
 mod collections;
+mod contract;
 mod error;
 #[cfg(test)]
 mod memory;
 mod object_relations;
 mod objects;
+mod observed;
 mod postgres;
 
-pub use class_relations::ClassRelationStore;
-pub use classes::ClassStore;
-pub use collections::{CollectionStore, DynStorage, Storage};
-pub use error::StorageError;
+pub(crate) use class_relations::ClassRelationStore;
+pub(crate) use classes::ClassStore;
+pub(crate) use collections::CollectionStore;
 #[cfg(test)]
-pub(crate) use memory::MemoryStorage;
-pub use object_relations::ObjectRelationStore;
-pub use objects::ObjectStore;
-pub use postgres::PostgresStorage;
+pub(crate) use contract::STORAGE_CONTRACT_VERSION;
+pub(crate) use contract::{
+    DynLifecycleStorage, LifecycleStorage, StorageBackend, StorageBackendDescriptor,
+    StorageBackendKind, StorageIdentity,
+};
+pub(crate) use error::{StorageError, StorageErrorKind};
+#[cfg(test)]
+pub(crate) use memory::MemoryStorageModel;
+pub(crate) use object_relations::ObjectRelationStore;
+pub(crate) use objects::ObjectStore;
+pub(crate) use postgres::PostgresStorage;

--- a/src/storage/object_relations.rs
+++ b/src/storage/object_relations.rs
@@ -10,7 +10,7 @@ use super::StorageError;
 
 /// Persistence capability for object-relation resolution and lifecycle writes.
 #[async_trait]
-pub trait ObjectRelationStore: Send + Sync {
+pub(crate) trait ObjectRelationStore: Send + Sync {
     async fn prepare_object_relation(
         &self,
         selector: ObjectRelationCreateSelector,

--- a/src/storage/objects.rs
+++ b/src/storage/objects.rs
@@ -14,7 +14,7 @@ use super::StorageError;
 /// implementations can recheck ID- and name-based mutations atomically before
 /// writing.
 #[async_trait]
-pub trait ObjectStore: Send + Sync {
+pub(crate) trait ObjectStore: Send + Sync {
     async fn resolve_object(
         &self,
         selector: ObjectSelector,

--- a/src/storage/observed.rs
+++ b/src/storage/observed.rs
@@ -1,0 +1,396 @@
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use tracing::{Instrument, debug, debug_span, warn};
+
+use crate::events::EventContext;
+use crate::models::{
+    ClassSelector, Collection, CollectionID, HubuumClass, HubuumClassRelationID, HubuumObject,
+    NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
+    ObjectDataPatchDocument, ObjectRelationCreateSelector, ObjectRelationSelector, ObjectSelector,
+    PreparedClassRelation, PreparedObjectRelation, ResolvedClassRelationTarget,
+    ResolvedClassTarget, ResolvedObjectRelationTarget, ResolvedObjectTarget, UpdateCollection,
+    UpdateHubuumClass, UpdateHubuumObject,
+};
+
+use super::{
+    ClassRelationStore, ClassStore, CollectionStore, LifecycleStorage, ObjectRelationStore,
+    ObjectStore, StorageError, StorageIdentity,
+};
+
+/// Uniform diagnostics around every lifecycle storage entrypoint.
+pub(super) struct ObservedLifecycleStorage {
+    backend: &'static str,
+    inner: Arc<dyn LifecycleStorage>,
+}
+
+impl ObservedLifecycleStorage {
+    pub(super) fn new(inner: Arc<dyn LifecycleStorage>) -> Self {
+        Self {
+            backend: inner.storage_name(),
+            inner,
+        }
+    }
+
+    async fn call<T>(
+        &self,
+        capability: &'static str,
+        operation: &'static str,
+        future: impl Future<Output = Result<T, StorageError>>,
+    ) -> Result<T, StorageError> {
+        let backend = self.backend;
+        let span = debug_span!("storage_operation", backend, capability, operation,);
+        async move {
+            let started_at = Instant::now();
+            let result = future.await;
+            let duration = started_at.elapsed();
+            let result_kind = result
+                .as_ref()
+                .map(|_| "ok")
+                .unwrap_or_else(|error| error.kind().as_str());
+            crate::observability::metrics::storage_operation_finished(
+                backend,
+                capability,
+                operation,
+                result_kind,
+                duration,
+            );
+
+            match &result {
+                Ok(_) => debug!(
+                    message = "storage operation complete",
+                    elapsed_ms = duration.as_millis(),
+                ),
+                Err(error) if error.kind().is_backend_failure() => warn!(
+                    message = "storage operation failed",
+                    error_kind = error.kind().as_str(),
+                    elapsed_ms = duration.as_millis(),
+                    error = %error,
+                ),
+                Err(error) => debug!(
+                    message = "storage operation rejected",
+                    error_kind = error.kind().as_str(),
+                    elapsed_ms = duration.as_millis(),
+                    error = %error,
+                ),
+            }
+            result
+        }
+        .instrument(span)
+        .await
+    }
+}
+
+impl StorageIdentity for ObservedLifecycleStorage {
+    fn storage_name(&self) -> &'static str {
+        self.backend
+    }
+}
+
+#[async_trait]
+impl CollectionStore for ObservedLifecycleStorage {
+    async fn get_collection(&self, id: CollectionID) -> Result<Collection, StorageError> {
+        self.call("collections", "get", self.inner.get_collection(id))
+            .await
+    }
+
+    async fn create_collection(
+        &self,
+        command: NewCollectionWithAssignee,
+        context: &EventContext,
+    ) -> Result<Collection, StorageError> {
+        self.call(
+            "collections",
+            "create",
+            self.inner.create_collection(command, context),
+        )
+        .await
+    }
+
+    async fn update_collection(
+        &self,
+        id: CollectionID,
+        changes: UpdateCollection,
+        context: &EventContext,
+    ) -> Result<Collection, StorageError> {
+        self.call(
+            "collections",
+            "update",
+            self.inner.update_collection(id, changes, context),
+        )
+        .await
+    }
+
+    async fn delete_collection(
+        &self,
+        id: CollectionID,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        self.call(
+            "collections",
+            "delete",
+            self.inner.delete_collection(id, context),
+        )
+        .await
+    }
+
+    async fn collection_children(&self, id: CollectionID) -> Result<Vec<Collection>, StorageError> {
+        self.call(
+            "collections",
+            "children",
+            self.inner.collection_children(id),
+        )
+        .await
+    }
+
+    async fn collection_ancestors(
+        &self,
+        id: CollectionID,
+    ) -> Result<Vec<Collection>, StorageError> {
+        self.call(
+            "collections",
+            "ancestors",
+            self.inner.collection_ancestors(id),
+        )
+        .await
+    }
+
+    async fn move_collection(
+        &self,
+        id: CollectionID,
+        new_parent_id: CollectionID,
+        context: &EventContext,
+    ) -> Result<Collection, StorageError> {
+        self.call(
+            "collections",
+            "move",
+            self.inner.move_collection(id, new_parent_id, context),
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl ClassStore for ObservedLifecycleStorage {
+    async fn resolve_class(
+        &self,
+        selector: ClassSelector,
+    ) -> Result<ResolvedClassTarget, StorageError> {
+        self.call("classes", "resolve", self.inner.resolve_class(selector))
+            .await
+    }
+
+    async fn create_class(
+        &self,
+        command: NewHubuumClass,
+        context: &EventContext,
+    ) -> Result<HubuumClass, StorageError> {
+        self.call(
+            "classes",
+            "create",
+            self.inner.create_class(command, context),
+        )
+        .await
+    }
+
+    async fn update_class(
+        &self,
+        target: &ResolvedClassTarget,
+        changes: UpdateHubuumClass,
+        context: &EventContext,
+    ) -> Result<HubuumClass, StorageError> {
+        self.call(
+            "classes",
+            "update",
+            self.inner.update_class(target, changes, context),
+        )
+        .await
+    }
+
+    async fn delete_class(
+        &self,
+        target: &ResolvedClassTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        self.call(
+            "classes",
+            "delete",
+            self.inner.delete_class(target, context),
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl ObjectStore for ObservedLifecycleStorage {
+    async fn resolve_object(
+        &self,
+        selector: ObjectSelector,
+    ) -> Result<ResolvedObjectTarget, StorageError> {
+        self.call("objects", "resolve", self.inner.resolve_object(selector))
+            .await
+    }
+
+    async fn create_object(
+        &self,
+        class: &ResolvedClassTarget,
+        command: NewHubuumObject,
+        context: &EventContext,
+    ) -> Result<HubuumObject, StorageError> {
+        self.call(
+            "objects",
+            "create",
+            self.inner.create_object(class, command, context),
+        )
+        .await
+    }
+
+    async fn update_object(
+        &self,
+        target: &ResolvedObjectTarget,
+        changes: UpdateHubuumObject,
+        context: &EventContext,
+    ) -> Result<HubuumObject, StorageError> {
+        self.call(
+            "objects",
+            "update",
+            self.inner.update_object(target, changes, context),
+        )
+        .await
+    }
+
+    async fn patch_object_data(
+        &self,
+        target: &ResolvedObjectTarget,
+        patch: ObjectDataPatchDocument,
+        context: &EventContext,
+    ) -> Result<HubuumObject, StorageError> {
+        self.call(
+            "objects",
+            "patch_data",
+            self.inner.patch_object_data(target, patch, context),
+        )
+        .await
+    }
+
+    async fn delete_object(
+        &self,
+        target: &ResolvedObjectTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        self.call(
+            "objects",
+            "delete",
+            self.inner.delete_object(target, context),
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl ClassRelationStore for ObservedLifecycleStorage {
+    async fn prepare_class_relation(
+        &self,
+        command: NewHubuumClassRelation,
+    ) -> Result<PreparedClassRelation, StorageError> {
+        self.call(
+            "class_relations",
+            "prepare_create",
+            self.inner.prepare_class_relation(command),
+        )
+        .await
+    }
+
+    async fn resolve_class_relation(
+        &self,
+        id: HubuumClassRelationID,
+    ) -> Result<ResolvedClassRelationTarget, StorageError> {
+        self.call(
+            "class_relations",
+            "resolve",
+            self.inner.resolve_class_relation(id),
+        )
+        .await
+    }
+
+    async fn create_class_relation(
+        &self,
+        prepared: &PreparedClassRelation,
+        context: &EventContext,
+    ) -> Result<ResolvedClassRelationTarget, StorageError> {
+        self.call(
+            "class_relations",
+            "create",
+            self.inner.create_class_relation(prepared, context),
+        )
+        .await
+    }
+
+    async fn delete_class_relation(
+        &self,
+        target: &ResolvedClassRelationTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        self.call(
+            "class_relations",
+            "delete",
+            self.inner.delete_class_relation(target, context),
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl ObjectRelationStore for ObservedLifecycleStorage {
+    async fn prepare_object_relation(
+        &self,
+        selector: ObjectRelationCreateSelector,
+    ) -> Result<PreparedObjectRelation, StorageError> {
+        self.call(
+            "object_relations",
+            "prepare_create",
+            self.inner.prepare_object_relation(selector),
+        )
+        .await
+    }
+
+    async fn resolve_object_relation(
+        &self,
+        selector: ObjectRelationSelector,
+    ) -> Result<ResolvedObjectRelationTarget, StorageError> {
+        self.call(
+            "object_relations",
+            "resolve",
+            self.inner.resolve_object_relation(selector),
+        )
+        .await
+    }
+
+    async fn create_object_relation(
+        &self,
+        prepared: &PreparedObjectRelation,
+        context: &EventContext,
+    ) -> Result<ResolvedObjectRelationTarget, StorageError> {
+        self.call(
+            "object_relations",
+            "create",
+            self.inner.create_object_relation(prepared, context),
+        )
+        .await
+    }
+
+    async fn delete_object_relation(
+        &self,
+        target: &ResolvedObjectRelationTarget,
+        context: &EventContext,
+    ) -> Result<(), StorageError> {
+        self.call(
+            "object_relations",
+            "delete",
+            self.inner.delete_object_relation(target, context),
+        )
+        .await
+    }
+}

--- a/src/storage/postgres.rs
+++ b/src/storage/postgres.rs
@@ -1,3 +1,5 @@
+mod error;
+
 use async_trait::async_trait;
 
 use crate::db::DbPool;
@@ -32,18 +34,30 @@ use crate::models::{
 };
 
 use super::{
-    ClassRelationStore, ClassStore, CollectionStore, ObjectRelationStore, ObjectStore, StorageError,
+    ClassRelationStore, ClassStore, CollectionStore, ObjectRelationStore, ObjectStore,
+    StorageError, StorageIdentity,
 };
+use error::map_postgres_error;
 
 /// Canonical production storage adapter.
 #[derive(Clone)]
-pub struct PostgresStorage {
+pub(crate) struct PostgresStorage {
     pool: DbPool,
 }
 
 impl PostgresStorage {
-    pub fn new(pool: DbPool) -> Self {
+    pub(crate) fn new(pool: DbPool) -> Self {
         Self { pool }
+    }
+
+    pub(crate) fn pool(&self) -> &DbPool {
+        &self.pool
+    }
+}
+
+impl StorageIdentity for PostgresStorage {
+    fn storage_name(&self) -> &'static str {
+        "postgresql"
     }
 }
 
@@ -52,7 +66,7 @@ impl CollectionStore for PostgresStorage {
     async fn get_collection(&self, id: CollectionID) -> Result<Collection, StorageError> {
         id.collection_from_backend(&self.pool)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn create_collection(
@@ -63,7 +77,7 @@ impl CollectionStore for PostgresStorage {
         command
             .save_collection_with_assignee_record(&self.pool, Some(context))
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn update_collection(
@@ -75,7 +89,7 @@ impl CollectionStore for PostgresStorage {
         changes
             .update_collection_record(&self.pool, id.id(), Some(context))
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn delete_collection(
@@ -85,13 +99,13 @@ impl CollectionStore for PostgresStorage {
     ) -> Result<(), StorageError> {
         id.delete_collection_record(&self.pool, Some(context))
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn collection_children(&self, id: CollectionID) -> Result<Vec<Collection>, StorageError> {
         collection_children_from_backend(&self.pool, id)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn collection_ancestors(
@@ -100,7 +114,7 @@ impl CollectionStore for PostgresStorage {
     ) -> Result<Vec<Collection>, StorageError> {
         collection_ancestors_from_backend(&self.pool, id)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn move_collection(
@@ -111,7 +125,7 @@ impl CollectionStore for PostgresStorage {
     ) -> Result<Collection, StorageError> {
         move_collection_record_from_backend(&self.pool, id.id(), new_parent_id.id(), Some(context))
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 }
 
@@ -124,7 +138,7 @@ impl ClassStore for PostgresStorage {
         let class = selector
             .resolve_class_selector_record(&self.pool)
             .await
-            .map_err(StorageError::from)?;
+            .map_err(map_postgres_error)?;
         Ok(ResolvedClassTarget::new(selector, class))
     }
 
@@ -133,11 +147,11 @@ impl ClassStore for PostgresStorage {
         command: NewHubuumClass,
         context: &EventContext,
     ) -> Result<HubuumClass, StorageError> {
-        command.validate_schema().map_err(StorageError::from)?;
+        command.validate_schema().map_err(map_postgres_error)?;
         command
             .create_class_record(&self.pool, Some(context))
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn update_class(
@@ -149,7 +163,7 @@ impl ClassStore for PostgresStorage {
         changes
             .update_resolved_class_record(&self.pool, target, context)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn delete_class(
@@ -160,7 +174,7 @@ impl ClassStore for PostgresStorage {
         target
             .delete_resolved_class_record(&self.pool, context)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 }
 
@@ -173,7 +187,7 @@ impl ClassRelationStore for PostgresStorage {
         command
             .prepare_class_relation_record(&self.pool)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn resolve_class_relation(
@@ -182,7 +196,7 @@ impl ClassRelationStore for PostgresStorage {
     ) -> Result<ResolvedClassRelationTarget, StorageError> {
         id.resolve_class_relation_target_record(&self.pool)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn create_class_relation(
@@ -193,13 +207,13 @@ impl ClassRelationStore for PostgresStorage {
         let relation = prepared
             .create_prepared_class_relation_record(&self.pool, context)
             .await
-            .map_err(StorageError::from)?;
+            .map_err(map_postgres_error)?;
         ResolvedClassRelationTarget::new(
             relation,
             prepared.from_class().clone(),
             prepared.to_class().clone(),
         )
-        .map_err(StorageError::from)
+        .map_err(map_postgres_error)
     }
 
     async fn delete_class_relation(
@@ -210,7 +224,7 @@ impl ClassRelationStore for PostgresStorage {
         target
             .delete_resolved_class_relation_record(&self.pool, context)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 }
 
@@ -223,7 +237,7 @@ impl ObjectRelationStore for PostgresStorage {
         selector
             .prepare_object_relation_record(&self.pool)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn resolve_object_relation(
@@ -233,7 +247,7 @@ impl ObjectRelationStore for PostgresStorage {
         selector
             .resolve_object_relation_target_record(&self.pool)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn create_object_relation(
@@ -244,14 +258,14 @@ impl ObjectRelationStore for PostgresStorage {
         let relation = prepared
             .create_prepared_object_relation_record(&self.pool, context)
             .await
-            .map_err(StorageError::from)?;
+            .map_err(map_postgres_error)?;
         ResolvedObjectRelationTarget::new(
             relation,
             prepared.from_object().clone(),
             prepared.to_object().clone(),
             prepared.class_relation().clone(),
         )
-        .map_err(StorageError::from)
+        .map_err(map_postgres_error)
     }
 
     async fn delete_object_relation(
@@ -262,7 +276,7 @@ impl ObjectRelationStore for PostgresStorage {
         target
             .delete_resolved_object_relation_record(&self.pool, context)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 }
 
@@ -275,7 +289,7 @@ impl ObjectStore for PostgresStorage {
         let (class, object) = selector
             .resolve_object_selector_record(&self.pool)
             .await
-            .map_err(StorageError::from)?;
+            .map_err(map_postgres_error)?;
         Ok(ResolvedObjectTarget::new(selector, class, object))
     }
 
@@ -288,7 +302,7 @@ impl ObjectStore for PostgresStorage {
         command
             .create_object_in_resolved_class_record(&self.pool, class, context)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn update_object(
@@ -300,7 +314,7 @@ impl ObjectStore for PostgresStorage {
         changes
             .update_resolved_object_record(&self.pool, target, context)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn patch_object_data(
@@ -312,7 +326,7 @@ impl ObjectStore for PostgresStorage {
         patch
             .patch_object_data_record(&self.pool, target, context)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 
     async fn delete_object(
@@ -323,6 +337,6 @@ impl ObjectStore for PostgresStorage {
         target
             .delete_resolved_object_record(&self.pool, context)
             .await
-            .map_err(StorageError::from)
+            .map_err(map_postgres_error)
     }
 }

--- a/src/storage/postgres/error.rs
+++ b/src/storage/postgres/error.rs
@@ -1,0 +1,94 @@
+use std::fmt;
+
+use crate::errors::ApiError;
+
+use super::super::{StorageError, StorageErrorKind};
+
+/// PostgreSQL adapter failure before it crosses the neutral storage boundary.
+///
+/// The adapter currently delegates to legacy database operations that return
+/// `ApiError`. Wrapping them here prevents that application error type from
+/// becoming part of the storage contract and gives the PostgreSQL adapter one
+/// deliberate translation point.
+#[derive(Debug)]
+pub(super) struct PostgresStorageError {
+    source: ApiError,
+}
+
+impl From<ApiError> for PostgresStorageError {
+    fn from(source: ApiError) -> Self {
+        Self { source }
+    }
+}
+
+impl fmt::Display for PostgresStorageError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.source)
+    }
+}
+
+impl std::error::Error for PostgresStorageError {}
+
+impl From<PostgresStorageError> for StorageError {
+    fn from(error: PostgresStorageError) -> Self {
+        let source = error.source;
+        match source {
+            ApiError::BadRequest(message)
+            | ApiError::InvalidIntegerRange(message)
+            | ApiError::OperatorMismatch(message) => {
+                Self::new(StorageErrorKind::BadRequest, message, None)
+            }
+            ApiError::NotAcceptable(message) => {
+                Self::new(StorageErrorKind::NotAcceptable, message, None)
+            }
+            ApiError::ValidationError(message) => {
+                Self::new(StorageErrorKind::Validation, message, None)
+            }
+            ApiError::PayloadTooLarge(message) => {
+                Self::new(StorageErrorKind::PayloadTooLarge, message, None)
+            }
+            ApiError::Conflict(message) => Self::new(StorageErrorKind::Conflict, message, None),
+            ApiError::DatabaseError(message) | ApiError::DbConnectionError(message) => {
+                Self::new(StorageErrorKind::Database, message, None)
+            }
+            ApiError::NotFound(message) | ApiError::Gone(message) => {
+                Self::new(StorageErrorKind::NotFound, message, None)
+            }
+            ApiError::PreconditionFailed(message, current_etag) => {
+                Self::new(StorageErrorKind::PreconditionFailed, message, current_etag)
+            }
+            ApiError::ServiceUnavailable(message) => {
+                Self::new(StorageErrorKind::Unavailable, message, None)
+            }
+            error => Self::new(
+                StorageErrorKind::Internal,
+                format!(
+                    "unexpected PostgreSQL storage adapter error ({}): {error}",
+                    error.class()
+                ),
+                None,
+            ),
+        }
+    }
+}
+
+pub(super) fn map_postgres_error(error: ApiError) -> StorageError {
+    PostgresStorageError::from(error).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn postgres_errors_are_classified_before_crossing_the_storage_boundary() {
+        assert_eq!(
+            map_postgres_error(ApiError::DatabaseError("query failed".to_string())).kind(),
+            StorageErrorKind::Database
+        );
+        assert_eq!(
+            map_postgres_error(ApiError::NotFound("missing".to_string())).kind(),
+            StorageErrorKind::NotFound
+        );
+    }
+}

--- a/src/tasks/execution.rs
+++ b/src/tasks/execution.rs
@@ -209,7 +209,7 @@ where
     C: BackendContext + ?Sized,
 {
     let total_timer = metrics::import_phase_timer(metrics::ImportMetricPhase::Total);
-    let pool = backend.db_pool();
+    let pool = crate::traits::backend_pool(backend);
     let payload = task
         .request_payload
         .clone()

--- a/src/tasks/planning.rs
+++ b/src/tasks/planning.rs
@@ -279,7 +279,7 @@ where
         return Ok(is_admin);
     }
 
-    let pool = backend.db_pool();
+    let pool = crate::traits::backend_pool(backend);
     let is_admin = match backend.permission_backend() {
         Some(permission_backend) if !permission_backend.uses_sql_permission_store() => {
             let principal = PrincipalRef::load(pool, user)
@@ -481,7 +481,7 @@ async fn plan_import_with_admin_status<C>(
 where
     C: BackendContext + ?Sized,
 {
-    let pool = backend.db_pool();
+    let pool = crate::traits::backend_pool(backend);
     let mode = request.mode();
     let mut state = PlanningState::new();
     state.scopes = scopes.cloned();
@@ -946,7 +946,7 @@ pub(super) async fn plan_collection<C>(
 where
     C: BackendContext + ?Sized,
 {
-    let pool = backend.db_pool();
+    let pool = crate::traits::backend_pool(backend);
     if let Some(reference) = &input.ref_
         && state.collections_by_ref.contains_key(reference)
     {
@@ -1163,7 +1163,7 @@ pub(super) async fn plan_class<C>(
 where
     C: BackendContext + ?Sized,
 {
-    let pool = backend.db_pool();
+    let pool = crate::traits::backend_pool(backend);
     if let Some(schema) = input.json_schema.as_ref() {
         crate::utilities::json_schema::validate_json_schema(schema).map_err(|error| {
             PlanningFailure {
@@ -1387,7 +1387,7 @@ pub(super) async fn plan_object<C>(
 where
     C: BackendContext + ?Sized,
 {
-    let pool = backend.db_pool();
+    let pool = crate::traits::backend_pool(backend);
     if let Some(reference) = &input.ref_
         && state.objects_by_ref.contains_key(reference)
     {
@@ -1601,7 +1601,7 @@ pub(super) async fn plan_class_relation<C>(
 where
     C: BackendContext + ?Sized,
 {
-    let pool = backend.db_pool();
+    let pool = crate::traits::backend_pool(backend);
     let from_class = resolve_class_planning(
         pool,
         state,
@@ -1747,7 +1747,7 @@ pub(super) async fn plan_object_relation<C>(
 where
     C: BackendContext + ?Sized,
 {
-    let pool = backend.db_pool();
+    let pool = crate::traits::backend_pool(backend);
     let from_object = resolve_object_planning(
         pool,
         state,
@@ -1917,7 +1917,7 @@ pub(super) async fn plan_collection_permission<C>(
 where
     C: BackendContext + ?Sized,
 {
-    let pool = backend.db_pool();
+    let pool = crate::traits::backend_pool(backend);
     let collection = resolve_collection_planning(
         pool,
         state,

--- a/src/tasks/remote_call.rs
+++ b/src/tasks/remote_call.rs
@@ -60,7 +60,7 @@ pub(super) async fn execute_remote_call_task<C>(
 where
     C: BackendContext + ?Sized,
 {
-    let pool = backend.db_pool();
+    let pool = crate::traits::backend_pool(backend);
     let payload = task
         .request_payload
         .clone()
@@ -138,7 +138,7 @@ async fn execute_remote_call<C>(
 where
     C: BackendContext + ?Sized,
 {
-    let pool = backend.db_pool();
+    let pool = crate::traits::backend_pool(backend);
     let target = request.target_id.instance(pool).await?;
     let resolved =
         authorize_remote_invocation(backend, user, scopes, &target, &request.subject).await?;

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -625,7 +625,10 @@ where
     }
 }
 
-async fn maybe_recover_expired_task_leases(pool: &DbPool) -> Result<(), ApiError> {
+async fn maybe_recover_expired_task_leases(
+    pool: &impl crate::traits::BackendContext,
+) -> Result<(), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let recovery_interval = task_worker_settings().recovery_interval();
     let previous_last_run = {
         let mut state = recovery_state().lock().map_err(|_| {
@@ -664,7 +667,10 @@ async fn maybe_recover_expired_task_leases(pool: &DbPool) -> Result<(), ApiError
     }
 }
 
-async fn maybe_cleanup_expired_task_outputs(pool: &DbPool) -> Result<(), ApiError> {
+async fn maybe_cleanup_expired_task_outputs(
+    pool: &impl crate::traits::BackendContext,
+) -> Result<(), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let cleanup_interval = task_worker_settings().export_output_cleanup_interval();
     let Some(reservation) = CleanupReservation::reserve(cleanup_state(), cleanup_interval)? else {
         return Ok(());
@@ -708,7 +714,7 @@ async fn process_claimed_task(
     task: &TaskRecord,
     backup_settings: &BackupSettings,
 ) -> Result<(), ApiError> {
-    let pool = &context.db_pool;
+    let pool = context;
     let task_kind = TaskKind::from_db(&task.kind)?;
     if task_kind == TaskKind::Reindex {
         return crate::db::traits::computed_field::execute_computed_reindex_task(pool, task).await;
@@ -765,10 +771,11 @@ async fn process_claimed_task(
 }
 
 pub(super) async fn mark_claimed_task_failed(
-    pool: &DbPool,
+    pool: &impl crate::traits::BackendContext,
     task: &TaskRecord,
     err: &ApiError,
 ) -> Result<(), ApiError> {
+    let pool = crate::traits::backend_pool(pool);
     let task_kind = TaskKind::from_db(&task.kind)?;
     let task = if task_kind == TaskKind::Reindex {
         task.find_record(pool).await?

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -1,0 +1,262 @@
+//! Compile-time-adjacent guards for the application/storage boundary.
+
+#[cfg(test)]
+use std::fs;
+#[cfg(test)]
+use std::path::{Path, PathBuf};
+
+#[cfg(test)]
+fn repository_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+#[cfg(test)]
+fn rust_files(directory: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut pending = vec![directory.to_path_buf()];
+
+    while let Some(current) = pending.pop() {
+        for entry in fs::read_dir(&current)
+            .unwrap_or_else(|error| panic!("could not read {}: {error}", current.display()))
+        {
+            let path = entry.expect("directory entry should be readable").path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path.extension().is_some_and(|extension| extension == "rs") {
+                files.push(path);
+            }
+        }
+    }
+
+    files.sort();
+    files
+}
+
+#[cfg(test)]
+fn is_storage_adapter(root: &Path, path: &Path) -> bool {
+    ["postgres", "memory"].into_iter().any(|adapter| {
+        path == root.join(format!("src/storage/{adapter}.rs"))
+            || path.starts_with(root.join(format!("src/storage/{adapter}")))
+    })
+}
+
+#[test]
+fn app_context_exposes_only_an_opaque_backend_handle() {
+    let root = repository_root();
+    let context_path = root.join("src/permissions/context.rs");
+    let context_source = fs::read_to_string(&context_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", context_path.display()));
+    let trait_path = root.join("src/traits/context.rs");
+    let trait_source = fs::read_to_string(&trait_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", trait_path.display()));
+    let application_path = root.join("src/application.rs");
+    let application_source = fs::read_to_string(&application_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", application_path.display()));
+
+    assert!(
+        context_source.contains("backend: BackendHandle"),
+        "AppContext must own the opaque backend handle"
+    );
+    for forbidden in [
+        "pub db_pool:",
+        "pub fn postgres_pool",
+        "pub fn clone_postgres_pool",
+        "impl Deref for AppContext",
+    ] {
+        assert!(
+            !context_source.contains(forbidden),
+            "AppContext exposes forbidden backend detail: {forbidden}"
+        );
+    }
+    let backend_context_body = trait_source
+        .split_once("pub trait BackendContext")
+        .and_then(|(_, remainder)| remainder.split_once("\n}"))
+        .map(|(body, _)| body)
+        .expect("BackendContext should have a readable trait body");
+    assert!(
+        !backend_context_body.contains("fn db_pool"),
+        "BackendContext must not expose a database-pool accessor"
+    );
+    assert!(
+        trait_source.contains("pub(crate) fn backend_pool"),
+        "backend adapters need a crate-private implementation access point"
+    );
+    assert!(
+        !application_source.contains(".app_data(Data::new(app_pool"),
+        "the production HTTP server must not register a raw database pool"
+    );
+    assert!(
+        !application_source.contains("pool: db::DbPool"),
+        "operational HTTP services must receive AppContext rather than DbPool"
+    );
+}
+
+#[test]
+fn application_consumers_do_not_import_database_implementation_details() {
+    let root = repository_root();
+    let mut paths = Vec::new();
+    for directory in ["src/api", "src/extractors", "src/middlewares"] {
+        paths.extend(rust_files(&root.join(directory)));
+    }
+    paths.push(root.join("src/observability/metrics/scrape.rs"));
+
+    let mut violations = Vec::new();
+    for path in paths {
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+        for forbidden in [
+            "crate::db",
+            "DbPool",
+            "backend_pool",
+            "diesel::",
+            "diesel_async",
+            "postgres_pool",
+            "pool: AppContext",
+            "pool: &AppContext",
+        ] {
+            if source.contains(forbidden) {
+                violations.push(format!("{} imports or uses {forbidden}", path.display()));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "application consumers crossed the opaque backend boundary:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn backend_neutral_layers_do_not_import_database_implementation_details() {
+    let root = repository_root();
+    let mut violations = Vec::new();
+
+    for directory in ["src/services", "src/storage"] {
+        for path in rust_files(&root.join(directory)) {
+            if is_storage_adapter(&root, &path) {
+                continue;
+            }
+
+            let source = fs::read_to_string(&path)
+                .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+            for forbidden in [
+                "crate::db::traits",
+                "crate::db::with_connection",
+                "crate::db::with_transaction",
+                "diesel::",
+                "diesel_async",
+                "BackendContext",
+                "postgres_pool",
+                "backend_pool",
+            ] {
+                if source.contains(forbidden) {
+                    violations.push(format!("{} imports or uses {forbidden}", path.display()));
+                }
+            }
+            if path.starts_with(root.join("src/storage")) && source.contains("ApiError") {
+                violations.push(format!(
+                    "{} couples backend-neutral storage to ApiError",
+                    path.display()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "backend-neutral service/storage code crossed into the PostgreSQL compatibility layer:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable() {
+    let root = repository_root();
+    let contract_path = root.join("src/storage/contract.rs");
+    let contract_source = fs::read_to_string(&contract_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", contract_path.display()));
+    let context_path = root.join("src/traits/context.rs");
+    let context_source = fs::read_to_string(&context_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", context_path.display()));
+
+    let contract_body = contract_source
+        .split_once("pub(crate) trait StorageBackend:")
+        .and_then(|(_, remainder)| remainder.split_once("\n{"))
+        .map(|(body, _)| body)
+        .expect("StorageBackend should have a readable aggregate trait declaration");
+    for required in [
+        "LifecycleStorage",
+        "IdentityAndAuthorizationStorage",
+        "QueryAndHistoryStorage",
+        "WorkflowStorage",
+        "OperationalStorage",
+        "sealed::CertifiedStorageBackend",
+    ] {
+        assert!(
+            contract_body.contains(required),
+            "complete storage contract is missing {required}"
+        );
+    }
+    assert!(
+        contract_source.contains("impl sealed::CertifiedStorageBackend for PostgresStorage"),
+        "PostgreSQL must be explicitly certified in the central storage contract"
+    );
+    assert!(
+        !contract_source.contains("CertifiedStorageBackend for MemoryStorageModel"),
+        "the focused memory contract model must not be selectable as a full backend"
+    );
+    assert!(
+        context_source.contains("assert_complete_storage_backend(&backend)"),
+        "application composition must enforce the complete storage contract"
+    );
+}
+
+#[test]
+fn storage_error_translation_has_one_way_dependency_direction() {
+    let root = repository_root();
+    let errors_path = root.join("src/errors.rs");
+    let errors_source = fs::read_to_string(&errors_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", errors_path.display()));
+    let postgres_error_path = root.join("src/storage/postgres/error.rs");
+    let postgres_error_source = fs::read_to_string(&postgres_error_path).unwrap_or_else(|error| {
+        panic!("could not read {}: {error}", postgres_error_path.display())
+    });
+
+    assert!(
+        !errors_source.contains("impl From<ApiError> for StorageError"),
+        "application errors must not provide a reverse conversion into storage"
+    );
+    assert!(
+        errors_source.contains("impl From<StorageError> for ApiError"),
+        "the application layer must own storage-to-API error translation"
+    );
+    assert!(
+        postgres_error_source.contains("struct PostgresStorageError"),
+        "the PostgreSQL adapter must own its backend-specific error"
+    );
+    assert!(
+        postgres_error_source.contains("impl From<PostgresStorageError> for StorageError"),
+        "the PostgreSQL adapter error must translate at the storage boundary"
+    );
+}
+
+#[test]
+fn persistence_facades_do_not_reexport_internal_layers_wholesale() {
+    let root = repository_root();
+    let backend_path = root.join("src/backend.rs");
+    let backend_source = fs::read_to_string(&backend_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", backend_path.display()));
+    let library_path = root.join("src/lib.rs");
+    let library_source = fs::read_to_string(&library_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", library_path.display()));
+
+    assert!(
+        !backend_source.contains("pub(crate) use crate::db::traits as capabilities"),
+        "the application capability facade must explicitly whitelist operations"
+    );
+    assert!(
+        !library_source.contains("pub mod storage;"),
+        "storage adapters are internal application composition details"
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,6 +2,7 @@
 pub mod acl;
 pub mod api_operations;
 pub use api_operations::app_context;
+pub mod application_boundary;
 pub mod asserts;
 #[cfg(test)]
 pub mod client_allowlist;
@@ -14,6 +15,8 @@ pub mod id_newtypes;
 pub mod permissions;
 #[cfg(test)]
 pub mod search;
+#[cfg(test)]
+pub(crate) mod storage_contract;
 #[cfg(test)]
 pub mod storage_performance;
 #[cfg(test)]

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -1,0 +1,60 @@
+use std::sync::{Arc, LazyLock};
+
+use actix_web::web::Data;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::db::DbPool;
+use crate::models::CollectionID;
+use crate::services::Services;
+use crate::storage::{STORAGE_CONTRACT_VERSION, StorageBackendKind};
+use crate::traits::BackendHandle;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum LifecycleContractImplementation {
+    MemoryModel,
+    PostgresAdapter,
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_composes_through_the_complete_contract() {
+    let _permit = postgres_permit().await;
+
+    for kind in StorageBackendKind::ALL {
+        match kind {
+            StorageBackendKind::Postgresql => {
+                let backend = BackendHandle::postgres(pool().get_ref().clone());
+                let descriptor = backend.descriptor();
+                assert_eq!(descriptor.kind(), kind);
+                assert_eq!(descriptor.contract_version(), STORAGE_CONTRACT_VERSION);
+
+                let services = Services::from_lifecycle_storage(backend.lifecycle_storage());
+                let root = services
+                    .collections()
+                    .get(CollectionID::new(1).expect("valid root collection id"))
+                    .await
+                    .expect("certified backend should serve lifecycle operations");
+                assert_eq!(root.id, 1);
+            }
+        }
+    }
+}
+
+pub(crate) async fn postgres_permit() -> OwnedSemaphorePermit {
+    static LIMITER: LazyLock<Arc<Semaphore>> = LazyLock::new(|| Arc::new(Semaphore::new(4)));
+    LIMITER
+        .clone()
+        .acquire_owned()
+        .await
+        .expect("storage contract semaphore should remain open")
+}
+
+pub(crate) fn pool() -> Data<DbPool> {
+    let config = crate::tests::integration_test_config()
+        .expect("integration test config should be initialized");
+    Data::new(crate::db::init_pool(&config.database_url, 2))
+}
+
+pub(crate) fn prefix(label: &str) -> String {
+    let suffix = crate::utilities::auth::generate_random_password(12).to_ascii_lowercase();
+    format!("storage_contract_{label}_{suffix}")
+}

--- a/src/token_retention.rs
+++ b/src/token_retention.rs
@@ -10,6 +10,7 @@ use crate::errors::ApiError;
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::TokenRetentionSettings;
 use crate::restores::MaintenanceActivityGuard;
+use crate::traits::{BackendContext, backend_pool};
 
 static TOKEN_RETENTION_WORKER: std::sync::Once = std::sync::Once::new();
 
@@ -93,7 +94,11 @@ fn spawn_token_retention_worker_loop(pool: DbPool, config: TokenRetentionWorkerC
     });
 }
 
-pub fn ensure_token_retention_worker_running(pool: DbPool) {
+pub fn ensure_token_retention_worker_running<C>(backend: C)
+where
+    C: BackendContext,
+{
+    let pool = backend_pool(&backend).clone();
     if get_config().is_ok_and(|config| !config.runtime_role.runs_background_workers()) {
         return;
     }

--- a/src/traits/accessors.rs
+++ b/src/traits/accessors.rs
@@ -51,7 +51,8 @@ where
     where
         C: BackendContext + ?Sized,
     {
-        self.instance_adapter(backend.db_pool()).await
+        self.instance_adapter(crate::traits::backend_pool(backend))
+            .await
     }
 }
 
@@ -104,14 +105,16 @@ where
     where
         C: BackendContext + ?Sized,
     {
-        self.collection_adapter(backend.db_pool()).await
+        self.collection_adapter(crate::traits::backend_pool(backend))
+            .await
     }
 
     async fn collection_id<C>(&self, backend: &C) -> Result<I, ApiError>
     where
         C: BackendContext + ?Sized,
     {
-        self.collection_id_adapter(backend.db_pool()).await
+        self.collection_id_adapter(crate::traits::backend_pool(backend))
+            .await
     }
 }
 
@@ -158,14 +161,16 @@ where
     where
         B: BackendContext + ?Sized,
     {
-        self.class_adapter(backend.db_pool()).await
+        self.class_adapter(crate::traits::backend_pool(backend))
+            .await
     }
 
     async fn class_id<B>(&self, backend: &B) -> Result<I, ApiError>
     where
         B: BackendContext + ?Sized,
     {
-        self.class_id_adapter(backend.db_pool()).await
+        self.class_id_adapter(crate::traits::backend_pool(backend))
+            .await
     }
 }
 
@@ -212,14 +217,16 @@ where
     where
         B: BackendContext + ?Sized,
     {
-        self.object_adapter(backend.db_pool()).await
+        self.object_adapter(crate::traits::backend_pool(backend))
+            .await
     }
 
     async fn object_id<B>(&self, backend: &B) -> Result<I, ApiError>
     where
         B: BackendContext + ?Sized,
     {
-        self.object_id_adapter(backend.db_pool()).await
+        self.object_id_adapter(crate::traits::backend_pool(backend))
+            .await
     }
 }
 

--- a/src/traits/context.rs
+++ b/src/traits/context.rs
@@ -1,26 +1,113 @@
 use actix_web::web::Data;
 
 use crate::db::DbPool;
-use crate::permissions::PermissionBackend;
+use crate::permissions::{AppContext, PermissionBackend};
+use crate::storage::{
+    DynLifecycleStorage, PostgresStorage, StorageBackend, StorageBackendDescriptor,
+};
 
-/// A thin adapter for public model APIs that need access to the shared database pool.
-///
-/// This trait exists so model-facing traits can accept either a raw [`DbPool`] or wrappers such
-/// as `actix_web::web::Data<DbPool>` without naming those concrete types in every signature.
-///
-/// This is intentionally small and pragmatic. It is not a backend-agnostic capability model; it
-/// simply provides access to the current database pool.
-pub trait BackendContext {
-    fn db_pool(&self) -> &DbPool;
+mod private {
+    use crate::db::DbPool;
 
+    pub trait BackendAccess {
+        fn db_pool(&self) -> &DbPool;
+    }
+}
+
+/// An opaque handle to Hubuum's configured persistence backend.
+///
+/// Application code passes this handle to domain operations without selecting
+/// a database implementation or handling a connection pool directly.
+#[derive(Clone)]
+pub(crate) struct BackendHandle {
+    implementation: BackendImplementation,
+}
+
+#[derive(Clone)]
+enum BackendImplementation {
+    Postgresql(PostgresStorage),
+}
+
+impl BackendHandle {
+    pub(crate) fn postgres(pool: DbPool) -> Self {
+        let backend = PostgresStorage::new(pool);
+        assert_complete_storage_backend(&backend);
+        Self {
+            implementation: BackendImplementation::Postgresql(backend),
+        }
+    }
+
+    pub(crate) fn descriptor(&self) -> StorageBackendDescriptor {
+        match &self.implementation {
+            BackendImplementation::Postgresql(backend) => backend.descriptor(),
+        }
+    }
+
+    pub(crate) fn lifecycle_storage(&self) -> DynLifecycleStorage {
+        match &self.implementation {
+            BackendImplementation::Postgresql(backend) => {
+                DynLifecycleStorage::from_backend(backend.clone())
+            }
+        }
+    }
+
+    fn postgres_pool(&self) -> &DbPool {
+        match &self.implementation {
+            BackendImplementation::Postgresql(backend) => backend.pool(),
+        }
+    }
+}
+
+fn assert_complete_storage_backend(backend: &impl StorageBackend) {
+    let _ = backend.descriptor();
+}
+
+/// A persistence capability accepted by Hubuum's domain and workflow APIs.
+///
+/// The trait is sealed so consumers cannot depend on backend implementation
+/// details. The current PostgreSQL adapter is selected at application
+/// composition time and remains hidden behind this capability.
+pub trait BackendContext: private::BackendAccess + Send + Sync {
     fn permission_backend(&self) -> Option<&dyn PermissionBackend> {
         None
     }
 }
 
-impl BackendContext for DbPool {
+pub(crate) fn backend_pool<C>(backend: &C) -> &DbPool
+where
+    C: BackendContext + ?Sized,
+{
+    private::BackendAccess::db_pool(backend)
+}
+
+impl private::BackendAccess for BackendHandle {
+    fn db_pool(&self) -> &DbPool {
+        self.postgres_pool()
+    }
+}
+
+impl BackendContext for BackendHandle {}
+
+impl private::BackendAccess for DbPool {
     fn db_pool(&self) -> &DbPool {
         self
+    }
+}
+
+impl BackendContext for DbPool {}
+
+impl private::BackendAccess for AppContext {
+    fn db_pool(&self) -> &DbPool {
+        private::BackendAccess::db_pool(self.backend())
+    }
+}
+
+impl<T> private::BackendAccess for &T
+where
+    T: BackendContext + ?Sized,
+{
+    fn db_pool(&self) -> &DbPool {
+        private::BackendAccess::db_pool(*self)
     }
 }
 
@@ -28,12 +115,17 @@ impl<T> BackendContext for &T
 where
     T: BackendContext + ?Sized,
 {
-    fn db_pool(&self) -> &DbPool {
-        (*self).db_pool()
-    }
-
     fn permission_backend(&self) -> Option<&dyn PermissionBackend> {
         (*self).permission_backend()
+    }
+}
+
+impl<T> private::BackendAccess for Data<T>
+where
+    T: BackendContext + ?Sized + 'static,
+{
+    fn db_pool(&self) -> &DbPool {
+        private::BackendAccess::db_pool(self.as_ref())
     }
 }
 
@@ -41,10 +133,6 @@ impl<T> BackendContext for Data<T>
 where
     T: BackendContext + ?Sized + 'static,
 {
-    fn db_pool(&self) -> &DbPool {
-        self.as_ref().db_pool()
-    }
-
     fn permission_backend(&self) -> Option<&dyn PermissionBackend> {
         self.as_ref().permission_backend()
     }

--- a/src/traits/crud.rs
+++ b/src/traits/crud.rs
@@ -91,14 +91,16 @@ where
     where
         C: BackendContext + ?Sized,
     {
-        self.delete_adapter_without_events(backend.db_pool()).await
+        self.delete_adapter_without_events(crate::traits::backend_pool(backend))
+            .await
     }
 
     async fn delete<C>(&self, backend: &C, context: &EventContext) -> Result<(), ApiError>
     where
         C: BackendContext + ?Sized,
     {
-        self.delete_adapter(backend.db_pool(), context).await
+        self.delete_adapter(crate::traits::backend_pool(backend), context)
+            .await
     }
 }
 
@@ -127,14 +129,16 @@ where
     where
         C: BackendContext + ?Sized,
     {
-        self.save_adapter_without_events(backend.db_pool()).await
+        self.save_adapter_without_events(crate::traits::backend_pool(backend))
+            .await
     }
 
     async fn save<C>(&self, backend: &C, context: &EventContext) -> Result<Self::Output, ApiError>
     where
         C: BackendContext + ?Sized,
     {
-        self.save_adapter(backend.db_pool(), context).await
+        self.save_adapter(crate::traits::backend_pool(backend), context)
+            .await
     }
 }
 
@@ -174,7 +178,7 @@ where
     where
         C: BackendContext + ?Sized,
     {
-        self.update_adapter_without_events(backend.db_pool(), entry_id)
+        self.update_adapter_without_events(crate::traits::backend_pool(backend), entry_id)
             .await
     }
 
@@ -187,7 +191,7 @@ where
     where
         C: BackendContext + ?Sized,
     {
-        self.update_adapter(backend.db_pool(), entry_id, context)
+        self.update_adapter(crate::traits::backend_pool(backend), entry_id, context)
             .await
     }
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -8,6 +8,7 @@ pub mod permissions;
 
 pub use accessors::{ClassAccessors, CollectionAccessors, ObjectAccessors, SelfAccessors};
 pub use context::BackendContext;
+pub(crate) use context::{BackendHandle, backend_pool};
 pub use crud::{CanDelete, CanSave, CanUpdate, Validate, ValidateAgainstSchema};
 pub use pagination::*;
 pub use permissions::PermissionController;

--- a/src/traits/permissions.rs
+++ b/src/traits/permissions.rs
@@ -68,8 +68,13 @@ pub trait PermissionController: Serialize + CollectionAccessors {
         C: BackendContext + ?Sized,
         S: AuthzSubject,
     {
-        self.user_can_all_from_backend(backend.db_pool(), subject, permission, scopes)
-            .await
+        self.user_can_all_from_backend(
+            crate::traits::backend_pool(backend),
+            subject,
+            permission,
+            scopes,
+        )
+        .await
     }
 
     /// Grant a set of permissions to a group.
@@ -144,7 +149,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
         C: BackendContext + ?Sized,
     {
         self.apply_permissions_from_backend_without_events(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             group_id_for_grant,
             permission_list,
             replace_existing,
@@ -164,7 +169,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
         C: BackendContext + ?Sized,
     {
         self.apply_permissions_from_backend(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             group_id_for_grant,
             permission_list,
             replace_existing,
@@ -208,7 +213,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
         C: BackendContext + ?Sized,
     {
         self.revoke_permissions_from_backend_without_events(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             group_id_for_revoke,
             permission_list,
         )
@@ -226,7 +231,7 @@ pub trait PermissionController: Serialize + CollectionAccessors {
         C: BackendContext + ?Sized,
     {
         self.revoke_permissions_from_backend(
-            backend.db_pool(),
+            crate::traits::backend_pool(backend),
             group_id_for_revoke,
             permission_list,
             context,
@@ -390,8 +395,11 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.revoke_all_from_backend_without_events(backend.db_pool(), group_id_for_revoke)
-            .await
+        self.revoke_all_from_backend_without_events(
+            crate::traits::backend_pool(backend),
+            group_id_for_revoke,
+        )
+        .await
     }
 
     async fn revoke_all<C>(
@@ -403,7 +411,11 @@ pub trait PermissionController: Serialize + CollectionAccessors {
     where
         C: BackendContext + ?Sized,
     {
-        self.revoke_all_from_backend(backend.db_pool(), group_id_for_revoke, context)
-            .await
+        self.revoke_all_from_backend(
+            crate::traits::backend_pool(backend),
+            group_id_for_revoke,
+            context,
+        )
+        .await
     }
 }

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -112,6 +112,33 @@ async fn metrics_endpoint_is_best_effort_when_database_refresh_fails() {
 }
 
 #[actix_web::test]
+async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() {
+    let body = scrape_recorded_metrics(|| {
+        metrics::storage_backend_identity("postgresql", 1);
+        metrics::storage_operation_finished(
+            "postgresql",
+            "objects",
+            "update",
+            "conflict",
+            Duration::from_millis(5),
+        );
+    })
+    .await;
+
+    assert!(
+        body.contains(
+            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"1\"} 1"
+        )
+    );
+    assert!(body.contains(
+        "hubuum_storage_operation_duration_seconds_bucket{backend=\"postgresql\",capability=\"objects\",operation=\"update\",result=\"conflict\""
+    ));
+    assert!(body.contains(
+        "hubuum_storage_operation_errors_total{backend=\"postgresql\",capability=\"objects\",operation=\"update\",result=\"conflict\"} 1"
+    ));
+}
+
+#[actix_web::test]
 async fn export_metrics_use_bounded_phase_and_template_labels() {
     let body = scrape_recorded_metrics(|| {
         metrics::export_completed("objects_in_class", "application/json");

--- a/tests/api_platform_suite/runtime_config.rs
+++ b/tests/api_platform_suite/runtime_config.rs
@@ -36,6 +36,18 @@ mod tests {
         let body: Value = test::read_body_json(response).await;
         let serialized = serde_json::to_string(&body).unwrap();
 
+        assert_eq!(body["database"]["backend"], "postgresql");
+        assert_eq!(body["database"]["contract_version"], 1);
+        assert_eq!(
+            body["database"]["capabilities"],
+            serde_json::json!([
+                "domain_lifecycle",
+                "identity_and_authorization_data",
+                "queries_and_history",
+                "workflows",
+                "operations"
+            ])
+        );
         assert_eq!(body["database"]["url"]["configured"], true);
         assert!(body["database"]["pool_size"].is_number());
         assert!(!serialized.contains("postgres://"));


### PR DESCRIPTION
## Summary

- enforce one sealed, all-or-nothing `StorageBackend` contract at application
  composition
- require lifecycle, identity/authorization data, query/history, workflow, and
  operational capability families before a backend can be selected
- keep PostgreSQL as the only available backend and rename the in-memory
  implementation to a focused lifecycle contract model that cannot be selected
- make `BackendHandle` an exhaustive private backend enum and compose services
  only from a certified complete backend
- give the PostgreSQL adapter and memory contract model implementation-owned
  error types that translate to `StorageError`; only the application error layer
  translates `StorageError` to `ApiError`
- wrap lifecycle storage entrypoints with consistent bounded tracing, duration
  metrics, and failure metrics, and apply equivalent diagnostics in the shared
  PostgreSQL connection/transaction helpers
- expose the selected backend, contract version, complete capability set, and
  non-secret effective pool settings in the redacted administrator configuration
- publish the same backend identity in startup logs and
  `hubuum_storage_backend_info`
- add an exhaustive available-backend compatibility registry while retaining
  shared PostgreSQL/memory-model lifecycle contracts and PostgreSQL-native
  transaction, locking, migration, recovery, concurrency, and query-budget tests
- document a staged workspace extraction into `hubuum-domain`,
  `hubuum-storage-core`, `hubuum-storage-postgres`, and a reusable storage
  contract-test crate

## Why

The earlier boundary kept application consumers away from direct pool access,
but its documentation still described the memory implementation as a backend
with only selected capabilities. That is not a viable backend contract: an
administrator must never be able to select an implementation that handles only
part of the application.

This layer now distinguishes complete selectable backends from focused test
models. `StorageBackend` is a sealed aggregate over every required capability
family. `BackendHandle` has one exhaustive implementation variant today:
PostgreSQL. Adding another variant is an explicit architecture change that must
certify every family, add redacted configuration metadata, and pass the complete
compatibility suite. The memory model remains useful for fast lifecycle semantic
tests without being advertised as a backend.

Some PostgreSQL operations still live in `src/db/traits/*` while the internal
migration continues. That is an implementation-location detail, not optional
backend support. A second backend cannot be registered while those paths remain
PostgreSQL-only; they must first gain backend-neutral operation-shaped ports.

## Complete backend guarantee

There is no partial selectable backend in this stack.

- `StorageBackend` requires all five capability families and private central
  certification.
- production composition accepts `StorageBackend`, not the narrower lifecycle
  test contract.
- `StorageBackendKind::ALL` and the private `BackendImplementation` enum are
  exhaustive and currently contain only PostgreSQL.
- the available-backend test iterates that registry and composes every entry
  through the real application service boundary.
- the in-memory lifecycle model cannot implement private certification and is
  absent from administrator configuration and startup metadata.

## Error and observability direction

Errors now cross the boundary in one direction:

```text
PostgresStorageError / memory-model error
                    |
                    v
              StorageError
                    |
                    v
                 ApiError
```

The common observation wrapper records stable backend, capability, operation,
and result labels. Expected domain rejections log at debug; database,
unavailable, and internal failures log at warning. Labels and diagnostic events
exclude entity IDs, user-controlled names, queries, URLs, credentials, and
payloads.

Storage metrics describe logical lifecycle calls. Existing database metrics
continue to describe pool acquisition and connection/transaction work, including
the PostgreSQL-backed capability families that have not yet moved into neutral
ports.

## Administrator impact

`GET /api/v1/admin/config` adds the following non-secret database fields:

- `backend`
- `contract_version`
- `capabilities`

The existing URL configured status, pool size, pool acquisition timeout, and
statement timeout remain available. Connection URLs and credentials are never
returned. The committed OpenAPI document, administrator guide, logging guide,
metrics guide, quick start, and distributed deployment guide are updated.

This is an additive API response change. There are no breaking configuration,
database-schema, migration, or endpoint changes.

## Workspace extraction

The documented target dependency direction is:

```text
root application -> hubuum-storage-postgres -> hubuum-storage-core -> hubuum-domain
                 -> hubuum-storage-core ---------------------------> hubuum-domain
                 -> hubuum-domain
```

The PostgreSQL crate can intentionally own Diesel, generated schema, migrations,
pool/TLS setup, transactions, persistence rows, queries, and adapter errors. It
must not depend on the root application crate or expose Diesel types through the
neutral contract.

Before moving the adapter, existing types that mix domain behavior with Diesel
derives and schema references need to split into backend-neutral domain types and
private PostgreSQL rows. Schema and migrations then move together. Adding those
workspace members will also update the Docker manifest-copy stage, CI change
classifier, Rust API policy, feature forwarding, and production-container
verification in the same extraction stack.

## Stack

This is the sixth and final layer of stack #286 and targets #289:

1. #284 collection service, PostgreSQL adapter, lifecycle contract model, shared
   contracts, and query baselines
2. #285 class service/storage boundary
3. #287 object service/storage boundary
4. #288 class-relation service/storage boundary
5. #289 object-relation service/storage boundary
6. **#290 complete application/backend composition, diagnostics, compatibility,
   and workspace extraction architecture**

## Verification

- `source .env && ./run_tests.sh` (2,198 passed, 8 expected ignored, 0 failed)
- isolated migrated-database regressions for administrator storage metadata and
  bounded storage metrics
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- OpenAPI regeneration with `hubuum-openapi`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `scripts/test-classify-ci-changes.sh`
- `git diff --check`

## Changelog

The `[Unreleased]` changelog documents the new redacted administrator storage
metadata, startup identity, and storage diagnostics.

Closes #27
