### PR TITLE
Stream structured search results over SSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   equivalent permission-aware behavior for SQL and external policy backends.
   Object searches additionally support an optional exact class selector and
   bounded existential related-object predicates.
+- Added `POST /api/v1/search/stream`, which accepts the same structured-search
+  DSL and emits `started`, ordered tagged `result`, and terminal `done` or
+  `error` server-sent events without holding a database connection under client
+  backpressure.
 - Class object lists now accept up to four named `related.<alias>` filter
   groups. Each group selects one target class, normal target-object fields, and
   an optional bidirectional depth up to 10; groups are combined with `AND`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   equivalent permission-aware behavior for SQL and external policy backends.
   Object searches additionally support an optional exact class selector and
   bounded existential related-object predicates.
+- Added `POST /api/v1/search/stream`, which accepts the same structured-search
+  DSL and emits `started`, ordered tagged `result`, and terminal `done` or
+  `error` server-sent events without holding a database connection under client
+  backpressure.
 - `hubuum-domain`, `hubuum-events-core`, `hubuum-query`,
   `hubuum-task-core`, and `hubuum-storage-core` now have explicit compatibility,
   MSRV, error, runtime, cancellation, and security policies in preparation for

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -18907,6 +18907,77 @@
             "bearer_auth": []
           }
         ]
+      },
+      "post": {
+        "tags": [
+          "search"
+        ],
+        "summary": "Post Api V1 Search Stream",
+        "description": "Runs the same versioned structured resource-search DSL as POST /api/v1/search and returns server-sent events. The stream emits started, zero or more tagged result events, and one terminal done event carrying cursor metadata; execution failures after streaming starts produce a terminal error event.",
+        "operationId": "postApiV1SearchStream",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StructuredSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Structured search server-sent event stream",
+            "content": {
+              "text/event-stream": {}
+            }
+          },
+          "400": {
+            "description": "Invalid DSL or request envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Request body exceeds the structured-search size limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Content type is not application/json",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
       }
     },
     "/api/v1/tasks": {
@@ -28667,6 +28738,72 @@
         },
         "additionalProperties": false
       },
+      "StructuredSearchDoneEvent": {
+        "type": "object",
+        "description": "Terminal success event emitted by the structured-search SSE endpoint.",
+        "required": [
+          "version",
+          "kind",
+          "page_limit"
+        ],
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/StructuredSearchResourceKind",
+            "description": "Resource kind shared by all preceding result events."
+          },
+          "next": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Opaque next-page cursor, or null at the final page."
+          },
+          "page_limit": {
+            "type": "integer",
+            "description": "Effective page size after applying server pagination limits.",
+            "minimum": 0
+          },
+          "total": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Exact authorized count when requested; otherwise null."
+          },
+          "version": {
+            "type": "integer",
+            "format": "int32",
+            "description": "DSL version used to execute the request.",
+            "minimum": 0
+          }
+        }
+      },
+      "StructuredSearchErrorEvent": {
+        "type": "object",
+        "description": "Terminal failure event emitted after an SSE response has started.",
+        "required": [
+          "version",
+          "kind",
+          "message"
+        ],
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/StructuredSearchResourceKind",
+            "description": "Resource kind selected by the request."
+          },
+          "message": {
+            "type": "string",
+            "description": "Public API error message."
+          },
+          "version": {
+            "type": "integer",
+            "format": "int32",
+            "description": "DSL version supplied by the request.",
+            "minimum": 0
+          }
+        }
+      },
       "StructuredSearchExpression": {
         "oneOf": [
           {
@@ -29189,6 +29326,26 @@
           "asc",
           "desc"
         ]
+      },
+      "StructuredSearchStartedEvent": {
+        "type": "object",
+        "description": "First event emitted by the structured-search SSE endpoint.",
+        "required": [
+          "version",
+          "kind"
+        ],
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/StructuredSearchResourceKind",
+            "description": "Resource kind selected by the request."
+          },
+          "version": {
+            "type": "integer",
+            "format": "int32",
+            "description": "DSL version used to execute the request.",
+            "minimum": 0
+          }
+        }
       },
       "StructuredSearchTarget": {
         "oneOf": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -18897,6 +18897,77 @@
             "bearer_auth": []
           }
         ]
+      },
+      "post": {
+        "tags": [
+          "search"
+        ],
+        "summary": "Post Api V1 Search Stream",
+        "description": "Runs the same versioned structured resource-search DSL as POST /api/v1/search and returns server-sent events. The stream emits started, zero or more tagged result events, and one terminal done event carrying cursor metadata; execution failures after streaming starts produce a terminal error event.",
+        "operationId": "postApiV1SearchStream",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StructuredSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Structured search server-sent event stream",
+            "content": {
+              "text/event-stream": {}
+            }
+          },
+          "400": {
+            "description": "Invalid DSL or request envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Request body exceeds the structured-search size limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Content type is not application/json",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
       }
     },
     "/api/v1/tasks": {
@@ -28620,6 +28691,72 @@
         },
         "additionalProperties": false
       },
