### PR TITLE
Extract authentication storage contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,6 +2292,7 @@ name = "hubuum-storage-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "hubuum-domain",
  "hubuum-events-core",
  "serde_json",

--- a/crates/hubuum-storage-core/Cargo.toml
+++ b/crates/hubuum-storage-core/Cargo.toml
@@ -12,6 +12,7 @@ rust-api = "workspace-internal"
 
 [dependencies]
 async-trait = "0.1"
+chrono = "0.4"
 hubuum-domain = { path = "../hubuum-domain" }
 hubuum-events-core = { path = "../hubuum-events-core" }
 serde_json = "1"

--- a/crates/hubuum-storage-core/src/identity.rs
+++ b/crates/hubuum-storage-core/src/identity.rs
@@ -1,0 +1,390 @@
+use async_trait::async_trait;
+use chrono::NaiveDateTime;
+
+use crate::StorageError;
+
+/// Principal kinds understood by authentication and authorization storage.
+///
+/// This enum belongs to the backend-neutral contract. Adapters must reject an
+/// unknown persisted kind instead of passing a storage-specific string to the
+/// application.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuthenticationPrincipalKind {
+    Human,
+    ServiceAccount,
+}
+
+impl AuthenticationPrincipalKind {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Human => "human",
+            Self::ServiceAccount => "service_account",
+        }
+    }
+
+    #[must_use]
+    pub const fn is_human(self) -> bool {
+        matches!(self, Self::Human)
+    }
+
+    #[must_use]
+    pub const fn is_service_account(self) -> bool {
+        matches!(self, Self::ServiceAccount)
+    }
+}
+
+/// Minimal principal data required after bearer-token validation.
+///
+/// Persistence metadata, settings documents, revisions, and provider sync
+/// state deliberately stay behind the storage boundary.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AuthenticationPrincipal {
+    id: i32,
+    kind: AuthenticationPrincipalKind,
+    name: String,
+    identity_scope_id: i32,
+}
+
+impl std::fmt::Debug for AuthenticationPrincipal {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AuthenticationPrincipal")
+            .field("id", &"<redacted>")
+            .field("kind", &self.kind)
+            .field("name", &"<redacted>")
+            .field("identity_scope_id", &"<redacted>")
+            .finish()
+    }
+}
+
+impl AuthenticationPrincipal {
+    #[must_use]
+    pub fn new(
+        id: i32,
+        kind: AuthenticationPrincipalKind,
+        name: impl Into<String>,
+        identity_scope_id: i32,
+    ) -> Self {
+        Self {
+            id,
+            kind,
+            name: name.into(),
+            identity_scope_id,
+        }
+    }
+
+    #[must_use]
+    pub const fn id(&self) -> i32 {
+        self.id
+    }
+
+    #[must_use]
+    pub const fn kind(&self) -> AuthenticationPrincipalKind {
+        self.kind
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub const fn identity_scope_id(&self) -> i32 {
+        self.identity_scope_id
+    }
+
+    #[must_use]
+    pub const fn is_human(&self) -> bool {
+        self.kind.is_human()
+    }
+
+    #[must_use]
+    pub const fn is_service_account(&self) -> bool {
+        self.kind.is_service_account()
+    }
+}
+
+/// Password-free human projection used by human-only request extractors.
+///
+/// Credential hashes are not selected by an adapter implementing this
+/// contract and therefore cannot accidentally cross into request handling or
+/// diagnostics.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AuthenticationHuman {
+    id: i32,
+    proper_name: Option<String>,
+    email: Option<String>,
+    created_at: NaiveDateTime,
+    updated_at: NaiveDateTime,
+    anonymized_at: Option<NaiveDateTime>,
+}
+
+impl std::fmt::Debug for AuthenticationHuman {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AuthenticationHuman")
+            .field("id", &"<redacted>")
+            .field(
+                "proper_name",
+                &self.proper_name.as_ref().map(|_| "<redacted>"),
+            )
+            .field("email", &self.email.as_ref().map(|_| "<redacted>"))
+            .field("created_at", &"<redacted>")
+            .field("updated_at", &"<redacted>")
+            .field(
+                "anonymized_at",
+                &self.anonymized_at.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+impl AuthenticationHuman {
+    #[must_use]
+    pub const fn new(
+        id: i32,
+        proper_name: Option<String>,
+        email: Option<String>,
+        created_at: NaiveDateTime,
+        updated_at: NaiveDateTime,
+        anonymized_at: Option<NaiveDateTime>,
+    ) -> Self {
+        Self {
+            id,
+            proper_name,
+            email,
+            created_at,
+            updated_at,
+            anonymized_at,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        i32,
+        Option<String>,
+        Option<String>,
+        NaiveDateTime,
+        NaiveDateTime,
+        Option<NaiveDateTime>,
+    ) {
+        (
+            self.id,
+            self.proper_name,
+            self.email,
+            self.created_at,
+            self.updated_at,
+            self.anonymized_at,
+        )
+    }
+}
+
+/// One consistent authentication read of a principal and its optional human
+/// subtype.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthenticationIdentity {
+    principal: AuthenticationPrincipal,
+    human: Option<AuthenticationHuman>,
+}
+
+impl AuthenticationIdentity {
+    #[must_use]
+    pub const fn new(
+        principal: AuthenticationPrincipal,
+        human: Option<AuthenticationHuman>,
+    ) -> Self {
+        Self { principal, human }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (AuthenticationPrincipal, Option<AuthenticationHuman>) {
+        (self.principal, self.human)
+    }
+}
+
+/// Complete information needed to load the narrowing dimensions of one token.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct AuthenticationTokenScopeQuery {
+    token_id: i32,
+    permission_scoped: bool,
+    resource_scoped: bool,
+}
+
+impl std::fmt::Debug for AuthenticationTokenScopeQuery {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AuthenticationTokenScopeQuery")
+            .field("token_id", &"<redacted>")
+            .field("permission_scoped", &self.permission_scoped)
+            .field("resource_scoped", &self.resource_scoped)
+            .finish()
+    }
+}
+
+impl AuthenticationTokenScopeQuery {
+    #[must_use]
+    pub const fn new(token_id: i32, permission_scoped: bool, resource_scoped: bool) -> Self {
+        Self {
+            token_id,
+            permission_scoped,
+            resource_scoped,
+        }
+    }
+
+    #[must_use]
+    pub const fn token_id(self) -> i32 {
+        self.token_id
+    }
+
+    #[must_use]
+    pub const fn is_permission_scoped(self) -> bool {
+        self.permission_scoped
+    }
+
+    #[must_use]
+    pub const fn is_resource_scoped(self) -> bool {
+        self.resource_scoped
+    }
+
+    #[must_use]
+    pub const fn is_scoped(self) -> bool {
+        self.permission_scoped || self.resource_scoped
+    }
+}
+
+/// Resource ids in one token's enabled resource-scope dimension.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct AuthenticationResourceScope {
+    collection_ids: Vec<i32>,
+    class_ids: Vec<i32>,
+    object_ids: Vec<i32>,
+}
+
+impl std::fmt::Debug for AuthenticationResourceScope {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AuthenticationResourceScope")
+            .field("collection_count", &self.collection_ids.len())
+            .field("class_count", &self.class_ids.len())
+            .field("object_count", &self.object_ids.len())
+            .finish()
+    }
+}
+
+impl AuthenticationResourceScope {
+    #[must_use]
+    pub const fn new(collection_ids: Vec<i32>, class_ids: Vec<i32>, object_ids: Vec<i32>) -> Self {
+        Self {
+            collection_ids,
+            class_ids,
+            object_ids,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (Vec<i32>, Vec<i32>, Vec<i32>) {
+        (self.collection_ids, self.class_ids, self.object_ids)
+    }
+}
+
+/// Backend-neutral snapshot of a token's enabled narrowing dimensions.
+///
+/// `None` means that a dimension is disabled. `Some(empty)` means that it is
+/// enabled but grants nothing; adapters must preserve that distinction.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AuthenticationTokenScope {
+    permissions: Option<Vec<String>>,
+    resources: Option<AuthenticationResourceScope>,
+}
+
+impl std::fmt::Debug for AuthenticationTokenScope {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AuthenticationTokenScope")
+            .field("permission_count", &self.permissions.as_ref().map(Vec::len))
+            .field("resources", &self.resources)
+            .finish()
+    }
+}
+
+impl AuthenticationTokenScope {
+    #[must_use]
+    pub const fn new(
+        permissions: Option<Vec<String>>,
+        resources: Option<AuthenticationResourceScope>,
+    ) -> Self {
+        Self {
+            permissions,
+            resources,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (Option<Vec<String>>, Option<AuthenticationResourceScope>) {
+        (self.permissions, self.resources)
+    }
+}
+
+/// Authentication data every selectable storage backend must provide.
+///
+/// Implementations own persistence joins and row decoding. Consumers receive
+/// only the projections required to build application authentication state.
+#[async_trait]
+pub trait AuthenticationStorage: Send + Sync {
+    async fn load_authentication_identity(
+        &self,
+        principal_id: i32,
+    ) -> Result<AuthenticationIdentity, StorageError>;
+
+    async fn load_authentication_token_scope(
+        &self,
+        query: AuthenticationTokenScopeQuery,
+    ) -> Result<Option<AuthenticationTokenScope>, StorageError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enabled_empty_scope_dimensions_remain_present() {
+        let scope = AuthenticationTokenScope::new(
+            Some(Vec::new()),
+            Some(AuthenticationResourceScope::default()),
+        );
+
+        let (permissions, resources) = scope.into_parts();
+        assert_eq!(permissions, Some(Vec::new()));
+        assert_eq!(
+            resources.map(AuthenticationResourceScope::into_parts),
+            Some((Vec::new(), Vec::new(), Vec::new()))
+        );
+    }
+
+    #[test]
+    fn unscoped_query_has_no_enabled_dimensions() {
+        let query = AuthenticationTokenScopeQuery::new(7, false, false);
+
+        assert!(!query.is_scoped());
+        assert!(!query.is_permission_scoped());
+        assert!(!query.is_resource_scoped());
+    }
+
+    #[test]
+    fn authentication_dto_debug_output_redacts_identity_values() {
+        let principal = AuthenticationPrincipal::new(
+            42,
+            AuthenticationPrincipalKind::Human,
+            "sensitive-name",
+            17,
+        );
+
+        let debug = format!("{principal:?}");
+        assert!(!debug.contains("sensitive-name"));
+        assert!(!debug.contains("42"));
+        assert!(!debug.contains("17"));
+    }
+}

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -5,12 +5,18 @@
 //! these values without reversing the dependency from storage into the server.
 
 mod events;
+mod identity;
 mod operational;
 
 pub use events::{
     EventArchive, EventDeliveryBatch, EventDeliveryClaim, EventDeliverySink, EventDeliveryStorage,
     EventDeliverySubscription, EventDeliveryWorkItem, EventFanoutStorage, EventRetentionStorage,
     EventRetentionSummary, RetainedEvent,
+};
+pub use identity::{
+    AuthenticationHuman, AuthenticationIdentity, AuthenticationPrincipal,
+    AuthenticationPrincipalKind, AuthenticationResourceScope, AuthenticationStorage,
+    AuthenticationTokenScope, AuthenticationTokenScopeQuery,
 };
 pub use operational::{
     EventDeliveryHealthSnapshot, EventDeliveryStatusSnapshot, EventFanoutSnapshot,

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -69,8 +69,14 @@ satisfy every capability family below before `StorageHandle` can compose it:
 
 The families are not feature flags and the admin configuration does not report
 optional support. Every selectable backend implements the entire list. The
-central certification implementations in `src/storage/contract.rs` make adding
-a backend an explicit architecture change rather than an incidental trait impl.
+sealed composition in `src/storage/contract.rs` makes adding a backend an
+explicit architecture change rather than an incidental trait implementation.
+During extraction, the query/history, workflow, and remaining operational
+families retain temporary central migration gates. Those gates prevent another
+backend from becoming selectable, but they are not behavioral proof and must
+be replaced by mandatory operation-shaped traits and shared tests. The former
+identity gate has now been replaced by the real `AuthenticationStorage`
+contract; no family is considered complete merely because a marker exists.
 
 PostgreSQL query implementations live in
 `src/storage/postgres/operations/*`. Separating their persistence rows from
@@ -152,6 +158,15 @@ sink settings, and an opaque claim to return on success or failure.
 purge transaction. It passes redacted-debug, serialized `RetainedEvent` DTOs to
 an application-owned `EventArchive`; an archive failure rolls back deletion.
 Neither side sees the PostgreSQL event row, connection, or claim state.
+
+`AuthenticationStorage` owns the consistent principal/human join and token
+scope reads used by bearer-token extractors. It returns a minimal
+`AuthenticationPrincipal`, an optional password-free `AuthenticationHuman`,
+and scope DTOs that distinguish a disabled dimension from an enabled empty
+deny-all dimension. PostgreSQL kind strings, credential hashes, Diesel rows,
+and scope-table layouts never cross into request handling. The opaque
+`StorageHandle` applies the common `authentication` tracing and metric labels
+before dispatching to the selected adapter.
 
 ## Error Direction
 
@@ -263,10 +278,10 @@ The first workspace boundaries are now in place:
   More domain DTOs move here as mixed Diesel/domain models are separated.
 
 - `hubuum-storage-core` owns backend-neutral descriptors, the contract version,
-  capability identities, `StorageError`, operational snapshot DTOs, and the
-  extracted operational state, event-health, event-fan-out, event-retention,
-  and token-retention traits without application, transport, or driver
-  dependencies.
+  capability identities, `StorageError`, authentication DTOs, operational
+  snapshot DTOs, and the extracted authentication, operational state,
+  event-health, event-fan-out, event-retention, and token-retention traits
+  without application, transport, or driver dependencies.
 - `hubuum-storage-postgres` owns PostgreSQL pool construction, TLS connection
   setup, safe endpoint diagnostics, JSONB validation, query capture, and its
   crate-owned pool-construction error.
@@ -297,9 +312,10 @@ The crates have deliberately different responsibilities:
   mixed models are an incremental extraction.
 - `hubuum-storage-core` ultimately owns the complete traits in addition to its
   current errors, descriptors, capability metadata, operational traits, and
-  storage DTOs. Behavioral traits that still name root domain types remain in
-  `src/storage` until those types move to `hubuum-domain`; the root aggregate
-  trait enforces completeness meanwhile.
+  storage DTOs. Its authentication contract already uses only crate-owned DTOs
+  and is mandatory in the root aggregate trait. Behavioral traits that still
+  name root domain types remain in `src/storage` until those types move to
+  `hubuum-domain`; the root aggregate trait enforces completeness meanwhile.
 - `hubuum-storage-postgres` currently owns pool and TLS setup, JSONB helpers,
   and query capture. It ultimately owns generated schema, migrations,
   transaction helpers, persistence rows, PostgreSQL queries, and

--- a/src/api/handlers/auth.rs
+++ b/src/api/handlers/auth.rs
@@ -311,7 +311,7 @@ pub async fn logout_other(
 pub async fn validate_token(user_access: Authenticated) -> Result<impl Responder, ApiError> {
     debug!(
         message = "Token validation successful",
-        principal_id = user_access.principal.id,
+        principal_id = user_access.principal.id(),
     );
 
     Ok(ApiResponse::message("Token is valid."))

--- a/src/api/v1/handlers/backups.rs
+++ b/src/api/v1/handlers/backups.rs
@@ -109,7 +109,7 @@ pub async fn create_backup(
     );
     let task_request = TaskCreateRequest::builder(
         TaskKind::Backup,
-        PrincipalID::new(requestor.principal.id)?,
+        PrincipalID::new(requestor.principal.id())?,
         payload,
         1,
     )

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -145,7 +145,7 @@ async fn computed_personal_owner(
     )
     .await
     {
-        Ok(()) => Ok(Some(requestor.principal.id)),
+        Ok(()) => Ok(Some(requestor.principal.id())),
         Err(ApiError::Forbidden(_)) => Ok(None),
         Err(error) => Err(error),
     }

--- a/src/api/v1/handlers/classes/object_aggregates.rs
+++ b/src/api/v1/handlers/classes/object_aggregates.rs
@@ -18,7 +18,7 @@ use crate::models::{
 };
 use crate::pagination::effective_page_limit;
 use crate::permissions::AppContext;
-use crate::traits::{Search, SelfAccessors};
+use crate::traits::Search;
 
 #[utoipa::path(
     get,

--- a/src/api/v1/handlers/collections.rs
+++ b/src/api/v1/handlers/collections.rs
@@ -70,7 +70,10 @@ pub async fn get_collections(
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
     let user = &requestor.principal;
-    debug!(message = "Collection list requested", requestor = user.name);
+    debug!(
+        message = "Collection list requested",
+        requestor = user.name()
+    );
 
     let query_string = req.query_string();
 
@@ -184,7 +187,7 @@ pub async fn get_collection(
 ) -> Result<impl Responder, ApiError> {
     debug!(
         message = "Collection get requested",
-        requestor = requestor.principal.name,
+        requestor = requestor.principal.name(),
         collection_id = collection_id.id()
     );
 
@@ -228,7 +231,7 @@ pub async fn update_collection(
     let collection_id = collection_id.into_inner();
     debug!(
         message = "Collection update requested",
-        requestor = requestor.principal.name,
+        requestor = requestor.principal.name(),
         collection_id = collection_id.id()
     );
 
@@ -279,7 +282,7 @@ pub async fn delete_collection(
 ) -> Result<impl Responder, ApiError> {
     debug!(
         message = "Collection delete requested",
-        requestor = requestor.principal.name,
+        requestor = requestor.principal.name(),
         collection_id = collection_id.id()
     );
 
@@ -474,7 +477,7 @@ pub async fn get_collection_permissions(
 ) -> Result<impl Responder, ApiError> {
     info!(
         message = "Collection permissions list requested",
-        requestor = requestor.principal.name,
+        requestor = requestor.principal.name(),
         collection_id = collection_id.id()
     );
 
@@ -534,7 +537,7 @@ pub async fn get_collection_group_permissions(
 
     info!(
         message = "Collection group permissions list requested",
-        requestor = requestor.principal.name,
+        requestor = requestor.principal.name(),
         collection_id = collection_id.id(),
         group_id = group_id.id()
     );
@@ -657,7 +660,7 @@ pub async fn grant_collection_group_permissions(
 
     info!(
         message = "Collection group permissions grant requested",
-        requestor = requestor.principal.id,
+        requestor = requestor.principal.id(),
         collection_id = collection_id.id(),
         group_id = group_id.id(),
         permissions = ?permissions
@@ -727,7 +730,7 @@ pub async fn replace_collection_group_permissions(
 
     info!(
         message = "Collection group permissions replace requested",
-        requestor = requestor.principal.id,
+        requestor = requestor.principal.id(),
         collection_id = collection_id.id(),
         group_id = group_id.id(),
         permissions = ?permissions
@@ -796,7 +799,7 @@ pub async fn revoke_collection_group_permissions(
 
     info!(
         message = "Collection group permissions revoke requested",
-        requestor = requestor.principal.name,
+        requestor = requestor.principal.name(),
         collection_id = collection_id.id(),
         group_id = group_id.id()
     );
@@ -858,7 +861,7 @@ pub async fn get_collection_group_permission(
 
     info!(
         message = "Collection group permission check requested",
-        requestor = requestor.principal.name,
+        requestor = requestor.principal.name(),
         collection_id = collection_id.id(),
         group_id = group_id.id(),
         permission = ?permission
@@ -917,7 +920,7 @@ pub async fn grant_collection_group_permission(
 
     info!(
         message = "Collection group permission grant requested",
-        requestor = requestor.principal.name,
+        requestor = requestor.principal.name(),
         collection_id = collection_id.id(),
         group_id = group_id.id(),
         permission = ?permission
@@ -984,7 +987,7 @@ pub async fn revoke_collection_group_permission(
 
     info!(
         message = "Collection group permission revoke requested",
-        requestor = requestor.principal.name,
+        requestor = requestor.principal.name(),
         collection_id = collection_id.id(),
         group_id = group_id.id(),
         permission = ?permission
@@ -1056,7 +1059,7 @@ pub async fn get_collection_principal_permissions(
 
     info!(
         message = "Collection principal permissions list requested",
-        requestor = requestor.principal.name,
+        requestor = requestor.principal.name(),
         collection_id = collection_id.id(),
         principal_id = principal_id.id()
     );
@@ -1159,7 +1162,7 @@ pub async fn get_collection_groups_with_permission(
 
     info!(
         message = "Collection groups with permission list requested",
-        requestor = requestor.principal.name,
+        requestor = requestor.principal.name(),
         collection_id = collection_id.id(),
         permission = ?permission
     );

--- a/src/api/v1/handlers/computed_fields.rs
+++ b/src/api/v1/handlers/computed_fields.rs
@@ -27,7 +27,7 @@ use crate::traits::SelfAccessors;
 
 fn require_human(requestor: &Authenticated) -> Result<i32, ApiError> {
     if requestor.principal.is_human() {
-        Ok(requestor.principal.id)
+        Ok(requestor.principal.id())
     } else {
         Err(ApiError::Forbidden(
             "Service accounts cannot manage personal computed fields".to_string(),
@@ -158,7 +158,7 @@ pub async fn create_shared_computed_field(
         &context,
         class.id,
         class.collection_id,
-        requestor.principal.id,
+        requestor.principal.id(),
         request.into_inner(),
         &event_context,
     )
@@ -219,7 +219,7 @@ pub async fn patch_shared_computed_field(
             class.id,
             class.collection_id,
             field_id.id(),
-            requestor.principal.id,
+            requestor.principal.id(),
             request.into_inner(),
             &event_context,
         ),
@@ -278,7 +278,7 @@ pub async fn delete_shared_computed_field(
             class.id,
             class.collection_id,
             field_id.id(),
-            requestor.principal.id,
+            requestor.principal.id(),
             &event_context,
         ),
     )
@@ -397,7 +397,7 @@ pub async fn rebuild_shared_computed_fields(
             &context,
             class.id,
             class.collection_id,
-            Some(requestor.principal.id),
+            Some(requestor.principal.id()),
         )
         .await?,
     ))

--- a/src/api/v1/handlers/export_templates.rs
+++ b/src/api/v1/handlers/export_templates.rs
@@ -60,7 +60,7 @@ pub async fn create_template(
 
     debug!(
         message = "Export template create requested",
-        user_id = user.id,
+        user_id = user.id(),
         collection_id = template.collection_id,
         template_name = template.name
     );
@@ -124,7 +124,7 @@ pub async fn get_templates(
 
     info!(
         message = "Export template list requested",
-        user_id = user.id
+        user_id = user.id()
     );
 
     let (templates, total_count) = if context
@@ -206,7 +206,7 @@ pub async fn get_template(
 
     debug!(
         message = "Export template get requested",
-        user_id = user.id,
+        user_id = user.id(),
         template_id = template_id.id()
     );
 
@@ -256,7 +256,7 @@ pub async fn run_template_export(
 
     debug!(
         message = "Export template execution requested",
-        user_id = user.id,
+        user_id = user.id(),
         template_id = template_id.id()
     );
 
@@ -321,7 +321,7 @@ pub async fn patch_template(
 
     debug!(
         message = "Export template patch requested",
-        user_id = user.id,
+        user_id = user.id(),
         template_id = template_id.id()
     );
 
@@ -385,7 +385,7 @@ pub async fn delete_template(
 
     debug!(
         message = "Export template delete requested",
-        user_id = user.id,
+        user_id = user.id(),
         template_id = template_id.id()
     );
 

--- a/src/api/v1/handlers/imports.rs
+++ b/src/api/v1/handlers/imports.rs
@@ -73,7 +73,7 @@ pub async fn create_import(
 
     let task = find_or_create_import_task(
         &context,
-        PrincipalID::new(requestor.principal.id)?,
+        PrincipalID::new(requestor.principal.id())?,
         snapshot,
         idempotency_key,
         payload,

--- a/src/api/v1/handlers/me.rs
+++ b/src/api/v1/handlers/me.rs
@@ -12,6 +12,7 @@ use crate::errors::ApiError;
 use crate::extractors::{
     AccessEventContext, Authenticated, ManagementAccess, PrincipalSettingsPatchPayload,
 };
+use crate::models::principal::load_principal_by_id;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
     Group, GroupResponse, PrincipalID, PrincipalSettings, PrincipalSettingsPatchDocument,
@@ -65,13 +66,13 @@ pub async fn get_me(
     context: AppContext,
     requestor: Authenticated,
 ) -> Result<impl Responder, ApiError> {
+    let principal = load_principal_by_id(&context, requestor.principal.id()).await?;
     let token = CurrentTokenMetadata::from_token_and_scope(&requestor.token_meta, requestor.scope)?;
 
     Ok(ApiResponse::new(
         MeResponse {
             principal: crate::models::MembershipPrincipalResponse::from_principal(
-                &context,
-                requestor.principal,
+                &context, principal,
             )
             .await?,
             token,
@@ -181,7 +182,7 @@ pub async fn get_my_settings(
     context: AppContext,
     requestor: Authenticated,
 ) -> Result<impl Responder, ApiError> {
-    let principal_id = PrincipalID::new(requestor.principal.id)?;
+    let principal_id = PrincipalID::new(requestor.principal.id())?;
     ApiResponse::ok_revisioned(principal_id.settings(&context).await?)
 }
 
@@ -204,7 +205,7 @@ pub async fn put_my_settings(
     settings: web::Json<PrincipalSettings>,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let principal_id = PrincipalID::new(requestor.principal.id)?;
+    let principal_id = PrincipalID::new(requestor.principal.id())?;
     let current = principal_id.settings(&context).await?;
     let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
@@ -257,7 +258,7 @@ pub async fn patch_my_settings(
     patch: PrincipalSettingsPatchPayload,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let principal_id = PrincipalID::new(requestor.principal.id)?;
+    let principal_id = PrincipalID::new(requestor.principal.id())?;
     let current = principal_id.settings(&context).await?;
     let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);
@@ -285,7 +286,7 @@ pub async fn delete_my_settings(
     requestor: Authenticated,
     req: HttpRequest,
 ) -> Result<impl Responder, ApiError> {
-    let principal_id = PrincipalID::new(requestor.principal.id)?;
+    let principal_id = PrincipalID::new(requestor.principal.id())?;
     let current = principal_id.settings(&context).await?;
     let precondition = revision_precondition(&req, &current)?;
     let event_context = requestor.event_context(&req);

--- a/src/api/v1/handlers/principals.rs
+++ b/src/api/v1/handlers/principals.rs
@@ -53,7 +53,7 @@ async fn ensure_can_manage_principal_settings(
     requestor: &Authenticated,
     target_principal_id: i32,
 ) -> Result<(), ApiError> {
-    if requestor.principal.id == target_principal_id {
+    if requestor.principal.id() == target_principal_id {
         return Ok(());
     }
 

--- a/src/api/v1/handlers/relations.rs
+++ b/src/api/v1/handlers/relations.rs
@@ -20,8 +20,6 @@ use crate::storage::capabilities::relations::{
 };
 use crate::storage::capabilities::user::UserSearchBackend;
 use crate::storage::capabilities::with_revision_precondition_scope;
-use crate::traits::SelfAccessors;
-
 use actix_web::delete;
 use tracing::debug;
 

--- a/src/api/v1/handlers/remote_targets.rs
+++ b/src/api/v1/handlers/remote_targets.rs
@@ -347,7 +347,7 @@ pub async fn invoke_remote_target(
     );
     let task = find_or_create_remote_call_task(
         &context,
-        PrincipalID::new(user.id)?,
+        PrincipalID::new(user.id())?,
         snapshot,
         idempotency_key_from_headers(req.headers())?,
         payload,

--- a/src/api/v1/handlers/tasks.rs
+++ b/src/api/v1/handlers/tasks.rs
@@ -113,7 +113,7 @@ pub async fn get_tasks(
     let submitted_by_filter = if is_admin {
         filters.submitted_by
     } else if backend.supports_sql_visibility_pushdown() {
-        Some(requestor.principal.id)
+        Some(requestor.principal.id())
     } else {
         None
     };

--- a/src/extractors/mod.rs
+++ b/src/extractors/mod.rs
@@ -1,17 +1,19 @@
 use crate::errors::ApiError;
 use crate::events::{EventContext, RequestProvenance};
-use crate::models::principal::{Principal, load_principal_by_id};
 use crate::models::token::{PrincipalToken, Token};
 use crate::models::user::User;
 use crate::models::{
-    MAX_OBJECT_DATA_PATCH_BYTES, MAX_PRINCIPAL_SETTINGS_PATCH_BYTES, ObjectDataPatchDocument,
-    PrincipalSettings, PrincipalSettingsPatch, PrincipalSettingsPatchDocument, TokenScope,
+    CollectionID, HubuumClassID, HubuumObjectID, MAX_OBJECT_DATA_PATCH_BYTES,
+    MAX_PRINCIPAL_SETTINGS_PATCH_BYTES, ObjectDataPatchDocument, Permissions, PrincipalSettings,
+    PrincipalSettingsPatch, PrincipalSettingsPatchDocument, TokenResourceScope, TokenScope,
 };
 use crate::permissions::{AppContext, PrincipalRef};
-use crate::storage::StorageContext;
 use crate::storage::capabilities::Status;
-use crate::storage::capabilities::authz::load_token_scope;
-use crate::storage::capabilities::principal::load_principal_with_user;
+use crate::storage::{
+    AuthenticationHuman, AuthenticationPrincipal, AuthenticationResourceScope,
+    AuthenticationStorage, AuthenticationTokenScope, AuthenticationTokenScopeQuery, StorageContext,
+    storage_handle,
+};
 
 use actix_web::{
     FromRequest, HttpMessage, HttpRequest, dev::Payload, error::JsonPayloadError, web::JsonBody,
@@ -183,7 +185,7 @@ pub struct Authenticated {
     /// The raw bearer token (e.g. for current-token logout).
     pub token: Token,
     pub token_meta: PrincipalToken,
-    pub principal: Principal,
+    pub principal: AuthenticationPrincipal,
     /// `None` = unscoped (full principal authority); `Some(..)` = the token's
     /// permission and/or resource narrowing boundary.
     pub scope: Option<TokenScope>,
@@ -227,7 +229,7 @@ pub trait AccessEventContext {
 
 impl AccessEventContext for Authenticated {
     fn event_context(&self, req: &HttpRequest) -> EventContext {
-        user_event_context(req, self.principal.id)
+        user_event_context(req, self.principal.id())
     }
 }
 
@@ -298,8 +300,20 @@ async fn build_authenticated_from_meta(
     token_meta: PrincipalToken,
 ) -> Result<Authenticated, ApiError> {
     crate::auth::refresh_principal_if_needed(backend, token_meta.principal_id).await?;
-    let principal = load_principal_by_id(backend, token_meta.principal_id).await?;
-    let scope = load_token_scope(backend, &token_meta).await?;
+    let storage = storage_handle(backend);
+    let identity = storage
+        .load_authentication_identity(token_meta.principal_id)
+        .await?;
+    let (principal, _) = identity.into_parts();
+    let scope = storage
+        .load_authentication_token_scope(AuthenticationTokenScopeQuery::new(
+            token_meta.id,
+            token_meta.permission_scoped,
+            token_meta.resource_scoped,
+        ))
+        .await?
+        .map(token_scope_from_storage)
+        .transpose()?;
     Ok(Authenticated {
         token,
         token_meta,
@@ -336,16 +350,73 @@ async fn human_unscoped_user_from_meta(
 
     crate::auth::refresh_principal_if_needed(backend, token_meta.principal_id).await?;
 
-    // Single round trip: fetch the principal and (when human) its `users` row
-    // together, rather than a separate principal load followed by a user load.
-    let (principal, user) = load_principal_with_user(backend, token_meta.principal_id).await?;
+    // Single round trip: fetch the backend-neutral principal projection and,
+    // when human, a password-free human projection from the same snapshot.
+    let storage = storage_handle(backend);
+    let identity = storage
+        .load_authentication_identity(token_meta.principal_id)
+        .await?;
+    let (principal, human) = identity.into_parts();
     if !principal.is_human() {
         return Err(ApiError::Forbidden(
             "Service accounts cannot use human/management endpoints".to_string(),
         ));
     }
 
-    user.ok_or_else(|| ApiError::Unauthorized("Invalid token".to_string()))
+    human
+        .map(authentication_human_to_user)
+        .ok_or_else(|| ApiError::Unauthorized("Invalid token".to_string()))
+}
+
+fn authentication_human_to_user(human: AuthenticationHuman) -> User {
+    let (id, proper_name, email, created_at, updated_at, anonymized_at) = human.into_parts();
+    User {
+        id,
+        kind: "human".to_string(),
+        password: None,
+        proper_name,
+        email,
+        created_at,
+        updated_at,
+        anonymized_at,
+    }
+}
+
+fn token_scope_from_storage(scope: AuthenticationTokenScope) -> Result<TokenScope, ApiError> {
+    let (permissions, resources) = scope.into_parts();
+    let permissions = permissions
+        .map(|permissions| {
+            permissions
+                .iter()
+                .map(|permission| Permissions::from_string(permission))
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?;
+    let resources = resources
+        .map(authentication_resources_from_storage)
+        .transpose()?;
+
+    TokenScope::from_stored_parts(permissions, resources)
+}
+
+fn authentication_resources_from_storage(
+    resources: AuthenticationResourceScope,
+) -> Result<Vec<TokenResourceScope>, ApiError> {
+    let (collection_ids, class_ids, object_ids) = resources.into_parts();
+    collection_ids
+        .into_iter()
+        .map(|id| CollectionID::new(id).map(TokenResourceScope::Collection))
+        .chain(
+            class_ids
+                .into_iter()
+                .map(|id| HubuumClassID::new(id).map(TokenResourceScope::Class)),
+        )
+        .chain(
+            object_ids
+                .into_iter()
+                .map(|id| HubuumObjectID::new(id).map(TokenResourceScope::Object)),
+        )
+        .collect()
 }
 
 async fn human_unscoped_user(

--- a/src/storage/capabilities.rs
+++ b/src/storage/capabilities.rs
@@ -17,7 +17,7 @@ pub(crate) mod active_tokens {
 
 pub(crate) mod authz {
     pub use crate::storage::postgres::operations::authz::{
-        AuthzSubject, PrincipalIdAccessor, load_token_scope, scope_allows, scope_allows_resource,
+        AuthzSubject, PrincipalIdAccessor, scope_allows, scope_allows_resource,
         scope_allows_resources,
     };
 }
@@ -97,10 +97,6 @@ pub(crate) mod meta {
     pub(crate) use crate::storage::postgres::operations::meta::{
         load_database_state, load_task_queue_state,
     };
-}
-
-pub(crate) mod principal {
-    pub(crate) use crate::storage::postgres::operations::principal::load_principal_with_user;
 }
 
 pub(crate) mod permissions {

--- a/src/storage/context.rs
+++ b/src/storage/context.rs
@@ -6,12 +6,13 @@ use crate::permissions::{AppContext, PermissionBackend};
 use crate::storage::observed::observe_storage_call;
 use crate::storage::postgres::PostgresPool;
 use crate::storage::{
-    DynLifecycleStorage, EventArchive, EventDeliveryBatch, EventDeliveryClaim,
-    EventDeliveryHealthSnapshot, EventDeliveryStorage, EventFanoutStorage, EventHealthStorage,
-    EventMetricsSnapshot, EventRetentionStorage, EventRetentionSummary, InventoryGaugeSnapshot,
-    MetricsStorage, OperationalStateStorage, PostgresStorage, ReadinessSnapshot, StorageBackend,
-    StorageBackendDescriptor, StorageError, StoragePoolState, TaskGaugeSnapshot,
-    TokenRetentionStorage,
+    AuthenticationIdentity, AuthenticationStorage, AuthenticationTokenScope,
+    AuthenticationTokenScopeQuery, DynLifecycleStorage, EventArchive, EventDeliveryBatch,
+    EventDeliveryClaim, EventDeliveryHealthSnapshot, EventDeliveryStorage, EventFanoutStorage,
+    EventHealthStorage, EventMetricsSnapshot, EventRetentionStorage, EventRetentionSummary,
+    InventoryGaugeSnapshot, MetricsStorage, OperationalStateStorage, PostgresStorage,
+    ReadinessSnapshot, StorageBackend, StorageBackendDescriptor, StorageError, StoragePoolState,
+    TaskGaugeSnapshot, TokenRetentionStorage,
 };
 use async_trait::async_trait;
 
@@ -68,6 +69,47 @@ impl StorageHandle {
         match &self.implementation {
             BackendImplementation::Postgresql(backend) => backend.pool(),
         }
+    }
+}
+
+#[async_trait]
+impl AuthenticationStorage for StorageHandle {
+    async fn load_authentication_identity(
+        &self,
+        principal_id: i32,
+    ) -> Result<AuthenticationIdentity, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "authentication",
+            "load_identity",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.load_authentication_identity(principal_id).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn load_authentication_token_scope(
+        &self,
+        query: AuthenticationTokenScopeQuery,
+    ) -> Result<Option<AuthenticationTokenScope>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "authentication",
+            "load_token_scope",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.load_authentication_token_scope(query).await
+                    }
+                }
+            },
+        )
+        .await
     }
 }
 

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use super::{
-    ClassRelationStore, ClassStore, CollectionStore, EventDeliveryStorage, EventFanoutStorage,
-    EventHealthStorage, EventRetentionStorage, MetricsStorage, ObjectRelationStore, ObjectStore,
-    OperationalStateStorage, PostgresStorage, TokenRetentionStorage,
-    observed::ObservedLifecycleStorage,
+    AuthenticationStorage, ClassRelationStore, ClassStore, CollectionStore, EventDeliveryStorage,
+    EventFanoutStorage, EventHealthStorage, EventRetentionStorage, MetricsStorage,
+    ObjectRelationStore, ObjectStore, OperationalStateStorage, PostgresStorage,
+    TokenRetentionStorage, observed::ObservedLifecycleStorage,
 };
 
 #[cfg(test)]
@@ -40,14 +40,13 @@ impl<T> LifecycleStorage for T where
 {
 }
 
-/// Certification gates for capability families that are still implemented by
-/// operation-shaped adapters outside `src/storage`.
+/// Temporary migration gates for capability families whose operation-shaped
+/// traits have not yet been extracted.
 ///
-/// These traits are intentionally sealed and implemented in this central
-/// contract module. They make the composition checklist compile-time visible:
-/// adding a selectable backend requires an explicit implementation for every
-/// family here, followed by the shared compatibility suite.
-pub(crate) trait IdentityAndAuthorizationStorage: Send + Sync {}
+/// These gates prevent another implementation from becoming selectable during
+/// the refactor, but they do not certify behavior. Each one must be replaced by
+/// mandatory operation-shaped traits and shared compatibility tests, as the
+/// authentication gate has been in this layer.
 pub(crate) trait QueryAndHistoryStorage: Send + Sync {}
 pub(crate) trait WorkflowStorage: Send + Sync {}
 pub(crate) trait OperationalStorage: Send + Sync {}
@@ -62,6 +61,7 @@ mod sealed {
 /// and therefore cannot be selected by `AppContext`.
 pub(crate) trait StorageBackend:
     LifecycleStorage
+    + AuthenticationStorage
     + EventDeliveryStorage
     + EventFanoutStorage
     + EventHealthStorage
@@ -69,7 +69,6 @@ pub(crate) trait StorageBackend:
     + MetricsStorage
     + OperationalStateStorage
     + TokenRetentionStorage
-    + IdentityAndAuthorizationStorage
     + QueryAndHistoryStorage
     + WorkflowStorage
     + OperationalStorage
@@ -78,7 +77,6 @@ pub(crate) trait StorageBackend:
     fn descriptor(&self) -> StorageBackendDescriptor;
 }
 
-impl IdentityAndAuthorizationStorage for PostgresStorage {}
 impl QueryAndHistoryStorage for PostgresStorage {}
 impl WorkflowStorage for PostgresStorage {}
 impl OperationalStorage for PostgresStorage {}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -25,9 +25,11 @@ pub(crate) use contract::{
     StorageBackendKind, StorageIdentity,
 };
 pub(crate) use hubuum_storage_core::{
-    EventArchive, EventDeliveryBatch, EventDeliveryClaim, EventDeliverySink, EventDeliveryStorage,
-    EventDeliverySubscription, EventDeliveryWorkItem, EventFanoutStorage, EventRetentionStorage,
-    EventRetentionSummary, RetainedEvent,
+    AuthenticationHuman, AuthenticationIdentity, AuthenticationPrincipal,
+    AuthenticationResourceScope, AuthenticationStorage, AuthenticationTokenScope,
+    AuthenticationTokenScopeQuery, EventArchive, EventDeliveryBatch, EventDeliveryClaim,
+    EventDeliverySink, EventDeliveryStorage, EventDeliverySubscription, EventDeliveryWorkItem,
+    EventFanoutStorage, EventRetentionStorage, EventRetentionSummary, RetainedEvent,
 };
 pub(crate) use hubuum_storage_core::{StorageError, StorageErrorKind};
 #[cfg(test)]

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -38,12 +38,13 @@ use crate::storage::postgres::operations::relations::{
 };
 
 use super::{
-    ClassRelationStore, ClassStore, CollectionStore, EventArchive, EventDeliveryBatch,
-    EventDeliveryClaim, EventDeliveryHealthSnapshot, EventDeliveryStorage, EventFanoutStorage,
-    EventHealthStorage, EventMetricsSnapshot, EventRetentionStorage, EventRetentionSummary,
-    InventoryGaugeSnapshot, MetricsStorage, ObjectRelationStore, ObjectStore,
-    OperationalStateStorage, ReadinessSnapshot, StorageError, StorageIdentity, StoragePoolState,
-    TaskGaugeSnapshot, TokenRetentionStorage,
+    AuthenticationIdentity, AuthenticationStorage, AuthenticationTokenScope,
+    AuthenticationTokenScopeQuery, ClassRelationStore, ClassStore, CollectionStore, EventArchive,
+    EventDeliveryBatch, EventDeliveryClaim, EventDeliveryHealthSnapshot, EventDeliveryStorage,
+    EventFanoutStorage, EventHealthStorage, EventMetricsSnapshot, EventRetentionStorage,
+    EventRetentionSummary, InventoryGaugeSnapshot, MetricsStorage, ObjectRelationStore,
+    ObjectStore, OperationalStateStorage, ReadinessSnapshot, StorageError, StorageIdentity,
+    StoragePoolState, TaskGaugeSnapshot, TokenRetentionStorage,
 };
 use error::map_postgres_error;
 
@@ -66,6 +67,27 @@ impl PostgresStorage {
 impl StorageIdentity for PostgresStorage {
     fn storage_name(&self) -> &'static str {
         "postgresql"
+    }
+}
+
+#[async_trait]
+impl AuthenticationStorage for PostgresStorage {
+    async fn load_authentication_identity(
+        &self,
+        principal_id: i32,
+    ) -> Result<AuthenticationIdentity, StorageError> {
+        operations::authentication::load_authentication_identity(&self.pool, principal_id)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn load_authentication_token_scope(
+        &self,
+        query: AuthenticationTokenScopeQuery,
+    ) -> Result<Option<AuthenticationTokenScope>, StorageError> {
+        operations::authentication::load_authentication_token_scope(&self.pool, query)
+            .await
+            .map_err(map_postgres_error)
     }
 }
 

--- a/src/storage/postgres/operations/authentication.rs
+++ b/src/storage/postgres/operations/authentication.rs
@@ -1,0 +1,193 @@
+use chrono::NaiveDateTime;
+use hubuum_storage_core::{
+    AuthenticationHuman, AuthenticationIdentity, AuthenticationPrincipal,
+    AuthenticationPrincipalKind, AuthenticationResourceScope, AuthenticationTokenScope,
+    AuthenticationTokenScopeQuery,
+};
+
+use crate::errors::ApiError;
+use crate::storage::postgres::prelude::*;
+use crate::storage::postgres::{PostgresPool, with_connection};
+
+type AuthenticationIdentityRow = (
+    i32,
+    String,
+    String,
+    i32,
+    Option<i32>,
+    Option<String>,
+    Option<String>,
+    Option<NaiveDateTime>,
+    Option<NaiveDateTime>,
+    Option<NaiveDateTime>,
+);
+
+pub(crate) async fn load_authentication_identity(
+    pool: &PostgresPool,
+    principal_id: i32,
+) -> Result<AuthenticationIdentity, ApiError> {
+    use crate::schema::{principals, users};
+
+    let row = with_connection(pool, async |conn| {
+        principals::table
+            .left_join(users::table.on(users::id.eq(principals::id)))
+            .filter(principals::id.eq(principal_id))
+            .select((
+                principals::id,
+                principals::kind,
+                principals::name,
+                principals::identity_scope_id,
+                users::id.nullable(),
+                users::proper_name.nullable(),
+                users::email.nullable(),
+                users::created_at.nullable(),
+                users::updated_at.nullable(),
+                users::anonymized_at.nullable(),
+            ))
+            .first::<AuthenticationIdentityRow>(conn)
+            .await
+    })
+    .await?;
+
+    authentication_identity_from_row(row)
+}
+
+fn authentication_identity_from_row(
+    row: AuthenticationIdentityRow,
+) -> Result<AuthenticationIdentity, ApiError> {
+    let (
+        principal_id,
+        persisted_kind,
+        name,
+        identity_scope_id,
+        human_id,
+        proper_name,
+        email,
+        created_at,
+        updated_at,
+        anonymized_at,
+    ) = row;
+    let kind = match persisted_kind.as_str() {
+        "human" => AuthenticationPrincipalKind::Human,
+        "service_account" => AuthenticationPrincipalKind::ServiceAccount,
+        other => {
+            return Err(ApiError::InternalServerError(format!(
+                "Unknown principal kind '{other}'"
+            )));
+        }
+    };
+    let principal = AuthenticationPrincipal::new(principal_id, kind, name, identity_scope_id);
+    let human = human_id
+        .map(|human_id| {
+            if kind != AuthenticationPrincipalKind::Human || human_id != principal_id {
+                return Err(ApiError::InternalServerError(format!(
+                    "Principal '{principal_id}' has an inconsistent human identity row"
+                )));
+            }
+            let created_at = created_at.ok_or_else(|| {
+                ApiError::InternalServerError(format!(
+                    "Human principal '{principal_id}' has no creation timestamp"
+                ))
+            })?;
+            let updated_at = updated_at.ok_or_else(|| {
+                ApiError::InternalServerError(format!(
+                    "Human principal '{principal_id}' has no update timestamp"
+                ))
+            })?;
+            Ok(AuthenticationHuman::new(
+                human_id,
+                proper_name,
+                email,
+                created_at,
+                updated_at,
+                anonymized_at,
+            ))
+        })
+        .transpose()?;
+
+    Ok(AuthenticationIdentity::new(principal, human))
+}
+
+pub(crate) async fn load_authentication_token_scope(
+    pool: &PostgresPool,
+    query: AuthenticationTokenScopeQuery,
+) -> Result<Option<AuthenticationTokenScope>, ApiError> {
+    use crate::schema::{
+        token_class_scopes, token_collection_scopes, token_object_scopes, token_scopes,
+    };
+
+    if !query.is_scoped() {
+        return Ok(None);
+    }
+
+    with_connection(pool, async |conn| {
+        let permissions = if query.is_permission_scoped() {
+            Some(
+                token_scopes::table
+                    .filter(token_scopes::token_id.eq(query.token_id()))
+                    .order_by(token_scopes::permission.asc())
+                    .select(token_scopes::permission)
+                    .load::<String>(conn)
+                    .await?,
+            )
+        } else {
+            None
+        };
+        let resources = if query.is_resource_scoped() {
+            let collection_ids = token_collection_scopes::table
+                .filter(token_collection_scopes::token_id.eq(query.token_id()))
+                .order_by(token_collection_scopes::collection_id.asc())
+                .select(token_collection_scopes::collection_id)
+                .load::<i32>(conn)
+                .await?;
+            let class_ids = token_class_scopes::table
+                .filter(token_class_scopes::token_id.eq(query.token_id()))
+                .order_by(token_class_scopes::class_id.asc())
+                .select(token_class_scopes::class_id)
+                .load::<i32>(conn)
+                .await?;
+            let object_ids = token_object_scopes::table
+                .filter(token_object_scopes::token_id.eq(query.token_id()))
+                .order_by(token_object_scopes::object_id.asc())
+                .select(token_object_scopes::object_id)
+                .load::<i32>(conn)
+                .await?;
+            Some(AuthenticationResourceScope::new(
+                collection_ids,
+                class_ids,
+                object_ids,
+            ))
+        } else {
+            None
+        };
+
+        Ok::<_, diesel::result::Error>(AuthenticationTokenScope::new(permissions, resources))
+    })
+    .await
+    .map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_unknown_persisted_principal_kind() {
+        let timestamp = NaiveDateTime::default();
+        let error = authentication_identity_from_row((
+            1,
+            "robot".to_string(),
+            "bad-kind".to_string(),
+            1,
+            None,
+            None,
+            None,
+            Some(timestamp),
+            Some(timestamp),
+            None,
+        ))
+        .unwrap_err();
+
+        assert!(error.to_string().contains("Unknown principal kind 'robot'"));
+    }
+}

--- a/src/storage/postgres/operations/authz.rs
+++ b/src/storage/postgres/operations/authz.rs
@@ -30,6 +30,7 @@ use crate::schema::{
     group_memberships, groups, identity_scopes, token_class_scopes, token_collection_scopes,
     token_object_scopes, token_scopes,
 };
+use crate::storage::AuthenticationPrincipal;
 use crate::storage::postgres::{PostgresConnection, with_connection, with_connection_async};
 
 /// Cheap, local access to a subject's principal id (no backend round-trip).
@@ -48,6 +49,11 @@ impl PrincipalIdAccessor for User {
 impl PrincipalIdAccessor for Principal {
     fn principal_id(&self) -> i32 {
         self.id
+    }
+}
+impl PrincipalIdAccessor for AuthenticationPrincipal {
+    fn principal_id(&self) -> i32 {
+        self.id()
     }
 }
 impl PrincipalIdAccessor for ServiceAccount {
@@ -308,18 +314,6 @@ pub(crate) async fn load_token_scope_conn(
     .map(Some)
 }
 
-/// Load all narrowing dimensions for a set of tokens in a bounded number of
-/// queries. Results preserve the input order.
-pub(crate) async fn load_token_scopes_for_tokens(
-    pool: &impl crate::storage::StorageContext,
-    tokens: &[PrincipalToken],
-) -> Result<Vec<Option<TokenScope>>, ApiError> {
-    with_connection(pool, async |conn| {
-        load_token_scopes_for_tokens_conn(conn, tokens).await
-    })
-    .await
-}
-
 /// Load complete token boundaries on an existing connection.
 ///
 /// Callers that hold token row locks use this form so cascading retention
@@ -447,20 +441,4 @@ pub(crate) async fn load_token_scopes_for_tokens_conn(
                 .map(Some)
         })
         .collect()
-}
-
-/// Load all narrowing dimensions for an authenticated token. The two scoped
-/// flags are the source of truth, so a flagged dimension with no rows becomes a
-/// present-but-empty deny-all dimension.
-pub async fn load_token_scope(
-    pool: &impl crate::storage::StorageContext,
-    token: &PrincipalToken,
-) -> Result<Option<TokenScope>, ApiError> {
-    Ok(
-        load_token_scopes_for_tokens(pool, std::slice::from_ref(token))
-            .await?
-            .into_iter()
-            .next()
-            .flatten(),
-    )
 }

--- a/src/storage/postgres/operations/mod.rs
+++ b/src/storage/postgres/operations/mod.rs
@@ -1,4 +1,5 @@
 pub mod active_tokens;
+pub(crate) mod authentication;
 pub mod authz;
 pub mod backup;
 pub mod bootstrap;

--- a/src/storage/postgres/operations/principal.rs
+++ b/src/storage/postgres/operations/principal.rs
@@ -243,25 +243,6 @@ fn stored_principal_settings(
     })
 }
 
-/// Load a principal and, when it is human, its `users` row in one left-joined
-/// query. A service account simply has no `users` row, so the user is `None`.
-pub async fn load_principal_with_user(
-    pool: &impl crate::storage::StorageContext,
-    principal_id_value: i32,
-) -> Result<(Principal, Option<User>), ApiError> {
-    use crate::schema::{principals, users};
-
-    with_connection(pool, async |conn| {
-        principals::table
-            .left_join(users::table.on(users::id.eq(principals::id)))
-            .filter(principals::id.eq(principal_id_value))
-            .select((Principal::as_select(), Option::<User>::as_select()))
-            .first::<(Principal, Option<User>)>(conn)
-            .await
-    })
-    .await
-}
-
 /// Load the rich, untagged user representation in one database snapshot.
 pub(crate) async fn load_user_response(
     pool: &impl crate::storage::StorageContext,

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -221,6 +221,7 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         .expect("StorageBackend should have a readable aggregate trait declaration");
     for required in [
         "LifecycleStorage",
+        "AuthenticationStorage",
         "EventDeliveryStorage",
         "EventFanoutStorage",
         "EventHealthStorage",
@@ -228,7 +229,6 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         "MetricsStorage",
         "OperationalStateStorage",
         "TokenRetentionStorage",
-        "IdentityAndAuthorizationStorage",
         "QueryAndHistoryStorage",
         "WorkflowStorage",
         "OperationalStorage",

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -10,9 +10,10 @@ use crate::services::Services;
 use crate::storage::StorageHandle;
 use crate::storage::postgres::PostgresPool;
 use crate::storage::{
-    EventArchive, EventDeliveryStorage, EventFanoutStorage, EventHealthStorage,
-    EventRetentionStorage, MetricsStorage, OperationalStateStorage, RetainedEvent,
-    STORAGE_CONTRACT_VERSION, StorageBackendKind, StorageError, TokenRetentionStorage,
+    AuthenticationStorage, AuthenticationTokenScopeQuery, EventArchive, EventDeliveryStorage,
+    EventFanoutStorage, EventHealthStorage, EventRetentionStorage, MetricsStorage,
+    OperationalStateStorage, RetainedEvent, STORAGE_CONTRACT_VERSION, StorageBackendKind,
+    StorageError, TokenRetentionStorage,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -47,6 +48,52 @@ async fn every_available_storage_backend_supplies_metrics_snapshots() {
             }
         }
     }
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_supplies_authentication_projections() {
+    let _permit = postgres_permit().await;
+    let pool = pool();
+    let user = crate::tests::create_user_with_params(
+        pool.get_ref(),
+        &prefix("authentication_user"),
+        "testpassword",
+    )
+    .await;
+
+    for kind in StorageBackendKind::ALL {
+        match kind {
+            StorageBackendKind::Postgresql => {
+                let backend = StorageHandle::postgres(pool.get_ref().clone());
+                let identity = backend
+                    .load_authentication_identity(user.id)
+                    .await
+                    .expect("certified backend should supply authentication identity data");
+                let (principal, human) = identity.into_parts();
+
+                assert_eq!(principal.id(), user.id);
+                assert!(principal.is_human());
+                assert!(human.is_some());
+
+                let scope = backend
+                    .load_authentication_token_scope(AuthenticationTokenScopeQuery::new(
+                        i32::MAX,
+                        true,
+                        false,
+                    ))
+                    .await
+                    .expect("certified backend should preserve empty scope dimensions")
+                    .expect("an enabled scope dimension should produce a scope snapshot");
+                let (permissions, resources) = scope.into_parts();
+                assert_eq!(permissions, Some(Vec::new()));
+                assert_eq!(resources, None);
+            }
+        }
+    }
+
+    user.delete_without_events(pool.get_ref())
+        .await
+        .expect("authentication compatibility fixture should be removed");
 }
 
 #[actix_web::test]


### PR DESCRIPTION
## Summary

- introduce password-free authentication DTOs in `hubuum-storage-core`
- require every selectable storage backend to implement the real `AuthenticationStorage` contract
- implement the contract in the PostgreSQL adapter with adapter-owned error translation
- route request authentication through `StorageHandle` with stable tracing and metrics labels
- add shared compatibility coverage for identity lookup and token-scope semantics

## Why

Authentication was still an application-to-PostgreSQL escape hatch: the extractor loaded Diesel models through PostgreSQL-specific helper functions. That made the advertised storage boundary incomplete and let a backend satisfy an empty marker trait without supplying the behavior needed by the application.

This layer moves authentication data across the boundary as storage-owned DTOs. Application consumers no longer acquire, select, or name a PostgreSQL pool for request authentication, and credential hashes never cross into request handling.

## Behavior and contracts

- `AuthenticationStorage` is a mandatory backend capability rather than a marker.
- Identity lookup returns a neutral principal plus password-free human metadata when applicable.
- Token scope distinguishes a disabled scope from an enabled but empty scope.
- PostgreSQL query and projection details remain inside the adapter.
- PostgreSQL failures become `PostgresStorageError`, then `StorageError`, before the application maps them to `ApiError`.
- `StorageHandle` records both calls with bounded operation names:
  - `authentication/load_identity`
  - `authentication/load_token_scope`
- DTO `Debug` output omits identity values, names, PII, token identifiers, and resource identifiers.
- The shared available-backend suite verifies the same authentication contract that production consumers rely upon.

The remaining empty query/history, workflow, and operational gates are now documented explicitly as temporary migration gates. They do not count as backend compatibility; subsequent stack layers will replace them with mandatory operation-shaped traits and shared tests.

## Stack

This draft is stacked on #298 and should be reviewed and merged after the lower storage-boundary layers.

## Changelog

No changelog entry is warranted: this is an internal boundary refactor with no intended user-facing API or behavior change.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `scripts/test-classify-ci-changes.sh`
- Rust API and supply-chain policy test suites
- `cargo deny check`
- regenerated OpenAPI is byte-identical to `docs/openapi.json`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`

