### PR TITLE
Stream unified search batches progressively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- Unified search SSE responses now begin before database search work and emit
+  collection, class, and object batches as each completes instead of buffering
+  the entire event sequence before returning the response.
 - Removed the legacy root PostgreSQL storage implementation tree and direct SQL
   from the storage compatibility harness. PostgreSQL composition is now
   confined to the storage factory, adapter-native fixtures are typed and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- Unified search SSE responses now begin before database search work and emit
+  collection, class, and object batches as each completes instead of buffering
+  the entire event sequence before returning the response.
 - **Breaking (Rust API support policy):** the root `hubuum` library and every
   current workspace crate are explicitly internal and non-publishable. Their
   Rust `pub` items are workspace construction details rather than supported

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -18781,6 +18781,9 @@
                 },
                 "description": "Effective page size used by the server after applying the configured default and maximum."
               }
+            },
+            "content": {
+              "text/event-stream": {}
             }
           },
           "400": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -18771,6 +18771,9 @@
                 },
                 "description": "Effective page size used by the server after applying the configured default and maximum."
               }
+            },
+            "content": {
+              "text/event-stream": {}
             }
           },
           "400": {

--- a/docs/search_api.md
+++ b/docs/search_api.md
@@ -35,6 +35,11 @@ The JSON endpoint returns grouped results and grouped next cursors:
 The stream endpoint returns server-sent events:
 
 - `started`
-- one `batch` per completed kind
+- one `batch` per completed kind, in completion order
 - `done`
 - `error` if the search fails partway through
+
+The server sends `started` before beginning search work and flushes each batch
+as soon as that kind completes. A client disconnect drops the outstanding
+batch futures; database statements remain bounded by the configured database
+timeout. A terminal `error` event replaces `done` when any batch fails.

--- a/src/api/v1/handlers/search.rs
+++ b/src/api/v1/handlers/search.rs
@@ -13,13 +13,13 @@ use crate::api::response::ApiResponse;
 use crate::errors::ApiError;
 use crate::extractors::Authenticated;
 use crate::models::{
-    Principal, TokenScope, UnifiedSearchBatchResponse, UnifiedSearchDoneEvent,
-    UnifiedSearchErrorEvent, UnifiedSearchKind, UnifiedSearchQuery, UnifiedSearchResponse,
-    UnifiedSearchStartedEvent, execute_unified_search, execute_unified_search_batch,
-    parse_unified_search_query,
+    StorageUnifiedSearchQuery, TokenScope, UnifiedSearchBatchResponse, UnifiedSearchDoneEvent,
+    UnifiedSearchErrorEvent, UnifiedSearchKind, UnifiedSearchResponse, UnifiedSearchStartedEvent,
+    execute_unified_search, execute_unified_search_batch, parse_unified_search_query,
 };
 use crate::pagination::PAGE_LIMIT_HEADER;
 use crate::permissions::AppContext;
+use crate::storage::StorageAuthenticationPrincipal;
 
 fn sse_event<T: Serialize>(event: &str, payload: &T) -> Result<Bytes, ApiError> {
     let data = serde_json::to_string(payload).map_err(|error| {
@@ -101,9 +101,9 @@ fn search_event_stream(
 
 fn execute_unified_search_stream(
     context: AppContext,
-    principal: Principal,
+    principal: StorageAuthenticationPrincipal,
     scope: Option<TokenScope>,
-    params: UnifiedSearchQuery,
+    params: StorageUnifiedSearchQuery,
 ) -> impl Stream<Item = Result<Bytes, actix_web::Error>> {
     let searches = FuturesUnordered::new();
 

--- a/src/api/v1/handlers/search.rs
+++ b/src/api/v1/handlers/search.rs
@@ -1,6 +1,10 @@
 use actix_web::{HttpRequest, HttpResponse, Responder, get, http::StatusCode};
 use bytes::Bytes;
-use futures_util::stream;
+use futures_util::{
+    FutureExt, Stream, StreamExt,
+    future::BoxFuture,
+    stream::{self, FuturesUnordered},
+};
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -9,7 +13,8 @@ use crate::api::response::ApiResponse;
 use crate::errors::ApiError;
 use crate::extractors::Authenticated;
 use crate::models::{
-    UnifiedSearchDoneEvent, UnifiedSearchErrorEvent, UnifiedSearchKind, UnifiedSearchResponse,
+    Principal, TokenScope, UnifiedSearchBatchResponse, UnifiedSearchDoneEvent,
+    UnifiedSearchErrorEvent, UnifiedSearchKind, UnifiedSearchQuery, UnifiedSearchResponse,
     UnifiedSearchStartedEvent, execute_unified_search, execute_unified_search_batch,
     parse_unified_search_query,
 };
@@ -21,6 +26,110 @@ fn sse_event<T: Serialize>(event: &str, payload: &T) -> Result<Bytes, ApiError> 
         ApiError::InternalServerError(format!("Failed to serialize SSE payload: {error}"))
     })?;
     Ok(Bytes::from(format!("event: {event}\ndata: {data}\n\n")))
+}
+
+type UnifiedSearchBatchFuture = BoxFuture<'static, Result<UnifiedSearchBatchResponse, ApiError>>;
+
+enum UnifiedSearchEventStreamPhase {
+    Starting,
+    Searching,
+    Finished,
+}
+
+struct UnifiedSearchEventStreamState {
+    query: String,
+    searches: FuturesUnordered<UnifiedSearchBatchFuture>,
+    phase: UnifiedSearchEventStreamPhase,
+}
+
+fn search_event_stream(
+    query: String,
+    searches: FuturesUnordered<UnifiedSearchBatchFuture>,
+) -> impl Stream<Item = Result<Bytes, actix_web::Error>> {
+    let state = UnifiedSearchEventStreamState {
+        query,
+        searches,
+        phase: UnifiedSearchEventStreamPhase::Starting,
+    };
+
+    stream::unfold(state, |mut state| async move {
+        match state.phase {
+            UnifiedSearchEventStreamPhase::Starting => {
+                state.phase = UnifiedSearchEventStreamPhase::Searching;
+                let event = sse_event(
+                    "started",
+                    &UnifiedSearchStartedEvent {
+                        query: state.query.clone(),
+                    },
+                )
+                .map_err(actix_web::Error::from);
+                Some((event, state))
+            }
+            UnifiedSearchEventStreamPhase::Searching => match state.searches.next().await {
+                Some(Ok(batch)) => {
+                    let event = sse_event("batch", &batch).map_err(actix_web::Error::from);
+                    Some((event, state))
+                }
+                Some(Err(error)) => {
+                    state.searches.clear();
+                    state.phase = UnifiedSearchEventStreamPhase::Finished;
+                    let event = sse_event(
+                        "error",
+                        &UnifiedSearchErrorEvent {
+                            message: error.public_message().to_string(),
+                        },
+                    )
+                    .map_err(actix_web::Error::from);
+                    Some((event, state))
+                }
+                None => {
+                    state.phase = UnifiedSearchEventStreamPhase::Finished;
+                    let event = sse_event(
+                        "done",
+                        &UnifiedSearchDoneEvent {
+                            query: state.query.clone(),
+                        },
+                    )
+                    .map_err(actix_web::Error::from);
+                    Some((event, state))
+                }
+            },
+            UnifiedSearchEventStreamPhase::Finished => None,
+        }
+    })
+}
+
+fn execute_unified_search_stream(
+    context: AppContext,
+    principal: Principal,
+    scope: Option<TokenScope>,
+    params: UnifiedSearchQuery,
+) -> impl Stream<Item = Result<Bytes, actix_web::Error>> {
+    let searches = FuturesUnordered::new();
+
+    for kind in [
+        UnifiedSearchKind::Collection,
+        UnifiedSearchKind::Class,
+        UnifiedSearchKind::Object,
+    ] {
+        if !params.includes(kind) {
+            continue;
+        }
+
+        let context = context.clone();
+        let principal = principal.clone();
+        let scope = scope.clone();
+        let params = params.clone();
+        searches.push(
+            async move {
+                execute_unified_search_batch(&principal, &context, &params, kind, scope.as_ref())
+                    .await
+            }
+            .boxed(),
+        );
+    }
+
+    search_event_stream(params.query, searches)
 }
 
 #[utoipa::path(
@@ -79,7 +188,7 @@ pub async fn get_search(
         ("search_object_data" = Option<bool>, Query, description = "Include object JSON string values in object matching")
     ),
     responses(
-        (status = 200, description = "Server-sent event stream for unified search"),
+        (status = 200, description = "Server-sent event stream for unified search", content_type = "text/event-stream"),
         (status = 400, description = "Bad request", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse)
     )
@@ -91,72 +200,158 @@ pub async fn stream_search(
     req: HttpRequest,
 ) -> Result<HttpResponse, ApiError> {
     let params = parse_unified_search_query(req.query_string())?;
-    let mut events = vec![sse_event(
-        "started",
-        &UnifiedSearchStartedEvent {
-            query: params.query.clone(),
-        },
-    )?];
+    let limit_per_kind = params.limit_per_kind;
+    let stream =
+        execute_unified_search_stream(context, requestor.principal, requestor.scope, params);
 
-    for kind in [
-        UnifiedSearchKind::Collection,
-        UnifiedSearchKind::Class,
-        UnifiedSearchKind::Object,
-    ] {
-        if !params.includes(kind) {
-            continue;
+    Ok(HttpResponse::Ok()
+        .insert_header(("Content-Type", "text/event-stream; charset=utf-8"))
+        .insert_header(("Cache-Control", "no-cache"))
+        .insert_header(("X-Accel-Buffering", "no"))
+        .insert_header((PAGE_LIMIT_HEADER, limit_per_kind.to_string()))
+        .streaming(stream))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures::channel::oneshot;
+    use futures_util::{FutureExt, StreamExt, future, pin_mut};
+
+    use super::*;
+
+    fn empty_batch(kind: &str) -> UnifiedSearchBatchResponse {
+        UnifiedSearchBatchResponse {
+            kind: kind.to_string(),
+            collections: vec![],
+            classes: vec![],
+            objects: vec![],
+            next: None,
         }
+    }
 
-        match execute_unified_search_batch(
-            &requestor.principal,
-            &context,
-            &params,
-            kind,
-            requestor.scopes(),
-        )
-        .await
-        {
-            Ok(batch) => events.push(sse_event("batch", &batch)?),
-            Err(error) => {
-                events.push(sse_event(
-                    "error",
-                    &UnifiedSearchErrorEvent {
-                        message: error.public_message().to_string(),
-                    },
-                )?);
+    struct DropNotifier(Option<oneshot::Sender<()>>);
 
-                let stream = stream::iter(
-                    events
-                        .into_iter()
-                        .map(Ok::<Bytes, actix_web::Error>)
-                        .collect::<Vec<_>>(),
-                );
-                return Ok(HttpResponse::Ok()
-                    .insert_header(("Content-Type", "text/event-stream"))
-                    .insert_header(("Cache-Control", "no-cache"))
-                    .insert_header((PAGE_LIMIT_HEADER, params.limit_per_kind.to_string()))
-                    .streaming(stream));
+    impl Drop for DropNotifier {
+        fn drop(&mut self) {
+            if let Some(notify) = self.0.take() {
+                let _ = notify.send(());
             }
         }
     }
 
-    events.push(sse_event(
-        "done",
-        &UnifiedSearchDoneEvent {
-            query: params.query.clone(),
-        },
-    )?);
+    #[actix_web::test]
+    async fn search_stream_emits_started_before_search_completes() {
+        let (release, blocked) = oneshot::channel::<()>();
+        let searches = FuturesUnordered::new();
+        searches.push(
+            async move {
+                blocked.await.unwrap();
+                Ok(empty_batch("objects"))
+            }
+            .boxed(),
+        );
+        let events = search_event_stream("needle".to_string(), searches);
+        pin_mut!(events);
 
-    let stream = stream::iter(
-        events
-            .into_iter()
-            .map(Ok::<Bytes, actix_web::Error>)
-            .collect::<Vec<_>>(),
-    );
+        let started = events.next().await.unwrap().unwrap();
+        assert!(
+            String::from_utf8(started.to_vec())
+                .unwrap()
+                .contains("event: started")
+        );
 
-    Ok(HttpResponse::Ok()
-        .insert_header(("Content-Type", "text/event-stream"))
-        .insert_header(("Cache-Control", "no-cache"))
-        .insert_header((PAGE_LIMIT_HEADER, params.limit_per_kind.to_string()))
-        .streaming(stream))
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), events.next())
+                .await
+                .is_err()
+        );
+
+        release.send(()).unwrap();
+    }
+
+    #[actix_web::test]
+    async fn search_stream_emits_batches_in_completion_order() {
+        let (release_classes, blocked_classes) = oneshot::channel::<()>();
+        let (release_objects, blocked_objects) = oneshot::channel::<()>();
+        let searches = FuturesUnordered::new();
+        searches.push(
+            async move {
+                blocked_classes.await.unwrap();
+                Ok(empty_batch("classes"))
+            }
+            .boxed(),
+        );
+        searches.push(
+            async move {
+                blocked_objects.await.unwrap();
+                Ok(empty_batch("objects"))
+            }
+            .boxed(),
+        );
+        let events = search_event_stream("needle".to_string(), searches);
+        pin_mut!(events);
+
+        events.next().await.unwrap().unwrap();
+        release_objects.send(()).unwrap();
+        let first_batch = events.next().await.unwrap().unwrap();
+
+        assert!(
+            String::from_utf8(first_batch.to_vec())
+                .unwrap()
+                .contains("\"kind\":\"objects\"")
+        );
+
+        release_classes.send(()).unwrap();
+    }
+
+    #[actix_web::test]
+    async fn search_stream_error_is_terminal() {
+        let searches = FuturesUnordered::new();
+        searches.push(
+            async {
+                Err(ApiError::BadRequest(
+                    "search batch deliberately failed".to_string(),
+                ))
+            }
+            .boxed(),
+        );
+        let events = search_event_stream("needle".to_string(), searches);
+        pin_mut!(events);
+
+        events.next().await.unwrap().unwrap();
+        let error = events.next().await.unwrap().unwrap();
+        let error = String::from_utf8(error.to_vec()).unwrap();
+        assert!(error.contains("event: error"));
+        assert!(error.contains("search batch deliberately failed"));
+        assert!(events.next().await.is_none());
+    }
+
+    #[actix_web::test]
+    async fn dropping_search_stream_drops_pending_batches() {
+        let (notify_drop, drop_observed) = oneshot::channel();
+        let searches = FuturesUnordered::new();
+        searches.push(
+            async move {
+                let _drop_notifier = DropNotifier(Some(notify_drop));
+                future::pending::<Result<UnifiedSearchBatchResponse, ApiError>>().await
+            }
+            .boxed(),
+        );
+        let mut events = Box::pin(search_event_stream("needle".to_string(), searches));
+
+        events.next().await.unwrap().unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), events.next())
+                .await
+                .is_err()
+        );
+        drop(events);
+
+        tokio::time::timeout(Duration::from_secs(1), drop_observed)
+            .await
+            .unwrap()
+            .unwrap();
+    }
 }

--- a/src/api/v1/handlers/search.rs
+++ b/src/api/v1/handlers/search.rs
@@ -1,6 +1,10 @@
 use actix_web::{HttpRequest, HttpResponse, Responder, get, http::StatusCode};
 use bytes::Bytes;
-use futures_util::stream;
+use futures_util::{
+    FutureExt, Stream, StreamExt,
+    future::BoxFuture,
+    stream::{self, FuturesUnordered},
+};
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -9,7 +13,8 @@ use crate::api::response::ApiResponse;
 use crate::errors::ApiError;
 use crate::extractors::Authenticated;
 use crate::models::{
-    UnifiedSearchDoneEvent, UnifiedSearchErrorEvent, UnifiedSearchKind, UnifiedSearchResponse,
+    Principal, TokenScope, UnifiedSearchBatchResponse, UnifiedSearchDoneEvent,
+    UnifiedSearchErrorEvent, UnifiedSearchKind, UnifiedSearchQuery, UnifiedSearchResponse,
     UnifiedSearchStartedEvent, execute_unified_search, execute_unified_search_batch,
     parse_unified_search_query,
 };
@@ -21,6 +26,109 @@ fn sse_event<T: Serialize>(event: &str, payload: &T) -> Result<Bytes, ApiError> 
         ApiError::InternalServerError(format!("Failed to serialize SSE payload: {error}"))
     })?;
     Ok(Bytes::from(format!("event: {event}\ndata: {data}\n\n")))
