### PR TITLE
Define storage capability DTO boundary

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -65,7 +65,7 @@ for package classifications, publishing policy, and promotion requirements.
   Behavioral interfaces used by handlers and models inside the application.
   `StorageContext` is a sealed, opaque persistence capability. Consumers pass
   it to operations but cannot extract or select the database implementation.
-- `src/backend.rs`:
+- `src/storage/capabilities.rs`:
   Application-facing capability facade for query, workflow, and operational
   contracts that do not yet have multiple storage implementations.
 - `src/storage/postgres/operations/*`:
@@ -87,8 +87,8 @@ When adding a feature:
    has migrated.
 2. Express persistence as an aggregate- or query-shaped capability in
    `src/storage`; avoid generic table repositories.
-3. Implement database details in `src/storage/postgres/operations` and adapt them through the
-   PostgreSQL storage implementation.
+3. Implement database details in `src/storage/postgres/operations` and adapt
+   them through the PostgreSQL storage implementation.
 4. Keep model methods thin while they remain in unmigrated paths.
 5. Add shared logical contract tests and retain PostgreSQL-specific query,
    transaction, migration, recovery, and concurrency tests.
@@ -110,11 +110,12 @@ capability facade instead of importing these modules directly.
 
 ### Collection hierarchy implementation
 
-Recursive collections are implemented in the database layer, not in a workspace
-crate. The implementation is coupled to Diesel schema modules, PostgreSQL
-closure-table SQL, temporal history, `ApiError`, and Hubuum's permission
-semantics. Keep hierarchy writes in `src/storage/postgres/operations/collection/records.rs` and
-permission reads in `src/storage/postgres/operations/collection/permissions.rs` or
+Recursive collections are implemented in the PostgreSQL adapter, not in a
+workspace crate. The implementation is coupled to Diesel schema modules,
+PostgreSQL closure-table SQL, temporal history, `ApiError`, and Hubuum's
+permission semantics. Keep hierarchy writes in
+`src/storage/postgres/operations/collection/records.rs` and permission reads in
+`src/storage/postgres/operations/collection/permissions.rs` or
 `src/storage/postgres/operations/user/*`.
 
 Normal collection and class lifecycle handlers enter this implementation

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -128,6 +128,14 @@ transactions, batching, locking, hierarchy maintenance, initial grants,
 cardinality enforcement, and atomic event persistence. The contract must not
 devolve into table repositories or expose query builders.
 
+Inputs and results crossing the boundary are storage-owned, backend-neutral
+DTOs. They may contain domain types, but they do not derive Diesel traits or
+expose SQL rows, query builders, connections, pools, or driver errors. Each
+adapter keeps its persistence rows private and explicitly converts them into
+the contract DTOs. Metrics use this pattern today: `MetricsStorage` returns
+neutral inventory, task, event, and pool snapshots while PostgreSQL keeps its
+queryable row structs inside the adapter.
+
 ## Error Direction
 
 Errors cross the boundary in one direction:
@@ -313,6 +321,7 @@ Architecture tests enforce that:
   implementation modules;
 - backend-neutral services and storage contracts do not import PostgreSQL or
   application API errors;
+- storage contract DTOs do not derive Diesel traits or expose adapter types;
 - only adapter modules translate implementation errors to `StorageError`;
 - the application error layer owns `StorageError` to `ApiError` conversion;
 - `AppContext` owns an opaque `StorageHandle` and composes services from a

--- a/src/api/handlers/meta.rs
+++ b/src/api/handlers/meta.rs
@@ -8,9 +8,8 @@ use crate::models::class::total_class_count;
 use crate::models::collection::total_collection_count;
 use crate::models::object::{objects_per_class_count, total_object_count};
 use crate::permissions::AppContext;