+      "StructuredSearchDoneEvent": {
+        "type": "object",
+        "description": "Terminal success event emitted by the structured-search SSE endpoint.",
+        "required": [
+          "version",
+          "kind",
+          "page_limit"
+        ],
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/StructuredSearchResourceKind",
+            "description": "Resource kind shared by all preceding result events."
+          },
+          "next": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Opaque next-page cursor, or null at the final page."
+          },
+          "page_limit": {
+            "type": "integer",
+            "description": "Effective page size after applying server pagination limits.",
+            "minimum": 0
+          },
+          "total": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Exact authorized count when requested; otherwise null."
+          },
+          "version": {
+            "type": "integer",
+            "format": "int32",
+            "description": "DSL version used to execute the request.",
+            "minimum": 0
+          }
+        }
+      },
+      "StructuredSearchErrorEvent": {
+        "type": "object",
+        "description": "Terminal failure event emitted after an SSE response has started.",
+        "required": [
+          "version",
+          "kind",
+          "message"
+        ],
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/StructuredSearchResourceKind",
+            "description": "Resource kind selected by the request."
+          },
+          "message": {
+            "type": "string",
+            "description": "Public API error message."
+          },
+          "version": {
+            "type": "integer",
+            "format": "int32",
+            "description": "DSL version supplied by the request.",
+            "minimum": 0
+          }
+        }
+      },
       "StructuredSearchExpression": {
         "oneOf": [
           {
@@ -29142,6 +29279,26 @@
           "asc",
           "desc"
         ]
+      },
+      "StructuredSearchStartedEvent": {
+        "type": "object",
+        "description": "First event emitted by the structured-search SSE endpoint.",
+        "required": [
+          "version",
+          "kind"
+        ],
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/StructuredSearchResourceKind",
+            "description": "Resource kind selected by the request."
+          },
+          "version": {
+            "type": "integer",
+            "format": "int32",
+            "description": "DSL version used to execute the request.",
+            "minimum": 0
+          }
+        }
       },
       "StructuredSearchTarget": {
         "oneOf": [

--- a/docs/search_api.md
+++ b/docs/search_api.md
@@ -6,8 +6,9 @@ resource:
 - `GET /api/v1/search` performs grouped plain-text discovery.
 - `GET /api/v1/search/stream` performs the same discovery over SSE.
 - `POST /api/v1/search` evaluates a versioned structured resource-search DSL.
+- `POST /api/v1/search/stream` streams that DSL over SSE.
 
-All three operations are read-only.
+All four operations are read-only.
 
 ## Plain-text discovery
 
@@ -57,11 +58,12 @@ timeout. A terminal `error` event replaces `done` when any batch fails.
 
 ## Structured resource search
 
-Use `POST /api/v1/search` when a query needs typed predicates or boolean
-expressions that would be ambiguous in a query string. Version 1 searches one
-resource kind per request: `collection`, `class`, `object`, `audit_event`, or
-`user`, `group`, or `service_account`. The request must use
-`Content-Type: application/json` and is limited to 64 KiB.
+Use `POST /api/v1/search` or `POST /api/v1/search/stream` when a query needs
+typed predicates or boolean expressions that would be ambiguous in a query
+string. Both operations accept the same request and execute the same search.
+Version 1 searches one resource kind per request: `collection`, `class`,
+`object`, `audit_event`, `user`, `group`, or `service_account`. The request must
+use `Content-Type: application/json` and is limited to 64 KiB.
 
 This is the complete request envelope:
 
@@ -509,9 +511,40 @@ a new DSL version. Unknown properties on the request, target, expression,
 predicate, related predicate, and sort objects remain errors so misspellings do
 not silently broaden a query.
 
-Version 1 returns a completed, globally sorted page. Progressive row streaming
-is not part of the POST contract: reachability and stable ordering must finish
-before the first row is final, and holding a database connection under client
-backpressure would reduce pool capacity. A future `POST /api/v1/search/stream`
-can expose progress or completed-page events without claiming that database
-rows are progressive.
+### Structured streaming
+
+`POST /api/v1/search/stream` returns `text/event-stream` and accepts the exact
+request envelope documented above. It emits these events in order:
+
+- one `started` event before search execution begins
+- zero or more `result` events, in the requested stable sort order
+- one terminal `done` event after successful execution
+- one terminal `error` event instead of results or `done` when execution fails
+
+The payload shapes are:
+
+```text
+event: started
+data: {"version":1,"kind":"object"}
+
+event: result
+data: {"kind":"object","resource":{...}}
+
+event: done
+data: {"version":1,"kind":"object","next":"...","total":42,"page_limit":100}
+```
+
+An `error` payload contains `version`, `kind`, and the public `message`. Request
+envelope failures that can be detected before streaming, such as malformed
+JSON, an unsupported DSL version, an oversized body, or an incorrect content
+type, use the normal HTTP `ApiError` response. Resolution, authorization, cursor,
+and database failures discovered after the SSE response starts use the terminal
+`error` event because the HTTP status and headers have already been sent.
+
+Structured results are deliberately page-progressive, not database-row
+progressive. Permission-aware reachability, exact totals, and stable ordering
+must finish before the first result is final. The completed page releases its
+database connection before result events are paced by the client, preventing a
+slow or disconnected consumer from occupying the connection pool. A disconnect
+before completion drops the pending search future; database statements remain
+bounded by the configured statement timeout.

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -54,8 +54,9 @@ use crate::models::{
     RemoteTargetID, RemoteTargetInvokeRequest, RemoteTargetSubjectType, ResourceRevision,
     RestoreConfirmRequest, RestoreJobStatus, RestoreStageResponse, RestoreTimestamps,
     RestoreValidationSummary, ServiceAccountPointResponse, ServiceAccountResponse,
-    SharedComputedScopeResponse, TaskDetails, TaskEventResponse, TaskKind, TaskLinks, TaskProgress,
-    TaskResponse, TaskStatus, TokenListState, TokenResourceScope, TokenScopeDetails,
+    SharedComputedScopeResponse, StructuredSearchDoneEvent, StructuredSearchErrorEvent,
+    StructuredSearchStartedEvent, TaskDetails, TaskEventResponse, TaskKind, TaskLinks,
+    TaskProgress, TaskResponse, TaskStatus, TokenListState, TokenResourceScope, TokenScopeDetails,
     UnifiedSearchBatchResponse, UnifiedSearchDoneEvent, UnifiedSearchErrorEvent, UnifiedSearchKind,
     UnifiedSearchResponse, UnifiedSearchStartedEvent, UpdateCollection, UpdateEventSink,
     UpdateEventSubscription, UpdateExportTemplate, UpdateGroup, UpdateHubuumClass,
@@ -183,6 +184,7 @@ use utoipa::{Modify, OpenApi, ToSchema};
         relations::delete_object_relation,
         search::get_search,
         search::post_search,
+        search::post_stream_search,
         search::stream_search,
         exports::run_export,
         exports::get_export,
@@ -506,6 +508,9 @@ use utoipa::{Modify, OpenApi, ToSchema};
             UnifiedSearchStartedEvent,
             UnifiedSearchDoneEvent,
             UnifiedSearchErrorEvent,
+            StructuredSearchStartedEvent,
+            StructuredSearchDoneEvent,
+            StructuredSearchErrorEvent,
             ExportTemplateID,
             ExportTemplateKind,
             ExportTemplate,
@@ -1896,6 +1901,42 @@ mod tests {
                 .iter()
                 .all(|expression| expression["maxProperties"] == 2),
             "expression schemas must reject unknown properties"
+        );
+
+        let stream = json
+            .pointer("/paths/~1api~1v1~1search~1stream/post")
+            .expect("structured search stream operation");
+        assert_eq!(
+            stream
+                .pointer("/requestBody/content/application~1json/schema/$ref")
+                .and_then(Value::as_str),
+            Some("#/components/schemas/StructuredSearchRequest")
+        );
+        for status in ["200", "400", "401", "413", "415"] {
+            assert!(
+                stream["responses"].get(status).is_some(),
+                "missing documented structured-search stream response {status}"
+            );
+        }
+        assert!(
+            stream
+                .pointer("/responses/200/content/text~1event-stream")
+                .is_some()
+        );
+        for schema in [
+            "StructuredSearchStartedEvent",
+            "StructuredSearchDoneEvent",
+            "StructuredSearchErrorEvent",
+        ] {
+            assert!(
+                json["components"]["schemas"].get(schema).is_some(),
+                "missing structured-search stream schema {schema}"
+            );
+        }
+        assert_eq!(
+            json["components"]["schemas"]["StructuredSearchDoneEvent"]["properties"]["page_limit"]
+                ["type"],
+            "integer"
         );
     }
 

--- a/src/api/v1/handlers/search.rs
+++ b/src/api/v1/handlers/search.rs
@@ -2,7 +2,7 @@ use actix_web::{HttpRequest, HttpResponse, Responder, get, http::StatusCode, pos
 use bytes::Bytes;
 use futures_util::{
     FutureExt, Stream, StreamExt,
-    future::BoxFuture,
+    future::{BoxFuture, LocalBoxFuture},
     stream::{self, FuturesUnordered},
 };
 use serde::Serialize;
@@ -27,8 +27,9 @@ use crate::extractors::{Authenticated, StructuredSearchPayload};
 use crate::models::traits::ResolveClassTarget;
 use crate::models::{
     Group, GroupResponse, MAX_STRUCTURED_SEARCH_EXTERNAL_CANDIDATES, Permissions, Principal,
-    ServiceAccountResponse, ServiceAccountWithName, StructuredSearchRequest,
-    StructuredSearchResourceKind, StructuredSearchResponse, StructuredSearchResult, TokenScope,
+    ServiceAccountResponse, ServiceAccountWithName, StructuredSearchDoneEvent,
+    StructuredSearchErrorEvent, StructuredSearchRequest, StructuredSearchResourceKind,
+    StructuredSearchResponse, StructuredSearchResult, StructuredSearchStartedEvent, TokenScope,
     UnifiedSearchBatchResponse, UnifiedSearchDoneEvent, UnifiedSearchErrorEvent, UnifiedSearchKind,
     UnifiedSearchQuery, UnifiedSearchResponse, UnifiedSearchStartedEvent, User, UserResponse,
     UserWithName, decode_structured_search_cursor, encode_structured_search_cursor,
@@ -195,6 +196,107 @@ pub async fn get_search(
 pub(crate) struct StructuredSearchExecution {
     pub(crate) response: StructuredSearchResponse,
     pub(crate) page_limit: usize,
+}
+
+type StructuredSearchFuture = LocalBoxFuture<'static, Result<StructuredSearchExecution, ApiError>>;
+
+enum StructuredSearchEventStreamPhase {
+    Starting(StructuredSearchFuture),
+    Searching(StructuredSearchFuture),
+    Delivering {
+        results: std::vec::IntoIter<StructuredSearchResult>,
+        done: StructuredSearchDoneEvent,
+    },
+    Finished,
+}
+
+struct StructuredSearchEventStreamState {
+    version: u8,
+    kind: StructuredSearchResourceKind,
+    phase: StructuredSearchEventStreamPhase,
+}
+
+fn structured_search_event_stream(
+    version: u8,
+    kind: StructuredSearchResourceKind,
+    execution: StructuredSearchFuture,
+) -> impl Stream<Item = Result<Bytes, actix_web::Error>> {
+    let state = StructuredSearchEventStreamState {
+        version,
+        kind,
+        phase: StructuredSearchEventStreamPhase::Starting(execution),
+    };
+
+    stream::unfold(state, |mut state| async move {
+        loop {
+            let phase =
+                std::mem::replace(&mut state.phase, StructuredSearchEventStreamPhase::Finished);
+            match phase {
+                StructuredSearchEventStreamPhase::Starting(execution) => {
+                    state.phase = StructuredSearchEventStreamPhase::Searching(execution);
+                    let event = sse_event(
+                        "started",
+                        &StructuredSearchStartedEvent {
+                            version: state.version,
+                            kind: state.kind,
+                        },
+                    )
+                    .map_err(actix_web::Error::from);
+                    return Some((event, state));
+                }
+                StructuredSearchEventStreamPhase::Searching(execution) => match execution.await {
+                    Ok(execution) => {
+                        let StructuredSearchExecution {
+                            response,
+                            page_limit,
+                        } = execution;
+                        let StructuredSearchResponse {
+                            version,
+                            kind,
+                            results,
+                            next,
+                            total,
+                        } = response;
+                        state.phase = StructuredSearchEventStreamPhase::Delivering {
+                            results: results.into_iter(),
+                            done: StructuredSearchDoneEvent {
+                                version,
+                                kind,
+                                next,
+                                total,
+                                page_limit,
+                            },
+                        };
+                    }
+                    Err(error) => {
+                        state.phase = StructuredSearchEventStreamPhase::Finished;
+                        let event = sse_event(
+                            "error",
+                            &StructuredSearchErrorEvent {
+                                version: state.version,
+                                kind: state.kind,
+                                message: error.public_message().to_string(),
+                            },
+                        )
+                        .map_err(actix_web::Error::from);
+                        return Some((event, state));
+                    }
+                },
+                StructuredSearchEventStreamPhase::Delivering { mut results, done } => {
+                    if let Some(result) = results.next() {
+                        state.phase =
+                            StructuredSearchEventStreamPhase::Delivering { results, done };
+                        let event = sse_event("result", &result).map_err(actix_web::Error::from);
+                        return Some((event, state));
+                    }
+                    state.phase = StructuredSearchEventStreamPhase::Finished;
+                    let event = sse_event("done", &done).map_err(actix_web::Error::from);
+                    return Some((event, state));
+                }
+                StructuredSearchEventStreamPhase::Finished => return None,
+            }
+        }
+    })
 }
 
 fn finalize_structured_search<T, F>(
@@ -658,6 +760,55 @@ pub async fn post_search(
 }
 
 #[utoipa::path(
+    post,
+    path = "/api/v1/search/stream",
+    tag = "search",
+    description = "Runs the same versioned structured resource-search DSL as POST /api/v1/search and returns server-sent events. The stream emits started, zero or more tagged result events, and one terminal done event carrying cursor metadata; execution failures after streaming starts produce a terminal error event.",
+    security(("bearer_auth" = [])),
+    request_body(content = StructuredSearchRequest, content_type = "application/json"),
+    responses(
+        (status = 200, description = "Structured search server-sent event stream", content_type = "text/event-stream"),
+        (status = 400, description = "Invalid DSL or request envelope", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 413, description = "Request body exceeds the structured-search size limit", body = ApiErrorResponse),
+        (status = 415, description = "Content type is not application/json", body = ApiErrorResponse)
+    )
+)]
+#[post("/stream")]
+pub async fn post_stream_search(
+    pool: AppContext,
+    requestor: Authenticated,
+    payload: StructuredSearchPayload,
+) -> Result<HttpResponse, ApiError> {
+    let request = payload.into_inner();
+    let version = request.version;
+    let kind = request.target.kind();
+    let principal = requestor.principal;
+    let token_id = requestor.token_meta.id;
+    let token_revision = requestor.token_meta.revision.get();
+    let scopes = requestor.scope;
+    let execution = async move {
+        execute_structured_search(
+            &pool,
+            &principal,
+            token_id,
+            token_revision,
+            scopes.as_ref(),
+            request,
+        )
+        .await
+    }
+    .boxed_local();
+    let stream = structured_search_event_stream(version, kind, execution);
+
+    Ok(HttpResponse::Ok()
+        .insert_header(("Content-Type", "text/event-stream; charset=utf-8"))
+        .insert_header(("Cache-Control", "private, no-store"))
+        .insert_header(("X-Accel-Buffering", "no"))
+        .streaming(stream))
+}
+
+#[utoipa::path(
     get,
     path = "/api/v1/search/stream",
     tag = "search",
@@ -712,6 +863,19 @@ mod tests {
             classes: vec![],
             objects: vec![],
             next: None,
+        }
+    }
+
+    fn empty_structured_execution() -> StructuredSearchExecution {
+        StructuredSearchExecution {
+            response: StructuredSearchResponse {
+                version: 1,
+                kind: StructuredSearchResourceKind::Object,
+                results: vec![],
+                next: Some("next-page".to_string()),
+                total: Some(0),
+            },
+            page_limit: 25,
         }
     }
 
@@ -824,6 +988,85 @@ mod tests {
             .boxed(),
         );
         let mut events = Box::pin(search_event_stream("needle".to_string(), searches));
+
+        events.next().await.unwrap().unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), events.next())
+                .await
+                .is_err()
+        );
+        drop(events);
+
+        tokio::time::timeout(Duration::from_secs(1), drop_observed)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    #[actix_web::test]
+    async fn structured_stream_emits_started_before_execution_completes() {
+        let (release, blocked) = oneshot::channel::<()>();
+        let execution = async move {
+            blocked.await.unwrap();
+            Ok(empty_structured_execution())
+        }
+        .boxed_local();
+        let events =
+            structured_search_event_stream(1, StructuredSearchResourceKind::Object, execution);
+        pin_mut!(events);
+
+        let started = events.next().await.unwrap().unwrap();
+        let started = String::from_utf8(started.to_vec()).unwrap();
+        assert!(started.contains("event: started"));
+        assert!(started.contains("\"kind\":\"object\""));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), events.next())
+                .await
+                .is_err()
+        );
+
+        release.send(()).unwrap();
+        let done = events.next().await.unwrap().unwrap();
+        let done = String::from_utf8(done.to_vec()).unwrap();
+        assert!(done.contains("event: done"));
+        assert!(done.contains("\"next\":\"next-page\""));
+        assert!(done.contains("\"page_limit\":25"));
+        assert!(events.next().await.is_none());
+    }
+
+    #[actix_web::test]
+    async fn structured_stream_error_is_terminal() {
+        let execution = async {
+            Err(ApiError::BadRequest(
+                "structured search deliberately failed".to_string(),
+            ))
+        }
+        .boxed_local();
+        let events =
+            structured_search_event_stream(1, StructuredSearchResourceKind::Collection, execution);
+        pin_mut!(events);
+
+        events.next().await.unwrap().unwrap();
+        let error = events.next().await.unwrap().unwrap();
+        let error = String::from_utf8(error.to_vec()).unwrap();
+        assert!(error.contains("event: error"));
+        assert!(error.contains("structured search deliberately failed"));
+        assert!(events.next().await.is_none());
+    }
+
+    #[actix_web::test]
+    async fn dropping_structured_stream_drops_pending_execution() {
+        let (notify_drop, drop_observed) = oneshot::channel();
+        let execution = async move {
+            let _drop_notifier = DropNotifier(Some(notify_drop));
+            future::pending::<Result<StructuredSearchExecution, ApiError>>().await
+        }
+        .boxed_local();
+        let mut events = Box::pin(structured_search_event_stream(
+            1,
+            StructuredSearchResourceKind::Object,
+            execution,
+        ));
 
         events.next().await.unwrap().unwrap();
         assert!(

--- a/src/api/v1/handlers/search.rs
+++ b/src/api/v1/handlers/search.rs
@@ -2,7 +2,7 @@ use actix_web::{HttpRequest, HttpResponse, Responder, get, http::StatusCode, pos
 use bytes::Bytes;
 use futures_util::{
     FutureExt, Stream, StreamExt,
-    future::BoxFuture,
+    future::{BoxFuture, LocalBoxFuture},
     stream::{self, FuturesUnordered},
 };
 use serde::Serialize;
@@ -17,8 +17,9 @@ use crate::extractors::{Authenticated, StructuredSearchPayload};
 use crate::models::traits::ResolveClassTarget;
 use crate::models::{
     GroupResponse, MAX_STRUCTURED_SEARCH_EXTERNAL_CANDIDATES, Permissions, ServiceAccountResponse,
-    ServiceAccountWithName, StorageUnifiedSearchQuery, StructuredSearchRequest,
-    StructuredSearchResourceKind, StructuredSearchResponse, StructuredSearchResult, TokenScope,
+    ServiceAccountWithName, StorageUnifiedSearchQuery, StructuredSearchDoneEvent,
+    StructuredSearchErrorEvent, StructuredSearchRequest, StructuredSearchResourceKind,
+    StructuredSearchResponse, StructuredSearchResult, StructuredSearchStartedEvent, TokenScope,
     UnifiedSearchBatchResponse, UnifiedSearchDoneEvent, UnifiedSearchErrorEvent, UnifiedSearchKind,
     UnifiedSearchResponse, UnifiedSearchStartedEvent, User, UserResponse, UserWithName,
     decode_structured_search_cursor, encode_structured_search_cursor, execute_unified_search,
@@ -190,6 +191,107 @@ pub async fn get_search(
 pub(crate) struct StructuredSearchExecution {
     pub(crate) response: StructuredSearchResponse,
     pub(crate) page_limit: usize,
+}
+
+type StructuredSearchFuture = LocalBoxFuture<'static, Result<StructuredSearchExecution, ApiError>>;
+
+enum StructuredSearchEventStreamPhase {
+    Starting(StructuredSearchFuture),
+    Searching(StructuredSearchFuture),
+    Delivering {
+        results: std::vec::IntoIter<StructuredSearchResult>,
+        done: StructuredSearchDoneEvent,
+    },
+    Finished,
+}
+
+struct StructuredSearchEventStreamState {
+    version: u8,
+    kind: StructuredSearchResourceKind,
+    phase: StructuredSearchEventStreamPhase,
+}
+
+fn structured_search_event_stream(
+    version: u8,
+    kind: StructuredSearchResourceKind,
+    execution: StructuredSearchFuture,
+) -> impl Stream<Item = Result<Bytes, actix_web::Error>> {
+    let state = StructuredSearchEventStreamState {
+        version,
+        kind,
+        phase: StructuredSearchEventStreamPhase::Starting(execution),
+    };
+
+    stream::unfold(state, |mut state| async move {
+        loop {
+            let phase =
+                std::mem::replace(&mut state.phase, StructuredSearchEventStreamPhase::Finished);
+            match phase {
+                StructuredSearchEventStreamPhase::Starting(execution) => {
+                    state.phase = StructuredSearchEventStreamPhase::Searching(execution);
+                    let event = sse_event(
+                        "started",
+                        &StructuredSearchStartedEvent {
+                            version: state.version,
+                            kind: state.kind,
+                        },
+                    )
+                    .map_err(actix_web::Error::from);
+                    return Some((event, state));
+                }
+                StructuredSearchEventStreamPhase::Searching(execution) => match execution.await {
+                    Ok(execution) => {
+                        let StructuredSearchExecution {
+                            response,
+                            page_limit,
+                        } = execution;
+                        let StructuredSearchResponse {
+                            version,
+                            kind,
+                            results,
+                            next,
+                            total,
+                        } = response;
+                        state.phase = StructuredSearchEventStreamPhase::Delivering {
+                            results: results.into_iter(),
+                            done: StructuredSearchDoneEvent {
+                                version,
+                                kind,
+                                next,
+                                total,
+                                page_limit,
+                            },
+                        };
+                    }
+                    Err(error) => {
+                        state.phase = StructuredSearchEventStreamPhase::Finished;
+                        let event = sse_event(
+                            "error",
+                            &StructuredSearchErrorEvent {
+                                version: state.version,
+                                kind: state.kind,
+                                message: error.public_message().to_string(),
+                            },
+                        )
+                        .map_err(actix_web::Error::from);
+                        return Some((event, state));
+                    }
+                },
+                StructuredSearchEventStreamPhase::Delivering { mut results, done } => {
+                    if let Some(result) = results.next() {
+                        state.phase =
+                            StructuredSearchEventStreamPhase::Delivering { results, done };
+                        let event = sse_event("result", &result).map_err(actix_web::Error::from);
+                        return Some((event, state));
+                    }
+                    state.phase = StructuredSearchEventStreamPhase::Finished;
+                    let event = sse_event("done", &done).map_err(actix_web::Error::from);
+                    return Some((event, state));
+                }
+                StructuredSearchEventStreamPhase::Finished => return None,
+            }
+        }
+    })
 }
 
 fn finalize_structured_search<T, F>(
@@ -598,6 +700,55 @@ pub async fn post_search(
 }
 
 #[utoipa::path(
+    post,
+    path = "/api/v1/search/stream",
+    tag = "search",
+    description = "Runs the same versioned structured resource-search DSL as POST /api/v1/search and returns server-sent events. The stream emits started, zero or more tagged result events, and one terminal done event carrying cursor metadata; execution failures after streaming starts produce a terminal error event.",
+    security(("bearer_auth" = [])),
+    request_body(content = StructuredSearchRequest, content_type = "application/json"),
+    responses(
+        (status = 200, description = "Structured search server-sent event stream", content_type = "text/event-stream"),
+        (status = 400, description = "Invalid DSL or request envelope", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 413, description = "Request body exceeds the structured-search size limit", body = ApiErrorResponse),
+        (status = 415, description = "Content type is not application/json", body = ApiErrorResponse)
+    )
+)]
+#[post("/stream")]
+pub async fn post_stream_search(
+    context: AppContext,
+    requestor: Authenticated,
+    payload: StructuredSearchPayload,
+) -> Result<HttpResponse, ApiError> {
+    let request = payload.into_inner();
+    let version = request.version;
+    let kind = request.target.kind();
+    let principal = requestor.principal;
+    let token_id = requestor.token_meta.id().id();
+    let token_revision = requestor.token_meta.revision().get();
+    let scopes = requestor.scope;
+    let execution = async move {
+        execute_structured_search(
+            &context,
+            &principal,
+            token_id,
+            token_revision,
+            scopes.as_ref(),
+            request,
+        )
+        .await
+    }
+    .boxed_local();
+    let stream = structured_search_event_stream(version, kind, execution);
+
+    Ok(HttpResponse::Ok()
+        .insert_header(("Content-Type", "text/event-stream; charset=utf-8"))
+        .insert_header(("Cache-Control", "private, no-store"))
+        .insert_header(("X-Accel-Buffering", "no"))
+        .streaming(stream))
+}
+
+#[utoipa::path(
     get,
     path = "/api/v1/search/stream",
     tag = "search",
@@ -653,6 +804,19 @@ mod tests {
             classes: vec![],
             objects: vec![],
             next: None,
+        }
+    }
+
+    fn empty_structured_execution() -> StructuredSearchExecution {
+        StructuredSearchExecution {
+            response: StructuredSearchResponse {
+                version: 1,
+                kind: StructuredSearchResourceKind::Object,
+                results: vec![],
+                next: Some("next-page".to_string()),
+                total: Some(0),
+            },
+            page_limit: 25,
         }
     }
 
@@ -765,6 +929,85 @@ mod tests {
             .boxed(),
         );
         let mut events = Box::pin(search_event_stream("needle".to_string(), searches));
+
+        events.next().await.unwrap().unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), events.next())
+                .await
+                .is_err()
+        );
+        drop(events);
+
+        tokio::time::timeout(Duration::from_secs(1), drop_observed)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    #[actix_web::test]
+    async fn structured_stream_emits_started_before_execution_completes() {
+        let (release, blocked) = oneshot::channel::<()>();
+        let execution = async move {
+            blocked.await.unwrap();
+            Ok(empty_structured_execution())
+        }
+        .boxed_local();
+        let events =
+            structured_search_event_stream(1, StructuredSearchResourceKind::Object, execution);
+        pin_mut!(events);
+
+        let started = events.next().await.unwrap().unwrap();
+        let started = String::from_utf8(started.to_vec()).unwrap();
+        assert!(started.contains("event: started"));
+        assert!(started.contains("\"kind\":\"object\""));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), events.next())
+                .await
+                .is_err()
+        );
+
+        release.send(()).unwrap();
+        let done = events.next().await.unwrap().unwrap();
+        let done = String::from_utf8(done.to_vec()).unwrap();
+        assert!(done.contains("event: done"));
+        assert!(done.contains("\"next\":\"next-page\""));
+        assert!(done.contains("\"page_limit\":25"));
+        assert!(events.next().await.is_none());
+    }
+
+    #[actix_web::test]
+    async fn structured_stream_error_is_terminal() {
+        let execution = async {
+            Err(ApiError::BadRequest(
+                "structured search deliberately failed".to_string(),
+            ))
+        }
+        .boxed_local();
+        let events =
+            structured_search_event_stream(1, StructuredSearchResourceKind::Collection, execution);
+        pin_mut!(events);
+
+        events.next().await.unwrap().unwrap();
+        let error = events.next().await.unwrap().unwrap();
+        let error = String::from_utf8(error.to_vec()).unwrap();
+        assert!(error.contains("event: error"));
+        assert!(error.contains("structured search deliberately failed"));
+        assert!(events.next().await.is_none());
+    }
+
+    #[actix_web::test]
+    async fn dropping_structured_stream_drops_pending_execution() {
+        let (notify_drop, drop_observed) = oneshot::channel();
+        let execution = async move {
+            let _drop_notifier = DropNotifier(Some(notify_drop));
+            future::pending::<Result<StructuredSearchExecution, ApiError>>().await
+        }
+        .boxed_local();
+        let mut events = Box::pin(structured_search_event_stream(
+            1,
+            StructuredSearchResourceKind::Object,
+            execution,
+        ));
 
         events.next().await.unwrap().unwrap();
         assert!(

--- a/src/api/v1/routes/search.rs
+++ b/src/api/v1/routes/search.rs
@@ -5,5 +5,6 @@ use crate::api::v1::handlers::search;
 pub fn config(cfg: &mut web::ServiceConfig) {
     cfg.service(search::get_search)
         .service(search::post_search)
+        .service(search::post_stream_search)
         .service(search::stream_search);
 }

--- a/src/models/structured_search.rs
+++ b/src/models/structured_search.rs
@@ -1129,6 +1129,41 @@ pub struct StructuredSearchResponse {
     pub total: Option<i64>,
 }
 
+/// First event emitted by the structured-search SSE endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct StructuredSearchStartedEvent {
+    /// DSL version used to execute the request.
+    pub version: u8,
+    /// Resource kind selected by the request.
+    pub kind: StructuredSearchResourceKind,
+}
+
+/// Terminal success event emitted by the structured-search SSE endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct StructuredSearchDoneEvent {
+    /// DSL version used to execute the request.
+    pub version: u8,
+    /// Resource kind shared by all preceding result events.
+    pub kind: StructuredSearchResourceKind,
+    /// Opaque next-page cursor, or null at the final page.
+    pub next: Option<String>,
+    /// Exact authorized count when requested; otherwise null.
+    pub total: Option<i64>,
+    /// Effective page size after applying server pagination limits.
+    pub page_limit: usize,
+}
+
+/// Terminal failure event emitted after an SSE response has started.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct StructuredSearchErrorEvent {
+    /// DSL version supplied by the request.
+    pub version: u8,
+    /// Resource kind selected by the request.
+    pub kind: StructuredSearchResourceKind,
+    /// Public API error message.
+    pub message: String,
+}
+
 /// Tagged union of public resource representations returned by the DSL.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(tag = "kind", content = "resource", rename_all = "snake_case")]

