### PR TITLE
Extract mandatory temporal history storage contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Breaking (administrator API):** the storage contract version is now `2`,
+  and the redacted administrator configuration reports the newly enforced
+  `temporal_history` capability instead of the broader provisional
+  `queries_and_history` label. Monitoring or administration clients matching
+  the old capability string must switch to `temporal_history`.
 - Event worker and retention configuration validation now uses backend-neutral
   policy terminology, matching the storage traits and DTOs used by application
   workers instead of exposing database implementation language.

--- a/crates/hubuum-storage-core/src/history.rs
+++ b/crates/hubuum-storage-core/src/history.rs
@@ -1,0 +1,787 @@
+use async_trait::async_trait;
+use chrono::{DateTime, NaiveDateTime, Utc};
+use hubuum_query::QueryOptions;
+use serde_json::Value;
+use std::num::NonZeroI64;
+
+use crate::StorageError;
+
+/// Collection visibility applied by the adapter before counting or paging.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HistoryCollectionScope {
+    All,
+    Visible(Vec<i32>),
+}
+
+/// Backend-neutral request for one resource's temporal history page.
+#[derive(Clone)]
+pub struct HistoryListQuery {
+    entity_id: i32,
+    query_options: QueryOptions,
+    collection_scope: HistoryCollectionScope,
+}
+
+impl HistoryListQuery {
+    #[must_use]
+    pub const fn new(
+        entity_id: i32,
+        query_options: QueryOptions,
+        collection_scope: HistoryCollectionScope,
+    ) -> Self {
+        Self {
+            entity_id,
+            query_options,
+            collection_scope,
+        }
+    }
+
+    #[must_use]
+    pub const fn entity_id(&self) -> i32 {
+        self.entity_id
+    }
+
+    #[must_use]
+    pub const fn query_options(&self) -> &QueryOptions {
+        &self.query_options
+    }
+
+    #[must_use]
+    pub const fn collection_scope(&self) -> &HistoryCollectionScope {
+        &self.collection_scope
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (i32, QueryOptions, HistoryCollectionScope) {
+        (self.entity_id, self.query_options, self.collection_scope)
+    }
+}
+
+/// Backend-neutral request for one object's temporal history page.
+#[derive(Clone)]
+pub struct ObjectHistoryListQuery {
+    object_id: i32,
+    class_id: i32,
+    query_options: QueryOptions,
+    collection_scope: HistoryCollectionScope,
+}
+
+impl ObjectHistoryListQuery {
+    #[must_use]
+    pub const fn new(
+        object_id: i32,
+        class_id: i32,
+        query_options: QueryOptions,
+        collection_scope: HistoryCollectionScope,
+    ) -> Self {
+        Self {
+            object_id,
+            class_id,
+            query_options,
+            collection_scope,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (i32, i32, QueryOptions, HistoryCollectionScope) {
+        (
+            self.object_id,
+            self.class_id,
+            self.query_options,
+            self.collection_scope,
+        )
+    }
+}
+
+/// Point-in-time lookup shared by non-object history resources.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HistoryAsOfQuery {
+    entity_id: i32,
+    at: DateTime<Utc>,
+}
+
+impl HistoryAsOfQuery {
+    #[must_use]
+    pub const fn new(entity_id: i32, at: DateTime<Utc>) -> Self {
+        Self { entity_id, at }
+    }
+
+    #[must_use]
+    pub const fn into_parts(self) -> (i32, DateTime<Utc>) {
+        (self.entity_id, self.at)
+    }
+}
+
+/// Point-in-time lookup for an object constrained by its class route.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ObjectHistoryAsOfQuery {
+    object_id: i32,
+    class_id: i32,
+    at: DateTime<Utc>,
+}
+
+impl ObjectHistoryAsOfQuery {
+    #[must_use]
+    pub const fn new(object_id: i32, class_id: i32, at: DateTime<Utc>) -> Self {
+        Self {
+            object_id,
+            class_id,
+            at,
+        }
+    }
+
+    #[must_use]
+    pub const fn into_parts(self) -> (i32, i32, DateTime<Utc>) {
+        (self.object_id, self.class_id, self.at)
+    }
+}
+
+/// Common temporal and provenance columns for one history row.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HistoryMetadata {
+    operation: String,
+    valid_from: DateTime<Utc>,
+    valid_to: Option<DateTime<Utc>>,
+    actor_id: Option<i32>,
+    history_id: i64,
+    actor_kind: Option<String>,
+    initiator_principal_id: Option<i32>,
+    task_id: Option<i32>,
+    revision: NonZeroI64,
+}
+
+impl HistoryMetadata {
+    #[must_use]
+    pub fn new(
+        operation: impl Into<String>,
+        valid_from: DateTime<Utc>,
+        valid_to: Option<DateTime<Utc>>,
+        history_id: i64,
+        revision: NonZeroI64,
+    ) -> Self {
+        Self {
+            operation: operation.into(),
+            valid_from,
+            valid_to,
+            actor_id: None,
+            history_id,
+            actor_kind: None,
+            initiator_principal_id: None,
+            task_id: None,
+            revision,
+        }
+    }
+
+    #[must_use]
+    pub fn actor(mut self, actor_id: Option<i32>, actor_kind: Option<String>) -> Self {
+        self.actor_id = actor_id;
+        self.actor_kind = actor_kind;
+        self
+    }
+
+    #[must_use]
+    pub const fn initiator_principal_id(mut self, initiator_principal_id: Option<i32>) -> Self {
+        self.initiator_principal_id = initiator_principal_id;
+        self
+    }
+
+    #[must_use]
+    pub const fn task_id(mut self, task_id: Option<i32>) -> Self {
+        self.task_id = task_id;
+        self
+    }
+
+    #[must_use]
+    #[allow(clippy::type_complexity)]
+    pub fn into_parts(
+        self,
+    ) -> (
+        String,
+        DateTime<Utc>,
+        Option<DateTime<Utc>>,
+        Option<i32>,
+        i64,
+        Option<String>,
+        Option<i32>,
+        Option<i32>,
+        i64,
+    ) {
+        (
+            self.operation,
+            self.valid_from,
+            self.valid_to,
+            self.actor_id,
+            self.history_id,
+            self.actor_kind,
+            self.initiator_principal_id,
+            self.task_id,
+            self.revision.get(),
+        )
+    }
+}
+
+/// One resolved principal name used to enrich history provenance.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HistoryPrincipalName {
+    principal_id: i32,
+    name: String,
+}
+
+impl HistoryPrincipalName {
+    #[must_use]
+    pub fn new(principal_id: i32, name: impl Into<String>) -> Self {
+        Self {
+            principal_id,
+            name: name.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (i32, String) {
+        (self.principal_id, self.name)
+    }
+}
+
+/// Backend-neutral page with the total computed under the same visibility.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HistoryPage<T> {
+    items: Vec<T>,
+    total_count: i64,
+}
+
+impl<T> HistoryPage<T> {
+    #[must_use]
+    pub const fn new(items: Vec<T>, total_count: i64) -> Self {
+        Self { items, total_count }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (Vec<T>, i64) {
+        (self.items, self.total_count)
+    }
+}
+
+/// One collection revision returned by [`HistoryStorage`].
+#[derive(Clone, PartialEq, Eq)]
+pub struct CollectionHistoryRecord {
+    id: i32,
+    name: String,
+    description: String,
+    created_at: NaiveDateTime,
+    updated_at: NaiveDateTime,
+    parent_collection_id: Option<i32>,
+    metadata: HistoryMetadata,
+}
+
+impl CollectionHistoryRecord {
+    #[must_use]
+    pub fn new(
+        id: i32,
+        name: String,
+        description: String,
+        created_at: NaiveDateTime,
+        updated_at: NaiveDateTime,
+        parent_collection_id: Option<i32>,
+        metadata: HistoryMetadata,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            description,
+            created_at,
+            updated_at,
+            parent_collection_id,
+            metadata,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        i32,
+        String,
+        String,
+        NaiveDateTime,
+        NaiveDateTime,
+        Option<i32>,
+        HistoryMetadata,
+    ) {
+        (
+            self.id,
+            self.name,
+            self.description,
+            self.created_at,
+            self.updated_at,
+            self.parent_collection_id,
+            self.metadata,
+        )
+    }
+}
+
+/// One class revision returned by [`HistoryStorage`].
+#[derive(Clone, PartialEq, Eq)]
+pub struct ClassHistoryRecord {
+    id: i32,
+    name: String,
+    collection_id: i32,
+    json_schema: Option<Value>,
+    validate_schema: bool,
+    description: String,
+    created_at: NaiveDateTime,
+    updated_at: NaiveDateTime,
+    metadata: HistoryMetadata,
+}
+
+impl ClassHistoryRecord {
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: i32,
+        name: String,
+        collection_id: i32,
+        json_schema: Option<Value>,
+        validate_schema: bool,
+        description: String,
+        created_at: NaiveDateTime,
+        updated_at: NaiveDateTime,
+        metadata: HistoryMetadata,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            collection_id,
+            json_schema,
+            validate_schema,
+            description,
+            created_at,
+            updated_at,
+            metadata,
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::type_complexity)]
+    pub fn into_parts(
+        self,
+    ) -> (
+        i32,
+        String,
+        i32,
+        Option<Value>,
+        bool,
+        String,
+        NaiveDateTime,
+        NaiveDateTime,
+        HistoryMetadata,
+    ) {
+        (
+            self.id,
+            self.name,
+            self.collection_id,
+            self.json_schema,
+            self.validate_schema,
+            self.description,
+            self.created_at,
+            self.updated_at,
+            self.metadata,
+        )
+    }
+}
+
+/// One object revision returned by [`HistoryStorage`].
+#[derive(Clone, PartialEq, Eq)]
+pub struct ObjectHistoryRecord {
+    id: i32,
+    name: String,
+    collection_id: i32,
+    class_id: i32,
+    data: Value,
+    description: String,
+    created_at: NaiveDateTime,
+    updated_at: NaiveDateTime,
+    metadata: HistoryMetadata,
+}
+
+impl ObjectHistoryRecord {
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: i32,
+        name: String,
+        collection_id: i32,
+        class_id: i32,
+        data: Value,
+        description: String,
+        created_at: NaiveDateTime,
+        updated_at: NaiveDateTime,
+        metadata: HistoryMetadata,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            collection_id,
+            class_id,
+            data,
+            description,
+            created_at,
+            updated_at,
+            metadata,
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::type_complexity)]
+    pub fn into_parts(
+        self,
+    ) -> (
+        i32,
+        String,
+        i32,
+        i32,
+        Value,
+        String,
+        NaiveDateTime,
+        NaiveDateTime,
+        HistoryMetadata,
+    ) {
+        (
+            self.id,
+            self.name,
+            self.collection_id,
+            self.class_id,
+            self.data,
+            self.description,
+            self.created_at,
+            self.updated_at,
+            self.metadata,
+        )
+    }
+}
+
+/// One export-template revision returned by [`HistoryStorage`].
+#[derive(Clone, PartialEq, Eq)]
+pub struct ExportTemplateHistoryRecord {
+    id: i32,
+    collection_id: i32,
+    name: String,
+    description: String,
+    content_type: String,
+    template: String,
+    kind: String,
+    scope_kind: Option<String>,
+    class_id: Option<i32>,
+    default_query: Option<String>,
+    include: Option<Value>,
+    relation_context: Option<Value>,
+    default_missing_data_policy: Option<String>,
+    default_limits: Option<Value>,
+    created_at: NaiveDateTime,
+    updated_at: NaiveDateTime,
+    metadata: HistoryMetadata,
+}
+
+impl ExportTemplateHistoryRecord {
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: i32,
+        collection_id: i32,
+        name: String,
+        description: String,
+        content_type: String,
+        template: String,
+        kind: String,
+        scope_kind: Option<String>,
+        class_id: Option<i32>,
+        default_query: Option<String>,
+        include: Option<Value>,
+        relation_context: Option<Value>,
+        default_missing_data_policy: Option<String>,
+        default_limits: Option<Value>,
+        created_at: NaiveDateTime,
+        updated_at: NaiveDateTime,
+        metadata: HistoryMetadata,
+    ) -> Self {
+        Self {
+            id,
+            collection_id,
+            name,
+            description,
+            content_type,
+            template,
+            kind,
+            scope_kind,
+            class_id,
+            default_query,
+            include,
+            relation_context,
+            default_missing_data_policy,
+            default_limits,
+            created_at,
+            updated_at,
+            metadata,
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::type_complexity)]
+    pub fn into_parts(
+        self,
+    ) -> (
+        i32,
+        i32,
+        String,
+        String,
+        String,
+        String,
+        String,
+        Option<String>,
+        Option<i32>,
+        Option<String>,
+        Option<Value>,
+        Option<Value>,
+        Option<String>,
+        Option<Value>,
+        NaiveDateTime,
+        NaiveDateTime,
+        HistoryMetadata,
+    ) {
+        (
+            self.id,
+            self.collection_id,
+            self.name,
+            self.description,
+            self.content_type,
+            self.template,
+            self.kind,
+            self.scope_kind,
+            self.class_id,
+            self.default_query,
+            self.include,
+            self.relation_context,
+            self.default_missing_data_policy,
+            self.default_limits,
+            self.created_at,
+            self.updated_at,
+            self.metadata,
+        )
+    }
+}
+
+/// One remote-target revision returned by [`HistoryStorage`].
+///
+/// Deliberately does not implement `Debug`: transport templates and
+/// authentication configuration may contain secrets.
+#[derive(Clone, PartialEq, Eq)]
+pub struct RemoteTargetHistoryRecord {
+    id: i32,
+    collection_id: i32,
+    class_id: Option<i32>,
+    name: String,
+    description: String,
+    method: String,
+    url_template: String,
+    headers_template: Value,
+    body_template: Option<String>,
+    auth_config: Value,
+    allowed_subject_types: Value,
+    timeout_ms: i32,
+    enabled: bool,
+    created_at: NaiveDateTime,
+    updated_at: NaiveDateTime,
+    metadata: HistoryMetadata,
+}
+
+impl RemoteTargetHistoryRecord {
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: i32,
+        collection_id: i32,
+        class_id: Option<i32>,
+        name: String,
+        description: String,
+        method: String,
+        url_template: String,
+        headers_template: Value,
+        body_template: Option<String>,
+        auth_config: Value,
+        allowed_subject_types: Value,
+        timeout_ms: i32,
+        enabled: bool,
+        created_at: NaiveDateTime,
+        updated_at: NaiveDateTime,
+        metadata: HistoryMetadata,
+    ) -> Self {
+        Self {
+            id,
+            collection_id,
+            class_id,
+            name,
+            description,
+            method,
+            url_template,
+            headers_template,
+            body_template,
+            auth_config,
+            allowed_subject_types,
+            timeout_ms,
+            enabled,
+            created_at,
+            updated_at,
+            metadata,
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::type_complexity)]
+    pub fn into_parts(
+        self,
+    ) -> (
+        i32,
+        i32,
+        Option<i32>,
+        String,
+        String,
+        String,
+        String,
+        Value,
+        Option<String>,
+        Value,
+        Value,
+        i32,
+        bool,
+        NaiveDateTime,
+        NaiveDateTime,
+        HistoryMetadata,
+    ) {
+        (
+            self.id,
+            self.collection_id,
+            self.class_id,
+            self.name,
+            self.description,
+            self.method,
+            self.url_template,
+            self.headers_template,
+            self.body_template,
+            self.auth_config,
+            self.allowed_subject_types,
+            self.timeout_ms,
+            self.enabled,
+            self.created_at,
+            self.updated_at,
+            self.metadata,
+        )
+    }
+}
+
+/// Complete temporal-history capability required of every selectable backend.
+#[async_trait]
+pub trait HistoryStorage: Send + Sync {
+    async fn resolve_history_principal_names(
+        &self,
+        principal_ids: Vec<i32>,
+    ) -> Result<Vec<HistoryPrincipalName>, StorageError>;
+
+    async fn list_collection_history(
+        &self,
+        query: HistoryListQuery,
+    ) -> Result<HistoryPage<CollectionHistoryRecord>, StorageError>;
+
+    async fn collection_history_as_of(
+        &self,
+        query: HistoryAsOfQuery,
+    ) -> Result<Option<CollectionHistoryRecord>, StorageError>;
+
+    async fn list_class_history(
+        &self,
+        query: HistoryListQuery,
+    ) -> Result<HistoryPage<ClassHistoryRecord>, StorageError>;
+
+    async fn class_history_as_of(
+        &self,
+        query: HistoryAsOfQuery,
+    ) -> Result<Option<ClassHistoryRecord>, StorageError>;
+
+    async fn list_object_history(
+        &self,
+        query: ObjectHistoryListQuery,
+    ) -> Result<HistoryPage<ObjectHistoryRecord>, StorageError>;
+
+    async fn object_history_as_of(
+        &self,
+        query: ObjectHistoryAsOfQuery,
+    ) -> Result<Option<ObjectHistoryRecord>, StorageError>;
+
+    async fn list_export_template_history(
+        &self,
+        query: HistoryListQuery,
+    ) -> Result<HistoryPage<ExportTemplateHistoryRecord>, StorageError>;
+
+    async fn export_template_history_as_of(
+        &self,
+        query: HistoryAsOfQuery,
+    ) -> Result<Option<ExportTemplateHistoryRecord>, StorageError>;
+
+    async fn list_remote_target_history(
+        &self,
+        query: HistoryListQuery,
+    ) -> Result<HistoryPage<RemoteTargetHistoryRecord>, StorageError>;
+
+    async fn remote_target_history_as_of(
+        &self,
+        query: HistoryAsOfQuery,
+    ) -> Result<Option<RemoteTargetHistoryRecord>, StorageError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    #[test]
+    fn history_queries_own_their_visibility_boundary() {
+        let query = HistoryListQuery::new(
+            17,
+            QueryOptions {
+                filters: Vec::new(),
+                sort: Vec::new(),
+                limit: Some(25),
+                cursor: None,
+                include_total: true,
+            },
+            HistoryCollectionScope::Visible(vec![3, 5]),
+        );
+
+        let (entity_id, options, scope) = query.into_parts();
+        assert_eq!(entity_id, 17);
+        assert_eq!(options.limit, Some(25));
+        assert_eq!(scope, HistoryCollectionScope::Visible(vec![3, 5]));
+    }
+
+    #[test]
+    fn history_metadata_preserves_complete_provenance() {
+        let valid_from = Utc.with_ymd_and_hms(2026, 8, 10, 12, 0, 0).unwrap();
+        let metadata = HistoryMetadata::new("U", valid_from, None, 41, NonZeroI64::new(7).unwrap())
+            .actor(Some(11), Some("human".to_string()))
+            .initiator_principal_id(Some(13))
+            .task_id(Some(17));
+
+        assert_eq!(
+            metadata.into_parts(),
+            (
+                "U".to_string(),
+                valid_from,
+                None,
+                Some(11),
+                41,
+                Some("human".to_string()),
+                Some(13),
+                Some(17),
+                7,
+            )
+        );
+    }
+}

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod authorization;
 mod events;