-use crate::storage::capabilities::meta::{
-    load_database_pool_state, load_database_state, load_task_queue_state,
-};
+use crate::storage::MetricsStorage;
+use crate::storage::capabilities::meta::{load_database_state, load_task_queue_state};
 use actix_web::{Responder, delete, get, http::StatusCode, web};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -100,7 +99,7 @@ pub async fn get_db_state(
     requestor: AdminAccess,
 ) -> Result<impl Responder, ApiError> {
     let row = load_database_state(&context).await?;
-    let state = load_database_pool_state(&context);
+    let state = context.backend().metrics_pool_state();
     debug!(
         message = "DB state requested",
         requestor = requestor.user.id

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -16,11 +16,11 @@ use tokio::sync::Mutex;
 use crate::errors::ApiError;
 use crate::models::user::{LoginUser, User, auth_failure};
 use crate::models::{LDAP_PROVIDER_KIND, LOCAL_IDENTITY_SCOPE, LOCAL_PROVIDER_KIND};
-use crate::storage::postgres::operations::external_identity::{
+use crate::storage::capabilities::external_identity::{
     ExternalPrincipalState, external_principal_state, mark_external_sync_attempted,
     sync_external_user as sync_external_user_from_backend,
 };
-use crate::storage::postgres::operations::identity::ensure_identity_scope;
+use crate::storage::capabilities::identity::ensure_identity_scope;
 
 const DEFAULT_REFRESH_TTL_SECONDS: i64 = 300;
 const DEFAULT_MAX_STALE_SECONDS: i64 = 3600;

--- a/src/backups/mod.rs
+++ b/src/backups/mod.rs
@@ -12,8 +12,8 @@ use crate::models::{
     TaskResultCounts, TaskStatus,
 };
 use crate::permissions::{AppContext, PrincipalRef};
-use crate::storage::postgres::operations::backup::snapshot_backup_db;
-use crate::storage::postgres::operations::task::{TaskBackend, TaskStateUpdate};
+use crate::storage::capabilities::backup::snapshot_backup_db;
+use crate::storage::capabilities::task::{TaskBackend, TaskStateUpdate};
 use crate::traits::AuthzSubject;
 
 #[derive(Clone, Debug)]

--- a/src/events/delivery.rs
+++ b/src/events/delivery.rs
@@ -23,13 +23,13 @@ use crate::models::{EventSink, EventSubscription, EventWorkerWakeupStats};
 use crate::observability::metrics;
 use crate::restores::MaintenanceActivityGuard;
 use crate::storage::StorageContext;
-use crate::storage::postgres::operations::event_delivery::{
+use crate::storage::capabilities::event_delivery::{
     ClaimedEventDelivery, claim_event_delivery_batch, mark_event_delivery_failed,
     mark_event_delivery_succeeded,
 };
-use crate::storage::postgres::operations::events::load_queued_task_initiators;
-use crate::storage::postgres::operations::history::resolve_principal_names;
-use crate::storage::postgres::{StorageCallSite, with_storage_call_site};
+use crate::storage::capabilities::events::load_queued_task_initiators;
+use crate::storage::capabilities::history::resolve_principal_names;
+use crate::storage::capabilities::{StorageCallSite, with_storage_call_site};
 use crate::storage::{StorageHandle, storage_handle};
 
 static EVENT_DELIVERY_WORKER: Once = Once::new();

--- a/src/events/fanout.rs
+++ b/src/events/fanout.rs
@@ -17,8 +17,8 @@ use crate::models::EventWorkerWakeupStats;
 use crate::observability::metrics;
 use crate::restores::MaintenanceActivityGuard;
 use crate::storage::StorageContext;
-use crate::storage::postgres::operations::event_fanout::process_event_fanout_batch;
-use crate::storage::postgres::{StorageCallSite, with_storage_call_site};
+use crate::storage::capabilities::event_fanout::process_event_fanout_batch;
+use crate::storage::capabilities::{StorageCallSite, with_storage_call_site};
 use crate::storage::{StorageHandle, storage_handle};
 
 static EVENT_FANOUT_WORKER: Once = Once::new();

--- a/src/events/retention.rs
+++ b/src/events/retention.rs
@@ -20,13 +20,10 @@ use crate::events::{Event, EventRetentionSettings};
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::restores::MaintenanceActivityGuard;
 use crate::storage::StorageContext;
-use crate::storage::postgres::operations::event_retention::{
-    EventRetentionPurgeSummary, purge_event_retention_batch_conn,
-    select_events_for_retention_purge_conn, try_acquire_event_retention_lock,
+use crate::storage::capabilities::event_retention::{
+    EventRetentionPurgeSummary, process_event_retention_batch_from_storage,
 };
-use crate::storage::postgres::operations::maintenance::maintenance_state_conn;
-use crate::storage::postgres::with_transaction;
-use crate::storage::postgres::{StorageCallSite, with_storage_call_site};
+use crate::storage::capabilities::{StorageCallSite, with_storage_call_site};
 use crate::storage::{StorageHandle, storage_handle};
 
 static EVENT_RETENTION_WORKER: std::sync::Once = std::sync::Once::new();
@@ -86,23 +83,13 @@ pub async fn process_event_retention_batch(
     archive_path: Option<&Path>,
 ) -> Result<EventRetentionPurgeSummary, ApiError> {
     let _activity = MaintenanceActivityGuard::begin();
-    with_transaction(pool, async |conn| -> Result<_, ApiError> {
-        if !maintenance_state_conn(conn).await?.is_normal() {
-            return Ok(EventRetentionPurgeSummary::default());
-        }
-        if !try_acquire_event_retention_lock(conn).await? {
-            return Ok(EventRetentionPurgeSummary::default());
-        }
-
-        let events = select_events_for_retention_purge_conn(conn, settings).await?;
+    process_event_retention_batch_from_storage(pool, settings, |events| {
         if let Some(path) = archive_path
             && !events.is_empty()
         {
-            append_event_archive(path, &events)?;
+            append_event_archive(path, events)?;
         }
-
-        let event_ids = events.iter().map(|event| event.id).collect::<Vec<_>>();
-        purge_event_retention_batch_conn(conn, settings, &event_ids).await
+        Ok(())
     })
     .await
 }

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -37,17 +37,17 @@ use crate::permissions::{
     ResourceRef,
 };
 use crate::storage::StorageContext;
-use crate::storage::postgres::operations::UserPermissions;
-use crate::storage::postgres::operations::authz::{scope_allows, scope_allows_resource};
-use crate::storage::postgres::operations::relations::{
+use crate::storage::capabilities::UserPermissions;
+use crate::storage::capabilities::authz::{scope_allows, scope_allows_resource};
+use crate::storage::capabilities::relations::{
     class_relation_authorization_resources, object_authorization_resources,
     object_relation_authorization_resources,
 };
-use crate::storage::postgres::operations::task::{
+use crate::storage::capabilities::task::{
     TaskBackend, TaskCreateRequest, TaskScopeSnapshot, TaskStateUpdate,
 };
-use crate::storage::postgres::operations::user::UserSearchBackend;
-use crate::storage::postgres::with_statement_timeout_scope;
+use crate::storage::capabilities::user::workflow::UserSearchBackend;
+use crate::storage::capabilities::with_statement_timeout_scope;
 use crate::tasks::request_hash;
 use crate::traits::{AuthzSubject, SelfAccessors};
 use crate::utilities::exporting::render_template;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -71,8 +71,8 @@ where
 /// can!(pool, subject, scopes, [Permissions::ReadCollection, Permissions::UpdateCollection], collection, class1, class2);
 /// ```
 ///
-/// [`UserPermissions::can`]: crate::storage::postgres::operations::UserPermissions::can
-/// [`UserPermissions`]: crate::storage::postgres::operations::UserPermissions
+/// [`UserPermissions::can`]: crate::storage::capabilities::UserPermissions::can
+/// [`UserPermissions`]: crate::storage::capabilities::UserPermissions
 /// [`CollectionAccessors`]: crate::traits::CollectionAccessors
 /// [`Permissions`]: crate::models::Permissions
 /// [`ApiError::Forbidden`]: crate::errors::ApiError::Forbidden
@@ -92,7 +92,7 @@ macro_rules! can {
         let resources = vec![
             $($collection.to_resource_ref(backend).await?),+
         ];
-        if !$crate::storage::postgres::operations::authz::scope_allows_resources($scopes, &resources) {
+        if !$crate::storage::capabilities::authz::scope_allows_resources($scopes, &resources) {
             return Err($crate::errors::ApiError::Forbidden("Permission denied".to_string()));
         }
 

--- a/src/observability/metrics/cache.rs
+++ b/src/observability/metrics/cache.rs
@@ -1,8 +1,6 @@
 use std::time::{Duration, Instant};
 
-use crate::storage::postgres::operations::metrics::{
-    EventMetricsSnapshot, InventoryGaugeSnapshot, TaskGaugeSnapshot,
-};
+use crate::storage::{EventMetricsSnapshot, InventoryGaugeSnapshot, TaskGaugeSnapshot};
 
 const DB_SCRAPE_CACHE_TTL: Duration = Duration::from_secs(30);
 

--- a/src/observability/metrics/db.rs
+++ b/src/observability/metrics/db.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use opentelemetry::KeyValue;
 
-use crate::storage::postgres::operations::meta::load_database_pool_state;
+use crate::storage::MetricsStorage;
 
 use super::{Metrics, current};
 
@@ -62,11 +62,8 @@ pub(crate) fn db_operation_finished(
     }
 }
 
-pub(super) fn refresh_pool_gauges(
-    metrics: &Metrics,
-    backend: &impl crate::storage::StorageContext,
-) {
-    let state = load_database_pool_state(backend);
+pub(super) fn refresh_pool_gauges(metrics: &Metrics, backend: &(impl MetricsStorage + ?Sized)) {
+    let state = backend.metrics_pool_state();
     metrics.db_pool_connections.record(
         u64::from(state.max_connections),
         &[KeyValue::new("state", "configured")],

--- a/src/observability/metrics/event.rs
+++ b/src/observability/metrics/event.rs
@@ -3,8 +3,7 @@ use std::time::{Duration, Instant};
 use opentelemetry::KeyValue;
 
 use crate::models::{EventDeliveryStatusCounts, EventWorkerHealth};
-use crate::storage::postgres::operations::event_observability::load_event_metrics_snapshot;
-use crate::storage::postgres::operations::metrics::EventMetricsSnapshot;
+use crate::storage::{EventMetricsSnapshot, MetricsStorage};
 
 use super::scrape::{RefreshOutcome, RefreshSource, record_refresh_attempt};
 use super::{Metrics, current};
@@ -20,7 +19,7 @@ pub fn event_worker_wakeup(worker: &'static str, kind: &'static str) {
 
 pub(super) async fn refresh_event_gauges(
     metrics: &Metrics,
-    backend: &impl crate::storage::StorageContext,
+    backend: &(impl MetricsStorage + ?Sized),
 ) {
     if let Some(snapshot) = cached_event_snapshot(metrics) {
         record_event_snapshot(metrics, &snapshot);
@@ -28,7 +27,7 @@ pub(super) async fn refresh_event_gauges(
     }
 
     let refresh_started_at = Instant::now();
-    match load_event_metrics_snapshot(backend).await {
+    match backend.metrics_event_snapshot().await {
         Ok(snapshot) => {
             record_refresh_attempt(
                 metrics,

--- a/src/observability/metrics/inventory.rs
+++ b/src/observability/metrics/inventory.rs
@@ -2,16 +2,14 @@ use std::time::Instant;
 
 use opentelemetry::KeyValue;
 
-use crate::storage::postgres::operations::metrics::{
-    InventoryGaugeSnapshot, MetricsRefreshBackend,
-};
+use crate::storage::{InventoryGaugeSnapshot, MetricsStorage};
 
 use super::Metrics;
 use super::scrape::{RefreshOutcome, RefreshSource, record_refresh_attempt};
 
 pub(super) async fn refresh_inventory_gauges(
     metrics: &Metrics,
-    backend: &impl crate::storage::StorageContext,
+    backend: &(impl MetricsStorage + ?Sized),
 ) {
     if let Some(row) = cached_inventory_snapshot(metrics) {
         record_inventory_snapshot(metrics, &row);
@@ -19,7 +17,7 @@ pub(super) async fn refresh_inventory_gauges(
     }
 
     let refresh_started_at = Instant::now();
-    match backend.metrics_inventory_gauge_snapshot().await {
+    match backend.metrics_inventory_snapshot().await {
         Ok(row) => {
             record_refresh_attempt(
                 metrics,

--- a/src/observability/metrics/scrape.rs
+++ b/src/observability/metrics/scrape.rs
@@ -56,7 +56,7 @@ pub async fn scrape(context: AppContext) -> Result<impl Responder, ApiError> {
     );
     with_storage_call_site(
         StorageCallSite::MetricsRefresh,
-        refresh_scrape_gauges(metrics, &context),
+        refresh_scrape_gauges(metrics, context.backend()),
     )
     .await;
 
@@ -74,7 +74,10 @@ pub async fn scrape(context: AppContext) -> Result<impl Responder, ApiError> {
         .body(body))
 }
 
-async fn refresh_scrape_gauges(metrics: &Metrics, backend: &impl crate::storage::StorageContext) {
+async fn refresh_scrape_gauges(
+    metrics: &Metrics,
+    backend: &(impl crate::storage::MetricsStorage + ?Sized),
+) {
     db::refresh_pool_gauges(metrics, backend);
     login::refresh_login_limiter_gauges(metrics).await;
     if let Ok(_refresh_guard) = metrics.db_refresh_lock.try_lock() {

--- a/src/observability/metrics/task.rs
+++ b/src/observability/metrics/task.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 use opentelemetry::KeyValue;
 
 use crate::models::{TaskKind, TaskStatus};
-use crate::storage::postgres::operations::metrics::{MetricsRefreshBackend, TaskGaugeSnapshot};
+use crate::storage::{MetricsStorage, TaskGaugeSnapshot};
 
 use super::scrape::{RefreshOutcome, RefreshSource, record_refresh_attempt};
 use super::{Metrics, current};
@@ -120,7 +120,7 @@ pub fn task_output_cleanup_deleted(kind: TaskOutputKind, count: usize) {
 
 pub(super) async fn refresh_task_gauges(
     metrics: &Metrics,
-    backend: &impl crate::storage::StorageContext,
+    backend: &(impl MetricsStorage + ?Sized),
 ) {
     if let Some(snapshot) = cached_task_snapshot(metrics) {
         record_task_snapshot(metrics, &snapshot);
@@ -128,7 +128,7 @@ pub(super) async fn refresh_task_gauges(
     }
 
     let refresh_started_at = Instant::now();
-    match backend.metrics_task_gauge_snapshot().await {
+    match backend.metrics_task_snapshot().await {
         Ok(snapshot) => {
             record_refresh_attempt(
                 metrics,

--- a/src/restores/mod.rs
+++ b/src/restores/mod.rs
@@ -24,16 +24,16 @@ use crate::models::{
     RestoreJobStatus, RestoreStageRequest, RestoreStageResponse, RestoreValidationSummary,
 };
 use crate::storage::StorageContext;
-use crate::storage::postgres::operations::identity::identity_scope_name_by_id;
-use crate::storage::postgres::operations::maintenance::maintenance_state_db;
-use crate::storage::postgres::operations::restore::{
+use crate::storage::capabilities::identity::identity_scope_name_by_id;
+use crate::storage::capabilities::maintenance::maintenance_state_db;
+use crate::storage::capabilities::restore::{
     RestoreCompletion, RestoreCoordinatorSnapshot, apply_restore_db, delete_server_instance_db,
     expire_restore_stage_db, fail_restore_and_resume_db, insert_restore_job_db,
     load_restore_coordinator_snapshot_db, load_restore_job_db, load_restore_status_job_db,
     maintenance_generation_and_instances_db, restore_coordinator_tick_db,
     resume_maintenance_without_job_db, resume_terminal_restore_db, start_restore_draining_db,
 };
-use crate::storage::postgres::{StorageCallSite, with_storage_call_site};
+use crate::storage::capabilities::{StorageCallSite, with_storage_call_site};
 use crate::storage::storage_handle;
 
 static RESTORE_COORDINATOR: Once = Once::new();

--- a/src/storage/capabilities.rs
+++ b/src/storage/capabilities.rs
@@ -16,7 +16,14 @@ pub(crate) mod active_tokens {
 }
 
 pub(crate) mod authz {
-    pub(crate) use crate::storage::postgres::operations::authz::{load_token_scope, scope_allows};
+    pub use crate::storage::postgres::operations::authz::{
+        AuthzSubject, PrincipalIdAccessor, load_token_scope, scope_allows, scope_allows_resource,
+        scope_allows_resources,
+    };
+}
+
+pub(crate) mod backup {
+    pub(crate) use crate::storage::postgres::operations::backup::snapshot_backup_db;
 }
 
 pub(crate) mod collection {
@@ -36,8 +43,19 @@ pub(crate) mod computed_field {
 
 pub(crate) mod event_delivery {
     pub(crate) use crate::storage::postgres::operations::event_delivery::{
-        list_event_deliveries_with_total_count, load_event_delivery, mark_event_delivery_dead,
-        release_event_delivery_for_retry,
+        ClaimedEventDelivery, claim_event_delivery_batch, list_event_deliveries_with_total_count,
+        load_event_delivery, mark_event_delivery_dead, mark_event_delivery_failed,
+        mark_event_delivery_succeeded, release_event_delivery_for_retry,
+    };
+}
+
+pub(crate) mod event_fanout {
+    pub(crate) use crate::storage::postgres::operations::event_fanout::process_event_fanout_batch;
+}
+
+pub(crate) mod event_retention {
+    pub(crate) use crate::storage::postgres::operations::event_retention::{
+        EventRetentionPurgeSummary, process_event_retention_batch_from_storage,
     };
 }
 
@@ -55,7 +73,14 @@ pub(crate) mod event_subscription {
 
 pub(crate) mod events {
     pub(crate) use crate::storage::postgres::operations::events::{
-        list_events_with_total_count, parse_event_filters,
+        list_events_with_total_count, load_queued_task_initiators, parse_event_filters,
+    };
+}
+
+pub(crate) mod external_identity {
+    pub(crate) use crate::storage::postgres::operations::external_identity::{
+        ExternalPrincipalState, external_principal_state, mark_external_sync_attempted,
+        sync_external_user,
     };
 }
 
@@ -73,14 +98,28 @@ pub(crate) mod history {
     };
 }
 
+pub(crate) mod identity {
+    pub(crate) use crate::storage::postgres::operations::identity::{
+        ensure_identity_scope, identity_scope_name_by_id,
+    };
+}
+
+pub(crate) mod maintenance {
+    pub(crate) use crate::storage::postgres::operations::maintenance::maintenance_state_db;
+}
+
 pub(crate) mod meta {
     pub(crate) use crate::storage::postgres::operations::meta::{
-        load_database_pool_state, load_database_state, load_task_queue_state,
+        load_database_state, load_task_queue_state,
     };
 }
 
 pub(crate) mod principal {
     pub(crate) use crate::storage::postgres::operations::principal::load_principal_with_user;
+}
+
+pub(crate) mod permissions {
+    pub(crate) use crate::storage::postgres::operations::permissions::PermissionControllerBackend;
 }
 
 pub(crate) mod probe {
@@ -89,14 +128,25 @@ pub(crate) mod probe {
 
 pub(crate) mod relations {
     pub(crate) use crate::storage::postgres::operations::relations::{
-        class_relation_authorization_resources, object_relation_authorization_resources,
+        class_relation_authorization_resources, object_authorization_resources,
+        object_relation_authorization_resources,
     };
 }
 
 pub(crate) mod remote_target {
     pub(crate) use crate::storage::postgres::operations::remote_target::{
         DeleteRemoteTargetRecord, SaveRemoteTargetRecord, UpdateRemoteTargetRecord,
-        emit_remote_target_invoked_event,
+        emit_remote_target_invoked_event, insert_remote_call_result,
+    };
+}
+
+pub(crate) mod restore {
+    pub(crate) use crate::storage::postgres::operations::restore::{
+        RestoreCompletion, RestoreCoordinatorSnapshot, apply_restore_db, delete_server_instance_db,
+        expire_restore_stage_db, fail_restore_and_resume_db, insert_restore_job_db,
+        load_restore_coordinator_snapshot_db, load_restore_job_db, load_restore_status_job_db,
+        maintenance_generation_and_instances_db, restore_coordinator_tick_db,
+        resume_maintenance_without_job_db, resume_terminal_restore_db, start_restore_draining_db,
     };
 }
 
@@ -110,9 +160,21 @@ pub(crate) mod service_account {
 
 pub(crate) mod task {
     pub(crate) use crate::storage::postgres::operations::task::{
-        TaskBackend, TaskCreateRequest, TaskScopeSnapshot, list_backup_task_output_summaries,
-        list_export_task_output_summaries, list_tasks_with_total_count, task_event_responses,
+        TaskBackend, TaskCreateRequest, TaskScopeSnapshot, TaskStateUpdate, insert_import_results,
+        list_backup_task_output_summaries, list_export_task_output_summaries,
+        list_tasks_with_total_count, task_event_responses,
     };
+}
+
+pub(crate) mod task_import {
+    pub(crate) use crate::storage::postgres::operations::task_import::{
+        lookup_classes_by_collection_and_names, lookup_collections_by_name,
+        lookup_objects_by_class_and_names,
+    };
+}
+
+pub(crate) mod token_retention {
+    pub(crate) use crate::storage::postgres::operations::token_retention::purge_expired_token_batch;
 }
 
 pub(crate) mod user {
@@ -414,8 +476,12 @@ pub(crate) mod user {
             externally_authorized_related_object_ids, search_computed_objects_with_authorized_ids,
         };
     }
+
+    pub(crate) mod workflow {
+        pub(crate) use crate::storage::postgres::operations::user::UserSearchBackend;
+    }
 }
 pub(crate) use crate::storage::postgres::{
     StorageCallSite, with_mutation_provenance_scope, with_revision_precondition_scope,
-    with_storage_call_site,
+    with_statement_timeout_scope, with_storage_call_site,
 };

--- a/src/storage/context.rs
+++ b/src/storage/context.rs
@@ -3,8 +3,11 @@ use actix_web::web::Data;
 use crate::permissions::{AppContext, PermissionBackend};
 use crate::storage::postgres::PostgresPool;
 use crate::storage::{
-    DynLifecycleStorage, PostgresStorage, StorageBackend, StorageBackendDescriptor,
+    DynLifecycleStorage, EventMetricsSnapshot, InventoryGaugeSnapshot, MetricsStorage,
+    PostgresStorage, StorageBackend, StorageBackendDescriptor, StorageError, StoragePoolState,
+    TaskGaugeSnapshot,
 };
+use async_trait::async_trait;
 
 mod private {
     use crate::storage::postgres::PostgresPool;
@@ -54,6 +57,35 @@ impl StorageHandle {
     fn postgres_pool(&self) -> &PostgresPool {
         match &self.implementation {
             BackendImplementation::Postgresql(backend) => backend.pool(),
+        }
+    }
+}
+
+#[async_trait]
+impl MetricsStorage for StorageHandle {
+    fn metrics_pool_state(&self) -> StoragePoolState {
+        match &self.implementation {
+            BackendImplementation::Postgresql(backend) => backend.metrics_pool_state(),
+        }
+    }
+
+    async fn metrics_inventory_snapshot(&self) -> Result<InventoryGaugeSnapshot, StorageError> {
+        match &self.implementation {
+            BackendImplementation::Postgresql(backend) => {
+                backend.metrics_inventory_snapshot().await
+            }
+        }
+    }
+
+    async fn metrics_task_snapshot(&self) -> Result<TaskGaugeSnapshot, StorageError> {
+        match &self.implementation {
+            BackendImplementation::Postgresql(backend) => backend.metrics_task_snapshot().await,
+        }
+    }
+
+    async fn metrics_event_snapshot(&self) -> Result<EventMetricsSnapshot, StorageError> {
+        match &self.implementation {
+            BackendImplementation::Postgresql(backend) => backend.metrics_event_snapshot().await,
         }
     }
 }

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use super::{
-    ClassRelationStore, ClassStore, CollectionStore, ObjectRelationStore, ObjectStore,
-    PostgresStorage, observed::ObservedLifecycleStorage,
+    ClassRelationStore, ClassStore, CollectionStore, MetricsStorage, ObjectRelationStore,
+    ObjectStore, PostgresStorage, observed::ObservedLifecycleStorage,
 };
 
 #[cfg(test)]
@@ -60,6 +60,7 @@ mod sealed {
 /// and therefore cannot be selected by `AppContext`.
 pub(crate) trait StorageBackend:
     LifecycleStorage
+    + MetricsStorage
     + IdentityAndAuthorizationStorage
     + QueryAndHistoryStorage
     + WorkflowStorage

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -1,0 +1,102 @@
+use async_trait::async_trait;
+use chrono::NaiveDateTime;
+
+use crate::models::{
+    EventDeliveryQueueHealth, EventFanoutHealth, ExportTemplateID, TaskKind, TaskStatus,
+};
+
+use super::StorageError;
+
+/// Backend-neutral state for the configured storage connection pool.
+#[derive(Debug)]
+pub(crate) struct StoragePoolState {
+    pub(crate) max_connections: u32,
+    pub(crate) total_connections: u32,
+    pub(crate) available_connections: u32,
+    pub(crate) idle_connections: u32,
+    pub(crate) in_use_connections: u32,
+    pub(crate) pending_acquisitions: u64,
+    pub(crate) acquisitions_started: u64,
+    pub(crate) acquisitions_direct: u64,
+    pub(crate) acquisitions_waited: u64,
+    pub(crate) acquisitions_timed_out: u64,
+    pub(crate) acquisition_wait_time_ms: u64,
+    pub(crate) connections_created: u64,
+    pub(crate) connections_closed_broken: u64,
+    pub(crate) connections_closed_invalid: u64,
+    pub(crate) connections_closed_max_lifetime: u64,
+    pub(crate) connections_closed_idle_timeout: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InventoryMetricsSnapshot {
+    pub(crate) collections: i64,
+    pub(crate) classes: i64,
+    pub(crate) objects: i64,
+    pub(crate) users: i64,
+    pub(crate) groups: i64,
+    pub(crate) service_accounts: i64,
+    pub(crate) remote_targets: i64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ExportTemplateMetricIdentity {
+    pub(crate) id: ExportTemplateID,
+    pub(crate) name: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct InventoryGaugeSnapshot {
+    pub(crate) counts: InventoryMetricsSnapshot,
+    pub(crate) export_templates: Vec<ExportTemplateMetricIdentity>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TaskGaugeCount {
+    pub(crate) kind: TaskKind,
+    pub(crate) status: TaskStatus,
+    pub(crate) count: i64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TaskGaugeAge {
+    pub(crate) kind: TaskKind,
+    pub(crate) oldest_queued_at: Option<NaiveDateTime>,
+    pub(crate) oldest_active_at: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TaskGaugeLastTerminal {
+    pub(crate) kind: TaskKind,
+    pub(crate) status: TaskStatus,
+    pub(crate) finished_at: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TaskGaugeSnapshot {
+    pub(crate) counts: Vec<TaskGaugeCount>,
+    pub(crate) ages: Vec<TaskGaugeAge>,
+    pub(crate) last_terminal: Vec<TaskGaugeLastTerminal>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct EventMetricsSnapshot {
+    pub(crate) fanout: EventFanoutHealth,
+    pub(crate) delivery: EventDeliveryQueueHealth,
+}
+
+/// Metrics data every selectable storage backend must provide.
+///
+/// Implementations translate their native failures into [`StorageError`]
+/// before crossing this boundary. Application metrics code therefore neither
+/// selects a database nor knows how its queries and pool are implemented.
+#[async_trait]
+pub(crate) trait MetricsStorage: Send + Sync {
+    fn metrics_pool_state(&self) -> StoragePoolState;
+
+    async fn metrics_inventory_snapshot(&self) -> Result<InventoryGaugeSnapshot, StorageError>;
+
+    async fn metrics_task_snapshot(&self) -> Result<TaskGaugeSnapshot, StorageError>;
+
+    async fn metrics_event_snapshot(&self) -> Result<EventMetricsSnapshot, StorageError>;
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -6,6 +6,7 @@ mod context;
 mod contract;
 #[cfg(test)]
 mod memory;
+mod metrics;
 mod object_relations;
 mod objects;
 mod observed;
@@ -25,6 +26,11 @@ pub(crate) use contract::{
 pub(crate) use hubuum_storage_core::{StorageError, StorageErrorKind};
 #[cfg(test)]
 pub(crate) use memory::MemoryStorageModel;
+pub(crate) use metrics::{
+    EventMetricsSnapshot, ExportTemplateMetricIdentity, InventoryGaugeSnapshot,
+    InventoryMetricsSnapshot, MetricsStorage, StoragePoolState, TaskGaugeAge, TaskGaugeCount,
+    TaskGaugeLastTerminal, TaskGaugeSnapshot,
+};
 pub(crate) use object_relations::ObjectRelationStore;
 pub(crate) use objects::ObjectStore;
 pub(crate) use postgres::PostgresStorage;

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -38,8 +38,9 @@ use crate::storage::postgres::operations::relations::{
 };
 
 use super::{
-    ClassRelationStore, ClassStore, CollectionStore, ObjectRelationStore, ObjectStore,
-    StorageError, StorageIdentity,
+    ClassRelationStore, ClassStore, CollectionStore, EventMetricsSnapshot, InventoryGaugeSnapshot,
+    MetricsStorage, ObjectRelationStore, ObjectStore, StorageError, StorageIdentity,
+    StoragePoolState, TaskGaugeSnapshot,
 };
 use error::map_postgres_error;
 
@@ -62,6 +63,52 @@ impl PostgresStorage {
 impl StorageIdentity for PostgresStorage {
     fn storage_name(&self) -> &'static str {
         "postgresql"
+    }
+}
+
+#[async_trait]
+impl MetricsStorage for PostgresStorage {
+    fn metrics_pool_state(&self) -> StoragePoolState {
+        let state = self.pool.state();
+        let max_connections = self.pool.config().max_size;
+        let in_use_connections = state.connections.saturating_sub(state.idle_connections);
+        StoragePoolState {
+            max_connections,
+            total_connections: state.connections,
+            available_connections: max_connections.saturating_sub(in_use_connections),
+            idle_connections: state.idle_connections,
+            in_use_connections,
+            pending_acquisitions: state.statistics.pending_gets(),
+            acquisitions_started: state.statistics.get_started,
+            acquisitions_direct: state.statistics.get_direct,
+            acquisitions_waited: state.statistics.get_waited,
+            acquisitions_timed_out: state.statistics.get_timed_out,
+            acquisition_wait_time_ms: u64::try_from(state.statistics.get_wait_time.as_millis())
+                .unwrap_or(u64::MAX),
+            connections_created: state.statistics.connections_created,
+            connections_closed_broken: state.statistics.connections_closed_broken,
+            connections_closed_invalid: state.statistics.connections_closed_invalid,
+            connections_closed_max_lifetime: state.statistics.connections_closed_max_lifetime,
+            connections_closed_idle_timeout: state.statistics.connections_closed_idle_timeout,
+        }
+    }
+
+    async fn metrics_inventory_snapshot(&self) -> Result<InventoryGaugeSnapshot, StorageError> {
+        operations::metrics::load_inventory_gauge_snapshot(&self.pool)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn metrics_task_snapshot(&self) -> Result<TaskGaugeSnapshot, StorageError> {
+        operations::metrics::load_task_gauge_snapshot(&self.pool)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn metrics_event_snapshot(&self) -> Result<EventMetricsSnapshot, StorageError> {
+        operations::event_observability::load_event_metrics_snapshot(&self.pool)
+            .await
+            .map_err(map_postgres_error)
     }
 }
 

--- a/src/storage/postgres/operations/event_observability.rs
+++ b/src/storage/postgres/operations/event_observability.rs
@@ -13,7 +13,7 @@ use crate::models::{
     EventDeliveryHealthResponse, EventDeliveryQueueHealth, EventDeliveryStatusCounts,
     EventFanoutHealth, EventSinkDeliveryHealth, EventSubscriptionDeliveryHealth, EventWorkerHealth,
 };
-use crate::storage::postgres::operations::metrics::EventMetricsSnapshot;
+use crate::storage::EventMetricsSnapshot;
 use crate::storage::postgres::with_connection;
 
 #[derive(Debug, QueryableByName)]
@@ -139,7 +139,7 @@ pub async fn load_event_delivery_health(
     .await
 }
 
-pub async fn load_event_metrics_snapshot(
+pub(crate) async fn load_event_metrics_snapshot(
     pool: &impl crate::storage::StorageContext,
 ) -> Result<EventMetricsSnapshot, ApiError> {
     with_connection(pool, async |conn| {

--- a/src/storage/postgres/operations/event_retention.rs
+++ b/src/storage/postgres/operations/event_retention.rs
@@ -5,7 +5,7 @@ use diesel::sql_types::{Array, BigInt, Bool, Timestamp};
 use crate::errors::ApiError;
 use crate::events::{Event, EventRetentionSettings};
 use crate::storage::postgres::PostgresConnection;
-#[cfg(test)]
+use crate::storage::postgres::operations::maintenance::maintenance_state_conn;
 use crate::storage::postgres::with_transaction;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -94,20 +94,41 @@ pub(crate) async fn purge_event_retention_batch_conn(
     })
 }
 
+/// Select, optionally archive, and purge one retention batch atomically.
+///
+/// The adapter owns the transaction, coordinator lock, and maintenance check.
+/// The callback lets the application persist an external archive before rows
+/// are deleted without exposing the PostgreSQL connection or transaction.
+pub(crate) async fn process_event_retention_batch_from_storage<F>(
+    backend: &impl crate::storage::StorageContext,
+    settings: EventRetentionSettings,
+    archive: F,
+) -> Result<EventRetentionPurgeSummary, ApiError>
+where
+    F: FnOnce(&[Event]) -> Result<(), ApiError> + Send,
+{
+    with_transaction(backend, async |conn| -> Result<_, ApiError> {
+        if !maintenance_state_conn(conn).await?.is_normal() {
+            return Ok(EventRetentionPurgeSummary::default());
+        }
+        if !try_acquire_event_retention_lock(conn).await? {
+            return Ok(EventRetentionPurgeSummary::default());
+        }
+
+        let events = select_events_for_retention_purge_conn(conn, settings).await?;
+        archive(&events)?;
+        let event_ids = events.iter().map(|event| event.id).collect::<Vec<_>>();
+        purge_event_retention_batch_conn(conn, settings, &event_ids).await
+    })
+    .await
+}
+
 #[cfg(test)]
 pub(crate) async fn purge_event_retention_without_archive(
     pool: &impl crate::storage::StorageContext,
     settings: EventRetentionSettings,
 ) -> Result<EventRetentionPurgeSummary, ApiError> {
-    with_transaction(pool, async |conn| -> Result<_, ApiError> {
-        if !try_acquire_event_retention_lock(conn).await? {
-            return Ok(EventRetentionPurgeSummary::default());
-        }
-        let events = select_events_for_retention_purge_conn(conn, settings).await?;
-        let event_ids = events.iter().map(|event| event.id).collect::<Vec<_>>();
-        purge_event_retention_batch_conn(conn, settings, &event_ids).await
-    })
-    .await
+    process_event_retention_batch_from_storage(pool, settings, |_| Ok(())).await
 }
 
 async fn select_event_ids_for_retention_purge(

--- a/src/storage/postgres/operations/meta.rs
+++ b/src/storage/postgres/operations/meta.rs
@@ -14,26 +14,6 @@ pub struct DatabaseState {
     pub last_vacuum_time: Option<chrono::NaiveDateTime>,
 }
 
-#[derive(Debug)]
-pub struct DatabasePoolState {
-    pub max_connections: u32,
-    pub total_connections: u32,
-    pub available_connections: u32,
-    pub idle_connections: u32,
-    pub in_use_connections: u32,
-    pub pending_acquisitions: u64,
-    pub acquisitions_started: u64,
-    pub acquisitions_direct: u64,
-    pub acquisitions_waited: u64,
-    pub acquisitions_timed_out: u64,
-    pub acquisition_wait_time_ms: u64,
-    pub connections_created: u64,
-    pub connections_closed_broken: u64,
-    pub connections_closed_invalid: u64,
-    pub connections_closed_max_lifetime: u64,
-    pub connections_closed_idle_timeout: u64,
-}
-
 #[derive(QueryableByName, Debug)]
 pub struct TaskQueueState {
     #[diesel(sql_type = BigInt)]
@@ -88,34 +68,6 @@ pub async fn load_database_state(
     .map_err(|error| {
         ApiError::InternalServerError(format!("Error getting state for the database: {error}"))
     })
-}
-
-pub fn load_database_pool_state(
-    backend: &impl crate::storage::StorageContext,
-) -> DatabasePoolState {
-    let pool = crate::storage::context::postgres_pool(backend);
-    let state = pool.state();
-    let max_connections = pool.config().max_size;
-    let in_use_connections = state.connections.saturating_sub(state.idle_connections);
-    DatabasePoolState {
-        max_connections,
-        total_connections: state.connections,
-        available_connections: max_connections.saturating_sub(in_use_connections),
-        idle_connections: state.idle_connections,
-        in_use_connections,
-        pending_acquisitions: state.statistics.pending_gets(),
-        acquisitions_started: state.statistics.get_started,
-        acquisitions_direct: state.statistics.get_direct,
-        acquisitions_waited: state.statistics.get_waited,
-        acquisitions_timed_out: state.statistics.get_timed_out,
-        acquisition_wait_time_ms: u64::try_from(state.statistics.get_wait_time.as_millis())
-            .unwrap_or(u64::MAX),
-        connections_created: state.statistics.connections_created,
-        connections_closed_broken: state.statistics.connections_closed_broken,
-        connections_closed_invalid: state.statistics.connections_closed_invalid,
-        connections_closed_max_lifetime: state.statistics.connections_closed_max_lifetime,
-        connections_closed_idle_timeout: state.statistics.connections_closed_idle_timeout,
-    }
 }
 
 pub async fn load_task_queue_state(

--- a/src/storage/postgres/operations/metrics.rs
+++ b/src/storage/postgres/operations/metrics.rs
@@ -5,253 +5,157 @@ use diesel::dsl::{count_star, max, min};
 use diesel::sql_types::BigInt;
 
 use crate::errors::ApiError;
-use crate::models::{
-    EventDeliveryQueueHealth, EventFanoutHealth, ExportTemplateID, TaskKind, TaskStatus,
-};
+use crate::models::{ExportTemplateID, TaskKind, TaskStatus};
 use crate::schema::{export_templates, tasks};
-use crate::storage::StorageContext;
 use crate::storage::postgres::prelude::*;
-use crate::storage::postgres::{PostgresConnection, with_connection};
+use crate::storage::postgres::{PostgresConnection, PostgresPool, with_connection};
+use crate::storage::{
+    ExportTemplateMetricIdentity, InventoryGaugeSnapshot, InventoryMetricsSnapshot, TaskGaugeAge,
+    TaskGaugeCount, TaskGaugeLastTerminal, TaskGaugeSnapshot,
+};
 
 #[derive(Debug, Clone, Copy, QueryableByName)]
-pub struct InventoryMetricsSnapshot {
+struct InventoryMetricsRow {
     #[diesel(sql_type = BigInt)]
-    pub collections: i64,
+    collections: i64,
     #[diesel(sql_type = BigInt)]
-    pub classes: i64,
+    classes: i64,
     #[diesel(sql_type = BigInt)]
-    pub objects: i64,
+    objects: i64,
     #[diesel(sql_type = BigInt)]
-    pub users: i64,
+    users: i64,
     #[diesel(sql_type = BigInt)]
-    pub groups: i64,
+    groups: i64,
     #[diesel(sql_type = BigInt)]
-    pub service_accounts: i64,
+    service_accounts: i64,
     #[diesel(sql_type = BigInt)]
-    pub remote_targets: i64,
+    remote_targets: i64,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct ExportTemplateMetricIdentity {
-    pub(crate) id: ExportTemplateID,
-    pub(crate) name: String,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct InventoryGaugeSnapshot {
-    pub(crate) counts: InventoryMetricsSnapshot,
-    pub(crate) export_templates: Vec<ExportTemplateMetricIdentity>,
-}
-
-#[derive(Debug, Clone)]
-pub struct TaskMetricsCount {
-    pub kind: String,
-    pub status: String,
-    pub count: i64,
-}
-
-#[derive(Debug, Clone)]
-pub struct TaskMetricsSnapshot {
-    pub counts: Vec<TaskMetricsCount>,
-    pub oldest_queued_at: Option<NaiveDateTime>,
-    pub oldest_active_at: Option<NaiveDateTime>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct TaskGaugeCount {
-    pub(crate) kind: TaskKind,
-    pub(crate) status: TaskStatus,
-    pub(crate) count: i64,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct TaskGaugeAge {
-    pub(crate) kind: TaskKind,
-    pub(crate) oldest_queued_at: Option<NaiveDateTime>,
-    pub(crate) oldest_active_at: Option<NaiveDateTime>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct TaskGaugeLastTerminal {
-    pub(crate) kind: TaskKind,
-    pub(crate) status: TaskStatus,
-    pub(crate) finished_at: Option<NaiveDateTime>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct TaskGaugeSnapshot {
-    pub(crate) counts: Vec<TaskGaugeCount>,
-    pub(crate) ages: Vec<TaskGaugeAge>,
-    pub(crate) last_terminal: Vec<TaskGaugeLastTerminal>,
-}
-
-#[derive(Debug, Clone)]
-pub struct EventMetricsSnapshot {
-    pub fanout: EventFanoutHealth,
-    pub delivery: EventDeliveryQueueHealth,
-}
-
-pub trait MetricsBackend {
-    async fn metrics_inventory_snapshot(&self) -> Result<InventoryMetricsSnapshot, ApiError>;
-    async fn metrics_task_snapshot(&self) -> Result<TaskMetricsSnapshot, ApiError>;
-}
-
-pub(crate) trait MetricsRefreshBackend {
-    async fn metrics_inventory_gauge_snapshot(&self) -> Result<InventoryGaugeSnapshot, ApiError>;
-    async fn metrics_task_gauge_snapshot(&self) -> Result<TaskGaugeSnapshot, ApiError>;
-}
-
-impl<T> MetricsBackend for T
-where
-    T: StorageContext + Sync + ?Sized,
-{
-    async fn metrics_inventory_snapshot(&self) -> Result<InventoryMetricsSnapshot, ApiError> {
-        with_connection(self, load_inventory_counts).await
+impl From<InventoryMetricsRow> for InventoryMetricsSnapshot {
+    fn from(row: InventoryMetricsRow) -> Self {
+        Self {
+            collections: row.collections,
+            classes: row.classes,
+            objects: row.objects,
+            users: row.users,
+            groups: row.groups,
+            service_accounts: row.service_accounts,
+            remote_targets: row.remote_targets,
+        }
     }
+}
 
-    async fn metrics_task_snapshot(&self) -> Result<TaskMetricsSnapshot, ApiError> {
-        with_connection(self, async |conn| {
-            let counts = load_task_count_rows(conn)
-                .await?
-                .into_iter()
-                .map(|(kind, status, count)| TaskMetricsCount {
-                    kind,
-                    status,
+pub(crate) async fn load_inventory_gauge_snapshot(
+    pool: &PostgresPool,
+) -> Result<InventoryGaugeSnapshot, ApiError> {
+    with_connection(pool, async |conn| {
+        let counts = load_inventory_counts(conn).await?;
+        let export_templates = export_templates::table
+            .select((export_templates::id, export_templates::name))
+            .order(export_templates::id)
+            .load::<(i32, String)>(conn)
+            .await?
+            .into_iter()
+            .map(|(id, name)| {
+                Ok(ExportTemplateMetricIdentity {
+                    id: ExportTemplateID::new(id)?,
+                    name,
+                })
+            })
+            .collect::<Result<Vec<_>, ApiError>>()?;
+
+        Ok::<_, ApiError>(InventoryGaugeSnapshot {
+            counts,
+            export_templates,
+        })
+    })
+    .await
+}
+
+pub(crate) async fn load_task_gauge_snapshot(
+    pool: &PostgresPool,
+) -> Result<TaskGaugeSnapshot, ApiError> {
+    with_connection(pool, async |conn| {
+        let counts = load_task_count_rows(conn)
+            .await?
+            .into_iter()
+            .map(|(kind, status, count)| {
+                Ok(TaskGaugeCount {
+                    kind: TaskKind::from_db(&kind)?,
+                    status: TaskStatus::from_db(&status)?,
                     count,
                 })
-                .collect();
-            let oldest_queued_at = tasks::table
-                .filter(tasks::status.eq(TaskStatus::Queued.as_str()))
-                .select(min(tasks::created_at))
-                .get_result::<Option<NaiveDateTime>>(conn)
-                .await?;
-            let oldest_active_at = tasks::table
-                .filter(tasks::status.eq_any(TaskStatus::ACTIVE.map(TaskStatus::as_str)))
-                .select(min(tasks::started_at))
-                .get_result::<Option<NaiveDateTime>>(conn)
-                .await?;
-
-            Ok::<_, ApiError>(TaskMetricsSnapshot {
-                counts,
-                oldest_queued_at,
-                oldest_active_at,
             })
-        })
-        .await
-    }
-}
+            .collect::<Result<Vec<_>, ApiError>>()?;
 
-impl<T> MetricsRefreshBackend for T
-where
-    T: StorageContext + Sync + ?Sized,
-{
-    async fn metrics_inventory_gauge_snapshot(&self) -> Result<InventoryGaugeSnapshot, ApiError> {
-        with_connection(self, async |conn| {
-            let counts = load_inventory_counts(conn).await?;
-            let export_templates = export_templates::table
-                .select((export_templates::id, export_templates::name))
-                .order(export_templates::id)
-                .load::<(i32, String)>(conn)
-                .await?
-                .into_iter()
-                .map(|(id, name)| {
-                    Ok(ExportTemplateMetricIdentity {
-                        id: ExportTemplateID::new(id)?,
-                        name,
-                    })
+        let oldest_queued = tasks::table
+            .filter(tasks::status.eq(TaskStatus::Queued.as_str()))
+            .group_by(tasks::kind)
+            .select((tasks::kind, min(tasks::created_at)))
+            .load::<(String, Option<NaiveDateTime>)>(conn)
+            .await?;
+        let oldest_active = tasks::table
+            .filter(tasks::status.eq_any(TaskStatus::ACTIVE.map(TaskStatus::as_str)))
+            .group_by(tasks::kind)
+            .select((tasks::kind, min(tasks::started_at)))
+            .load::<(String, Option<NaiveDateTime>)>(conn)
+            .await?;
+        let last_terminal = tasks::table
+            .filter(tasks::status.eq_any(TaskStatus::TERMINAL.map(TaskStatus::as_str)))
+            .group_by((tasks::kind, tasks::status))
+            .select((tasks::kind, tasks::status, max(tasks::finished_at)))
+            .load::<(String, String, Option<NaiveDateTime>)>(conn)
+            .await?
+            .into_iter()
+            .map(|(kind, status, finished_at)| {
+                Ok(TaskGaugeLastTerminal {
+                    kind: TaskKind::from_db(&kind)?,
+                    status: TaskStatus::from_db(&status)?,
+                    finished_at,
                 })
-                .collect::<Result<Vec<_>, ApiError>>()?;
-
-            Ok::<_, ApiError>(InventoryGaugeSnapshot {
-                counts,
-                export_templates,
             })
-        })
-        .await
-    }
+            .collect::<Result<Vec<_>, ApiError>>()?;
 
-    async fn metrics_task_gauge_snapshot(&self) -> Result<TaskGaugeSnapshot, ApiError> {
-        with_connection(self, async |conn| {
-            let counts = load_task_count_rows(conn)
-                .await?
-                .into_iter()
-                .map(|(kind, status, count)| {
-                    Ok(TaskGaugeCount {
-                        kind: TaskKind::from_db(&kind)?,
-                        status: TaskStatus::from_db(&status)?,
-                        count,
-                    })
-                })
-                .collect::<Result<Vec<_>, ApiError>>()?;
-
-            let oldest_queued = tasks::table
-                .filter(tasks::status.eq(TaskStatus::Queued.as_str()))
-                .group_by(tasks::kind)
-                .select((tasks::kind, min(tasks::created_at)))
-                .load::<(String, Option<NaiveDateTime>)>(conn)
-                .await?;
-            let oldest_active = tasks::table
-                .filter(tasks::status.eq_any(TaskStatus::ACTIVE.map(TaskStatus::as_str)))
-                .group_by(tasks::kind)
-                .select((tasks::kind, min(tasks::started_at)))
-                .load::<(String, Option<NaiveDateTime>)>(conn)
-                .await?;
-            let last_terminal = tasks::table
-                .filter(tasks::status.eq_any(TaskStatus::TERMINAL.map(TaskStatus::as_str)))
-                .group_by((tasks::kind, tasks::status))
-                .select((tasks::kind, tasks::status, max(tasks::finished_at)))
-                .load::<(String, String, Option<NaiveDateTime>)>(conn)
-                .await?
-                .into_iter()
-                .map(|(kind, status, finished_at)| {
-                    Ok(TaskGaugeLastTerminal {
-                        kind: TaskKind::from_db(&kind)?,
-                        status: TaskStatus::from_db(&status)?,
-                        finished_at,
-                    })
-                })
-                .collect::<Result<Vec<_>, ApiError>>()?;
-
-            let mut ages_by_kind = HashMap::new();
-            for (kind, timestamp) in oldest_queued {
-                ages_by_kind
-                    .entry(TaskKind::from_db(&kind)?)
-                    .or_insert((None, None))
-                    .0 = timestamp;
-            }
-            for (kind, timestamp) in oldest_active {
-                ages_by_kind
-                    .entry(TaskKind::from_db(&kind)?)
-                    .or_insert((None, None))
-                    .1 = timestamp;
-            }
-            let ages = TaskKind::ALL
-                .into_iter()
-                .map(|kind| {
-                    let (oldest_queued_at, oldest_active_at) =
-                        ages_by_kind.remove(&kind).unwrap_or((None, None));
-                    TaskGaugeAge {
-                        kind,
-                        oldest_queued_at,
-                        oldest_active_at,
-                    }
-                })
-                .collect();
-
-            Ok::<_, ApiError>(TaskGaugeSnapshot {
-                counts,
-                ages,
-                last_terminal,
+        let mut ages_by_kind = HashMap::new();
+        for (kind, timestamp) in oldest_queued {
+            ages_by_kind
+                .entry(TaskKind::from_db(&kind)?)
+                .or_insert((None, None))
+                .0 = timestamp;
+        }
+        for (kind, timestamp) in oldest_active {
+            ages_by_kind
+                .entry(TaskKind::from_db(&kind)?)
+                .or_insert((None, None))
+                .1 = timestamp;
+        }
+        let ages = TaskKind::ALL
+            .into_iter()
+            .map(|kind| {
+                let (oldest_queued_at, oldest_active_at) =
+                    ages_by_kind.remove(&kind).unwrap_or((None, None));
+                TaskGaugeAge {
+                    kind,
+                    oldest_queued_at,
+                    oldest_active_at,
+                }
             })
+            .collect();
+
+        Ok::<_, ApiError>(TaskGaugeSnapshot {
+            counts,
+            ages,
+            last_terminal,
         })
-        .await
-    }
+    })
+    .await
 }
 
 async fn load_inventory_counts(
     conn: &mut PostgresConnection,
 ) -> Result<InventoryMetricsSnapshot, ApiError> {
-    Ok(diesel::sql_query(
+    let row = diesel::sql_query(
         r#"
         SELECT
             (SELECT COUNT(*) FROM collections) AS collections,
@@ -263,8 +167,9 @@ async fn load_inventory_counts(
             (SELECT COUNT(*) FROM remote_targets) AS remote_targets
         "#,
     )
-    .get_result::<InventoryMetricsSnapshot>(conn)
-    .await?)
+    .get_result::<InventoryMetricsRow>(conn)
+    .await?;
+    Ok(row.into())
 }
 
 async fn load_task_count_rows(

--- a/src/tasks/helpers.rs
+++ b/src/tasks/helpers.rs
@@ -8,7 +8,7 @@ use crate::models::{
     Collection, HubuumClass, HubuumObject, ImportAtomicity, ImportCollisionPolicy, ImportMode,
     ImportPermissionPolicy,
 };
-use crate::storage::postgres::operations::task::insert_import_results;
+use crate::storage::capabilities::task::insert_import_results;
 
 use super::types::{
     ClassResolution, CollectionResolution, ExecutionAccumulator, FailureKind,

--- a/src/tasks/preload.rs
+++ b/src/tasks/preload.rs
@@ -7,7 +7,7 @@ use super::resolution::{
 };
 use super::types::{CollectionResolution, PlanningState};
 use crate::models::{ClassKey, ImportRequest, ObjectKey};
-use crate::storage::postgres::operations::task_import::{
+use crate::storage::capabilities::task_import::{
     lookup_classes_by_collection_and_names, lookup_collections_by_name,
     lookup_objects_by_class_and_names,
 };

--- a/src/tasks/remote_call.rs
+++ b/src/tasks/remote_call.rs
@@ -23,8 +23,8 @@ use crate::models::{
 };
 use crate::observability::metrics;
 use crate::storage::StorageContext;
-use crate::storage::postgres::operations::remote_target::insert_remote_call_result;
-use crate::storage::postgres::operations::task::{TaskBackend, TaskStateUpdate};
+use crate::storage::capabilities::remote_target::insert_remote_call_result;
+use crate::storage::capabilities::task::{TaskBackend, TaskStateUpdate};
 use crate::traits::AuthzSubject;
 
 #[cfg(feature = "integration-test-support")]

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -100,16 +100,35 @@ fn application_consumers_do_not_import_database_implementation_details() {
         "src/services",
         "src/extractors",
         "src/middlewares",
+        "src/observability/metrics",
     ] {
         paths.extend(rust_files(&root.join(directory)));
     }
-    paths.push(root.join("src/observability/metrics/scrape.rs"));
+    for file in [
+        "src/auth.rs",
+        "src/backups/mod.rs",
+        "src/events/delivery.rs",
+        "src/events/fanout.rs",
+        "src/events/retention.rs",
+        "src/exports/mod.rs",
+        "src/restores/mod.rs",
+        "src/tasks/helpers.rs",
+        "src/tasks/preload.rs",
+        "src/tasks/remote_call.rs",
+        "src/token_retention.rs",
+        "src/traits/mod.rs",
+        "src/traits/permissions.rs",
+    ] {
+        paths.push(root.join(file));
+    }
 
     let mut violations = Vec::new();
     for path in paths {
         let source = fs::read_to_string(&path)
             .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
-        let source = if path.starts_with(root.join("src/services")) {
+        let source = if path.starts_with(root.join("src/services"))
+            || path == root.join("src/exports/mod.rs")
+        {
             source.split("#[cfg(test)]").next().unwrap_or(&source)
         } else {
             &source
@@ -202,6 +221,7 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         .expect("StorageBackend should have a readable aggregate trait declaration");
     for required in [
         "LifecycleStorage",
+        "MetricsStorage",
         "IdentityAndAuthorizationStorage",
         "QueryAndHistoryStorage",
         "WorkflowStorage",

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -7,12 +7,40 @@ use crate::models::CollectionID;
 use crate::services::Services;
 use crate::storage::StorageHandle;
 use crate::storage::postgres::PostgresPool;
-use crate::storage::{STORAGE_CONTRACT_VERSION, StorageBackendKind};
+use crate::storage::{MetricsStorage, STORAGE_CONTRACT_VERSION, StorageBackendKind};
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum LifecycleContractImplementation {
     MemoryModel,
     PostgresAdapter,
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_supplies_metrics_snapshots() {
+    let _permit = postgres_permit().await;
+
+    for kind in StorageBackendKind::ALL {
+        match kind {
+            StorageBackendKind::Postgresql => {
+                let backend = StorageHandle::postgres(pool().get_ref().clone());
+
+                let pool_state = backend.metrics_pool_state();
+                assert!(pool_state.max_connections > 0);
+                backend
+                    .metrics_inventory_snapshot()
+                    .await
+                    .expect("certified backend should supply inventory metrics");
+                backend
+                    .metrics_task_snapshot()
+                    .await
+                    .expect("certified backend should supply task metrics");
+                backend
+                    .metrics_event_snapshot()
+                    .await
+                    .expect("certified backend should supply event metrics");
+            }
+        }
+    }
 }
 
 #[actix_web::test]

--- a/src/token_retention.rs
+++ b/src/token_retention.rs
@@ -8,8 +8,8 @@ use crate::errors::ApiError;
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::TokenRetentionSettings;
 use crate::restores::MaintenanceActivityGuard;
-use crate::storage::postgres::operations::token_retention::purge_expired_token_batch;
-use crate::storage::postgres::{StorageCallSite, with_storage_call_site};
+use crate::storage::capabilities::token_retention::purge_expired_token_batch;
+use crate::storage::capabilities::{StorageCallSite, with_storage_call_site};
 use crate::storage::{StorageContext, StorageHandle, storage_handle};
 
 static TOKEN_RETENTION_WORKER: std::sync::Once = std::sync::Once::new();

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,5 +1,5 @@
 pub use crate::models::traits::{GroupAccessors, Search};
-pub use crate::storage::postgres::operations::authz::{AuthzSubject, PrincipalIdAccessor};
+pub use crate::storage::capabilities::authz::{AuthzSubject, PrincipalIdAccessor};
 pub mod accessors;
 pub mod crud;
 pub mod pagination;

--- a/src/traits/permissions.rs
+++ b/src/traits/permissions.rs
@@ -5,8 +5,8 @@ use crate::errors::ApiError;
 use crate::events::EventContext;
 use crate::models::{GroupID, Permission, Permissions, PermissionsList};
 use crate::storage::StorageContext;
-use crate::storage::postgres::operations::authz::AuthzSubject;
-use crate::storage::postgres::operations::permissions::PermissionControllerBackend;
+use crate::storage::capabilities::authz::AuthzSubject;
+use crate::storage::capabilities::permissions::PermissionControllerBackend;
 
 use super::CollectionAccessors;
 


### PR DESCRIPTION
## Summary

- route application consumers through the explicit storage capability facade instead of importing PostgreSQL operation modules;
- add backend-neutral metrics DTOs and make `MetricsStorage` a required part of the sealed `StorageBackend` contract;
- keep Diesel query rows private to the PostgreSQL adapter and explicitly convert them into storage DTOs;
- dispatch pool, inventory, task, and event metrics through the opaque `StorageHandle`, translating adapter failures into `StorageError` before they reach the application;
- move event-retention transaction, maintenance, and advisory-lock coordination behind the storage boundary while retaining the application-owned archive callback;
- expand architecture and available-backend compatibility tests, and document the DTO conversion rule.

## Why

The workspace extraction in #293 moved PostgreSQL runtime ownership out of the root package, but several application modules still named the PostgreSQL implementation directly and metrics contracts were implemented as adapter-local traits returning `ApiError`. That left a syntactic and error-direction leak even though composition was opaque.

This layer establishes the intended dependency shape for remaining capability families: application code sees storage traits and storage-owned DTOs; an adapter sees its native rows, pool, and errors; conversion happens once at the adapter edge.

## Behavior and impact

- There is no public HTTP or configuration behavior change.
- Metrics scrape caching, labels, and best-effort failure behavior are preserved.
- The admin database-state endpoint now obtains pool statistics through the selected storage backend rather than a PostgreSQL helper.
- Every selectable backend must implement the metrics capability, and the shared compatibility registry exercises all four snapshots.
- PostgreSQL remains the only selectable production backend.

This is an internal architecture change and has no changelog-worthy user-facing impact, so no `[Unreleased]` entry is added.

## Breaking changes

None to Hubuum's supported API surface. The root Rust crate and these storage interfaces remain internal as documented in `docs/rust_api_boundary.md`.

## Verification

- `cargo check --all-targets --locked`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `source .env && ./run_tests.sh`
  - library: 1,208 passed, 4 ignored
  - server binary: 34 passed
  - admin CLI: 8 passed
  - core API: 461 passed
  - identity API: 273 passed, 1 ignored
  - jobs API: 136 passed, 1 ignored
  - platform API: 57 passed
  - binary smoke: 3 passed
  - restore round trip: 1 passed
  - doctests: 5 passed, 2 ignored
- `git diff --check`

Stacked on #293. Part of #27.