+}
+
+type UnifiedSearchBatchFuture = BoxFuture<'static, Result<UnifiedSearchBatchResponse, ApiError>>;
+
+enum UnifiedSearchEventStreamPhase {
+    Starting,
+    Searching,
+    Finished,
+}
+
+struct UnifiedSearchEventStreamState {
+    query: String,
+    searches: FuturesUnordered<UnifiedSearchBatchFuture>,
+    phase: UnifiedSearchEventStreamPhase,
+}
+
+fn search_event_stream(
+    query: String,
+    searches: FuturesUnordered<UnifiedSearchBatchFuture>,
+) -> impl Stream<Item = Result<Bytes, actix_web::Error>> {
+    let state = UnifiedSearchEventStreamState {
+        query,
+        searches,
+        phase: UnifiedSearchEventStreamPhase::Starting,
+    };
+
+    stream::unfold(state, |mut state| async move {
+        match state.phase {
+            UnifiedSearchEventStreamPhase::Starting => {
+                state.phase = UnifiedSearchEventStreamPhase::Searching;
+                let event = sse_event(
+                    "started",
+                    &UnifiedSearchStartedEvent {
+                        query: state.query.clone(),
+                    },
+                )
+                .map_err(actix_web::Error::from);
+                Some((event, state))
+            }
+            UnifiedSearchEventStreamPhase::Searching => match state.searches.next().await {
+                Some(Ok(batch)) => {
+                    let event = sse_event("batch", &batch).map_err(actix_web::Error::from);
+                    Some((event, state))
+                }
+                Some(Err(error)) => {
+                    state.searches.clear();
+                    state.phase = UnifiedSearchEventStreamPhase::Finished;
+                    let event = sse_event(
+                        "error",
+                        &UnifiedSearchErrorEvent {
+                            message: error.public_message().to_string(),
+                        },
+                    )
+                    .map_err(actix_web::Error::from);
+                    Some((event, state))
+                }
+                None => {
+                    state.phase = UnifiedSearchEventStreamPhase::Finished;
+                    let event = sse_event(
+                        "done",
+                        &UnifiedSearchDoneEvent {
+                            query: state.query.clone(),
+                        },
+                    )
+                    .map_err(actix_web::Error::from);
+                    Some((event, state))
+                }
+            },
+            UnifiedSearchEventStreamPhase::Finished => None,
+        }
+    })
+}
+
+fn execute_unified_search_stream(
+    pool: AppContext,
+    principal: Principal,
+    scope: Option<TokenScope>,
+    params: UnifiedSearchQuery,
+) -> impl Stream<Item = Result<Bytes, actix_web::Error>> {
+    let searches = FuturesUnordered::new();
+
+    for kind in [
+        UnifiedSearchKind::Collection,
+        UnifiedSearchKind::Class,
+        UnifiedSearchKind::Object,
+    ] {
+        if !params.includes(kind) {
+            continue;
+        }
+
+        let pool = pool.clone();
+        let principal = principal.clone();
+        let scope = scope.clone();
+        let params = params.clone();
+        searches.push(
+            async move {
+                execute_unified_search_batch(&principal, &pool, &params, kind, scope.as_ref()).await
+            }
+            .boxed(),
+        );
+    }
+
+    search_event_stream(params.query, searches)
 }
 
 #[utoipa::path(