--- a/src/models/structured_search.rs
+++ b/src/models/structured_search.rs
@@ -1072,6 +1072,41 @@ pub struct StructuredSearchResponse {
     pub total: Option<i64>,
 }
 
+/// First event emitted by the structured-search SSE endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct StructuredSearchStartedEvent {
+    /// DSL version used to execute the request.
+    pub version: u8,
+    /// Resource kind selected by the request.
+    pub kind: StructuredSearchResourceKind,
+}
+
+/// Terminal success event emitted by the structured-search SSE endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct StructuredSearchDoneEvent {
+    /// DSL version used to execute the request.
+    pub version: u8,
+    /// Resource kind shared by all preceding result events.
+    pub kind: StructuredSearchResourceKind,
+    /// Opaque next-page cursor, or null at the final page.
+    pub next: Option<String>,
+    /// Exact authorized count when requested; otherwise null.
+    pub total: Option<i64>,
+    /// Effective page size after applying server pagination limits.
+    pub page_limit: usize,
+}
+
+/// Terminal failure event emitted after an SSE response has started.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct StructuredSearchErrorEvent {
+    /// DSL version supplied by the request.
+    pub version: u8,
+    /// Resource kind selected by the request.
+    pub kind: StructuredSearchResourceKind,
+    /// Public API error message.
+    pub message: String,
+}
+
 /// Tagged union of public resource representations returned by the DSL.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(tag = "kind", content = "resource", rename_all = "snake_case")]

