### PR TITLE
Extract mandatory task queue storage contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
-- **Breaking (administrator API):** the storage contract version is now `8`,
+- **Breaking (administrator API):** the storage contract version is now `9`,
   and the redacted administrator configuration reports independently enforced
   `catalog_queries`, `computed_object_queries`, `computed_field_lifecycle`,
   `object_aggregates`, `relation_queries`, `temporal_history`, and
-  `unified_search` capabilities instead of the broader provisional
+  `unified_search`, and `task_queue` capabilities instead of the broader provisional
   `queries_and_history` label. Monitoring or administration clients matching
   the version or capability list must accept the new contract and labels.
 - Event worker and retention configuration validation now uses backend-neutral

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,6 +2296,7 @@ dependencies = [
  "hubuum-domain",
  "hubuum-events-core",
  "hubuum-query",
+ "hubuum-task-core",
  "serde_json",
  "uuid",
 ]

--- a/crates/hubuum-storage-core/Cargo.toml
+++ b/crates/hubuum-storage-core/Cargo.toml
@@ -16,5 +16,6 @@ chrono = "0.4"
 hubuum-domain = { path = "../hubuum-domain" }
 hubuum-events-core = { path = "../hubuum-events-core" }
 hubuum-query = { path = "../hubuum-query" }
+hubuum-task-core = { path = "../hubuum-task-core" }
 serde_json = "1"
 uuid = "1"

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -14,6 +14,7 @@ mod identity;
 mod object_aggregate;
 mod operational;
 mod relation_query;
