### PR TITLE
Complete permission storage query boundary

### DIFF
--- a/crates/hubuum-storage-core/src/authorization.rs
+++ b/crates/hubuum-storage-core/src/authorization.rs
@@ -585,6 +585,40 @@ pub struct AuthorizationGroupGrantPage {
     total_count: i64,
 }
 
+/// One complete local-policy row for backend-neutral policy export.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthorizationPolicySnapshotRow {
+    grant: AuthorizationGrant,
+    group: AuthorizationGroup,
+    collection: AuthorizationCollection,
+}
+
+impl AuthorizationPolicySnapshotRow {
+    #[must_use]
+    pub const fn new(
+        grant: AuthorizationGrant,
+        group: AuthorizationGroup,
+        collection: AuthorizationCollection,
+    ) -> Self {
+        Self {
+            grant,
+            group,
+            collection,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        AuthorizationGrant,
+        AuthorizationGroup,
+        AuthorizationCollection,
+    ) {
+        (self.grant, self.group, self.collection)
+    }
+}
+
 impl AuthorizationGroupGrantPage {
     #[must_use]
     pub const fn new(items: Vec<AuthorizationGroupGrant>, total_count: i64) -> Self {
@@ -765,6 +799,19 @@ pub trait AuthorizationStorage: Send + Sync {
         &self,
         query: AuthorizationCollectionsQuery,
     ) -> Result<Vec<AuthorizationCollection>, StorageError>;
+
+    async fn list_authorization_collection_candidates(
+        &self,
+    ) -> Result<Vec<AuthorizationCollection>, StorageError>;
+
+    async fn list_authorization_group_candidates(
+        &self,
+        query_options: QueryOptions,
+    ) -> Result<Vec<AuthorizationGroup>, StorageError>;
+
+    async fn authorization_policy_snapshot(
+        &self,
+    ) -> Result<Vec<AuthorizationPolicySnapshotRow>, StorageError>;
 
     async fn list_local_collection_grants(
         &self,

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -15,7 +15,7 @@ pub use authorization::{
     AuthorizationGrantKey, AuthorizationGrantMutation, AuthorizationGroup, AuthorizationGroupGrant,
     AuthorizationGroupGrantPage, AuthorizationGroupIdentity, AuthorizationGroupMembershipQuery,
     AuthorizationGroupProfile, AuthorizationGroupSyncState, AuthorizationPermission,
-    AuthorizationPrincipal, AuthorizationStorage,
+    AuthorizationPolicySnapshotRow, AuthorizationPrincipal, AuthorizationStorage,
 };
 pub use events::{
     EventArchive, EventDeliveryBatch, EventDeliveryClaim, EventDeliverySink, EventDeliveryStorage,

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -179,6 +179,13 @@ permission-set DTOs and are converted into API models only in the permission
 application layer. The opaque handle observes every entry point with bounded
 `authorization/*` operation labels.
 
+External policy evaluation uses the same boundary. Candidate collection and
+group reads, along with complete local-policy snapshots used for Cedar export,
+are mandatory authorization operations rather than connection recovery paths.
+Consequently the complete `src/permissions` application tree is independent of
+PostgreSQL, Diesel, generated schema modules, and connection pools; a source
+guard enforces that boundary.
+
 ## Error Direction
 
 Errors cross the boundary in one direction:

--- a/src/api/v1/handlers/history.rs
+++ b/src/api/v1/handlers/history.rs
@@ -325,15 +325,17 @@ mod tests {
 
         let allow_backend = MockTreetopBackend::new();
         allow_backend.add_admin_rule(policy_group.id);
-        let allow_context =
-            AppContext::postgres(test.pool.get_ref().clone(), Arc::new(allow_backend));
+        let allow_context = crate::tests::app_context_with_permission_backend(
+            test.pool.get_ref().clone(),
+            Arc::new(allow_backend),
+        );
         assert!(
             can_read_deleted_history(&allow_context, &test.normal_user, false)
                 .await
                 .unwrap()
         );
 
-        let deny_context = AppContext::postgres(
+        let deny_context = crate::tests::app_context_with_permission_backend(
             test.pool.get_ref().clone(),
             Arc::new(MockTreetopBackend::new()),
         );
@@ -370,7 +372,10 @@ mod tests {
                 ..Default::default()
             },
         });
-        let context = AppContext::postgres(test.pool.get_ref().clone(), backend.clone());
+        let context = crate::tests::app_context_with_permission_backend(
+            test.pool.get_ref().clone(),
+            backend.clone(),
+        );
         let timestamp = Utc::now();
         let visible = HubuumClassHistory {
             id: 41,

--- a/src/application.rs
+++ b/src/application.rs
@@ -526,7 +526,7 @@ mod tests {
 
     fn unreachable_context() -> AppContext {
         let pool = unreachable_pool();
-        AppContext::postgres(
+        crate::tests::app_context_with_permission_backend(
             pool.clone(),
             Arc::new(LocalPermissionBackend::new(
                 StorageHandle::postgres(pool),

--- a/src/backups/mod.rs
+++ b/src/backups/mod.rs
@@ -197,14 +197,13 @@ mod tests {
 
     use super::{BackupSettings, authorize_backup_request};
     use crate::errors::ApiError;
-    use crate::permissions::AppContext;
     use crate::permissions::test_support::MockTreetopBackend;
     use crate::tests::{TestContext, create_test_group};
 
     #[tokio::test]
     async fn configured_backend_can_deny_a_sql_administrator_backup() {
         let test = TestContext::new().await;
-        let context = AppContext::postgres(
+        let context = crate::tests::app_context_with_permission_backend(
             test.pool.get_ref().clone(),
             Arc::new(MockTreetopBackend::new()),
         );
@@ -224,7 +223,10 @@ mod tests {
             .unwrap();
         let backend = MockTreetopBackend::new();
         backend.add_admin_rule(policy_group.id);
-        let context = AppContext::postgres(test.pool.get_ref().clone(), Arc::new(backend));
+        let context = crate::tests::app_context_with_permission_backend(
+            test.pool.get_ref().clone(),
+            Arc::new(backend),
+        );
 
         authorize_backup_request(&context, &test.normal_user, None)
             .await

--- a/src/events/sink.rs
+++ b/src/events/sink.rs
@@ -82,7 +82,6 @@ impl SinkResolver for DefaultSinkResolver {
             #[cfg(feature = "valkey")]
             "valkey_stream" => Some(&self.valkey),
             "webhook" => Some(&self.webhook),
-            #[cfg(not(all(feature = "amqp", feature = "email", feature = "valkey")))]
             _ => None,
         }
     }
@@ -196,6 +195,11 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+
+    #[test]
+    fn default_resolver_rejects_unknown_sink_kinds() {
+        assert!(DefaultSinkResolver::default().resolve("unknown").is_none());
+    }
 
     struct RecordingSink;
 

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -2886,7 +2886,7 @@ mod tests {
         NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, Permissions,
     };
     use crate::permissions::test_support::{MockAllowRule, MockTreetopBackend};
-    use crate::permissions::{AppContext, ResourceAttrs, ResourceKind};
+    use crate::permissions::{ResourceAttrs, ResourceKind};
 
     use super::{
         AuthorizationCandidates, ExportRuntime, HydrationBudget, ObjectGraphEdge,
@@ -2991,8 +2991,10 @@ mod tests {
                 ..Default::default()
             },
         });
-        let backend =
-            AppContext::postgres(context.pool.get_ref().clone(), Arc::new(permission_backend));
+        let backend = crate::tests::app_context_with_permission_backend(
+            context.pool.get_ref().clone(),
+            Arc::new(permission_backend),
+        );
         let exporter = PermissionAwareExport::new(&backend, &context.normal_user, None)
             .await
             .unwrap();
@@ -3079,8 +3081,10 @@ mod tests {
             resource_id: Some(source_object.id),
             attrs: ResourceAttrs::default(),
         });
-        let backend =
-            AppContext::postgres(context.pool.get_ref().clone(), Arc::new(permission_backend));
+        let backend = crate::tests::app_context_with_permission_backend(
+            context.pool.get_ref().clone(),
+            Arc::new(permission_backend),
+        );
         let exporter = PermissionAwareExport::new(&backend, &context.normal_user, None)
             .await
             .unwrap();
@@ -3243,8 +3247,10 @@ mod tests {
                 attrs: ResourceAttrs::default(),
             });
         }
-        let backend =
-            AppContext::postgres(context.pool.get_ref().clone(), Arc::new(permission_backend));
+        let backend = crate::tests::app_context_with_permission_backend(
+            context.pool.get_ref().clone(),
+            Arc::new(permission_backend),
+        );
         let exporter = PermissionAwareExport::new(&backend, &context.normal_user, None)
             .await
             .unwrap();

--- a/src/models/unified_search.rs
+++ b/src/models/unified_search.rs
@@ -15,9 +15,9 @@ use crate::permissions::{
     PermissionBackend, PrincipalRef, ResourceAttrs, ResourceKind, ResourceRef,
 };
 use crate::storage::StorageContext;
-use crate::storage::postgres::operations::authz::scope_allows;
 use crate::storage::postgres::operations::user::UnifiedSearchBackend;
 use crate::traits::Search;
+use crate::traits::scope_allows;
 use crate::utilities::extensions::CustomStringExtensions;
 
 const MAX_UNIFIED_SEARCH_QUERY_LENGTH: usize = 256;

--- a/src/permissions/context.rs
+++ b/src/permissions/context.rs
@@ -3,8 +3,6 @@ use std::sync::Arc;
 use actix_web::{FromRequest, HttpRequest, dev::Payload, web::Data};
 use futures_util::future::{Ready, ready};
 
-#[cfg(any(test, feature = "integration-test-support"))]
-use crate::config::get_config;
 use crate::errors::ApiError;
 use crate::services::{
     ClassRelationService, ClassService, CollectionService, ObjectRelationService, ObjectService,
@@ -12,12 +10,8 @@ use crate::services::{
 };
 use crate::storage::StorageContext;
 use crate::storage::StorageHandle;
-#[cfg(any(test, feature = "integration-test-support"))]
-use crate::storage::postgres::PostgresPool;
 
 use super::backend::PermissionBackend;
-#[cfg(any(test, feature = "integration-test-support"))]
-use super::local::LocalPermissionBackend;
 
 #[derive(Clone)]
 pub struct AppContext {
@@ -36,30 +30,9 @@ impl AppContext {
         }
     }
 
-    /// PostgreSQL composition helper retained for integration tests.
-    #[doc(hidden)]
-    #[cfg(any(test, feature = "integration-test-support"))]
-    pub fn postgres(db_pool: PostgresPool, permissions: Arc<dyn PermissionBackend>) -> Self {
-        Self::new(StorageHandle::postgres(db_pool), permissions)
-    }
-
     pub(crate) fn from_http_request(req: &HttpRequest) -> Result<Self, ApiError> {
         if let Some(context) = req.app_data::<Data<Self>>() {
             return Ok(context.get_ref().clone());
-        }
-
-        #[cfg(any(test, feature = "integration-test-support"))]
-        if let Some(pool) = req.app_data::<Data<PostgresPool>>() {
-            let admin_groupname = get_config()
-                .map(|config| config.admin_groupname.clone())
-                .unwrap_or_else(|_| "admin".to_string());
-            return Ok(Self::postgres(
-                pool.get_ref().clone(),
-                Arc::new(LocalPermissionBackend::new(
-                    StorageHandle::postgres(pool.get_ref().clone()),
-                    admin_groupname,
-                )),
-            ));
         }
 
         Err(ApiError::InternalServerError(

--- a/src/permissions/export.rs
+++ b/src/permissions/export.rs
@@ -1,10 +1,10 @@
-//! SQL → Cedar policy export.
+//! Local permission-store → Cedar policy export.
 //!
-//! Walks the `permissions` table and emits one Cedar `permit` clause per
+//! Walks the local authorization snapshot and emits one Cedar `permit` clause per
 //! `(group_id, collection_id, resource_kind)` bucket. The output is a
 //! complete Cedar policy bundle that, when uploaded to a Treetop server
 //! configured with `docs/treetop/schema.cedarschema`, grants exactly the
-//! permissions the SQL table currently records.
+//! permissions the local store currently records.
 //!
 //! This is a one-shot tool: Hubuum does not push policies at runtime;
 //! the operator uploads the file via Treetop's own tooling. See
@@ -12,11 +12,11 @@
 
 use std::io::Write;
 
-use crate::storage::postgres::prelude::*;
-
 use crate::errors::ApiError;
 use crate::models::{Collection, Group, Permission};
-use crate::storage::postgres::with_connection;
+use crate::storage::{AuthorizationStorage, storage_handle};
+
+use super::storage::{collection_from_storage, grant_from_storage, group_from_storage};
 
 /// Helper macro to convert io::Error to ApiError for writeln! calls
 macro_rules! w {
@@ -30,23 +30,22 @@ macro_rules! w {
 
 /// Emit the Cedar bundle to `writer`.
 pub async fn export_cedar_to<W: Write>(
-    pool: &impl crate::storage::StorageContext,
+    backend: &impl crate::storage::StorageContext,
     writer: &mut W,
 ) -> Result<(), ApiError> {
-    use crate::schema::{collections, groups, permissions as perms_schema};
-
-    let rows: Vec<(Permission, Group, Collection)> = with_connection(pool, async |conn| {
-        perms_schema::table
-            .inner_join(groups::table.on(perms_schema::group_id.eq(groups::id)))
-            .inner_join(collections::table.on(perms_schema::collection_id.eq(collections::id)))
-            .order_by((
-                perms_schema::collection_id.asc(),
-                perms_schema::group_id.asc(),
+    let rows = storage_handle(backend)
+        .authorization_policy_snapshot()
+        .await?
+        .into_iter()
+        .map(|row| {
+            let (grant, group, collection) = row.into_parts();
+            Ok((
+                grant_from_storage(grant),
+                group_from_storage(group)?,
+                collection_from_storage(collection)?,
             ))
-            .load::<(Permission, Group, Collection)>(conn)
-            .await
-    })
-    .await?;
+        })
+        .collect::<Result<Vec<(Permission, Group, Collection)>, ApiError>>()?;
 
     w!(
         writer,
@@ -61,7 +60,7 @@ pub async fn export_cedar_to<W: Write>(
         "// Group IDs and Collection IDs are numeric; names appear in comments only."
     )?;
     w!(writer, "//")?;
-    w!(writer, "// Source: SQL permissions table at export time.")?;
+    w!(writer, "// Source: local permission store at export time.")?;
     w!(writer, "//")?;
     w!(
         writer,
@@ -69,7 +68,7 @@ pub async fn export_cedar_to<W: Write>(
     )?;
     w!(
         writer,
-        "// on EITHER endpoint collection can act on the relation. The Local SQL"
+        "// on EITHER endpoint collection can act on the relation. The local"
     )?;
     w!(
         writer,

--- a/src/permissions/mod.rs
+++ b/src/permissions/mod.rs
@@ -30,9 +30,8 @@ use std::sync::Arc;
 use crate::config::{AppConfig, PermissionBackendKind};
 use crate::errors::ApiError;
 use crate::models::{Permissions, TokenScope};
-use crate::storage::postgres::operations::authz::{scope_allows, scope_allows_resources};
 use crate::storage::{StorageContext, StorageHandle};
-use crate::traits::{AuthzSubject, PrincipalIdAccessor};
+use crate::traits::{AuthzSubject, PrincipalIdAccessor, scope_allows, scope_allows_resources};
 
 pub async fn authorize_resources<S>(
     backend: &dyn PermissionBackend,

--- a/src/permissions/storage.rs
+++ b/src/permissions/storage.rs
@@ -58,7 +58,7 @@ pub(super) fn collection_from_storage(
     })
 }
 
-fn group_from_storage(group: AuthorizationGroup) -> Result<Group, ApiError> {
+pub(super) fn group_from_storage(group: AuthorizationGroup) -> Result<Group, ApiError> {
     Ok(Group {
         id: group.id(),
         groupname: group.group_name().to_string(),

--- a/src/permissions/treetop/mod.rs
+++ b/src/permissions/treetop/mod.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 use std::time::{Duration, Instant};
 
-use crate::storage::postgres::prelude::*;
 use async_trait::async_trait;
 use reqwest::Certificate;
 use treetop_client::{
@@ -11,19 +10,17 @@ use treetop_client::{
 
 use crate::config::AppConfig;
 use crate::errors::ApiError;
-use crate::models::search::{FilterField, QueryOptions, QueryParamsExt};
+use crate::models::search::{QueryOptions, QueryParamsExt};
 use crate::models::{
-    Collection, CollectionID, Group, GroupID, GroupPermission, Permission, Permissions,
-    PermissionsList,
+    Collection, CollectionID, GroupID, GroupPermission, Permission, Permissions, PermissionsList,
 };
 use crate::pagination::{known_count_or_skipped, paginate_in_memory};
-use crate::schema::collections;
-use crate::storage::StorageHandle;
-use crate::storage::postgres::with_connection;
+use crate::storage::{AuthorizationStorage, StorageHandle};
 use crate::utilities::bounded_file::{MAX_CERTIFICATE_BUNDLE_BYTES, read_bounded_regular_file};
 
 use super::backend::PermissionBackend;
 use super::observability::{record_authorize_many, record_is_admin, record_reverse_query};
+use super::storage::{collection_from_storage, group_from_storage};
 use super::types::{PermissionDecision, PermissionRequest, PrincipalRef, ResourceRef};
 
 const BACKEND_KIND: &str = "treetop";
@@ -79,16 +76,6 @@ impl TreetopPermissionBackend {
         client.health().await.map_err(treetop_to_api_error)?;
 
         Ok(Self { client, storage })
-    }
-
-    #[doc(hidden)]
-    #[cfg(any(test, feature = "integration-test-support"))]
-    pub async fn connect_postgres(
-        url: &str,
-        cfg: &AppConfig,
-        pool: crate::storage::postgres::PostgresPool,
-    ) -> Result<Self, ApiError> {
-        Self::connect(url, cfg, StorageHandle::postgres(pool)).await
     }
 
     async fn authorize_cedar_requests(
@@ -363,14 +350,17 @@ impl PermissionBackend for TreetopPermissionBackend {
         principal: &PrincipalRef,
         permissions: &[Permissions],
     ) -> Result<Vec<Collection>, ApiError> {
-        // Enumerate candidates from the local DB, filter via Treetop.
+        // Enumerate candidates from storage, then filter via Treetop.
         // We load all collections without any permission filtering, then
         // use paginate_authorized to filter via Treetop batch authorization.
         let start = Instant::now();
-        let all_collections = with_connection(&self.storage, async |conn| {
-            collections::table.load::<Collection>(conn).await
-        })
-        .await?;
+        let all_collections = self
+            .storage
+            .list_authorization_collection_candidates()
+            .await?
+            .into_iter()
+            .map(collection_from_storage)
+            .collect::<Result<Vec<_>, _>>()?;
         let candidate_count = all_collections.len();
         let tested_permissions = if permissions.is_empty() {
             Permissions::all()
@@ -425,41 +415,15 @@ impl PermissionBackend for TreetopPermissionBackend {
         permissions_filter: &[Permissions],
         page: &QueryOptions,
     ) -> Result<(Vec<GroupPermission>, i64), ApiError> {
-        use crate::schema::groups::dsl::{
-            created_at, groupname, groups as groups_dsl, id, updated_at,
-        };
-        use crate::{date_search, numeric_search, string_search};
-
         let start = Instant::now();
         let collection_id = collection_id.id();
-
-        let mut group_query = groups_dsl.into_boxed();
-        for param in &page.filters {
-            let operator = param.operator.clone();
-            match param.field {
-                FilterField::Id => numeric_search!(group_query, param, operator, id),
-                FilterField::Name | FilterField::Groupname => {
-                    string_search!(group_query, param, operator, groupname)
-                }
-                FilterField::CreatedAt => {
-                    date_search!(group_query, param, operator, created_at)
-                }
-                FilterField::UpdatedAt => {
-                    date_search!(group_query, param, operator, updated_at)
-                }
-                FilterField::Permissions => {}
-                _ => {
-                    return Err(ApiError::BadRequest(format!(
-                        "Field '{}' isn't searchable (or does not exist) for permissions",
-                        param.field
-                    )));
-                }
-            }
-        }
-        let all_groups: Vec<Group> = with_connection(&self.storage, async |conn| {
-            group_query.load::<Group>(conn).await
-        })
-        .await?;
+        let all_groups = self
+            .storage
+            .list_authorization_group_candidates(page.clone())
+            .await?
+            .into_iter()
+            .map(group_from_storage)
+            .collect::<Result<Vec<_>, _>>()?;
         let candidate_count = all_groups.len();
 
         if all_groups.is_empty() {

--- a/src/permissions/visibility.rs
+++ b/src/permissions/visibility.rs
@@ -4,8 +4,7 @@ use crate::errors::ApiError;
 use crate::models::search::QueryOptions;
 use crate::models::{Permissions, TokenScope};
 use crate::pagination::{known_count_or_skipped, paginate_in_memory};
-use crate::storage::postgres::operations::authz::{scope_allows, scope_allows_resource};
-use crate::traits::CursorPaginated;
+use crate::traits::{CursorPaginated, scope_allows, scope_allows_resource};
 
 use super::backend::PermissionBackend;
 use super::observability::record_paginate_authorized;

--- a/src/storage/capabilities.rs
+++ b/src/storage/capabilities.rs
@@ -16,9 +16,7 @@ pub(crate) mod active_tokens {
 }
 
 pub(crate) mod authz {
-    pub use crate::storage::postgres::operations::authz::{
-        scope_allows, scope_allows_resource, scope_allows_resources,
-    };
+    pub use crate::traits::{scope_allows, scope_allows_resource, scope_allows_resources};
 }
 
 pub(crate) mod backup {

--- a/src/storage/context.rs
+++ b/src/storage/context.rs
@@ -1,6 +1,7 @@
 use actix_web::web::Data;
 
 use crate::events::{EventDeliverySettings, EventFanoutSettings, EventRetentionSettings};
+use crate::models::search::QueryOptions;
 use crate::models::{MaintenanceState, TokenRetentionSettings};
 use crate::permissions::{AppContext, PermissionBackend};
 use crate::storage::observed::observe_storage_call;
@@ -9,14 +10,14 @@ use crate::storage::{
     AuthenticationIdentity, AuthenticationStorage, AuthenticationTokenScope,
     AuthenticationTokenScopeQuery, AuthorizationCollection, AuthorizationCollectionAccessQuery,
     AuthorizationCollectionGrantListQuery, AuthorizationCollectionsQuery, AuthorizationGrant,
-    AuthorizationGrantKey, AuthorizationGrantMutation, AuthorizationGroupGrantPage,
-    AuthorizationGroupMembershipQuery, AuthorizationPrincipal, AuthorizationStorage,
-    DynLifecycleStorage, EventArchive, EventDeliveryBatch, EventDeliveryClaim,
-    EventDeliveryHealthSnapshot, EventDeliveryStorage, EventFanoutStorage, EventHealthStorage,
-    EventMetricsSnapshot, EventRetentionStorage, EventRetentionSummary, InventoryGaugeSnapshot,
-    MetricsStorage, OperationalStateStorage, PostgresStorage, ReadinessSnapshot, StorageBackend,
-    StorageBackendDescriptor, StorageError, StoragePoolState, TaskGaugeSnapshot,
-    TokenRetentionStorage,
+    AuthorizationGrantKey, AuthorizationGrantMutation, AuthorizationGroup,
+    AuthorizationGroupGrantPage, AuthorizationGroupMembershipQuery, AuthorizationPolicySnapshotRow,
+    AuthorizationPrincipal, AuthorizationStorage, DynLifecycleStorage, EventArchive,
+    EventDeliveryBatch, EventDeliveryClaim, EventDeliveryHealthSnapshot, EventDeliveryStorage,
+    EventFanoutStorage, EventHealthStorage, EventMetricsSnapshot, EventRetentionStorage,
+    EventRetentionSummary, InventoryGaugeSnapshot, MetricsStorage, OperationalStateStorage,
+    PostgresStorage, ReadinessSnapshot, StorageBackend, StorageBackendDescriptor, StorageError,
+    StoragePoolState, TaskGaugeSnapshot, TokenRetentionStorage,
 };
 use async_trait::async_trait;
 
@@ -188,6 +189,63 @@ impl AuthorizationStorage for StorageHandle {
                 match &self.implementation {
                     BackendImplementation::Postgresql(backend) => {
                         backend.local_authorized_collections(query).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn list_authorization_collection_candidates(
+        &self,
+    ) -> Result<Vec<AuthorizationCollection>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "authorization",
+            "list_collection_candidates",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.list_authorization_collection_candidates().await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn list_authorization_group_candidates(
+        &self,
+        query_options: QueryOptions,
+    ) -> Result<Vec<AuthorizationGroup>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "authorization",
+            "list_group_candidates",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend
+                            .list_authorization_group_candidates(query_options)
+                            .await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn authorization_policy_snapshot(
+        &self,
+    ) -> Result<Vec<AuthorizationPolicySnapshotRow>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "authorization",
+            "policy_snapshot",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.authorization_policy_snapshot().await
                     }
                 }
             },

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -32,10 +32,10 @@ pub(crate) use hubuum_storage_core::{
     AuthorizationGrantKey, AuthorizationGrantMutation, AuthorizationGroup, AuthorizationGroupGrant,
     AuthorizationGroupGrantPage, AuthorizationGroupIdentity, AuthorizationGroupMembershipQuery,
     AuthorizationGroupProfile, AuthorizationGroupSyncState, AuthorizationPermission,
-    AuthorizationPrincipal, AuthorizationStorage, EventArchive, EventDeliveryBatch,
-    EventDeliveryClaim, EventDeliverySink, EventDeliveryStorage, EventDeliverySubscription,
-    EventDeliveryWorkItem, EventFanoutStorage, EventRetentionStorage, EventRetentionSummary,
-    RetainedEvent,
+    AuthorizationPolicySnapshotRow, AuthorizationPrincipal, AuthorizationStorage, EventArchive,
+    EventDeliveryBatch, EventDeliveryClaim, EventDeliverySink, EventDeliveryStorage,
+    EventDeliverySubscription, EventDeliveryWorkItem, EventFanoutStorage, EventRetentionStorage,
+    EventRetentionSummary, RetainedEvent,
 };
 pub(crate) use hubuum_storage_core::{StorageError, StorageErrorKind};
 #[cfg(test)]

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -8,6 +8,7 @@ pub use runtime::*;
 use async_trait::async_trait;
 
 use crate::events::{EventContext, EventFanoutSettings, EventRetentionSettings};
+use crate::models::search::QueryOptions;
 use crate::models::{
     ClassSelector, Collection, CollectionID, HubuumClass, HubuumClassRelationID, HubuumObject,
     MaintenanceState, NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation,
@@ -41,14 +42,14 @@ use super::{
     AuthenticationIdentity, AuthenticationStorage, AuthenticationTokenScope,
     AuthenticationTokenScopeQuery, AuthorizationCollection, AuthorizationCollectionAccessQuery,
     AuthorizationCollectionGrantListQuery, AuthorizationCollectionsQuery, AuthorizationGrant,
-    AuthorizationGrantKey, AuthorizationGrantMutation, AuthorizationGroupGrantPage,
-    AuthorizationGroupMembershipQuery, AuthorizationPrincipal, AuthorizationStorage,
-    ClassRelationStore, ClassStore, CollectionStore, EventArchive, EventDeliveryBatch,
-    EventDeliveryClaim, EventDeliveryHealthSnapshot, EventDeliveryStorage, EventFanoutStorage,
-    EventHealthStorage, EventMetricsSnapshot, EventRetentionStorage, EventRetentionSummary,
-    InventoryGaugeSnapshot, MetricsStorage, ObjectRelationStore, ObjectStore,
-    OperationalStateStorage, ReadinessSnapshot, StorageError, StorageIdentity, StoragePoolState,
-    TaskGaugeSnapshot, TokenRetentionStorage,
+    AuthorizationGrantKey, AuthorizationGrantMutation, AuthorizationGroup,
+    AuthorizationGroupGrantPage, AuthorizationGroupMembershipQuery, AuthorizationPolicySnapshotRow,
+    AuthorizationPrincipal, AuthorizationStorage, ClassRelationStore, ClassStore, CollectionStore,
+    EventArchive, EventDeliveryBatch, EventDeliveryClaim, EventDeliveryHealthSnapshot,
+    EventDeliveryStorage, EventFanoutStorage, EventHealthStorage, EventMetricsSnapshot,
+    EventRetentionStorage, EventRetentionSummary, InventoryGaugeSnapshot, MetricsStorage,
+    ObjectRelationStore, ObjectStore, OperationalStateStorage, ReadinessSnapshot, StorageError,
+    StorageIdentity, StoragePoolState, TaskGaugeSnapshot, TokenRetentionStorage,
 };
 use error::map_postgres_error;
 
@@ -129,6 +130,31 @@ impl AuthorizationStorage for PostgresStorage {
         query: AuthorizationCollectionsQuery,
     ) -> Result<Vec<AuthorizationCollection>, StorageError> {
         operations::authorization::local_authorized_collections(&self.pool, query)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn list_authorization_collection_candidates(
+        &self,
+    ) -> Result<Vec<AuthorizationCollection>, StorageError> {
+        operations::authorization::list_authorization_collection_candidates(&self.pool)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn list_authorization_group_candidates(
+        &self,
+        query_options: QueryOptions,
+    ) -> Result<Vec<AuthorizationGroup>, StorageError> {
+        operations::authorization::list_authorization_group_candidates(&self.pool, query_options)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn authorization_policy_snapshot(
+        &self,
+    ) -> Result<Vec<AuthorizationPolicySnapshotRow>, StorageError> {
+        operations::authorization::authorization_policy_snapshot(&self.pool)
             .await
             .map_err(map_postgres_error)
     }

--- a/src/storage/postgres/operations/authorization.rs
+++ b/src/storage/postgres/operations/authorization.rs
@@ -1,6 +1,7 @@
 use diesel::dsl::{exists, select};
 
 use crate::errors::ApiError;
+use crate::models::search::{FilterField, QueryOptions};
 use crate::models::{
     Collection, CollectionID, Group, GroupID, GroupPermission, Permission, Permissions,
     PermissionsList, PrincipalID,
@@ -14,7 +15,7 @@ use crate::storage::{
     AuthorizationGrantKey, AuthorizationGrantMutation, AuthorizationGroup, AuthorizationGroupGrant,
     AuthorizationGroupGrantPage, AuthorizationGroupIdentity, AuthorizationGroupMembershipQuery,
     AuthorizationGroupProfile, AuthorizationGroupSyncState, AuthorizationPermission,
-    AuthorizationPrincipal,
+    AuthorizationPolicySnapshotRow, AuthorizationPrincipal,
 };
 use crate::traits::PermissionController;
 
@@ -271,6 +272,84 @@ pub(crate) async fn local_authorized_collections(
     })
     .await?;
     Ok(rows.into_iter().map(collection_to_storage).collect())
+}
+
+pub(crate) async fn list_authorization_collection_candidates(
+    pool: &PostgresPool,
+) -> Result<Vec<AuthorizationCollection>, ApiError> {
+    use crate::schema::collections;
+
+    let rows = with_connection(pool, async |conn| {
+        collections::table
+            .order_by(collections::id.asc())
+            .load::<Collection>(conn)
+            .await
+    })
+    .await?;
+    Ok(rows.into_iter().map(collection_to_storage).collect())
+}
+
+pub(crate) async fn list_authorization_group_candidates(
+    pool: &PostgresPool,
+    query_options: QueryOptions,
+) -> Result<Vec<AuthorizationGroup>, ApiError> {
+    use crate::schema::groups::dsl::{created_at, groupname, groups as groups_dsl, id, updated_at};
+    use crate::{date_search, numeric_search, string_search};
+
+    let mut query = groups_dsl.into_boxed();
+    for parameter in &query_options.filters {
+        let operator = parameter.operator.clone();
+        match parameter.field {
+            FilterField::Id => numeric_search!(query, parameter, operator, id),
+            FilterField::Name | FilterField::Groupname => {
+                string_search!(query, parameter, operator, groupname)
+            }
+            FilterField::CreatedAt => {
+                date_search!(query, parameter, operator, created_at)
+            }
+            FilterField::UpdatedAt => {
+                date_search!(query, parameter, operator, updated_at)
+            }
+            FilterField::Permissions => {}
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' isn't searchable (or does not exist) for permissions",
+                    parameter.field
+                )));
+            }
+        }
+    }
+    let rows = with_connection(pool, async |conn| query.load::<Group>(conn).await).await?;
+    Ok(rows.into_iter().map(group_to_storage).collect())
+}
+
+pub(crate) async fn authorization_policy_snapshot(
+    pool: &PostgresPool,
+) -> Result<Vec<AuthorizationPolicySnapshotRow>, ApiError> {
+    use crate::schema::{collections, groups, permissions};
+
+    let rows = with_connection(pool, async |conn| {
+        permissions::table
+            .inner_join(groups::table.on(permissions::group_id.eq(groups::id)))
+            .inner_join(collections::table.on(permissions::collection_id.eq(collections::id)))
+            .order_by((
+                permissions::collection_id.asc(),
+                permissions::group_id.asc(),
+            ))
+            .load::<(Permission, Group, Collection)>(conn)
+            .await
+    })
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(grant, group, collection)| {
+            AuthorizationPolicySnapshotRow::new(
+                grant_to_storage(grant),
+                group_to_storage(group),
+                collection_to_storage(collection),
+            )
+        })
+        .collect())
 }
 
 pub(crate) async fn list_local_collection_grants(

--- a/src/storage/postgres/operations/authz.rs
+++ b/src/storage/postgres/operations/authz.rs
@@ -22,12 +22,12 @@ use crate::models::permissions::Permissions;
 use crate::models::{
     CollectionID, HubuumClassID, HubuumObjectID, PrincipalToken, TokenResourceScope, TokenScope,
 };
-use crate::permissions::ResourceRef;
 use crate::schema::{
     group_memberships, token_class_scopes, token_collection_scopes, token_object_scopes,
     token_scopes,
 };
 use crate::storage::postgres::{PostgresConnection, with_connection};
+pub use crate::traits::{scope_allows, scope_allows_resource, scope_allows_resources};
 
 /// Identity-only authorization subject: principal id, group membership, admin
 /// status, and kind. Implemented once (blanket) for everything that can name a
@@ -46,35 +46,6 @@ pub trait AuthzSubject: crate::traits::AuthzSubject {
 }
 
 impl<T: crate::traits::AuthzSubject + ?Sized> AuthzSubject for T {}
-
-/// Fail-closed token-scope pre-filter.
-///
-/// Returns `true` iff the token scope set permits *all* of `requested`:
-/// * `None`        ⇒ unscoped ⇒ always allowed.
-/// * `Some(scope)` ⇒ every requested permission must be present when the
-///   permission dimension is enabled; an empty enabled dimension denies all.
-///
-/// Callers apply this **before** the admin-bypass so a scoped admin token can
-/// never exceed its scopes.
-pub fn scope_allows(scopes: Option<&TokenScope>, requested: &[Permissions]) -> bool {
-    match scopes {
-        None => true,
-        Some(scope) => scope.allows_permissions(requested),
-    }
-}
-
-/// Fail-closed resource-identity pre-filter for a token scope.
-pub fn scope_allows_resource(scope: Option<&TokenScope>, resource: &ResourceRef) -> bool {
-    scope.is_none_or(|scope| scope.allows_resource(resource))
-}
-
-/// Require every resource touched by an operation to be inside the token's
-/// resource boundary.
-pub fn scope_allows_resources(scope: Option<&TokenScope>, resources: &[ResourceRef]) -> bool {
-    resources
-        .iter()
-        .all(|resource| scope_allows_resource(scope, resource))
-}
 
 /// Load a token's permission dimension from `token_scopes`, validating each
 /// stored string against the `Permissions` enum (fail-closed on an unknown

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -36,9 +36,9 @@ use crate::models::{
     RemoteAuthConfig, RemoteHttpMethod, RemoteTargetSubjectType, ResourceRevision,
     RestoreTimestamps, TaskKind, TaskStatus,
 };
+use crate::permissions::PermissionBackend;
 use crate::permissions::test_support::{MockAllowRule, MockTreetopBackend};
 use crate::permissions::types::{ResourceAttrs, ResourceKind};
-use crate::permissions::{AppContext, PermissionBackend};
 use crate::schema::collections::dsl::{collections, name as collection_name};
 use crate::schema::hubuumclass::dsl::{hubuumclass, name as class_name};
 use crate::schema::tasks::dsl::{created_at, id as task_id, tasks};
@@ -196,7 +196,10 @@ async fn import_planning_uses_the_task_execution_permission_backend() {
         .collection_fixture("external_task_authorization")
         .await;
     let permissions: Arc<dyn PermissionBackend> = Arc::new(MockTreetopBackend::new());
-    let backend = AppContext::postgres(context.pool.get_ref().clone(), permissions);
+    let backend = crate::tests::app_context_with_permission_backend(
+        context.pool.get_ref().clone(),
+        permissions,
+    );
     let request = ImportRequest {
         version: CURRENT_IMPORT_VERSION,
         dry_run: Some(true),
@@ -320,8 +323,10 @@ async fn relation_timestamp_overwrite_requires_update_permission(
             },
         });
     }
-    let backend =
-        AppContext::postgres(context.pool.get_ref().clone(), Arc::new(permission_backend));
+    let backend = crate::tests::app_context_with_permission_backend(
+        context.pool.get_ref().clone(),
+        Arc::new(permission_backend),
+    );
 
     let collection_key = |index: usize| CollectionKey {
         name: fixtures[index].collection.name.clone(),
@@ -884,7 +889,7 @@ async fn core_imports_without_timestamps_use_database_transaction_time() {
 #[tokio::test]
 async fn test_extended_import_uses_backend_denial_for_sql_administrator() {
     let test = TestContext::new().await;
-    let context = AppContext::postgres(
+    let context = crate::tests::app_context_with_permission_backend(
         test.pool.get_ref().clone(),
         Arc::new(MockTreetopBackend::new()),
     );
@@ -909,7 +914,10 @@ async fn test_extended_import_uses_backend_grant_for_non_sql_administrator() {
         .unwrap();
     let backend = MockTreetopBackend::new();
     backend.add_admin_rule(policy_group.id);
-    let context = AppContext::postgres(test.pool.get_ref().clone(), Arc::new(backend));
+    let context = crate::tests::app_context_with_permission_backend(
+        test.pool.get_ref().clone(),
+        Arc::new(backend),
+    );
     let request = extended_import_request(test.scoped_name("backend_allowed_import"));
 
     let planning = plan_import(&context, &test.normal_user, None, &request).await;

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -223,7 +223,7 @@ fn task_worker_context(context: AppContext) -> AppContext {
         crate::storage::StorageHandle::postgres(pool.clone()),
         config.admin_groupname.clone(),
     ));
-    AppContext::postgres(pool, permissions)
+    crate::tests::app_context_with_permission_backend(pool, permissions)
 }
 
 fn configured_backup_settings() -> BackupSettings {

--- a/src/tests/acl.rs
+++ b/src/tests/acl.rs
@@ -30,6 +30,7 @@ async fn test_endpoint_access() {
             ))
             .app_data(Data::new(RunningConfig::from(&config)))
             .app_data(Data::new(pool.clone()))
+            .app_data(crate::tests::app_context(&pool))
             .configure(crate::api::config),
     )
     .await;

--- a/src/tests/api_operations.rs
+++ b/src/tests/api_operations.rs
@@ -21,7 +21,17 @@ pub fn app_context(pool: &PostgresPool) -> Data<AppContext> {
         StorageHandle::postgres(pool.clone()),
         config.admin_groupname.clone(),
     );
-    Data::new(AppContext::postgres(pool.clone(), Arc::new(permissions)))
+    Data::new(app_context_with_permission_backend(
+        pool.clone(),
+        Arc::new(permissions),
+    ))
+}
+
+pub fn app_context_with_permission_backend(
+    pool: PostgresPool,
+    permissions: Arc<dyn PermissionBackend>,
+) -> AppContext {
+    AppContext::new(StorageHandle::postgres(pool), permissions)
 }
 
 fn create_token_header(token: &str) -> (http::header::HeaderName, String) {
@@ -115,7 +125,10 @@ pub async fn get_request_with_permission_backend(
     endpoint: &str,
     permissions: Arc<dyn PermissionBackend>,
 ) -> actix_web::dev::ServiceResponse {
-    let context = Data::new(AppContext::postgres(pool.clone(), permissions));
+    let context = Data::new(app_context_with_permission_backend(
+        pool.clone(),
+        permissions,
+    ));
     get_request_with_headers_and_context(pool, token, endpoint, Vec::new(), context).await
 }
 

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -62,6 +62,9 @@ fn app_context_exposes_only_an_opaque_backend_handle() {
         "pub fn postgres_pool",
         "pub fn clone_postgres_pool",
         "impl Deref for AppContext",
+        "crate::storage::postgres",
+        "PostgresPool",
+        "fn postgres",
     ] {
         assert!(
             !context_source.contains(forbidden),
@@ -101,6 +104,7 @@ fn application_consumers_do_not_import_database_implementation_details() {
         "src/extractors",
         "src/middlewares",
         "src/observability/metrics",
+        "src/permissions",
     ] {
         paths.extend(rust_files(&root.join(directory)));
     }
@@ -111,9 +115,6 @@ fn application_consumers_do_not_import_database_implementation_details() {
         "src/events/fanout.rs",
         "src/events/retention.rs",
         "src/exports/mod.rs",
-        "src/permissions/local/mod.rs",
-        "src/permissions/storage.rs",
-        "src/permissions/types.rs",
         "src/restores/mod.rs",
         "src/tasks/helpers.rs",
         "src/tasks/preload.rs",

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 pub mod acl;
 pub mod api_operations;
-pub use api_operations::app_context;
+pub use api_operations::{app_context, app_context_with_permission_backend};
 pub mod application_boundary;
 pub mod asserts;
 #[cfg(test)]

--- a/src/tests/permissions/exporter_round_trip.rs
+++ b/src/tests/permissions/exporter_round_trip.rs
@@ -1,6 +1,6 @@
-//! Round-trip test for the SQL → Cedar exporter.
+//! Round-trip test for the local permission-store → Cedar exporter.
 //!
-//! Builds a fixture in the SQL `permissions` table via
+//! Builds a fixture in the local permission store via
 //! `LocalPermissionBackend`, runs the exporter, parses the Cedar output
 //! into `MockAllowRule`s, installs them on a `MockTreetopBackend`, and
 //! verifies both backends produce identical decisions for representative

--- a/src/tests/permissions/live_treetop_parity.rs
+++ b/src/tests/permissions/live_treetop_parity.rs
@@ -22,6 +22,7 @@ use crate::models::{CollectionID, GroupID, Permissions};
 use crate::permissions::backend::PermissionBackend;
 use crate::permissions::treetop::TreetopPermissionBackend;
 use crate::permissions::types::{PermissionDecision, PermissionRequest, PrincipalRef, ResourceRef};
+use crate::storage::StorageHandle;
 use crate::tests::get_test_pool;
 
 /// Numeric IDs the external Treetop fixture is expected to recognize.
@@ -38,8 +39,8 @@ fn treetop_url() -> Option<String> {
 }
 
 /// Build a TreetopPermissionBackend pointed at the live server. Uses the
-/// shared test pool so the candidate-enumeration paths in the backend
-/// (e.g. collections_user_can) have a real DB to query.
+/// shared test storage so candidate-enumeration paths exercise the production
+/// adapter contract.
 async fn live_backend(url: &str) -> Result<TreetopPermissionBackend, ApiError> {
     let pool = get_test_pool().get_ref().clone();
     // In test context, get_config() uses get_config_from_env() which reads
@@ -47,7 +48,7 @@ async fn live_backend(url: &str) -> Result<TreetopPermissionBackend, ApiError> {
     let mut cfg = get_config().expect("failed to load test config").clone();
     cfg.treetop_url = Some(url.to_string());
     cfg.permission_backend = PermissionBackendKind::Treetop;
-    TreetopPermissionBackend::connect_postgres(url, &cfg, pool).await
+    TreetopPermissionBackend::connect(url, &cfg, StorageHandle::postgres(pool)).await
 }
 
 #[actix_test]

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -215,6 +215,43 @@ async fn every_available_storage_backend_supplies_local_authorization_data() {
                 assert!(total_count >= 1);
                 assert!(!items.is_empty());
 
+                let collection_candidates = backend
+                    .list_authorization_collection_candidates()
+                    .await
+                    .expect("certified backend should list authorization collection candidates");
+                assert!(
+                    collection_candidates
+                        .iter()
+                        .any(|collection| collection.id() == fixture.collection.id)
+                );
+
+                let group_candidates = backend
+                    .list_authorization_group_candidates(QueryOptions {
+                        filters: Vec::new(),
+                        sort: Vec::new(),
+                        limit: None,
+                        cursor: None,
+                        include_total: false,
+                    })
+                    .await
+                    .expect("certified backend should list authorization group candidates");
+                assert!(
+                    group_candidates
+                        .iter()
+                        .any(|candidate| candidate.id() == group.id)
+                );
+
+                let policy_snapshot = backend
+                    .authorization_policy_snapshot()
+                    .await
+                    .expect("certified backend should supply the local policy snapshot");
+                assert!(policy_snapshot.into_iter().any(|row| {
+                    let (grant, snapshot_group, collection) = row.into_parts();
+                    grant.group_id() == group.id
+                        && snapshot_group.id() == group.id
+                        && collection.id() == fixture.collection.id
+                }));
+
                 backend
                     .revoke_local_collection_grant(AuthorizationGrantMutation::new(
                         key,

--- a/src/traits/authz.rs
+++ b/src/traits/authz.rs
@@ -6,7 +6,10 @@
 
 use crate::errors::ApiError;
 use crate::models::identity::LOCAL_IDENTITY_SCOPE;
-use crate::models::{Principal, PrincipalID, ServiceAccount, ServiceAccountID, User, UserID};
+use crate::models::{
+    Permissions, Principal, PrincipalID, ServiceAccount, ServiceAccountID, TokenScope, User, UserID,
+};
+use crate::permissions::ResourceRef;
 use crate::storage::{
     AuthenticationPrincipal, AuthorizationGroupMembershipQuery, AuthorizationStorage,
     StorageContext, storage_handle,
@@ -108,3 +111,24 @@ pub trait AuthzSubject: PrincipalIdAccessor {
 }
 
 impl<T: PrincipalIdAccessor + ?Sized> AuthzSubject for T {}
+
+/// Fail-closed token-scope permission pre-filter.
+pub fn scope_allows(scopes: Option<&TokenScope>, requested: &[Permissions]) -> bool {
+    match scopes {
+        None => true,
+        Some(scope) => scope.allows_permissions(requested),
+    }
+}
+
+/// Fail-closed resource-identity pre-filter for a token scope.
+pub fn scope_allows_resource(scope: Option<&TokenScope>, resource: &ResourceRef) -> bool {
+    scope.is_none_or(|scope| scope.allows_resource(resource))
+}
+
+/// Require every resource touched by an operation to be inside the token's
+/// resource boundary.
+pub fn scope_allows_resources(scope: Option<&TokenScope>, resources: &[ResourceRef]) -> bool {
+    resources
+        .iter()
+        .all(|resource| scope_allows_resource(scope, resource))
+}

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -6,7 +6,9 @@ pub mod pagination;
 pub mod permissions;
 
 pub use accessors::{ClassAccessors, CollectionAccessors, ObjectAccessors, SelfAccessors};
-pub use authz::{AuthzSubject, PrincipalIdAccessor};
+pub use authz::{
+    AuthzSubject, PrincipalIdAccessor, scope_allows, scope_allows_resource, scope_allows_resources,
+};
 pub use crud::{CanDelete, CanSave, CanUpdate, Validate, ValidateAgainstSchema};
 pub use pagination::*;
 pub use permissions::PermissionController;

--- a/tests/api_core_data_suite/object_aggregates/external_authorization.rs
+++ b/tests/api_core_data_suite/object_aggregates/external_authorization.rs
@@ -9,10 +9,12 @@ async fn get_with_permission_backend(
     let app = test::init_service(
         App::new()
             .app_data(Data::new(context.pool.get_ref().clone()))
-            .app_data(Data::new(AppContext::postgres(
-                context.pool.get_ref().clone(),
-                backend,
-            )))
+            .app_data(Data::new(
+                crate::tests::app_context_with_permission_backend(
+                    context.pool.get_ref().clone(),
+                    backend,
+                ),
+            ))
             .configure(crate::api::config),
     )
     .await;

--- a/tests/api_core_data_suite/object_aggregates/mod.rs
+++ b/tests/api_core_data_suite/object_aggregates/mod.rs
@@ -12,7 +12,7 @@ use crate::models::{
 };
 use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER};
 use crate::permissions::test_support::mock_treetop::{MockAllowRule, MockTreetopBackend};
-use crate::permissions::{AppContext, PermissionBackend, ResourceAttrs, ResourceKind};
+use crate::permissions::{PermissionBackend, ResourceAttrs, ResourceKind};
 use crate::storage::postgres::operations::computed_field::{
     class_computation_state_for, create_personal_definition, create_shared_definition,
     execute_computed_reindex_task, update_shared_definition,

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -35,6 +35,7 @@ async fn metrics_endpoint_exports_prometheus_text(#[future(awt)] test_context: T
     let app = test::init_service(
         App::new()
             .app_data(context.pool.clone())
+            .app_data(crate::tests::app_context(&context.pool))
             .route("/metrics", web::get().to(metrics::scrape)),
     )
     .await;
@@ -90,9 +91,11 @@ async fn metrics_endpoint_is_best_effort_when_database_refresh_fails() {
     metrics::init().unwrap();
     clear_metrics_scrape_cache();
 
+    let pool = web::Data::new(unreachable_pool());
     let app = test::init_service(
         App::new()
-            .app_data(web::Data::new(unreachable_pool()))
+            .app_data(pool.clone())
+            .app_data(crate::tests::app_context(&pool))
             .route("/metrics", web::get().to(metrics::scrape)),
     )
     .await;
@@ -258,6 +261,7 @@ async fn task_gauges_export_zero_for_bounded_kind_status_pairs(
     let app = test::init_service(
         App::new()
             .app_data(context.pool.clone())
+            .app_data(crate::tests::app_context(&context.pool))
             .route("/metrics", web::get().to(metrics::scrape)),
     )
     .await;
@@ -320,6 +324,7 @@ async fn task_terminal_gauge_exports_latest_finished_timestamp(
     let app = test::init_service(
         App::new()
             .app_data(context.pool.clone())
+            .app_data(crate::tests::app_context(&context.pool))
             .route("/metrics", web::get().to(metrics::scrape)),
     )
     .await;
@@ -364,10 +369,12 @@ async fn tracing_metrics_keep_stable_route_templates() {
         HttpResponse::Ok().finish()
     }
 
+    let pool = web::Data::new(unreachable_pool());
     let app = test::init_service(
         App::new()
             .wrap(TracingMiddleware::new())
-            .app_data(web::Data::new(unreachable_pool()))
+            .app_data(pool.clone())
+            .app_data(crate::tests::app_context(&pool))
             .route(
                 "/api/v1/classes/{class_id}/objects/{object_id}",
                 web::get().to(ok),
@@ -438,9 +445,11 @@ async fn scrape_recorded_metrics(record: impl FnOnce()) -> String {
     clear_metrics_scrape_cache();
     record();
 
+    let pool = web::Data::new(unreachable_pool());
     let app = test::init_service(
         App::new()
-            .app_data(web::Data::new(unreachable_pool()))
+            .app_data(pool.clone())
+            .app_data(crate::tests::app_context(&pool))
             .route("/metrics", web::get().to(metrics::scrape)),
     )
     .await;

--- a/tests/api_platform_suite/probes.rs
+++ b/tests/api_platform_suite/probes.rs
@@ -20,9 +20,11 @@ async fn test_healthz_returns_ok_without_database_pool() {
 
 #[actix_web::test]
 async fn test_readyz_checks_database_connectivity() {
+    let pool = get_test_pool();
     let app = test::init_service(
         App::new()
-            .app_data(get_test_pool())
+            .app_data(pool.clone())
+            .app_data(crate::tests::app_context(&pool))
             .configure(prod_api::config),
     )
     .await;


### PR DESCRIPTION
## Summary

Complete the storage boundary used by both local and external authorization by making policy candidates and policy snapshots mandatory backend operations.

This layer removes the final PostgreSQL, Diesel, schema, and pool dependencies from the complete `src/permissions` application tree. It also removes the test-only `AppContext` PostgreSQL fallback so application composition must install an explicit opaque storage handle.

## What changed

- Add mandatory authorization operations for collection candidates, filtered group candidates, and complete local-policy snapshots.
- Add backend-neutral policy snapshot DTOs to `hubuum-storage-core` and implement the contract in the PostgreSQL adapter.
- Route every new operation through `StorageHandle` with bounded `authorization/*` metric labels and adapter-error translation.
- Make Treetop candidate enumeration and Cedar policy export consume the authorization storage contract instead of Diesel queries.
- Move pure token-scope checks out of PostgreSQL operations and into the backend-neutral authorization layer.
- Remove `AppContext::postgres` and raw-pool fallback extraction; tests now compose an explicit application context.
- Extend the shared backend compatibility suite and source guards so every selectable backend must provide these operations and the whole permissions tree remains implementation-neutral.
- Keep the default event-sink resolver exhaustive under the complete feature combination, with a regression test for unknown sink kinds.

## Why

External policy engines still need local resource candidates and policy-export data. Those needs are storage capabilities, not reasons for consumers to recover a PostgreSQL connection. Making them part of the enforced trait keeps the application and permission layers independent of the selected adapter and prevents partially implemented backends.

## Impact

This is an internal architecture change. HTTP behavior and OpenAPI output are unchanged. Storage backend implementations must satisfy the expanded mandatory authorization contract and the shared compatibility suite.

## Changelog

No changelog entry: this changes internal storage composition without user-facing behavior.

## Verification

```text
source .env && ./run_tests.sh
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"
python3 scripts/check-rust-api-policy.py
python3 scripts/test-rust-api-policy.py
python3 scripts/check-supply-chain-policy.py
python3 scripts/test-supply-chain-policy.py
scripts/test-classify-ci-changes.sh
cargo deny --all-features --locked check
diff -u docs/openapi.json <(cargo run --quiet --bin hubuum-openapi --locked)
cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked
source .env && ./run_tests.sh --features permissions-treetop --lib exporter_round_trip -- --nocapture
```

All passed. The full suite included 1,191 library tests, all API integration binaries, restore round-trip coverage, binary smoke tests, and doctests.

## Stack

Stacked on #300. This is the permission-query layer before the general query/search/history storage contract.
