### PR TITLE
Extract mandatory unified search storage contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
-- **Breaking (administrator API):** the storage contract version is now `2`,
-  and the redacted administrator configuration reports the newly enforced
-  `temporal_history` capability instead of the broader provisional
-  `queries_and_history` label. Monitoring or administration clients matching
-  the old capability string must switch to `temporal_history`.
+- **Breaking (administrator API):** the storage contract version is now `3`,
+  and the redacted administrator configuration reports the independently
+  enforced `temporal_history` and `unified_search` capabilities instead of the
+  broader provisional `queries_and_history` label. Monitoring or administration
+  clients matching the old capability string must switch to the new labels.
 - Event worker and retention configuration validation now uses backend-neutral
   policy terminology, matching the storage traits and DTOs used by application
   workers instead of exposing database implementation language.

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -9,6 +9,7 @@ mod events;
 mod history;
 mod identity;
 mod operational;
+mod unified_search;
 
 pub use authorization::{
     AuthorizationCollection, AuthorizationCollectionAccessQuery,
@@ -40,6 +41,10 @@ pub use operational::{
     EventSubscriptionHealthSnapshot, OperationalStateStorage, ReadinessSnapshot,
     TokenRetentionStorage,
 };
+pub use unified_search::{
+    UnifiedSearchClass, UnifiedSearchCollection, UnifiedSearchCursor, UnifiedSearchObject,
+    UnifiedSearchQuery, UnifiedSearchResourceScope, UnifiedSearchStorage, UnifiedSearchVisibility,
+};
 
 use std::fmt;
 
@@ -47,7 +52,7 @@ use std::fmt;
 ///
 /// Increment this when a selectable backend must implement a new capability
 /// family or when an existing family's externally observable semantics change.
-pub const STORAGE_CONTRACT_VERSION: u16 = 2;
+pub const STORAGE_CONTRACT_VERSION: u16 = 3;
 
 /// Stable identity of a selectable storage backend.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -73,15 +78,17 @@ pub enum StorageCapability {
     DomainLifecycle,
     IdentityAndAuthorizationData,
     TemporalHistory,
+    UnifiedSearch,
     Workflows,
     Operations,
 }
 
 impl StorageCapability {
-    pub const ALL: [Self; 5] = [
+    pub const ALL: [Self; 6] = [
         Self::DomainLifecycle,
         Self::IdentityAndAuthorizationData,
         Self::TemporalHistory,
+        Self::UnifiedSearch,
         Self::Workflows,
         Self::Operations,
     ];
@@ -92,6 +99,7 @@ impl StorageCapability {
             Self::DomainLifecycle => "domain_lifecycle",
             Self::IdentityAndAuthorizationData => "identity_and_authorization_data",
             Self::TemporalHistory => "temporal_history",
+            Self::UnifiedSearch => "unified_search",
             Self::Workflows => "workflows",
             Self::Operations => "operations",
         }
@@ -244,6 +252,7 @@ mod tests {
                 "domain_lifecycle",
                 "identity_and_authorization_data",
                 "temporal_history",
+                "unified_search",
                 "workflows",
                 "operations",
             ]

--- a/crates/hubuum-storage-core/src/unified_search.rs
+++ b/crates/hubuum-storage-core/src/unified_search.rs
@@ -1,0 +1,522 @@
+use std::fmt;
+
+use async_trait::async_trait;
+use chrono::NaiveDateTime;
+use serde_json::Value;
+
+use crate::{AuthorizationPermission, StorageError};
+
+/// Normalized collection, class, and object boundary for a scoped search.
+#[derive(Clone, PartialEq, Eq)]
+pub struct UnifiedSearchResourceScope {
+    collection_ids: Vec<i32>,
+    class_ids: Vec<i32>,
+    object_ids: Vec<i32>,
+}
+
+impl UnifiedSearchResourceScope {
+    #[must_use]
+    pub fn new(
+        collection_ids: impl IntoIterator<Item = i32>,
+        class_ids: impl IntoIterator<Item = i32>,
+        object_ids: impl IntoIterator<Item = i32>,
+    ) -> Self {
+        Self {
+            collection_ids: normalized_ids(collection_ids),
+            class_ids: normalized_ids(class_ids),
+            object_ids: normalized_ids(object_ids),
+        }
+    }
+
+    #[must_use]
+    pub fn collection_ids(&self) -> &[i32] {
+        &self.collection_ids
+    }
+
+    #[must_use]
+    pub fn class_ids(&self) -> &[i32] {
+        &self.class_ids
+    }
+
+    #[must_use]
+    pub fn object_ids(&self) -> &[i32] {
+        &self.object_ids
+    }
+}
+
+impl fmt::Debug for UnifiedSearchResourceScope {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("UnifiedSearchResourceScope")
+            .field("collection_count", &self.collection_ids.len())
+            .field("class_count", &self.class_ids.len())
+            .field("object_count", &self.object_ids.len())
+            .finish()
+    }
+}
+
+fn normalized_ids(ids: impl IntoIterator<Item = i32>) -> Vec<i32> {
+    let mut ids = ids.into_iter().collect::<Vec<_>>();
+    ids.sort_unstable();
+    ids.dedup();
+    ids
+}
+
+/// Principal and token boundaries which the adapter must apply before paging.
+///
+/// An absent permission or resource dimension is unrestricted. A present but
+/// empty permission dimension denies every permission and therefore fails
+/// closed for all search kinds.
+#[derive(Clone, PartialEq, Eq)]
+pub struct UnifiedSearchVisibility {
+    principal_id: i32,
+    is_admin: bool,
+    permissions: Option<Vec<AuthorizationPermission>>,
+    resources: Option<UnifiedSearchResourceScope>,
+}
+
+impl UnifiedSearchVisibility {
+    #[must_use]
+    pub fn new(
+        principal_id: i32,
+        is_admin: bool,
+        permissions: Option<impl IntoIterator<Item = AuthorizationPermission>>,
+        resources: Option<UnifiedSearchResourceScope>,
+    ) -> Self {
+        let permissions = permissions.map(|permissions| {
+            let mut permissions = permissions.into_iter().collect::<Vec<_>>();
+            permissions.sort_unstable();
+            permissions.dedup();
+            permissions
+        });
+        Self {
+            principal_id,
+            is_admin,
+            permissions,
+            resources,
+        }
+    }
+
+    #[must_use]
+    pub const fn principal_id(&self) -> i32 {
+        self.principal_id
+    }
+
+    #[must_use]
+    pub const fn is_admin(&self) -> bool {
+        self.is_admin
+    }
+
+    #[must_use]
+    pub fn permissions(&self) -> Option<&[AuthorizationPermission]> {
+        self.permissions.as_deref()
+    }
+
+    #[must_use]
+    pub const fn resources(&self) -> Option<&UnifiedSearchResourceScope> {
+        self.resources.as_ref()
+    }
+
+    #[must_use]
+    pub fn allows_permissions(&self, required: &[AuthorizationPermission]) -> bool {
+        self.permissions.as_ref().is_none_or(|allowed| {
+            required
+                .iter()
+                .all(|permission| allowed.contains(permission))
+        })
+    }
+}
+
+impl fmt::Debug for UnifiedSearchVisibility {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("UnifiedSearchVisibility")
+            .field("principal_id", &"[redacted]")
+            .field("is_admin", &self.is_admin)
+            .field("permission_count", &self.permissions.as_ref().map(Vec::len))
+            .field("resources", &self.resources)
+            .finish()
+    }
+}
+
+/// Backend-neutral decoded cursor for one ranked search kind.
+#[derive(Clone, PartialEq, Eq)]
+pub struct UnifiedSearchCursor {
+    rank: i32,
+    normalized_name: String,
+    id: i32,
+}
+
+impl UnifiedSearchCursor {
+    #[must_use]
+    pub fn new(rank: i32, normalized_name: impl Into<String>, id: i32) -> Self {
+        Self {
+            rank,
+            normalized_name: normalized_name.into(),
+            id,
+        }
+    }
+
+    #[must_use]
+    pub const fn rank(&self) -> i32 {
+        self.rank
+    }
+
+    #[must_use]
+    pub fn normalized_name(&self) -> &str {
+        &self.normalized_name
+    }
+
+    #[must_use]
+    pub const fn id(&self) -> i32 {
+        self.id
+    }
+}
+
+impl fmt::Debug for UnifiedSearchCursor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("UnifiedSearchCursor")
+            .field("rank", &self.rank)
+            .field("normalized_name", &"[redacted]")
+            .field("id", &"[redacted]")
+            .finish()
+    }
+}
+
+/// One operation-shaped ranked search request.
+#[derive(Clone, PartialEq, Eq)]
+pub struct UnifiedSearchQuery {
+    search_term: String,
+    limit: usize,
+    search_extended_document: bool,
+    cursor: Option<UnifiedSearchCursor>,
+    visibility: UnifiedSearchVisibility,
+}
+
+impl UnifiedSearchQuery {
+    #[must_use]
+    pub fn new(
+        search_term: impl Into<String>,
+        limit: usize,
+        visibility: UnifiedSearchVisibility,
+    ) -> Self {
+        Self {
+            search_term: search_term.into(),
+            limit,
+            search_extended_document: false,
+            cursor: None,
+            visibility,
+        }
+    }
+
+    #[must_use]
+    pub const fn search_extended_document(mut self, enabled: bool) -> Self {
+        self.search_extended_document = enabled;
+        self
+    }
+
+    #[must_use]
+    pub fn cursor(mut self, cursor: Option<UnifiedSearchCursor>) -> Self {
+        self.cursor = cursor;
+        self
+    }
+
+    #[must_use]
+    pub fn search_term(&self) -> &str {
+        &self.search_term
+    }
+
+    #[must_use]
+    pub const fn limit(&self) -> usize {
+        self.limit
+    }
+
+    #[must_use]
+    pub const fn searches_extended_document(&self) -> bool {
+        self.search_extended_document
+    }
+
+    #[must_use]
+    pub const fn search_cursor(&self) -> Option<&UnifiedSearchCursor> {
+        self.cursor.as_ref()
+    }
+
+    #[must_use]
+    pub const fn visibility(&self) -> &UnifiedSearchVisibility {
+        &self.visibility
+    }
+}
+
+impl fmt::Debug for UnifiedSearchQuery {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("UnifiedSearchQuery")
+            .field("search_term", &"[redacted]")
+            .field("limit", &self.limit)
+            .field("search_extended_document", &self.search_extended_document)
+            .field("cursor", &self.cursor)
+            .field("visibility", &self.visibility)
+            .finish()
+    }
+}
+
+/// Collection projection returned by unified search.
+#[derive(Clone, PartialEq, Eq)]
+pub struct UnifiedSearchCollection {
+    id: i32,
+    name: String,
+    description: String,
+    created_at: NaiveDateTime,
+    updated_at: NaiveDateTime,
+    parent_collection_id: Option<i32>,
+    revision: i64,
+}
+
+impl UnifiedSearchCollection {
+    #[must_use]
+    pub fn new(
+        id: i32,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        created_at: NaiveDateTime,
+        updated_at: NaiveDateTime,
+        parent_collection_id: Option<i32>,
+        revision: i64,
+    ) -> Self {
+        Self {
+            id,
+            name: name.into(),
+            description: description.into(),
+            created_at,
+            updated_at,
+            parent_collection_id,
+            revision,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        i32,
+        String,
+        String,
+        NaiveDateTime,
+        NaiveDateTime,
+        Option<i32>,
+        i64,
+    ) {
+        (
+            self.id,
+            self.name,
+            self.description,
+            self.created_at,
+            self.updated_at,
+            self.parent_collection_id,
+            self.revision,
+        )
+    }
+}
+
+/// Class projection returned by unified search, including its collection.
+#[derive(Clone, PartialEq)]
+pub struct UnifiedSearchClass {
+    id: i32,
+    name: String,
+    collection: UnifiedSearchCollection,
+    json_schema: Option<Value>,
+    validate_schema: bool,
+    description: String,
+    created_at: NaiveDateTime,
+    updated_at: NaiveDateTime,
+    revision: i64,
+}
+
+impl UnifiedSearchClass {
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: i32,
+        name: impl Into<String>,
+        collection: UnifiedSearchCollection,
+        json_schema: Option<Value>,
+        validate_schema: bool,
+        description: impl Into<String>,
+        created_at: NaiveDateTime,
+        updated_at: NaiveDateTime,
+        revision: i64,
+    ) -> Self {
+        Self {
+            id,
+            name: name.into(),
+            collection,
+            json_schema,
+            validate_schema,
+            description: description.into(),
+            created_at,
+            updated_at,
+            revision,
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::type_complexity)]
+    pub fn into_parts(
+        self,
+    ) -> (
+        i32,
+        String,
+        UnifiedSearchCollection,
+        Option<Value>,
+        bool,
+        String,
+        NaiveDateTime,
+        NaiveDateTime,
+        i64,
+    ) {
+        (
+            self.id,
+            self.name,
+            self.collection,
+            self.json_schema,
+            self.validate_schema,
+            self.description,
+            self.created_at,
+            self.updated_at,
+            self.revision,
+        )
+    }
+}
+
+/// Object projection returned by unified search.
+#[derive(Clone, PartialEq)]
+pub struct UnifiedSearchObject {
+    id: i32,
+    name: String,
+    collection_id: i32,
+    class_id: i32,
+    data: Value,
+    description: String,
+    created_at: NaiveDateTime,
+    updated_at: NaiveDateTime,
+    revision: i64,
+}
+
+impl UnifiedSearchObject {
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: i32,
+        name: impl Into<String>,
+        collection_id: i32,
+        class_id: i32,
+        data: Value,
+        description: impl Into<String>,
+        created_at: NaiveDateTime,
+        updated_at: NaiveDateTime,
+        revision: i64,
+    ) -> Self {
+        Self {
+            id,
+            name: name.into(),
+            collection_id,
+            class_id,
+            data,
+            description: description.into(),
+            created_at,
+            updated_at,
+            revision,
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::type_complexity)]
+    pub fn into_parts(
+        self,
+    ) -> (
+        i32,
+        String,
+        i32,
+        i32,
+        Value,
+        String,
+        NaiveDateTime,
+        NaiveDateTime,
+        i64,
+    ) {
+        (
+            self.id,
+            self.name,
+            self.collection_id,
+            self.class_id,
+            self.data,
+            self.description,
+            self.created_at,
+            self.updated_at,
+            self.revision,
+        )
+    }
+}
+
+/// Mandatory backend contract for the three ranked unified-search projections.
+#[async_trait]
+pub trait UnifiedSearchStorage: Send + Sync {
+    async fn search_unified_collections(
+        &self,
+        query: UnifiedSearchQuery,
+    ) -> Result<Vec<UnifiedSearchCollection>, StorageError>;
+
+    async fn search_unified_classes(
+        &self,
+        query: UnifiedSearchQuery,
+    ) -> Result<Vec<UnifiedSearchClass>, StorageError>;
+
+    async fn search_unified_objects(
+        &self,
+        query: UnifiedSearchQuery,
+    ) -> Result<Vec<UnifiedSearchObject>, StorageError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scoped_permissions_fail_closed() {
+        let visibility = UnifiedSearchVisibility::new(
+            42,
+            true,
+            Some([AuthorizationPermission::ReadCollection]),
+            None,
+        );
+
+        assert!(visibility.allows_permissions(&[AuthorizationPermission::ReadCollection]));
+        assert!(!visibility.allows_permissions(&[
+            AuthorizationPermission::ReadCollection,
+            AuthorizationPermission::ReadObject,
+        ]));
+    }
+
+    #[test]
+    fn resource_scope_normalizes_identifiers() {
+        let scope = UnifiedSearchResourceScope::new([3, 1, 3], [8, 4, 8], [7, 2, 7]);
+
+        assert_eq!(scope.collection_ids(), &[1, 3]);
+        assert_eq!(scope.class_ids(), &[4, 8]);
+        assert_eq!(scope.object_ids(), &[2, 7]);
+    }
+
+    #[test]
+    fn debug_output_redacts_search_and_principal_values() {
+        let visibility =
+            UnifiedSearchVisibility::new(42, false, None::<[AuthorizationPermission; 0]>, None);
+        let query = UnifiedSearchQuery::new("secret asset", 10, visibility)
+            .cursor(Some(UnifiedSearchCursor::new(2, "secret asset", 99)));
+
+        let debug = format!("{query:?}");
+        assert!(!debug.contains("secret asset"));
+        assert!(!debug.contains("42"));
+        assert!(!debug.contains("99"));
+    }
+}

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -64,6 +64,7 @@ satisfy every capability family below before `StorageHandle` can compose it:
 | Domain lifecycle | Collection, class, object, class-relation, and object-relation resolution and lifecycle behavior |
 | Identity and authorization data | Principals, credentials, memberships, grants, and data needed by configured authorization providers |
 | Temporal history | Revision-filtered pages, stable cursors, point-in-time reads, visibility pushdown, and provenance-name resolution |