+mod task_queue;
 mod unified_search;
 
 pub use authorization::{
@@ -79,6 +80,16 @@ pub use relation_query::{
     StorageRecordMetadata, StorageRelatedDirection, StorageRelatedObjectForRootRow,
     StorageRelatedObjectIncludeRow, StorageRelatedSort,
 };
+pub use task_queue::{
+    StorageBackupOutput, StorageBackupOutputSummary, StorageExportOutput,
+    StorageExportOutputBuilder, StorageExportOutputSummary, StorageImportTaskResult,
+    StorageImportTaskResultBuilder, StorageImportTaskResultPage, StorageTask, StorageTaskAccess,
+    StorageTaskBuilder, StorageTaskCreateRequest, StorageTaskCreateRequestBuilder,
+    StorageTaskDurations, StorageTaskEvent, StorageTaskEventBuilder, StorageTaskEventPage,
+    StorageTaskKind, StorageTaskListQuery, StorageTaskOutputLookup, StorageTaskPage,
+    StorageTaskPageQuery, StorageTaskProgress, StorageTaskScopeSnapshot, StorageTaskStatus,
+    TaskQueueStorage,
+};
 pub use unified_search::{
     UnifiedSearchClass, UnifiedSearchCollection, UnifiedSearchCursor, UnifiedSearchObject,
     UnifiedSearchQuery, UnifiedSearchResourceScope, UnifiedSearchStorage, UnifiedSearchVisibility,
@@ -97,7 +108,7 @@ use std::fmt;
 ///
 /// Increment this when a selectable backend must implement a new capability
 /// family or when an existing family's externally observable semantics change.
-pub const STORAGE_CONTRACT_VERSION: u16 = 8;
+pub const STORAGE_CONTRACT_VERSION: u16 = 9;
 
 /// Stable identity of a selectable storage backend.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -129,12 +140,13 @@ pub enum StorageCapability {
     IdentityAndAuthorizationData,
     TemporalHistory,
     UnifiedSearch,
+    TaskQueue,
     Workflows,
     Operations,
 }
 
 impl StorageCapability {
-    pub const ALL: [Self; 11] = [
+    pub const ALL: [Self; 12] = [
         Self::DomainLifecycle,
         Self::CatalogQueries,
         Self::ComputedObjectQueries,
@@ -144,6 +156,7 @@ impl StorageCapability {
         Self::IdentityAndAuthorizationData,
         Self::TemporalHistory,
         Self::UnifiedSearch,
+        Self::TaskQueue,
         Self::Workflows,
         Self::Operations,
     ];
@@ -160,6 +173,7 @@ impl StorageCapability {
             Self::IdentityAndAuthorizationData => "identity_and_authorization_data",
             Self::TemporalHistory => "temporal_history",
             Self::UnifiedSearch => "unified_search",
+            Self::TaskQueue => "task_queue",
             Self::Workflows => "workflows",
             Self::Operations => "operations",
         }
@@ -204,6 +218,7 @@ pub enum StorageErrorKind {
     NotAcceptable,
     PayloadTooLarge,
     PreconditionFailed,
+    TooManyRequests,
     Unavailable,
     Validation,
 }
@@ -221,6 +236,7 @@ impl StorageErrorKind {
             Self::NotAcceptable => "not_acceptable",
             Self::PayloadTooLarge => "payload_too_large",
             Self::PreconditionFailed => "precondition_failed",
+            Self::TooManyRequests => "too_many_requests",
             Self::Unavailable => "unavailable",
             Self::Validation => "validation",
         }
@@ -323,6 +339,7 @@ mod tests {
                 "identity_and_authorization_data",
                 "temporal_history",
                 "unified_search",
+                "task_queue",
                 "workflows",
                 "operations",
             ]

--- a/crates/hubuum-storage-core/src/task_queue.rs
+++ b/crates/hubuum-storage-core/src/task_queue.rs
@@ -1,0 +1,1445 @@
+use std::fmt;
+
+use async_trait::async_trait;
+use chrono::NaiveDateTime;
+use hubuum_query::QueryOptions;
+use hubuum_task_core::IdempotencyKey;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::StorageError;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum StorageTaskKind {
+    Import,
+    Export,
+    Backup,
+    Reindex,
+    RemoteCall,
+}
+
+impl StorageTaskKind {
+    pub const ALL: [Self; 5] = [
+        Self::Import,
+        Self::Export,
+        Self::Backup,
+        Self::Reindex,
+        Self::RemoteCall,
+    ];
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Import => "import",
+            Self::Export => "export",
+            Self::Backup => "backup",
+            Self::Reindex => "reindex",
+            Self::RemoteCall => "remote_call",
+        }
+    }
+
+    #[must_use]
+    pub fn from_persisted(value: &str) -> Option<Self> {
+        match value {
+            "import" => Some(Self::Import),
+            "export" => Some(Self::Export),
+            "backup" => Some(Self::Backup),
+            "reindex" => Some(Self::Reindex),
+            "remote_call" => Some(Self::RemoteCall),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum StorageTaskStatus {
+    Queued,
+    Validating,
+    Running,
+    Succeeded,
+    Failed,
+    PartiallySucceeded,
+    Cancelled,
+}
+
+impl StorageTaskStatus {
+    pub const ALL: [Self; 7] = [
+        Self::Queued,
+        Self::Validating,
+        Self::Running,
+        Self::Succeeded,
+        Self::Failed,
+        Self::PartiallySucceeded,
+        Self::Cancelled,
+    ];
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Validating => "validating",
+            Self::Running => "running",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::PartiallySucceeded => "partially_succeeded",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    #[must_use]
+    pub fn from_persisted(value: &str) -> Option<Self> {
+        match value {
+            "queued" => Some(Self::Queued),
+            "validating" => Some(Self::Validating),
+            "running" => Some(Self::Running),
+            "succeeded" => Some(Self::Succeeded),
+            "failed" => Some(Self::Failed),
+            "partially_succeeded" => Some(Self::PartiallySucceeded),
+            "cancelled" => Some(Self::Cancelled),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StorageTaskProgress {
+    total: i32,
+    processed: i32,
+    succeeded: i32,
+    failed: i32,
+}
+
+impl StorageTaskProgress {
+    #[must_use]
+    pub const fn new(total: i32, processed: i32, succeeded: i32, failed: i32) -> Self {
+        Self {
+            total,
+            processed,
+            succeeded,
+            failed,
+        }
+    }
+
+    #[must_use]
+    pub const fn total(self) -> i32 {
+        self.total
+    }
+
+    #[must_use]
+    pub const fn processed(self) -> i32 {
+        self.processed
+    }
+
+    #[must_use]
+    pub const fn succeeded(self) -> i32 {
+        self.succeeded
+    }
+
+    #[must_use]
+    pub const fn failed(self) -> i32 {
+        self.failed
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct StorageTaskScopeSnapshot {
+    token_id: Option<i32>,
+    scoped: bool,
+    scopes: Value,
+}
+
+impl StorageTaskScopeSnapshot {
+    #[must_use]
+    pub const fn new(token_id: Option<i32>, scoped: bool, scopes: Value) -> Self {
+        Self {
+            token_id,
+            scoped,
+            scopes,
+        }
+    }
+
+    #[must_use]
+    pub const fn unscoped() -> Self {
+        Self {
+            token_id: None,
+            scoped: false,
+            scopes: Value::Array(Vec::new()),
+        }
+    }
+
+    #[must_use]
+    pub const fn token_id(&self) -> Option<i32> {
+        self.token_id
+    }
+
+    #[must_use]
+    pub const fn scoped(&self) -> bool {
+        self.scoped
+    }
+
+    #[must_use]
+    pub const fn scopes(&self) -> &Value {
+        &self.scopes
+    }
+}
+
+impl fmt::Debug for StorageTaskScopeSnapshot {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageTaskScopeSnapshot")
+            .field("has_token", &self.token_id.is_some())
+            .field("scoped", &self.scoped)
+            .field("scopes", &"[redacted]")
+            .finish()
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct StorageTaskCreateRequest {
+    kind: StorageTaskKind,
+    submitted_by: i32,
+    request_payload: Value,
+    total_items: i32,
+    idempotency_key: Option<IdempotencyKey>,
+    request_hash: Option<String>,
+    scope_snapshot: StorageTaskScopeSnapshot,
+    maximum_active_tasks: usize,
+}
+
+impl StorageTaskCreateRequest {
+    #[must_use]
+    pub fn builder(
+        kind: StorageTaskKind,
+        submitted_by: i32,
+        request_payload: Value,
+        total_items: i32,
+    ) -> StorageTaskCreateRequestBuilder {
+        StorageTaskCreateRequestBuilder {
+            kind,
+            submitted_by,
+            request_payload,
+            total_items,
+            idempotency_key: None,
+            request_hash: None,
+            scope_snapshot: StorageTaskScopeSnapshot::unscoped(),
+        }
+    }
+
+    #[must_use]
+    pub const fn kind(&self) -> StorageTaskKind {
+        self.kind
+    }
+
+    #[must_use]
+    pub const fn submitted_by(&self) -> i32 {
+        self.submitted_by
+    }
+
+    #[must_use]
+    pub const fn request_payload(&self) -> &Value {
+        &self.request_payload
+    }
+
+    #[must_use]
+    pub const fn total_items(&self) -> i32 {
+        self.total_items
+    }
+
+    #[must_use]
+    pub const fn idempotency_key(&self) -> Option<&IdempotencyKey> {
+        self.idempotency_key.as_ref()
+    }
+
+    #[must_use]
+    pub fn request_hash(&self) -> Option<&str> {
+        self.request_hash.as_deref()
+    }
+
+    #[must_use]
+    pub const fn scope_snapshot(&self) -> &StorageTaskScopeSnapshot {
+        &self.scope_snapshot
+    }
+
+    #[must_use]
+    pub const fn maximum_active_tasks(&self) -> usize {
+        self.maximum_active_tasks
+    }
+}
+
+impl fmt::Debug for StorageTaskCreateRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageTaskCreateRequest")
+            .field("kind", &self.kind)
+            .field("total_items", &self.total_items)
+            .field("has_idempotency_key", &self.idempotency_key.is_some())
+            .field("has_request_hash", &self.request_hash.is_some())
+            .field("scope", &self.scope_snapshot)
+            .field("maximum_active_tasks", &self.maximum_active_tasks)
+            .field("identity_and_payload", &"[redacted]")
+            .finish()
+    }
+}
+
+pub struct StorageTaskCreateRequestBuilder {
+    kind: StorageTaskKind,
+    submitted_by: i32,
+    request_payload: Value,
+    total_items: i32,
+    idempotency_key: Option<IdempotencyKey>,
+    request_hash: Option<String>,
+    scope_snapshot: StorageTaskScopeSnapshot,
+}
+
+impl StorageTaskCreateRequestBuilder {
+    #[must_use]
+    pub fn idempotency_key(mut self, idempotency_key: Option<IdempotencyKey>) -> Self {
+        self.idempotency_key = idempotency_key;
+        self
+    }
+
+    #[must_use]
+    pub fn request_hash(mut self, request_hash: Option<String>) -> Self {
+        self.request_hash = request_hash;
+        self
+    }
+
+    #[must_use]
+    pub fn scope_snapshot(mut self, scope_snapshot: StorageTaskScopeSnapshot) -> Self {
+        self.scope_snapshot = scope_snapshot;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self, maximum_active_tasks: usize) -> StorageTaskCreateRequest {
+        StorageTaskCreateRequest {
+            kind: self.kind,
+            submitted_by: self.submitted_by,
+            request_payload: self.request_payload,
+            total_items: self.total_items,
+            idempotency_key: self.idempotency_key,
+            request_hash: self.request_hash,
+            scope_snapshot: self.scope_snapshot,
+            maximum_active_tasks,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct StorageTask {
+    id: i32,
+    kind: StorageTaskKind,
+    status: StorageTaskStatus,
+    submitted_by: Option<i32>,
+    idempotency_key: Option<String>,
+    request_hash: Option<String>,
+    request_payload: Option<Value>,
+    summary: Option<String>,
+    progress: StorageTaskProgress,
+    scope_snapshot: StorageTaskScopeSnapshot,
+    request_redacted_at: Option<NaiveDateTime>,
+    started_at: Option<NaiveDateTime>,
+    finished_at: Option<NaiveDateTime>,
+    deleted_at: Option<NaiveDateTime>,
+    deleted_by: Option<i32>,
+    created_at: NaiveDateTime,
+    updated_at: NaiveDateTime,
+    lease_token: Option<Uuid>,
+    lease_expires_at: Option<NaiveDateTime>,
+    attempt_count: i32,
+    initiator_principal_id: Option<i32>,
+}
+
+impl StorageTask {
+    #[must_use]
+    pub fn builder(
+        id: i32,
+        kind: StorageTaskKind,
+        status: StorageTaskStatus,
+        created_at: NaiveDateTime,
+        updated_at: NaiveDateTime,
+    ) -> StorageTaskBuilder {
+        StorageTaskBuilder {
+            task: Self {
+                id,
+                kind,
+                status,
+                submitted_by: None,
+                idempotency_key: None,
+                request_hash: None,
+                request_payload: None,
+                summary: None,
+                progress: StorageTaskProgress::default(),
+                scope_snapshot: StorageTaskScopeSnapshot::unscoped(),
+                request_redacted_at: None,
+                started_at: None,
+                finished_at: None,
+                deleted_at: None,
+                deleted_by: None,
+                created_at,
+                updated_at,
+                lease_token: None,
+                lease_expires_at: None,
+                attempt_count: 0,
+                initiator_principal_id: None,
+            },
+        }
+    }
+
+    #[must_use]
+    pub const fn id(&self) -> i32 {
+        self.id
+    }
+
+    #[must_use]
+    pub const fn kind(&self) -> StorageTaskKind {
+        self.kind
+    }
+
+    #[must_use]
+    pub const fn status(&self) -> StorageTaskStatus {
+        self.status
+    }
+
+    #[must_use]
+    pub const fn submitted_by(&self) -> Option<i32> {
+        self.submitted_by
+    }
+
+    #[must_use]
+    pub fn summary(&self) -> Option<&str> {
+        self.summary.as_deref()
+    }
+
+    #[must_use]
+    pub const fn progress(&self) -> StorageTaskProgress {
+        self.progress
+    }
+
+    #[must_use]
+    pub const fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    #[must_use]
+    pub const fn started_at(&self) -> Option<NaiveDateTime> {
+        self.started_at
+    }
+
+    #[must_use]
+    pub const fn finished_at(&self) -> Option<NaiveDateTime> {
+        self.finished_at
+    }
+
+    #[must_use]
+    pub const fn request_redacted_at(&self) -> Option<NaiveDateTime> {
+        self.request_redacted_at
+    }
+
+    #[must_use]
+    pub fn idempotency_key(&self) -> Option<&str> {
+        self.idempotency_key.as_deref()
+    }
+
+    #[must_use]
+    pub fn request_hash(&self) -> Option<&str> {
+        self.request_hash.as_deref()
+    }
+
+    #[must_use]
+    pub const fn request_payload(&self) -> Option<&Value> {
+        self.request_payload.as_ref()
+    }
+
+    #[must_use]
+    pub const fn scope_snapshot(&self) -> &StorageTaskScopeSnapshot {
+        &self.scope_snapshot
+    }
+
+    #[must_use]
+    pub const fn deleted_at(&self) -> Option<NaiveDateTime> {
+        self.deleted_at
+    }
+
+    #[must_use]
+    pub const fn deleted_by(&self) -> Option<i32> {
+        self.deleted_by
+    }
+
+    #[must_use]
+    pub const fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
+    }
+
+    #[must_use]
+    pub const fn lease_token(&self) -> Option<Uuid> {
+        self.lease_token
+    }
+
+    #[must_use]
+    pub const fn lease_expires_at(&self) -> Option<NaiveDateTime> {
+        self.lease_expires_at
+    }
+
+    #[must_use]
+    pub const fn attempt_count(&self) -> i32 {
+        self.attempt_count
+    }
+
+    #[must_use]
+    pub const fn initiator_principal_id(&self) -> Option<i32> {
+        self.initiator_principal_id
+    }
+}
+
+impl fmt::Debug for StorageTask {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageTask")
+            .field("kind", &self.kind)
+            .field("status", &self.status)
+            .field("progress", &self.progress)
+            .field("has_submitter", &self.submitted_by.is_some())
+            .field("has_summary", &self.summary.is_some())
+            .field("has_request_payload", &self.request_payload.is_some())
+            .field("has_lease", &self.lease_token.is_some())
+            .field("identity_and_payload", &"[redacted]")
+            .finish_non_exhaustive()
+    }
+}
+
+pub struct StorageTaskBuilder {
+    task: StorageTask,
+}
+
+impl StorageTaskBuilder {
+    #[must_use]
+    pub const fn submitted_by(mut self, submitted_by: Option<i32>) -> Self {
+        self.task.submitted_by = submitted_by;
+        self
+    }
+
+    #[must_use]
+    pub fn idempotency_key(mut self, idempotency_key: Option<String>) -> Self {
+        self.task.idempotency_key = idempotency_key;
+        self
+    }
+
+    #[must_use]
+    pub fn request_hash(mut self, request_hash: Option<String>) -> Self {
+        self.task.request_hash = request_hash;
+        self
+    }
+
+    #[must_use]
+    pub fn request_payload(mut self, request_payload: Option<Value>) -> Self {
+        self.task.request_payload = request_payload;
+        self
+    }
+
+    #[must_use]
+    pub fn summary(mut self, summary: Option<String>) -> Self {
+        self.task.summary = summary;
+        self
+    }
+
+    #[must_use]
+    pub const fn progress(mut self, progress: StorageTaskProgress) -> Self {
+        self.task.progress = progress;
+        self
+    }
+
+    #[must_use]
+    pub fn scope_snapshot(mut self, scope_snapshot: StorageTaskScopeSnapshot) -> Self {
+        self.task.scope_snapshot = scope_snapshot;
+        self
+    }
+
+    #[must_use]
+    pub const fn request_redacted_at(mut self, request_redacted_at: Option<NaiveDateTime>) -> Self {
+        self.task.request_redacted_at = request_redacted_at;
+        self
+    }
+
+    #[must_use]
+    pub const fn started_at(mut self, started_at: Option<NaiveDateTime>) -> Self {
+        self.task.started_at = started_at;
+        self
+    }
+
+    #[must_use]
+    pub const fn finished_at(mut self, finished_at: Option<NaiveDateTime>) -> Self {
+        self.task.finished_at = finished_at;
+        self
+    }
+
+    #[must_use]
+    pub const fn deletion(
+        mut self,
+        deleted_at: Option<NaiveDateTime>,
+        deleted_by: Option<i32>,
+    ) -> Self {
+        self.task.deleted_at = deleted_at;
+        self.task.deleted_by = deleted_by;
+        self
+    }
+
+    #[must_use]
+    pub const fn lease(
+        mut self,
+        lease_token: Option<Uuid>,
+        lease_expires_at: Option<NaiveDateTime>,
+    ) -> Self {
+        self.task.lease_token = lease_token;
+        self.task.lease_expires_at = lease_expires_at;
+        self
+    }
+
+    #[must_use]
+    pub const fn attempt_count(mut self, attempt_count: i32) -> Self {
+        self.task.attempt_count = attempt_count;
+        self
+    }
+
+    #[must_use]
+    pub const fn initiator_principal_id(mut self, initiator_principal_id: Option<i32>) -> Self {
+        self.task.initiator_principal_id = initiator_principal_id;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> StorageTask {
+        self.task
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct StorageTaskAccess {
+    task: StorageTask,
+    submitter_owner_group_id: Option<i32>,
+}
+
+impl StorageTaskAccess {
+    #[must_use]
+    pub const fn new(task: StorageTask, submitter_owner_group_id: Option<i32>) -> Self {
+        Self {
+            task,
+            submitter_owner_group_id,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (StorageTask, Option<i32>) {
+        (self.task, self.submitter_owner_group_id)
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct StorageTaskListQuery {
+    submitted_by: Option<i32>,
+    kind: Option<StorageTaskKind>,
+    status: Option<StorageTaskStatus>,
+    options: QueryOptions,
+}
+
+impl StorageTaskListQuery {
+    #[must_use]
+    pub const fn new(
+        submitted_by: Option<i32>,
+        kind: Option<StorageTaskKind>,
+        status: Option<StorageTaskStatus>,
+        options: QueryOptions,
+    ) -> Self {
+        Self {
+            submitted_by,
+            kind,
+            status,
+            options,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        Option<i32>,
+        Option<StorageTaskKind>,
+        Option<StorageTaskStatus>,
+        QueryOptions,
+    ) {
+        (self.submitted_by, self.kind, self.status, self.options)
+    }
+}
+
+impl fmt::Debug for StorageTaskListQuery {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageTaskListQuery")
+            .field("has_submitter", &self.submitted_by.is_some())
+            .field("kind", &self.kind)
+            .field("status", &self.status)
+            .field("filter_count", &self.options.filters.len())
+            .field("sort_count", &self.options.sort.len())
+            .field("limit", &self.options.limit)
+            .field("has_cursor", &self.options.cursor.is_some())
+            .field("include_total", &self.options.include_total)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct StorageTaskPage {
+    tasks: Vec<StorageTask>,
+    total: Option<i64>,
+}
+
+impl StorageTaskPage {
+    #[must_use]
+    pub const fn new(tasks: Vec<StorageTask>, total: Option<i64>) -> Self {
+        Self { tasks, total }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (Vec<StorageTask>, Option<i64>) {
+        (self.tasks, self.total)
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct StorageTaskPageQuery {
+    task_id: i32,
+    options: QueryOptions,
+}
+
+impl StorageTaskPageQuery {
+    #[must_use]
+    pub const fn new(task_id: i32, options: QueryOptions) -> Self {
+        Self { task_id, options }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (i32, QueryOptions) {
+        (self.task_id, self.options)
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct StorageTaskEvent {
+    id: i64,
+    task_id: i32,
+    event_type: String,
+    message: String,
+    data: Option<Value>,
+    created_at: NaiveDateTime,
+    actor_principal_id: Option<i32>,
+    actor_kind: String,
+    initiator_principal_id: Option<i32>,
+    provenance_task_id: Option<i32>,
+}
+
+impl StorageTaskEvent {
+    #[must_use]
+    pub fn builder(
+        id: i64,
+        task_id: i32,
+        event_type: impl Into<String>,
+        message: impl Into<String>,
+        created_at: NaiveDateTime,
+        actor_kind: impl Into<String>,
+    ) -> StorageTaskEventBuilder {
+        StorageTaskEventBuilder {
+            event: Self {
+                id,
+                task_id,
+                event_type: event_type.into(),
+                message: message.into(),
+                data: None,
+                created_at,
+                actor_principal_id: None,
+                actor_kind: actor_kind.into(),
+                initiator_principal_id: None,
+                provenance_task_id: None,
+            },
+        }
+    }
+
+    #[must_use]
+    pub const fn id(&self) -> i64 {
+        self.id
+    }
+
+    #[must_use]
+    pub const fn task_id(&self) -> i32 {
+        self.task_id
+    }
+
+    #[must_use]
+    pub fn event_type(&self) -> &str {
+        &self.event_type
+    }
+
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    #[must_use]
+    pub const fn data(&self) -> Option<&Value> {
+        self.data.as_ref()
+    }
+
+    #[must_use]
+    pub const fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    #[must_use]
+    pub const fn actor_principal_id(&self) -> Option<i32> {
+        self.actor_principal_id
+    }
+
+    #[must_use]
+    pub fn actor_kind(&self) -> &str {
+        &self.actor_kind
+    }
+
+    #[must_use]
+    pub const fn initiator_principal_id(&self) -> Option<i32> {
+        self.initiator_principal_id
+    }
+
+    #[must_use]
+    pub const fn provenance_task_id(&self) -> Option<i32> {
+        self.provenance_task_id
+    }
+}
+
+pub struct StorageTaskEventBuilder {
+    event: StorageTaskEvent,
+}
+
+impl StorageTaskEventBuilder {
+    #[must_use]
+    pub fn data(mut self, data: Option<Value>) -> Self {
+        self.event.data = data;
+        self
+    }
+
+    #[must_use]
+    pub const fn actor_principal_id(mut self, actor_principal_id: Option<i32>) -> Self {
+        self.event.actor_principal_id = actor_principal_id;
+        self
+    }
+
+    #[must_use]
+    pub const fn provenance(
+        mut self,
+        initiator_principal_id: Option<i32>,
+        provenance_task_id: Option<i32>,
+    ) -> Self {
+        self.event.initiator_principal_id = initiator_principal_id;
+        self.event.provenance_task_id = provenance_task_id;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> StorageTaskEvent {
+        self.event
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct StorageTaskEventPage {
+    events: Vec<StorageTaskEvent>,
+    total: Option<i64>,
+}
+
+impl StorageTaskEventPage {
+    #[must_use]
+    pub const fn new(events: Vec<StorageTaskEvent>, total: Option<i64>) -> Self {
+        Self { events, total }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (Vec<StorageTaskEvent>, Option<i64>) {
+        (self.events, self.total)
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct StorageImportTaskResult {
+    id: i32,
+    task_id: i32,
+    item_ref: Option<String>,
+    entity_kind: String,
+    action: String,
+    identifier: Option<String>,
+    outcome: String,
+    error: Option<String>,
+    details: Option<Value>,
+    created_at: NaiveDateTime,
+}
+
+impl StorageImportTaskResult {
+    #[must_use]
+    pub fn builder(
+        id: i32,
+        task_id: i32,
+        entity_kind: impl Into<String>,
+        action: impl Into<String>,
+        outcome: impl Into<String>,
+        created_at: NaiveDateTime,
+    ) -> StorageImportTaskResultBuilder {
+        StorageImportTaskResultBuilder {
+            result: Self {
+                id,
+                task_id,
+                item_ref: None,
+                entity_kind: entity_kind.into(),
+                action: action.into(),
+                identifier: None,
+                outcome: outcome.into(),
+                error: None,
+                details: None,
+                created_at,
+            },
+        }
+    }
+
+    #[must_use]
+    pub const fn id(&self) -> i32 {
+        self.id
+    }
+
+    #[must_use]
+    pub const fn task_id(&self) -> i32 {
+        self.task_id
+    }
+
+    #[must_use]
+    pub fn item_ref(&self) -> Option<&str> {
+        self.item_ref.as_deref()
+    }
+
+    #[must_use]
+    pub fn entity_kind(&self) -> &str {
+        &self.entity_kind
+    }
+
+    #[must_use]
+    pub fn action(&self) -> &str {
+        &self.action
+    }
+
+    #[must_use]
+    pub fn identifier(&self) -> Option<&str> {
+        self.identifier.as_deref()
+    }
+
+    #[must_use]
+    pub fn outcome(&self) -> &str {
+        &self.outcome
+    }
+
+    #[must_use]
+    pub fn error(&self) -> Option<&str> {
+        self.error.as_deref()
+    }
+
+    #[must_use]
+    pub const fn details(&self) -> Option<&Value> {
+        self.details.as_ref()
+    }
+
+    #[must_use]
+    pub const fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+}
+
+pub struct StorageImportTaskResultBuilder {
+    result: StorageImportTaskResult,
+}
+
+impl StorageImportTaskResultBuilder {
+    #[must_use]
+    pub fn item_ref(mut self, item_ref: Option<String>) -> Self {
+        self.result.item_ref = item_ref;
+        self
+    }
+
+    #[must_use]
+    pub fn identifier(mut self, identifier: Option<String>) -> Self {
+        self.result.identifier = identifier;
+        self
+    }
+
+    #[must_use]
+    pub fn error(mut self, error: Option<String>) -> Self {
+        self.result.error = error;
+        self
+    }
+
+    #[must_use]
+    pub fn details(mut self, details: Option<Value>) -> Self {
+        self.result.details = details;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> StorageImportTaskResult {
+        self.result
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct StorageImportTaskResultPage {
+    results: Vec<StorageImportTaskResult>,
+    total: Option<i64>,
+}
+
+impl StorageImportTaskResultPage {
+    #[must_use]
+    pub const fn new(results: Vec<StorageImportTaskResult>, total: Option<i64>) -> Self {
+        Self { results, total }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (Vec<StorageImportTaskResult>, Option<i64>) {
+        (self.results, self.total)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StorageTaskDurations {
+    total_ms: i32,
+    query_ms: i32,
+    hydration_ms: i32,
+    render_ms: i32,
+}
+
+impl StorageTaskDurations {
+    #[must_use]
+    pub const fn new(total_ms: i32, query_ms: i32, hydration_ms: i32, render_ms: i32) -> Self {
+        Self {
+            total_ms,
+            query_ms,
+            hydration_ms,
+            render_ms,
+        }
+    }
+
+    #[must_use]
+    pub const fn total_ms(self) -> i32 {
+        self.total_ms
+    }
+
+    #[must_use]
+    pub const fn query_ms(self) -> i32 {
+        self.query_ms
+    }
+
+    #[must_use]
+    pub const fn hydration_ms(self) -> i32 {
+        self.hydration_ms
+    }
+
+    #[must_use]
+    pub const fn render_ms(self) -> i32 {
+        self.render_ms
+    }
+}
+
+macro_rules! task_output_accessors {
+    () => {
+        #[must_use]
+        pub const fn task_id(&self) -> i32 {
+            self.task_id
+        }
+
+        #[must_use]
+        pub fn template_name(&self) -> Option<&str> {
+            self.template_name.as_deref()
+        }
+
+        #[must_use]
+        pub fn content_type(&self) -> &str {
+            &self.content_type
+        }
+
+        #[must_use]
+        pub const fn warning_count(&self) -> i32 {
+            self.warning_count
+        }
+
+        #[must_use]
+        pub const fn truncated(&self) -> bool {
+            self.truncated
+        }
+
+        #[must_use]
+        pub const fn output_expires_at(&self) -> NaiveDateTime {
+            self.output_expires_at
+        }
+
+        #[must_use]
+        pub const fn durations(&self) -> StorageTaskDurations {
+            self.durations
+        }
+    };
+}
+
+macro_rules! backup_output_accessors {
+    () => {
+        #[must_use]
+        pub const fn task_id(&self) -> i32 {
+            self.task_id
+        }
+
+        #[must_use]
+        pub const fn byte_size(&self) -> i64 {
+            self.byte_size
+        }
+
+        #[must_use]
+        pub fn sha256(&self) -> &str {
+            &self.sha256
+        }
+
+        #[must_use]
+        pub const fn output_expires_at(&self) -> NaiveDateTime {
+            self.output_expires_at
+        }
+    };
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct StorageExportOutputSummary {
+    task_id: i32,
+    template_name: Option<String>,
+    content_type: String,
+    warning_count: i32,
+    truncated: bool,
+    output_expires_at: NaiveDateTime,
+    durations: StorageTaskDurations,
+}
+
+impl StorageExportOutputSummary {
+    #[must_use]
+    pub fn new(
+        task_id: i32,
+        template_name: Option<String>,
+        content_type: impl Into<String>,
+        warning_count: i32,
+        truncated: bool,
+        output_expires_at: NaiveDateTime,
+        durations: StorageTaskDurations,
+    ) -> Self {
+        Self {
+            task_id,
+            template_name,
+            content_type: content_type.into(),
+            warning_count,
+            truncated,
+            output_expires_at,
+            durations,
+        }
+    }
+
+    task_output_accessors!();
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct StorageBackupOutputSummary {
+    task_id: i32,
+    byte_size: i64,
+    sha256: String,
+    output_expires_at: NaiveDateTime,
+}
+
+impl StorageBackupOutputSummary {
+    #[must_use]
+    pub fn new(
+        task_id: i32,
+        byte_size: i64,
+        sha256: impl Into<String>,
+        output_expires_at: NaiveDateTime,
+    ) -> Self {
+        Self {
+            task_id,
+            byte_size,
+            sha256: sha256.into(),
+            output_expires_at,
+        }
+    }
+
+    backup_output_accessors!();
+}
+
+#[derive(Clone, PartialEq)]
+pub struct StorageExportOutput {
+    task_id: i32,
+    template_name: Option<String>,
+    content_type: String,
+    json_output: Option<Value>,
+    text_output: Option<String>,
+    metadata: Value,
+    warnings: Value,
+    warning_count: i32,
+    truncated: bool,
+    output_expires_at: NaiveDateTime,
+    durations: StorageTaskDurations,
+    created_at: NaiveDateTime,
+}
+
+impl StorageExportOutput {
+    #[must_use]
+    pub fn builder(
+        task_id: i32,
+        content_type: impl Into<String>,
+        metadata: Value,
+        warnings: Value,
+        output_expires_at: NaiveDateTime,
+        created_at: NaiveDateTime,
+    ) -> StorageExportOutputBuilder {
+        StorageExportOutputBuilder {
+            output: Self {
+                task_id,
+                template_name: None,
+                content_type: content_type.into(),
+                json_output: None,
+                text_output: None,
+                metadata,
+                warnings,
+                warning_count: 0,
+                truncated: false,
+                output_expires_at,
+                durations: StorageTaskDurations::default(),
+                created_at,
+            },
+        }
+    }
+
+    task_output_accessors!();
+
+    #[must_use]
+    pub const fn json_output(&self) -> Option<&Value> {
+        self.json_output.as_ref()
+    }
+
+    #[must_use]
+    pub fn text_output(&self) -> Option<&str> {
+        self.text_output.as_deref()
+    }
+
+    #[must_use]
+    pub const fn metadata(&self) -> &Value {
+        &self.metadata
+    }
+
+    #[must_use]
+    pub const fn warnings(&self) -> &Value {
+        &self.warnings
+    }
+
+    #[must_use]
+    pub const fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+}
+
+pub struct StorageExportOutputBuilder {
+    output: StorageExportOutput,
+}
+
+impl StorageExportOutputBuilder {
+    #[must_use]
+    pub fn template_name(mut self, template_name: Option<String>) -> Self {
+        self.output.template_name = template_name;
+        self
+    }
+
+    #[must_use]
+    pub fn output(mut self, json_output: Option<Value>, text_output: Option<String>) -> Self {
+        self.output.json_output = json_output;
+        self.output.text_output = text_output;
+        self
+    }
+
+    #[must_use]
+    pub const fn warning_state(mut self, warning_count: i32, truncated: bool) -> Self {
+        self.output.warning_count = warning_count;
+        self.output.truncated = truncated;
+        self
+    }
+
+    #[must_use]
+    pub const fn durations(mut self, durations: StorageTaskDurations) -> Self {
+        self.output.durations = durations;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> StorageExportOutput {
+        self.output
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct StorageBackupOutput {
+    task_id: i32,
+    document: Vec<u8>,
+    byte_size: i64,
+    sha256: String,
+    output_expires_at: NaiveDateTime,
+    created_at: NaiveDateTime,
+}
+
+impl StorageBackupOutput {
+    #[must_use]
+    pub fn new(
+        task_id: i32,
+        document: Vec<u8>,
+        byte_size: i64,
+        sha256: impl Into<String>,
+        output_expires_at: NaiveDateTime,
+        created_at: NaiveDateTime,
+    ) -> Self {
+        Self {
+            task_id,
+            document,
+            byte_size,
+            sha256: sha256.into(),
+            output_expires_at,
+            created_at,
+        }
+    }
+
+    backup_output_accessors!();
+
+    #[must_use]
+    pub fn document(&self) -> &[u8] {
+        &self.document
+    }
+
+    #[must_use]
+    pub const fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub enum StorageTaskOutputLookup<T> {
+    Available(T),
+    Expired { expires_at: NaiveDateTime },
+    Missing,
+}
+
+#[async_trait]
+pub trait TaskQueueStorage: Send + Sync {
+    async fn create_task(
+        &self,
+        request: StorageTaskCreateRequest,
+    ) -> Result<StorageTask, StorageError>;
+
+    async fn get_task_access(&self, task_id: i32) -> Result<StorageTaskAccess, StorageError>;
+
+    async fn list_tasks(
+        &self,
+        query: StorageTaskListQuery,
+    ) -> Result<StorageTaskPage, StorageError>;
+
+    async fn list_task_events(
+        &self,
+        query: StorageTaskPageQuery,
+    ) -> Result<StorageTaskEventPage, StorageError>;
+
+    async fn list_import_task_results(
+        &self,
+        query: StorageTaskPageQuery,
+    ) -> Result<StorageImportTaskResultPage, StorageError>;
+
+    async fn list_export_output_summaries(
+        &self,
+        task_ids: Vec<i32>,
+    ) -> Result<Vec<StorageExportOutputSummary>, StorageError>;
+
+    async fn list_backup_output_summaries(
+        &self,
+        task_ids: Vec<i32>,
+    ) -> Result<Vec<StorageBackupOutputSummary>, StorageError>;
+
+    async fn get_export_output_summary(
+        &self,
+        task_id: i32,
+    ) -> Result<StorageTaskOutputLookup<StorageExportOutputSummary>, StorageError>;
+
+    async fn get_backup_output_summary(
+        &self,
+        task_id: i32,
+    ) -> Result<StorageTaskOutputLookup<StorageBackupOutputSummary>, StorageError>;
+
+    async fn get_export_output(
+        &self,
+        task_id: i32,
+    ) -> Result<StorageTaskOutputLookup<StorageExportOutput>, StorageError>;
+
+    async fn get_backup_output(
+        &self,
+        task_id: i32,
+    ) -> Result<StorageTaskOutputLookup<StorageBackupOutput>, StorageError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_debug_redacts_identity_payload_scope_and_claim() {
+        let now = chrono::Utc::now().naive_utc();
+        let task = StorageTask::builder(
+            91_001,
+            StorageTaskKind::Import,
+            StorageTaskStatus::Running,
+            now,
+            now,
+        )
+        .submitted_by(Some(91_002))
+        .idempotency_key(Some("secret idempotency".to_string()))
+        .request_hash(Some("secret hash".to_string()))
+        .request_payload(Some(serde_json::json!({"secret": "payload"})))
+        .summary(Some("summary".to_string()))
+        .progress(StorageTaskProgress::new(2, 1, 1, 0))
+        .scope_snapshot(StorageTaskScopeSnapshot::new(
+            Some(91_003),
+            true,
+            serde_json::json!({"permissions": ["secret"]}),
+        ))
+        .started_at(Some(now))
+        .lease(
+            Some(Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap()),
+            Some(now),
+        )
+        .attempt_count(1)
+        .initiator_principal_id(Some(91_004))
+        .build();
+
+        let debug = format!("{task:?}");
+
+        for secret in [
+            "91001",
+            "91002",
+            "91003",
+            "91004",
+            "secret idempotency",
+            "secret hash",
+            "secret\": \"payload",
+            "permissions\": [\"secret",
+            "11111111",
+        ] {
+            assert!(!debug.contains(secret));
+        }
+        assert!(debug.contains("Import"));
+        assert!(debug.contains("Running"));
+    }
+}

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -70,6 +70,7 @@ satisfy every capability family below before `StorageHandle` can compose it:
 | Identity and authorization data | Principals, credentials, memberships, grants, and data needed by configured authorization providers |
 | Temporal history | Revision-filtered pages, stable cursors, point-in-time reads, visibility pushdown, and provenance-name resolution |
 | Unified search | Ranked collection, class, and object search with stable per-kind cursors and token visibility pushdown |
+| Task queue | Idempotent task submission, access facts, task/event/result paging, and retained export and backup output reads |
 | Workflows | Imports, restores, tasks, backups, exports, remote calls, and their atomic state transitions |
 | Operations | Probes, metrics snapshots, retention, event delivery, leases, locking, and worker coordination |
 
@@ -86,7 +87,10 @@ now been replaced by the real `AuthenticationStorage`,
 `AuthorizationStorage`, `HistoryStorage`, `CatalogStorage`,
 `ComputedObjectStorage`, `ComputedFieldLifecycleStorage`,
 `ObjectAggregateStorage`, `RelationQueryStorage`, and `UnifiedSearchStorage`
-contracts; no family is
+contracts. `TaskQueueStorage` now replaces the task submission and read portion
+of the workflow gate; worker leases and workflow-specific atomic transitions
+remain in that gate until their complete contracts and compatibility tests land.
+No family is
 considered complete merely because a marker exists.
 
 PostgreSQL query implementations live in
@@ -281,6 +285,18 @@ edges before canonical paths and limits are selected. The opaque handle
 observes every operation under bounded `relations/*` labels, and the shared
 available-backend compatibility test exercises all twelve operations.
 
+`TaskQueueStorage` owns the complete application-facing task queue surface:
+idempotent submission under active-task limits, task access facts, filtered
+task pages, lifecycle events, import item results, and retained export and
+backup outputs. The PostgreSQL adapter converts persistence records and legacy
+event provenance into private-field storage DTOs. The application task service
+owns authorization decisions, principal-name resolution, and API/domain model
+conversion; handlers do not call task query traits or receive Diesel records.
+All eleven entry points are observed under bounded `tasks/*` labels, and the
+available-backend compatibility test invokes every operation. Claiming,
+leasing, terminal transitions, and workflow-specific atomic writes remain a
+separate mandatory extraction rather than optional backend behavior.
+
 ## Error Direction
 
 Errors cross the boundary in one direction:
@@ -400,7 +416,7 @@ The first workspace boundaries are now in place:
   capability identities, `StorageError`, authentication and authorization
   DTOs, operational snapshot DTOs, and the extracted authentication,
   authorization, catalog-query, temporal-history, unified-search, operational
-  state, computed-object, computed-field lifecycle, object-aggregate,
+  state, computed-object, computed-field lifecycle, object-aggregate, task-queue,
   relation-query, event-health, event-fan-out, event-retention, and
   token-retention traits without application, transport, or driver
   dependencies.

--- a/src/api/v1/handlers/backups.rs
+++ b/src/api/v1/handlers/backups.rs
@@ -8,11 +8,14 @@ use crate::backups::{BackupSettings, authorize_backup_request};
 use crate::errors::ApiError;
 use crate::extractors::Authenticated;
 use crate::models::{
-    BackupDocument, BackupOutputLookup, BackupRequest, PrincipalID, TaskID, TaskKind, TaskRecord,
-    TaskResponse, TokenID,
+    BackupDocument, BackupOutputLookup, BackupRequest, PrincipalID, TaskID, TaskKind, TaskResponse,
+    TokenID,
 };
-use crate::permissions::{AppContext, AuthzTarget, PermissionDecision, PrincipalRef};
-use crate::storage::capabilities::task::{TaskBackend, TaskCreateRequest, TaskScopeSnapshot};
+use crate::permissions::AppContext;
+use crate::services::tasks::{
+    TaskSubmission, backup_output, backup_output_summary, load_authorized_backup, submit_task,
+    task_scope_snapshot,
+};
 use crate::tasks::{idempotency_key_from_headers, kick_task_worker, request_hash};
 
 fn digest_header_from_sha256(sha256: &str) -> Result<String, ApiError> {
@@ -45,37 +48,6 @@ fn invalid_stored_sha256() -> ApiError {
     ApiError::InternalServerError("Stored backup SHA-256 is invalid".to_string())
 }
 
-async fn load_authorized_backup(
-    context: &AppContext,
-    requestor: &Authenticated,
-    task_id: TaskID,
-) -> Result<TaskRecord, ApiError> {
-    if context.permission_backend().uses_local_permission_store() {
-        return task_id
-            .load_authorized_backup(context, &requestor.principal)
-            .await;
-    }
-
-    let task = task_id.find_record(context).await?;
-    if task.kind != TaskKind::Backup.as_str() {
-        return Err(ApiError::NotFound(format!(
-            "Backup task {} not found",
-            task_id.id()
-        )));
-    }
-    let principal = PrincipalRef::load(context, &requestor.principal).await?;
-    let resource = task.to_resource_ref(context).await?;
-    if context
-        .permission_backend()
-        .authorize_task(&principal, &resource)
-        .await?
-        != PermissionDecision::Allow
-    {
-        return Err(ApiError::NotFound("Backup task not found".to_string()));
-    }
-    Ok(task)
-}
-
 #[utoipa::path(
     post,
     path = "/api/v1/backups",
@@ -103,23 +75,24 @@ pub async fn create_backup(
     authorize_backup_request(&context, &requestor.principal, requestor.scopes()).await?;
     let payload = serde_json::to_value(&request)?;
     let hash = request_hash(&payload)?;
-    let scope_snapshot = TaskScopeSnapshot::from_request(
+    let scope_snapshot = task_scope_snapshot(
         Some(TokenID::new(requestor.token_meta.id)?),
         requestor.scopes(),
     );
-    let task_request = TaskCreateRequest::builder(
-        TaskKind::Backup,
-        PrincipalID::new(requestor.principal.id())?,
-        payload,
-        1,
+    let task = submit_task(
+        &context,
+        TaskSubmission::new(
+            TaskKind::Backup,
+            PrincipalID::new(requestor.principal.id())?,
+            payload,
+            1,
+            settings.max_active_tasks_per_user(),
+        )
+        .idempotency_key(idempotency_key_from_headers(req.headers())?)
+        .request_hash(Some(hash))
+        .scope_snapshot(scope_snapshot),
     )
-    .idempotency_key(idempotency_key_from_headers(req.headers())?)
-    .request_hash(Some(hash))
-    .scope_snapshot(scope_snapshot)
-    .build();
-    let task = task_request
-        .create_idempotently_with_active_limit(&context, settings.max_active_tasks_per_user())
-        .await?;
+    .await?;
     let response = task.to_response()?;
     kick_task_worker(context.clone());
     Ok(ApiResponse::accepted_at(
@@ -148,8 +121,9 @@ pub async fn get_backup(
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     authorize_backup_request(&context, &requestor.principal, requestor.scopes()).await?;
-    let task = load_authorized_backup(&context, &requestor, task_id.into_inner()).await?;
-    let output = task.find_backup_output_summary(&context).await?;
+    let task_id = task_id.into_inner();
+    let task = load_authorized_backup(&context, &requestor.principal, task_id).await?;
+    let output = backup_output_summary(&context, task_id).await?;
     Ok(ApiResponse::new(
         task.to_response_with_backup_output(output.as_ref())?,
         StatusCode::OK,
@@ -185,8 +159,8 @@ pub async fn get_backup_output(
 ) -> Result<HttpResponse, ApiError> {
     let task_id = task_id.into_inner();
     authorize_backup_request(&context, &requestor.principal, requestor.scopes()).await?;
-    load_authorized_backup(&context, &requestor, task_id).await?;
-    match task_id.find_backup_output(&context).await? {
+    load_authorized_backup(&context, &requestor.principal, task_id).await?;
+    match backup_output(&context, task_id).await? {
         BackupOutputLookup::Available(output) => {
             let digest = digest_header_from_sha256(&output.sha256)?;
             Ok(HttpResponse::Ok()

--- a/src/api/v1/handlers/exports.rs
+++ b/src/api/v1/handlers/exports.rs
@@ -8,16 +8,16 @@ use crate::exports::{ExportTaskSubmission, submit_export_task};
 use crate::extractors::Authenticated;
 use crate::models::{
     ExportContentType, ExportJsonResponse, ExportMeta, ExportOutputLookup, ExportRequest,
-    ExportTaskOutputRecord, ExportWarning, TaskID, TaskResponse, TokenID,
+    ExportTaskOutput, ExportWarning, TaskID, TaskResponse, TokenID,
 };
 use crate::permissions::AppContext;
-use crate::storage::capabilities::task::TaskBackend;
+use crate::services::tasks::{export_output, export_output_summary, load_authorized_export};
 use crate::tasks::{ensure_task_worker_running, idempotency_key_from_headers, kick_task_worker};
 
 const EXPORT_WARNINGS_HEADER: &str = "X-Hubuum-Export-Warnings";
 const EXPORT_TRUNCATED_HEADER: &str = "X-Hubuum-Export-Truncated";
 
-fn render_export_task_output(output: ExportTaskOutputRecord) -> Result<HttpResponse, ApiError> {
+fn render_export_task_output(output: ExportTaskOutput) -> Result<HttpResponse, ApiError> {
     let content_type = ExportContentType::from_mime(&output.content_type)?;
     let _meta: ExportMeta = serde_json::from_value(output.meta_json)?;
     let warnings: Vec<ExportWarning> = serde_json::from_value(output.warnings_json)?;
@@ -105,11 +105,9 @@ pub async fn get_export(
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(context.clone());
-    let task = task_id
-        .into_inner()
-        .load_authorized_export(&context, &requestor.principal)
-        .await?;
-    let output = task.find_export_output_summary(&context).await?;
+    let task_id = task_id.into_inner();
+    let task = load_authorized_export(&context, &requestor.principal, task_id).await?;
+    let output = export_output_summary(&context, task_id).await?;
     Ok(ApiResponse::new(
         task.to_response_with_export_output(output.as_ref())?,
         StatusCode::OK,
@@ -148,10 +146,8 @@ pub async fn get_export_output(
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(context.clone());
     let task_id = task_id.into_inner();
-    task_id
-        .load_authorized_export(&context, &requestor.principal)
-        .await?;
-    match task_id.find_export_output(&context).await? {
+    load_authorized_export(&context, &requestor.principal, task_id).await?;
+    match export_output(&context, task_id).await? {
         ExportOutputLookup::Available(output) => render_export_task_output(output),
         ExportOutputLookup::Expired { expires_at } => Err(ApiError::Gone(format!(
             "Export output expired at {expires_at} UTC"
@@ -167,17 +163,8 @@ mod tests {
     use super::*;
     use crate::models::{ExportScope, ExportScopeKind};
 
-    fn test_timestamp() -> chrono::NaiveDateTime {
-        chrono::DateTime::from_timestamp(1_700_000_000, 0)
-            .unwrap()
-            .naive_utc()
-    }
-
-    fn text_export_output(meta_truncated: bool, output_truncated: bool) -> ExportTaskOutputRecord {
-        ExportTaskOutputRecord {
-            id: 1,
-            task_id: 1,
-            template_name: Some("summary".to_string()),
+    fn text_export_output(meta_truncated: bool, output_truncated: bool) -> ExportTaskOutput {
+        ExportTaskOutput {
             content_type: ExportContentType::TextPlain.as_mime().to_string(),
             json_output: None,
             text_output: Some("ok".to_string()),
@@ -193,14 +180,7 @@ mod tests {
             })
             .unwrap(),
             warnings_json: serde_json::json!([]),
-            warning_count: 0,
             truncated: output_truncated,
-            output_expires_at: test_timestamp(),
-            total_duration_ms: 0,
-            query_duration_ms: 0,
-            hydration_duration_ms: 0,
-            render_duration_ms: 0,
-            created_at: test_timestamp(),
         }
     }
 

--- a/src/api/v1/handlers/imports.rs
+++ b/src/api/v1/handlers/imports.rs
@@ -1,5 +1,4 @@
 use actix_web::{HttpRequest, Responder, get, http::StatusCode, post, web};
-use hubuum_task_core::IdempotencyKey;
 
 use crate::api::locations as api_locations;
 use crate::api::openapi::ApiErrorResponse;
@@ -9,33 +8,16 @@ use crate::errors::ApiError;
 use crate::extractors::Authenticated;
 use crate::models::search::parse_query_parameter;
 use crate::models::{
-    ImportRequest, ImportTaskResultResponse, PrincipalID, TaskID, TaskKind, TaskRecord,
-    TaskResponse, TokenID,
+    ImportRequest, ImportTaskResultResponse, PrincipalID, TaskID, TaskKind, TaskResponse, TokenID,
 };
 use crate::pagination::prepare_db_pagination;
 use crate::permissions::AppContext;
-use crate::storage::capabilities::task::{TaskBackend, TaskCreateRequest, TaskScopeSnapshot};
+use crate::services::tasks::{
+    TaskSubmission, list_import_results, load_authorized_import, submit_task, task_scope_snapshot,
+};
 use crate::tasks::{
     ensure_task_worker_running, idempotency_key_from_headers, kick_task_worker, request_hash,
 };
-
-async fn find_or_create_import_task(
-    context: &impl crate::storage::StorageContext,
-    submitted_by: PrincipalID,
-    snapshot: TaskScopeSnapshot,
-    idempotency_key: Option<IdempotencyKey>,
-    payload: serde_json::Value,
-    request_hash: String,
-    total_items: i32,
-) -> Result<TaskRecord, ApiError> {
-    TaskCreateRequest::builder(TaskKind::Import, submitted_by, payload, total_items)
-        .idempotency_key(idempotency_key)
-        .request_hash(Some(request_hash))
-        .scope_snapshot(snapshot)
-        .build()
-        .create_idempotently_with_active_limit(context, max_active_import_tasks_per_user())
-        .await
-}
 
 #[utoipa::path(
     post,
@@ -66,19 +48,23 @@ pub async fn create_import(
     let payload = serde_json::to_value(&import_request)?;
     let hash = request_hash(&payload)?;
     let idempotency_key = idempotency_key_from_headers(req.headers())?;
-    let snapshot = TaskScopeSnapshot::from_request(
+    let snapshot = task_scope_snapshot(
         Some(TokenID::new(requestor.token_meta.id)?),
         requestor.scopes(),
     );
 
-    let task = find_or_create_import_task(
+    let task = submit_task(
         &context,
-        PrincipalID::new(requestor.principal.id())?,
-        snapshot,
-        idempotency_key,
-        payload,
-        hash,
-        import_request.total_items(),
+        TaskSubmission::new(
+            TaskKind::Import,
+            PrincipalID::new(requestor.principal.id())?,
+            payload,
+            import_request.total_items(),
+            max_active_import_tasks_per_user(),
+        )
+        .idempotency_key(idempotency_key)
+        .request_hash(Some(hash))
+        .scope_snapshot(snapshot),
     )
     .await?;
 
@@ -119,10 +105,7 @@ pub async fn get_import(
     task_id: web::Path<TaskID>,
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(context.clone());
-    let task = task_id
-        .into_inner()
-        .load_authorized_import(&context, &requestor.principal)
-        .await?;
+    let task = load_authorized_import(&context, &requestor.principal, task_id.into_inner()).await?;
     Ok(ApiResponse::new(task.to_response()?, StatusCode::OK))
 }
 
@@ -150,14 +133,10 @@ pub async fn get_import_results(
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(context.clone());
     let task_id = task_id.into_inner();
-    task_id
-        .load_authorized_import(&context, &requestor.principal)
-        .await?;
+    load_authorized_import(&context, &requestor.principal, task_id).await?;
     let params = parse_query_parameter(req.query_string())?;
     let search_params = prepare_db_pagination::<ImportTaskResultResponse>(&params)?;
-    let (results, total_count) = task_id
-        .list_import_results_with_total_count(&context, &search_params)
-        .await?;
+    let (results, total_count) = list_import_results(&context, task_id, search_params).await?;
     let results = results
         .into_iter()
         .map(ImportTaskResultResponse::from)

--- a/src/api/v1/handlers/remote_targets.rs
+++ b/src/api/v1/handlers/remote_targets.rs
@@ -24,13 +24,14 @@ use crate::permissions::{AppContext, PrincipalRef};
 use crate::services::history::{
     HistoryCollectionFilter, remote_target_as_of, remote_target_history_paginated_with_total_count,
 };
+use crate::services::tasks::{TaskSubmission, submit_task, task_scope_snapshot};
+use crate::storage::StorageTaskScopeSnapshot;
 use crate::storage::capabilities::UserPermissions;
 use crate::storage::capabilities::authz::scope_allows;
 use crate::storage::capabilities::remote_target::{
     DeleteRemoteTargetRecord, SaveRemoteTargetRecord, UpdateRemoteTargetRecord,
     emit_remote_target_invoked_event,
 };
-use crate::storage::capabilities::task::{TaskCreateRequest, TaskScopeSnapshot};
 use crate::storage::capabilities::with_revision_precondition_scope;
 use crate::tasks::{
     ensure_task_worker_running, idempotency_key_from_headers, kick_task_worker, request_hash,
@@ -341,7 +342,7 @@ pub async fn invoke_remote_target(
         parameters: invoke.parameters,
         body_override: invoke.body_override,
     })?;
-    let snapshot = TaskScopeSnapshot::from_request(
+    let snapshot = task_scope_snapshot(
         Some(TokenID::new(requestor.token_meta.id)?),
         requestor.scopes(),
     );
@@ -382,7 +383,7 @@ pub async fn invoke_remote_target(
 async fn find_or_create_remote_call_task(
     context: &impl crate::storage::StorageContext,
     submitted_by: PrincipalID,
-    snapshot: TaskScopeSnapshot,
+    snapshot: StorageTaskScopeSnapshot,
     idempotency_key: Option<IdempotencyKey>,
     payload: serde_json::Value,
 ) -> Result<TaskRecord, ApiError> {
@@ -392,13 +393,20 @@ async fn find_or_create_remote_call_task(
         message = "Creating remote call task",
         submitted_by = submitted_by.id()
     );
-    TaskCreateRequest::builder(TaskKind::RemoteCall, submitted_by, payload, 1)
+    submit_task(
+        context,
+        TaskSubmission::new(
+            TaskKind::RemoteCall,
+            submitted_by,
+            payload,
+            1,
+            max_active_remote_call_tasks_per_user(),
+        )
         .idempotency_key(idempotency_key)
         .request_hash(Some(hash))
-        .scope_snapshot(snapshot)
-        .build()
-        .create_idempotently_with_active_limit(context, max_active_remote_call_tasks_per_user())
-        .await
+        .scope_snapshot(snapshot),
+    )
+    .await
 }
 
 fn max_active_remote_call_tasks_per_user() -> usize {

--- a/src/api/v1/handlers/tasks.rs
+++ b/src/api/v1/handlers/tasks.rs
@@ -13,10 +13,11 @@ use crate::pagination::{
     count_query_options, known_count_or_skipped, paginate_in_memory, prepare_db_pagination,
 };
 use crate::permissions::AppContext;
-use crate::permissions::{AuthzTarget, PermissionDecision, PrincipalRef};
-use crate::storage::capabilities::task::{
-    TaskBackend, list_backup_task_output_summaries, list_export_task_output_summaries,
-    list_tasks_with_total_count, task_event_responses,
+use crate::permissions::{PermissionDecision, PrincipalRef};
+use crate::services::tasks::{
+    backup_output_summary, export_output_summary, list_backup_output_summaries,
+    list_export_output_summaries, list_task_events, list_tasks, load_authorized_task,
+    task_resource,
 };
 use crate::tasks::ensure_task_worker_running;
 
@@ -118,34 +119,27 @@ pub async fn get_tasks(
         None
     };
     let (tasks, total_count) = if backend.supports_storage_visibility_filtering() {
-        list_tasks_with_total_count(
+        list_tasks(
             &context,
             submitted_by_filter,
-            filters.kind.map(TaskKind::as_str),
-            filters.status.map(TaskStatus::as_str),
-            &search_params,
+            filters.kind,
+            filters.status,
+            search_params.clone(),
         )
         .await?
     } else {
         let mut candidate_options = count_query_options(&params);
         candidate_options.include_total = false;
-        let (candidates, _) = list_tasks_with_total_count(
+        let (candidates, _) = list_tasks(
             &context,
             submitted_by_filter,
-            filters.kind.map(TaskKind::as_str),
-            filters.status.map(TaskStatus::as_str),
-            &candidate_options,
+            filters.kind,
+            filters.status,
+            candidate_options,
         )
         .await?;
-        let resources = candidates
-            .iter()
-            .map(|task| task.to_resource_ref(&context))
-            .collect::<Vec<_>>();
-        let mut task_resources = Vec::with_capacity(resources.len());
-        for resource in resources {
-            task_resources.push(resource.await?);
-        }
-        let decisions = backend.authorize_tasks(&principal, &task_resources).await?;
+        let resources = candidates.iter().map(task_resource).collect::<Vec<_>>();
+        let decisions = backend.authorize_tasks(&principal, &resources).await?;
         let authorized = candidates
             .into_iter()
             .zip(decisions)
@@ -159,7 +153,7 @@ pub async fn get_tasks(
         .filter(|task| task.kind == TaskKind::Export.as_str())
         .map(|task| task.id)
         .collect::<Vec<_>>();
-    let export_outputs = list_export_task_output_summaries(&context, &export_task_ids)
+    let export_outputs = list_export_output_summaries(&context, export_task_ids)
         .await?
         .into_iter()
         .map(|output| (output.task_id, output))
@@ -169,7 +163,7 @@ pub async fn get_tasks(
         .filter(|task| task.kind == TaskKind::Backup.as_str())
         .map(|task| task.id)
         .collect::<Vec<_>>();
-    let backup_outputs = list_backup_task_output_summaries(&context, &backup_task_ids)
+    let backup_outputs = list_backup_output_summaries(&context, backup_task_ids)
         .await?
         .into_iter()
         .map(|output| (output.task_id, output))
@@ -228,31 +222,14 @@ pub async fn get_task(
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(context.clone());
     let task_id = task_id.into_inner();
-    let task = if context.permission_backend().uses_local_permission_store() {
-        task_id
-            .load_authorized(&context, &requestor.principal)
-            .await?
-    } else {
-        let task = task_id.find_record(&context).await?;
-        let principal = PrincipalRef::load(&context, &requestor.principal).await?;
-        let resource = task.to_resource_ref(&context).await?;
-        if context
-            .permission_backend()
-            .authorize_task(&principal, &resource)
-            .await?
-            != PermissionDecision::Allow
-        {
-            return Err(ApiError::Forbidden("Permission denied".to_string()));
-        }
-        task
-    };
+    let task = load_authorized_task(&context, &requestor.principal, task_id).await?;
     let export_output = if task.kind == TaskKind::Export.as_str() {
-        task.find_export_output_summary(&context).await?
+        export_output_summary(&context, task_id).await?
     } else {
         ExportOutputLookup::Missing
     };
     let backup_output = if task.kind == TaskKind::Backup.as_str() {
-        task.find_backup_output_summary(&context).await?
+        backup_output_summary(&context, task_id).await?
     } else {
         BackupOutputLookup::Missing
     };
@@ -286,28 +263,9 @@ pub async fn get_task_events(
 ) -> Result<impl Responder, ApiError> {
     ensure_task_worker_running(context.clone());
     let task_id = task_id.into_inner();
-    if context.permission_backend().uses_local_permission_store() {
-        task_id
-            .load_authorized(&context, &requestor.principal)
-            .await?;
-    } else {
-        let task = task_id.find_record(&context).await?;
-        let principal = PrincipalRef::load(&context, &requestor.principal).await?;
-        let resource = task.to_resource_ref(&context).await?;
-        if context
-            .permission_backend()
-            .authorize_task(&principal, &resource)
-            .await?
-            != PermissionDecision::Allow
-        {
-            return Err(ApiError::Forbidden("Permission denied".to_string()));
-        }
-    }
+    load_authorized_task(&context, &requestor.principal, task_id).await?;
     let (params, _) = parse_query_parameter_with_passthrough(req.query_string(), &[])?;
     let search_params = prepare_db_pagination::<TaskEventResponse>(&params)?;
-    let (events, total_count) = task_id
-        .list_events_with_total_count(&context, &search_params)
-        .await?;
-    let events = task_event_responses(&context, events).await?;
+    let (events, total_count) = list_task_events(&context, task_id, search_params).await?;
     ApiResponse::paginated(events, total_count, &params)
 }

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -453,7 +453,7 @@ mod tests {
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
         assert!(json.contains("\"backend\":\"postgresql\""));
-        assert!(json.contains("\"contract_version\":8"));
+        assert!(json.contains("\"contract_version\":9"));
         assert!(json.contains("\"catalog_queries\""));
         assert!(json.contains("\"computed_object_queries\""));
         assert!(json.contains("\"computed_field_lifecycle\""));
@@ -461,6 +461,7 @@ mod tests {
         assert!(json.contains("\"relation_queries\""));
         assert!(json.contains("\"temporal_history\""));
         assert!(json.contains("\"unified_search\""));
+        assert!(json.contains("\"task_queue\""));
         assert!(!debug.contains("secret-password"));
         assert!(!debug.contains("correct horse battery staple"));
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -179,6 +179,7 @@ impl From<StorageError> for ApiError {
             StorageErrorKind::NotAcceptable => Self::NotAcceptable(message),
             StorageErrorKind::PayloadTooLarge => Self::PayloadTooLarge(message),
             StorageErrorKind::PreconditionFailed => Self::PreconditionFailed(message, current_etag),
+            StorageErrorKind::TooManyRequests => Self::TooManyRequests(message),
             StorageErrorKind::Unavailable => Self::ServiceUnavailable(message),
             StorageErrorKind::Validation => Self::ValidationError(message),
         }
@@ -509,6 +510,14 @@ mod tests {
                     Some("\"collection-1-r2\"".to_string()),
                 ),
                 "precondition_failed",
+            ),
+            (
+                StorageError::new(
+                    StorageErrorKind::TooManyRequests,
+                    "task capacity reached",
+                    None,
+                ),
+                "too_many_requests",
             ),
         ] {
             assert_eq!(ApiError::from(error).class(), expected_class);

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -38,17 +38,16 @@ use crate::permissions::{
 };
 use crate::services::catalog as catalog_service;
 use crate::services::relation_queries;
-use crate::storage::StorageContext;
+use crate::services::tasks::{TaskSubmission, submit_task, task_scope_snapshot};
 use crate::storage::capabilities::UserPermissions;
 use crate::storage::capabilities::authz::{scope_allows, scope_allows_resource};
 use crate::storage::capabilities::relations::{
     class_relation_authorization_resources, object_authorization_resources,
     object_relation_authorization_resources,
 };
-use crate::storage::capabilities::task::{
-    TaskBackend, TaskCreateRequest, TaskScopeSnapshot, TaskStateUpdate,
-};
+use crate::storage::capabilities::task::{TaskBackend, TaskStateUpdate};
 use crate::storage::capabilities::with_statement_timeout_scope;
+use crate::storage::{StorageContext, StorageTaskScopeSnapshot};
 use crate::tasks::request_hash;
 use crate::traits::{AuthzSubject, SelfAccessors};
 use crate::utilities::exporting::render_template;
@@ -955,7 +954,7 @@ pub(crate) struct ExportTaskSubmission {
     export: ExportRequest,
     template: Option<ExportTemplate>,
     idempotency_key: Option<IdempotencyKey>,
-    scope_snapshot: TaskScopeSnapshot,
+    scope_snapshot: StorageTaskScopeSnapshot,
 }
 
 impl ExportTaskSubmission {
@@ -968,7 +967,7 @@ impl ExportTaskSubmission {
             export,
             template: None,
             idempotency_key: None,
-            scope_snapshot: TaskScopeSnapshot::from_request(Some(token_id), scopes),
+            scope_snapshot: task_scope_snapshot(Some(token_id), scopes),
         }
     }
 
@@ -1093,18 +1092,25 @@ fn runtime_to_task_payload(runtime: &ExportRuntime) -> Result<StoredExportTaskPa
 async fn find_or_create_export_task(
     pool: &impl crate::storage::StorageContext,
     submitted_by: PrincipalID,
-    snapshot: TaskScopeSnapshot,
+    snapshot: StorageTaskScopeSnapshot,
     idempotency_key: Option<IdempotencyKey>,
     payload: serde_json::Value,
     request_hash_value: String,
 ) -> Result<TaskRecord, ApiError> {
-    TaskCreateRequest::builder(TaskKind::Export, submitted_by, payload, 1)
+    submit_task(
+        pool,
+        TaskSubmission::new(
+            TaskKind::Export,
+            submitted_by,
+            payload,
+            1,
+            max_active_export_tasks_per_user(),
+        )
         .idempotency_key(idempotency_key)
         .request_hash(Some(request_hash_value))
-        .scope_snapshot(snapshot)
-        .build()
-        .create_idempotently_with_active_limit(pool, max_active_export_tasks_per_user())
-        .await
+        .scope_snapshot(snapshot),
+    )
+    .await
 }
 
 pub(crate) async fn execute_export_task<C>(

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -15,7 +15,6 @@ use crate::models::{
 };
 use crate::permissions::{AuthzTarget, ResourceAttrs, ResourceKind, ResourceRef};
 use crate::schema::{backup_task_outputs, export_task_outputs, import_task_results, tasks};
-use crate::storage::postgres::operations::task::TaskBackend;
 use crate::traits::SelfAccessors;
 use crate::traits::accessors::{IdAccessor, InstanceAdapter};
 use crate::traits::{
@@ -500,6 +499,16 @@ pub struct ExportTaskOutputRecord {
     pub created_at: NaiveDateTime,
 }
 
+/// Backend-neutral application projection of a retained export output.
+pub struct ExportTaskOutput {
+    pub content_type: String,
+    pub json_output: Option<serde_json::Value>,
+    pub text_output: Option<String>,
+    pub meta_json: serde_json::Value,
+    pub warnings_json: serde_json::Value,
+    pub truncated: bool,
+}
+
 #[derive(Clone, Insertable)]
 #[diesel(table_name = export_task_outputs)]
 pub struct NewExportTaskOutputRecord {
@@ -561,6 +570,20 @@ pub struct ExportTaskOutputSummaryRecord {
     pub created_at: NaiveDateTime,
 }
 
+#[derive(Debug, Clone)]
+pub struct ExportTaskOutputSummary {
+    pub task_id: i32,
+    pub template_name: Option<String>,
+    pub content_type: String,
+    pub warning_count: i32,
+    pub truncated: bool,
+    pub output_expires_at: NaiveDateTime,
+    pub total_duration_ms: i32,
+    pub query_duration_ms: i32,
+    pub hydration_duration_ms: i32,
+    pub render_duration_ms: i32,
+}
+
 #[derive(Debug, Clone, Queryable, Selectable)]
 #[diesel(table_name = backup_task_outputs)]
 pub struct BackupTaskOutputSummaryRecord {
@@ -570,6 +593,19 @@ pub struct BackupTaskOutputSummaryRecord {
     pub output_expires_at: NaiveDateTime,
 }
 
+#[derive(Debug, Clone)]
+pub struct BackupTaskOutputSummary {
+    pub task_id: i32,
+    pub byte_size: i64,
+    pub sha256: String,
+    pub output_expires_at: NaiveDateTime,
+}
+
+pub struct BackupTaskOutput {
+    pub document: Vec<u8>,
+    pub sha256: String,
+}
+
 impl TaskRecord {
     pub fn to_response(&self) -> Result<TaskResponse, ApiError> {
         self.to_response_with_outputs(ExportOutputLookup::Missing, BackupOutputLookup::Missing)
@@ -577,22 +613,22 @@ impl TaskRecord {
 
     pub fn to_response_with_export_output(
         &self,
-        export_output: ExportOutputLookup<&ExportTaskOutputSummaryRecord>,
+        export_output: ExportOutputLookup<&ExportTaskOutputSummary>,
     ) -> Result<TaskResponse, ApiError> {
         self.to_response_with_outputs(export_output, BackupOutputLookup::Missing)
     }
 
     pub fn to_response_with_backup_output(
         &self,
-        backup_output: BackupOutputLookup<&BackupTaskOutputSummaryRecord>,
+        backup_output: BackupOutputLookup<&BackupTaskOutputSummary>,
     ) -> Result<TaskResponse, ApiError> {
         self.to_response_with_outputs(ExportOutputLookup::Missing, backup_output)
     }
 
     pub(crate) fn to_response_with_outputs(
         &self,
-        export_output: ExportOutputLookup<&ExportTaskOutputSummaryRecord>,
-        backup_output: BackupOutputLookup<&BackupTaskOutputSummaryRecord>,
+        export_output: ExportOutputLookup<&ExportTaskOutputSummary>,
+        backup_output: BackupOutputLookup<&BackupTaskOutputSummary>,
     ) -> Result<TaskResponse, ApiError> {
         let kind = TaskKind::from_db(&self.kind)?;
         let status = TaskStatus::from_db(&self.status)?;
@@ -1005,7 +1041,7 @@ impl InstanceAdapter<TaskRecord> for TaskID {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<TaskRecord, ApiError> {
-        self.find_record(pool).await
+        crate::services::tasks::find_task(pool, *self).await
     }
 }
 
@@ -1192,8 +1228,7 @@ mod tests {
             attempt_count: 1,
             initiator_user_id: Some(1),
         };
-        let output = ExportTaskOutputSummaryRecord {
-            id: 3,
+        let output = ExportTaskOutputSummary {
             task_id: task.id,
             template_name: Some("inventory".to_string()),
             content_type: "text/plain".to_string(),
@@ -1204,7 +1239,6 @@ mod tests {
             query_duration_ms: 40,
             hydration_duration_ms: 30,
             render_duration_ms: 70,
-            created_at: timestamp,
         };
 
         let response = task

--- a/src/models/traits/task.rs
+++ b/src/models/traits/task.rs
@@ -1,103 +1,40 @@
-//! Authorization-aware task loads, as methods on the `TaskID` newtype.
-//!
-//! Tasks are user-owned rather than collection-scoped, so they do not use the `PermissionController`
-//! path the other resources do. Authorization is "the submitter or an admin"; denial (and a kind
-//! mismatch) returns a `404` rather than a `403` so the existence of another user's task is not
-//! revealed. These methods replace the per-handler free functions that previously took a bare id.
+//! Authorization-aware task loads backed by the neutral task application service.
 
 use crate::errors::ApiError;
-use crate::models::{TaskID, TaskKind, TaskRecord};
-use crate::storage::postgres::operations::service_account::{
-    is_human_owner_group_member, load_service_account_by_id,
-};
-use crate::storage::postgres::operations::task::TaskBackend;
+use crate::models::{TaskID, TaskRecord};
+use crate::storage::StorageContext;
 use crate::traits::AuthzSubject;
 
 impl TaskID {
-    /// Load this task for `requestor`, enforcing principal-centric authorization.
     pub async fn load_authorized(
         &self,
-        pool: &impl crate::storage::StorageContext,
-        requestor: &impl AuthzSubject,
+        backend: &impl StorageContext,
+        requestor: &(impl AuthzSubject + ?Sized),
     ) -> Result<TaskRecord, ApiError> {
-        self.load_authorized_of_kind(pool, requestor, None, "Task")
-            .await
+        crate::services::tasks::load_authorized_task(backend, requestor, *self).await
     }
 
-    /// Load this task, additionally requiring it to be an export task.
     pub async fn load_authorized_export(
         &self,
-        pool: &impl crate::storage::StorageContext,
-        requestor: &impl AuthzSubject,
+        backend: &impl StorageContext,
+        requestor: &(impl AuthzSubject + ?Sized),
     ) -> Result<TaskRecord, ApiError> {
-        self.load_authorized_of_kind(pool, requestor, Some(TaskKind::Export), "Export task")
-            .await
+        crate::services::tasks::load_authorized_export(backend, requestor, *self).await
     }
 
     pub async fn load_authorized_backup(
         &self,
-        pool: &impl crate::storage::StorageContext,
-        requestor: &impl AuthzSubject,
+        backend: &impl StorageContext,
+        requestor: &(impl AuthzSubject + ?Sized),
     ) -> Result<TaskRecord, ApiError> {
-        self.load_authorized_of_kind(pool, requestor, Some(TaskKind::Backup), "Backup task")
-            .await
+        crate::services::tasks::load_authorized_backup(backend, requestor, *self).await
     }
 
-    /// Load this task, additionally requiring it to be an import task.
     pub async fn load_authorized_import(
         &self,
-        pool: &impl crate::storage::StorageContext,
-        requestor: &impl AuthzSubject,
+        backend: &impl StorageContext,
+        requestor: &(impl AuthzSubject + ?Sized),
     ) -> Result<TaskRecord, ApiError> {
-        self.load_authorized_of_kind(pool, requestor, Some(TaskKind::Import), "Import task")
-            .await
-    }
-
-    /// Authorization (denial returns `404` to avoid revealing other principals'
-    /// tasks): an **admin**, the **submitting principal itself**, or — when the
-    /// task was submitted by a service account — a **human member of that SA's
-    /// owner group**.
-    async fn load_authorized_of_kind(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-        requestor: &impl AuthzSubject,
-        kind: Option<TaskKind>,
-        label: &str,
-    ) -> Result<TaskRecord, ApiError> {
-        let task = self.find_record(pool).await?;
-
-        if let Some(kind) = kind
-            && task.kind != kind.as_str()
-        {
-            return Err(ApiError::NotFound(format!(
-                "{label} {} not found",
-                self.id()
-            )));
-        }
-
-        let not_found = || ApiError::NotFound(format!("{label} not found"));
-
-        if requestor.is_admin(pool).await? {
-            return Ok(task);
-        }
-
-        let Some(submitter_id) = task.submitted_by else {
-            return Err(not_found());
-        };
-
-        // Submitting principal itself.
-        if submitter_id == requestor.principal_id() {
-            return Ok(task);
-        }
-
-        // SA-submitted task: a human member of the SA's owner group may manage it.
-        if let Ok(sa) = load_service_account_by_id(pool, submitter_id).await
-            && is_human_owner_group_member(pool, requestor.principal_id(), sa.owner_group_id)
-                .await?
-        {
-            return Ok(task);
-        }
-
-        Err(not_found())
+        crate::services::tasks::load_authorized_import(backend, requestor, *self).await
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -11,6 +11,7 @@ mod objects;
 pub(crate) mod related_filter_authorization;
 pub(crate) mod relation_queries;
 mod storage_boundary;
+pub(crate) mod tasks;
 pub(crate) mod unified_search;
 
 pub use class_relations::ClassRelationService;

--- a/src/services/tasks.rs
+++ b/src/services/tasks.rs
@@ -1,0 +1,546 @@
+use hubuum_task_core::IdempotencyKey;
+
+use crate::errors::ApiError;
+use crate::models::search::QueryOptions;
+use crate::models::{
+    BackupOutputLookup, BackupTaskOutput, BackupTaskOutputSummary, ExportOutputLookup,
+    ExportTaskOutput, ExportTaskOutputSummary, ImportTaskResultRecord, PrincipalID,
+    TaskEventRecord, TaskID, TaskKind, TaskRecord, TaskStatus, TokenID, TokenScope,
+};
+use crate::pagination::SKIPPED_TOTAL_COUNT;
+use crate::permissions::{
+    PermissionDecision, PrincipalRef, ResourceAttrs, ResourceKind, ResourceRef,
+};
+use crate::storage::{
+    AuthenticationStorage, StorageBackupOutput, StorageBackupOutputSummary, StorageContext,
+    StorageExportOutput, StorageExportOutputSummary, StorageImportTaskResult, StorageTask,
+    StorageTaskCreateRequest, StorageTaskEvent, StorageTaskKind, StorageTaskListQuery,
+    StorageTaskOutputLookup, StorageTaskPageQuery, StorageTaskScopeSnapshot, StorageTaskStatus,
+    TaskQueueStorage, storage_handle,
+};
+use crate::traits::AuthzSubject;
+
+pub(crate) struct TaskSubmission {
+    kind: TaskKind,
+    submitted_by: PrincipalID,
+    payload: serde_json::Value,
+    total_items: i32,
+    maximum_active_tasks: usize,
+    idempotency_key: Option<IdempotencyKey>,
+    request_hash: Option<String>,
+    scope_snapshot: StorageTaskScopeSnapshot,
+}
+
+impl TaskSubmission {
+    pub(crate) fn new(
+        kind: TaskKind,
+        submitted_by: PrincipalID,
+        payload: serde_json::Value,
+        total_items: i32,
+        maximum_active_tasks: usize,
+    ) -> Self {
+        Self {
+            kind,
+            submitted_by,
+            payload,
+            total_items,
+            maximum_active_tasks,
+            idempotency_key: None,
+            request_hash: None,
+            scope_snapshot: StorageTaskScopeSnapshot::unscoped(),
+        }
+    }
+
+    pub(crate) fn idempotency_key(mut self, idempotency_key: Option<IdempotencyKey>) -> Self {
+        self.idempotency_key = idempotency_key;
+        self
+    }
+
+    pub(crate) fn request_hash(mut self, request_hash: Option<String>) -> Self {
+        self.request_hash = request_hash;
+        self
+    }
+
+    pub(crate) fn scope_snapshot(mut self, scope_snapshot: StorageTaskScopeSnapshot) -> Self {
+        self.scope_snapshot = scope_snapshot;
+        self
+    }
+}
+
+pub(crate) fn task_scope_snapshot(
+    token_id: Option<TokenID>,
+    scopes: Option<&TokenScope>,
+) -> StorageTaskScopeSnapshot {
+    StorageTaskScopeSnapshot::new(
+        token_id.map(TokenID::id),
+        scopes.is_some(),
+        scopes
+            .map(TokenScope::snapshot_json)
+            .unwrap_or_else(|| serde_json::json!([])),
+    )
+}
+
+pub(crate) async fn submit_task(
+    backend: &impl StorageContext,
+    submission: TaskSubmission,
+) -> Result<TaskRecord, ApiError> {
+    let request = StorageTaskCreateRequest::builder(
+        task_kind_to_storage(submission.kind),
+        submission.submitted_by.id(),
+        submission.payload,
+        submission.total_items,
+    )
+    .idempotency_key(submission.idempotency_key)
+    .request_hash(submission.request_hash)
+    .scope_snapshot(submission.scope_snapshot)
+    .build(submission.maximum_active_tasks);
+    storage_handle(backend)
+        .create_task(request)
+        .await
+        .map_err(ApiError::from)
+        .and_then(task_from_storage)
+}
+
+pub(crate) async fn find_task(
+    backend: &impl StorageContext,
+    task_id: TaskID,
+) -> Result<TaskRecord, ApiError> {
+    let (task, _) = storage_handle(backend)
+        .get_task_access(task_id.id())
+        .await?
+        .into_parts();
+    task_from_storage(task)
+}
+
+pub(crate) async fn load_authorized_task<S>(
+    backend: &impl StorageContext,
+    requestor: &S,
+    task_id: TaskID,
+) -> Result<TaskRecord, ApiError>
+where
+    S: AuthzSubject + ?Sized,
+{
+    load_authorized_task_of_kind(backend, requestor, task_id, None, "Task", false).await
+}
+
+pub(crate) async fn load_authorized_import<S>(
+    backend: &impl StorageContext,
+    requestor: &S,
+    task_id: TaskID,
+) -> Result<TaskRecord, ApiError>
+where
+    S: AuthzSubject + ?Sized,
+{
+    load_authorized_task_of_kind(
+        backend,
+        requestor,
+        task_id,
+        Some(TaskKind::Import),
+        "Import task",
+        true,
+    )
+    .await
+}
+
+pub(crate) async fn load_authorized_export<S>(
+    backend: &impl StorageContext,
+    requestor: &S,
+    task_id: TaskID,
+) -> Result<TaskRecord, ApiError>
+where
+    S: AuthzSubject + ?Sized,
+{
+    load_authorized_task_of_kind(
+        backend,
+        requestor,
+        task_id,
+        Some(TaskKind::Export),
+        "Export task",
+        true,
+    )
+    .await
+}
+
+pub(crate) async fn load_authorized_backup<S>(
+    backend: &impl StorageContext,
+    requestor: &S,
+    task_id: TaskID,
+) -> Result<TaskRecord, ApiError>
+where
+    S: AuthzSubject + ?Sized,
+{
+    load_authorized_task_of_kind(
+        backend,
+        requestor,
+        task_id,
+        Some(TaskKind::Backup),
+        "Backup task",
+        true,
+    )
+    .await
+}
+
+async fn load_authorized_task_of_kind<S>(
+    backend: &impl StorageContext,
+    requestor: &S,
+    task_id: TaskID,
+    required_kind: Option<TaskKind>,
+    label: &str,
+    hide_external_denial: bool,
+) -> Result<TaskRecord, ApiError>
+where
+    S: AuthzSubject + ?Sized,
+{
+    let (stored, submitter_owner_group_id) = storage_handle(backend)
+        .get_task_access(task_id.id())
+        .await?
+        .into_parts();
+    let task = task_from_storage(stored)?;
+    if required_kind.is_some_and(|kind| task.kind != kind.as_str()) {
+        return Err(ApiError::NotFound(format!(
+            "{label} {} not found",
+            task_id.id()
+        )));
+    }
+
+    let principal = PrincipalRef::load(backend, requestor).await?;
+    let permissions = backend.permission_backend();
+    let local = permissions.is_none_or(|backend| backend.uses_local_permission_store());
+    let allowed = if local {
+        let (identity, _) = storage_handle(backend)
+            .load_authentication_identity(requestor.principal_id())
+            .await?
+            .into_parts();
+        requestor.is_admin(backend).await?
+            || task.submitted_by == Some(principal.user_id)
+            || (identity.is_human()
+                && submitter_owner_group_id
+                    .is_some_and(|group_id| principal.group_ids.contains(&group_id)))
+    } else {
+        permissions
+            .expect("external authorization path requires a permission backend")
+            .authorize_task(&principal, &task_resource(&task))
+            .await?
+            == PermissionDecision::Allow
+    };
+    if allowed {
+        Ok(task)
+    } else if local || hide_external_denial {
+        Err(ApiError::NotFound(format!("{label} not found")))
+    } else {
+        Err(ApiError::Forbidden("Permission denied".to_string()))
+    }
+}
+
+pub(crate) async fn list_tasks(
+    backend: &impl StorageContext,
+    submitted_by: Option<i32>,
+    kind: Option<TaskKind>,
+    status: Option<TaskStatus>,
+    options: QueryOptions,
+) -> Result<(Vec<TaskRecord>, i64), ApiError> {
+    let (tasks, total) = storage_handle(backend)
+        .list_tasks(StorageTaskListQuery::new(
+            submitted_by,
+            kind.map(task_kind_to_storage),
+            status.map(task_status_to_storage),
+            options,
+        ))
+        .await?
+        .into_parts();
+    Ok((
+        tasks
+            .into_iter()
+            .map(task_from_storage)
+            .collect::<Result<_, _>>()?,
+        total.unwrap_or(SKIPPED_TOTAL_COUNT),
+    ))
+}
+
+pub(crate) async fn list_task_events(
+    backend: &impl StorageContext,
+    task_id: TaskID,
+    options: QueryOptions,
+) -> Result<(Vec<crate::models::TaskEventResponse>, i64), ApiError> {
+    let (events, total) = storage_handle(backend)
+        .list_task_events(StorageTaskPageQuery::new(task_id.id(), options))
+        .await?
+        .into_parts();
+    let records = events
+        .into_iter()
+        .map(task_event_from_storage)
+        .collect::<Vec<_>>();
+    let principal_ids = records
+        .iter()
+        .flat_map(|record| [record.actor_user_id, record.initiator_user_id])
+        .flatten()
+        .collect();
+    let principal_names =
+        crate::services::history::resolve_principal_names(backend, principal_ids).await?;
+    Ok((
+        records
+            .into_iter()
+            .map(|record| {
+                crate::models::TaskEventResponse::from_record_with_names(record, &principal_names)
+            })
+            .collect(),
+        total.unwrap_or(SKIPPED_TOTAL_COUNT),
+    ))
+}
+
+pub(crate) async fn list_import_results(
+    backend: &impl StorageContext,
+    task_id: TaskID,
+    options: QueryOptions,
+) -> Result<(Vec<ImportTaskResultRecord>, i64), ApiError> {
+    let (results, total) = storage_handle(backend)
+        .list_import_task_results(StorageTaskPageQuery::new(task_id.id(), options))
+        .await?
+        .into_parts();
+    Ok((
+        results
+            .into_iter()
+            .map(import_result_from_storage)
+            .collect(),
+        total.unwrap_or(SKIPPED_TOTAL_COUNT),
+    ))
+}
+
+pub(crate) async fn list_export_output_summaries(
+    backend: &impl StorageContext,
+    task_ids: Vec<i32>,
+) -> Result<Vec<ExportTaskOutputSummary>, ApiError> {
+    Ok(storage_handle(backend)
+        .list_export_output_summaries(task_ids)
+        .await?
+        .into_iter()
+        .map(export_summary_from_storage)
+        .collect())
+}
+
+pub(crate) async fn list_backup_output_summaries(
+    backend: &impl StorageContext,
+    task_ids: Vec<i32>,
+) -> Result<Vec<BackupTaskOutputSummary>, ApiError> {
+    Ok(storage_handle(backend)
+        .list_backup_output_summaries(task_ids)
+        .await?
+        .into_iter()
+        .map(backup_summary_from_storage)
+        .collect())
+}
+
+pub(crate) async fn export_output_summary(
+    backend: &impl StorageContext,
+    task_id: TaskID,
+) -> Result<ExportOutputLookup<ExportTaskOutputSummary>, ApiError> {
+    Ok(map_export_lookup(
+        storage_handle(backend)
+            .get_export_output_summary(task_id.id())
+            .await?,
+        export_summary_from_storage,
+    ))
+}
+
+pub(crate) async fn backup_output_summary(
+    backend: &impl StorageContext,
+    task_id: TaskID,
+) -> Result<BackupOutputLookup<BackupTaskOutputSummary>, ApiError> {
+    Ok(map_backup_lookup(
+        storage_handle(backend)
+            .get_backup_output_summary(task_id.id())
+            .await?,
+        backup_summary_from_storage,
+    ))
+}
+
+pub(crate) async fn export_output(
+    backend: &impl StorageContext,
+    task_id: TaskID,
+) -> Result<ExportOutputLookup<ExportTaskOutput>, ApiError> {
+    Ok(map_export_lookup(
+        storage_handle(backend)
+            .get_export_output(task_id.id())
+            .await?,
+        export_output_from_storage,
+    ))
+}
+
+pub(crate) async fn backup_output(
+    backend: &impl StorageContext,
+    task_id: TaskID,
+) -> Result<BackupOutputLookup<BackupTaskOutput>, ApiError> {
+    Ok(map_backup_lookup(
+        storage_handle(backend)
+            .get_backup_output(task_id.id())
+            .await?,
+        backup_output_from_storage,
+    ))
+}
+
+pub(crate) fn task_resource(task: &TaskRecord) -> ResourceRef {
+    ResourceRef {
+        kind: ResourceKind::Task,
+        id: task.id,
+        attrs: ResourceAttrs {
+            submitted_by: task.submitted_by,
+            ..Default::default()
+        },
+    }
+}
+
+fn task_kind_to_storage(kind: TaskKind) -> StorageTaskKind {
+    match kind {
+        TaskKind::Import => StorageTaskKind::Import,
+        TaskKind::Export => StorageTaskKind::Export,
+        TaskKind::Backup => StorageTaskKind::Backup,
+        TaskKind::Reindex => StorageTaskKind::Reindex,
+        TaskKind::RemoteCall => StorageTaskKind::RemoteCall,
+    }
+}
+
+fn task_status_to_storage(status: TaskStatus) -> StorageTaskStatus {
+    match status {
+        TaskStatus::Queued => StorageTaskStatus::Queued,
+        TaskStatus::Validating => StorageTaskStatus::Validating,
+        TaskStatus::Running => StorageTaskStatus::Running,
+        TaskStatus::Succeeded => StorageTaskStatus::Succeeded,
+        TaskStatus::Failed => StorageTaskStatus::Failed,
+        TaskStatus::PartiallySucceeded => StorageTaskStatus::PartiallySucceeded,
+        TaskStatus::Cancelled => StorageTaskStatus::Cancelled,
+    }
+}
+
+fn task_from_storage(task: StorageTask) -> Result<TaskRecord, ApiError> {
+    let kind = TaskKind::from_db(task.kind().as_str())?;
+    let status = TaskStatus::from_db(task.status().as_str())?;
+    let scope = task.scope_snapshot();
+    let progress = task.progress();
+    Ok(TaskRecord {
+        id: task.id(),
+        kind: kind.as_str().to_string(),
+        status: status.as_str().to_string(),
+        submitted_by: task.submitted_by(),
+        idempotency_key: task.idempotency_key().map(str::to_string),
+        request_hash: task.request_hash().map(str::to_string),
+        request_payload: task.request_payload().cloned(),
+        summary: task.summary().map(str::to_string),
+        total_items: progress.total(),
+        processed_items: progress.processed(),
+        success_items: progress.succeeded(),
+        failed_items: progress.failed(),
+        submitted_token_id: scope.token_id(),
+        submitted_token_scoped: scope.scoped(),
+        submitted_token_scopes: scope.scopes().clone(),
+        request_redacted_at: task.request_redacted_at(),
+        started_at: task.started_at(),
+        finished_at: task.finished_at(),
+        deleted_at: task.deleted_at(),
+        deleted_by: task.deleted_by(),
+        created_at: task.created_at(),
+        updated_at: task.updated_at(),
+        lease_token: task.lease_token(),
+        lease_expires_at: task.lease_expires_at(),
+        attempt_count: task.attempt_count(),
+        initiator_user_id: task.initiator_principal_id(),
+    })
+}
+
+fn task_event_from_storage(event: StorageTaskEvent) -> TaskEventRecord {
+    TaskEventRecord {
+        id: event.id(),
+        task_id: event.task_id(),
+        event_type: event.event_type().to_string(),
+        message: event.message().to_string(),
+        data: event.data().cloned(),
+        created_at: event.created_at(),
+        actor_user_id: event.actor_principal_id(),
+        actor_kind: event.actor_kind().to_string(),
+        initiator_user_id: event.initiator_principal_id(),
+        provenance_task_id: event.provenance_task_id(),
+    }
+}
+
+fn import_result_from_storage(result: StorageImportTaskResult) -> ImportTaskResultRecord {
+    ImportTaskResultRecord {
+        id: result.id(),
+        task_id: result.task_id(),
+        item_ref: result.item_ref().map(str::to_string),
+        entity_kind: result.entity_kind().to_string(),
+        action: result.action().to_string(),
+        identifier: result.identifier().map(str::to_string),
+        outcome: result.outcome().to_string(),
+        error: result.error().map(str::to_string),
+        details: result.details().cloned(),
+        created_at: result.created_at(),
+    }
+}
+
+fn export_summary_from_storage(output: StorageExportOutputSummary) -> ExportTaskOutputSummary {
+    let durations = output.durations();
+    ExportTaskOutputSummary {
+        task_id: output.task_id(),
+        template_name: output.template_name().map(str::to_string),
+        content_type: output.content_type().to_string(),
+        warning_count: output.warning_count(),
+        truncated: output.truncated(),
+        output_expires_at: output.output_expires_at(),
+        total_duration_ms: durations.total_ms(),
+        query_duration_ms: durations.query_ms(),
+        hydration_duration_ms: durations.hydration_ms(),
+        render_duration_ms: durations.render_ms(),
+    }
+}
+
+fn backup_summary_from_storage(output: StorageBackupOutputSummary) -> BackupTaskOutputSummary {
+    BackupTaskOutputSummary {
+        task_id: output.task_id(),
+        byte_size: output.byte_size(),
+        sha256: output.sha256().to_string(),
+        output_expires_at: output.output_expires_at(),
+    }
+}
+
+fn export_output_from_storage(output: StorageExportOutput) -> ExportTaskOutput {
+    ExportTaskOutput {
+        content_type: output.content_type().to_string(),
+        json_output: output.json_output().cloned(),
+        text_output: output.text_output().map(str::to_string),
+        meta_json: output.metadata().clone(),
+        warnings_json: output.warnings().clone(),
+        truncated: output.truncated(),
+    }
+}
+
+fn backup_output_from_storage(output: StorageBackupOutput) -> BackupTaskOutput {
+    BackupTaskOutput {
+        document: output.document().to_vec(),
+        sha256: output.sha256().to_string(),
+    }
+}
+
+fn map_export_lookup<T, U>(
+    lookup: StorageTaskOutputLookup<T>,
+    map: impl FnOnce(T) -> U,
+) -> ExportOutputLookup<U> {
+    match lookup {
+        StorageTaskOutputLookup::Available(value) => ExportOutputLookup::Available(map(value)),
+        StorageTaskOutputLookup::Expired { expires_at } => {
+            ExportOutputLookup::Expired { expires_at }
+        }
+        StorageTaskOutputLookup::Missing => ExportOutputLookup::Missing,
+    }
+}
+
+fn map_backup_lookup<T, U>(
+    lookup: StorageTaskOutputLookup<T>,
+    map: impl FnOnce(T) -> U,
+) -> BackupOutputLookup<U> {
+    match lookup {
+        StorageTaskOutputLookup::Available(value) => BackupOutputLookup::Available(map(value)),
+        StorageTaskOutputLookup::Expired { expires_at } => {
+            BackupOutputLookup::Expired { expires_at }
+        }
+        StorageTaskOutputLookup::Missing => BackupOutputLookup::Missing,
+    }
+}

--- a/src/storage/capabilities.rs
+++ b/src/storage/capabilities.rs
@@ -113,9 +113,7 @@ pub(crate) mod service_account {
 
 pub(crate) mod task {
     pub(crate) use crate::storage::postgres::operations::task::{
-        TaskBackend, TaskCreateRequest, TaskScopeSnapshot, TaskStateUpdate, insert_import_results,
-        list_backup_task_output_summaries, list_export_task_output_summaries,
-        list_tasks_with_total_count, task_event_responses,
+        TaskBackend, TaskStateUpdate, insert_import_results,
     };
 }
 

--- a/src/storage/context.rs
+++ b/src/storage/context.rs
@@ -25,17 +25,21 @@ use crate::storage::{
     ObjectRelationsTouchingIdsQuery, OperationalStateStorage, PostgresStorage, ReadinessSnapshot,
     RelatedObjectsForRootsQuery, RelationGraphQuery, RelationIdsQuery, RelationListQuery,
     RelationPage, RelationQueryStorage, RelationTouchingQuery, RemoteTargetHistoryRecord,
-    StorageBackend, StorageBackendDescriptor, StorageClass, StorageClassComputationState,
-    StorageClassGraphRow, StorageClassRelation, StorageCollection, StorageComputedFieldDefinition,
-    StorageComputedFieldMutation, StorageComputedFieldPage, StorageComputedFieldRebuildRequest,
-    StorageComputedObject, StorageError, StorageObject, StorageObjectAggregatePage,
-    StorageObjectGraphRow, StorageObjectRelation, StoragePersonalComputedFieldCreate,
-    StoragePersonalComputedFieldDelete, StoragePersonalComputedFieldListQuery,
-    StoragePersonalComputedFieldUpdate, StoragePoolState, StorageRelatedObjectForRootRow,
-    StorageRelatedObjectIncludeRow, StorageSharedComputedFieldCreate,
-    StorageSharedComputedFieldDelete, StorageSharedComputedFieldUpdate, TaskGaugeSnapshot,
-    TokenRetentionStorage, UnifiedSearchClass, UnifiedSearchCollection, UnifiedSearchObject,
-    UnifiedSearchQuery, UnifiedSearchStorage,
+    StorageBackend, StorageBackendDescriptor, StorageBackupOutput, StorageBackupOutputSummary,
+    StorageClass, StorageClassComputationState, StorageClassGraphRow, StorageClassRelation,
+    StorageCollection, StorageComputedFieldDefinition, StorageComputedFieldMutation,
+    StorageComputedFieldPage, StorageComputedFieldRebuildRequest, StorageComputedObject,
+    StorageError, StorageExportOutput, StorageExportOutputSummary, StorageImportTaskResultPage,
+    StorageObject, StorageObjectAggregatePage, StorageObjectGraphRow, StorageObjectRelation,
+    StoragePersonalComputedFieldCreate, StoragePersonalComputedFieldDelete,
+    StoragePersonalComputedFieldListQuery, StoragePersonalComputedFieldUpdate, StoragePoolState,
+    StorageRelatedObjectForRootRow, StorageRelatedObjectIncludeRow,
+    StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
+    StorageSharedComputedFieldUpdate, StorageTask, StorageTaskAccess, StorageTaskCreateRequest,
+    StorageTaskEventPage, StorageTaskListQuery, StorageTaskOutputLookup, StorageTaskPage,
+    StorageTaskPageQuery, TaskGaugeSnapshot, TaskQueueStorage, TokenRetentionStorage,
+    UnifiedSearchClass, UnifiedSearchCollection, UnifiedSearchObject, UnifiedSearchQuery,
+    UnifiedSearchStorage,
 };
 use crate::storage::{ClassHistoryRecord, CollectionHistoryRecord};
 use async_trait::async_trait;
@@ -603,6 +607,154 @@ impl ComputedObjectStorage for StorageHandle {
             match &self.implementation {
                 BackendImplementation::Postgresql(backend) => {
                     backend.enrich_objects_with_computed(query).await
+                }
+            }
+        })
+        .await
+    }
+}
+
+#[async_trait]
+impl TaskQueueStorage for StorageHandle {
+    async fn create_task(
+        &self,
+        request: StorageTaskCreateRequest,
+    ) -> Result<StorageTask, StorageError> {
+        observe_storage_call(self.backend_name(), "tasks", "create", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => backend.create_task(request).await,
+            }
+        })
+        .await
+    }
+
+    async fn get_task_access(&self, task_id: i32) -> Result<StorageTaskAccess, StorageError> {
+        observe_storage_call(self.backend_name(), "tasks", "get_access", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.get_task_access(task_id).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn list_tasks(
+        &self,
+        query: StorageTaskListQuery,
+    ) -> Result<StorageTaskPage, StorageError> {
+        observe_storage_call(self.backend_name(), "tasks", "list", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => backend.list_tasks(query).await,
+            }
+        })
+        .await
+    }
+
+    async fn list_task_events(
+        &self,
+        query: StorageTaskPageQuery,
+    ) -> Result<StorageTaskEventPage, StorageError> {
+        observe_storage_call(self.backend_name(), "tasks", "list_events", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => backend.list_task_events(query).await,
+            }
+        })
+        .await
+    }
+
+    async fn list_import_task_results(
+        &self,
+        query: StorageTaskPageQuery,
+    ) -> Result<StorageImportTaskResultPage, StorageError> {
+        observe_storage_call(self.backend_name(), "tasks", "list_import_results", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.list_import_task_results(query).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn list_export_output_summaries(
+        &self,
+        task_ids: Vec<i32>,
+    ) -> Result<Vec<StorageExportOutputSummary>, StorageError> {
+        observe_storage_call(self.backend_name(), "tasks", "list_export_outputs", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.list_export_output_summaries(task_ids).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn list_backup_output_summaries(
+        &self,
+        task_ids: Vec<i32>,
+    ) -> Result<Vec<StorageBackupOutputSummary>, StorageError> {
+        observe_storage_call(self.backend_name(), "tasks", "list_backup_outputs", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.list_backup_output_summaries(task_ids).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn get_export_output_summary(
+        &self,
+        task_id: i32,
+    ) -> Result<StorageTaskOutputLookup<StorageExportOutputSummary>, StorageError> {
+        observe_storage_call(self.backend_name(), "tasks", "get_export_summary", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.get_export_output_summary(task_id).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn get_backup_output_summary(
+        &self,
+        task_id: i32,
+    ) -> Result<StorageTaskOutputLookup<StorageBackupOutputSummary>, StorageError> {
+        observe_storage_call(self.backend_name(), "tasks", "get_backup_summary", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.get_backup_output_summary(task_id).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn get_export_output(
+        &self,
+        task_id: i32,
+    ) -> Result<StorageTaskOutputLookup<StorageExportOutput>, StorageError> {
+        observe_storage_call(self.backend_name(), "tasks", "get_export_output", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.get_export_output(task_id).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn get_backup_output(
+        &self,
+        task_id: i32,
+    ) -> Result<StorageTaskOutputLookup<StorageBackupOutput>, StorageError> {
+        observe_storage_call(self.backend_name(), "tasks", "get_backup_output", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.get_backup_output(task_id).await
                 }
             }
         })

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -5,8 +5,8 @@ use super::{
     CollectionStore, ComputedFieldLifecycleStorage, ComputedObjectStorage, EventDeliveryStorage,
     EventFanoutStorage, EventHealthStorage, EventRetentionStorage, HistoryStorage, MetricsStorage,
     ObjectAggregateStorage, ObjectRelationStore, ObjectStore, OperationalStateStorage,
-    PostgresStorage, RelationQueryStorage, TokenRetentionStorage, UnifiedSearchStorage,
-    observed::ObservedLifecycleStorage,
+    PostgresStorage, RelationQueryStorage, TaskQueueStorage, TokenRetentionStorage,
+    UnifiedSearchStorage, observed::ObservedLifecycleStorage,
 };
 
 #[cfg(test)]
@@ -78,6 +78,7 @@ pub(crate) trait StorageBackend:
     + OperationalStateStorage
     + TokenRetentionStorage
     + UnifiedSearchStorage
+    + TaskQueueStorage
     + WorkflowStorage
     + OperationalStorage
     + sealed::CertifiedStorageBackend
@@ -147,6 +148,7 @@ mod tests {
                 "identity_and_authorization_data",
                 "temporal_history",
                 "unified_search",
+                "task_queue",
                 "workflows",
                 "operations",
             ]

--- a/src/storage/memory/error.rs
+++ b/src/storage/memory/error.rs
@@ -52,6 +52,9 @@ impl From<MemoryStorageModelError> for StorageError {
             ApiError::PreconditionFailed(message, current_etag) => {
                 Self::new(StorageErrorKind::PreconditionFailed, message, current_etag)
             }
+            ApiError::TooManyRequests(message) => {
+                Self::new(StorageErrorKind::TooManyRequests, message, None)
+            }
             ApiError::ServiceUnavailable(message) => {
                 Self::new(StorageErrorKind::Unavailable, message, None)
             }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -61,11 +61,18 @@ pub(crate) use hubuum_storage_core::{
     StorageRecordMetadata, StorageRelatedDirection, StorageRelatedObjectForRootRow,
     StorageRelatedObjectIncludeRow, StorageRelatedSort, StorageResourceScope,
     StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
-    StorageSharedComputedFieldUpdate, StorageSharedComputedScope, StorageVisibility,
-    UnifiedSearchClass, UnifiedSearchCollection, UnifiedSearchCursor, UnifiedSearchObject,
-    UnifiedSearchQuery, UnifiedSearchStorage,
+    StorageSharedComputedFieldUpdate, StorageSharedComputedScope, StorageTask, StorageTaskAccess,
+    StorageTaskCreateRequest, StorageTaskDurations, StorageTaskEvent, StorageTaskEventPage,
+    StorageTaskKind, StorageTaskListQuery, StorageTaskOutputLookup, StorageTaskPage,
+    StorageTaskPageQuery, StorageTaskProgress, StorageTaskScopeSnapshot, StorageTaskStatus,
+    StorageVisibility, TaskQueueStorage, UnifiedSearchClass, UnifiedSearchCollection,
+    UnifiedSearchCursor, UnifiedSearchObject, UnifiedSearchQuery, UnifiedSearchStorage,
 };
 pub(crate) use hubuum_storage_core::{ClassHistoryRecord, CollectionHistoryRecord};
+pub(crate) use hubuum_storage_core::{
+    StorageBackupOutput, StorageBackupOutputSummary, StorageExportOutput,
+    StorageExportOutputSummary, StorageImportTaskResult, StorageImportTaskResultPage,
+};
 pub(crate) use hubuum_storage_core::{StorageError, StorageErrorKind};
 #[cfg(test)]
 pub(crate) use memory::MemoryStorageModel;

--- a/src/storage/postgres/error.rs
+++ b/src/storage/postgres/error.rs
@@ -60,6 +60,9 @@ impl From<PostgresStorageError> for StorageError {
             ApiError::PreconditionFailed(message, current_etag) => {
                 Self::new(StorageErrorKind::PreconditionFailed, message, current_etag)
             }
+            ApiError::TooManyRequests(message) => {
+                Self::new(StorageErrorKind::TooManyRequests, message, None)
+            }
             ApiError::ServiceUnavailable(message) => {
                 Self::new(StorageErrorKind::Unavailable, message, None)
             }
@@ -99,6 +102,10 @@ mod tests {
             ))
             .kind(),
             StorageErrorKind::AuthorizationUnavailable
+        );
+        assert_eq!(
+            map_postgres_error(ApiError::TooManyRequests("capacity reached".to_string())).kind(),
+            StorageErrorKind::TooManyRequests
         );
     }
 }

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -3,6 +3,7 @@ mod error;
 #[doc(hidden)]
 pub mod operations;
 mod runtime;
+mod task_queue;
 
 pub use runtime::*;
 

--- a/src/storage/postgres/operations/task.rs
+++ b/src/storage/postgres/operations/task.rs
@@ -26,6 +26,7 @@ use crate::models::{
 };
 use crate::observability::metrics;
 use crate::pagination::{CursorValue, decode_cursor_values, page_limits_or_defaults};
+#[cfg(test)]
 use crate::storage::postgres::operations::history::resolve_principal_names;
 use crate::storage::postgres::operations::maintenance::maintenance_state_conn;
 use crate::storage::postgres::{with_connection, with_transaction};
@@ -123,6 +124,18 @@ impl TaskScopeSnapshot {
 
     pub fn unscoped() -> Self {
         Self::from_request(None, None)
+    }
+
+    pub(in crate::storage::postgres) fn from_persisted(
+        token_id: Option<i32>,
+        scoped: bool,
+        scopes: serde_json::Value,
+    ) -> Result<Self, ApiError> {
+        Ok(Self {
+            token_id: token_id.map(TokenID::new).transpose()?,
+            scoped,
+            scopes,
+        })
     }
 }
 
@@ -998,10 +1011,30 @@ pub async fn list_tasks_with_total_count(
 
 /// Enrich one task-event page with legacy queued-event initiators and one
 /// batched principal-name lookup.
+#[cfg(test)]
 pub(crate) async fn task_event_responses(
     pool: &impl crate::storage::StorageContext,
-    mut records: Vec<TaskEventRecord>,
+    records: Vec<TaskEventRecord>,
 ) -> Result<Vec<crate::models::TaskEventResponse>, ApiError> {
+    let records = enrich_legacy_task_event_initiators(pool, records).await?;
+    let principal_ids = records
+        .iter()
+        .flat_map(|record| [record.actor_user_id, record.initiator_user_id])
+        .flatten()
+        .collect();
+    let principal_names = resolve_principal_names(pool, principal_ids).await?;
+    Ok(records
+        .into_iter()
+        .map(|record| {
+            crate::models::TaskEventResponse::from_record_with_names(record, &principal_names)
+        })
+        .collect())
+}
+
+pub(crate) async fn enrich_legacy_task_event_initiators(
+    pool: &impl crate::storage::StorageContext,
+    mut records: Vec<TaskEventRecord>,
+) -> Result<Vec<TaskEventRecord>, ApiError> {
     use crate::schema::events::dsl as stored;
 
     let legacy_task_ids = records
@@ -1039,18 +1072,7 @@ pub(crate) async fn task_event_responses(
         }
     }
 
-    let principal_ids = records
-        .iter()
-        .flat_map(|record| [record.actor_user_id, record.initiator_user_id])
-        .flatten()
-        .collect();
-    let principal_names = resolve_principal_names(pool, principal_ids).await?;
-    Ok(records
-        .into_iter()
-        .map(|record| {
-            crate::models::TaskEventResponse::from_record_with_names(record, &principal_names)
-        })
-        .collect())
+    Ok(records)
 }
 
 pub async fn list_export_task_output_summaries(

--- a/src/storage/postgres/task_queue.rs
+++ b/src/storage/postgres/task_queue.rs
@@ -1,0 +1,366 @@
+use async_trait::async_trait;
+
+use crate::errors::ApiError;
+use crate::models::{
+    BackupOutputLookup, BackupTaskOutputRecord, BackupTaskOutputSummaryRecord, ExportOutputLookup,
+    ExportTaskOutputRecord, ExportTaskOutputSummaryRecord, ImportTaskResultRecord, PrincipalID,
+    TaskEventRecord, TaskID, TaskKind, TaskRecord,
+};
+use crate::pagination::SKIPPED_TOTAL_COUNT;
+use crate::storage::{
+    StorageBackupOutput, StorageBackupOutputSummary, StorageError, StorageExportOutput,
+    StorageExportOutputSummary, StorageImportTaskResult, StorageImportTaskResultPage, StorageTask,
+    StorageTaskAccess, StorageTaskCreateRequest, StorageTaskDurations, StorageTaskEvent,
+    StorageTaskEventPage, StorageTaskKind, StorageTaskListQuery, StorageTaskOutputLookup,
+    StorageTaskPage, StorageTaskPageQuery, StorageTaskProgress, StorageTaskScopeSnapshot,
+    StorageTaskStatus, TaskQueueStorage,
+};
+
+use super::PostgresStorage;
+use super::error::map_postgres_error;
+use super::operations::service_account::load_service_account_by_id;
+use super::operations::task::{
+    TaskBackend, TaskCreateRequest, TaskScopeSnapshot, enrich_legacy_task_event_initiators,
+    list_backup_task_output_summaries, list_export_task_output_summaries,
+    list_tasks_with_total_count,
+};
+
+#[async_trait]
+impl TaskQueueStorage for PostgresStorage {
+    async fn create_task(
+        &self,
+        request: StorageTaskCreateRequest,
+    ) -> Result<StorageTask, StorageError> {
+        let snapshot = request.scope_snapshot();
+        let snapshot = TaskScopeSnapshot::from_persisted(
+            snapshot.token_id(),
+            snapshot.scoped(),
+            snapshot.scopes().clone(),
+        )
+        .map_err(map_postgres_error)?;
+        let legacy = TaskCreateRequest::builder(
+            task_kind_from_storage(request.kind()),
+            PrincipalID::new(request.submitted_by()).map_err(map_postgres_error)?,
+            request.request_payload().clone(),
+            request.total_items(),
+        )
+        .idempotency_key(request.idempotency_key().cloned())
+        .request_hash(request.request_hash().map(str::to_string))
+        .scope_snapshot(snapshot)
+        .build();
+        legacy
+            .create_idempotently_with_active_limit(self.pool(), request.maximum_active_tasks())
+            .await
+            .and_then(task_to_storage)
+            .map_err(map_postgres_error)
+    }
+
+    async fn get_task_access(&self, task_id: i32) -> Result<StorageTaskAccess, StorageError> {
+        let task_id = TaskID::new(task_id).map_err(map_postgres_error)?;
+        let task = task_id
+            .find_record(self.pool())
+            .await
+            .map_err(map_postgres_error)?;
+        let submitter_owner_group_id = match task.submitted_by {
+            Some(submitter_id) => match load_service_account_by_id(self.pool(), submitter_id).await
+            {
+                Ok(account) => Some(account.owner_group_id),
+                Err(ApiError::NotFound(_)) => None,
+                Err(error) => return Err(map_postgres_error(error)),
+            },
+            None => None,
+        };
+        task_to_storage(task)
+            .map(|task| StorageTaskAccess::new(task, submitter_owner_group_id))
+            .map_err(map_postgres_error)
+    }
+
+    async fn list_tasks(
+        &self,
+        query: StorageTaskListQuery,
+    ) -> Result<StorageTaskPage, StorageError> {
+        let (submitted_by, kind, status, options) = query.into_parts();
+        let (tasks, total) = list_tasks_with_total_count(
+            self.pool(),
+            submitted_by,
+            kind.map(StorageTaskKind::as_str),
+            status.map(StorageTaskStatus::as_str),
+            &options,
+        )
+        .await
+        .map_err(map_postgres_error)?;
+        let tasks = tasks
+            .into_iter()
+            .map(task_to_storage)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_postgres_error)?;
+        Ok(StorageTaskPage::new(
+            tasks,
+            (total != SKIPPED_TOTAL_COUNT).then_some(total),
+        ))
+    }
+
+    async fn list_task_events(
+        &self,
+        query: StorageTaskPageQuery,
+    ) -> Result<StorageTaskEventPage, StorageError> {
+        let (task_id, options) = query.into_parts();
+        let task_id = TaskID::new(task_id).map_err(map_postgres_error)?;
+        let (events, total) = task_id
+            .list_events_with_total_count(self.pool(), &options)
+            .await
+            .map_err(map_postgres_error)?;
+        let events = enrich_legacy_task_event_initiators(self.pool(), events)
+            .await
+            .map_err(map_postgres_error)?;
+        Ok(StorageTaskEventPage::new(
+            events.into_iter().map(event_to_storage).collect(),
+            (total != SKIPPED_TOTAL_COUNT).then_some(total),
+        ))
+    }
+
+    async fn list_import_task_results(
+        &self,
+        query: StorageTaskPageQuery,
+    ) -> Result<StorageImportTaskResultPage, StorageError> {
+        let (task_id, options) = query.into_parts();
+        let task_id = TaskID::new(task_id).map_err(map_postgres_error)?;
+        let (results, total) = task_id
+            .list_import_results_with_total_count(self.pool(), &options)
+            .await
+            .map_err(map_postgres_error)?;
+        Ok(StorageImportTaskResultPage::new(
+            results.into_iter().map(import_result_to_storage).collect(),
+            (total != SKIPPED_TOTAL_COUNT).then_some(total),
+        ))
+    }
+
+    async fn list_export_output_summaries(
+        &self,
+        task_ids: Vec<i32>,
+    ) -> Result<Vec<StorageExportOutputSummary>, StorageError> {
+        list_export_task_output_summaries(self.pool(), &task_ids)
+            .await
+            .map(|outputs| outputs.into_iter().map(export_summary_to_storage).collect())
+            .map_err(map_postgres_error)
+    }
+
+    async fn list_backup_output_summaries(
+        &self,
+        task_ids: Vec<i32>,
+    ) -> Result<Vec<StorageBackupOutputSummary>, StorageError> {
+        list_backup_task_output_summaries(self.pool(), &task_ids)
+            .await
+            .map(|outputs| outputs.into_iter().map(backup_summary_to_storage).collect())
+            .map_err(map_postgres_error)
+    }
+
+    async fn get_export_output_summary(
+        &self,
+        task_id: i32,
+    ) -> Result<StorageTaskOutputLookup<StorageExportOutputSummary>, StorageError> {
+        let task_id = TaskID::new(task_id).map_err(map_postgres_error)?;
+        task_id
+            .find_export_output_summary(self.pool())
+            .await
+            .map(|lookup| map_export_lookup(lookup, export_summary_to_storage))
+            .map_err(map_postgres_error)
+    }
+
+    async fn get_backup_output_summary(
+        &self,
+        task_id: i32,
+    ) -> Result<StorageTaskOutputLookup<StorageBackupOutputSummary>, StorageError> {
+        let task_id = TaskID::new(task_id).map_err(map_postgres_error)?;
+        task_id
+            .find_backup_output_summary(self.pool())
+            .await
+            .map(|lookup| map_backup_lookup(lookup, backup_summary_to_storage))
+            .map_err(map_postgres_error)
+    }
+
+    async fn get_export_output(
+        &self,
+        task_id: i32,
+    ) -> Result<StorageTaskOutputLookup<StorageExportOutput>, StorageError> {
+        let task_id = TaskID::new(task_id).map_err(map_postgres_error)?;
+        task_id
+            .find_export_output(self.pool())
+            .await
+            .map(|lookup| map_export_lookup(lookup, export_output_to_storage))
+            .map_err(map_postgres_error)
+    }
+
+    async fn get_backup_output(
+        &self,
+        task_id: i32,
+    ) -> Result<StorageTaskOutputLookup<StorageBackupOutput>, StorageError> {
+        let task_id = TaskID::new(task_id).map_err(map_postgres_error)?;
+        task_id
+            .find_backup_output(self.pool())
+            .await
+            .map(|lookup| map_backup_lookup(lookup, backup_output_to_storage))
+            .map_err(map_postgres_error)
+    }
+}
+
+fn task_kind_from_storage(kind: StorageTaskKind) -> TaskKind {
+    match kind {
+        StorageTaskKind::Import => TaskKind::Import,
+        StorageTaskKind::Export => TaskKind::Export,
+        StorageTaskKind::Backup => TaskKind::Backup,
+        StorageTaskKind::Reindex => TaskKind::Reindex,
+        StorageTaskKind::RemoteCall => TaskKind::RemoteCall,
+    }
+}
+
+fn task_to_storage(task: TaskRecord) -> Result<StorageTask, ApiError> {
+    let kind = StorageTaskKind::from_persisted(&task.kind).ok_or_else(|| {
+        ApiError::InternalServerError(format!("Unknown stored task kind '{}'", task.kind))
+    })?;
+    let status = StorageTaskStatus::from_persisted(&task.status).ok_or_else(|| {
+        ApiError::InternalServerError(format!("Unknown stored task status '{}'", task.status))
+    })?;
+    Ok(
+        StorageTask::builder(task.id, kind, status, task.created_at, task.updated_at)
+            .submitted_by(task.submitted_by)
+            .idempotency_key(task.idempotency_key)
+            .request_hash(task.request_hash)
+            .request_payload(task.request_payload)
+            .summary(task.summary)
+            .progress(StorageTaskProgress::new(
+                task.total_items,
+                task.processed_items,
+                task.success_items,
+                task.failed_items,
+            ))
+            .scope_snapshot(StorageTaskScopeSnapshot::new(
+                task.submitted_token_id,
+                task.submitted_token_scoped,
+                task.submitted_token_scopes,
+            ))
+            .request_redacted_at(task.request_redacted_at)
+            .started_at(task.started_at)
+            .finished_at(task.finished_at)
+            .deletion(task.deleted_at, task.deleted_by)
+            .lease(task.lease_token, task.lease_expires_at)
+            .attempt_count(task.attempt_count)
+            .initiator_principal_id(task.initiator_user_id)
+            .build(),
+    )
+}
+
+fn event_to_storage(event: TaskEventRecord) -> StorageTaskEvent {
+    StorageTaskEvent::builder(
+        event.id,
+        event.task_id,
+        event.event_type,
+        event.message,
+        event.created_at,
+        event.actor_kind,
+    )
+    .data(event.data)
+    .actor_principal_id(event.actor_user_id)
+    .provenance(event.initiator_user_id, event.provenance_task_id)
+    .build()
+}
+
+fn import_result_to_storage(result: ImportTaskResultRecord) -> StorageImportTaskResult {
+    StorageImportTaskResult::builder(
+        result.id,
+        result.task_id,
+        result.entity_kind,
+        result.action,
+        result.outcome,
+        result.created_at,
+    )
+    .item_ref(result.item_ref)
+    .identifier(result.identifier)
+    .error(result.error)
+    .details(result.details)
+    .build()
+}
+
+fn export_summary_to_storage(output: ExportTaskOutputSummaryRecord) -> StorageExportOutputSummary {
+    StorageExportOutputSummary::new(
+        output.task_id,
+        output.template_name,
+        output.content_type,
+        output.warning_count,
+        output.truncated,
+        output.output_expires_at,
+        StorageTaskDurations::new(
+            output.total_duration_ms,
+            output.query_duration_ms,
+            output.hydration_duration_ms,
+            output.render_duration_ms,
+        ),
+    )
+}
+
+fn backup_summary_to_storage(output: BackupTaskOutputSummaryRecord) -> StorageBackupOutputSummary {
+    StorageBackupOutputSummary::new(
+        output.task_id,
+        output.byte_size,
+        output.sha256,
+        output.output_expires_at,
+    )
+}
+
+fn export_output_to_storage(output: ExportTaskOutputRecord) -> StorageExportOutput {
+    StorageExportOutput::builder(
+        output.task_id,
+        output.content_type,
+        output.meta_json,
+        output.warnings_json,
+        output.output_expires_at,
+        output.created_at,
+    )
+    .template_name(output.template_name)
+    .output(output.json_output, output.text_output)
+    .warning_state(output.warning_count, output.truncated)
+    .durations(StorageTaskDurations::new(
+        output.total_duration_ms,
+        output.query_duration_ms,
+        output.hydration_duration_ms,
+        output.render_duration_ms,
+    ))
+    .build()
+}
+
+fn backup_output_to_storage(output: BackupTaskOutputRecord) -> StorageBackupOutput {
+    StorageBackupOutput::new(
+        output.task_id,
+        output.document,
+        output.byte_size,
+        output.sha256,
+        output.output_expires_at,
+        output.created_at,
+    )
+}
+
+fn map_export_lookup<T, U>(
+    lookup: ExportOutputLookup<T>,
+    map: impl FnOnce(T) -> U,
+) -> StorageTaskOutputLookup<U> {
+    match lookup {
+        ExportOutputLookup::Available(value) => StorageTaskOutputLookup::Available(map(value)),
+        ExportOutputLookup::Expired { expires_at } => {
+            StorageTaskOutputLookup::Expired { expires_at }
+        }
+        ExportOutputLookup::Missing => StorageTaskOutputLookup::Missing,
+    }
+}
+
+fn map_backup_lookup<T, U>(
+    lookup: BackupOutputLookup<T>,
+    map: impl FnOnce(T) -> U,
+) -> StorageTaskOutputLookup<U> {
+    match lookup {
+        BackupOutputLookup::Available(value) => StorageTaskOutputLookup::Available(map(value)),
+        BackupOutputLookup::Expired { expires_at } => {
+            StorageTaskOutputLookup::Expired { expires_at }
+        }
+        BackupOutputLookup::Missing => StorageTaskOutputLookup::Missing,
+    }
+}

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -242,6 +242,7 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         "TokenRetentionStorage",
         "HistoryStorage",
         "UnifiedSearchStorage",
+        "TaskQueueStorage",
         "WorkflowStorage",
         "OperationalStorage",
         "sealed::CertifiedStorageBackend",
@@ -298,6 +299,24 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         compact_context.contains("\"object_aggregates\",\"aggregate\""),
         "object aggregation must use the common storage observer"
     );
+    for operation in [
+        "create",
+        "get_access",
+        "list",
+        "list_events",
+        "list_import_results",
+        "list_export_outputs",
+        "list_backup_outputs",
+        "get_export_summary",
+        "get_backup_summary",
+        "get_export_output",
+        "get_backup_output",
+    ] {
+        assert!(
+            compact_context.contains(&format!("\"tasks\",\"{operation}\"")),
+            "task queue operation {operation} must use the common storage observer"
+        );
+    }
     for operation in [
         "list_classes",
         "list_objects",

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -2,7 +2,9 @@ use std::sync::{Arc, LazyLock};
 
 use actix_web::web::Data;
 use async_trait::async_trait;
+use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
+use hubuum_task_core::IdempotencyKey;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::events::{EventContext, EventFanoutSettings, EventRetentionSettings};
@@ -43,8 +45,10 @@ use crate::storage::{
     StoragePersonalComputedFieldDelete, StoragePersonalComputedFieldListQuery,
     StoragePersonalComputedFieldUpdate, StorageRelatedDirection, StorageRelatedSort,
     StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
-    StorageSharedComputedFieldUpdate, StorageVisibility, TokenRetentionStorage, UnifiedSearchQuery,
-    UnifiedSearchStorage,
+    StorageSharedComputedFieldUpdate, StorageTaskCreateRequest, StorageTaskKind,
+    StorageTaskListQuery, StorageTaskOutputLookup, StorageTaskPageQuery, StorageTaskScopeSnapshot,
+    StorageTaskStatus, StorageVisibility, TaskQueueStorage, TokenRetentionStorage,
+    UnifiedSearchQuery, UnifiedSearchStorage,
 };
 use crate::traits::CanSave;
 
@@ -147,6 +151,137 @@ async fn every_available_storage_backend_supplies_authentication_projections() {
     user.delete_without_events(pool.get_ref())
         .await
         .expect("authentication compatibility fixture should be removed");
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_supplies_the_complete_task_queue() {
+    let _permit = postgres_permit().await;
+    let pool = pool();
+    let user = crate::tests::create_user_with_params(
+        pool.get_ref(),
+        &prefix("task_queue_user"),
+        "testpassword",
+    )
+    .await;
+    let options = || QueryOptions {
+        filters: Vec::new(),
+        sort: Vec::new(),
+        limit: Some(10),
+        cursor: None,
+        include_total: true,
+    };
+
+    for kind in StorageBackendKind::ALL {
+        match kind {
+            StorageBackendKind::Postgresql => {
+                let backend = StorageHandle::postgres(pool.get_ref().clone());
+                let task = backend
+                    .create_task(
+                        StorageTaskCreateRequest::builder(
+                            StorageTaskKind::Import,
+                            user.id,
+                            serde_json::json!({"items": []}),
+                            0,
+                        )
+                        .idempotency_key(Some(
+                            IdempotencyKey::new(prefix("task_queue_key"))
+                                .expect("compatibility idempotency key should be valid"),
+                        ))
+                        .request_hash(Some(prefix("task_queue_hash")))
+                        .scope_snapshot(StorageTaskScopeSnapshot::unscoped())
+                        .build(10),
+                    )
+                    .await
+                    .expect("certified backend should create a task");
+                let task_id = task.id();
+                assert_eq!(task.kind(), StorageTaskKind::Import);
+                assert_eq!(task.status(), StorageTaskStatus::Queued);
+
+                let access = backend
+                    .get_task_access(task_id)
+                    .await
+                    .expect("certified backend should return task access facts");
+                assert_eq!(access.into_parts().0.id(), task_id);
+
+                let (tasks, total) = backend
+                    .list_tasks(StorageTaskListQuery::new(
+                        Some(user.id),
+                        Some(StorageTaskKind::Import),
+                        Some(StorageTaskStatus::Queued),
+                        options(),
+                    ))
+                    .await
+                    .expect("certified backend should list tasks")
+                    .into_parts();
+                assert_eq!(total, Some(1));
+                assert_eq!(tasks.len(), 1);
+
+                let (events, event_total) = backend
+                    .list_task_events(StorageTaskPageQuery::new(task_id, options()))
+                    .await
+                    .expect("certified backend should list task events")
+                    .into_parts();
+                assert_eq!(event_total, Some(1));
+                assert_eq!(events.len(), 1);
+
+                let (results, result_total) = backend
+                    .list_import_task_results(StorageTaskPageQuery::new(task_id, options()))
+                    .await
+                    .expect("certified backend should list import results")
+                    .into_parts();
+                assert_eq!(result_total, Some(0));
+                assert!(results.is_empty());
+
+                assert!(
+                    backend
+                        .list_export_output_summaries(vec![task_id])
+                        .await
+                        .expect("certified backend should list export output summaries")
+                        .is_empty()
+                );
+                assert!(
+                    backend
+                        .list_backup_output_summaries(vec![task_id])
+                        .await
+                        .expect("certified backend should list backup output summaries")
+                        .is_empty()
+                );
+                assert!(matches!(
+                    backend.get_export_output_summary(task_id).await,
+                    Ok(StorageTaskOutputLookup::Missing)
+                ));
+                assert!(matches!(
+                    backend.get_backup_output_summary(task_id).await,
+                    Ok(StorageTaskOutputLookup::Missing)
+                ));
+                assert!(matches!(
+                    backend.get_export_output(task_id).await,
+                    Ok(StorageTaskOutputLookup::Missing)
+                ));
+                assert!(matches!(
+                    backend.get_backup_output(task_id).await,
+                    Ok(StorageTaskOutputLookup::Missing)
+                ));
+
+                crate::storage::postgres::with_transaction(
+                    pool.get_ref(),
+                    async |conn| -> Result<(), crate::errors::ApiError> {
+                        use crate::schema::tasks::dsl::{id, tasks};
+                        diesel::delete(tasks.filter(id.eq(task_id)))
+                            .execute(conn)
+                            .await?;
+                        Ok(())
+                    },
+                )
+                .await
+                .expect("task queue compatibility fixture should be removed");
+            }
+        }
+    }
+
+    user.delete_without_events(pool.get_ref())
+        .await
+        .expect("task queue compatibility user should be removed");
 }
 
 #[actix_web::test]

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -133,7 +133,7 @@ async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() 
 
     assert!(
         body.contains(
-            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"8\"} 1"
+            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"9\"} 1"
         )
     );
     assert!(body.contains(

--- a/tests/api_platform_suite/runtime_config.rs
+++ b/tests/api_platform_suite/runtime_config.rs
@@ -37,7 +37,7 @@ mod tests {
         let serialized = serde_json::to_string(&body).unwrap();
 
         assert_eq!(body["database"]["backend"], "postgresql");
-        assert_eq!(body["database"]["contract_version"], 8);
+        assert_eq!(body["database"]["contract_version"], 9);
         assert_eq!(
             body["database"]["capabilities"],
             serde_json::json!([
@@ -50,6 +50,7 @@ mod tests {
                 "identity_and_authorization_data",
                 "temporal_history",
                 "unified_search",
+                "task_queue",
                 "workflows",
                 "operations"
             ])


### PR DESCRIPTION
## Summary

- define the mandatory `TaskQueueStorage` contract in `hubuum-storage-core`, with backend-neutral request, task, event, result, and output DTOs
- implement the complete contract in the PostgreSQL adapter and route task, import, backup, export, and remote-target HTTP handlers through application services
- keep task authorization, response conversion, and resource projection in the application layer instead of exposing PostgreSQL records or query helpers to consumers
- advertise the required `task_queue` capability, bump the storage contract to version 9, and exercise every operation against every available backend
- apply bounded storage-operation tracing and metrics to the full task-queue surface, including lossless propagation of rate-limit errors

## Architecture and behavior

This layer makes queue submission, lookup, listing, events, import results, and export/backup output reads mandatory for every selectable storage backend. The application composes these operations through crate-owned DTOs and traits; PostgreSQL records and Diesel details remain inside the adapter.

Worker leases and atomic task-state transitions are deliberately identified as the next mandatory contract extraction, not as optional backend support. The temporary workflow capability cannot be removed until those execution paths and the remaining workflow-specific atomic operations have crossed the same boundary.

Task visibility remains application-owned and preserves local principal/service-account rules as well as configured external authorization behavior. Generic unauthorized task reads return `403`, while kind-specific output reads retain hidden-existence `404` behavior.

## Breaking change

The administrator-visible storage contract version is now 9 and the capability list includes `task_queue`. Integrations that validate this metadata must accept the new version and required capability. No HTTP request or response schema changes are introduced.

## Changelog

The breaking storage-contract metadata change is documented under `[Unreleased]`.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- generated OpenAPI byte comparison against `docs/openapi.json`
- Rust API, supply-chain, and CI-classifier policy tests
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`

Advances #27

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