--- a/src/tests/search/structured.rs
+++ b/src/tests/search/structured.rs
@@ -187,6 +187,75 @@ async fn structured_search_targets_collections() {
 }
 
 #[actix_web::test]
+async fn structured_search_streams_the_same_tagged_collection_results() {
+    let context = TestContext::new().await;
+    let collection = context
+        .collection_fixture("structured_collection_stream")
+        .await;
+    let request = json!({
+        "version": 1,
+        "target": {"kind": "collection"},
+        "filter": {
+            "op": "field",
+            "predicate": {
+                "field": "name",
+                "operator": "equals",
+                "value": collection.collection.name
+            }
+        },
+        "include_total": true
+    });
+
+    let response = post_request(
+        &context.pool,
+        &context.admin_token,
+        "/api/v1/search/stream",
+        request,
+    )
+    .await;
+    let response = assert_response_status(response, http::StatusCode::OK).await;
+    assert_eq!(
+        response.headers().get(http::header::CONTENT_TYPE).unwrap(),
+        "text/event-stream; charset=utf-8"
+    );
+    let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+    let started = body.find("event: started").unwrap();
+    let result = body.find("event: result").unwrap();
+    let done = body.find("event: done").unwrap();
+
+    assert!(started < result && result < done);
+    assert!(body.contains("\"kind\":\"collection\""));
+    assert!(body.contains(&collection.collection.name));
+    assert!(body.contains("\"total\":1"));
+    collection.cleanup().await.unwrap();
+}
+
+#[actix_web::test]
+async fn structured_search_stream_reports_execution_authorization_errors_as_terminal_events() {
+    let context = TestContext::new().await;
+    let request = json!({
+        "version": 1,
+        "target": {"kind": "user"}
+    });
+
+    let response = post_request(
+        &context.pool,
+        &context.normal_token,
+        "/api/v1/search/stream",
+        request,
+    )
+    .await;
+    let response = assert_response_status(response, http::StatusCode::OK).await;
+    let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+
+    assert!(body.contains("event: started"));
+    assert!(body.contains("event: error"));
+    assert!(body.contains("user search requires administrator access"));
+    assert!(!body.contains("event: result"));
+    assert!(!body.contains("event: done"));
+}
+
+#[actix_web::test]
 async fn structured_search_targets_classes() {
     let context = TestContext::new().await;
     let collection = context.collection_fixture("structured_class").await;

--- a/src/tests/search/structured.rs
+++ b/src/tests/search/structured.rs
@@ -186,6 +186,75 @@ async fn structured_search_targets_collections() {
 }
 
 #[actix_web::test]
+async fn structured_search_streams_the_same_tagged_collection_results() {
+    let context = TestContext::new().await;
+    let collection = context
+        .collection_fixture("structured_collection_stream")
+        .await;
+    let request = json!({
+        "version": 1,
+        "target": {"kind": "collection"},
+        "filter": {
+            "op": "field",
+            "predicate": {
+                "field": "name",
+                "operator": "equals",
+                "value": collection.collection.name
+            }
+        },
+        "include_total": true
+    });
+
+    let response = post_request(
+        &context.pool,
+        &context.admin_token,
+        "/api/v1/search/stream",
+        request,
+    )
+    .await;
+    let response = assert_response_status(response, http::StatusCode::OK).await;
+    assert_eq!(
+        response.headers().get(http::header::CONTENT_TYPE).unwrap(),
+        "text/event-stream; charset=utf-8"
+    );
+    let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+    let started = body.find("event: started").unwrap();
+    let result = body.find("event: result").unwrap();
+    let done = body.find("event: done").unwrap();
+
+    assert!(started < result && result < done);
+    assert!(body.contains("\"kind\":\"collection\""));
+    assert!(body.contains(&collection.collection.name));
+    assert!(body.contains("\"total\":1"));
+    collection.cleanup().await.unwrap();
+}
+
+#[actix_web::test]
+async fn structured_search_stream_reports_execution_authorization_errors_as_terminal_events() {
+    let context = TestContext::new().await;
+    let request = json!({
+        "version": 1,
+        "target": {"kind": "user"}
+    });
+
+    let response = post_request(
+        &context.pool,
+        &context.normal_token,
+        "/api/v1/search/stream",
+        request,
+    )
+    .await;
+    let response = assert_response_status(response, http::StatusCode::OK).await;
+    let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+
+    assert!(body.contains("event: started"));
+    assert!(body.contains("event: error"));
+    assert!(body.contains("user search requires administrator access"));
+    assert!(!body.contains("event: result"));
+    assert!(!body.contains("event: done"));
+}
+
+#[actix_web::test]
 async fn structured_search_targets_classes() {
     let context = TestContext::new().await;
     let collection = context.collection_fixture("structured_class").await;


### PR DESCRIPTION
## Summary

- add POST /api/v1/search/stream using the same versioned request DSL and execution path as POST /api/v1/search
- emit started before execution, one tagged result event per ordered page item, and a terminal done event with next cursor, exact total, and effective page limit
- encode resolution, authorization, cursor, and database failures discovered after headers as a terminal error event
- release database connections before client-paced result delivery and drop pending execution when the client disconnects
- document the complete SSE lifecycle and add OpenAPI event schemas plus protocol regression coverage

## Design notes

Structured streaming is page-progressive rather than database-row progressive. Permission-aware reachability, exact totals, and stable ordering complete before the first result is final. The completed page is then delivered without retaining a database connection under client backpressure.

The request extractor still returns normal HTTP errors for malformed JSON, unsupported versions, oversized bodies, and incorrect content types before streaming begins. Once the 200 SSE response starts, later failures are represented by exactly one terminal error event.

This PR depends on #292, which adds the generic structured search DSL. #292 depends on #291, which fixes progressive delivery for the existing GET stream. The three PRs are published as native GitHub stack #297.

## Verification

- source .env && ./run_tests.sh
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"
- cargo run --quiet --bin hubuum-openapi > docs/openapi.json
- scripts/classify-ci-changes.sh
- focused SSE cancellation, ordering, success, and authorization-error tests

## Changelog

The structured SSE endpoint is documented in the Unreleased section of CHANGELOG.md.

Part of #282