+| Unified search | Ranked collection, class, and object search with stable per-kind cursors and token visibility pushdown |
 | Workflows | Imports, restores, tasks, backups, exports, remote calls, and their atomic state transitions |
 | Operations | Probes, metrics snapshots, retention, event delivery, leases, locking, and worker coordination |
 
@@ -75,9 +76,10 @@ During extraction, the workflow and remaining operational
 families retain temporary central migration gates. Those gates prevent another
 backend from becoming selectable, but they are not behavioral proof and must
 be replaced by mandatory operation-shaped traits and shared tests. The former
-identity and history gates have now been replaced by the real
+identity, history, and unified-search gates have now been replaced by the real
 `AuthenticationStorage`, `AuthorizationStorage`, and `HistoryStorage`
-contracts; no family is considered complete merely because a marker exists.
+contracts plus `UnifiedSearchStorage`; no family is considered complete merely
+because a marker exists.
 
 PostgreSQL query implementations live in
 `src/storage/postgres/operations/*`. Separating their persistence rows from
@@ -196,6 +198,16 @@ calls with bounded `history/*` labels. The application history service converts
 DTOs into response models and is the only layer that maps `StorageError` into
 `ApiError`.
 
+`UnifiedSearchStorage` owns all three ranked search projections as one complete
+capability: collections, classes with their collection projection, and objects.
+The request owns decoded cursor state, query options, administrator status, and
+independent token permission/resource dimensions. The PostgreSQL adapter maps
+those DTOs to its private query implementation and returns private-field DTOs;
+the application service alone reconstructs API/domain models. Each entry point
+is observed with a bounded `unified_search/{collections,classes,objects}` label,
+and the available-backend compatibility test exercises every operation with
+real matching rows.
+
 ## Error Direction
 
 Errors cross the boundary in one direction:
@@ -310,7 +322,8 @@ The first workspace boundaries are now in place:
 - `hubuum-storage-core` owns backend-neutral descriptors, the contract version,
   capability identities, `StorageError`, authentication and authorization
   DTOs, operational snapshot DTOs, and the extracted authentication,
-  authorization, temporal-history, operational state, event-health, event-fan-out,
+  authorization, temporal-history, unified-search, operational state,
+  event-health, event-fan-out,
   event-retention, and token-retention traits without application, transport,
   or driver dependencies.
 - `hubuum-storage-postgres` owns PostgreSQL pool construction, TLS connection

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -453,8 +453,9 @@ mod tests {
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
         assert!(json.contains("\"backend\":\"postgresql\""));
-        assert!(json.contains("\"contract_version\":2"));
+        assert!(json.contains("\"contract_version\":3"));
         assert!(json.contains("\"temporal_history\""));
+        assert!(json.contains("\"unified_search\""));
         assert!(!debug.contains("secret-password"));
         assert!(!debug.contains("correct horse battery staple"));
     }

--- a/src/models/traits/user.rs
+++ b/src/models/traits/user.rs
@@ -6,14 +6,14 @@ use crate::models::{
     ClassGraphRow, Collection, ExportIncludeRelatedQuery, Group, HubuumClass, HubuumClassExpanded,
     HubuumClassRelation, HubuumObject, HubuumObjectRelation, ObjectAggregateBackendRequest,
     ObjectAggregatePage, Permissions, RelatedObjectForRootRow, RelatedObjectGraphRow,
-    RelatedObjectIncludeRow, UnifiedSearchSpec, User, UserID,
+    RelatedObjectIncludeRow, User, UserID,
 };
 
 use crate::errors::ApiError;
 use crate::storage::StorageContext;
 use crate::storage::postgres::operations::user::{
     LoadPermittedCollections, LoadUserGroups, LoadUserGroupsPaginated, LoadUserRecord,
-    ObjectAggregateBackend, UnifiedSearchBackend, UserSearchBackend,
+    ObjectAggregateBackend, UserSearchBackend,
 };
 use crate::traits::accessors::{IdAccessor, InstanceAdapter};
 use crate::traits::{AuthzSubject, ClassAccessors, SelfAccessors};
@@ -312,45 +312,6 @@ pub trait Search: UserCollectionAccessors {
         C: StorageContext,
     {
         self.search_object_relations_between_ids_from_backend(backend, object_ids, scopes)
-            .await
-    }
-
-    async fn search_unified_collections<C>(
-        &self,
-        backend: &C,
-        query: &UnifiedSearchSpec,
-        scopes: Option<&TokenScope>,
-    ) -> Result<Vec<Collection>, ApiError>
-    where
-        C: StorageContext,
-    {
-        self.search_unified_collections_from_backend(backend, query, scopes)
-            .await
-    }
-
-    async fn search_unified_classes<C>(
-        &self,
-        backend: &C,
-        query: &UnifiedSearchSpec,
-        scopes: Option<&TokenScope>,
-    ) -> Result<Vec<HubuumClassExpanded>, ApiError>
-    where
-        C: StorageContext,
-    {
-        self.search_unified_classes_from_backend(backend, query, scopes)
-            .await
-    }
-
-    async fn search_unified_objects<C>(
-        &self,
-        backend: &C,
-        query: &UnifiedSearchSpec,
-        scopes: Option<&TokenScope>,
-    ) -> Result<Vec<HubuumObject>, ApiError>
-    where
-        C: StorageContext,
-    {
-        self.search_unified_objects_from_backend(backend, query, scopes)
             .await
     }
 }

--- a/src/models/unified_search.rs
+++ b/src/models/unified_search.rs
@@ -14,9 +14,9 @@ use crate::permissions::visibility::authorize_all_candidates;
 use crate::permissions::{
     PermissionBackend, PrincipalRef, ResourceAttrs, ResourceKind, ResourceRef,
 };
+use crate::services::unified_search as unified_search_service;
 use crate::storage::StorageContext;
-use crate::storage::postgres::operations::user::UnifiedSearchBackend;
-use crate::traits::Search;
+use crate::traits::AuthzSubject;
 use crate::traits::scope_allows;
 use crate::utilities::extensions::CustomStringExtensions;
 
