### PR TITLE
Extract mandatory task execution storage contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
-- **Breaking (administrator API):** the storage contract version is now `9`,
+- **Breaking (administrator API):** the storage contract version is now `10`,
   and the redacted administrator configuration reports independently enforced
   `catalog_queries`, `computed_object_queries`, `computed_field_lifecycle`,
   `object_aggregates`, `relation_queries`, `temporal_history`, and
-  `unified_search`, and `task_queue` capabilities instead of the broader provisional
-  `queries_and_history` label. Monitoring or administration clients matching
-  the version or capability list must accept the new contract and labels.
+  `unified_search`, `task_queue`, and `task_execution` capabilities instead of
+  the broader provisional `queries_and_history` label. Monitoring or
+  administration clients matching the version or capability list must accept
+  the new contract and labels. Task workers now carry opaque backend claims and
+  use the mandatory execution contract for lease management, lifecycle events,
+  state changes, terminal artifacts, failure accounting, and output retention.
 - Event worker and retention configuration validation now uses backend-neutral
   policy terminology, matching the storage traits and DTOs used by application
   workers instead of exposing database implementation language.

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -14,6 +14,7 @@ mod identity;
 mod object_aggregate;
 mod operational;
 mod relation_query;
+mod task_execution;
 mod task_queue;
 mod unified_search;
 
@@ -80,6 +81,14 @@ pub use relation_query::{
     StorageRecordMetadata, StorageRelatedDirection, StorageRelatedObjectForRootRow,
     StorageRelatedObjectIncludeRow, StorageRelatedSort,
 };