@@ -79,7 +187,7 @@ pub async fn get_search(
         ("search_object_data" = Option<bool>, Query, description = "Include object JSON string values in object matching")
     ),
     responses(
-        (status = 200, description = "Server-sent event stream for unified search"),
+        (status = 200, description = "Server-sent event stream for unified search", content_type = "text/event-stream"),
         (status = 400, description = "Bad request", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse)
     )
@@ -91,72 +199,157 @@ pub async fn stream_search(
     req: HttpRequest,
 ) -> Result<HttpResponse, ApiError> {
     let params = parse_unified_search_query(req.query_string())?;
-    let mut events = vec![sse_event(
-        "started",
-        &UnifiedSearchStartedEvent {
-            query: params.query.clone(),
-        },
-    )?];
+    let limit_per_kind = params.limit_per_kind;
+    let stream = execute_unified_search_stream(pool, requestor.principal, requestor.scope, params);
 
-    for kind in [
-        UnifiedSearchKind::Collection,
-        UnifiedSearchKind::Class,
-        UnifiedSearchKind::Object,
-    ] {
-        if !params.includes(kind) {
-            continue;
+    Ok(HttpResponse::Ok()
+        .insert_header(("Content-Type", "text/event-stream; charset=utf-8"))
+        .insert_header(("Cache-Control", "no-cache"))
+        .insert_header(("X-Accel-Buffering", "no"))
+        .insert_header((PAGE_LIMIT_HEADER, limit_per_kind.to_string()))
+        .streaming(stream))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures::channel::oneshot;
+    use futures_util::{FutureExt, StreamExt, future, pin_mut};
+
+    use super::*;
+
+    fn empty_batch(kind: &str) -> UnifiedSearchBatchResponse {
+        UnifiedSearchBatchResponse {
+            kind: kind.to_string(),
+            collections: vec![],
+            classes: vec![],
+            objects: vec![],
+            next: None,
         }
+    }
 
-        match execute_unified_search_batch(
-            &requestor.principal,
-            &pool,
-            &params,
-            kind,
-            requestor.scopes(),
-        )
-        .await
-        {
-            Ok(batch) => events.push(sse_event("batch", &batch)?),
-            Err(error) => {
-                events.push(sse_event(
-                    "error",
-                    &UnifiedSearchErrorEvent {
-                        message: error.public_message().to_string(),
-                    },
-                )?);
+    struct DropNotifier(Option<oneshot::Sender<()>>);
 
-                let stream = stream::iter(
-                    events
-                        .into_iter()
-                        .map(Ok::<Bytes, actix_web::Error>)
-                        .collect::<Vec<_>>(),
-                );
-                return Ok(HttpResponse::Ok()
-                    .insert_header(("Content-Type", "text/event-stream"))
-                    .insert_header(("Cache-Control", "no-cache"))
-                    .insert_header((PAGE_LIMIT_HEADER, params.limit_per_kind.to_string()))
-                    .streaming(stream));
+    impl Drop for DropNotifier {
+        fn drop(&mut self) {
+            if let Some(notify) = self.0.take() {
+                let _ = notify.send(());
             }
         }
     }
 
-    events.push(sse_event(
-        "done",
-        &UnifiedSearchDoneEvent {
-            query: params.query.clone(),
-        },
-    )?);
+    #[actix_web::test]
+    async fn search_stream_emits_started_before_search_completes() {
+        let (release, blocked) = oneshot::channel::<()>();
+        let searches = FuturesUnordered::new();
+        searches.push(
+            async move {
+                blocked.await.unwrap();
+                Ok(empty_batch("objects"))
+            }
+            .boxed(),
+        );
+        let events = search_event_stream("needle".to_string(), searches);
+        pin_mut!(events);
 
-    let stream = stream::iter(
-        events
-            .into_iter()
-            .map(Ok::<Bytes, actix_web::Error>)
-            .collect::<Vec<_>>(),
-    );
+        let started = events.next().await.unwrap().unwrap();
+        assert!(
+            String::from_utf8(started.to_vec())
+                .unwrap()
+                .contains("event: started")
+        );
 
-    Ok(HttpResponse::Ok()
-        .insert_header(("Content-Type", "text/event-stream"))
-        .insert_header(("Cache-Control", "no-cache"))
-        .insert_header((PAGE_LIMIT_HEADER, params.limit_per_kind.to_string()))
-        .streaming(stream))
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), events.next())
+                .await
+                .is_err()
+        );
+
+        release.send(()).unwrap();
+    }
+
+    #[actix_web::test]
+    async fn search_stream_emits_batches_in_completion_order() {
+        let (release_classes, blocked_classes) = oneshot::channel::<()>();
+        let (release_objects, blocked_objects) = oneshot::channel::<()>();
+        let searches = FuturesUnordered::new();
+        searches.push(
+            async move {
+                blocked_classes.await.unwrap();
+                Ok(empty_batch("classes"))
+            }
+            .boxed(),
+        );
+        searches.push(
+            async move {
+                blocked_objects.await.unwrap();
+                Ok(empty_batch("objects"))
+            }
+            .boxed(),
+        );
+        let events = search_event_stream("needle".to_string(), searches);
+        pin_mut!(events);
+
+        events.next().await.unwrap().unwrap();
+        release_objects.send(()).unwrap();
+        let first_batch = events.next().await.unwrap().unwrap();
+
+        assert!(
+            String::from_utf8(first_batch.to_vec())
+                .unwrap()
+                .contains("\"kind\":\"objects\"")
+        );
+
+        release_classes.send(()).unwrap();
+    }
+
+    #[actix_web::test]
+    async fn search_stream_error_is_terminal() {
+        let searches = FuturesUnordered::new();
+        searches.push(
+            async {
+                Err(ApiError::BadRequest(
+                    "search batch deliberately failed".to_string(),
+                ))
+            }
+            .boxed(),
+        );
+        let events = search_event_stream("needle".to_string(), searches);
+        pin_mut!(events);
+
+        events.next().await.unwrap().unwrap();
+        let error = events.next().await.unwrap().unwrap();
+        let error = String::from_utf8(error.to_vec()).unwrap();
+        assert!(error.contains("event: error"));
+        assert!(error.contains("search batch deliberately failed"));
+        assert!(events.next().await.is_none());
+    }
+
+    #[actix_web::test]
+    async fn dropping_search_stream_drops_pending_batches() {
+        let (notify_drop, drop_observed) = oneshot::channel();
+        let searches = FuturesUnordered::new();
+        searches.push(
+            async move {
+                let _drop_notifier = DropNotifier(Some(notify_drop));
+                future::pending::<Result<UnifiedSearchBatchResponse, ApiError>>().await
+            }
+            .boxed(),
+        );
+        let mut events = Box::pin(search_event_stream("needle".to_string(), searches));
+
+        events.next().await.unwrap().unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), events.next())
+                .await
+                .is_err()
+        );
+        drop(events);
+
+        tokio::time::timeout(Duration::from_secs(1), drop_observed)
+            .await
+            .unwrap()
+            .unwrap();
+    }
 }


### PR DESCRIPTION
## Summary

- return the unified-search SSE response before database search work begins
- run requested collection, class, and object searches concurrently
- emit each result batch as it completes, followed by one terminal `done` or `error` event
- drop pending batch futures when the response stream is dropped or a batch fails
- document the streaming contract and advertise the SSE response media type in OpenAPI

## Rationale

`GET /api/v1/search/stream` previously awaited every requested search and accumulated all events before constructing the response stream. Clients received valid SSE framing, but no progressive delivery and no useful cancellation boundary.

This change makes the existing batch-oriented contract truthful without retaining a database connection under client backpressure for row-by-row streaming.

## Behavior

Batches are emitted in completion order. A batch failure emits a terminal error event and drops other pending batch futures. Client disconnects drop the response stream and its pending futures; PostgreSQL statements remain bounded by the configured database statement timeout.

There are no breaking HTTP API changes.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- regenerated `docs/openapi.json`