+mod history;
 mod identity;
 mod operational;
 
@@ -21,6 +22,12 @@ pub use events::{
     EventArchive, EventDeliveryBatch, EventDeliveryClaim, EventDeliverySink, EventDeliveryStorage,
     EventDeliverySubscription, EventDeliveryWorkItem, EventFanoutStorage, EventRetentionStorage,
     EventRetentionSummary, RetainedEvent,
+};
+pub use history::{
+    ClassHistoryRecord, CollectionHistoryRecord, ExportTemplateHistoryRecord, HistoryAsOfQuery,
+    HistoryCollectionScope, HistoryListQuery, HistoryMetadata, HistoryPage, HistoryPrincipalName,
+    HistoryStorage, ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectHistoryRecord,
+    RemoteTargetHistoryRecord,
 };
 pub use identity::{
     AuthenticationHuman, AuthenticationIdentity, AuthenticationPrincipal,
@@ -40,7 +47,7 @@ use std::fmt;
 ///
 /// Increment this when a selectable backend must implement a new capability
 /// family or when an existing family's externally observable semantics change.
-pub const STORAGE_CONTRACT_VERSION: u16 = 1;
+pub const STORAGE_CONTRACT_VERSION: u16 = 2;
 
 /// Stable identity of a selectable storage backend.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -65,7 +72,7 @@ impl StorageBackendKind {
 pub enum StorageCapability {
     DomainLifecycle,
     IdentityAndAuthorizationData,
-    QueriesAndHistory,
+    TemporalHistory,
     Workflows,
     Operations,
 }
@@ -74,7 +81,7 @@ impl StorageCapability {
     pub const ALL: [Self; 5] = [
         Self::DomainLifecycle,
         Self::IdentityAndAuthorizationData,
-        Self::QueriesAndHistory,
+        Self::TemporalHistory,
         Self::Workflows,
         Self::Operations,
     ];
@@ -84,7 +91,7 @@ impl StorageCapability {
         match self {
             Self::DomainLifecycle => "domain_lifecycle",
             Self::IdentityAndAuthorizationData => "identity_and_authorization_data",
-            Self::QueriesAndHistory => "queries_and_history",
+            Self::TemporalHistory => "temporal_history",
             Self::Workflows => "workflows",
             Self::Operations => "operations",
         }
@@ -236,7 +243,7 @@ mod tests {
             [
                 "domain_lifecycle",
                 "identity_and_authorization_data",
-                "queries_and_history",
+                "temporal_history",
                 "workflows",
                 "operations",
             ]

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -63,7 +63,7 @@ satisfy every capability family below before `StorageHandle` can compose it:
 | --- | --- |
 | Domain lifecycle | Collection, class, object, class-relation, and object-relation resolution and lifecycle behavior |
 | Identity and authorization data | Principals, credentials, memberships, grants, and data needed by configured authorization providers |
-| Queries and history | Lists, filtering, stable pagination, search, aggregates, computed enrichment, graphs, and temporal history |
+| Temporal history | Revision-filtered pages, stable cursors, point-in-time reads, visibility pushdown, and provenance-name resolution |
 | Workflows | Imports, restores, tasks, backups, exports, remote calls, and their atomic state transitions |
 | Operations | Probes, metrics snapshots, retention, event delivery, leases, locking, and worker coordination |
 
@@ -71,13 +71,13 @@ The families are not feature flags and the admin configuration does not report
 optional support. Every selectable backend implements the entire list. The
 sealed composition in `src/storage/contract.rs` makes adding a backend an
 explicit architecture change rather than an incidental trait implementation.
-During extraction, the query/history, workflow, and remaining operational
+During extraction, the workflow and remaining operational
 families retain temporary central migration gates. Those gates prevent another
 backend from becoming selectable, but they are not behavioral proof and must
 be replaced by mandatory operation-shaped traits and shared tests. The former
-identity gate has now been replaced by the real `AuthenticationStorage`
-and `AuthorizationStorage` contracts; no family is considered complete merely
-because a marker exists.
+identity and history gates have now been replaced by the real
+`AuthenticationStorage`, `AuthorizationStorage`, and `HistoryStorage`
+contracts; no family is considered complete merely because a marker exists.
 
 PostgreSQL query implementations live in
 `src/storage/postgres/operations/*`. Separating their persistence rows from
@@ -85,7 +85,7 @@ root domain models is the next extraction layer; the current location is an
 implementation detail, not partial backend support. `StorageHandle` selects
 one certified PostgreSQL adapter, and only the storage implementation can
 recover its pool. Application consumers use `StorageContext`, lifecycle
-traits, or the explicit capability facade. No second backend can be added to
+traits, mandatory capability traits, or application services. No second backend can be added to
 composition without implementing every operation behind those contracts.
 
 The storage contract version changes when a required family is added or when
@@ -186,6 +186,16 @@ Consequently the complete `src/permissions` application tree is independent of
 PostgreSQL, Diesel, generated schema modules, and connection pools; a source
 guard enforces that boundary.
 
+`HistoryStorage` owns every temporal-history read exposed by the HTTP API:
+collection, class, object, export-template, and remote-target pages and
+point-in-time lookups, plus batched principal-name resolution for provenance.
+Visibility is an owned backend-neutral request, counting happens under the same
+visibility predicate as page selection, and adapter rows are converted to
+private-field DTOs before crossing the boundary. `StorageHandle` observes these
+calls with bounded `history/*` labels. The application history service converts
+DTOs into response models and is the only layer that maps `StorageError` into
+`ApiError`.
+
 ## Error Direction
 
 Errors cross the boundary in one direction:
@@ -260,12 +270,14 @@ There are two complementary test layers:
    PostgreSQL adapter and the in-memory contract model.
 2. The available-backend compatibility registry iterates every selectable
    `StorageBackendKind`, composes it through `StorageHandle`, verifies its
-   contract descriptor, and exercises the service boundary.
+   contract descriptor, and exercises every mandatory operation family. The
+   temporal-history contract test covers all list, point-in-time, visibility,
+   and provenance-resolution entry points.
 
 PostgreSQL-specific tests remain responsible for behavior a logical model
 cannot reproduce: transactions, rollbacks, isolation, row locks, trigger
-serialization, migrations, temporal history, recovery, concurrency, query
-budgets, and production feature combinations. The complete repository test
+serialization, migrations, temporal trigger semantics, recovery, concurrency,
+query budgets, and production feature combinations. The complete repository test
 suite is therefore part of PostgreSQL backend certification, not a substitute
 for the shared logical contracts.
 
@@ -298,7 +310,7 @@ The first workspace boundaries are now in place:
 - `hubuum-storage-core` owns backend-neutral descriptors, the contract version,
   capability identities, `StorageError`, authentication and authorization
   DTOs, operational snapshot DTOs, and the extracted authentication,
-  authorization, operational state, event-health, event-fan-out,
+  authorization, temporal-history, operational state, event-health, event-fan-out,
   event-retention, and token-retention traits without application, transport,
   or driver dependencies.
 - `hubuum-storage-postgres` owns PostgreSQL pool construction, TLS connection

--- a/src/api/v1/handlers/classes.rs
+++ b/src/api/v1/handlers/classes.rs
@@ -25,13 +25,13 @@ use crate::permissions::{
     AppContext, AuthzTarget, PrincipalRef, ResourceAttrs, ResourceKind, ResourceRef,
     authorize_resources,
 };
-use crate::storage::capabilities::UserPermissions;
-use crate::storage::capabilities::authz::scope_allows;
-use crate::storage::capabilities::computed_field::enrich_objects_with_computed;
-use crate::storage::capabilities::history::{
+use crate::services::history::{
     HistoryCollectionFilter, class_as_of, class_history_paginated_with_total_count, object_as_of,
     object_history_paginated_with_total_count,
 };
+use crate::storage::capabilities::UserPermissions;
+use crate::storage::capabilities::authz::scope_allows;
+use crate::storage::capabilities::computed_field::enrich_objects_with_computed;
 use crate::storage::capabilities::relations::{
     class_relation_authorization_resources, object_relation_authorization_resources,
 };

--- a/src/api/v1/handlers/collections.rs
+++ b/src/api/v1/handlers/collections.rs
@@ -17,11 +17,11 @@ use crate::models::{
 use crate::pagination::{SKIPPED_TOTAL_COUNT, count_query_options, prepare_db_pagination};
 use crate::permissions::visibility::authorize_cursor_page;
 use crate::permissions::{AppContext, PrincipalRef, ResourceRef};
-use crate::storage::capabilities::UserPermissions;
-use crate::storage::capabilities::authz::scope_allows;
-use crate::storage::capabilities::history::{
+use crate::services::history::{
     HistoryCollectionFilter, collection_as_of, collection_history_paginated_with_total_count,
 };
+use crate::storage::capabilities::UserPermissions;
+use crate::storage::capabilities::authz::scope_allows;
 use crate::storage::capabilities::user::UserSearchBackend;
 use crate::storage::capabilities::with_revision_precondition_scope;
 use actix_web::{

--- a/src/api/v1/handlers/export_templates.rs
+++ b/src/api/v1/handlers/export_templates.rs
@@ -22,12 +22,12 @@ use crate::permissions::visibility::authorize_cursor_page;
 use crate::permissions::{
     AppContext, PrincipalRef, ResourceAttrs, ResourceKind, ResourceRef, authorize_resources,
 };
-use crate::storage::capabilities::UserPermissions;
-use crate::storage::capabilities::authz::scope_allows;
-use crate::storage::capabilities::history::{
+use crate::services::history::{
     HistoryCollectionFilter, export_template_as_of,
     export_template_history_paginated_with_total_count,
 };
+use crate::storage::capabilities::UserPermissions;
+use crate::storage::capabilities::authz::scope_allows;
 use crate::storage::capabilities::with_revision_precondition_scope;
 use crate::tasks::{idempotency_key_from_headers, kick_task_worker};
 use crate::traits::{CanDelete, CanSave, CanUpdate, SelfAccessors};

--- a/src/api/v1/handlers/history.rs
+++ b/src/api/v1/handlers/history.rs
@@ -15,8 +15,8 @@ use crate::models::{
 use crate::pagination::count_query_options;
 use crate::permissions::visibility::authorize_cursor_page;
 use crate::permissions::{AppContext, PrincipalRef, authorize_resources};
+use crate::services::history::resolve_principal_names;
 use crate::storage::capabilities::authz::scope_allows;
-use crate::storage::capabilities::history::resolve_principal_names;
 use crate::traits::{AuthzSubject, CursorPaginated};
 
 /// A serialized history row plus the resolved username of its actor (if any).

--- a/src/api/v1/handlers/remote_targets.rs
+++ b/src/api/v1/handlers/remote_targets.rs
@@ -21,11 +21,11 @@ use crate::models::{
 };
 use crate::pagination::prepare_db_pagination;
 use crate::permissions::{AppContext, PrincipalRef};
-use crate::storage::capabilities::UserPermissions;
-use crate::storage::capabilities::authz::scope_allows;
-use crate::storage::capabilities::history::{
+use crate::services::history::{
     HistoryCollectionFilter, remote_target_as_of, remote_target_history_paginated_with_total_count,
 };
+use crate::storage::capabilities::UserPermissions;
+use crate::storage::capabilities::authz::scope_allows;
 use crate::storage::capabilities::remote_target::{
     DeleteRemoteTargetRecord, SaveRemoteTargetRecord, UpdateRemoteTargetRecord,
     emit_remote_target_invoked_event,

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -453,8 +453,8 @@ mod tests {
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
         assert!(json.contains("\"backend\":\"postgresql\""));
-        assert!(json.contains("\"contract_version\":1"));
-        assert!(json.contains("\"queries_and_history\""));
+        assert!(json.contains("\"contract_version\":2"));
+        assert!(json.contains("\"temporal_history\""));
         assert!(!debug.contains("secret-password"));
         assert!(!debug.contains("correct horse battery staple"));
     }

--- a/src/services/history.rs
+++ b/src/services/history.rs
@@ -1,0 +1,385 @@
+use chrono::{DateTime, Utc};
+
+use crate::errors::ApiError;
+use crate::events::PrincipalNames;
+use crate::models::search::QueryOptions;
+use crate::models::{
+    CollectionHistory, ExportTemplateHistory, HubuumClassHistory, HubuumObjectHistory,
+    RemoteTargetHistory, ResourceRevision,
+};
+use crate::storage::{
+    ClassHistoryRecord, CollectionHistoryRecord, ExportTemplateHistoryRecord, HistoryAsOfQuery,
+    HistoryCollectionScope, HistoryListQuery, HistoryMetadata, HistoryStorage,
+    ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectHistoryRecord, RemoteTargetHistoryRecord,
+    StorageContext, storage_handle,
+};
+
+/// Collection visibility applied before history rows are counted or paged.
+#[derive(Clone, Copy)]
+pub enum HistoryCollectionFilter<'a> {
+    All,
+    Visible(&'a [i32]),
+}
+
+impl From<HistoryCollectionFilter<'_>> for HistoryCollectionScope {
+    fn from(value: HistoryCollectionFilter<'_>) -> Self {
+        match value {
+            HistoryCollectionFilter::All => Self::All,
+            HistoryCollectionFilter::Visible(collection_ids) => {
+                Self::Visible(collection_ids.to_vec())
+            }
+        }
+    }
+}
+
+struct AppHistoryMetadata {
+    operation: String,
+    valid_from: DateTime<Utc>,
+    valid_to: Option<DateTime<Utc>>,
+    actor_id: Option<i32>,
+    history_id: i64,
+    actor_kind: Option<String>,
+    initiator_principal_id: Option<i32>,
+    task_id: Option<i32>,
+    revision: ResourceRevision,
+}
+
+impl TryFrom<HistoryMetadata> for AppHistoryMetadata {
+    type Error = ApiError;
+
+    fn try_from(value: HistoryMetadata) -> Result<Self, Self::Error> {
+        let (
+            operation,
+            valid_from,
+            valid_to,
+            actor_id,
+            history_id,
+            actor_kind,
+            initiator_principal_id,
+            task_id,
+            revision,
+        ) = value.into_parts();
+        Ok(Self {
+            operation,
+            valid_from,
+            valid_to,
+            actor_id,
+            history_id,
+            actor_kind,
+            initiator_principal_id,
+            task_id,
+            revision: ResourceRevision::new(revision)?,
+        })
+    }
+}
+
+fn collection_from_storage(row: CollectionHistoryRecord) -> Result<CollectionHistory, ApiError> {
+    let (id, name, description, created_at, updated_at, parent_collection_id, metadata) =
+        row.into_parts();
+    let metadata = AppHistoryMetadata::try_from(metadata)?;
+    Ok(CollectionHistory {
+        id,
+        name,
+        description,
+        created_at,
+        updated_at,
+        parent_collection_id,
+        op: metadata.operation,
+        valid_from: metadata.valid_from,
+        valid_to: metadata.valid_to,
+        actor_id: metadata.actor_id,
+        history_id: metadata.history_id,
+        actor_kind: metadata.actor_kind,
+        initiator_user_id: metadata.initiator_principal_id,
+        task_id: metadata.task_id,
+        revision: metadata.revision,
+    })
+}
+
+fn class_from_storage(row: ClassHistoryRecord) -> Result<HubuumClassHistory, ApiError> {
+    let (
+        id,
+        name,
+        collection_id,
+        json_schema,
+        validate_schema,
+        description,
+        created_at,
+        updated_at,
+        metadata,
+    ) = row.into_parts();
+    let metadata = AppHistoryMetadata::try_from(metadata)?;
+    Ok(HubuumClassHistory {
+        id,
+        name,
+        collection_id,
+        json_schema,
+        validate_schema,
+        description,
+        created_at,
+        updated_at,
+        op: metadata.operation,
+        valid_from: metadata.valid_from,
+        valid_to: metadata.valid_to,
+        actor_id: metadata.actor_id,
+        history_id: metadata.history_id,
+        actor_kind: metadata.actor_kind,
+        initiator_user_id: metadata.initiator_principal_id,
+        task_id: metadata.task_id,
+        revision: metadata.revision,
+    })
+}
+
+fn object_from_storage(row: ObjectHistoryRecord) -> Result<HubuumObjectHistory, ApiError> {
+    let (
+        id,
+        name,
+        collection_id,
+        hubuum_class_id,
+        data,
+        description,
+        created_at,
+        updated_at,
+        metadata,
+    ) = row.into_parts();
+    let metadata = AppHistoryMetadata::try_from(metadata)?;
+    Ok(HubuumObjectHistory {
+        id,
+        name,
+        collection_id,
+        hubuum_class_id,
+        data,
+        description,
+        created_at,
+        updated_at,
+        op: metadata.operation,
+        valid_from: metadata.valid_from,
+        valid_to: metadata.valid_to,
+        actor_id: metadata.actor_id,
+        history_id: metadata.history_id,
+        actor_kind: metadata.actor_kind,
+        initiator_user_id: metadata.initiator_principal_id,
+        task_id: metadata.task_id,
+        revision: metadata.revision,
+    })
+}
+
+fn export_template_from_storage(
+    row: ExportTemplateHistoryRecord,
+) -> Result<ExportTemplateHistory, ApiError> {
+    let (
+        id,
+        collection_id,
+        name,
+        description,
+        content_type,
+        template,
+        kind,
+        scope_kind,
+        class_id,
+        default_query,
+        include,
+        relation_context,
+        default_missing_data_policy,
+        default_limits,
+        created_at,
+        updated_at,
+        metadata,
+    ) = row.into_parts();
+    let metadata = AppHistoryMetadata::try_from(metadata)?;
+    Ok(ExportTemplateHistory {
+        id,
+        collection_id,
+        name,
+        description,
+        content_type,
+        template,
+        kind,
+        scope_kind,
+        class_id,
+        default_query,
+        include,
+        relation_context,
+        default_missing_data_policy,
+        default_limits,
+        created_at,
+        updated_at,
+        op: metadata.operation,
+        valid_from: metadata.valid_from,
+        valid_to: metadata.valid_to,
+        actor_id: metadata.actor_id,
+        history_id: metadata.history_id,
+        actor_kind: metadata.actor_kind,
+        initiator_user_id: metadata.initiator_principal_id,
+        task_id: metadata.task_id,
+        revision: metadata.revision,
+    })
+}
+
+fn remote_target_from_storage(
+    row: RemoteTargetHistoryRecord,
+) -> Result<RemoteTargetHistory, ApiError> {
+    let (
+        id,
+        collection_id,
+        class_id,
+        name,
+        description,
+        method,
+        url_template,
+        headers_template,
+        body_template,
+        auth_config,
+        allowed_subject_types,
+        timeout_ms,
+        enabled,
+        created_at,
+        updated_at,
+        metadata,
+    ) = row.into_parts();
+    let metadata = AppHistoryMetadata::try_from(metadata)?;
+    Ok(RemoteTargetHistory {
+        id,
+        collection_id,
+        class_id,
+        name,
+        description,
+        method,
+        url_template,
+        headers_template,
+        body_template,
+        auth_config,
+        allowed_subject_types,
+        timeout_ms,
+        enabled,
+        created_at,
+        updated_at,
+        op: metadata.operation,
+        valid_from: metadata.valid_from,
+        valid_to: metadata.valid_to,
+        actor_id: metadata.actor_id,
+        history_id: metadata.history_id,
+        actor_kind: metadata.actor_kind,
+        initiator_user_id: metadata.initiator_principal_id,
+        task_id: metadata.task_id,
+        revision: metadata.revision,
+    })
+}
+
+pub async fn resolve_principal_names(
+    backend: &impl StorageContext,
+    principal_ids: Vec<i32>,
+) -> Result<PrincipalNames, ApiError> {
+    Ok(storage_handle(backend)
+        .resolve_history_principal_names(principal_ids)
+        .await?
+        .into_iter()
+        .map(|row| row.into_parts())
+        .collect())
+}
+
+macro_rules! history_service {
+    ($list:ident, $as_of:ident, $storage_list:ident, $storage_as_of:ident, $from:ident, $ty:ty) => {
+        pub async fn $list(
+            entity_id: i32,
+            backend: &impl StorageContext,
+            query_options: &QueryOptions,
+            collection_filter: HistoryCollectionFilter<'_>,
+        ) -> Result<(Vec<$ty>, i64), ApiError> {
+            let (rows, total_count) = storage_handle(backend)
+                .$storage_list(HistoryListQuery::new(
+                    entity_id,
+                    query_options.clone(),
+                    collection_filter.into(),
+                ))
+                .await?
+                .into_parts();
+            Ok((
+                rows.into_iter().map($from).collect::<Result<_, _>>()?,
+                total_count,
+            ))
+        }
+
+        pub async fn $as_of(
+            entity_id: i32,
+            at: DateTime<Utc>,
+            backend: &impl StorageContext,
+        ) -> Result<Option<$ty>, ApiError> {
+            storage_handle(backend)
+                .$storage_as_of(HistoryAsOfQuery::new(entity_id, at))
+                .await?
+                .map($from)
+                .transpose()
+        }
+    };
+}
+
+history_service!(
+    collection_history_paginated_with_total_count,
+    collection_as_of,
+    list_collection_history,
+    collection_history_as_of,
+    collection_from_storage,
+    CollectionHistory
+);
+history_service!(
+    class_history_paginated_with_total_count,
+    class_as_of,
+    list_class_history,
+    class_history_as_of,
+    class_from_storage,
+    HubuumClassHistory
+);
+history_service!(
+    export_template_history_paginated_with_total_count,
+    export_template_as_of,
+    list_export_template_history,
+    export_template_history_as_of,
+    export_template_from_storage,
+    ExportTemplateHistory
+);
+history_service!(
+    remote_target_history_paginated_with_total_count,
+    remote_target_as_of,
+    list_remote_target_history,
+    remote_target_history_as_of,
+    remote_target_from_storage,
+    RemoteTargetHistory
+);
+
+pub async fn object_history_paginated_with_total_count(
+    object_id: i32,
+    class_id: i32,
+    backend: &impl StorageContext,
+    query_options: &QueryOptions,
+    collection_filter: HistoryCollectionFilter<'_>,
+) -> Result<(Vec<HubuumObjectHistory>, i64), ApiError> {
+    let (rows, total_count) = storage_handle(backend)
+        .list_object_history(ObjectHistoryListQuery::new(
+            object_id,
+            class_id,
+            query_options.clone(),
+            collection_filter.into(),
+        ))
+        .await?
+        .into_parts();
+    Ok((
+        rows.into_iter()
+            .map(object_from_storage)
+            .collect::<Result<_, _>>()?,
+        total_count,
+    ))
+}
+
+pub async fn object_as_of(
+    object_id: i32,
+    class_id: i32,
+    at: DateTime<Utc>,
+    backend: &impl StorageContext,
+) -> Result<Option<HubuumObjectHistory>, ApiError> {
+    storage_handle(backend)
+        .object_history_as_of(ObjectHistoryAsOfQuery::new(object_id, class_id, at))
+        .await?
+        .map(object_from_storage)
+        .transpose()
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,6 +1,7 @@
 mod class_relations;
 mod classes;
 mod collections;
+pub(crate) mod history;
 mod object_relations;
 mod objects;
 

--- a/src/storage/capabilities.rs
+++ b/src/storage/capabilities.rs
@@ -74,16 +74,6 @@ pub(crate) mod group {
     pub(crate) use crate::storage::postgres::operations::group::principal_group_by_ids;
 }
 
-pub(crate) mod history {
-    pub(crate) use crate::storage::postgres::operations::history::{
-        HistoryCollectionFilter, class_as_of, class_history_paginated_with_total_count,
-        collection_as_of, collection_history_paginated_with_total_count, export_template_as_of,
-        export_template_history_paginated_with_total_count, object_as_of,
-        object_history_paginated_with_total_count, remote_target_as_of,
-        remote_target_history_paginated_with_total_count, resolve_principal_names,
-    };
-}
-
 pub(crate) mod identity {
     pub(crate) use crate::storage::postgres::operations::identity::{
         ensure_identity_scope, identity_scope_name_by_id,

--- a/src/storage/context.rs
+++ b/src/storage/context.rs
@@ -15,10 +15,14 @@ use crate::storage::{
     AuthorizationPrincipal, AuthorizationStorage, DynLifecycleStorage, EventArchive,
     EventDeliveryBatch, EventDeliveryClaim, EventDeliveryHealthSnapshot, EventDeliveryStorage,
     EventFanoutStorage, EventHealthStorage, EventMetricsSnapshot, EventRetentionStorage,
-    EventRetentionSummary, InventoryGaugeSnapshot, MetricsStorage, OperationalStateStorage,
-    PostgresStorage, ReadinessSnapshot, StorageBackend, StorageBackendDescriptor, StorageError,
-    StoragePoolState, TaskGaugeSnapshot, TokenRetentionStorage,
+    EventRetentionSummary, ExportTemplateHistoryRecord, HistoryAsOfQuery, HistoryListQuery,
+    HistoryPage, HistoryPrincipalName, HistoryStorage, InventoryGaugeSnapshot, MetricsStorage,
+    ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectHistoryRecord, OperationalStateStorage,
+    PostgresStorage, ReadinessSnapshot, RemoteTargetHistoryRecord, StorageBackend,
+    StorageBackendDescriptor, StorageError, StoragePoolState, TaskGaugeSnapshot,
+    TokenRetentionStorage,
 };
+use crate::storage::{ClassHistoryRecord, CollectionHistoryRecord};
 use async_trait::async_trait;
 
 mod private {
@@ -341,6 +345,178 @@ impl AuthorizationStorage for StorageHandle {
                 match &self.implementation {
                     BackendImplementation::Postgresql(backend) => {
                         backend.revoke_all_local_collection_grants(key).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl HistoryStorage for StorageHandle {
+    async fn resolve_history_principal_names(
+        &self,
+        principal_ids: Vec<i32>,
+    ) -> Result<Vec<HistoryPrincipalName>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "history",
+            "resolve_principal_names",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.resolve_history_principal_names(principal_ids).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn list_collection_history(
+        &self,
+        query: HistoryListQuery,
+    ) -> Result<HistoryPage<CollectionHistoryRecord>, StorageError> {
+        observe_storage_call(self.backend_name(), "history", "list_collections", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.list_collection_history(query).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn collection_history_as_of(
+        &self,
+        query: HistoryAsOfQuery,
+    ) -> Result<Option<CollectionHistoryRecord>, StorageError> {
+        observe_storage_call(self.backend_name(), "history", "collection_as_of", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.collection_history_as_of(query).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn list_class_history(
+        &self,
+        query: HistoryListQuery,
+    ) -> Result<HistoryPage<ClassHistoryRecord>, StorageError> {
+        observe_storage_call(self.backend_name(), "history", "list_classes", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.list_class_history(query).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn class_history_as_of(
+        &self,
+        query: HistoryAsOfQuery,
+    ) -> Result<Option<ClassHistoryRecord>, StorageError> {
+        observe_storage_call(self.backend_name(), "history", "class_as_of", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.class_history_as_of(query).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn list_object_history(
+        &self,
+        query: ObjectHistoryListQuery,
+    ) -> Result<HistoryPage<ObjectHistoryRecord>, StorageError> {
+        observe_storage_call(self.backend_name(), "history", "list_objects", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.list_object_history(query).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn object_history_as_of(
+        &self,
+        query: ObjectHistoryAsOfQuery,
+    ) -> Result<Option<ObjectHistoryRecord>, StorageError> {
+        observe_storage_call(self.backend_name(), "history", "object_as_of", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.object_history_as_of(query).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn list_export_template_history(
+        &self,
+        query: HistoryListQuery,
+    ) -> Result<HistoryPage<ExportTemplateHistoryRecord>, StorageError> {
+        observe_storage_call(self.backend_name(), "history", "list_templates", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.list_export_template_history(query).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn export_template_history_as_of(
+        &self,
+        query: HistoryAsOfQuery,
+    ) -> Result<Option<ExportTemplateHistoryRecord>, StorageError> {
+        observe_storage_call(self.backend_name(), "history", "template_as_of", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.export_template_history_as_of(query).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn list_remote_target_history(
+        &self,
+        query: HistoryListQuery,
+    ) -> Result<HistoryPage<RemoteTargetHistoryRecord>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "history",
+            "list_remote_targets",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.list_remote_target_history(query).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn remote_target_history_as_of(
+        &self,
+        query: HistoryAsOfQuery,
+    ) -> Result<Option<RemoteTargetHistoryRecord>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "history",
+            "remote_target_as_of",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.remote_target_history_as_of(query).await
                     }
                 }
             },

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use super::{
     AuthenticationStorage, AuthorizationStorage, ClassRelationStore, ClassStore, CollectionStore,
     EventDeliveryStorage, EventFanoutStorage, EventHealthStorage, EventRetentionStorage,
-    MetricsStorage, ObjectRelationStore, ObjectStore, OperationalStateStorage, PostgresStorage,
-    TokenRetentionStorage, observed::ObservedLifecycleStorage,
+    HistoryStorage, MetricsStorage, ObjectRelationStore, ObjectStore, OperationalStateStorage,
+    PostgresStorage, TokenRetentionStorage, observed::ObservedLifecycleStorage,
 };
 
 #[cfg(test)]
@@ -47,7 +47,6 @@ impl<T> LifecycleStorage for T where
 /// the refactor, but they do not certify behavior. Each one must be replaced by
 /// mandatory operation-shaped traits and shared compatibility tests, as the
 /// authentication gate has been in this layer.
-pub(crate) trait QueryAndHistoryStorage: Send + Sync {}
 pub(crate) trait WorkflowStorage: Send + Sync {}
 pub(crate) trait OperationalStorage: Send + Sync {}
 
@@ -67,10 +66,10 @@ pub(crate) trait StorageBackend:
     + EventFanoutStorage
     + EventHealthStorage
     + EventRetentionStorage
+    + HistoryStorage
     + MetricsStorage
     + OperationalStateStorage
     + TokenRetentionStorage
-    + QueryAndHistoryStorage
     + WorkflowStorage
     + OperationalStorage
     + sealed::CertifiedStorageBackend
@@ -78,7 +77,6 @@ pub(crate) trait StorageBackend:
     fn descriptor(&self) -> StorageBackendDescriptor;
 }
 
-impl QueryAndHistoryStorage for PostgresStorage {}
 impl WorkflowStorage for PostgresStorage {}
 impl OperationalStorage for PostgresStorage {}
 impl sealed::CertifiedStorageBackend for PostgresStorage {}
@@ -134,7 +132,7 @@ mod tests {
             [
                 "domain_lifecycle",
                 "identity_and_authorization_data",
-                "queries_and_history",
+                "temporal_history",
                 "workflows",
                 "operations",
             ]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -35,8 +35,12 @@ pub(crate) use hubuum_storage_core::{
     AuthorizationPolicySnapshotRow, AuthorizationPrincipal, AuthorizationStorage, EventArchive,
     EventDeliveryBatch, EventDeliveryClaim, EventDeliverySink, EventDeliveryStorage,
     EventDeliverySubscription, EventDeliveryWorkItem, EventFanoutStorage, EventRetentionStorage,
-    EventRetentionSummary, RetainedEvent,
+    EventRetentionSummary, ExportTemplateHistoryRecord, HistoryAsOfQuery, HistoryCollectionScope,
+    HistoryListQuery, HistoryMetadata, HistoryPage, HistoryPrincipalName, HistoryStorage,
+    ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectHistoryRecord, RemoteTargetHistoryRecord,
+    RetainedEvent,
 };
+pub(crate) use hubuum_storage_core::{ClassHistoryRecord, CollectionHistoryRecord};
 pub(crate) use hubuum_storage_core::{StorageError, StorageErrorKind};
 #[cfg(test)]
 pub(crate) use memory::MemoryStorageModel;

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -47,10 +47,14 @@ use super::{
     AuthorizationPrincipal, AuthorizationStorage, ClassRelationStore, ClassStore, CollectionStore,
     EventArchive, EventDeliveryBatch, EventDeliveryClaim, EventDeliveryHealthSnapshot,
     EventDeliveryStorage, EventFanoutStorage, EventHealthStorage, EventMetricsSnapshot,
-    EventRetentionStorage, EventRetentionSummary, InventoryGaugeSnapshot, MetricsStorage,
-    ObjectRelationStore, ObjectStore, OperationalStateStorage, ReadinessSnapshot, StorageError,
-    StorageIdentity, StoragePoolState, TaskGaugeSnapshot, TokenRetentionStorage,
+    EventRetentionStorage, EventRetentionSummary, ExportTemplateHistoryRecord, HistoryAsOfQuery,
+    HistoryCollectionScope, HistoryListQuery, HistoryPage, HistoryPrincipalName, HistoryStorage,
+    InventoryGaugeSnapshot, MetricsStorage, ObjectHistoryAsOfQuery, ObjectHistoryListQuery,
+    ObjectHistoryRecord, ObjectRelationStore, ObjectStore, OperationalStateStorage,
+    ReadinessSnapshot, RemoteTargetHistoryRecord, StorageError, StorageIdentity, StoragePoolState,
+    TaskGaugeSnapshot, TokenRetentionStorage,
 };
+use super::{ClassHistoryRecord, CollectionHistoryRecord};
 use error::map_postgres_error;
 
 /// Canonical production storage adapter.
@@ -201,6 +205,205 @@ impl AuthorizationStorage for PostgresStorage {
     ) -> Result<(), StorageError> {
         operations::authorization::revoke_all_local_collection_grants(&self.pool, key)
             .await
+            .map_err(map_postgres_error)
+    }
+}
+
+fn history_collection_filter(
+    scope: &HistoryCollectionScope,
+) -> operations::history::HistoryCollectionFilter<'_> {
+    match scope {
+        HistoryCollectionScope::All => operations::history::HistoryCollectionFilter::All,
+        HistoryCollectionScope::Visible(collection_ids) => {
+            operations::history::HistoryCollectionFilter::Visible(collection_ids)
+        }
+    }
+}
+
+#[async_trait]
+impl HistoryStorage for PostgresStorage {
+    async fn resolve_history_principal_names(
+        &self,
+        principal_ids: Vec<i32>,
+    ) -> Result<Vec<HistoryPrincipalName>, StorageError> {
+        operations::history::resolve_principal_name_rows(&self.pool, principal_ids)
+            .await
+            .map(|rows| {
+                rows.into_iter()
+                    .map(operations::history::principal_name_to_storage)
+                    .collect()
+            })
+            .map_err(map_postgres_error)
+    }
+
+    async fn list_collection_history(
+        &self,
+        query: HistoryListQuery,
+    ) -> Result<HistoryPage<CollectionHistoryRecord>, StorageError> {
+        let (entity_id, query_options, scope) = query.into_parts();
+        operations::history::collection_history_paginated_with_total_count(
+            entity_id,
+            &self.pool,
+            &query_options,
+            history_collection_filter(&scope),
+        )
+        .await
+        .map(|(rows, total)| {
+            HistoryPage::new(
+                rows.into_iter()
+                    .map(operations::history::collection_history_to_storage)
+                    .collect(),
+                total,
+            )
+        })
+        .map_err(map_postgres_error)
+    }
+
+    async fn collection_history_as_of(
+        &self,
+        query: HistoryAsOfQuery,
+    ) -> Result<Option<CollectionHistoryRecord>, StorageError> {
+        let (entity_id, at) = query.into_parts();
+        operations::history::collection_as_of(entity_id, at, &self.pool)
+            .await
+            .map(|row| row.map(operations::history::collection_history_to_storage))
+            .map_err(map_postgres_error)
+    }
+
+    async fn list_class_history(
+        &self,
+        query: HistoryListQuery,
+    ) -> Result<HistoryPage<ClassHistoryRecord>, StorageError> {
+        let (entity_id, query_options, scope) = query.into_parts();
+        operations::history::class_history_paginated_with_total_count(
+            entity_id,
+            &self.pool,
+            &query_options,
+            history_collection_filter(&scope),
+        )
+        .await
+        .map(|(rows, total)| {
+            HistoryPage::new(
+                rows.into_iter()
+                    .map(operations::history::class_history_to_storage)
+                    .collect(),
+                total,
+            )
+        })
+        .map_err(map_postgres_error)
+    }
+
+    async fn class_history_as_of(
+        &self,
+        query: HistoryAsOfQuery,
+    ) -> Result<Option<ClassHistoryRecord>, StorageError> {
+        let (entity_id, at) = query.into_parts();
+        operations::history::class_as_of(entity_id, at, &self.pool)
+            .await
+            .map(|row| row.map(operations::history::class_history_to_storage))
+            .map_err(map_postgres_error)
+    }
+
+    async fn list_object_history(
+        &self,
+        query: ObjectHistoryListQuery,
+    ) -> Result<HistoryPage<ObjectHistoryRecord>, StorageError> {
+        let (object_id, class_id, query_options, scope) = query.into_parts();
+        operations::history::object_history_paginated_with_total_count(
+            object_id,
+            class_id,
+            &self.pool,
+            &query_options,
+            history_collection_filter(&scope),
+        )
+        .await
+        .map(|(rows, total)| {
+            HistoryPage::new(
+                rows.into_iter()
+                    .map(operations::history::object_history_to_storage)
+                    .collect(),
+                total,
+            )
+        })
+        .map_err(map_postgres_error)
+    }
+
+    async fn object_history_as_of(
+        &self,
+        query: ObjectHistoryAsOfQuery,
+    ) -> Result<Option<ObjectHistoryRecord>, StorageError> {
+        let (object_id, class_id, at) = query.into_parts();
+        operations::history::object_as_of(object_id, class_id, at, &self.pool)
+            .await
+            .map(|row| row.map(operations::history::object_history_to_storage))
+            .map_err(map_postgres_error)
+    }
+
+    async fn list_export_template_history(
+        &self,
+        query: HistoryListQuery,
+    ) -> Result<HistoryPage<ExportTemplateHistoryRecord>, StorageError> {
+        let (entity_id, query_options, scope) = query.into_parts();
+        operations::history::export_template_history_paginated_with_total_count(
+            entity_id,
+            &self.pool,
+            &query_options,
+            history_collection_filter(&scope),
+        )
+        .await
+        .map(|(rows, total)| {
+            HistoryPage::new(
+                rows.into_iter()
+                    .map(operations::history::export_template_history_to_storage)
+                    .collect(),
+                total,
+            )
+        })
+        .map_err(map_postgres_error)
+    }
+
+    async fn export_template_history_as_of(
+        &self,
+        query: HistoryAsOfQuery,
+    ) -> Result<Option<ExportTemplateHistoryRecord>, StorageError> {
+        let (entity_id, at) = query.into_parts();
+        operations::history::export_template_as_of(entity_id, at, &self.pool)
+            .await
+            .map(|row| row.map(operations::history::export_template_history_to_storage))
+            .map_err(map_postgres_error)
+    }
+
+    async fn list_remote_target_history(
+        &self,
+        query: HistoryListQuery,
+    ) -> Result<HistoryPage<RemoteTargetHistoryRecord>, StorageError> {
+        let (entity_id, query_options, scope) = query.into_parts();
+        operations::history::remote_target_history_paginated_with_total_count(
+            entity_id,
+            &self.pool,
+            &query_options,
+            history_collection_filter(&scope),
+        )
+        .await
+        .map(|(rows, total)| {
+            HistoryPage::new(
+                rows.into_iter()
+                    .map(operations::history::remote_target_history_to_storage)
+                    .collect(),
+                total,
+            )
+        })
+        .map_err(map_postgres_error)
+    }
+
+    async fn remote_target_history_as_of(
+        &self,
+        query: HistoryAsOfQuery,
+    ) -> Result<Option<RemoteTargetHistoryRecord>, StorageError> {
+        let (entity_id, at) = query.into_parts();
+        operations::history::remote_target_as_of(entity_id, at, &self.pool)
+            .await
+            .map(|row| row.map(operations::history::remote_target_history_to_storage))
             .map_err(map_postgres_error)
     }
 }

--- a/src/storage/postgres/operations/history.rs
+++ b/src/storage/postgres/operations/history.rs
@@ -1,9 +1,18 @@
 use crate::errors::ApiError;
 use crate::events::PrincipalNames;
 use crate::models::search::QueryOptions;
+use crate::models::{
+    CollectionHistory, ExportTemplateHistory, HubuumClassHistory, HubuumObjectHistory,
+    RemoteTargetHistory,
+};
 use crate::storage::postgres::prelude::*;
 use crate::storage::postgres::with_connection;
+use crate::storage::{
+    ClassHistoryRecord, CollectionHistoryRecord, ExportTemplateHistoryRecord, HistoryMetadata,
+    HistoryPrincipalName, ObjectHistoryRecord, RemoteTargetHistoryRecord,
+};
 use chrono::{DateTime, Utc};
+use std::num::NonZeroI64;
 
 /// Collection visibility to apply before history rows are counted or paginated.
 #[derive(Clone, Copy)]
@@ -16,23 +25,139 @@ pub enum HistoryCollectionFilter<'a> {
 /// their tombstoned principal name; ids with no matching principal are absent).
 pub(crate) async fn resolve_principal_names(
     pool: &impl crate::storage::StorageContext,
-    mut principal_ids: Vec<i32>,
+    principal_ids: Vec<i32>,
 ) -> Result<PrincipalNames, ApiError> {
+    Ok(resolve_principal_name_rows(pool, principal_ids)
+        .await?
+        .into_iter()
+        .collect())
+}
+
+pub(crate) async fn resolve_principal_name_rows(
+    pool: &impl crate::storage::StorageContext,
+    mut principal_ids: Vec<i32>,
+) -> Result<Vec<(i32, String)>, ApiError> {
     use crate::schema::principals::dsl::{id, name, principals};
     principal_ids.sort_unstable();
     principal_ids.dedup();
     if principal_ids.is_empty() {
-        return Ok(PrincipalNames::default());
+        return Ok(Vec::new());
     }
-    let rows: Vec<(i32, String)> = with_connection(pool, async |conn| {
+    with_connection(pool, async |conn| {
         principals
             .filter(id.eq_any(&principal_ids))
             .select((id, name))
             .load(conn)
             .await
     })
-    .await?;
-    Ok(rows.into_iter().collect())
+    .await
+}
+
+pub(crate) fn principal_name_to_storage(row: (i32, String)) -> HistoryPrincipalName {
+    HistoryPrincipalName::new(row.0, row.1)
+}
+
+macro_rules! metadata_to_storage {
+    ($row:expr) => {
+        HistoryMetadata::new(
+            $row.op,
+            $row.valid_from,
+            $row.valid_to,
+            $row.history_id,
+            NonZeroI64::new($row.revision.get())
+                .expect("ResourceRevision always contains a positive value"),
+        )
+        .actor($row.actor_id, $row.actor_kind)
+        .initiator_principal_id($row.initiator_user_id)
+        .task_id($row.task_id)
+    };
+}
+
+pub(crate) fn collection_history_to_storage(row: CollectionHistory) -> CollectionHistoryRecord {
+    CollectionHistoryRecord::new(
+        row.id,
+        row.name,
+        row.description,
+        row.created_at,
+        row.updated_at,
+        row.parent_collection_id,
+        metadata_to_storage!(row),
+    )
+}
+
+pub(crate) fn class_history_to_storage(row: HubuumClassHistory) -> ClassHistoryRecord {
+    ClassHistoryRecord::new(
+        row.id,
+        row.name,
+        row.collection_id,
+        row.json_schema,
+        row.validate_schema,
+        row.description,
+        row.created_at,
+        row.updated_at,
+        metadata_to_storage!(row),
+    )
+}
+
+pub(crate) fn object_history_to_storage(row: HubuumObjectHistory) -> ObjectHistoryRecord {
+    ObjectHistoryRecord::new(
+        row.id,
+        row.name,
+        row.collection_id,
+        row.hubuum_class_id,
+        row.data,
+        row.description,
+        row.created_at,
+        row.updated_at,
+        metadata_to_storage!(row),
+    )
+}
+
+pub(crate) fn export_template_history_to_storage(
+    row: ExportTemplateHistory,
+) -> ExportTemplateHistoryRecord {
+    ExportTemplateHistoryRecord::new(
+        row.id,
+        row.collection_id,
+        row.name,
+        row.description,
+        row.content_type,
+        row.template,
+        row.kind,
+        row.scope_kind,
+        row.class_id,
+        row.default_query,
+        row.include,
+        row.relation_context,
+        row.default_missing_data_policy,
+        row.default_limits,
+        row.created_at,
+        row.updated_at,
+        metadata_to_storage!(row),
+    )
+}
+
+pub(crate) fn remote_target_history_to_storage(
+    row: RemoteTargetHistory,
+) -> RemoteTargetHistoryRecord {
+    RemoteTargetHistoryRecord::new(
+        row.id,
+        row.collection_id,
+        row.class_id,
+        row.name,
+        row.description,
+        row.method,
+        row.url_template,
+        row.headers_template,
+        row.body_template,
+        row.auth_config,
+        row.allowed_subject_types,
+        row.timeout_ms,
+        row.enabled,
+        row.created_at,
+        row.updated_at,
+        metadata_to_storage!(row),
+    )
 }
 
 macro_rules! history_db_fns {

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -235,7 +235,7 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         "MetricsStorage",
         "OperationalStateStorage",
         "TokenRetentionStorage",
-        "QueryAndHistoryStorage",
+        "HistoryStorage",
         "WorkflowStorage",
         "OperationalStorage",
         "sealed::CertifiedStorageBackend",

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -4,10 +4,14 @@ use actix_web::web::Data;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::events::{EventFanoutSettings, EventRetentionSettings};
-use crate::models::CollectionID;
 use crate::models::TokenRetentionSettings;
 use crate::models::identity::LOCAL_IDENTITY_SCOPE;
 use crate::models::search::QueryOptions;
+use crate::models::{
+    CollectionHistory, CollectionID, ExportTemplateHistory, HubuumClassHistory,
+    HubuumObjectHistory, RemoteTargetHistory,
+};
+use crate::pagination::prepare_db_pagination;
 use crate::services::Services;
 use crate::storage::StorageHandle;
 use crate::storage::postgres::PostgresPool;
@@ -16,9 +20,10 @@ use crate::storage::{
     AuthorizationCollectionGrantListQuery, AuthorizationCollectionsQuery, AuthorizationGrantKey,
     AuthorizationGrantMutation, AuthorizationGroupMembershipQuery, AuthorizationPermission,
     AuthorizationStorage, EventArchive, EventDeliveryStorage, EventFanoutStorage,
-    EventHealthStorage, EventRetentionStorage, MetricsStorage, OperationalStateStorage,
-    RetainedEvent, STORAGE_CONTRACT_VERSION, StorageBackendKind, StorageError,
-    TokenRetentionStorage,
+    EventHealthStorage, EventRetentionStorage, HistoryAsOfQuery, HistoryCollectionScope,
+    HistoryListQuery, HistoryStorage, MetricsStorage, ObjectHistoryAsOfQuery,
+    ObjectHistoryListQuery, OperationalStateStorage, RetainedEvent, STORAGE_CONTRACT_VERSION,
+    StorageBackendKind, StorageError, TokenRetentionStorage,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -289,6 +294,155 @@ async fn every_available_storage_backend_supplies_local_authorization_data() {
     user.delete_without_events(pool.get_ref())
         .await
         .expect("authorization compatibility user should be removed");
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_supplies_complete_temporal_history() {
+    let _permit = postgres_permit().await;
+    let pool = pool();
+    let fixture =
+        crate::tests::create_collection_fixture(pool.get_ref(), &prefix("history_collection"))
+            .await;
+    let actor_name = prefix("history_actor");
+    let actor =
+        crate::tests::create_user_with_params(pool.get_ref(), &actor_name, "testpassword").await;
+    let at = chrono::Utc::now();
+
+    for kind in StorageBackendKind::ALL {
+        match kind {
+            StorageBackendKind::Postgresql => {
+                let backend = StorageHandle::postgres(pool.get_ref().clone());
+                let collection_options = prepare_db_pagination::<CollectionHistory>(
+                    &crate::models::search::parse_query_parameter("limit=10")
+                        .expect("history compatibility query should parse"),
+                )
+                .expect("collection history pagination should prepare");
+                let collection_page = backend
+                    .list_collection_history(HistoryListQuery::new(
+                        fixture.collection.id,
+                        collection_options,
+                        HistoryCollectionScope::All,
+                    ))
+                    .await
+                    .expect("certified backend should list collection history");
+                let (collection_rows, total_count) = collection_page.into_parts();
+                assert!(!collection_rows.is_empty());
+                assert!(total_count >= 1);
+                assert!(
+                    backend
+                        .collection_history_as_of(HistoryAsOfQuery::new(fixture.collection.id, at,))
+                        .await
+                        .expect("certified backend should load collection history as of a point")
+                        .is_some()
+                );
+
+                let class_options = prepare_db_pagination::<HubuumClassHistory>(
+                    &crate::models::search::parse_query_parameter("limit=10")
+                        .expect("history compatibility query should parse"),
+                )
+                .expect("class history pagination should prepare");
+                backend
+                    .list_class_history(HistoryListQuery::new(
+                        i32::MAX,
+                        class_options,
+                        HistoryCollectionScope::All,
+                    ))
+                    .await
+                    .expect("certified backend should list class history");
+                assert!(
+                    backend
+                        .class_history_as_of(HistoryAsOfQuery::new(i32::MAX, at))
+                        .await
+                        .expect("certified backend should query class history as of a point")
+                        .is_none()
+                );
+
+                let object_options = prepare_db_pagination::<HubuumObjectHistory>(
+                    &crate::models::search::parse_query_parameter("limit=10")
+                        .expect("history compatibility query should parse"),
+                )
+                .expect("object history pagination should prepare");
+                backend
+                    .list_object_history(ObjectHistoryListQuery::new(
+                        i32::MAX,
+                        i32::MAX,
+                        object_options,
+                        HistoryCollectionScope::All,
+                    ))
+                    .await
+                    .expect("certified backend should list object history");
+                assert!(
+                    backend
+                        .object_history_as_of(ObjectHistoryAsOfQuery::new(i32::MAX, i32::MAX, at))
+                        .await
+                        .expect("certified backend should query object history as of a point")
+                        .is_none()
+                );
+
+                let template_options = prepare_db_pagination::<ExportTemplateHistory>(
+                    &crate::models::search::parse_query_parameter("limit=10")
+                        .expect("history compatibility query should parse"),
+                )
+                .expect("template history pagination should prepare");
+                backend
+                    .list_export_template_history(HistoryListQuery::new(
+                        i32::MAX,
+                        template_options,
+                        HistoryCollectionScope::All,
+                    ))
+                    .await
+                    .expect("certified backend should list template history");
+                assert!(
+                    backend
+                        .export_template_history_as_of(HistoryAsOfQuery::new(i32::MAX, at))
+                        .await
+                        .expect("certified backend should query template history as of a point")
+                        .is_none()
+                );
+
+                let remote_target_options = prepare_db_pagination::<RemoteTargetHistory>(
+                    &crate::models::search::parse_query_parameter("limit=10")
+                        .expect("history compatibility query should parse"),
+                )
+                .expect("remote-target history pagination should prepare");
+                backend
+                    .list_remote_target_history(HistoryListQuery::new(
+                        i32::MAX,
+                        remote_target_options,
+                        HistoryCollectionScope::All,
+                    ))
+                    .await
+                    .expect("certified backend should list remote-target history");
+                assert!(
+                    backend
+                        .remote_target_history_as_of(HistoryAsOfQuery::new(i32::MAX, at))
+                        .await
+                        .expect(
+                            "certified backend should query remote-target history as of a point"
+                        )
+                        .is_none()
+                );
+
+                let names = backend
+                    .resolve_history_principal_names(vec![actor.id])
+                    .await
+                    .expect("certified backend should resolve history principal names");
+                assert!(names.into_iter().any(|row| {
+                    let (principal_id, name) = row.into_parts();
+                    principal_id == actor.id && name == actor_name
+                }));
+            }
+        }
+    }
+
+    fixture
+        .cleanup()
+        .await
+        .expect("history compatibility collection should be removed");
+    actor
+        .delete_without_events(pool.get_ref())
+        .await
+        .expect("history compatibility actor should be removed");
 }
 
 #[actix_web::test]

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -117,7 +117,7 @@ async fn metrics_endpoint_is_best_effort_when_database_refresh_fails() {
 #[actix_web::test]
 async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() {
     let body = scrape_recorded_metrics(|| {
-        metrics::storage_backend_identity("postgresql", 1);
+        metrics::storage_backend_identity("postgresql", 2);
         metrics::storage_operation_finished(
             "postgresql",
             "objects",
@@ -130,7 +130,7 @@ async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() 
 
     assert!(
         body.contains(
-            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"1\"} 1"
+            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"2\"} 1"
         )
     );
     assert!(body.contains(

--- a/tests/api_platform_suite/runtime_config.rs
+++ b/tests/api_platform_suite/runtime_config.rs
@@ -37,13 +37,13 @@ mod tests {
         let serialized = serde_json::to_string(&body).unwrap();
 
         assert_eq!(body["database"]["backend"], "postgresql");
-        assert_eq!(body["database"]["contract_version"], 1);
+        assert_eq!(body["database"]["contract_version"], 2);
         assert_eq!(
             body["database"]["capabilities"],
             serde_json::json!([
                 "domain_lifecycle",
                 "identity_and_authorization_data",
-                "queries_and_history",
+                "temporal_history",
                 "workflows",
                 "operations"
             ])


### PR DESCRIPTION
## Summary

- replace the provisional query/history marker with a mandatory, operation-shaped `HistoryStorage` contract
- move every public temporal-history read behind backend-neutral request and response DTOs owned by `hubuum-storage-core`
- make the PostgreSQL adapter translate its private rows and errors at the boundary, while the application service alone translates storage DTOs and `StorageError` into domain responses and `ApiError`
- instrument every history entry point with bounded `history/*` operation labels
- extend available-backend compatibility tests across all eleven history operations, including visibility, point-in-time lookup, and provenance-name resolution

## Boundary behavior

The root application and HTTP handlers no longer call the PostgreSQL history capability facade. They depend on `HistoryStorage` through `StorageHandle`, and do not receive Diesel models, connections, pools, or PostgreSQL errors.

Any selectable backend must now implement collection, class, object, export-template, and remote-target history pagination and as-of reads, plus principal-name resolution. This is enforced by the sealed `StorageBackend` supertrait and exercised by the shared compatibility suite; a partially implemented backend cannot be composed.

## Breaking administrator API change

The reported storage contract version is now `2`, and the redacted running configuration reports `temporal_history` instead of the provisional `queries_and_history` capability label. Monitoring and administration clients matching the old string must migrate to `temporal_history`.

This is recorded under `[Unreleased]` in `CHANGELOG.md`.

## Stack

This PR is stacked on #301 and is the next required storage-boundary layer. It should be reviewed and merged after its parent.

## Verification

- `source .env && ./run_tests.sh`
- `cargo test -p hubuum-storage-core --locked`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- Rust API, supply-chain, CI-classifier, and `cargo deny --all-features --locked check` policy suites
- regenerated OpenAPI matches `docs/openapi.json`