@@ -453,11 +453,12 @@ async fn search_collections<C, S>(
     params: &UnifiedSearchQuery,
     search_spec: &UnifiedSearchSpec,
     scopes: Option<&TokenScope>,
+    is_admin: bool,
     authorization: Option<(&dyn PermissionBackend, &PrincipalRef)>,
 ) -> Result<SearchPage<Collection>, ApiError>
 where
     C: StorageContext,
-    S: Search + ?Sized,
+    S: AuthzSubject + ?Sized,
 {
     let rows = if let Some((permission_backend, principal)) = authorization {
         if !scope_allows(scopes, &[Permissions::ReadCollection]) {
@@ -465,14 +466,14 @@ where
         } else {
             let mut candidate_spec = search_spec.clone();
             candidate_spec.limit_per_kind = usize::MAX;
-            let candidates = user
-                .search_unified_collections_from_backend_with_admin_status(
-                    backend,
-                    &candidate_spec,
-                    None,
-                    true,
-                )
-                .await?;
+            let candidates = unified_search_service::search_collections(
+                backend,
+                user.principal_id(),
+                true,
+                None,
+                &candidate_spec,
+            )
+            .await?;
             authorize_all_candidates(
                 permission_backend,
                 principal,
@@ -484,8 +485,14 @@ where
             .await?
         }
     } else {
-        user.search_unified_collections(backend, search_spec, scopes)
-            .await?
+        unified_search_service::search_collections(
+            backend,
+            user.principal_id(),
+            is_admin,
+            scopes,
+            search_spec,
+        )
+        .await?
     };
     if rows.is_empty() {
         return Ok(SearchPage {
@@ -525,11 +532,12 @@ async fn search_classes<C, S>(
     params: &UnifiedSearchQuery,
     search_spec: &UnifiedSearchSpec,
     scopes: Option<&TokenScope>,
+    is_admin: bool,
     authorization: Option<(&dyn PermissionBackend, &PrincipalRef)>,
 ) -> Result<SearchPage<HubuumClassExpanded>, ApiError>
 where
     C: StorageContext,
-    S: Search + ?Sized,
+    S: AuthzSubject + ?Sized,
 {
     let rows = if let Some((permission_backend, principal)) = authorization {
         if !scope_allows(scopes, &[Permissions::ReadClass]) {
@@ -537,14 +545,14 @@ where
         } else {
             let mut candidate_spec = search_spec.clone();
             candidate_spec.limit_per_kind = usize::MAX;
-            let candidates = user
-                .search_unified_classes_from_backend_with_admin_status(
-                    backend,
-                    &candidate_spec,
-                    None,
-                    true,
-                )
-                .await?;
+            let candidates = unified_search_service::search_classes(
+                backend,
+                user.principal_id(),
+                true,
+                None,
+                &candidate_spec,
+            )
+            .await?;
             authorize_all_candidates(
                 permission_backend,
                 principal,
@@ -564,8 +572,14 @@ where
             .await?
         }
     } else {
-        user.search_unified_classes(backend, search_spec, scopes)
-            .await?
+        unified_search_service::search_classes(
+            backend,
+            user.principal_id(),
+            is_admin,
+            scopes,
+            search_spec,
+        )
+        .await?
     };
     if rows.is_empty() {
         return Ok(SearchPage {
@@ -603,11 +617,12 @@ async fn search_objects<C, S>(
     params: &UnifiedSearchQuery,
     search_spec: &UnifiedSearchSpec,
     scopes: Option<&TokenScope>,
+    is_admin: bool,
     authorization: Option<(&dyn PermissionBackend, &PrincipalRef)>,
 ) -> Result<SearchPage<HubuumObject>, ApiError>
 where
     C: StorageContext,
-    S: Search + ?Sized,
+    S: AuthzSubject + ?Sized,
 {
     let rows = if let Some((permission_backend, principal)) = authorization {
         if !scope_allows(scopes, &[Permissions::ReadObject]) {
@@ -615,14 +630,14 @@ where
         } else {
             let mut candidate_spec = search_spec.clone();
             candidate_spec.limit_per_kind = usize::MAX;
-            let candidates = user
-                .search_unified_objects_from_backend_with_admin_status(
-                    backend,
-                    &candidate_spec,
-                    None,
-                    true,
-                )
-                .await?;
+            let candidates = unified_search_service::search_objects(
+                backend,
+                user.principal_id(),
+                true,
+                None,
+                &candidate_spec,
+            )
+            .await?;
             authorize_all_candidates(
                 permission_backend,
                 principal,
@@ -643,8 +658,14 @@ where
             .await?
         }
     } else {
-        user.search_unified_objects(backend, search_spec, scopes)
-            .await?
+        unified_search_service::search_objects(
+            backend,
+            user.principal_id(),
+            is_admin,
+            scopes,
+            search_spec,
+        )
+        .await?
     };
     if rows.is_empty() {
         return Ok(SearchPage {
@@ -680,7 +701,7 @@ pub async fn execute_unified_search<C, S>(
 ) -> Result<UnifiedSearchResponse, ApiError>
 where
     C: StorageContext,
-    S: Search + ?Sized,
+    S: AuthzSubject + ?Sized,
 {
     let search_spec = params.search_spec();
     let external_backend = backend
@@ -691,10 +712,24 @@ where
     } else {
         None
     };
+    let is_admin = if external_backend.is_some() {
+        true
+    } else {
+        crate::traits::AuthzSubject::is_admin(user, backend).await?
+    };
     let authorization = external_backend.zip(principal.as_ref());
     let collections_future = async {
         if params.includes(UnifiedSearchKind::Collection) {
-            search_collections(user, backend, params, &search_spec, scopes, authorization).await
+            search_collections(
+                user,
+                backend,
+                params,
+                &search_spec,
+                scopes,
+                is_admin,
+                authorization,
+            )
+            .await
         } else {
             Ok(SearchPage {
                 items: vec![],
@@ -704,7 +739,16 @@ where
     };
     let classes_future = async {
         if params.includes(UnifiedSearchKind::Class) {
-            search_classes(user, backend, params, &search_spec, scopes, authorization).await
+            search_classes(
+                user,
+                backend,
+                params,
+                &search_spec,
+                scopes,
+                is_admin,
+                authorization,
+            )
+            .await
         } else {
             Ok(SearchPage {
                 items: vec![],
@@ -714,7 +758,16 @@ where
     };
     let objects_future = async {
         if params.includes(UnifiedSearchKind::Object) {
-            search_objects(user, backend, params, &search_spec, scopes, authorization).await
+            search_objects(
+                user,
+                backend,
+                params,
+                &search_spec,
+                scopes,
+                is_admin,
+                authorization,
+            )
+            .await
         } else {
             Ok(SearchPage {
                 items: vec![],
@@ -749,7 +802,7 @@ pub async fn execute_unified_search_batch<C, S>(
 ) -> Result<UnifiedSearchBatchResponse, ApiError>
 where
     C: StorageContext,
-    S: Search + ?Sized,
+    S: AuthzSubject + ?Sized,
 {
     let search_spec = params.search_spec();
     let external_backend = backend
@@ -760,12 +813,24 @@ where
     } else {
         None
     };
+    let is_admin = if external_backend.is_some() {
+        true
+    } else {
+        crate::traits::AuthzSubject::is_admin(user, backend).await?
+    };
     let authorization = external_backend.zip(principal.as_ref());
     match kind {
         UnifiedSearchKind::Collection => {
-            let page =
-                search_collections(user, backend, params, &search_spec, scopes, authorization)
-                    .await?;
+            let page = search_collections(
+                user,
+                backend,
+                params,
+                &search_spec,
+                scopes,
+                is_admin,
+                authorization,
+            )
+            .await?;
             Ok(UnifiedSearchBatchResponse {
                 kind: kind.batch_key().to_string(),
                 collections: page.items,
@@ -775,8 +840,16 @@ where
             })
         }
         UnifiedSearchKind::Class => {
-            let page =
-                search_classes(user, backend, params, &search_spec, scopes, authorization).await?;
+            let page = search_classes(
+                user,
+                backend,
+                params,
+                &search_spec,
+                scopes,
+                is_admin,
+                authorization,
+            )
+            .await?;
             Ok(UnifiedSearchBatchResponse {
                 kind: kind.batch_key().to_string(),
                 collections: vec![],
@@ -786,8 +859,16 @@ where
             })
         }
         UnifiedSearchKind::Object => {
-            let page =
-                search_objects(user, backend, params, &search_spec, scopes, authorization).await?;
+            let page = search_objects(
+                user,
+                backend,
+                params,
+                &search_spec,
+                scopes,
+                is_admin,
+                authorization,
+            )
+            .await?;
             Ok(UnifiedSearchBatchResponse {
                 kind: kind.batch_key().to_string(),
                 collections: vec![],

--- a/src/permissions/mod.rs
+++ b/src/permissions/mod.rs
@@ -20,6 +20,7 @@ pub mod test_support;
 pub use backend::PermissionBackend;
 pub use context::AppContext;
 pub use local::LocalPermissionBackend;
+pub(crate) use storage::permission_to_storage;
 pub use types::{
     AuthzTarget, PermissionDecision, PermissionRequest, PrincipalRef, ResourceAttrs, ResourceKind,
     ResourceRef,

--- a/src/permissions/storage.rs
+++ b/src/permissions/storage.rs
@@ -8,7 +8,7 @@ use crate::models::{
     Collection, Group, GroupPermission, Permission, Permissions, ResourceRevision,
 };
 
-pub(super) const fn permission_to_storage(permission: Permissions) -> AuthorizationPermission {
+pub(crate) const fn permission_to_storage(permission: Permissions) -> AuthorizationPermission {
     match permission {
         Permissions::ReadCollection => AuthorizationPermission::ReadCollection,
         Permissions::UpdateCollection => AuthorizationPermission::UpdateCollection,

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -4,6 +4,7 @@ mod collections;
 pub(crate) mod history;
 mod object_relations;
 mod objects;
+pub(crate) mod unified_search;
 
 pub use class_relations::ClassRelationService;
 pub use classes::ClassService;

--- a/src/services/unified_search.rs
+++ b/src/services/unified_search.rs
@@ -1,0 +1,233 @@
+use crate::errors::ApiError;
+use crate::models::{
+    Collection, HubuumClassExpanded, HubuumObject, ResourceRevision, TokenResourceScope,
+    TokenScope, UnifiedSearchCursorToken, UnifiedSearchSpec,
+};
+use crate::permissions::permission_to_storage;
+use crate::storage::{
+    StorageContext, UnifiedSearchClass, UnifiedSearchCollection, UnifiedSearchCursor,
+    UnifiedSearchObject, UnifiedSearchQuery, UnifiedSearchResourceScope, UnifiedSearchStorage,
+    UnifiedSearchVisibility, storage_handle,
+};
+
+fn resource_scope(scope: &TokenScope) -> Result<Option<UnifiedSearchResourceScope>, ApiError> {
+    let Some(resources) = scope.resources()? else {
+        return Ok(None);
+    };
+    let mut collection_ids = Vec::new();
+    let mut class_ids = Vec::new();
+    let mut object_ids = Vec::new();
+    for resource in resources {
+        match resource {
+            TokenResourceScope::Collection(id) => collection_ids.push(id.id()),
+            TokenResourceScope::Class(id) => class_ids.push(id.id()),
+            TokenResourceScope::Object(id) => object_ids.push(id.id()),
+        }
+    }
+    Ok(Some(UnifiedSearchResourceScope::new(
+        collection_ids,
+        class_ids,
+        object_ids,
+    )))
+}
+
+fn visibility(
+    principal_id: i32,
+    is_admin: bool,
+    scope: Option<&TokenScope>,
+) -> Result<UnifiedSearchVisibility, ApiError> {
+    let permissions = scope.and_then(TokenScope::permissions).map(|permissions| {
+        permissions
+            .iter()
+            .copied()
+            .map(permission_to_storage)
+            .collect::<Vec<_>>()
+    });
+    let resources = scope.map(resource_scope).transpose()?.flatten();
+    Ok(UnifiedSearchVisibility::new(
+        principal_id,
+        is_admin,
+        permissions,
+        resources,
+    ))
+}
+
+fn cursor(cursor: Option<&UnifiedSearchCursorToken>) -> Option<UnifiedSearchCursor> {
+    cursor.map(|cursor| UnifiedSearchCursor::new(cursor.rank, cursor.name.clone(), cursor.id))
+}
+
+fn query(
+    principal_id: i32,
+    is_admin: bool,
+    scope: Option<&TokenScope>,
+    spec: &UnifiedSearchSpec,
+    cursor: Option<&UnifiedSearchCursorToken>,
+    search_extended_document: bool,
+) -> Result<UnifiedSearchQuery, ApiError> {
+    Ok(UnifiedSearchQuery::new(
+        spec.query.clone(),
+        spec.limit_per_kind,
+        visibility(principal_id, is_admin, scope)?,
+    )
+    .search_extended_document(search_extended_document)
+    .cursor(self::cursor(cursor)))
+}
+
+fn collection_from_storage(row: UnifiedSearchCollection) -> Result<Collection, ApiError> {
+    let (id, name, description, created_at, updated_at, parent_collection_id, revision) =
+        row.into_parts();
+    Ok(Collection {
+        id,
+        name,
+        description,
+        created_at,
+        updated_at,
+        parent_collection_id,
+        revision: ResourceRevision::new(revision)?,
+    })
+}
+
+fn class_from_storage(row: UnifiedSearchClass) -> Result<HubuumClassExpanded, ApiError> {
+    let (
+        id,
+        name,
+        collection,
+        json_schema,
+        validate_schema,
+        description,
+        created_at,
+        updated_at,
+        revision,
+    ) = row.into_parts();
+    Ok(HubuumClassExpanded {
+        id,
+        name,
+        collection: collection_from_storage(collection)?,
+        json_schema,
+        validate_schema,
+        description,
+        created_at,
+        updated_at,
+        revision: ResourceRevision::new(revision)?,
+    })
+}
+
+fn object_from_storage(row: UnifiedSearchObject) -> Result<HubuumObject, ApiError> {
+    let (
+        id,
+        name,
+        collection_id,
+        hubuum_class_id,
+        data,
+        description,
+        created_at,
+        updated_at,
+        revision,
+    ) = row.into_parts();
+    Ok(HubuumObject {
+        id,
+        name,
+        collection_id,
+        hubuum_class_id,
+        data,
+        description,
+        created_at,
+        updated_at,
+        revision: ResourceRevision::new(revision)?,
+    })
+}
+
+pub async fn search_collections(
+    backend: &impl StorageContext,
+    principal_id: i32,
+    is_admin: bool,
+    scope: Option<&TokenScope>,
+    spec: &UnifiedSearchSpec,
+) -> Result<Vec<Collection>, ApiError> {
+    storage_handle(backend)
+        .search_unified_collections(query(
+            principal_id,
+            is_admin,
+            scope,
+            spec,
+            spec.collection_cursor.as_ref(),
+            false,
+        )?)
+        .await?
+        .into_iter()
+        .map(collection_from_storage)
+        .collect()
+}
+
+pub async fn search_classes(
+    backend: &impl StorageContext,
+    principal_id: i32,
+    is_admin: bool,
+    scope: Option<&TokenScope>,
+    spec: &UnifiedSearchSpec,
+) -> Result<Vec<HubuumClassExpanded>, ApiError> {
+    storage_handle(backend)
+        .search_unified_classes(query(
+            principal_id,
+            is_admin,
+            scope,
+            spec,
+            spec.class_cursor.as_ref(),
+            spec.search_class_schema,
+        )?)
+        .await?
+        .into_iter()
+        .map(class_from_storage)
+        .collect()
+}
+
+pub async fn search_objects(
+    backend: &impl StorageContext,
+    principal_id: i32,
+    is_admin: bool,
+    scope: Option<&TokenScope>,
+    spec: &UnifiedSearchSpec,
+) -> Result<Vec<HubuumObject>, ApiError> {
+    storage_handle(backend)
+        .search_unified_objects(query(
+            principal_id,
+            is_admin,
+            scope,
+            spec,
+            spec.object_cursor.as_ref(),
+            spec.search_object_data,
+        )?)
+        .await?
+        .into_iter()
+        .map(object_from_storage)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{CollectionID, HubuumClassID, Permissions};
+
+    #[test]
+    fn visibility_preserves_independent_token_dimensions() {
+        let scope = TokenScope::from_stored_parts(
+            Some(vec![Permissions::ReadCollection, Permissions::ReadClass]),
+            Some(vec![
+                TokenResourceScope::Collection(CollectionID::new(7).unwrap()),
+                TokenResourceScope::Class(HubuumClassID::new(9).unwrap()),
+            ]),
+        )
+        .unwrap();
+
+        let visibility = visibility(42, false, Some(&scope)).unwrap();
+
+        assert!(visibility.allows_permissions(&[
+            crate::storage::AuthorizationPermission::ReadCollection,
+            crate::storage::AuthorizationPermission::ReadClass,
+        ]));
+        let resources = visibility.resources().unwrap();
+        assert_eq!(resources.collection_ids(), &[7]);
+        assert_eq!(resources.class_ids(), &[9]);
+        assert!(resources.object_ids().is_empty());
+    }
+}

--- a/src/storage/context.rs
+++ b/src/storage/context.rs
@@ -20,7 +20,8 @@ use crate::storage::{
     ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectHistoryRecord, OperationalStateStorage,
     PostgresStorage, ReadinessSnapshot, RemoteTargetHistoryRecord, StorageBackend,
     StorageBackendDescriptor, StorageError, StoragePoolState, TaskGaugeSnapshot,
-    TokenRetentionStorage,
+    TokenRetentionStorage, UnifiedSearchClass, UnifiedSearchCollection, UnifiedSearchObject,
+    UnifiedSearchQuery, UnifiedSearchStorage,
 };
 use crate::storage::{ClassHistoryRecord, CollectionHistoryRecord};
 use async_trait::async_trait;
@@ -521,6 +522,56 @@ impl HistoryStorage for StorageHandle {
                 }
             },
         )
+        .await
+    }
+}
+
+#[async_trait]
+impl UnifiedSearchStorage for StorageHandle {
+    async fn search_unified_collections(
+        &self,
+        query: UnifiedSearchQuery,
+    ) -> Result<Vec<UnifiedSearchCollection>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "unified_search",
+            "collections",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.search_unified_collections(query).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn search_unified_classes(
+        &self,
+        query: UnifiedSearchQuery,
+    ) -> Result<Vec<UnifiedSearchClass>, StorageError> {
+        observe_storage_call(self.backend_name(), "unified_search", "classes", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.search_unified_classes(query).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn search_unified_objects(
+        &self,
+        query: UnifiedSearchQuery,
+    ) -> Result<Vec<UnifiedSearchObject>, StorageError> {
+        observe_storage_call(self.backend_name(), "unified_search", "objects", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.search_unified_objects(query).await
+                }
+            }
+        })
         .await
     }
 }

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -4,7 +4,8 @@ use super::{
     AuthenticationStorage, AuthorizationStorage, ClassRelationStore, ClassStore, CollectionStore,
     EventDeliveryStorage, EventFanoutStorage, EventHealthStorage, EventRetentionStorage,
     HistoryStorage, MetricsStorage, ObjectRelationStore, ObjectStore, OperationalStateStorage,
-    PostgresStorage, TokenRetentionStorage, observed::ObservedLifecycleStorage,
+    PostgresStorage, TokenRetentionStorage, UnifiedSearchStorage,
+    observed::ObservedLifecycleStorage,
 };
 
 #[cfg(test)]
@@ -70,6 +71,7 @@ pub(crate) trait StorageBackend:
     + MetricsStorage
     + OperationalStateStorage
     + TokenRetentionStorage
+    + UnifiedSearchStorage
     + WorkflowStorage
     + OperationalStorage
     + sealed::CertifiedStorageBackend
@@ -133,6 +135,7 @@ mod tests {
                 "domain_lifecycle",
                 "identity_and_authorization_data",
                 "temporal_history",
+                "unified_search",
                 "workflows",
                 "operations",
             ]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -38,7 +38,9 @@ pub(crate) use hubuum_storage_core::{
     EventRetentionSummary, ExportTemplateHistoryRecord, HistoryAsOfQuery, HistoryCollectionScope,
     HistoryListQuery, HistoryMetadata, HistoryPage, HistoryPrincipalName, HistoryStorage,
     ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectHistoryRecord, RemoteTargetHistoryRecord,
-    RetainedEvent,
+    RetainedEvent, UnifiedSearchClass, UnifiedSearchCollection, UnifiedSearchCursor,
+    UnifiedSearchObject, UnifiedSearchQuery, UnifiedSearchResourceScope, UnifiedSearchStorage,
+    UnifiedSearchVisibility,
 };
 pub(crate) use hubuum_storage_core::{ClassHistoryRecord, CollectionHistoryRecord};
 pub(crate) use hubuum_storage_core::{StorageError, StorageErrorKind};

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -52,7 +52,8 @@ use super::{
     InventoryGaugeSnapshot, MetricsStorage, ObjectHistoryAsOfQuery, ObjectHistoryListQuery,
     ObjectHistoryRecord, ObjectRelationStore, ObjectStore, OperationalStateStorage,
     ReadinessSnapshot, RemoteTargetHistoryRecord, StorageError, StorageIdentity, StoragePoolState,
-    TaskGaugeSnapshot, TokenRetentionStorage,
+    TaskGaugeSnapshot, TokenRetentionStorage, UnifiedSearchClass, UnifiedSearchCollection,
+    UnifiedSearchObject, UnifiedSearchQuery, UnifiedSearchStorage,
 };
 use super::{ClassHistoryRecord, CollectionHistoryRecord};
 use error::map_postgres_error;
@@ -404,6 +405,36 @@ impl HistoryStorage for PostgresStorage {
         operations::history::remote_target_as_of(entity_id, at, &self.pool)
             .await
             .map(|row| row.map(operations::history::remote_target_history_to_storage))
+            .map_err(map_postgres_error)
+    }
+}
+
+#[async_trait]
+impl UnifiedSearchStorage for PostgresStorage {
+    async fn search_unified_collections(
+        &self,
+        query: UnifiedSearchQuery,
+    ) -> Result<Vec<UnifiedSearchCollection>, StorageError> {
+        operations::ranked_search::search_collections(&self.pool, query)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn search_unified_classes(
+        &self,
+        query: UnifiedSearchQuery,
+    ) -> Result<Vec<UnifiedSearchClass>, StorageError> {
+        operations::ranked_search::search_classes(&self.pool, query)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn search_unified_objects(
+        &self,
+        query: UnifiedSearchQuery,
+    ) -> Result<Vec<UnifiedSearchObject>, StorageError> {
+        operations::ranked_search::search_objects(&self.pool, query)
+            .await
             .map_err(map_postgres_error)
     }
 }

--- a/src/storage/postgres/operations/authorization.rs
+++ b/src/storage/postgres/operations/authorization.rs
@@ -19,7 +19,7 @@ use crate::storage::{
 };
 use crate::traits::PermissionController;
 
-const fn permission_from_storage(permission: AuthorizationPermission) -> Permissions {
+pub(crate) const fn permission_from_storage(permission: AuthorizationPermission) -> Permissions {
     match permission {
         AuthorizationPermission::ReadCollection => Permissions::ReadCollection,
         AuthorizationPermission::UpdateCollection => Permissions::UpdateCollection,

--- a/src/storage/postgres/operations/mod.rs
+++ b/src/storage/postgres/operations/mod.rs
@@ -26,6 +26,7 @@ pub mod object;
 pub mod permissions;
 pub mod principal;
 pub(crate) mod probe;
+pub(crate) mod ranked_search;
 pub mod relations;
 pub mod remote_target;
 pub(crate) mod resource_scope;

--- a/src/storage/postgres/operations/ranked_search.rs
+++ b/src/storage/postgres/operations/ranked_search.rs
@@ -1,0 +1,207 @@
+use crate::errors::ApiError;
+use crate::models::{
+    Collection, CollectionID, HubuumClassExpanded, HubuumClassID, HubuumObject, HubuumObjectID,
+    TokenResourceScope, TokenScope, UnifiedSearchCursorToken, UnifiedSearchSpec, UserID,
+};
+use crate::storage::postgres::PostgresPool;
+use crate::storage::postgres::operations::authorization::permission_from_storage;
+use crate::storage::postgres::operations::user::UnifiedSearchBackend;
+use crate::storage::{
+    UnifiedSearchClass, UnifiedSearchCollection, UnifiedSearchObject, UnifiedSearchQuery,
+};
+
+#[derive(Clone, Copy)]
+enum SearchKind {
+    Collection,
+    Class,
+    Object,
+}
+
+fn collection_to_storage(collection: Collection) -> UnifiedSearchCollection {
+    UnifiedSearchCollection::new(
+        collection.id,
+        collection.name,
+        collection.description,
+        collection.created_at,
+        collection.updated_at,
+        collection.parent_collection_id,
+        collection.revision.get(),
+    )
+}
+
+fn class_to_storage(class: HubuumClassExpanded) -> UnifiedSearchClass {
+    UnifiedSearchClass::new(
+        class.id,
+        class.name,
+        collection_to_storage(class.collection),
+        class.json_schema,
+        class.validate_schema,
+        class.description,
+        class.created_at,
+        class.updated_at,
+        class.revision.get(),
+    )
+}
+
+fn object_to_storage(object: HubuumObject) -> UnifiedSearchObject {
+    UnifiedSearchObject::new(
+        object.id,
+        object.name,
+        object.collection_id,
+        object.hubuum_class_id,
+        object.data,
+        object.description,
+        object.created_at,
+        object.updated_at,
+        object.revision.get(),
+    )
+}
+
+fn cursor(query: &UnifiedSearchQuery) -> Option<UnifiedSearchCursorToken> {
+    query
+        .search_cursor()
+        .map(|cursor| UnifiedSearchCursorToken {
+            rank: cursor.rank(),
+            name: cursor.normalized_name().to_string(),
+            id: cursor.id(),
+        })
+}
+
+fn spec(query: &UnifiedSearchQuery, kind: SearchKind) -> UnifiedSearchSpec {
+    let cursor = cursor(query);
+    UnifiedSearchSpec {
+        query: query.search_term().to_string(),
+        search_class_schema: matches!(kind, SearchKind::Class)
+            && query.searches_extended_document(),
+        search_object_data: matches!(kind, SearchKind::Object)
+            && query.searches_extended_document(),
+        limit_per_kind: query.limit(),
+        collection_cursor: matches!(kind, SearchKind::Collection)
+            .then_some(cursor.clone())
+            .flatten(),
+        class_cursor: matches!(kind, SearchKind::Class)
+            .then_some(cursor.clone())
+            .flatten(),
+        object_cursor: matches!(kind, SearchKind::Object)
+            .then_some(cursor)
+            .flatten(),
+    }
+}
+
+fn token_scope(query: &UnifiedSearchQuery) -> Result<Option<TokenScope>, ApiError> {
+    let visibility = query.visibility();
+    let permissions = visibility.permissions().map(|permissions| {
+        permissions
+            .iter()
+            .copied()
+            .map(permission_from_storage)
+            .collect::<Vec<_>>()
+    });
+    let resources = visibility
+        .resources()
+        .map(|scope| {
+            scope
+                .collection_ids()
+                .iter()
+                .copied()
+                .map(|id| CollectionID::new(id).map(TokenResourceScope::Collection))
+                .chain(
+                    scope
+                        .class_ids()
+                        .iter()
+                        .copied()
+                        .map(|id| HubuumClassID::new(id).map(TokenResourceScope::Class)),
+                )
+                .chain(
+                    scope
+                        .object_ids()
+                        .iter()
+                        .copied()
+                        .map(|id| HubuumObjectID::new(id).map(TokenResourceScope::Object)),
+                )
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?;
+
+    if permissions.is_none() && resources.is_none() {
+        Ok(None)
+    } else {
+        TokenScope::from_stored_parts(permissions, resources).map(Some)
+    }
+}
+
+fn principal(query: &UnifiedSearchQuery) -> Result<UserID, ApiError> {
+    UserID::new(query.visibility().principal_id())
+}
+
+pub(crate) async fn search_collections(
+    pool: &PostgresPool,
+    query: UnifiedSearchQuery,
+) -> Result<Vec<UnifiedSearchCollection>, ApiError> {
+    if !query
+        .visibility()
+        .allows_permissions(&[crate::storage::AuthorizationPermission::ReadCollection])
+    {
+        return Ok(Vec::new());
+    }
+    let principal = principal(&query)?;
+    let scope = token_scope(&query)?;
+    let spec = spec(&query, SearchKind::Collection);
+    principal
+        .search_unified_collections_from_backend_with_admin_status(
+            pool,
+            &spec,
+            scope.as_ref(),
+            query.visibility().is_admin(),
+        )
+        .await
+        .map(|rows| rows.into_iter().map(collection_to_storage).collect())
+}
+
+pub(crate) async fn search_classes(
+    pool: &PostgresPool,
+    query: UnifiedSearchQuery,
+) -> Result<Vec<UnifiedSearchClass>, ApiError> {
+    if !query.visibility().allows_permissions(&[
+        crate::storage::AuthorizationPermission::ReadCollection,
+        crate::storage::AuthorizationPermission::ReadClass,
+    ]) {
+        return Ok(Vec::new());
+    }
+    let principal = principal(&query)?;
+    let scope = token_scope(&query)?;
+    let spec = spec(&query, SearchKind::Class);
+    principal
+        .search_unified_classes_from_backend_with_admin_status(
+            pool,
+            &spec,
+            scope.as_ref(),
+            query.visibility().is_admin(),
+        )
+        .await
+        .map(|rows| rows.into_iter().map(class_to_storage).collect())
+}
+
+pub(crate) async fn search_objects(
+    pool: &PostgresPool,
+    query: UnifiedSearchQuery,
+) -> Result<Vec<UnifiedSearchObject>, ApiError> {
+    if !query.visibility().allows_permissions(&[
+        crate::storage::AuthorizationPermission::ReadCollection,
+        crate::storage::AuthorizationPermission::ReadObject,
+    ]) {
+        return Ok(Vec::new());
+    }
+    let principal = principal(&query)?;
+    let scope = token_scope(&query)?;
+    let spec = spec(&query, SearchKind::Object);
+    principal
+        .search_unified_objects_from_backend_with_admin_status(
+            pool,
+            &spec,
+            scope.as_ref(),
+            query.visibility().is_admin(),
+        )
+        .await
+        .map(|rows| rows.into_iter().map(object_to_storage).collect())
+}

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -236,6 +236,7 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         "OperationalStateStorage",
         "TokenRetentionStorage",
         "HistoryStorage",
+        "UnifiedSearchStorage",
         "WorkflowStorage",
         "OperationalStorage",
         "sealed::CertifiedStorageBackend",

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -9,7 +9,7 @@ use crate::models::identity::LOCAL_IDENTITY_SCOPE;
 use crate::models::search::QueryOptions;
 use crate::models::{
     CollectionHistory, CollectionID, ExportTemplateHistory, HubuumClassHistory,
-    HubuumObjectHistory, RemoteTargetHistory,
+    HubuumObjectHistory, NewHubuumClass, NewHubuumObject, RemoteTargetHistory,
 };
 use crate::pagination::prepare_db_pagination;
 use crate::services::Services;
@@ -23,7 +23,8 @@ use crate::storage::{
     EventHealthStorage, EventRetentionStorage, HistoryAsOfQuery, HistoryCollectionScope,
     HistoryListQuery, HistoryStorage, MetricsStorage, ObjectHistoryAsOfQuery,
     ObjectHistoryListQuery, OperationalStateStorage, RetainedEvent, STORAGE_CONTRACT_VERSION,
-    StorageBackendKind, StorageError, TokenRetentionStorage,
+    StorageBackendKind, StorageError, TokenRetentionStorage, UnifiedSearchQuery,
+    UnifiedSearchStorage, UnifiedSearchVisibility,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -443,6 +444,87 @@ async fn every_available_storage_backend_supplies_complete_temporal_history() {
         .delete_without_events(pool.get_ref())
         .await
         .expect("history compatibility actor should be removed");
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_supplies_ranked_unified_search() {
+    let _permit = postgres_permit().await;
+    let pool = pool();
+    let needle = prefix("unified_search");
+    let collection = crate::tests::create_collection_fixture(pool.get_ref(), &needle).await;
+    let fixture = crate::tests::create_object_fixture(
+        pool.get_ref(),
+        collection,
+        NewHubuumClass {
+            name: format!("{needle}_class"),
+            collection_id: 0,
+            json_schema: Some(serde_json::json!({"title": needle})),
+            validate_schema: Some(false),
+            description: "unified search compatibility class".to_string(),
+        },
+        vec![NewHubuumObject {
+            name: format!("{needle}_object"),
+            collection_id: 0,
+            hubuum_class_id: 0,
+            data: serde_json::json!({"needle": needle}),
+            description: "unified search compatibility object".to_string(),
+        }],
+    )
+    .await
+    .expect("unified search compatibility fixture should be created");
+
+    for kind in StorageBackendKind::ALL {
+        match kind {
+            StorageBackendKind::Postgresql => {
+                let backend = StorageHandle::postgres(pool.get_ref().clone());
+                let request = || {
+                    UnifiedSearchQuery::new(
+                        needle.clone(),
+                        10,
+                        UnifiedSearchVisibility::new(
+                            i32::MAX,
+                            true,
+                            None::<Vec<AuthorizationPermission>>,
+                            None,
+                        ),
+                    )
+                    .search_extended_document(true)
+                };
+
+                let collections = backend
+                    .search_unified_collections(request())
+                    .await
+                    .expect("certified backend should search collections");
+                assert!(collections.into_iter().any(|row| {
+                    let (id, ..) = row.into_parts();
+                    id == fixture.collection.collection.id
+                }));
+
+                let classes = backend
+                    .search_unified_classes(request())
+                    .await
+                    .expect("certified backend should search classes");
+                assert!(classes.into_iter().any(|row| {
+                    let (id, ..) = row.into_parts();
+                    id == fixture.class.id
+                }));
+
+                let objects = backend
+                    .search_unified_objects(request())
+                    .await
+                    .expect("certified backend should search objects");
+                assert!(objects.into_iter().any(|row| {
+                    let (id, ..) = row.into_parts();
+                    id == fixture.objects[0].id
+                }));
+            }
+        }
+    }
+
+    fixture
+        .cleanup()
+        .await
+        .expect("unified search compatibility fixture should be removed");
 }
 
 #[actix_web::test]

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -117,7 +117,10 @@ async fn metrics_endpoint_is_best_effort_when_database_refresh_fails() {
 #[actix_web::test]
 async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() {
     let body = scrape_recorded_metrics(|| {
-        metrics::storage_backend_identity("postgresql", 2);
+        metrics::storage_backend_identity(
+            "postgresql",
+            hubuum_storage_core::STORAGE_CONTRACT_VERSION,
+        );
         metrics::storage_operation_finished(
             "postgresql",
             "objects",
@@ -130,7 +133,7 @@ async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() 
 
     assert!(
         body.contains(
-            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"2\"} 1"
+            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"3\"} 1"
         )
     );
     assert!(body.contains(

--- a/tests/api_platform_suite/runtime_config.rs
+++ b/tests/api_platform_suite/runtime_config.rs
@@ -37,13 +37,14 @@ mod tests {
         let serialized = serde_json::to_string(&body).unwrap();
 
         assert_eq!(body["database"]["backend"], "postgresql");
-        assert_eq!(body["database"]["contract_version"], 2);
+        assert_eq!(body["database"]["contract_version"], 3);
         assert_eq!(
             body["database"]["capabilities"],
             serde_json::json!([
                 "domain_lifecycle",
                 "identity_and_authorization_data",
                 "temporal_history",
+                "unified_search",
                 "workflows",
                 "operations"
             ])


### PR DESCRIPTION
## Summary

- replace direct application calls into the PostgreSQL ranked-search facade with a mandatory, operation-shaped `UnifiedSearchStorage` contract
- move collection, class, and object search requests, visibility scopes, cursors, and projections behind private-field DTOs owned by `hubuum-storage-core`
- make the PostgreSQL adapter translate its private search specification, rows, and errors at the boundary, while the application service alone reconstructs domain models and translates `StorageError` into `ApiError`
- preserve external-policy candidate authorization while pushing local permission and resource scopes into the selected backend before pagination
- instrument every search entry point with bounded `unified_search/*` operation labels and exercise all three operations for every available backend

## Boundary behavior

The unified-search model no longer imports the PostgreSQL search facade, Diesel, generated schema modules, pools, or connections. It depends on `UnifiedSearchStorage` through the opaque `StorageHandle`; search terms, cursors, and principal identifiers also have redacted `Debug` output.

Any selectable backend must implement ranked collection, class, and object search with stable cursor behavior and visibility pushdown. The sealed `StorageBackend` supertrait enforces the complete family at compile time, and the shared compatibility test creates real matching rows and exercises every operation. A partially implemented backend cannot be composed.

## Breaking administrator API change

The reported storage contract version is now `3`, and the redacted running configuration adds the required `unified_search` capability alongside `temporal_history`. Monitoring and administration clients validating the capability list or contract version must accept the new version and label.

This is recorded under `[Unreleased]` in `CHANGELOG.md`.

## Stack

This PR is stacked on #302 and is the next required storage-boundary layer. It should be reviewed and merged after its parent. Part of #27.

## Verification

- `source .env && ./run_tests.sh`
- `cargo test -p hubuum-storage-core --locked`
- focused available-backend unified-search compatibility and complete API search suites
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`
- Rust API, supply-chain, CI-classifier, and `cargo deny --all-features --locked check` policy suites
- regenerated OpenAPI matches `docs/openapi.json`