+pub use task_execution::{
+    StorageBackupTaskArtifact, StorageExportTaskArtifact, StorageExportTaskArtifactBuilder,
+    StorageExportTaskArtifactContent, StorageExportTaskArtifactIdentity,
+    StorageExportTaskArtifactReport, StorageTaskClaim, StorageTaskClaimToken,
+    StorageTaskCompletion, StorageTaskCompletionArtifact, StorageTaskEventAppend,
+    StorageTaskEventInput, StorageTaskFailure, StorageTaskLease, StorageTaskLeaseDuration,
+    StorageTaskResultCounts, StorageTaskStateUpdate, TaskExecutionStorage,
+};
 pub use task_queue::{
     StorageBackupOutput, StorageBackupOutputSummary, StorageExportOutput,
     StorageExportOutputBuilder, StorageExportOutputSummary, StorageImportTaskResult,
@@ -108,7 +117,7 @@ use std::fmt;
 ///
 /// Increment this when a selectable backend must implement a new capability
 /// family or when an existing family's externally observable semantics change.
-pub const STORAGE_CONTRACT_VERSION: u16 = 9;
+pub const STORAGE_CONTRACT_VERSION: u16 = 10;
 
 /// Stable identity of a selectable storage backend.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -141,12 +150,13 @@ pub enum StorageCapability {
     TemporalHistory,
     UnifiedSearch,
     TaskQueue,
+    TaskExecution,
     Workflows,
     Operations,
 }
 
 impl StorageCapability {
-    pub const ALL: [Self; 12] = [
+    pub const ALL: [Self; 13] = [
         Self::DomainLifecycle,
         Self::CatalogQueries,
         Self::ComputedObjectQueries,
@@ -157,6 +167,7 @@ impl StorageCapability {
         Self::TemporalHistory,
         Self::UnifiedSearch,
         Self::TaskQueue,
+        Self::TaskExecution,
         Self::Workflows,
         Self::Operations,
     ];
@@ -174,6 +185,7 @@ impl StorageCapability {
             Self::TemporalHistory => "temporal_history",
             Self::UnifiedSearch => "unified_search",
             Self::TaskQueue => "task_queue",
+            Self::TaskExecution => "task_execution",
             Self::Workflows => "workflows",
             Self::Operations => "operations",
         }
@@ -340,6 +352,7 @@ mod tests {
                 "temporal_history",
                 "unified_search",
                 "task_queue",
+                "task_execution",
                 "workflows",
                 "operations",
             ]

--- a/crates/hubuum-storage-core/src/task_execution.rs
+++ b/crates/hubuum-storage-core/src/task_execution.rs
@@ -1,0 +1,645 @@
+use std::fmt;
+
+use async_trait::async_trait;
+use chrono::NaiveDateTime;
+use serde_json::Value;
+
+use crate::{StorageError, StorageTask, StorageTaskDurations, StorageTaskStatus};
+
+/// Validated lease duration shared with a storage adapter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StorageTaskLeaseDuration {
+    milliseconds: i64,
+}
+
+impl StorageTaskLeaseDuration {
+    #[must_use]
+    pub const fn from_milliseconds(milliseconds: i64) -> Option<Self> {
+        if milliseconds > 0 {
+            Some(Self { milliseconds })
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub const fn milliseconds(self) -> i64 {
+        self.milliseconds
+    }
+}
+
+/// Backend-owned claim token that application code only carries between calls.
+#[derive(Clone, PartialEq, Eq)]
+pub struct StorageTaskClaimToken(String);
+
+impl StorageTaskClaimToken {
+    /// Construct an opaque token at the adapter boundary.
+    #[must_use]
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Read the opaque value inside a storage adapter.
+    #[must_use]
+    pub fn adapter_value(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for StorageTaskClaimToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("StorageTaskClaimToken([redacted])")
+    }
+}
+
+/// Proof that a worker owns a task until the backend-managed lease expires.
+#[derive(Clone, PartialEq, Eq)]
+pub struct StorageTaskLease {
+    task_id: i32,
+    token: StorageTaskClaimToken,
+}
+
+impl StorageTaskLease {
+    #[must_use]
+    pub const fn new(task_id: i32, token: StorageTaskClaimToken) -> Self {
+        Self { task_id, token }
+    }
+
+    #[must_use]
+    pub const fn task_id(&self) -> i32 {
+        self.task_id
+    }
+
+    #[must_use]
+    pub const fn token(&self) -> &StorageTaskClaimToken {
+        &self.token
+    }
+}
+
+impl fmt::Debug for StorageTaskLease {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageTaskLease")
+            .field("task_id", &self.task_id)
+            .field("token", &self.token)
+            .finish()
+    }
+}
+
+/// A claimed task and its opaque ownership proof.
+#[derive(Clone, PartialEq)]
+pub struct StorageTaskClaim {
+    task: StorageTask,
+    lease: StorageTaskLease,
+}
+
+impl StorageTaskClaim {
+    #[must_use]
+    pub const fn new(task: StorageTask, lease: StorageTaskLease) -> Self {
+        Self { task, lease }
+    }
+
+    #[must_use]
+    pub const fn task(&self) -> &StorageTask {
+        &self.task
+    }
+
+    #[must_use]
+    pub const fn lease(&self) -> &StorageTaskLease {
+        &self.lease
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (StorageTask, StorageTaskLease) {
+        (self.task, self.lease)
+    }
+}
+
+impl fmt::Debug for StorageTaskClaim {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageTaskClaim")
+            .field("task", &self.task)
+            .field("lease", &self.lease)
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StorageTaskResultCounts {
+    processed: i32,
+    succeeded: i32,
+    failed: i32,
+}
+
+impl StorageTaskResultCounts {
+    #[must_use]
+    pub const fn new(processed: i32, succeeded: i32, failed: i32) -> Self {
+        Self {
+            processed,
+            succeeded,
+            failed,
+        }
+    }
+
+    #[must_use]
+    pub const fn processed(self) -> i32 {
+        self.processed
+    }
+
+    #[must_use]
+    pub const fn succeeded(self) -> i32 {
+        self.succeeded
+    }
+
+    #[must_use]
+    pub const fn failed(self) -> i32 {
+        self.failed
+    }
+}
+
+/// Lifecycle event emitted while a worker owns a task.
+#[derive(Clone, Debug, PartialEq)]
+pub struct StorageTaskEventInput {
+    event_type: String,
+    message: String,
+    data: Option<Value>,
+}
+
+impl StorageTaskEventInput {
+    #[must_use]
+    pub fn new(event_type: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            event_type: event_type.into(),
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_data(mut self, data: Option<Value>) -> Self {
+        self.data = data;
+        self
+    }
+
+    #[must_use]
+    pub fn event_type(&self) -> &str {
+        &self.event_type
+    }
+
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    #[must_use]
+    pub const fn data(&self) -> Option<&Value> {
+        self.data.as_ref()
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (String, String, Option<Value>) {
+        (self.event_type, self.message, self.data)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct StorageTaskEventAppend {
+    lease: StorageTaskLease,
+    event: StorageTaskEventInput,
+}
+
+impl StorageTaskEventAppend {
+    #[must_use]
+    pub const fn new(lease: StorageTaskLease, event: StorageTaskEventInput) -> Self {
+        Self { lease, event }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (StorageTaskLease, StorageTaskEventInput) {
+        (self.lease, self.event)
+    }
+}
+
+/// Non-terminal or terminal state values supplied by task execution.
+#[derive(Clone, Debug, PartialEq)]
+pub struct StorageTaskStateUpdate {
+    lease: StorageTaskLease,
+    status: StorageTaskStatus,
+    summary: Option<String>,
+    counts: StorageTaskResultCounts,
+    started_at: Option<NaiveDateTime>,
+}
+
+impl StorageTaskStateUpdate {
+    #[must_use]
+    pub const fn new(
+        lease: StorageTaskLease,
+        status: StorageTaskStatus,
+        counts: StorageTaskResultCounts,
+    ) -> Self {
+        Self {
+            lease,
+            status,
+            summary: None,
+            counts,
+            started_at: None,
+        }
+    }
+
+    #[must_use]
+    pub fn summary(mut self, summary: Option<String>) -> Self {
+        self.summary = summary;
+        self
+    }
+
+    #[must_use]
+    pub const fn started_at(mut self, started_at: Option<NaiveDateTime>) -> Self {
+        self.started_at = started_at;
+        self
+    }
+
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        StorageTaskLease,
+        StorageTaskStatus,
+        Option<String>,
+        StorageTaskResultCounts,
+        Option<NaiveDateTime>,
+    ) {
+        (
+            self.lease,
+            self.status,
+            self.summary,
+            self.counts,
+            self.started_at,
+        )
+    }
+}
+
+/// Export artifact stored atomically with the terminal task transition.
+#[derive(Clone, PartialEq)]
+pub struct StorageExportTaskArtifact {
+    template_name: Option<String>,
+    content_type: String,
+    json_output: Option<Value>,
+    text_output: Option<String>,
+    metadata: Value,
+    warnings: Value,
+    warning_count: i32,
+    truncated: bool,
+    output_expires_at: NaiveDateTime,
+    durations: StorageTaskDurations,
+}
+
+/// Template identity and response media type for a persisted export artifact.
+pub struct StorageExportTaskArtifactIdentity {
+    template_name: Option<String>,
+    content_type: String,
+}
+
+impl StorageExportTaskArtifactIdentity {
+    #[must_use]
+    pub fn into_parts(self) -> (Option<String>, String) {
+        (self.template_name, self.content_type)
+    }
+}
+
+/// Mutually exclusive structured or rendered content for an export artifact.
+pub struct StorageExportTaskArtifactContent {
+    json_output: Option<Value>,
+    text_output: Option<String>,
+}
+
+impl StorageExportTaskArtifactContent {
+    #[must_use]
+    pub fn into_parts(self) -> (Option<Value>, Option<String>) {
+        (self.json_output, self.text_output)
+    }
+}
+
+/// Bounded rendering metadata stored with an export artifact.
+pub struct StorageExportTaskArtifactReport {
+    metadata: Value,
+    warnings: Value,
+    warning_count: i32,
+    truncated: bool,
+}
+
+impl StorageExportTaskArtifactReport {
+    #[must_use]
+    pub fn into_parts(self) -> (Value, Value, i32, bool) {
+        (
+            self.metadata,
+            self.warnings,
+            self.warning_count,
+            self.truncated,
+        )
+    }
+}
+
+impl StorageExportTaskArtifact {
+    #[must_use]
+    pub fn builder(
+        content_type: impl Into<String>,
+        metadata: Value,
+        warnings: Value,
+        output_expires_at: NaiveDateTime,
+    ) -> StorageExportTaskArtifactBuilder {
+        StorageExportTaskArtifactBuilder {
+            artifact: Self {
+                template_name: None,
+                content_type: content_type.into(),
+                json_output: None,
+                text_output: None,
+                metadata,
+                warnings,
+                warning_count: 0,
+                truncated: false,
+                output_expires_at,
+                durations: StorageTaskDurations::default(),
+            },
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        StorageExportTaskArtifactIdentity,
+        StorageExportTaskArtifactContent,
+        StorageExportTaskArtifactReport,
+        NaiveDateTime,
+        StorageTaskDurations,
+    ) {
+        (
+            StorageExportTaskArtifactIdentity {
+                template_name: self.template_name,
+                content_type: self.content_type,
+            },
+            StorageExportTaskArtifactContent {
+                json_output: self.json_output,
+                text_output: self.text_output,
+            },
+            StorageExportTaskArtifactReport {
+                metadata: self.metadata,
+                warnings: self.warnings,
+                warning_count: self.warning_count,
+                truncated: self.truncated,
+            },
+            self.output_expires_at,
+            self.durations,
+        )
+    }
+}
+
+impl fmt::Debug for StorageExportTaskArtifact {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageExportTaskArtifact")
+            .field("content_type", &self.content_type)
+            .field("warning_count", &self.warning_count)
+            .field("truncated", &self.truncated)
+            .field("output", &"[redacted]")
+            .finish()
+    }
+}
+
+pub struct StorageExportTaskArtifactBuilder {
+    artifact: StorageExportTaskArtifact,
+}
+
+impl StorageExportTaskArtifactBuilder {
+    #[must_use]
+    pub fn template_name(mut self, template_name: Option<String>) -> Self {
+        self.artifact.template_name = template_name;
+        self
+    }
+
+    #[must_use]
+    pub fn output(mut self, json_output: Option<Value>, text_output: Option<String>) -> Self {
+        self.artifact.json_output = json_output;
+        self.artifact.text_output = text_output;
+        self
+    }
+
+    #[must_use]
+    pub const fn warning_state(mut self, warning_count: i32, truncated: bool) -> Self {
+        self.artifact.warning_count = warning_count;
+        self.artifact.truncated = truncated;
+        self
+    }
+
+    #[must_use]
+    pub const fn durations(mut self, durations: StorageTaskDurations) -> Self {
+        self.artifact.durations = durations;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> StorageExportTaskArtifact {
+        self.artifact
+    }
+}
+
+/// Backup artifact stored atomically with the terminal task transition.
+#[derive(Clone, PartialEq)]
+pub struct StorageBackupTaskArtifact {
+    document: Vec<u8>,
+    byte_size: i64,
+    sha256: String,
+    output_expires_at: NaiveDateTime,
+}
+
+impl StorageBackupTaskArtifact {
+    #[must_use]
+    pub fn new(
+        document: Vec<u8>,
+        byte_size: i64,
+        sha256: impl Into<String>,
+        output_expires_at: NaiveDateTime,
+    ) -> Self {
+        Self {
+            document,
+            byte_size,
+            sha256: sha256.into(),
+            output_expires_at,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (Vec<u8>, i64, String, NaiveDateTime) {
+        (
+            self.document,
+            self.byte_size,
+            self.sha256,
+            self.output_expires_at,
+        )
+    }
+}
+
+impl fmt::Debug for StorageBackupTaskArtifact {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageBackupTaskArtifact")
+            .field("byte_size", &self.byte_size)
+            .field("document", &"[redacted]")
+            .field("sha256", &"[redacted]")
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum StorageTaskCompletionArtifact {
+    None,
+    Export(StorageExportTaskArtifact),
+    Backup(StorageBackupTaskArtifact),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct StorageTaskCompletion {
+    update: StorageTaskStateUpdate,
+    event: StorageTaskEventInput,
+    artifact: StorageTaskCompletionArtifact,
+}
+
+impl StorageTaskCompletion {
+    #[must_use]
+    pub const fn new(update: StorageTaskStateUpdate, event: StorageTaskEventInput) -> Self {
+        Self {
+            update,
+            event,
+            artifact: StorageTaskCompletionArtifact::None,
+        }
+    }
+
+    #[must_use]
+    pub fn artifact(mut self, artifact: StorageTaskCompletionArtifact) -> Self {
+        self.artifact = artifact;
+        self
+    }
+
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        StorageTaskStateUpdate,
+        StorageTaskEventInput,
+        StorageTaskCompletionArtifact,
+    ) {
+        (self.update, self.event, self.artifact)
+    }
+}
+
+/// Failure request whose result counts are derived by the backend.
+#[derive(Clone, Debug, PartialEq)]
+pub struct StorageTaskFailure {
+    lease: StorageTaskLease,
+    summary: String,
+    event: StorageTaskEventInput,
+}
+
+impl StorageTaskFailure {
+    #[must_use]
+    pub fn new(
+        lease: StorageTaskLease,
+        summary: impl Into<String>,
+        event: StorageTaskEventInput,
+    ) -> Self {
+        Self {
+            lease,
+            summary: summary.into(),
+            event,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (StorageTaskLease, String, StorageTaskEventInput) {
+        (self.lease, self.summary, self.event)
+    }
+}
+
+/// Mandatory worker state-machine behavior for every selectable backend.
+#[async_trait]
+pub trait TaskExecutionStorage: Send + Sync {
+    async fn claim_next_task(
+        &self,
+        lease_duration: StorageTaskLeaseDuration,
+    ) -> Result<Option<StorageTaskClaim>, StorageError>;
+
+    async fn renew_task_lease(
+        &self,
+        lease: StorageTaskLease,
+        lease_duration: StorageTaskLeaseDuration,
+    ) -> Result<bool, StorageError>;
+
+    async fn recover_expired_task_leases(
+        &self,
+        batch_size: usize,
+    ) -> Result<Vec<StorageTask>, StorageError>;
+
+    async fn append_task_event(&self, event: StorageTaskEventAppend) -> Result<(), StorageError>;
+
+    async fn update_task_state(
+        &self,
+        update: StorageTaskStateUpdate,
+    ) -> Result<StorageTask, StorageError>;
+
+    async fn complete_task(
+        &self,
+        completion: StorageTaskCompletion,
+    ) -> Result<StorageTask, StorageError>;
+
+    async fn fail_task(&self, failure: StorageTaskFailure) -> Result<StorageTask, StorageError>;
+
+    async fn purge_expired_export_outputs(&self) -> Result<usize, StorageError>;
+
+    async fn purge_expired_backup_outputs(&self) -> Result<usize, StorageError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{StorageTaskKind, StorageTaskProgress, StorageTaskScopeSnapshot};
+
+    #[test]
+    fn worker_dtos_redact_claims_and_artifacts() {
+        let now = chrono::Utc::now().naive_utc();
+        let task = StorageTask::builder(
+            88_001,
+            StorageTaskKind::Export,
+            StorageTaskStatus::Running,
+            now,
+            now,
+        )
+        .request_payload(Some(serde_json::json!({"secret": "payload"})))
+        .progress(StorageTaskProgress::new(1, 0, 0, 0))
+        .scope_snapshot(StorageTaskScopeSnapshot::unscoped())
+        .build();
+        let claim = StorageTaskClaim::new(
+            task,
+            StorageTaskLease::new(88_001, StorageTaskClaimToken::new("secret-backend-claim")),
+        );
+        let artifact = StorageExportTaskArtifact::builder(
+            "application/json",
+            serde_json::json!({"secret": "metadata"}),
+            serde_json::json!([]),
+            now,
+        )
+        .output(Some(serde_json::json!({"secret": "output"})), None)
+        .build();
+
+        let debug = format!("{claim:?} {artifact:?}");
+
+        for secret in [
+            "secret-backend-claim",
+            "secret\": \"payload",
+            "secret\": \"metadata",
+            "secret\": \"output",
+        ] {
+            assert!(!debug.contains(secret));
+        }
+    }
+}

--- a/crates/hubuum-storage-core/src/task_queue.rs
+++ b/crates/hubuum-storage-core/src/task_queue.rs
@@ -99,6 +99,19 @@ impl StorageTaskStatus {
             _ => None,
         }
     }
+
+    #[must_use]
+    pub const fn is_active(self) -> bool {
+        matches!(self, Self::Validating | Self::Running)
+    }
+
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Succeeded | Self::Failed | Self::PartiallySucceeded | Self::Cancelled
+        )
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -71,8 +71,9 @@ satisfy every capability family below before `StorageHandle` can compose it:
 | Temporal history | Revision-filtered pages, stable cursors, point-in-time reads, visibility pushdown, and provenance-name resolution |
 | Unified search | Ranked collection, class, and object search with stable per-kind cursors and token visibility pushdown |
 | Task queue | Idempotent task submission, access facts, task/event/result paging, and retained export and backup output reads |
-| Workflows | Imports, restores, tasks, backups, exports, remote calls, and their atomic state transitions |
-| Operations | Probes, metrics snapshots, retention, event delivery, leases, locking, and worker coordination |
+| Task execution | Opaque claims, lease renewal and recovery, claim-checked events and state changes, atomic terminal artifacts, failure accounting, and output retention |
+| Workflows | Import, restore, backup, export, remote-call, and reindex execution with backend-owned atomic entity mutations |
+| Operations | Probes, metrics snapshots, retention, event delivery, locking, and worker coordination |
 
 The families are not feature flags and the admin configuration does not report
 optional support. Every selectable backend implements the entire list. The
@@ -87,10 +88,10 @@ now been replaced by the real `AuthenticationStorage`,
 `AuthorizationStorage`, `HistoryStorage`, `CatalogStorage`,
 `ComputedObjectStorage`, `ComputedFieldLifecycleStorage`,
 `ObjectAggregateStorage`, `RelationQueryStorage`, and `UnifiedSearchStorage`
-contracts. `TaskQueueStorage` now replaces the task submission and read portion
-of the workflow gate; worker leases and workflow-specific atomic transitions
-remain in that gate until their complete contracts and compatibility tests land.
-No family is
+contracts. `TaskQueueStorage` replaces task submission and reads, while
+`TaskExecutionStorage` owns the complete worker claim and state machine. The
+remaining workflow-specific entity mutations stay behind the workflow gate
+until their complete contracts and compatibility tests land. No family is
 considered complete merely because a marker exists.
 
 PostgreSQL query implementations live in
@@ -255,6 +256,18 @@ bounded `computed_fields/*` observation label. Reindex task execution is a
 workflow responsibility and will cross the boundary with the complete task
 state machine rather than leaking worker persistence into this lifecycle
 trait.
+
+`TaskExecutionStorage` owns every persistence transition needed by task
+workers. Claims cross the boundary as a task DTO plus an opaque, redacted token;
+the application can only return that token for renewal, events, state updates,
+completion, or failure. PostgreSQL's UUID representation, lease SQL, durable
+timestamps, row locks, task/output insert records, and workflow result counting
+remain adapter-private. Completion stores an optional export or backup artifact
+and the terminal lifecycle event in the same backend operation. Failure counts
+are derived by the backend so the application never queries workflow result
+tables. The opaque handle observes all nine entry points with bounded
+`task_execution/*` labels, and every selectable backend must pass the shared
+state-machine compatibility test.
 
 `ObjectAggregateStorage` owns filtered grouping, numeric measures, computed
 aggregate snapshots, exact group counts, and stable aggregate cursors. The

--- a/src/backups/mod.rs
+++ b/src/backups/mod.rs
@@ -8,12 +8,12 @@ use crate::errors::ApiError;
 use crate::models::retention::FutureRetention;
 use crate::models::{
     BackupDocument, BackupHistory, BackupManifest, BackupRequest, BackupState,
-    CURRENT_BACKUP_VERSION, NewBackupTaskOutputRecord, NewTaskEventRecord, TaskRecord,
-    TaskResultCounts, TaskStatus,
+    CURRENT_BACKUP_VERSION, NewTaskEventRecord, TaskResultCounts, TaskStatus,
 };
 use crate::permissions::{AppContext, PrincipalRef};
+use crate::services::tasks::{ClaimedTask, TaskStateChange, complete_task};
 use crate::storage::capabilities::backup::snapshot_backup_db;
-use crate::storage::capabilities::task::{TaskBackend, TaskStateUpdate};
+use crate::storage::{StorageBackupTaskArtifact, StorageTaskCompletionArtifact};
 use crate::traits::AuthzSubject;
 
 #[derive(Clone, Debug)]
@@ -109,9 +109,9 @@ pub async fn create_backup_document(
     })
 }
 
-pub async fn execute_backup_task(
+pub(crate) async fn execute_backup_task(
     context: &AppContext,
-    task: &TaskRecord,
+    task: &ClaimedTask,
     user: &impl AuthzSubject,
     scopes: Option<&TokenScope>,
     settings: &BackupSettings,
@@ -144,14 +144,15 @@ pub async fn execute_backup_task(
         total_items,
         bytes.len()
     );
-    task.finalize_backup_with_output(
+    complete_task(
         context,
-        TaskStateUpdate::new(
+        task,
+        TaskStateChange::new(
             TaskStatus::Succeeded,
             TaskResultCounts::from_outcomes(total_items, 0)?,
         )
-        .with_summary(summary.clone())
-        .with_started_at(task.started_at),
+        .summary(summary.clone())
+        .started_at(task.started_at),
         NewTaskEventRecord {
             task_id: task.id,
             event_type: TaskStatus::Succeeded.as_str().to_string(),
@@ -163,13 +164,9 @@ pub async fn execute_backup_task(
                 "include_history": request.include_history,
             })),
         },
-        NewBackupTaskOutputRecord {
-            task_id: task.id,
-            document: bytes,
-            byte_size,
-            sha256,
-            output_expires_at: expires_at,
-        },
+        StorageTaskCompletionArtifact::Backup(StorageBackupTaskArtifact::new(
+            bytes, byte_size, sha256, expires_at,
+        )),
     )
     .await?;
     Ok(())

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -453,7 +453,7 @@ mod tests {
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
         assert!(json.contains("\"backend\":\"postgresql\""));
-        assert!(json.contains("\"contract_version\":9"));
+        assert!(json.contains("\"contract_version\":10"));
         assert!(json.contains("\"catalog_queries\""));
         assert!(json.contains("\"computed_object_queries\""));
         assert!(json.contains("\"computed_field_lifecycle\""));
@@ -462,6 +462,7 @@ mod tests {
         assert!(json.contains("\"temporal_history\""));
         assert!(json.contains("\"unified_search\""));
         assert!(json.contains("\"task_queue\""));
+        assert!(json.contains("\"task_execution\""));
         assert!(!debug.contains("secret-password"));
         assert!(!debug.contains("correct horse battery staple"));
     }

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -22,11 +22,10 @@ use crate::models::{
     ExportIncludeRelatedDirection, ExportIncludeRelatedQuery, ExportIncludeRelatedSort,
     ExportJsonResponse, ExportMeta, ExportMissingDataPolicy, ExportRequest, ExportTemplate,
     ExportTemplateID, ExportWarning, HubuumClassExpanded, HubuumClassRelation, HubuumObject,
-    HubuumObjectID, HubuumObjectRelation, HubuumObjectWithPath, NewExportTaskOutputRecord,
-    NewTaskEventRecord, Permissions, PermissionsList, PrincipalID, RELATED_INCLUDE_DEFAULT_LIMIT,
-    RELATED_INCLUDE_DEFAULT_MAX_DEPTH, RelatedObjectForRootRow, RelatedObjectGraphRow,
-    RelatedObjectIncludeRow, TaskKind, TaskRecord, TaskResultCounts, TaskStatus, TokenID,
-    TokenScope, ValidatedExportScope,
+    HubuumObjectID, HubuumObjectRelation, HubuumObjectWithPath, NewTaskEventRecord, Permissions,
+    PermissionsList, PrincipalID, RELATED_INCLUDE_DEFAULT_LIMIT, RELATED_INCLUDE_DEFAULT_MAX_DEPTH,
+    RelatedObjectForRootRow, RelatedObjectGraphRow, RelatedObjectIncludeRow, TaskKind, TaskRecord,
+    TaskResultCounts, TaskStatus, TokenID, TokenScope, ValidatedExportScope,
 };
 use crate::observability::metrics;
 use crate::pagination::{
@@ -38,16 +37,21 @@ use crate::permissions::{
 };
 use crate::services::catalog as catalog_service;
 use crate::services::relation_queries;
-use crate::services::tasks::{TaskSubmission, submit_task, task_scope_snapshot};
+use crate::services::tasks::{
+    ClaimedTask, TaskStateChange, TaskSubmission, append_task_event, complete_task, submit_task,
+    task_scope_snapshot, update_task_state,
+};
 use crate::storage::capabilities::UserPermissions;
 use crate::storage::capabilities::authz::{scope_allows, scope_allows_resource};
 use crate::storage::capabilities::relations::{
     class_relation_authorization_resources, object_authorization_resources,
     object_relation_authorization_resources,
 };
-use crate::storage::capabilities::task::{TaskBackend, TaskStateUpdate};
 use crate::storage::capabilities::with_statement_timeout_scope;
-use crate::storage::{StorageContext, StorageTaskScopeSnapshot};
+use crate::storage::{
+    StorageContext, StorageExportTaskArtifact, StorageTaskCompletionArtifact, StorageTaskDurations,
+    StorageTaskScopeSnapshot,
+};
 use crate::tasks::request_hash;
 use crate::traits::{AuthzSubject, SelfAccessors};
 use crate::utilities::exporting::render_template;
@@ -1115,7 +1119,7 @@ async fn find_or_create_export_task(
 
 pub(crate) async fn execute_export_task<C>(
     backend: &C,
-    task: &TaskRecord,
+    task: &ClaimedTask,
     subject: &impl crate::traits::Search,
     scopes: Option<&TokenScope>,
 ) -> Result<(), ApiError>
@@ -1150,31 +1154,38 @@ where
         metrics::export_phase_timer(metrics::ExportMetricPhase::Total, metric_template_id);
     let mut timings = ExportExecutionTimings::default();
 
-    NewTaskEventRecord {
-        task_id: task.id,
-        event_type: "running".to_string(),
-        message: "Export execution started".to_string(),
-        data: None,
-    }
-    .append(pool)
-    .await?;
-    task.update_state(
+    append_task_event(
         pool,
-        TaskStateUpdate::new(TaskStatus::Running, TaskResultCounts::default())
-            .with_started_at(task.started_at),
+        task,
+        NewTaskEventRecord {
+            task_id: task.id,
+            event_type: "running".to_string(),
+            message: "Export execution started".to_string(),
+            data: None,
+        },
+    )
+    .await?;
+    update_task_state(
+        pool,
+        task,
+        TaskStateChange::new(TaskStatus::Running, TaskResultCounts::default())
+            .started_at(task.started_at),
     )
     .await?;
 
-    NewTaskEventRecord {
-        task_id: task.id,
-        event_type: "running".to_string(),
-        message: "Query execution started".to_string(),
-        data: Some(serde_json::json!({
-            "scope": runtime.scope.kind().as_str(),
-            "content_type": runtime.content_type.as_mime(),
-        })),
-    }
-    .append(pool)
+    append_task_event(
+        pool,
+        task,
+        NewTaskEventRecord {
+            task_id: task.id,
+            event_type: "running".to_string(),
+            message: "Query execution started".to_string(),
+            data: Some(serde_json::json!({
+                "scope": runtime.scope.kind().as_str(),
+                "content_type": runtime.content_type.as_mime(),
+            })),
+        },
+    )
     .await?;
 
     // Export-scoped, in-flight query budget. While these query stages run, every
@@ -1209,17 +1220,20 @@ where
         .as_ref()
         .is_some_and(|plan| plan.enabled_for_scope)
     {
-        NewTaskEventRecord {
-            task_id: task.id,
-            event_type: "running".to_string(),
-            message: "Hydrating relation-aware template context".to_string(),
-            data: relation_hydration.as_ref().map(|plan| {
-                serde_json::json!({
-                    "depth_limit": plan.depth_limit,
-                })
-            }),
-        }
-        .append(pool)
+        append_task_event(
+            pool,
+            task,
+            NewTaskEventRecord {
+                task_id: task.id,
+                event_type: "running".to_string(),
+                message: "Hydrating relation-aware template context".to_string(),
+                data: relation_hydration.as_ref().map(|plan| {
+                    serde_json::json!({
+                        "depth_limit": plan.depth_limit,
+                    })
+                }),
+            },
+        )
         .await?;
     }
 
@@ -1265,13 +1279,16 @@ where
         source,
     };
 
-    NewTaskEventRecord {
-        task_id: task.id,
-        event_type: "running".to_string(),
-        message: "Rendering export output".to_string(),
-        data: None,
-    }
-    .append(pool)
+    append_task_event(
+        pool,
+        task,
+        NewTaskEventRecord {
+            task_id: task.id,
+            event_type: "running".to_string(),
+            message: "Rendering export output".to_string(),
+            data: None,
+        },
+    )
     .await?;
 
     let render_metric =
@@ -1298,23 +1315,27 @@ where
     let metric_truncated = artifact.meta.truncated;
     let metric_warning_count = artifact.warnings.len();
 
-    NewTaskEventRecord {
-        task_id: task.id,
-        event_type: "running".to_string(),
-        message: "Persisting export output".to_string(),
-        data: None,
-    }
-    .append(pool)
+    append_task_event(
+        pool,
+        task,
+        NewTaskEventRecord {
+            task_id: task.id,
+            event_type: "running".to_string(),
+            message: "Persisting export output".to_string(),
+            data: None,
+        },
+    )
     .await?;
 
-    task.finalize_export_with_output(
+    complete_task(
         pool,
-        TaskStateUpdate::new(
+        task,
+        TaskStateChange::new(
             TaskStatus::Succeeded,
             TaskResultCounts::from_outcomes(1, 0)?,
         )
-        .with_summary("Export completed successfully")
-        .with_started_at(task.started_at),
+        .summary("Export completed successfully")
+        .started_at(task.started_at),
         NewTaskEventRecord {
             task_id: task.id,
             event_type: TaskStatus::Succeeded.as_str().to_string(),
@@ -1330,7 +1351,7 @@ where
                 "render_duration_ms": artifact.timings.render_millis(),
             })),
         },
-        artifact_to_output_record(task.id, artifact)?,
+        StorageTaskCompletionArtifact::Export(artifact_to_storage(artifact)?),
     )
     .await?;
 
@@ -1349,10 +1370,7 @@ where
     Ok(())
 }
 
-fn artifact_to_output_record(
-    task_id: i32,
-    artifact: ExportArtifact,
-) -> Result<NewExportTaskOutputRecord, ApiError> {
+fn artifact_to_storage(artifact: ExportArtifact) -> Result<StorageExportTaskArtifact, ApiError> {
     let retention_hours = get_config()
         .map(|config| config.export_output_retention_hours)
         .unwrap_or(DEFAULT_EXPORT_OUTPUT_RETENTION_HOURS);
@@ -1360,22 +1378,28 @@ fn artifact_to_output_record(
         FutureRetention::from_hours(retention_hours, "export_output_retention_hours")
             .and_then(|retention| retention.expires_at(chrono::Utc::now().naive_utc()))
             .map_err(ApiError::BadRequest)?;
-    Ok(NewExportTaskOutputRecord {
-        task_id,
-        template_name: artifact.template_name,
-        content_type: artifact.content_type.as_mime().to_string(),
-        json_output: artifact.json_output.map(serde_json::to_value).transpose()?,
-        text_output: artifact.text_output,
-        meta_json: serde_json::to_value(&artifact.meta)?,
-        warnings_json: serde_json::to_value(&artifact.warnings)?,
-        warning_count: i32::try_from(artifact.warnings.len()).unwrap_or(i32::MAX),
-        truncated: artifact.meta.truncated,
+    Ok(StorageExportTaskArtifact::builder(
+        artifact.content_type.as_mime(),
+        serde_json::to_value(&artifact.meta)?,
+        serde_json::to_value(&artifact.warnings)?,
         output_expires_at,
-        total_duration_ms: artifact.timings.total_millis(),
-        query_duration_ms: artifact.timings.query_millis(),
-        hydration_duration_ms: artifact.timings.hydration_millis(),
-        render_duration_ms: artifact.timings.render_millis(),
-    })
+    )
+    .template_name(artifact.template_name)
+    .output(
+        artifact.json_output.map(serde_json::to_value).transpose()?,
+        artifact.text_output,
+    )
+    .warning_state(
+        i32::try_from(artifact.warnings.len()).unwrap_or(i32::MAX),
+        artifact.meta.truncated,
+    )
+    .durations(StorageTaskDurations::new(
+        artifact.timings.total_millis(),
+        artifact.timings.query_millis(),
+        artifact.timings.hydration_millis(),
+        artifact.timings.render_millis(),
+    ))
+    .build())
 }
 
 fn validate_export_include(

--- a/src/services/tasks.rs
+++ b/src/services/tasks.rs
@@ -1,11 +1,14 @@
 use hubuum_task_core::IdempotencyKey;
+use std::ops::Deref;
+use std::time::Duration;
 
 use crate::errors::ApiError;
 use crate::models::search::QueryOptions;
 use crate::models::{
     BackupOutputLookup, BackupTaskOutput, BackupTaskOutputSummary, ExportOutputLookup,
-    ExportTaskOutput, ExportTaskOutputSummary, ImportTaskResultRecord, PrincipalID,
-    TaskEventRecord, TaskID, TaskKind, TaskRecord, TaskStatus, TokenID, TokenScope,
+    ExportTaskOutput, ExportTaskOutputSummary, ImportTaskResultRecord, NewTaskEventRecord,
+    PrincipalID, TaskEventRecord, TaskID, TaskKind, TaskRecord, TaskResultCounts, TaskStatus,
+    TokenID, TokenScope,
 };
 use crate::pagination::SKIPPED_TOTAL_COUNT;
 use crate::permissions::{
@@ -14,8 +17,11 @@ use crate::permissions::{
 use crate::storage::{
     AuthenticationStorage, StorageBackupOutput, StorageBackupOutputSummary, StorageContext,
     StorageExportOutput, StorageExportOutputSummary, StorageImportTaskResult, StorageTask,
-    StorageTaskCreateRequest, StorageTaskEvent, StorageTaskKind, StorageTaskListQuery,
-    StorageTaskOutputLookup, StorageTaskPageQuery, StorageTaskScopeSnapshot, StorageTaskStatus,
+    StorageTaskClaim, StorageTaskCompletion, StorageTaskCompletionArtifact,
+    StorageTaskCreateRequest, StorageTaskEvent, StorageTaskEventAppend, StorageTaskEventInput,
+    StorageTaskFailure, StorageTaskKind, StorageTaskLease, StorageTaskLeaseDuration,
+    StorageTaskListQuery, StorageTaskOutputLookup, StorageTaskPageQuery, StorageTaskResultCounts,
+    StorageTaskScopeSnapshot, StorageTaskStateUpdate, StorageTaskStatus, TaskExecutionStorage,
     TaskQueueStorage, storage_handle,
 };
 use crate::traits::AuthzSubject;
@@ -29,6 +35,236 @@ pub(crate) struct TaskSubmission {
     idempotency_key: Option<IdempotencyKey>,
     request_hash: Option<String>,
     scope_snapshot: StorageTaskScopeSnapshot,
+}
+
+/// Application-owned task projection paired with an opaque backend claim.
+pub(crate) struct ClaimedTask {
+    task: TaskRecord,
+    lease: StorageTaskLease,
+}
+
+impl ClaimedTask {
+    fn from_storage(claim: StorageTaskClaim) -> Result<Self, ApiError> {
+        let (task, lease) = claim.into_parts();
+        Ok(Self {
+            task: task_from_storage(task)?,
+            lease,
+        })
+    }
+
+    pub(crate) const fn lease(&self) -> &StorageTaskLease {
+        &self.lease
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_record(task: TaskRecord) -> Result<Self, ApiError> {
+        let token = task.lease_token.ok_or_else(|| {
+            ApiError::InternalServerError("Test task does not carry a claim token".to_string())
+        })?;
+        Ok(Self {
+            lease: StorageTaskLease::new(
+                task.id,
+                crate::storage::StorageTaskClaimToken::new(token.to_string()),
+            ),
+            task,
+        })
+    }
+}
+
+impl Deref for ClaimedTask {
+    type Target = TaskRecord;
+
+    fn deref(&self) -> &Self::Target {
+        &self.task
+    }
+}
+
+pub(crate) struct TaskStateChange {
+    status: TaskStatus,
+    counts: TaskResultCounts,
+    summary: Option<String>,
+    started_at: Option<chrono::NaiveDateTime>,
+}
+
+impl TaskStateChange {
+    pub(crate) const fn new(status: TaskStatus, counts: TaskResultCounts) -> Self {
+        Self {
+            status,
+            counts,
+            summary: None,
+            started_at: None,
+        }
+    }
+
+    pub(crate) fn summary(mut self, summary: impl Into<String>) -> Self {
+        self.summary = Some(summary.into());
+        self
+    }
+
+    pub(crate) const fn started_at(mut self, started_at: Option<chrono::NaiveDateTime>) -> Self {
+        self.started_at = started_at;
+        self
+    }
+}
+
+fn storage_lease_duration(duration: Duration) -> Result<StorageTaskLeaseDuration, ApiError> {
+    let milliseconds = i64::try_from(duration.as_millis()).map_err(|_| {
+        ApiError::BadRequest("Task lease duration is too large for storage".to_string())
+    })?;
+    StorageTaskLeaseDuration::from_milliseconds(milliseconds).ok_or_else(|| {
+        ApiError::BadRequest("Task lease duration must be greater than zero".to_string())
+    })
+}
+
+fn storage_task_state_update(
+    task: &ClaimedTask,
+    change: TaskStateChange,
+) -> StorageTaskStateUpdate {
+    let (processed, succeeded, failed) = change.counts.into();
+    StorageTaskStateUpdate::new(
+        task.lease.clone(),
+        task_status_to_storage(change.status),
+        StorageTaskResultCounts::new(processed, succeeded, failed),
+    )
+    .summary(change.summary)
+    .started_at(change.started_at)
+}
+
+fn storage_task_event(event: NewTaskEventRecord) -> StorageTaskEventInput {
+    StorageTaskEventInput::new(event.event_type, event.message).with_data(event.data)
+}
+
+pub(crate) async fn claim_next_task(
+    backend: &impl StorageContext,
+    lease_duration: Duration,
+) -> Result<Option<ClaimedTask>, ApiError> {
+    storage_handle(backend)
+        .claim_next_task(storage_lease_duration(lease_duration)?)
+        .await?
+        .map(ClaimedTask::from_storage)
+        .transpose()
+}
+
+pub(crate) async fn renew_task_lease(
+    backend: &impl StorageContext,
+    lease: StorageTaskLease,
+    lease_duration: Duration,
+) -> Result<bool, ApiError> {
+    storage_handle(backend)
+        .renew_task_lease(lease, storage_lease_duration(lease_duration)?)
+        .await
+        .map_err(ApiError::from)
+}
+
+pub(crate) async fn recover_expired_task_leases(
+    backend: &impl StorageContext,
+    batch_size: usize,
+) -> Result<Vec<TaskRecord>, ApiError> {
+    storage_handle(backend)
+        .recover_expired_task_leases(batch_size)
+        .await?
+        .into_iter()
+        .map(task_from_storage)
+        .collect()
+}
+
+pub(crate) async fn append_task_event(
+    backend: &impl StorageContext,
+    task: &ClaimedTask,
+    event: NewTaskEventRecord,
+) -> Result<(), ApiError> {
+    if event.task_id != task.id {
+        return Err(ApiError::InternalServerError(format!(
+            "Task lifecycle event id {} does not match claimed task {}",
+            event.task_id, task.id
+        )));
+    }
+    storage_handle(backend)
+        .append_task_event(StorageTaskEventAppend::new(
+            task.lease.clone(),
+            storage_task_event(event),
+        ))
+        .await
+        .map_err(ApiError::from)
+}
+
+pub(crate) async fn update_task_state(
+    backend: &impl StorageContext,
+    task: &ClaimedTask,
+    change: TaskStateChange,
+) -> Result<TaskRecord, ApiError> {
+    storage_handle(backend)
+        .update_task_state(storage_task_state_update(task, change))
+        .await
+        .map_err(ApiError::from)
+        .and_then(task_from_storage)
+}
+
+pub(crate) async fn complete_task(
+    backend: &impl StorageContext,
+    task: &ClaimedTask,
+    change: TaskStateChange,
+    event: NewTaskEventRecord,
+    artifact: StorageTaskCompletionArtifact,
+) -> Result<TaskRecord, ApiError> {
+    if event.task_id != task.id {
+        return Err(ApiError::InternalServerError(format!(
+            "Task completion event id {} does not match claimed task {}",
+            event.task_id, task.id
+        )));
+    }
+    let completion = StorageTaskCompletion::new(
+        storage_task_state_update(task, change),
+        storage_task_event(event),
+    )
+    .artifact(artifact);
+    storage_handle(backend)
+        .complete_task(completion)
+        .await
+        .map_err(ApiError::from)
+        .and_then(task_from_storage)
+}
+
+pub(crate) async fn fail_task(
+    backend: &impl StorageContext,
+    task: &ClaimedTask,
+    summary: impl Into<String>,
+    event: NewTaskEventRecord,
+) -> Result<TaskRecord, ApiError> {
+    if event.task_id != task.id {
+        return Err(ApiError::InternalServerError(format!(
+            "Task failure event id {} does not match claimed task {}",
+            event.task_id, task.id
+        )));
+    }
+    let summary = summary.into();
+    storage_handle(backend)
+        .fail_task(StorageTaskFailure::new(
+            task.lease.clone(),
+            summary,
+            storage_task_event(event),
+        ))
+        .await
+        .map_err(ApiError::from)
+        .and_then(task_from_storage)
+}
+
+pub(crate) async fn purge_expired_export_outputs(
+    backend: &impl StorageContext,
+) -> Result<usize, ApiError> {
+    storage_handle(backend)
+        .purge_expired_export_outputs()
+        .await
+        .map_err(ApiError::from)
+}
+
+pub(crate) async fn purge_expired_backup_outputs(
+    backend: &impl StorageContext,
+) -> Result<usize, ApiError> {
+    storage_handle(backend)
+        .purge_expired_backup_outputs()
+        .await
+        .map_err(ApiError::from)
 }
 
 impl TaskSubmission {

--- a/src/storage/capabilities.rs
+++ b/src/storage/capabilities.rs
@@ -112,9 +112,7 @@ pub(crate) mod service_account {
 }
 
 pub(crate) mod task {
-    pub(crate) use crate::storage::postgres::operations::task::{
-        TaskBackend, TaskStateUpdate, insert_import_results,
-    };
+    pub(crate) use crate::storage::postgres::operations::task::insert_import_results;
 }
 
 pub(crate) mod task_import {

--- a/src/storage/context.rs
+++ b/src/storage/context.rs
@@ -35,9 +35,11 @@ use crate::storage::{
     StoragePersonalComputedFieldListQuery, StoragePersonalComputedFieldUpdate, StoragePoolState,
     StorageRelatedObjectForRootRow, StorageRelatedObjectIncludeRow,
     StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
-    StorageSharedComputedFieldUpdate, StorageTask, StorageTaskAccess, StorageTaskCreateRequest,
-    StorageTaskEventPage, StorageTaskListQuery, StorageTaskOutputLookup, StorageTaskPage,
-    StorageTaskPageQuery, TaskGaugeSnapshot, TaskQueueStorage, TokenRetentionStorage,
+    StorageSharedComputedFieldUpdate, StorageTask, StorageTaskAccess, StorageTaskClaim,
+    StorageTaskCompletion, StorageTaskCreateRequest, StorageTaskEventAppend, StorageTaskEventPage,
+    StorageTaskFailure, StorageTaskLease, StorageTaskLeaseDuration, StorageTaskListQuery,
+    StorageTaskOutputLookup, StorageTaskPage, StorageTaskPageQuery, StorageTaskStateUpdate,
+    TaskExecutionStorage, TaskGaugeSnapshot, TaskQueueStorage, TokenRetentionStorage,
     UnifiedSearchClass, UnifiedSearchCollection, UnifiedSearchObject, UnifiedSearchQuery,
     UnifiedSearchStorage,
 };
@@ -758,6 +760,152 @@ impl TaskQueueStorage for StorageHandle {
                 }
             }
         })
+        .await
+    }
+}
+
+#[async_trait]
+impl TaskExecutionStorage for StorageHandle {
+    async fn claim_next_task(
+        &self,
+        lease_duration: StorageTaskLeaseDuration,
+    ) -> Result<Option<StorageTaskClaim>, StorageError> {
+        observe_storage_call(self.backend_name(), "task_execution", "claim", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.claim_next_task(lease_duration).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn renew_task_lease(
+        &self,
+        lease: StorageTaskLease,
+        lease_duration: StorageTaskLeaseDuration,
+    ) -> Result<bool, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "task_execution",
+            "renew_lease",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.renew_task_lease(lease, lease_duration).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn recover_expired_task_leases(
+        &self,
+        batch_size: usize,
+    ) -> Result<Vec<StorageTask>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "task_execution",
+            "recover_leases",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.recover_expired_task_leases(batch_size).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn append_task_event(&self, event: StorageTaskEventAppend) -> Result<(), StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "task_execution",
+            "append_event",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.append_task_event(event).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn update_task_state(
+        &self,
+        update: StorageTaskStateUpdate,
+    ) -> Result<StorageTask, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "task_execution",
+            "update_state",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.update_task_state(update).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn complete_task(
+        &self,
+        completion: StorageTaskCompletion,
+    ) -> Result<StorageTask, StorageError> {
+        observe_storage_call(self.backend_name(), "task_execution", "complete", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.complete_task(completion).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn fail_task(&self, failure: StorageTaskFailure) -> Result<StorageTask, StorageError> {
+        observe_storage_call(self.backend_name(), "task_execution", "fail", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => backend.fail_task(failure).await,
+            }
+        })
+        .await
+    }
+
+    async fn purge_expired_export_outputs(&self) -> Result<usize, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "task_execution",
+            "purge_export_outputs",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.purge_expired_export_outputs().await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn purge_expired_backup_outputs(&self) -> Result<usize, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "task_execution",
+            "purge_backup_outputs",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.purge_expired_backup_outputs().await
+                    }
+                }
+            },
+        )
         .await
     }
 }

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -5,8 +5,8 @@ use super::{
     CollectionStore, ComputedFieldLifecycleStorage, ComputedObjectStorage, EventDeliveryStorage,
     EventFanoutStorage, EventHealthStorage, EventRetentionStorage, HistoryStorage, MetricsStorage,
     ObjectAggregateStorage, ObjectRelationStore, ObjectStore, OperationalStateStorage,
-    PostgresStorage, RelationQueryStorage, TaskQueueStorage, TokenRetentionStorage,
-    UnifiedSearchStorage, observed::ObservedLifecycleStorage,
+    PostgresStorage, RelationQueryStorage, TaskExecutionStorage, TaskQueueStorage,
+    TokenRetentionStorage, UnifiedSearchStorage, observed::ObservedLifecycleStorage,
 };
 
 #[cfg(test)]
@@ -79,6 +79,7 @@ pub(crate) trait StorageBackend:
     + TokenRetentionStorage
     + UnifiedSearchStorage
     + TaskQueueStorage
+    + TaskExecutionStorage
     + WorkflowStorage
     + OperationalStorage
     + sealed::CertifiedStorageBackend
@@ -149,6 +150,7 @@ mod tests {
                 "temporal_history",
                 "unified_search",
                 "task_queue",
+                "task_execution",
                 "workflows",
                 "operations",
             ]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -62,16 +62,20 @@ pub(crate) use hubuum_storage_core::{
     StorageRelatedObjectIncludeRow, StorageRelatedSort, StorageResourceScope,
     StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
     StorageSharedComputedFieldUpdate, StorageSharedComputedScope, StorageTask, StorageTaskAccess,
-    StorageTaskCreateRequest, StorageTaskDurations, StorageTaskEvent, StorageTaskEventPage,
-    StorageTaskKind, StorageTaskListQuery, StorageTaskOutputLookup, StorageTaskPage,
-    StorageTaskPageQuery, StorageTaskProgress, StorageTaskScopeSnapshot, StorageTaskStatus,
-    StorageVisibility, TaskQueueStorage, UnifiedSearchClass, UnifiedSearchCollection,
+    StorageTaskClaim, StorageTaskClaimToken, StorageTaskCompletion, StorageTaskCompletionArtifact,
+    StorageTaskCreateRequest, StorageTaskDurations, StorageTaskEvent, StorageTaskEventAppend,
+    StorageTaskEventInput, StorageTaskEventPage, StorageTaskFailure, StorageTaskKind,
+    StorageTaskLease, StorageTaskLeaseDuration, StorageTaskListQuery, StorageTaskOutputLookup,
+    StorageTaskPage, StorageTaskPageQuery, StorageTaskProgress, StorageTaskResultCounts,
+    StorageTaskScopeSnapshot, StorageTaskStateUpdate, StorageTaskStatus, StorageVisibility,
+    TaskExecutionStorage, TaskQueueStorage, UnifiedSearchClass, UnifiedSearchCollection,
     UnifiedSearchCursor, UnifiedSearchObject, UnifiedSearchQuery, UnifiedSearchStorage,
 };
 pub(crate) use hubuum_storage_core::{ClassHistoryRecord, CollectionHistoryRecord};
 pub(crate) use hubuum_storage_core::{
-    StorageBackupOutput, StorageBackupOutputSummary, StorageExportOutput,
-    StorageExportOutputSummary, StorageImportTaskResult, StorageImportTaskResultPage,
+    StorageBackupOutput, StorageBackupOutputSummary, StorageBackupTaskArtifact,
+    StorageExportOutput, StorageExportOutputSummary, StorageExportTaskArtifact,
+    StorageImportTaskResult, StorageImportTaskResultPage,
 };
 pub(crate) use hubuum_storage_core::{StorageError, StorageErrorKind};
 #[cfg(test)]

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -3,6 +3,7 @@ mod error;
 #[doc(hidden)]
 pub mod operations;
 mod runtime;
+mod task_execution;
 mod task_queue;
 
 pub use runtime::*;

--- a/src/storage/postgres/operations/task.rs
+++ b/src/storage/postgres/operations/task.rs
@@ -1310,6 +1310,33 @@ impl NewTaskEventRecord {
     }
 }
 
+/// Append an in-flight lifecycle event only while the supplied worker still
+/// owns the task's live lease.
+pub(crate) async fn append_task_event_while_claimed(
+    pool: &impl crate::storage::StorageContext,
+    task_id_value: i32,
+    claim_token: Uuid,
+    event: NewTaskEventRecord,
+) -> Result<TaskEventRecord, ApiError> {
+    with_transaction(pool, async |conn| -> Result<TaskEventRecord, ApiError> {
+        use crate::schema::tasks::dsl::{id, lease_expires_at, lease_token, status, tasks};
+
+        let active_statuses = TaskStatus::ACTIVE.map(TaskStatus::as_str);
+        let task = tasks
+            .filter(id.eq(task_id_value))
+            .filter(lease_token.eq(Some(claim_token)))
+            .filter(lease_expires_at.gt(sql::<Nullable<Timestamp>>(DATABASE_UTC_NOW_SQL)))
+            .filter(status.eq_any(active_statuses))
+            .for_update()
+            .first::<TaskRecord>(conn)
+            .await?;
+        emit_task_lifecycle_event(conn, &task, &event, &task.worker_provenance())
+            .await?
+            .try_into()
+    })
+    .await
+}
+
 pub async fn insert_import_results(
     pool: &impl crate::storage::StorageContext,
     entries: &[NewImportTaskResultRecord],

--- a/src/storage/postgres/task_execution.rs
+++ b/src/storage/postgres/task_execution.rs
@@ -1,0 +1,405 @@
+#[cfg(not(test))]
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::config::get_config;
+use crate::errors::ApiError;
+use crate::models::{
+    NewBackupTaskOutputRecord, NewExportTaskOutputRecord, NewTaskEventRecord, TaskKind,
+    TaskResultCounts, TaskStatus,
+};
+use crate::storage::{
+    StorageBackupTaskArtifact, StorageError, StorageExportTaskArtifact, StorageTask,
+    StorageTaskClaim, StorageTaskClaimToken, StorageTaskCompletion, StorageTaskCompletionArtifact,
+    StorageTaskEventAppend, StorageTaskEventInput, StorageTaskFailure, StorageTaskLease,
+    StorageTaskLeaseDuration, StorageTaskResultCounts, StorageTaskStateUpdate, StorageTaskStatus,
+    TaskExecutionStorage,
+};
+use crate::tasks::TaskLeaseDuration;
+
+use super::PostgresStorage;
+use super::error::map_postgres_error;
+use super::operations::computed_field::mark_computed_reindex_failed;
+use super::operations::task::{
+    TaskBackend, TaskIdentifier, TaskStateUpdate, append_task_event_while_claimed,
+    claim_next_queued_task, purge_expired_backup_outputs, purge_expired_export_outputs,
+    recover_expired_task_leases, renew_task_lease,
+};
+use super::task_queue::task_to_storage;
+use super::{PostgresPool, PostgresPoolSettings, init_postgres_pool_with_settings};
+
+struct ClaimedTaskIdentifier {
+    task_id: i32,
+    token: Uuid,
+}
+
+const TASK_LEASE_POOL_SIZE: u32 = 1;
+
+#[cfg(not(test))]
+static TASK_LEASE_POOL: OnceLock<PostgresPool> = OnceLock::new();
+
+fn new_task_lease_pool() -> PostgresPool {
+    let config = get_config().expect("task lease renewal requires database configuration");
+    let settings = PostgresPoolSettings::builder(config.database_url.clone())
+        .max_size(TASK_LEASE_POOL_SIZE)
+        .statement_timeout_ms(config.db_statement_timeout_ms)
+        .acquire_timeout_ms(config.db_pool_acquire_timeout_ms)
+        .build()
+        .expect("task lease pool settings must be valid");
+    init_postgres_pool_with_settings(&settings)
+}
+
+#[cfg(not(test))]
+fn task_lease_pool() -> PostgresPool {
+    TASK_LEASE_POOL.get_or_init(new_task_lease_pool).clone()
+}
+
+// Test runtimes are short-lived, so do not retain async PostgreSQL connections
+// after the runtime that established them has stopped.
+#[cfg(test)]
+fn task_lease_pool() -> PostgresPool {
+    new_task_lease_pool()
+}
+
+impl TaskIdentifier for ClaimedTaskIdentifier {
+    fn task_id(&self) -> i32 {
+        self.task_id
+    }
+
+    fn task_lease_token(&self) -> Option<Uuid> {
+        Some(self.token)
+    }
+}
+
+fn lease_duration_from_storage(
+    duration: StorageTaskLeaseDuration,
+) -> Result<TaskLeaseDuration, ApiError> {
+    let milliseconds = u64::try_from(duration.milliseconds()).map_err(|_| {
+        ApiError::BadRequest("Task lease duration must be greater than zero".to_string())
+    })?;
+    TaskLeaseDuration::new(Duration::from_millis(milliseconds)).map_err(ApiError::BadRequest)
+}
+
+fn claim_token_from_storage(token: &StorageTaskClaimToken) -> Result<Uuid, ApiError> {
+    Uuid::parse_str(token.adapter_value()).map_err(|_| {
+        ApiError::BadRequest("Task claim token is not valid for this backend".to_string())
+    })
+}
+
+fn claimed_identifier(lease: &StorageTaskLease) -> Result<ClaimedTaskIdentifier, ApiError> {
+    Ok(ClaimedTaskIdentifier {
+        task_id: lease.task_id(),
+        token: claim_token_from_storage(lease.token())?,
+    })
+}
+
+fn task_status_from_storage(status: StorageTaskStatus) -> TaskStatus {
+    match status {
+        StorageTaskStatus::Queued => TaskStatus::Queued,
+        StorageTaskStatus::Validating => TaskStatus::Validating,
+        StorageTaskStatus::Running => TaskStatus::Running,
+        StorageTaskStatus::Succeeded => TaskStatus::Succeeded,
+        StorageTaskStatus::Failed => TaskStatus::Failed,
+        StorageTaskStatus::PartiallySucceeded => TaskStatus::PartiallySucceeded,
+        StorageTaskStatus::Cancelled => TaskStatus::Cancelled,
+    }
+}
+
+fn state_update_from_storage(
+    update: StorageTaskStateUpdate,
+) -> Result<(ClaimedTaskIdentifier, TaskStateUpdate, TaskStatus), ApiError> {
+    let (lease, status, summary, counts, started_at) = update.into_parts();
+    let counts = task_result_counts_from_storage(counts)?;
+    let status = task_status_from_storage(status);
+    let mut update = TaskStateUpdate::new(status, counts).with_started_at(started_at);
+    if let Some(summary) = summary {
+        update = update.with_summary(summary);
+    }
+    Ok((claimed_identifier(&lease)?, update, status))
+}
+
+fn task_result_counts_from_storage(
+    counts: StorageTaskResultCounts,
+) -> Result<TaskResultCounts, ApiError> {
+    TaskResultCounts::from_stored(counts.processed(), counts.succeeded(), counts.failed())
+}
+
+fn event_from_storage(task_id: i32, event: StorageTaskEventInput) -> NewTaskEventRecord {
+    let (event_type, message, data) = event.into_parts();
+    NewTaskEventRecord {
+        task_id,
+        event_type,
+        message,
+        data,
+    }
+}
+
+fn export_artifact_from_storage(
+    task_id: i32,
+    artifact: StorageExportTaskArtifact,
+) -> NewExportTaskOutputRecord {
+    let (identity, content, report, output_expires_at, durations) = artifact.into_parts();
+    let (template_name, content_type) = identity.into_parts();
+    let (json_output, text_output) = content.into_parts();
+    let (meta_json, warnings_json, warning_count, truncated) = report.into_parts();
+    NewExportTaskOutputRecord {
+        task_id,
+        template_name,
+        content_type,
+        json_output,
+        text_output,
+        meta_json,
+        warnings_json,
+        warning_count,
+        truncated,
+        output_expires_at,
+        total_duration_ms: durations.total_ms(),
+        query_duration_ms: durations.query_ms(),
+        hydration_duration_ms: durations.hydration_ms(),
+        render_duration_ms: durations.render_ms(),
+    }
+}
+
+fn backup_artifact_from_storage(
+    task_id: i32,
+    artifact: StorageBackupTaskArtifact,
+) -> NewBackupTaskOutputRecord {
+    let (document, byte_size, sha256, output_expires_at) = artifact.into_parts();
+    NewBackupTaskOutputRecord {
+        task_id,
+        document,
+        byte_size,
+        sha256,
+        output_expires_at,
+    }
+}
+
+#[async_trait]
+impl TaskExecutionStorage for PostgresStorage {
+    async fn claim_next_task(
+        &self,
+        lease_duration: StorageTaskLeaseDuration,
+    ) -> Result<Option<StorageTaskClaim>, StorageError> {
+        let task = claim_next_queued_task(
+            self.pool(),
+            lease_duration_from_storage(lease_duration).map_err(map_postgres_error)?,
+        )
+        .await
+        .map_err(map_postgres_error)?;
+        task.map(|task| {
+            let token = task.lease_token.ok_or_else(|| {
+                ApiError::InternalServerError(
+                    "Claimed task did not include a backend claim token".to_string(),
+                )
+            })?;
+            let lease =
+                StorageTaskLease::new(task.id, StorageTaskClaimToken::new(token.to_string()));
+            Ok(StorageTaskClaim::new(task_to_storage(task)?, lease))
+        })
+        .transpose()
+        .map_err(map_postgres_error)
+    }
+
+    async fn renew_task_lease(
+        &self,
+        lease: StorageTaskLease,
+        lease_duration: StorageTaskLeaseDuration,
+    ) -> Result<bool, StorageError> {
+        let task_id = lease.task_id();
+        let token = claim_token_from_storage(lease.token()).map_err(map_postgres_error)?;
+        let duration = lease_duration_from_storage(lease_duration).map_err(map_postgres_error)?;
+        renew_task_lease(&task_lease_pool(), task_id, token, duration)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn recover_expired_task_leases(
+        &self,
+        batch_size: usize,
+    ) -> Result<Vec<StorageTask>, StorageError> {
+        let batch_size = i64::try_from(batch_size)
+            .map_err(|_| StorageError::bad_request("Task recovery batch size is too large"))?;
+        recover_expired_task_leases(self.pool(), batch_size)
+            .await
+            .map_err(map_postgres_error)?
+            .into_iter()
+            .map(task_to_storage)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_postgres_error)
+    }
+
+    async fn append_task_event(&self, event: StorageTaskEventAppend) -> Result<(), StorageError> {
+        let (lease, event) = event.into_parts();
+        let task_id = lease.task_id();
+        let token = claim_token_from_storage(lease.token()).map_err(map_postgres_error)?;
+        append_task_event_while_claimed(
+            self.pool(),
+            task_id,
+            token,
+            event_from_storage(task_id, event),
+        )
+        .await
+        .map(|_| ())
+        .map_err(map_postgres_error)
+    }
+
+    async fn update_task_state(
+        &self,
+        update: StorageTaskStateUpdate,
+    ) -> Result<StorageTask, StorageError> {
+        let (task, update, status) =
+            state_update_from_storage(update).map_err(map_postgres_error)?;
+        if !TaskStatus::ACTIVE.contains(&status) {
+            return Err(map_postgres_error(ApiError::BadRequest(format!(
+                "Task state updates require an active status, received '{}'",
+                status.as_str()
+            ))));
+        }
+        task.update_state(self.pool(), update)
+            .await
+            .and_then(task_to_storage)
+            .map_err(map_postgres_error)
+    }
+
+    async fn complete_task(
+        &self,
+        completion: StorageTaskCompletion,
+    ) -> Result<StorageTask, StorageError> {
+        let (update, event, artifact) = completion.into_parts();
+        let (task, update, status) =
+            state_update_from_storage(update).map_err(map_postgres_error)?;
+        if !status.is_terminal() {
+            return Err(map_postgres_error(ApiError::BadRequest(format!(
+                "Task completion requires a terminal status, received '{}'",
+                status.as_str()
+            ))));
+        }
+        let task_id = task.task_id;
+        let stored_kind = task
+            .find_record(self.pool())
+            .await
+            .and_then(|record| TaskKind::from_db(&record.kind))
+            .map_err(map_postgres_error)?;
+        let artifact_matches_kind = matches!(
+            (&artifact, stored_kind),
+            (StorageTaskCompletionArtifact::None, _)
+                | (StorageTaskCompletionArtifact::Export(_), TaskKind::Export)
+                | (StorageTaskCompletionArtifact::Backup(_), TaskKind::Backup)
+        );
+        if !artifact_matches_kind {
+            return Err(map_postgres_error(ApiError::BadRequest(format!(
+                "Task completion artifact does not match task kind '{}'",
+                stored_kind.as_str()
+            ))));
+        }
+        let event = event_from_storage(task_id, event);
+        let result = match artifact {
+            StorageTaskCompletionArtifact::None => {
+                task.finalize_terminal(self.pool(), update, event).await
+            }
+            StorageTaskCompletionArtifact::Export(artifact) => {
+                task.finalize_export_with_output(
+                    self.pool(),
+                    update,
+                    event,
+                    export_artifact_from_storage(task_id, artifact),
+                )
+                .await
+            }
+            StorageTaskCompletionArtifact::Backup(artifact) => {
+                task.finalize_backup_with_output(
+                    self.pool(),
+                    update,
+                    event,
+                    backup_artifact_from_storage(task_id, artifact),
+                )
+                .await
+            }
+        };
+        result.and_then(task_to_storage).map_err(map_postgres_error)
+    }
+
+    async fn fail_task(&self, failure: StorageTaskFailure) -> Result<StorageTask, StorageError> {
+        let (lease, summary, event) = failure.into_parts();
+        let task = claimed_identifier(&lease).map_err(map_postgres_error)?;
+        let record = task
+            .find_record(self.pool())
+            .await
+            .map_err(map_postgres_error)?;
+        let kind = TaskKind::from_db(&record.kind).map_err(map_postgres_error)?;
+        let counts = match kind {
+            TaskKind::Import => task
+                .count_import_results(self.pool())
+                .await
+                .map_err(map_postgres_error)?,
+            TaskKind::Export | TaskKind::Backup | TaskKind::RemoteCall => {
+                TaskResultCounts::from_outcomes(0, 1).map_err(map_postgres_error)?
+            }
+            TaskKind::Reindex => {
+                TaskResultCounts::from_stored(record.processed_items, record.success_items, 1)
+                    .map_err(map_postgres_error)?
+            }
+        };
+        let update = TaskStateUpdate::new(TaskStatus::Failed, counts)
+            .with_summary(summary.clone())
+            .with_started_at(record.started_at);
+        let finalized = task
+            .finalize_terminal(self.pool(), update, event_from_storage(record.id, event))
+            .await
+            .map_err(map_postgres_error)?;
+        if kind == TaskKind::Reindex {
+            mark_computed_reindex_failed(self.pool(), &record, &summary)
+                .await
+                .map_err(map_postgres_error)?;
+        }
+        task_to_storage(finalized).map_err(map_postgres_error)
+    }
+
+    async fn purge_expired_export_outputs(&self) -> Result<usize, StorageError> {
+        purge_expired_export_outputs(self.pool())
+            .await
+            .map(|task_ids| task_ids.len())
+            .map_err(map_postgres_error)
+    }
+
+    async fn purge_expired_backup_outputs(&self) -> Result<usize, StorageError> {
+        purge_expired_backup_outputs(self.pool())
+            .await
+            .map(|task_ids| task_ids.len())
+            .map_err(map_postgres_error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn lease_pool_remains_available_when_an_execution_pool_is_exhausted() {
+        let config = get_config().expect("test requires database configuration");
+        let settings = PostgresPoolSettings::builder(config.database_url.clone())
+            .max_size(1)
+            .statement_timeout_ms(config.db_statement_timeout_ms)
+            .acquire_timeout_ms(config.db_pool_acquire_timeout_ms)
+            .build()
+            .expect("single-connection execution pool settings should be valid");
+        let execution_pool = init_postgres_pool_with_settings(&settings);
+        let _execution_connection = execution_pool
+            .get()
+            .await
+            .expect("execution connection should be available");
+
+        let lease_pool = task_lease_pool();
+        timeout(Duration::from_secs(5), lease_pool.get())
+            .await
+            .expect("lease checkout must not wait for the execution pool")
+            .expect("lease pool should connect to the test database");
+    }
+}

--- a/src/storage/postgres/task_queue.rs
+++ b/src/storage/postgres/task_queue.rs
@@ -214,7 +214,7 @@ fn task_kind_from_storage(kind: StorageTaskKind) -> TaskKind {
     }
 }
 
-fn task_to_storage(task: TaskRecord) -> Result<StorageTask, ApiError> {
+pub(super) fn task_to_storage(task: TaskRecord) -> Result<StorageTask, ApiError> {
     let kind = StorageTaskKind::from_persisted(&task.kind).ok_or_else(|| {
         ApiError::InternalServerError(format!("Unknown stored task kind '{}'", task.kind))
     })?;

--- a/src/tasks/execution.rs
+++ b/src/tasks/execution.rs
@@ -6,12 +6,15 @@ use crate::models::{
     ImportAtomicity, ImportClassRelationInput, ImportCollisionPolicy,
     ImportComputedFieldVisibility, ImportExportTemplateInput, ImportMode,
     ImportObjectRelationInput, ImportPermissionPolicy, ImportPrincipalSubtype, ImportRequest,
-    NewHubuumClassRelation, NewTaskEventRecord, PrincipalKey, TaskRecord, TaskResultCounts,
-    TaskStatus, TokenScope,
+    NewHubuumClassRelation, NewTaskEventRecord, PrincipalKey, TaskResultCounts, TaskStatus,
+    TokenScope,
 };
 use crate::observability::metrics;
+use crate::services::tasks::{
+    ClaimedTask, TaskStateChange, append_task_event, complete_task, update_task_state,
+};
 use crate::storage::StorageContext;
-use crate::storage::postgres::operations::task::{TaskBackend, TaskStateUpdate};
+use crate::storage::StorageTaskCompletionArtifact;
 use crate::storage::postgres::with_transaction;
 
 use super::helpers::{
@@ -201,7 +204,7 @@ async fn resolve_object_relation_runtime(
 
 pub(super) async fn execute_import_task<C>(
     backend: &C,
-    task: &TaskRecord,
+    task: &ClaimedTask,
     user: &impl crate::traits::AuthzSubject,
     scopes: Option<&TokenScope>,
 ) -> Result<(), ApiError>
@@ -310,28 +313,32 @@ where
             planning_time = ?planning_time
         );
 
-        NewTaskEventRecord {
-            task_id: task.id,
-            event_type: "running".to_string(),
-            message: if request.dry_run() {
-                "Import dry run planned successfully".to_string()
-            } else if failures.is_empty() {
-                "Import execution started".to_string()
-            } else {
-                format!(
-                    "Import execution started with {} planned failure(s)",
-                    failures.len()
-                )
+        append_task_event(
+            pool,
+            task,
+            NewTaskEventRecord {
+                task_id: task.id,
+                event_type: "running".to_string(),
+                message: if request.dry_run() {
+                    "Import dry run planned successfully".to_string()
+                } else if failures.is_empty() {
+                    "Import execution started".to_string()
+                } else {
+                    format!(
+                        "Import execution started with {} planned failure(s)",
+                        failures.len()
+                    )
+                },
+                data: None,
             },
-            data: None,
-        }
-        .append(pool)
+        )
         .await?;
 
-        task.update_state(
+        update_task_state(
             pool,
-            TaskStateUpdate::new(TaskStatus::Running, TaskResultCounts::default())
-                .with_started_at(task.started_at),
+            task,
+            TaskStateChange::new(TaskStatus::Running, TaskResultCounts::default())
+                .started_at(task.started_at),
         )
         .await?;
 
@@ -444,20 +451,22 @@ where
 
 async fn finalize_task(
     pool: &impl crate::storage::StorageContext,
-    task: &TaskRecord,
+    task: &ClaimedTask,
     terminal: TerminalTaskUpdate,
 ) -> Result<(), ApiError> {
-    task.finalize_terminal(
+    complete_task(
         pool,
-        TaskStateUpdate::new(terminal.status, terminal.counts)
-            .with_summary(terminal.summary.clone())
-            .with_started_at(task.started_at),
+        task,
+        TaskStateChange::new(terminal.status, terminal.counts)
+            .summary(terminal.summary.clone())
+            .started_at(task.started_at),
         NewTaskEventRecord {
             task_id: task.id,
             event_type: terminal.status.as_str().to_string(),
             message: terminal.summary.clone(),
             data: terminal.event_data,
         },
+        StorageTaskCompletionArtifact::None,
     )
     .await?;
     Ok(())

--- a/src/tasks/remote_call.rs
+++ b/src/tasks/remote_call.rs
@@ -18,13 +18,12 @@ use crate::errors::ApiError;
 use crate::models::{
     NewRemoteCallResult, NewTaskEventRecord, RemoteAuthConfig, RemoteHttpMethod,
     RemoteInvocationBodyOverride, RemoteInvocationParameters, RemoteTemplateContext,
-    StoredRemoteCallTaskPayload, TaskRecord, TaskResultCounts, TaskStatus,
-    authorize_remote_invocation,
+    StoredRemoteCallTaskPayload, TaskResultCounts, TaskStatus, authorize_remote_invocation,
 };
 use crate::observability::metrics;
-use crate::storage::StorageContext;
+use crate::services::tasks::{ClaimedTask, TaskStateChange, complete_task, update_task_state};
 use crate::storage::capabilities::remote_target::insert_remote_call_result;
-use crate::storage::capabilities::task::{TaskBackend, TaskStateUpdate};
+use crate::storage::{StorageContext, StorageTaskCompletionArtifact};
 use crate::traits::AuthzSubject;
 
 #[cfg(feature = "integration-test-support")]
@@ -53,7 +52,7 @@ fn local_remote_targets_enabled_for_tests() -> bool {
 
 pub(super) async fn execute_remote_call_task<C>(
     backend: &C,
-    task: &TaskRecord,
+    task: &ClaimedTask,
     user: &impl AuthzSubject,
     scopes: Option<&TokenScope>,
 ) -> Result<(), ApiError>
@@ -67,10 +66,11 @@ where
         .ok_or_else(|| ApiError::BadRequest("Remote call task payload is missing".to_string()))?;
     let request: StoredRemoteCallTaskPayload = serde_json::from_value(payload)?;
 
-    task.update_state(
+    update_task_state(
         pool,
-        TaskStateUpdate::new(TaskStatus::Running, TaskResultCounts::default())
-            .with_started_at(task.started_at),
+        task,
+        TaskStateChange::new(TaskStatus::Running, TaskResultCounts::default())
+            .started_at(task.started_at),
     )
     .await?;
 
@@ -342,7 +342,7 @@ fn remote_error_outcome(error: &OutboundHttpError) -> &'static str {
 
 async fn finalize_remote_task(
     pool: &impl crate::storage::StorageContext,
-    task: &TaskRecord,
+    task: &ClaimedTask,
     outcome: RemoteExecutionOutcome,
 ) -> Result<(), ApiError> {
     let status = if outcome.success {
@@ -350,23 +350,25 @@ async fn finalize_remote_task(
     } else {
         TaskStatus::Failed
     };
-    task.finalize_terminal(
+    complete_task(
         pool,
-        TaskStateUpdate::new(
+        task,
+        TaskStateChange::new(
             status,
             TaskResultCounts::from_outcomes(
                 i32::from(outcome.success),
                 i32::from(!outcome.success),
             )?,
         )
-        .with_summary(outcome.summary.clone())
-        .with_started_at(task.started_at),
+        .summary(outcome.summary.clone())
+        .started_at(task.started_at),
         NewTaskEventRecord {
             task_id: task.id,
             event_type: status.as_str().to_string(),
             message: outcome.summary,
             data: outcome.event_data,
         },
+        StorageTaskCompletionArtifact::None,
     )
     .await?;
     Ok(())

--- a/src/tasks/settings.rs
+++ b/src/tasks/settings.rs
@@ -41,10 +41,6 @@ impl TaskWorkerSettings {
     pub const fn export_output_cleanup_interval(self) -> Duration {
         self.export_output_cleanup_interval
     }
-
-    pub(crate) const fn validated_lease_duration(self) -> TaskLeaseDuration {
-        self.lease_duration
-    }
 }
 
 /// Builder for the multi-field task-worker policy.
@@ -210,7 +206,9 @@ mod tests {
             Duration::from_secs(300)
         );
         assert_eq!(
-            settings.validated_lease_duration().database_milliseconds(),
+            TaskLeaseDuration::new(settings.lease_duration())
+                .unwrap()
+                .database_milliseconds(),
             60_000
         );
     }

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -42,6 +42,7 @@ use crate::permissions::types::{ResourceAttrs, ResourceKind};
 use crate::schema::collections::dsl::{collections, name as collection_name};
 use crate::schema::hubuumclass::dsl::{hubuumclass, name as class_name};
 use crate::schema::tasks::dsl::{created_at, id as task_id, tasks};
+use crate::services::tasks::ClaimedTask;
 use crate::storage::postgres::operations::collection::DeleteCollectionRecord;
 use crate::storage::postgres::operations::task::{TaskBackend, insert_import_results};
 use crate::storage::postgres::operations::task_import::{
@@ -2909,6 +2910,25 @@ async fn test_mark_claimed_task_failed_uses_recorded_result_counts() {
     .create(&context.pool))
     .await
     .unwrap();
+    let claim_token = uuid::Uuid::new_v4();
+    with_connection(&context.pool, async |conn| {
+        use crate::schema::tasks::dsl::{
+            id, lease_expires_at, lease_token, started_at, status, tasks,
+        };
+        let now = chrono::Utc::now().naive_utc();
+        diesel::update(tasks.filter(id.eq(task.id)))
+            .set((
+                status.eq(TaskStatus::Running.as_str()),
+                started_at.eq(Some(now)),
+                lease_token.eq(Some(claim_token)),
+                lease_expires_at.eq(Some(now + chrono::Duration::minutes(1))),
+            ))
+            .execute(conn)
+            .await
+    })
+    .await
+    .unwrap();
+    let claimed = ClaimedTask::from_record(task.find_record(&context.pool).await.unwrap()).unwrap();
 
     (insert_import_results(
         &context.pool,
@@ -2940,7 +2960,7 @@ async fn test_mark_claimed_task_failed_uses_recorded_result_counts() {
 
     (mark_claimed_task_failed(
         &context.pool,
-        &task,
+        &claimed,
         &ApiError::InternalServerError("boom".to_string()),
     ))
     .await
@@ -2977,6 +2997,25 @@ async fn test_reindex_failure_finalization_reloads_persisted_progress() {
     .create(&context.pool))
     .await
     .unwrap();
+    let claim_token = uuid::Uuid::new_v4();
+    with_connection(&context.pool, async |conn| {
+        use crate::schema::tasks::dsl::{
+            id, lease_expires_at, lease_token, started_at, status, tasks,
+        };
+        let now = chrono::Utc::now().naive_utc();
+        diesel::update(tasks.filter(id.eq(task.id)))
+            .set((
+                status.eq(TaskStatus::Running.as_str()),
+                started_at.eq(Some(now)),
+                lease_token.eq(Some(claim_token)),
+                lease_expires_at.eq(Some(now + chrono::Duration::minutes(1))),
+            ))
+            .execute(conn)
+            .await
+    })
+    .await
+    .unwrap();
+    let claimed = ClaimedTask::from_record(task.find_record(&context.pool).await.unwrap()).unwrap();
 
     with_connection(&context.pool, async |conn| {
         use crate::schema::tasks::dsl::{id, processed_items, success_items, tasks};
@@ -2990,7 +3029,7 @@ async fn test_reindex_failure_finalization_reloads_persisted_progress() {
 
     mark_claimed_task_failed(
         &context.pool,
-        &task,
+        &claimed,
         &ApiError::InternalServerError("batch failed".to_string()),
     )
     .await

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -19,20 +19,19 @@ use crate::events::{TASK_QUEUE_CHANNEL, spawn_postgres_notification_listener};
 use crate::exports::execute_export_task;
 use crate::lifecycle::{ShutdownSignal, spawn_background_worker};
 use crate::models::principal::load_principal_by_id;
-use crate::models::{NewTaskEventRecord, TaskKind, TaskRecord, TaskResultCounts, TaskStatus};
+use crate::models::{NewTaskEventRecord, TaskKind};
 use crate::observability::metrics;
 #[cfg(test)]
 use crate::permissions::LocalPermissionBackend;
 use crate::permissions::{AppContext, require_unscoped_runtime_admin};
 use crate::restores::{MaintenanceActivityGuard, current_maintenance_state};
-use crate::storage::postgres::operations::service_account::principal_is_disabled;
-use crate::storage::postgres::operations::task::{
-    TaskBackend, TaskStateUpdate, claim_next_queued_task, purge_expired_backup_outputs,
+use crate::services::tasks::{
+    ClaimedTask, claim_next_task, fail_task, purge_expired_backup_outputs,
     purge_expired_export_outputs, recover_expired_task_leases, renew_task_lease,
 };
+use crate::storage::postgres::operations::service_account::principal_is_disabled;
 use crate::storage::postgres::{
-    PostgresPool, PostgresPoolSettings, StorageCallSite, init_postgres_pool_with_settings,
-    with_mutation_provenance_scope, with_storage_call_site,
+    StorageCallSite, with_mutation_provenance_scope, with_storage_call_site,
 };
 
 use super::TaskWorkerSettings;
@@ -47,8 +46,6 @@ static TASK_WORKER_NOTIFY: OnceLock<Notify> = OnceLock::new();
 static TASK_OUTPUT_CLEANUP_STATE: OnceLock<Mutex<CleanupSchedule>> = OnceLock::new();
 static TASK_RECOVERY_STATE: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
 static TASK_WORKER_SETTINGS: OnceLock<TaskWorkerSettings> = OnceLock::new();
-#[cfg(not(test))]
-static TASK_LEASE_POOL: OnceLock<PostgresPool> = OnceLock::new();
 static TASK_LEASE_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     tokio::runtime::Builder::new_multi_thread()
         .worker_threads(1)
@@ -57,8 +54,6 @@ static TASK_LEASE_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| 
         .build()
         .expect("task lease heartbeat runtime must start")
 });
-
-const TASK_LEASE_POOL_SIZE: u32 = 1;
 
 pub fn initialize_task_worker_settings(settings: TaskWorkerSettings) -> Result<(), String> {
     TASK_WORKER_SETTINGS
@@ -106,29 +101,6 @@ fn configured_task_worker_count() -> usize {
 
 fn configured_task_poll_interval() -> Duration {
     task_worker_settings().poll_interval()
-}
-
-fn new_task_lease_pool() -> PostgresPool {
-    let config = get_config().expect("task lease renewal requires database configuration");
-    let settings = PostgresPoolSettings::builder(config.database_url.clone())
-        .max_size(TASK_LEASE_POOL_SIZE)
-        .statement_timeout_ms(config.db_statement_timeout_ms)
-        .acquire_timeout_ms(config.db_pool_acquire_timeout_ms)
-        .build()
-        .expect("task lease pool settings must be valid");
-    init_postgres_pool_with_settings(&settings)
-}
-
-#[cfg(not(test))]
-fn task_lease_pool() -> PostgresPool {
-    TASK_LEASE_POOL.get_or_init(new_task_lease_pool).clone()
-}
-
-// Test runtimes are short-lived, so do not retain async Postgres connections in
-// a process-global pool after the runtime that established them has stopped.
-#[cfg(test)]
-fn task_lease_pool() -> PostgresPool {
-    new_task_lease_pool()
 }
 
 pub(super) fn background_worker_action(result: &Result<bool, ApiError>) -> WorkerLoopAction {
@@ -327,7 +299,7 @@ async fn process_one_task_with_settings(
 
     let settings = task_worker_settings();
     let claim_started_at = TokioInstant::now();
-    let task = match claim_next_queued_task(context, settings.validated_lease_duration()).await {
+    let task = match claim_next_task(context, settings.lease_duration()).await {
         Ok(task) => task,
         Err(error) => {
             metrics::task_worker_iteration("error");
@@ -353,7 +325,7 @@ async fn process_one_task_with_settings(
     let provenance = task.worker_provenance();
     with_mutation_provenance_scope(Some(provenance), async {
         let mut heartbeat = start_task_lease_heartbeat(
-            task_lease_pool(),
+            context.backend().clone(),
             &task,
             claim_started_at + settings.lease_duration(),
         );
@@ -475,28 +447,24 @@ impl TaskLeaseHeartbeat {
 }
 
 fn start_task_lease_heartbeat(
-    pool: PostgresPool,
-    task: &TaskRecord,
+    storage: crate::storage::StorageHandle,
+    task: &ClaimedTask,
     initial_confirmed_expiry: TokioInstant,
 ) -> Option<TaskLeaseHeartbeat> {
-    let claim_token = task.lease_token?;
     let settings = task_worker_settings();
     let task_id = task.id;
+    let lease = task.lease().clone();
     Some(spawn_task_lease_monitor(
         task_id,
         settings,
         initial_confirmed_expiry,
         move || {
-            let pool = pool.clone();
+            let storage = storage.clone();
+            let lease = lease.clone();
             async move {
                 with_storage_call_site(
                     StorageCallSite::TaskLease,
-                    renew_task_lease(
-                        &pool,
-                        task_id,
-                        claim_token,
-                        settings.validated_lease_duration(),
-                    ),
+                    renew_task_lease(&storage, lease, settings.lease_duration()),
                 )
                 .await
             }
@@ -681,25 +649,24 @@ async fn maybe_cleanup_expired_task_outputs(
     };
 
     metrics::task_output_cleanup_run(metrics::TaskOutputKind::Export);
-    match purge_expired_export_outputs(pool).await {
-        Ok(deleted) => {
-            metrics::task_output_cleanup_deleted(metrics::TaskOutputKind::Export, deleted.len())
-        }
+    let deleted_exports = match purge_expired_export_outputs(pool).await {
+        Ok(deleted) => deleted,
         Err(error) => {
             metrics::task_output_cleanup_failed(metrics::TaskOutputKind::Export);
             return Err(error);
         }
-    }
+    };
+    metrics::task_output_cleanup_deleted(metrics::TaskOutputKind::Export, deleted_exports);
+
     metrics::task_output_cleanup_run(metrics::TaskOutputKind::Backup);
-    match purge_expired_backup_outputs(pool).await {
-        Ok(deleted) => {
-            metrics::task_output_cleanup_deleted(metrics::TaskOutputKind::Backup, deleted.len())
-        }
+    let deleted_backups = match purge_expired_backup_outputs(pool).await {
+        Ok(deleted) => deleted,
         Err(error) => {
             metrics::task_output_cleanup_failed(metrics::TaskOutputKind::Backup);
             return Err(error);
         }
-    }
+    };
+    metrics::task_output_cleanup_deleted(metrics::TaskOutputKind::Backup, deleted_backups);
     reservation.commit()?;
 
     Ok(())
@@ -715,7 +682,7 @@ fn duration_since(timestamp: chrono::NaiveDateTime) -> Option<Duration> {
 
 async fn process_claimed_task(
     context: &AppContext,
-    task: &TaskRecord,
+    task: &ClaimedTask,
     backup_settings: &BackupSettings,
 ) -> Result<(), ApiError> {
     let pool = context;
@@ -776,48 +743,23 @@ async fn process_claimed_task(
 
 pub(super) async fn mark_claimed_task_failed(
     pool: &impl crate::storage::StorageContext,
-    task: &TaskRecord,
+    task: &ClaimedTask,
     err: &ApiError,
 ) -> Result<(), ApiError> {
-    let task_kind = TaskKind::from_db(&task.kind)?;
-    let task = if task_kind == TaskKind::Reindex {
-        task.find_record(pool).await?
-    } else {
-        task.clone()
-    };
     let summary = sanitize_error_for_storage(err);
-    if task_kind == TaskKind::Reindex {
-        crate::storage::postgres::operations::computed_field::mark_computed_reindex_failed(
-            pool, &task, &summary,
-        )
-        .await?;
-    }
-    let counts = match task_kind {
-        TaskKind::Import => task.count_import_results(pool).await?,
-        TaskKind::Export => TaskResultCounts::from_outcomes(0, 1)?,
-        TaskKind::RemoteCall => TaskResultCounts::from_outcomes(0, 1)?,
-        TaskKind::Backup => TaskResultCounts::from_outcomes(0, 1)?,
-        TaskKind::Reindex => {
-            TaskResultCounts::from_stored(task.processed_items, task.success_items, 1)?
-        }
-    };
 
     warn!(
         message = "Claimed task failed",
         task_id = task.id,
         task_kind = task.kind.as_str(),
         status = task.status.as_str(),
-        processed_items = counts.processed(),
-        success_items = counts.success(),
-        failed_items = counts.failed(),
         error = %err
     );
 
-    task.finalize_terminal(
+    fail_task(
         pool,
-        TaskStateUpdate::new(TaskStatus::Failed, counts)
-            .with_summary(summary.clone())
-            .with_started_at(task.started_at),
+        task,
+        summary.clone(),
         NewTaskEventRecord {
             task_id: task.id,
             event_type: "failed".to_string(),
@@ -916,17 +858,6 @@ mod lease_heartbeat_tests {
             .unwrap()
     }
 
-    fn new_single_connection_execution_pool() -> PostgresPool {
-        let config = get_config().expect("test requires database configuration");
-        let settings = PostgresPoolSettings::builder(config.database_url.clone())
-            .max_size(1)
-            .statement_timeout_ms(config.db_statement_timeout_ms)
-            .acquire_timeout_ms(config.db_pool_acquire_timeout_ms)
-            .build()
-            .unwrap();
-        init_postgres_pool_with_settings(&settings)
-    }
-
     #[test]
     fn heartbeat_progresses_while_task_runtime_thread_is_blocked() {
         let renewal_attempts = Arc::new(AtomicUsize::new(0));
@@ -1007,18 +938,6 @@ mod lease_heartbeat_tests {
         assert!(finalized);
         heartbeat.unwrap().stop().await;
         assert!(stopped.load(Ordering::Acquire));
-    }
-
-    #[tokio::test]
-    async fn lease_pool_remains_available_when_execution_pool_is_exhausted() {
-        let execution_pool = new_single_connection_execution_pool();
-        let _execution_connection = execution_pool.get().await.unwrap();
-
-        let lease_pool = new_task_lease_pool();
-        timeout(Duration::from_secs(5), lease_pool.get())
-            .await
-            .expect("lease checkout must not wait for the execution pool")
-            .expect("lease pool should connect to the test database");
     }
 
     #[tokio::test]

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -243,6 +243,7 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         "HistoryStorage",
         "UnifiedSearchStorage",
         "TaskQueueStorage",
+        "TaskExecutionStorage",
         "WorkflowStorage",
         "OperationalStorage",
         "sealed::CertifiedStorageBackend",
@@ -295,6 +296,22 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
             "computed-field lifecycle operation {operation} must use the common storage observer"
         );
     }
+    for operation in [
+        "claim",
+        "renew_lease",
+        "recover_leases",
+        "append_event",
+        "update_state",
+        "complete",
+        "fail",
+        "purge_export_outputs",
+        "purge_backup_outputs",
+    ] {
+        assert!(
+            compact_context.contains(&format!("\"task_execution\",\"{operation}\"")),
+            "task execution operation {operation} must use the common storage observer"
+        );
+    }
     assert!(
         compact_context.contains("\"object_aggregates\",\"aggregate\""),
         "object aggregation must use the common storage observer"
@@ -335,6 +352,37 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
             compact_context.contains(&format!("\"relations\",\"{operation}\"")),
             "relation operation {operation} must use the common storage observer"
         );
+    }
+}
+
+#[test]
+fn task_execution_consumers_do_not_import_postgres_task_state_helpers() {
+    let root = repository_root();
+    for file in [
+        "src/backups/mod.rs",
+        "src/exports/mod.rs",
+        "src/tasks/execution.rs",
+        "src/tasks/remote_call.rs",
+        "src/tasks/worker.rs",
+    ] {
+        let path = root.join(file);
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+        for forbidden in [
+            "TaskBackend",
+            "TaskStateUpdate",
+            "claim_next_queued_task",
+            "renew_task_lease(&pool",
+            "storage::capabilities::task",
+            "storage::postgres::operations::task::{",
+            "storage::postgres::operations::task::purge_expired_",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{} still imports PostgreSQL task state helper {forbidden}",
+                path.display()
+            );
+        }
     }
 }
 

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -45,10 +45,12 @@ use crate::storage::{
     StoragePersonalComputedFieldDelete, StoragePersonalComputedFieldListQuery,
     StoragePersonalComputedFieldUpdate, StorageRelatedDirection, StorageRelatedSort,
     StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
-    StorageSharedComputedFieldUpdate, StorageTaskCreateRequest, StorageTaskKind,
-    StorageTaskListQuery, StorageTaskOutputLookup, StorageTaskPageQuery, StorageTaskScopeSnapshot,
-    StorageTaskStatus, StorageVisibility, TaskQueueStorage, TokenRetentionStorage,
-    UnifiedSearchQuery, UnifiedSearchStorage,
+    StorageSharedComputedFieldUpdate, StorageTaskCompletion, StorageTaskCompletionArtifact,
+    StorageTaskCreateRequest, StorageTaskEventAppend, StorageTaskEventInput, StorageTaskFailure,
+    StorageTaskKind, StorageTaskLeaseDuration, StorageTaskListQuery, StorageTaskOutputLookup,
+    StorageTaskPageQuery, StorageTaskResultCounts, StorageTaskScopeSnapshot,
+    StorageTaskStateUpdate, StorageTaskStatus, StorageVisibility, TaskExecutionStorage,
+    TaskQueueStorage, TokenRetentionStorage, UnifiedSearchQuery, UnifiedSearchStorage,
 };
 use crate::traits::CanSave;
 
@@ -282,6 +284,161 @@ async fn every_available_storage_backend_supplies_the_complete_task_queue() {
     user.delete_without_events(pool.get_ref())
         .await
         .expect("task queue compatibility user should be removed");
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_supplies_the_complete_task_state_machine() {
+    let _permit = postgres_permit().await;
+    let pool = pool();
+    let user = crate::tests::create_user_with_params(
+        pool.get_ref(),
+        &prefix("task_execution_user"),
+        "testpassword",
+    )
+    .await;
+
+    for kind in StorageBackendKind::ALL {
+        match kind {
+            StorageBackendKind::Postgresql => {
+                let backend = StorageHandle::postgres(pool.get_ref().clone());
+                let mut fixture_ids = Vec::new();
+                for task_kind in StorageTaskKind::ALL {
+                    let task = backend
+                        .create_task(
+                            StorageTaskCreateRequest::builder(
+                                task_kind,
+                                user.id,
+                                serde_json::json!({"compatibility": true}),
+                                1,
+                            )
+                            .idempotency_key(Some(
+                                IdempotencyKey::new(prefix(&format!(
+                                    "task_execution_{}",
+                                    task_kind.as_str()
+                                )))
+                                .expect("compatibility idempotency key should be valid"),
+                            ))
+                            .request_hash(Some(prefix(&format!(
+                                "task_execution_hash_{}",
+                                task_kind.as_str()
+                            ))))
+                            .scope_snapshot(StorageTaskScopeSnapshot::unscoped())
+                            .build(10),
+                        )
+                        .await
+                        .expect("certified backend should create an executable task");
+                    fixture_ids.push(task.id());
+                }
+                crate::storage::postgres::with_connection(pool.get_ref(), async |conn| {
+                    use crate::schema::tasks::dsl::{created_at, id, tasks};
+                    diesel::update(tasks.filter(id.eq_any(&fixture_ids)))
+                        .set(
+                            created_at.eq(chrono::NaiveDate::from_ymd_opt(2000, 1, 1)
+                                .expect("compatibility date")
+                                .and_hms_opt(0, 0, 0)
+                                .expect("compatibility time")),
+                        )
+                        .execute(conn)
+                        .await
+                })
+                .await
+                .expect("compatibility tasks should be made claim-first");
+
+                let lease_duration = StorageTaskLeaseDuration::from_milliseconds(60_000)
+                    .expect("compatibility lease duration should be valid");
+                assert!(
+                    backend
+                        .recover_expired_task_leases(0)
+                        .await
+                        .expect("certified backend should recover expired claims")
+                        .is_empty()
+                );
+
+                let first = backend
+                    .claim_next_task(lease_duration)
+                    .await
+                    .expect("certified backend should claim the next task")
+                    .expect("a compatibility task should be claimable");
+                assert!(fixture_ids.contains(&first.task().id()));
+                assert!(
+                    backend
+                        .renew_task_lease(first.lease().clone(), lease_duration)
+                        .await
+                        .expect("certified backend should renew a live claim")
+                );
+                backend
+                    .append_task_event(StorageTaskEventAppend::new(
+                        first.lease().clone(),
+                        StorageTaskEventInput::new("running", "Compatibility event"),
+                    ))
+                    .await
+                    .expect("certified backend should append a claim-owned event");
+                backend
+                    .update_task_state(StorageTaskStateUpdate::new(
+                        first.lease().clone(),
+                        StorageTaskStatus::Running,
+                        StorageTaskResultCounts::new(0, 0, 0),
+                    ))
+                    .await
+                    .expect("certified backend should update claimed task state");
+                backend
+                    .complete_task(
+                        StorageTaskCompletion::new(
+                            StorageTaskStateUpdate::new(
+                                first.lease().clone(),
+                                StorageTaskStatus::Succeeded,
+                                StorageTaskResultCounts::new(1, 1, 0),
+                            ),
+                            StorageTaskEventInput::new("succeeded", "Compatibility completed"),
+                        )
+                        .artifact(StorageTaskCompletionArtifact::None),
+                    )
+                    .await
+                    .expect("certified backend should complete a claimed task");
+
+                let second = backend
+                    .claim_next_task(lease_duration)
+                    .await
+                    .expect("certified backend should claim another task")
+                    .expect("another compatibility task should be claimable");
+                assert!(fixture_ids.contains(&second.task().id()));
+                backend
+                    .fail_task(StorageTaskFailure::new(
+                        second.lease().clone(),
+                        "Compatibility failure",
+                        StorageTaskEventInput::new("failed", "Compatibility failure"),
+                    ))
+                    .await
+                    .expect("certified backend should fail a claimed task");
+
+                backend
+                    .purge_expired_export_outputs()
+                    .await
+                    .expect("certified backend should purge expired export outputs");
+                backend
+                    .purge_expired_backup_outputs()
+                    .await
+                    .expect("certified backend should purge expired backup outputs");
+
+                crate::storage::postgres::with_transaction(
+                    pool.get_ref(),
+                    async |conn| -> Result<(), crate::errors::ApiError> {
+                        use crate::schema::tasks::dsl::{id, tasks};
+                        diesel::delete(tasks.filter(id.eq_any(&fixture_ids)))
+                            .execute(conn)
+                            .await?;
+                        Ok(())
+                    },
+                )
+                .await
+                .expect("task execution compatibility fixtures should be removed");
+            }
+        }
+    }
+
+    user.delete_without_events(pool.get_ref())
+        .await
+        .expect("task execution compatibility user should be removed");
 }
 
 #[actix_web::test]

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -133,7 +133,7 @@ async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() 
 
     assert!(
         body.contains(
-            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"9\"} 1"
+            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"10\"} 1"
         )
     );
     assert!(body.contains(

--- a/tests/api_platform_suite/runtime_config.rs
+++ b/tests/api_platform_suite/runtime_config.rs
@@ -37,7 +37,7 @@ mod tests {
         let serialized = serde_json::to_string(&body).unwrap();
 
         assert_eq!(body["database"]["backend"], "postgresql");
-        assert_eq!(body["database"]["contract_version"], 9);
+        assert_eq!(body["database"]["contract_version"], 10);
         assert_eq!(
             body["database"]["capabilities"],
             serde_json::json!([
@@ -51,6 +51,7 @@ mod tests {
                 "temporal_history",
                 "unified_search",
                 "task_queue",
+                "task_execution",
                 "workflows",
                 "operations"
             ])


### PR DESCRIPTION
## Summary

- add a mandatory `TaskExecutionStorage` contract to `hubuum-storage-core`
- move worker claims, lease renewal and recovery, lifecycle events, active state updates, terminal completion, failure accounting, and output retention behind backend-neutral DTOs
- implement the complete contract in the PostgreSQL adapter and route import, export, backup, remote-call, and worker consumers through application services
- enforce bounded `task_execution/*` observation labels and separate export/backup cleanup operations so metrics retain correct failure attribution
- certify the state machine in the shared available-backend compatibility suite and forbid application consumers from importing PostgreSQL task-state helpers

## Rationale

Task queue submission and reads were already backend-neutral, but execution still exposed PostgreSQL claim tokens, task traits, pools, and state-update records to application workers. That left a selectable backend unable to implement task behavior without application code knowing its persistence model.

This layer makes execution a required backend capability. Claims now cross the boundary as a task DTO plus an opaque redacted token. The application can only carry that proof back to the backend, while lease SQL, row locking, durable timestamps, atomic task/output writes, and workflow result counting remain adapter-owned.

## Behavior and compatibility

- `StorageBackend` now requires all nine task-execution operations.
- PostgreSQL maps its adapter error at the storage boundary; application services map `StorageError` into `ApiError`.
- Completion stores a lifecycle event and optional kind-specific export or backup artifact atomically.
- Failure result counts are derived inside the backend.
- Lease renewal uses a dedicated one-connection pool so an exhausted execution pool cannot starve heartbeats.
- Stale workers cannot append lifecycle events after claim expiry or recovery.
- Export and backup retention are independently observed and metered.
- The administrator-visible storage contract advances from version `9` to `10` and reports the required `task_execution` capability.

## Breaking change

Administration and monitoring clients that match the storage contract version or exact capability list must accept contract version `10` and the new `task_execution` capability. No data migration or operator configuration change is required.

Part of #27.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- generated OpenAPI is byte-identical to `docs/openapi.json`
- Rust API, supply-chain, and CI change-classifier policy checks
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg "CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release" --tag hubuum-server:verify .`