### PR TITLE
Complete backup and task workflow storage boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,16 +27,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
-- **Breaking (administrator API):** the storage contract version is now `10`,
+- **Breaking (administrator API):** the storage contract version is now `11`,
   and the redacted administrator configuration reports independently enforced
   `catalog_queries`, `computed_object_queries`, `computed_field_lifecycle`,
   `object_aggregates`, `relation_queries`, `temporal_history`, and
-  `unified_search`, `task_queue`, and `task_execution` capabilities instead of
+  `unified_search`, `task_queue`, `task_execution`, and `backup_snapshots`
+  capabilities instead of
   the broader provisional `queries_and_history` label. Monitoring or
   administration clients matching the version or capability list must accept
   the new contract and labels. Task workers now carry opaque backend claims and
   use the mandatory execution contract for lease management, lifecycle events,
-  state changes, terminal artifacts, failure accounting, and output retention.
+  state changes, terminal artifacts (including remote-call results), failure
+  accounting, and output retention. Backup snapshots and computed-field rebuild
+  execution now also cross mandatory backend contracts instead of exposing
+  PostgreSQL operations to application workers.
 - Event worker and retention configuration validation now uses backend-neutral
   policy terminology, matching the storage traits and DTOs used by application
   workers instead of exposing database implementation language.

--- a/crates/hubuum-storage-core/src/backup_snapshot.rs
+++ b/crates/hubuum-storage-core/src/backup_snapshot.rs
@@ -1,0 +1,97 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::StorageError;
+
+/// Named logical sections in Hubuum's versioned full-system backup format.
+pub type StorageBackupSections = BTreeMap<String, Vec<Value>>;
+
+/// Canonical logical sections used to construct a full-system backup document.
+///
+/// Section names and row shapes belong to the versioned Hubuum backup format,
+/// not to the application consumer or a database driver. Every selectable
+/// backend must project its durable state into this representation.
+#[derive(Clone, PartialEq)]
+pub struct StorageBackupSnapshot {
+    state_sections: StorageBackupSections,
+    history_sections: Option<StorageBackupSections>,
+}
+
+impl StorageBackupSnapshot {
+    #[must_use]
+    pub const fn new(
+        state_sections: StorageBackupSections,
+        history_sections: Option<StorageBackupSections>,
+    ) -> Self {
+        Self {
+            state_sections,
+            history_sections,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (StorageBackupSections, Option<StorageBackupSections>) {
+        (self.state_sections, self.history_sections)
+    }
+}
+
+impl fmt::Debug for StorageBackupSnapshot {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageBackupSnapshot")
+            .field("state_section_count", &self.state_sections.len())
+            .field(
+                "state_row_count",
+                &self.state_sections.values().map(Vec::len).sum::<usize>(),
+            )
+            .field(
+                "history_section_count",
+                &self.history_sections.as_ref().map(BTreeMap::len),
+            )
+            .field(
+                "history_row_count",
+                &self
+                    .history_sections
+                    .as_ref()
+                    .map(|sections| sections.values().map(Vec::len).sum::<usize>()),
+            )
+            .finish()
+    }
+}
+
+/// Mandatory full-system snapshot behavior for every selectable backend.
+#[async_trait]
+pub trait BackupSnapshotStorage: Send + Sync {
+    async fn snapshot_backup(
+        &self,
+        include_history: bool,
+    ) -> Result<StorageBackupSnapshot, StorageError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_debug_reports_shape_without_row_content() {
+        let snapshot = StorageBackupSnapshot::new(
+            BTreeMap::from([(
+                "secret-state-section".to_string(),
+                vec![serde_json::json!({"secret": "state"})],
+            )]),
+            Some(BTreeMap::from([(
+                "secret-history-section".to_string(),
+                vec![serde_json::json!({"secret": "history"})],
+            )])),
+        );
+
+        let debug = format!("{snapshot:?}");
+
+        assert!(!debug.contains("secret"));
+        assert!(debug.contains("state_section_count: 1"));
+        assert!(debug.contains("history_row_count: Some(1)"));
+    }
+}

--- a/crates/hubuum-storage-core/src/computed_field_lifecycle.rs
+++ b/crates/hubuum-storage-core/src/computed_field_lifecycle.rs
@@ -6,7 +6,7 @@ use hubuum_events_core::EventContext;
 use hubuum_query::QueryOptions;
 use serde_json::Value;
 
-use crate::{StorageError, StorageRecordMetadata};
+use crate::{StorageError, StorageRecordMetadata, StorageTask, StorageTaskLease};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum StorageComputedFieldVisibility {
@@ -811,6 +811,13 @@ pub trait ComputedFieldLifecycleStorage: Send + Sync {
         &self,
         request: StorageComputedFieldRebuildRequest,
     ) -> Result<StorageClassComputationState, StorageError>;
+
+    /// Execute the backend-owned materialization workflow for a claimed
+    /// computed-field rebuild task.
+    async fn execute_computed_field_rebuild(
+        &self,
+        lease: StorageTaskLease,
+    ) -> Result<StorageTask, StorageError>;
 }
 
 #[cfg(test)]

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -5,6 +5,7 @@
 //! these values without reversing the dependency from storage into the server.
 
 mod authorization;
+mod backup_snapshot;
 mod catalog;
 mod computed_field_lifecycle;
 mod computed_objects;
@@ -26,6 +27,7 @@ pub use authorization::{
     AuthorizationGroupProfile, AuthorizationGroupSyncState, AuthorizationPermission,
     AuthorizationPolicySnapshotRow, AuthorizationPrincipal, AuthorizationStorage,
 };
+pub use backup_snapshot::{BackupSnapshotStorage, StorageBackupSections, StorageBackupSnapshot};
 pub use catalog::{CatalogListQuery, CatalogPage, CatalogStorage};
 pub use computed_field_lifecycle::{
     ComputedFieldLifecycleStorage, StorageClassComputationState, StorageComputedFieldDefinition,
@@ -84,10 +86,12 @@ pub use relation_query::{
 pub use task_execution::{
     StorageBackupTaskArtifact, StorageExportTaskArtifact, StorageExportTaskArtifactBuilder,
     StorageExportTaskArtifactContent, StorageExportTaskArtifactIdentity,
-    StorageExportTaskArtifactReport, StorageTaskClaim, StorageTaskClaimToken,
-    StorageTaskCompletion, StorageTaskCompletionArtifact, StorageTaskEventAppend,
-    StorageTaskEventInput, StorageTaskFailure, StorageTaskLease, StorageTaskLeaseDuration,
-    StorageTaskResultCounts, StorageTaskStateUpdate, TaskExecutionStorage,
+    StorageExportTaskArtifactReport, StorageRemoteCallArtifactOutcome,
+    StorageRemoteCallArtifactResponse, StorageRemoteCallArtifactTarget,
+    StorageRemoteCallTaskArtifact, StorageTaskClaim, StorageTaskClaimToken, StorageTaskCompletion,
+    StorageTaskCompletionArtifact, StorageTaskEventAppend, StorageTaskEventInput,
+    StorageTaskFailure, StorageTaskLease, StorageTaskLeaseDuration, StorageTaskResultCounts,
+    StorageTaskStateUpdate, TaskExecutionStorage,
 };
 pub use task_queue::{
     StorageBackupOutput, StorageBackupOutputSummary, StorageExportOutput,
@@ -117,7 +121,7 @@ use std::fmt;
 ///
 /// Increment this when a selectable backend must implement a new capability
 /// family or when an existing family's externally observable semantics change.
-pub const STORAGE_CONTRACT_VERSION: u16 = 10;
+pub const STORAGE_CONTRACT_VERSION: u16 = 11;
 
 /// Stable identity of a selectable storage backend.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -151,12 +155,13 @@ pub enum StorageCapability {
     UnifiedSearch,
     TaskQueue,
     TaskExecution,
+    BackupSnapshots,
     Workflows,
     Operations,
 }
 
 impl StorageCapability {
-    pub const ALL: [Self; 13] = [
+    pub const ALL: [Self; 14] = [
         Self::DomainLifecycle,
         Self::CatalogQueries,
         Self::ComputedObjectQueries,
@@ -168,6 +173,7 @@ impl StorageCapability {
         Self::UnifiedSearch,
         Self::TaskQueue,
         Self::TaskExecution,
+        Self::BackupSnapshots,
         Self::Workflows,
         Self::Operations,
     ];
@@ -186,6 +192,7 @@ impl StorageCapability {
             Self::UnifiedSearch => "unified_search",
             Self::TaskQueue => "task_queue",
             Self::TaskExecution => "task_execution",
+            Self::BackupSnapshots => "backup_snapshots",
             Self::Workflows => "workflows",
             Self::Operations => "operations",
         }
@@ -353,6 +360,7 @@ mod tests {
                 "unified_search",
                 "task_queue",
                 "task_execution",
+                "backup_snapshots",
                 "workflows",
                 "operations",
             ]

--- a/crates/hubuum-storage-core/src/task_execution.rs
+++ b/crates/hubuum-storage-core/src/task_execution.rs
@@ -491,11 +491,172 @@ impl fmt::Debug for StorageBackupTaskArtifact {
     }
 }
 
+/// Target and rendered request facts stored for a remote-call task.
+#[derive(Clone, PartialEq, Eq)]
+pub struct StorageRemoteCallArtifactTarget {
+    target_id: Option<i32>,
+    subject_type: String,
+    subject_id: i32,
+    method: String,
+    rendered_url: String,
+}
+
+impl StorageRemoteCallArtifactTarget {
+    #[must_use]
+    pub fn new(
+        target_id: Option<i32>,
+        subject_type: impl Into<String>,
+        subject_id: i32,
+        method: impl Into<String>,
+        rendered_url: impl Into<String>,
+    ) -> Self {
+        Self {
+            target_id,
+            subject_type: subject_type.into(),
+            subject_id,
+            method: method.into(),
+            rendered_url: rendered_url.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (Option<i32>, String, i32, String, String) {
+        (
+            self.target_id,
+            self.subject_type,
+            self.subject_id,
+            self.method,
+            self.rendered_url,
+        )
+    }
+}
+
+impl fmt::Debug for StorageRemoteCallArtifactTarget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageRemoteCallArtifactTarget")
+            .field("has_target", &self.target_id.is_some())
+            .field("method", &self.method)
+            .field("identity", &"[redacted]")
+            .field("rendered_url", &"[redacted]")
+            .finish()
+    }
+}
+
+/// Sanitized response material retained for a remote-call task.
+#[derive(Clone, PartialEq)]
+pub struct StorageRemoteCallArtifactResponse {
+    status: Option<i32>,
+    headers: Option<Value>,
+    body_preview: Option<String>,
+}
+
+impl StorageRemoteCallArtifactResponse {
+    #[must_use]
+    pub const fn new(
+        status: Option<i32>,
+        headers: Option<Value>,
+        body_preview: Option<String>,
+    ) -> Self {
+        Self {
+            status,
+            headers,
+            body_preview,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (Option<i32>, Option<Value>, Option<String>) {
+        (self.status, self.headers, self.body_preview)
+    }
+}
+
+impl fmt::Debug for StorageRemoteCallArtifactResponse {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageRemoteCallArtifactResponse")
+            .field("status", &self.status)
+            .field("has_headers", &self.headers.is_some())
+            .field("has_body_preview", &self.body_preview.is_some())
+            .finish()
+    }
+}
+
+/// Terminal outcome stored with a remote-call task.
+#[derive(Clone, PartialEq, Eq)]
+pub struct StorageRemoteCallArtifactOutcome {
+    duration_ms: i32,
+    success: bool,
+    error: Option<String>,
+}
+
+impl StorageRemoteCallArtifactOutcome {
+    #[must_use]
+    pub const fn new(duration_ms: i32, success: bool, error: Option<String>) -> Self {
+        Self {
+            duration_ms,
+            success,
+            error,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (i32, bool, Option<String>) {
+        (self.duration_ms, self.success, self.error)
+    }
+}
+
+impl fmt::Debug for StorageRemoteCallArtifactOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageRemoteCallArtifactOutcome")
+            .field("duration_ms", &self.duration_ms)
+            .field("success", &self.success)
+            .field("has_error", &self.error.is_some())
+            .finish()
+    }
+}
+
+/// Remote-call result stored atomically with the terminal task transition.
+#[derive(Clone, Debug, PartialEq)]
+pub struct StorageRemoteCallTaskArtifact {
+    target: StorageRemoteCallArtifactTarget,
+    response: StorageRemoteCallArtifactResponse,
+    outcome: StorageRemoteCallArtifactOutcome,
+}
+
+impl StorageRemoteCallTaskArtifact {
+    #[must_use]
+    pub const fn new(
+        target: StorageRemoteCallArtifactTarget,
+        response: StorageRemoteCallArtifactResponse,
+        outcome: StorageRemoteCallArtifactOutcome,
+    ) -> Self {
+        Self {
+            target,
+            response,
+            outcome,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        StorageRemoteCallArtifactTarget,
+        StorageRemoteCallArtifactResponse,
+        StorageRemoteCallArtifactOutcome,
+    ) {
+        (self.target, self.response, self.outcome)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum StorageTaskCompletionArtifact {
     None,
     Export(StorageExportTaskArtifact),
     Backup(StorageBackupTaskArtifact),
+    RemoteCall(StorageRemoteCallTaskArtifact),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -630,14 +791,38 @@ mod tests {
         )
         .output(Some(serde_json::json!({"secret": "output"})), None)
         .build();
+        let remote_artifact = StorageRemoteCallTaskArtifact::new(
+            StorageRemoteCallArtifactTarget::new(
+                Some(7),
+                "object-secret",
+                8,
+                "POST",
+                "https://example.invalid/?secret=url",
+            ),
+            StorageRemoteCallArtifactResponse::new(
+                Some(200),
+                Some(serde_json::json!({"secret": "headers"})),
+                Some("secret response body".to_string()),
+            ),
+            StorageRemoteCallArtifactOutcome::new(
+                9,
+                false,
+                Some("secret remote error".to_string()),
+            ),
+        );
 
-        let debug = format!("{claim:?} {artifact:?}");
+        let debug = format!("{claim:?} {artifact:?} {remote_artifact:?}");
 
         for secret in [
             "secret-backend-claim",
             "secret\": \"payload",
             "secret\": \"metadata",
             "secret\": \"output",
+            "object-secret",
+            "secret=url",
+            "secret\": \"headers",
+            "secret response body",
+            "secret remote error",
         ] {
             assert!(!debug.contains(secret));
         }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -19370,7 +19370,7 @@
       },
       "BackupHistory": {
         "type": "object",
-        "description": "Privileged, restore-only table snapshots. In backup version 4, each section\nname and row shape corresponds to the PostgreSQL table restored from it.\nThese are versioned disaster-recovery internals, not portable import data.",
+        "description": "Privileged, restore-only logical snapshots. Backup version 4 defines one\ncanonical row shape per section; the PostgreSQL restore adapter maps those\nshapes to its tables. Other selectable adapters must project to and restore\nfrom the same format. These are versioned disaster-recovery internals, not\nportable import data.",
         "required": [
           "sections"
         ],
@@ -19410,7 +19410,7 @@
       },
       "BackupState": {
         "type": "object",
-        "description": "Exact logical rows used by the destructive full-system restore path.",
+        "description": "Canonical logical rows used by the destructive full-system restore path.",
         "required": [
           "sections"
         ],

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -64,7 +64,7 @@ satisfy every capability family below before `StorageHandle` can compose it:
 | Domain lifecycle | Collection, class, object, class-relation, and object-relation resolution and lifecycle behavior |
 | Catalog queries | Permission- and resource-scoped collection, class, and object filtering, cursor paging, and optional exact counts |
 | Computed object queries | Computed filtering and sorting, exact counts, cursor-boundary snapshots, and computed-value enrichment |
-| Computed-field lifecycle | Shared and personal definition CRUD, class computation state, rebuild scheduling, and atomic audit behavior |
+| Computed-field lifecycle | Shared and personal definition CRUD, class computation state, rebuild scheduling and claimed execution, and atomic audit behavior |
 | Object aggregates | Permission-scoped grouping, numeric measures, stable aggregate cursors, and bounded delegated-policy batching |
 | Relation queries | Relation filtering and paging, endpoint-set queries, graph traversal, and export-oriented multi-root expansion |
 | Identity and authorization data | Principals, credentials, memberships, grants, and data needed by configured authorization providers |
@@ -72,7 +72,8 @@ satisfy every capability family below before `StorageHandle` can compose it:
 | Unified search | Ranked collection, class, and object search with stable per-kind cursors and token visibility pushdown |
 | Task queue | Idempotent task submission, access facts, task/event/result paging, and retained export and backup output reads |
 | Task execution | Opaque claims, lease renewal and recovery, claim-checked events and state changes, atomic terminal artifacts, failure accounting, and output retention |
-| Workflows | Import, restore, backup, export, remote-call, and reindex execution with backend-owned atomic entity mutations |
+| Backup snapshots | Canonical state and optional history sections read from one consistent backend snapshot |
+| Workflows | Remaining import, restore, export-hydration, and remote-target operations with backend-owned atomic entity mutations |
 | Operations | Probes, metrics snapshots, retention, event delivery, locking, and worker coordination |
 
 The families are not feature flags and the admin configuration does not report
@@ -89,10 +90,12 @@ now been replaced by the real `AuthenticationStorage`,
 `ComputedObjectStorage`, `ComputedFieldLifecycleStorage`,
 `ObjectAggregateStorage`, `RelationQueryStorage`, and `UnifiedSearchStorage`
 contracts. `TaskQueueStorage` replaces task submission and reads, while
-`TaskExecutionStorage` owns the complete worker claim and state machine. The
-remaining workflow-specific entity mutations stay behind the workflow gate
-until their complete contracts and compatibility tests land. No family is
-considered complete merely because a marker exists.
+`TaskExecutionStorage` owns the complete worker claim and state machine.
+`BackupSnapshotStorage` owns consistent full-system reads, and computed rebuild
+execution is part of `ComputedFieldLifecycleStorage`. Remaining import,
+restore, export-hydration, and remote-target workflow operations stay behind
+the workflow gate until their complete contracts and compatibility tests land.
+No family is considered complete merely because a marker exists.
 
 PostgreSQL query implementations live in
 `src/storage/postgres/operations/*`. Separating their persistence rows from
@@ -246,28 +249,36 @@ both operations.
 
 `ComputedFieldLifecycleStorage` owns the complete application-facing
 definition lifecycle: class state, shared and personal listing, point lookup,
-shared and personal create/update/delete, and explicit rebuild scheduling.
+shared and personal create/update/delete, explicit rebuild scheduling, and
+execution of the backend-owned rebuild workflow under an opaque task lease.
 Requests and results cross the boundary as private-field DTOs; persistence
 rows, visibility strings, revisions, Diesel transactions, audit inserts, task
 cancellation, and rebuild enqueueing remain PostgreSQL adapter details. The
 application service validates API models, converts DTOs into response models,
 and owns the pure preview evaluator. Every opaque-handle entry point uses a
-bounded `computed_fields/*` observation label. Reindex task execution is a
-workflow responsibility and will cross the boundary with the complete task
-state machine rather than leaking worker persistence into this lifecycle
-trait.
+bounded `computed_fields/*` observation label. Each rebuild batch validates and
+locks the live task lease in the same transaction as its materialization
+writes, so a stale worker cannot commit computed data after losing its claim.
 
 `TaskExecutionStorage` owns every persistence transition needed by task
 workers. Claims cross the boundary as a task DTO plus an opaque, redacted token;
 the application can only return that token for renewal, events, state updates,
 completion, or failure. PostgreSQL's UUID representation, lease SQL, durable
 timestamps, row locks, task/output insert records, and workflow result counting
-remain adapter-private. Completion stores an optional export or backup artifact
-and the terminal lifecycle event in the same backend operation. Failure counts
+remain adapter-private. Completion stores an optional export, backup, or
+remote-call artifact and the terminal lifecycle event in the same backend
+operation. Failure counts
 are derived by the backend so the application never queries workflow result
 tables. The opaque handle observes all nine entry points with bounded
 `task_execution/*` labels, and every selectable backend must pass the shared
 state-machine compatibility test.
+
+`BackupSnapshotStorage` projects live backend state into Hubuum's canonical,
+versioned backup document sections. The application owns document metadata,
+serialization, hashing, and retention artifacts; adapters own consistent reads
+and the mapping from their private representation into those logical sections.
+Both state-only and history-inclusive snapshots cross private-field DTOs and
+are observed with the bounded `backup_snapshots/snapshot` label.
 
 `ObjectAggregateStorage` owns filtered grouping, numeric measures, computed
 aggregate snapshots, exact group counts, and stable aggregate cursors. The
@@ -430,9 +441,9 @@ The first workspace boundaries are now in place:
   DTOs, operational snapshot DTOs, and the extracted authentication,
   authorization, catalog-query, temporal-history, unified-search, operational
   state, computed-object, computed-field lifecycle, object-aggregate, task-queue,
-  relation-query, event-health, event-fan-out, event-retention, and
-  token-retention traits without application, transport, or driver
-  dependencies.
+  task-execution, backup-snapshot, relation-query, event-health, event-fan-out,
+  event-retention, and token-retention traits without application, transport,
+  or driver dependencies.
 - `hubuum-storage-postgres` owns PostgreSQL pool construction, TLS connection
   setup, safe endpoint diagnostics, JSONB validation, query capture, and its
   crate-owned pool-construction error.

--- a/src/backups/mod.rs
+++ b/src/backups/mod.rs
@@ -11,8 +11,8 @@ use crate::models::{
     CURRENT_BACKUP_VERSION, NewTaskEventRecord, TaskResultCounts, TaskStatus,
 };
 use crate::permissions::{AppContext, PrincipalRef};
+use crate::services::backups::snapshot_backup;
 use crate::services::tasks::{ClaimedTask, TaskStateChange, complete_task};
-use crate::storage::capabilities::backup::snapshot_backup_db;
 use crate::storage::{StorageBackupTaskArtifact, StorageTaskCompletionArtifact};
 use crate::traits::AuthzSubject;
 
@@ -93,11 +93,11 @@ fn build_manifest(state: &BackupState, history: Option<&BackupHistory>) -> Backu
 }
 
 pub async fn create_backup_document(
-    pool: &impl crate::storage::StorageContext,
+    backend: &impl crate::storage::StorageContext,
     request: &BackupRequest,
 ) -> Result<BackupDocument, ApiError> {
     let include_history = request.include_history;
-    let (state, history) = snapshot_backup_db(pool, include_history).await?;
+    let (state, history) = snapshot_backup(backend, include_history).await?;
     let manifest = build_manifest(&state, history.as_ref());
     Ok(BackupDocument {
         backup_version: CURRENT_BACKUP_VERSION,

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -453,7 +453,7 @@ mod tests {
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
         assert!(json.contains("\"backend\":\"postgresql\""));
-        assert!(json.contains("\"contract_version\":10"));
+        assert!(json.contains("\"contract_version\":11"));
         assert!(json.contains("\"catalog_queries\""));
         assert!(json.contains("\"computed_object_queries\""));
         assert!(json.contains("\"computed_field_lifecycle\""));
@@ -463,6 +463,7 @@ mod tests {
         assert!(json.contains("\"unified_search\""));
         assert!(json.contains("\"task_queue\""));
         assert!(json.contains("\"task_execution\""));
+        assert!(json.contains("\"backup_snapshots\""));
         assert!(!debug.contains("secret-password"));
         assert!(!debug.contains("correct horse battery staple"));
     }

--- a/src/models/backup.rs
+++ b/src/models/backup.rs
@@ -167,9 +167,11 @@ pub struct BackupManifest {
     pub exclusions: Vec<String>,
 }
 
-/// Privileged, restore-only table snapshots. In backup version 4, each section
-/// name and row shape corresponds to the PostgreSQL table restored from it.
-/// These are versioned disaster-recovery internals, not portable import data.
+/// Privileged, restore-only logical snapshots. Backup version 4 defines one
+/// canonical row shape per section; the PostgreSQL restore adapter maps those
+/// shapes to its tables. Other selectable adapters must project to and restore
+/// from the same format. These are versioned disaster-recovery internals, not
+/// portable import data.
 #[derive(Clone, Serialize, Deserialize, PartialEq, ToSchema, Default)]
 pub struct BackupHistory {
     #[schema(value_type = Object)]
@@ -189,7 +191,7 @@ impl fmt::Debug for BackupHistory {
     }
 }
 
-/// Exact logical rows used by the destructive full-system restore path.
+/// Canonical logical rows used by the destructive full-system restore path.
 #[derive(Clone, Serialize, Deserialize, PartialEq, ToSchema, Default)]
 pub struct BackupState {
     #[schema(value_type = Object)]

--- a/src/services/backups.rs
+++ b/src/services/backups.rs
@@ -1,0 +1,19 @@
+use crate::errors::ApiError;
+use crate::models::{BackupHistory, BackupState};
+use crate::storage::{BackupSnapshotStorage, StorageContext, storage_handle};
+
+pub(crate) async fn snapshot_backup(
+    backend: &impl StorageContext,
+    include_history: bool,
+) -> Result<(BackupState, Option<BackupHistory>), ApiError> {
+    let (state_sections, history_sections) = storage_handle(backend)
+        .snapshot_backup(include_history)
+        .await?
+        .into_parts();
+    Ok((
+        BackupState {
+            sections: state_sections,
+        },
+        history_sections.map(|sections| BackupHistory { sections }),
+    ))
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod backups;
 pub(crate) mod catalog;
 mod class_relations;
 mod classes;

--- a/src/services/tasks.rs
+++ b/src/services/tasks.rs
@@ -15,14 +15,15 @@ use crate::permissions::{
     PermissionDecision, PrincipalRef, ResourceAttrs, ResourceKind, ResourceRef,
 };
 use crate::storage::{
-    AuthenticationStorage, StorageBackupOutput, StorageBackupOutputSummary, StorageContext,
-    StorageExportOutput, StorageExportOutputSummary, StorageImportTaskResult, StorageTask,
-    StorageTaskClaim, StorageTaskCompletion, StorageTaskCompletionArtifact,
-    StorageTaskCreateRequest, StorageTaskEvent, StorageTaskEventAppend, StorageTaskEventInput,
-    StorageTaskFailure, StorageTaskKind, StorageTaskLease, StorageTaskLeaseDuration,
-    StorageTaskListQuery, StorageTaskOutputLookup, StorageTaskPageQuery, StorageTaskResultCounts,
-    StorageTaskScopeSnapshot, StorageTaskStateUpdate, StorageTaskStatus, TaskExecutionStorage,
-    TaskQueueStorage, storage_handle,
+    AuthenticationStorage, ComputedFieldLifecycleStorage, StorageBackupOutput,
+    StorageBackupOutputSummary, StorageContext, StorageExportOutput, StorageExportOutputSummary,
+    StorageImportTaskResult, StorageTask, StorageTaskClaim, StorageTaskCompletion,
+    StorageTaskCompletionArtifact, StorageTaskCreateRequest, StorageTaskEvent,
+    StorageTaskEventAppend, StorageTaskEventInput, StorageTaskFailure, StorageTaskKind,
+    StorageTaskLease, StorageTaskLeaseDuration, StorageTaskListQuery, StorageTaskOutputLookup,
+    StorageTaskPageQuery, StorageTaskResultCounts, StorageTaskScopeSnapshot,
+    StorageTaskStateUpdate, StorageTaskStatus, TaskExecutionStorage, TaskQueueStorage,
+    storage_handle,
 };
 use crate::traits::AuthzSubject;
 
@@ -265,6 +266,17 @@ pub(crate) async fn purge_expired_backup_outputs(
         .purge_expired_backup_outputs()
         .await
         .map_err(ApiError::from)
+}
+
+pub(crate) async fn execute_computed_field_rebuild(
+    backend: &impl StorageContext,
+    task: &ClaimedTask,
+) -> Result<TaskRecord, ApiError> {
+    storage_handle(backend)
+        .execute_computed_field_rebuild(task.lease.clone())
+        .await
+        .map_err(ApiError::from)
+        .and_then(task_from_storage)
 }
 
 impl TaskSubmission {

--- a/src/storage/capabilities.rs
+++ b/src/storage/capabilities.rs
@@ -19,10 +19,6 @@ pub(crate) mod authz {
     pub use crate::traits::{scope_allows, scope_allows_resource, scope_allows_resources};
 }
 
-pub(crate) mod backup {
-    pub(crate) use crate::storage::postgres::operations::backup::snapshot_backup_db;
-}
-
 pub(crate) mod collection {
     pub(crate) use crate::storage::postgres::operations::collection::collection_permission_set_from_backend;
 }
@@ -89,7 +85,7 @@ pub(crate) mod relations {
 pub(crate) mod remote_target {
     pub(crate) use crate::storage::postgres::operations::remote_target::{
         DeleteRemoteTargetRecord, SaveRemoteTargetRecord, UpdateRemoteTargetRecord,
-        emit_remote_target_invoked_event, insert_remote_call_result,
+        emit_remote_target_invoked_event,
     };
 }
 

--- a/src/storage/context.rs
+++ b/src/storage/context.rs
@@ -12,26 +12,26 @@ use crate::storage::{
     AuthorizationCollectionGrantListQuery, AuthorizationCollectionsQuery, AuthorizationGrant,
     AuthorizationGrantKey, AuthorizationGrantMutation, AuthorizationGroup,
     AuthorizationGroupGrantPage, AuthorizationGroupMembershipQuery, AuthorizationPolicySnapshotRow,
-    AuthorizationPrincipal, AuthorizationStorage, BidirectionalRelatedObjectsQuery,
-    CatalogListQuery, CatalogPage, CatalogStorage, ComputedFieldLifecycleStorage,
-    ComputedObjectEnrichmentQuery, ComputedObjectListQuery, ComputedObjectPage,
-    ComputedObjectStorage, DynLifecycleStorage, EventArchive, EventDeliveryBatch,
-    EventDeliveryClaim, EventDeliveryHealthSnapshot, EventDeliveryStorage, EventFanoutStorage,
-    EventHealthStorage, EventMetricsSnapshot, EventRetentionStorage, EventRetentionSummary,
-    ExportTemplateHistoryRecord, HistoryAsOfQuery, HistoryListQuery, HistoryPage,
-    HistoryPrincipalName, HistoryStorage, InventoryGaugeSnapshot, MetricsStorage,
+    AuthorizationPrincipal, AuthorizationStorage, BackupSnapshotStorage,
+    BidirectionalRelatedObjectsQuery, CatalogListQuery, CatalogPage, CatalogStorage,
+    ComputedFieldLifecycleStorage, ComputedObjectEnrichmentQuery, ComputedObjectListQuery,
+    ComputedObjectPage, ComputedObjectStorage, DynLifecycleStorage, EventArchive,
+    EventDeliveryBatch, EventDeliveryClaim, EventDeliveryHealthSnapshot, EventDeliveryStorage,
+    EventFanoutStorage, EventHealthStorage, EventMetricsSnapshot, EventRetentionStorage,
+    EventRetentionSummary, ExportTemplateHistoryRecord, HistoryAsOfQuery, HistoryListQuery,
+    HistoryPage, HistoryPrincipalName, HistoryStorage, InventoryGaugeSnapshot, MetricsStorage,
     ObjectAggregateAuthorizer, ObjectAggregateStorage, ObjectAggregateStorageQuery,
     ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectHistoryRecord,
     ObjectRelationsTouchingIdsQuery, OperationalStateStorage, PostgresStorage, ReadinessSnapshot,
     RelatedObjectsForRootsQuery, RelationGraphQuery, RelationIdsQuery, RelationListQuery,
     RelationPage, RelationQueryStorage, RelationTouchingQuery, RemoteTargetHistoryRecord,
     StorageBackend, StorageBackendDescriptor, StorageBackupOutput, StorageBackupOutputSummary,
-    StorageClass, StorageClassComputationState, StorageClassGraphRow, StorageClassRelation,
-    StorageCollection, StorageComputedFieldDefinition, StorageComputedFieldMutation,
-    StorageComputedFieldPage, StorageComputedFieldRebuildRequest, StorageComputedObject,
-    StorageError, StorageExportOutput, StorageExportOutputSummary, StorageImportTaskResultPage,
-    StorageObject, StorageObjectAggregatePage, StorageObjectGraphRow, StorageObjectRelation,
-    StoragePersonalComputedFieldCreate, StoragePersonalComputedFieldDelete,
+    StorageBackupSnapshot, StorageClass, StorageClassComputationState, StorageClassGraphRow,
+    StorageClassRelation, StorageCollection, StorageComputedFieldDefinition,
+    StorageComputedFieldMutation, StorageComputedFieldPage, StorageComputedFieldRebuildRequest,
+    StorageComputedObject, StorageError, StorageExportOutput, StorageExportOutputSummary,
+    StorageImportTaskResultPage, StorageObject, StorageObjectAggregatePage, StorageObjectGraphRow,
+    StorageObjectRelation, StoragePersonalComputedFieldCreate, StoragePersonalComputedFieldDelete,
     StoragePersonalComputedFieldListQuery, StoragePersonalComputedFieldUpdate, StoragePoolState,
     StorageRelatedObjectForRootRow, StorageRelatedObjectIncludeRow,
     StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
@@ -911,6 +911,23 @@ impl TaskExecutionStorage for StorageHandle {
 }
 
 #[async_trait]
+impl BackupSnapshotStorage for StorageHandle {
+    async fn snapshot_backup(
+        &self,
+        include_history: bool,
+    ) -> Result<StorageBackupSnapshot, StorageError> {
+        observe_storage_call(self.backend_name(), "backup_snapshots", "snapshot", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.snapshot_backup(include_history).await
+                }
+            }
+        })
+        .await
+    }
+}
+
+#[async_trait]
 impl ComputedFieldLifecycleStorage for StorageHandle {
     async fn computed_field_state(
         &self,
@@ -1104,6 +1121,25 @@ impl ComputedFieldLifecycleStorage for StorageHandle {
                 match &self.implementation {
                     BackendImplementation::Postgresql(backend) => {
                         backend.request_computed_field_rebuild(request).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn execute_computed_field_rebuild(
+        &self,
+        lease: StorageTaskLease,
+    ) -> Result<StorageTask, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "computed_fields",
+            "execute_rebuild",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.execute_computed_field_rebuild(lease).await
                     }
                 }
             },

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
 use super::{
-    AuthenticationStorage, AuthorizationStorage, CatalogStorage, ClassRelationStore, ClassStore,
-    CollectionStore, ComputedFieldLifecycleStorage, ComputedObjectStorage, EventDeliveryStorage,
-    EventFanoutStorage, EventHealthStorage, EventRetentionStorage, HistoryStorage, MetricsStorage,
-    ObjectAggregateStorage, ObjectRelationStore, ObjectStore, OperationalStateStorage,
-    PostgresStorage, RelationQueryStorage, TaskExecutionStorage, TaskQueueStorage,
-    TokenRetentionStorage, UnifiedSearchStorage, observed::ObservedLifecycleStorage,
+    AuthenticationStorage, AuthorizationStorage, BackupSnapshotStorage, CatalogStorage,
+    ClassRelationStore, ClassStore, CollectionStore, ComputedFieldLifecycleStorage,
+    ComputedObjectStorage, EventDeliveryStorage, EventFanoutStorage, EventHealthStorage,
+    EventRetentionStorage, HistoryStorage, MetricsStorage, ObjectAggregateStorage,
+    ObjectRelationStore, ObjectStore, OperationalStateStorage, PostgresStorage,
+    RelationQueryStorage, TaskExecutionStorage, TaskQueueStorage, TokenRetentionStorage,
+    UnifiedSearchStorage, observed::ObservedLifecycleStorage,
 };
 
 #[cfg(test)]
@@ -80,6 +81,7 @@ pub(crate) trait StorageBackend:
     + UnifiedSearchStorage
     + TaskQueueStorage
     + TaskExecutionStorage
+    + BackupSnapshotStorage
     + WorkflowStorage
     + OperationalStorage
     + sealed::CertifiedStorageBackend
@@ -151,6 +153,7 @@ mod tests {
                 "unified_search",
                 "task_queue",
                 "task_execution",
+                "backup_snapshots",
                 "workflows",
                 "operations",
             ]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -59,24 +59,26 @@ pub(crate) use hubuum_storage_core::{
     StorageObjectRelation, StoragePersonalComputedFieldCreate, StoragePersonalComputedFieldDelete,
     StoragePersonalComputedFieldListQuery, StoragePersonalComputedFieldUpdate,
     StorageRecordMetadata, StorageRelatedDirection, StorageRelatedObjectForRootRow,
-    StorageRelatedObjectIncludeRow, StorageRelatedSort, StorageResourceScope,
-    StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
-    StorageSharedComputedFieldUpdate, StorageSharedComputedScope, StorageTask, StorageTaskAccess,
-    StorageTaskClaim, StorageTaskClaimToken, StorageTaskCompletion, StorageTaskCompletionArtifact,
-    StorageTaskCreateRequest, StorageTaskDurations, StorageTaskEvent, StorageTaskEventAppend,
-    StorageTaskEventInput, StorageTaskEventPage, StorageTaskFailure, StorageTaskKind,
-    StorageTaskLease, StorageTaskLeaseDuration, StorageTaskListQuery, StorageTaskOutputLookup,
-    StorageTaskPage, StorageTaskPageQuery, StorageTaskProgress, StorageTaskResultCounts,
-    StorageTaskScopeSnapshot, StorageTaskStateUpdate, StorageTaskStatus, StorageVisibility,
-    TaskExecutionStorage, TaskQueueStorage, UnifiedSearchClass, UnifiedSearchCollection,
-    UnifiedSearchCursor, UnifiedSearchObject, UnifiedSearchQuery, UnifiedSearchStorage,
+    StorageRelatedObjectIncludeRow, StorageRelatedSort, StorageRemoteCallArtifactOutcome,
+    StorageRemoteCallArtifactResponse, StorageRemoteCallArtifactTarget,
+    StorageRemoteCallTaskArtifact, StorageResourceScope, StorageSharedComputedFieldCreate,
+    StorageSharedComputedFieldDelete, StorageSharedComputedFieldUpdate, StorageSharedComputedScope,
+    StorageTask, StorageTaskAccess, StorageTaskClaim, StorageTaskClaimToken, StorageTaskCompletion,
+    StorageTaskCompletionArtifact, StorageTaskCreateRequest, StorageTaskDurations,
+    StorageTaskEvent, StorageTaskEventAppend, StorageTaskEventInput, StorageTaskEventPage,
+    StorageTaskFailure, StorageTaskKind, StorageTaskLease, StorageTaskLeaseDuration,
+    StorageTaskListQuery, StorageTaskOutputLookup, StorageTaskPage, StorageTaskPageQuery,
+    StorageTaskProgress, StorageTaskResultCounts, StorageTaskScopeSnapshot, StorageTaskStateUpdate,
+    StorageTaskStatus, StorageVisibility, TaskExecutionStorage, TaskQueueStorage,
+    UnifiedSearchClass, UnifiedSearchCollection, UnifiedSearchCursor, UnifiedSearchObject,
+    UnifiedSearchQuery, UnifiedSearchStorage,
+};
+pub(crate) use hubuum_storage_core::{
+    BackupSnapshotStorage, StorageBackupOutput, StorageBackupOutputSummary, StorageBackupSnapshot,
+    StorageBackupTaskArtifact, StorageExportOutput, StorageExportOutputSummary,
+    StorageExportTaskArtifact, StorageImportTaskResult, StorageImportTaskResultPage,
 };
 pub(crate) use hubuum_storage_core::{ClassHistoryRecord, CollectionHistoryRecord};
-pub(crate) use hubuum_storage_core::{
-    StorageBackupOutput, StorageBackupOutputSummary, StorageBackupTaskArtifact,
-    StorageExportOutput, StorageExportOutputSummary, StorageExportTaskArtifact,
-    StorageImportTaskResult, StorageImportTaskResultPage,
-};
 pub(crate) use hubuum_storage_core::{StorageError, StorageErrorKind};
 #[cfg(test)]
 pub(crate) use memory::MemoryStorageModel;

--- a/src/storage/postgres/backup_snapshot.rs
+++ b/src/storage/postgres/backup_snapshot.rs
@@ -1,0 +1,22 @@
+use async_trait::async_trait;
+
+use crate::storage::{BackupSnapshotStorage, StorageBackupSnapshot, StorageError};
+
+use super::PostgresStorage;
+use super::error::map_postgres_error;
+use super::operations::backup::snapshot_backup_db;
+
+#[async_trait]
+impl BackupSnapshotStorage for PostgresStorage {
+    async fn snapshot_backup(
+        &self,
+        include_history: bool,
+    ) -> Result<StorageBackupSnapshot, StorageError> {
+        snapshot_backup_db(self.pool(), include_history)
+            .await
+            .map(|(state, history)| {
+                StorageBackupSnapshot::new(state.sections, history.map(|value| value.sections))
+            })
+            .map_err(map_postgres_error)
+    }
+}

--- a/src/storage/postgres/computed_fields.rs
+++ b/src/storage/postgres/computed_fields.rs
@@ -15,10 +15,14 @@ use crate::storage::{
     StorageComputedFieldVisibility, StorageError, StoragePersonalComputedFieldCreate,
     StoragePersonalComputedFieldDelete, StoragePersonalComputedFieldListQuery,
     StoragePersonalComputedFieldUpdate, StorageRecordMetadata, StorageSharedComputedFieldCreate,
-    StorageSharedComputedFieldDelete, StorageSharedComputedFieldUpdate,
+    StorageSharedComputedFieldDelete, StorageSharedComputedFieldUpdate, StorageTask,
+    StorageTaskLease,
 };
 
 use super::error::map_postgres_error;
+use super::operations::task::TaskBackend;
+use super::task_execution::claimed_identifier;
+use super::task_queue::task_to_storage;
 use super::{PostgresStorage, operations};
 
 #[async_trait]
@@ -186,6 +190,24 @@ impl ComputedFieldLifecycleStorage for PostgresStorage {
         .await
         .map(state_to_storage)
         .map_err(map_postgres_error)
+    }
+
+    async fn execute_computed_field_rebuild(
+        &self,
+        lease: StorageTaskLease,
+    ) -> Result<StorageTask, StorageError> {
+        let task = claimed_identifier(&lease).map_err(map_postgres_error)?;
+        let record = task
+            .find_claimed_record(self.pool())
+            .await
+            .map_err(map_postgres_error)?;
+        operations::computed_field::execute_computed_reindex_task(self.pool(), &record)
+            .await
+            .map_err(map_postgres_error)?;
+        task.find_record(self.pool())
+            .await
+            .and_then(task_to_storage)
+            .map_err(map_postgres_error)
     }
 }
 

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -1,3 +1,4 @@
+mod backup_snapshot;
 mod computed_fields;
 mod error;
 #[doc(hidden)]

--- a/src/storage/postgres/operations/computed_field.rs
+++ b/src/storage/postgres/operations/computed_field.rs
@@ -50,11 +50,10 @@ pub(crate) use query::{
 #[cfg(test)]
 use query::{validate_computed_filter_count, validate_computed_query_count};
 pub(crate) use rebuild::{
-    enqueue_restored_computed_rebuilds, mark_recovered_computed_reindex_failed,
+    enqueue_restored_computed_rebuilds, mark_computed_reindex_failed_conn,
+    mark_recovered_computed_reindex_failed,
 };
-pub use rebuild::{
-    execute_computed_reindex_task, mark_computed_reindex_failed, request_class_rebuild,
-};
+pub use rebuild::{execute_computed_reindex_task, request_class_rebuild};
 
 const COMPUTED_CLASS_LOCK_NAMESPACE: i32 = 1_133_113;
 const REINDEX_PAYLOAD_TYPE: &str = "computed_fields";

--- a/src/storage/postgres/operations/computed_field/rebuild.rs
+++ b/src/storage/postgres/operations/computed_field/rebuild.rs
@@ -69,6 +69,10 @@ async fn process_reindex_batch(
     cursor: i32,
 ) -> Result<ReindexBatch, ApiError> {
     with_transaction(pool, async |conn| -> Result<_, ApiError> {
+        let claim_token = task.lease_token.ok_or_else(|| {
+            ApiError::BadRequest("Computed-field rebuild task has no claim token".to_string())
+        })?;
+        super::super::task::live_claimed_task_conn(conn, task.id, claim_token).await?;
         use crate::schema::hubuumobject::dsl::{hubuum_class_id, hubuumobject, id};
         let objects = hubuumobject
             .filter(hubuum_class_id.eq(payload.class_id))
@@ -106,6 +110,7 @@ async fn process_reindex_batch(
                 upsert_materialized(conn, object, payload.target_revision, result).await?;
             }
         }
+        super::super::task::live_claimed_task_conn(conn, task.id, claim_token).await?;
         Ok(ReindexBatch::Rows {
             last_id: objects.last().expect("non-empty batch").id,
             count: objects.len() as i32,
@@ -177,7 +182,11 @@ pub async fn execute_computed_reindex_task(
         }
     }
 
-    let ready = with_transaction(pool, async |conn| -> Result<bool, ApiError> {
+    let (status, finalized) = with_transaction(pool, async |conn| {
+        let claim_token = task.lease_token.ok_or_else(|| {
+            ApiError::BadRequest("Computed-field rebuild task has no claim token".to_string())
+        })?;
+        super::super::task::live_claimed_task_conn(conn, task.id, claim_token).await?;
         acquire_computed_class_shared_lock(conn, payload.class_id).await?;
         use crate::schema::class_computation_state::dsl::{
             active_task_id, class_computation_state, class_id, evaluation_revision, last_error,
@@ -197,33 +206,36 @@ pub async fn execute_computed_reindex_task(
         ))
         .execute(conn)
         .await?;
-        Ok(changed == 1)
+        let (status, summary) = if changed == 1 {
+            (
+                TaskStatus::Succeeded,
+                format!("Computed-field rebuild completed for {processed} objects"),
+            )
+        } else {
+            (
+                TaskStatus::Cancelled,
+                "Computed-field rebuild superseded before completion".to_string(),
+            )
+        };
+        let finalized = super::super::task::finalize_terminal_conn(
+            conn,
+            task.id,
+            Some(claim_token),
+            TaskStateUpdate::new(status, TaskResultCounts::from_outcomes(processed, 0)?)
+                .with_summary(summary.clone())
+                .with_started_at(task.started_at),
+            NewTaskEventRecord {
+                task_id: task.id,
+                event_type: status.as_str().to_string(),
+                message: summary,
+                data: None,
+            },
+        )
+        .await?;
+        Ok::<_, ApiError>((status, finalized))
     })
     .await?;
-    let (status, summary) = if ready {
-        (
-            TaskStatus::Succeeded,
-            format!("Computed-field rebuild completed for {processed} objects"),
-        )
-    } else {
-        (
-            TaskStatus::Cancelled,
-            "Computed-field rebuild superseded before completion".to_string(),
-        )
-    };
-    task.finalize_terminal(
-        pool,
-        TaskStateUpdate::new(status, TaskResultCounts::from_outcomes(processed, 0)?)
-            .with_summary(summary.clone())
-            .with_started_at(task.started_at),
-        NewTaskEventRecord {
-            task_id: task.id,
-            event_type: status.as_str().to_string(),
-            message: summary,
-            data: None,
-        },
-    )
-    .await?;
+    super::super::task::record_task_terminal(&finalized);
     crate::observability::metrics::computed_rebuild_finished(status.as_str(), started.elapsed());
     info!(
         message = "Computed-field rebuild finished",
@@ -235,8 +247,8 @@ pub async fn execute_computed_reindex_task(
     Ok(())
 }
 
-pub async fn mark_computed_reindex_failed(
-    pool: &impl crate::storage::StorageContext,
+pub(crate) async fn mark_computed_reindex_failed_conn(
+    conn: &mut PostgresConnection,
     task: &TaskRecord,
     stored_error: &str,
 ) -> Result<(), ApiError> {
@@ -247,28 +259,24 @@ pub async fn mark_computed_reindex_failed(
     else {
         return Ok(());
     };
-    with_connection(pool, async |conn| {
-        use crate::schema::class_computation_state::dsl::{
-            active_task_id, class_computation_state, class_id, evaluation_revision, last_error,
-            rebuild_status, updated_at,
-        };
-        diesel::update(
-            class_computation_state
-                .filter(class_id.eq(payload.class_id))
-                .filter(evaluation_revision.eq(payload.target_revision))
-                .filter(active_task_id.eq(Some(task.id))),
-        )
-        .set((
-            rebuild_status.eq("failed"),
-            active_task_id.eq::<Option<i32>>(None),
-            last_error.eq(Some(stored_error.chars().take(512).collect::<String>())),
-            updated_at.eq(diesel::dsl::now),
-        ))
-        .execute(conn)
-        .await
-    })
+    use crate::schema::class_computation_state::dsl::{
+        active_task_id, class_computation_state, class_id, evaluation_revision, last_error,
+        rebuild_status, updated_at,
+    };
+    diesel::update(
+        class_computation_state
+            .filter(class_id.eq(payload.class_id))
+            .filter(evaluation_revision.eq(payload.target_revision))
+            .filter(active_task_id.eq(Some(task.id))),
+    )
+    .set((
+        rebuild_status.eq("failed"),
+        active_task_id.eq::<Option<i32>>(None),
+        last_error.eq(Some(stored_error.chars().take(512).collect::<String>())),
+        updated_at.eq(diesel::dsl::now),
+    ))
+    .execute(conn)
     .await?;
-    crate::observability::metrics::computed_rebuild_finished("failed", std::time::Duration::ZERO);
     Ok(())
 }
 

--- a/src/storage/postgres/operations/remote_target.rs
+++ b/src/storage/postgres/operations/remote_target.rs
@@ -362,36 +362,32 @@ fn build_list_query<'a>(
     Ok(query)
 }
 
-pub async fn insert_remote_call_result(
-    pool: &impl crate::storage::StorageContext,
+pub(crate) async fn upsert_remote_call_result_conn(
+    conn: &mut crate::storage::postgres::PostgresConnection,
     entry: NewRemoteCallResult,
 ) -> Result<RemoteCallResult, ApiError> {
     use crate::schema::remote_call_results::dsl::{remote_call_results, task_id};
 
-    with_connection(pool, async |conn| {
-        diesel::insert_into(remote_call_results)
-            .values(&entry)
-            .on_conflict(task_id)
-            .do_update()
-            .set((
-                crate::schema::remote_call_results::target_id.eq(entry.target_id),
-                crate::schema::remote_call_results::subject_type.eq(entry.subject_type.clone()),
-                crate::schema::remote_call_results::subject_id.eq(entry.subject_id),
-                crate::schema::remote_call_results::method.eq(entry.method.clone()),
-                crate::schema::remote_call_results::rendered_url.eq(entry.rendered_url.clone()),
-                crate::schema::remote_call_results::response_status.eq(entry.response_status),
-                crate::schema::remote_call_results::response_headers
-                    .eq(entry.response_headers.clone()),
-                crate::schema::remote_call_results::response_body_preview
-                    .eq(entry.response_body_preview.clone()),
-                crate::schema::remote_call_results::duration_ms.eq(entry.duration_ms),
-                crate::schema::remote_call_results::success.eq(entry.success),
-                crate::schema::remote_call_results::error.eq(entry.error.clone()),
-            ))
-            .get_result::<RemoteCallResult>(conn)
-            .await
-    })
-    .await
+    Ok(diesel::insert_into(remote_call_results)
+        .values(&entry)
+        .on_conflict(task_id)
+        .do_update()
+        .set((
+            crate::schema::remote_call_results::target_id.eq(entry.target_id),
+            crate::schema::remote_call_results::subject_type.eq(entry.subject_type.clone()),
+            crate::schema::remote_call_results::subject_id.eq(entry.subject_id),
+            crate::schema::remote_call_results::method.eq(entry.method.clone()),
+            crate::schema::remote_call_results::rendered_url.eq(entry.rendered_url.clone()),
+            crate::schema::remote_call_results::response_status.eq(entry.response_status),
+            crate::schema::remote_call_results::response_headers.eq(entry.response_headers.clone()),
+            crate::schema::remote_call_results::response_body_preview
+                .eq(entry.response_body_preview.clone()),
+            crate::schema::remote_call_results::duration_ms.eq(entry.duration_ms),
+            crate::schema::remote_call_results::success.eq(entry.success),
+            crate::schema::remote_call_results::error.eq(entry.error.clone()),
+        ))
+        .get_result::<RemoteCallResult>(conn)
+        .await?)
 }
 
 impl RemoteTargetID {

--- a/src/storage/postgres/operations/task.rs
+++ b/src/storage/postgres/operations/task.rs
@@ -21,8 +21,8 @@ use crate::models::{
     BackupOutputLookup, BackupTaskOutputRecord, BackupTaskOutputSummaryRecord, ExportOutputLookup,
     ExportTaskOutputRecord, ExportTaskOutputSummaryRecord, ImportTaskResultRecord,
     NewBackupTaskOutputRecord, NewExportTaskOutputRecord, NewImportTaskResultRecord,
-    NewTaskEventRecord, NewTaskRecord, PrincipalID, TaskEventRecord, TaskID, TaskKind, TaskRecord,
-    TaskResponse, TaskResultCounts, TaskStatus, TokenID,
+    NewRemoteCallResult, NewTaskEventRecord, NewTaskRecord, PrincipalID, TaskEventRecord, TaskID,
+    TaskKind, TaskRecord, TaskResponse, TaskResultCounts, TaskStatus, TokenID,
 };
 use crate::observability::metrics;
 use crate::pagination::{CursorValue, decode_cursor_values, page_limits_or_defaults};
@@ -372,6 +372,20 @@ pub trait TaskBackend: TaskIdentifier {
         .await
     }
 
+    async fn find_claimed_record(
+        &self,
+        pool: &impl crate::storage::StorageContext,
+    ) -> Result<TaskRecord, ApiError> {
+        let claim_token = self.task_lease_token().ok_or_else(|| {
+            ApiError::BadRequest("A live task claim is required for this operation".to_string())
+        })?;
+        let task_id = self.task_id();
+        with_transaction(pool, async |conn| {
+            live_claimed_task_conn(conn, task_id, claim_token).await
+        })
+        .await
+    }
+
     async fn list_events_with_total_count(
         &self,
         pool: &impl crate::storage::StorageContext,
@@ -690,62 +704,14 @@ pub trait TaskBackend: TaskIdentifier {
         update: TaskStateUpdate,
         event: NewTaskEventRecord,
     ) -> Result<TaskRecord, ApiError> {
-        use crate::schema::tasks::dsl::{
-            failed_items, finished_at, id, lease_expires_at, lease_token, processed_items,
-            request_payload, request_redacted_at, started_at, status, success_items, summary,
-            tasks, updated_at,
-        };
-
         let task_id_value = self.task_id();
         let task_lease_token = self.task_lease_token();
         let record = with_transaction(pool, async |conn| -> Result<TaskRecord, ApiError> {
-            let task = tasks
-                .filter(id.eq(task_id_value))
-                .first::<TaskRecord>(conn)
-                .await?;
-            let event_record =
-                emit_task_lifecycle_event(conn, &task, &event, &task.worker_provenance()).await?;
-            let no_lease_token: diesel::dsl::AsExprOf<bool, Bool> =
-                <bool as AsExpression<Bool>>::as_expression(task_lease_token.is_none());
-
-            Ok(diesel::update(
-                tasks.filter(id.eq(task_id_value)).filter(
-                    lease_token
-                        .eq(task_lease_token)
-                        .and(lease_expires_at.gt(sql::<Nullable<Timestamp>>(DATABASE_UTC_NOW_SQL)))
-                        .or(lease_token.is_null().and(no_lease_token)),
-                ),
-            )
-            .set((
-                status.eq(update.status.as_str()),
-                summary.eq(update.summary),
-                processed_items.eq(update.counts.processed()),
-                success_items.eq(update.counts.success()),
-                failed_items.eq(update.counts.failed()),
-                started_at.eq(update.started_at),
-                finished_at.eq(Some(event_record.occurred_at)),
-                request_payload.eq::<Option<serde_json::Value>>(None),
-                request_redacted_at.eq(event_record.occurred_at),
-                lease_token.eq::<Option<Uuid>>(None),
-                lease_expires_at.eq::<Option<chrono::NaiveDateTime>>(None),
-                updated_at.eq(event_record.occurred_at),
-            ))
-            .get_result::<TaskRecord>(conn)
-            .await?)
+            finalize_terminal_conn(conn, task_id_value, task_lease_token, update, event).await
         })
         .await?;
 
-        info!(
-            message = "Task reached terminal state",
-            task_id = record.id,
-            task_kind = record.kind.as_str(),
-            status = record.status.as_str(),
-            processed_items = record.processed_items,
-            success_items = record.success_items,
-            failed_items = record.failed_items,
-            summary = record.summary.as_deref()
-        );
-        record_task_completion_metrics(&record);
+        record_task_terminal(&record);
 
         Ok(record)
     }
@@ -760,12 +726,6 @@ pub trait TaskBackend: TaskIdentifier {
         use crate::schema::export_task_outputs::dsl::{
             export_task_outputs, task_id as export_output_task_id,
         };
-        use crate::schema::tasks::dsl::{
-            failed_items, finished_at, id, lease_expires_at, lease_token, processed_items,
-            request_payload, request_redacted_at, started_at, status, success_items, summary,
-            tasks, updated_at,
-        };
-
         let task_id_value = self.task_id();
         let task_lease_token = self.task_lease_token();
         let record = with_transaction(pool, async |conn| -> Result<TaskRecord, ApiError> {
@@ -778,54 +738,11 @@ pub trait TaskBackend: TaskIdentifier {
                 .do_nothing()
                 .execute(conn)
                 .await?;
-
-            let task = tasks
-                .filter(id.eq(task_id_value))
-                .first::<TaskRecord>(conn)
-                .await?;
-            let event_record =
-                emit_task_lifecycle_event(conn, &task, &event, &task.worker_provenance()).await?;
-            let no_lease_token: diesel::dsl::AsExprOf<bool, Bool> =
-                <bool as AsExpression<Bool>>::as_expression(task_lease_token.is_none());
-
-            Ok(diesel::update(
-                tasks.filter(id.eq(task_id_value)).filter(
-                    lease_token
-                        .eq(task_lease_token)
-                        .and(lease_expires_at.gt(sql::<Nullable<Timestamp>>(DATABASE_UTC_NOW_SQL)))
-                        .or(lease_token.is_null().and(no_lease_token)),
-                ),
-            )
-            .set((
-                status.eq(update.status.as_str()),
-                summary.eq(update.summary),
-                processed_items.eq(update.counts.processed()),
-                success_items.eq(update.counts.success()),
-                failed_items.eq(update.counts.failed()),
-                started_at.eq(update.started_at),
-                finished_at.eq(Some(event_record.occurred_at)),
-                request_payload.eq::<Option<serde_json::Value>>(None),
-                request_redacted_at.eq(event_record.occurred_at),
-                lease_token.eq::<Option<Uuid>>(None),
-                lease_expires_at.eq::<Option<chrono::NaiveDateTime>>(None),
-                updated_at.eq(event_record.occurred_at),
-            ))
-            .get_result::<TaskRecord>(conn)
-            .await?)
+            finalize_terminal_conn(conn, task_id_value, task_lease_token, update, event).await
         })
         .await?;
 
-        info!(
-            message = "Export task output stored and task finalized",
-            task_id = record.id,
-            task_kind = record.kind.as_str(),
-            status = record.status.as_str(),
-            processed_items = record.processed_items,
-            success_items = record.success_items,
-            failed_items = record.failed_items,
-            summary = record.summary.as_deref()
-        );
-        record_task_completion_metrics(&record);
+        record_task_terminal(&record);
 
         Ok(record)
     }
@@ -840,12 +757,6 @@ pub trait TaskBackend: TaskIdentifier {
         use crate::schema::backup_task_outputs::dsl::{
             backup_task_outputs, task_id as backup_output_task_id,
         };
-        use crate::schema::tasks::dsl::{
-            failed_items, finished_at, id, lease_expires_at, lease_token, processed_items,
-            request_payload, request_redacted_at, started_at, status, success_items, summary,
-            tasks, updated_at,
-        };
-
         let task_id_value = self.task_id();
         let task_lease_token = self.task_lease_token();
         let record = with_transaction(pool, async |conn| -> Result<TaskRecord, ApiError> {
@@ -855,49 +766,120 @@ pub trait TaskBackend: TaskIdentifier {
                 .do_nothing()
                 .execute(conn)
                 .await?;
-
-            let task = tasks
-                .filter(id.eq(task_id_value))
-                .first::<TaskRecord>(conn)
-                .await?;
-            let event_record =
-                emit_task_lifecycle_event(conn, &task, &event, &task.worker_provenance()).await?;
-            let no_lease_token: diesel::dsl::AsExprOf<bool, Bool> =
-                <bool as AsExpression<Bool>>::as_expression(task_lease_token.is_none());
-
-            Ok(diesel::update(
-                tasks.filter(id.eq(task_id_value)).filter(
-                    lease_token
-                        .eq(task_lease_token)
-                        .and(lease_expires_at.gt(sql::<Nullable<Timestamp>>(DATABASE_UTC_NOW_SQL)))
-                        .or(lease_token.is_null().and(no_lease_token)),
-                ),
-            )
-            .set((
-                status.eq(update.status.as_str()),
-                summary.eq(update.summary),
-                processed_items.eq(update.counts.processed()),
-                success_items.eq(update.counts.success()),
-                failed_items.eq(update.counts.failed()),
-                started_at.eq(update.started_at),
-                finished_at.eq(Some(event_record.occurred_at)),
-                request_payload.eq::<Option<serde_json::Value>>(None),
-                request_redacted_at.eq(event_record.occurred_at),
-                lease_token.eq::<Option<Uuid>>(None),
-                lease_expires_at.eq::<Option<chrono::NaiveDateTime>>(None),
-                updated_at.eq(event_record.occurred_at),
-            ))
-            .get_result::<TaskRecord>(conn)
-            .await?)
+            finalize_terminal_conn(conn, task_id_value, task_lease_token, update, event).await
         })
         .await?;
 
-        record_task_completion_metrics(&record);
+        record_task_terminal(&record);
+        Ok(record)
+    }
+
+    async fn finalize_remote_call_with_result(
+        &self,
+        pool: &impl crate::storage::StorageContext,
+        update: TaskStateUpdate,
+        event: NewTaskEventRecord,
+        result: NewRemoteCallResult,
+    ) -> Result<TaskRecord, ApiError> {
+        let task_id_value = self.task_id();
+        let task_lease_token = self.task_lease_token();
+        let record = with_transaction(pool, async |conn| -> Result<TaskRecord, ApiError> {
+            super::remote_target::upsert_remote_call_result_conn(conn, result).await?;
+            finalize_terminal_conn(conn, task_id_value, task_lease_token, update, event).await
+        })
+        .await?;
+
+        record_task_terminal(&record);
         Ok(record)
     }
 }
 
 impl<T: TaskIdentifier + ?Sized> TaskBackend for T {}
+
+pub(crate) async fn finalize_terminal_conn(
+    conn: &mut crate::storage::postgres::PostgresConnection,
+    task_id_value: i32,
+    task_lease_token: Option<Uuid>,
+    update: TaskStateUpdate,
+    event: NewTaskEventRecord,
+) -> Result<TaskRecord, ApiError> {
+    use crate::schema::tasks::dsl::{
+        failed_items, finished_at, id, lease_expires_at, lease_token, processed_items,
+        request_payload, request_redacted_at, started_at, status, success_items, summary, tasks,
+        updated_at,
+    };
+
+    let task = tasks
+        .filter(id.eq(task_id_value))
+        .first::<TaskRecord>(conn)
+        .await?;
+    let event_record =
+        emit_task_lifecycle_event(conn, &task, &event, &task.worker_provenance()).await?;
+    let no_lease_token: diesel::dsl::AsExprOf<bool, Bool> =
+        <bool as AsExpression<Bool>>::as_expression(task_lease_token.is_none());
+
+    Ok(diesel::update(
+        tasks.filter(id.eq(task_id_value)).filter(
+            lease_token
+                .eq(task_lease_token)
+                .and(lease_expires_at.gt(sql::<Nullable<Timestamp>>(DATABASE_UTC_NOW_SQL)))
+                .or(lease_token.is_null().and(no_lease_token)),
+        ),
+    )
+    .set((
+        status.eq(update.status.as_str()),
+        summary.eq(update.summary),
+        processed_items.eq(update.counts.processed()),
+        success_items.eq(update.counts.success()),
+        failed_items.eq(update.counts.failed()),
+        started_at.eq(update.started_at),
+        finished_at.eq(Some(event_record.occurred_at)),
+        request_payload.eq::<Option<serde_json::Value>>(None),
+        request_redacted_at.eq(event_record.occurred_at),
+        lease_token.eq::<Option<Uuid>>(None),
+        lease_expires_at.eq::<Option<chrono::NaiveDateTime>>(None),
+        updated_at.eq(event_record.occurred_at),
+    ))
+    .get_result::<TaskRecord>(conn)
+    .await?)
+}
+
+/// Load and lock a task only while the caller owns its unexpired active lease.
+///
+/// Backend workflows use this inside the same transaction as their mutations,
+/// preventing a stale worker from committing domain data after losing its
+/// claim.
+pub(crate) async fn live_claimed_task_conn(
+    conn: &mut crate::storage::postgres::PostgresConnection,
+    task_id_value: i32,
+    claim_token: Uuid,
+) -> Result<TaskRecord, ApiError> {
+    use crate::schema::tasks::dsl::{id, lease_expires_at, lease_token, status, tasks};
+
+    tasks
+        .filter(id.eq(task_id_value))
+        .filter(lease_token.eq(Some(claim_token)))
+        .filter(lease_expires_at.gt(sql::<Nullable<Timestamp>>(DATABASE_UTC_NOW_SQL)))
+        .filter(status.eq_any(TaskStatus::ACTIVE.map(TaskStatus::as_str)))
+        .for_update()
+        .first::<TaskRecord>(conn)
+        .await
+        .map_err(ApiError::from)
+}
+
+pub(crate) fn record_task_terminal(record: &TaskRecord) {
+    info!(
+        message = "Task reached terminal state",
+        task_id = record.id,
+        task_kind = record.kind.as_str(),
+        status = record.status.as_str(),
+        processed_items = record.processed_items,
+        success_items = record.success_items,
+        failed_items = record.failed_items,
+        summary = record.summary.as_deref()
+    );
+    record_task_completion_metrics(record);
+}
 
 fn record_task_completion_metrics(record: &TaskRecord) {
     metrics::task_completed(
@@ -1465,6 +1447,40 @@ pub(crate) async fn claim_next_queued_task(
     Ok(record)
 }
 
+/// Claim one known task for adapter integration tests that exercise a backend
+/// workflow directly without running the process-global worker.
+#[cfg(feature = "integration-test-support")]
+#[doc(hidden)]
+pub async fn claim_task_for_backend_test(
+    pool: &impl crate::storage::StorageContext,
+    task_id_value: i32,
+) -> Result<TaskRecord, ApiError> {
+    use crate::schema::tasks::dsl::{
+        attempt_count, id, lease_expires_at, lease_token, started_at, status, tasks, updated_at,
+    };
+
+    with_connection(pool, async |conn| {
+        diesel::update(
+            tasks
+                .filter(id.eq(task_id_value))
+                .filter(status.eq(TaskStatus::Queued.as_str())),
+        )
+        .set((
+            status.eq(TaskStatus::Validating.as_str()),
+            started_at.eq(sql::<Nullable<Timestamp>>(DATABASE_UTC_NOW_SQL)),
+            lease_token.eq(Some(Uuid::new_v4())),
+            lease_expires_at.eq(sql::<Nullable<Timestamp>>(
+                "((clock_timestamp() AT TIME ZONE 'UTC') + INTERVAL '1 minute')",
+            )),
+            attempt_count.eq(attempt_count + 1),
+            updated_at.eq(sql::<Timestamp>(DATABASE_UTC_NOW_SQL)),
+        ))
+        .get_result::<TaskRecord>(conn)
+        .await
+    })
+    .await
+}
+
 /// Extend an active task lease if this worker still owns it.
 pub(crate) async fn renew_task_lease(
     pool: &impl crate::storage::StorageContext,
@@ -1933,8 +1949,8 @@ mod tests {
     use crate::events::{Action, ActorKind, EntityType, NewEvent, emit_event};
     use crate::models::search::QueryOptions;
     use crate::models::{
-        CollectionID, NewBackupTaskOutputRecord, NewImportTaskResultRecord, NewTaskEventRecord,
-        NewTaskRecord, Permissions, PrincipalID, RemoteInvocationBodyOverride,
+        CollectionID, NewBackupTaskOutputRecord, NewImportTaskResultRecord, NewRemoteCallResult,
+        NewTaskEventRecord, NewTaskRecord, Permissions, PrincipalID, RemoteInvocationBodyOverride,
         RemoteInvocationParameters, RemoteInvocationSubject, RemoteTargetID,
         StoredRemoteCallTaskPayload, TaskID, TaskKind, TaskResultCounts, TaskStatus, TokenID,
         TokenScope,
@@ -2608,6 +2624,71 @@ mod tests {
 
         assert_eq!(
             (result.is_err(), persisted.status.as_str(), output_count),
+            (true, TaskStatus::Failed.as_str(), 0)
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_remote_call_worker_cannot_persist_a_result() {
+        let context = TestContext::new().await;
+        let leased = create_leased_task_of_kind(
+            &context,
+            "stale-remote-call-finalization-fence",
+            TaskKind::RemoteCall,
+            Utc::now().naive_utc() - ChronoDuration::seconds(1),
+        )
+        .await;
+        recover_expired_task_lease(&context.pool, leased.id)
+            .await
+            .unwrap();
+
+        let result = leased
+            .finalize_remote_call_with_result(
+                &context.pool,
+                TaskStateUpdate::new(
+                    TaskStatus::Succeeded,
+                    TaskResultCounts::from_outcomes(1, 0).unwrap(),
+                )
+                .with_summary("stale remote-call completion")
+                .with_started_at(leased.started_at),
+                NewTaskEventRecord {
+                    task_id: leased.id,
+                    event_type: TaskStatus::Succeeded.as_str().to_string(),
+                    message: "stale remote-call completion".to_string(),
+                    data: None,
+                },
+                NewRemoteCallResult {
+                    task_id: leased.id,
+                    target_id: None,
+                    subject_type: "collection".to_string(),
+                    subject_id: 1,
+                    method: "GET".to_string(),
+                    rendered_url: "https://compatibility.invalid".to_string(),
+                    response_status: Some(200),
+                    response_headers: Some(serde_json::json!({})),
+                    response_body_preview: Some("stale".to_string()),
+                    duration_ms: 1,
+                    success: true,
+                    error: None,
+                },
+            )
+            .await;
+
+        let persisted = leased.find_record(&context.pool).await.unwrap();
+        let result_count = with_connection(&context.pool, async |conn| {
+            use crate::schema::remote_call_results::dsl::{remote_call_results, task_id};
+
+            remote_call_results
+                .filter(task_id.eq(leased.id))
+                .count()
+                .get_result::<i64>(conn)
+                .await
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            (result.is_err(), persisted.status.as_str(), result_count),
             (true, TaskStatus::Failed.as_str(), 0)
         );
     }

--- a/src/storage/postgres/task_execution.rs
+++ b/src/storage/postgres/task_execution.rs
@@ -8,30 +8,33 @@ use uuid::Uuid;
 use crate::config::get_config;
 use crate::errors::ApiError;
 use crate::models::{
-    NewBackupTaskOutputRecord, NewExportTaskOutputRecord, NewTaskEventRecord, TaskKind,
-    TaskResultCounts, TaskStatus,
+    NewBackupTaskOutputRecord, NewExportTaskOutputRecord, NewRemoteCallResult, NewTaskEventRecord,
+    TaskKind, TaskResultCounts, TaskStatus,
 };
 use crate::storage::{
-    StorageBackupTaskArtifact, StorageError, StorageExportTaskArtifact, StorageTask,
-    StorageTaskClaim, StorageTaskClaimToken, StorageTaskCompletion, StorageTaskCompletionArtifact,
-    StorageTaskEventAppend, StorageTaskEventInput, StorageTaskFailure, StorageTaskLease,
-    StorageTaskLeaseDuration, StorageTaskResultCounts, StorageTaskStateUpdate, StorageTaskStatus,
-    TaskExecutionStorage,
+    StorageBackupTaskArtifact, StorageError, StorageExportTaskArtifact,
+    StorageRemoteCallTaskArtifact, StorageTask, StorageTaskClaim, StorageTaskClaimToken,
+    StorageTaskCompletion, StorageTaskCompletionArtifact, StorageTaskEventAppend,
+    StorageTaskEventInput, StorageTaskFailure, StorageTaskLease, StorageTaskLeaseDuration,
+    StorageTaskResultCounts, StorageTaskStateUpdate, StorageTaskStatus, TaskExecutionStorage,
 };
 use crate::tasks::TaskLeaseDuration;
 
 use super::PostgresStorage;
 use super::error::map_postgres_error;
-use super::operations::computed_field::mark_computed_reindex_failed;
+use super::operations::computed_field::mark_computed_reindex_failed_conn;
 use super::operations::task::{
     TaskBackend, TaskIdentifier, TaskStateUpdate, append_task_event_while_claimed,
-    claim_next_queued_task, purge_expired_backup_outputs, purge_expired_export_outputs,
+    claim_next_queued_task, finalize_terminal_conn, live_claimed_task_conn,
+    purge_expired_backup_outputs, purge_expired_export_outputs, record_task_terminal,
     recover_expired_task_leases, renew_task_lease,
 };
 use super::task_queue::task_to_storage;
-use super::{PostgresPool, PostgresPoolSettings, init_postgres_pool_with_settings};
+use super::{
+    PostgresPool, PostgresPoolSettings, init_postgres_pool_with_settings, with_transaction,
+};
 
-struct ClaimedTaskIdentifier {
+pub(super) struct ClaimedTaskIdentifier {
     task_id: i32,
     token: Uuid,
 }
@@ -89,7 +92,9 @@ fn claim_token_from_storage(token: &StorageTaskClaimToken) -> Result<Uuid, ApiEr
     })
 }
 
-fn claimed_identifier(lease: &StorageTaskLease) -> Result<ClaimedTaskIdentifier, ApiError> {
+pub(super) fn claimed_identifier(
+    lease: &StorageTaskLease,
+) -> Result<ClaimedTaskIdentifier, ApiError> {
     Ok(ClaimedTaskIdentifier {
         task_id: lease.task_id(),
         token: claim_token_from_storage(lease.token())?,
@@ -174,6 +179,30 @@ fn backup_artifact_from_storage(
         byte_size,
         sha256,
         output_expires_at,
+    }
+}
+
+fn remote_call_artifact_from_storage(
+    task_id: i32,
+    artifact: StorageRemoteCallTaskArtifact,
+) -> NewRemoteCallResult {
+    let (target, response, outcome) = artifact.into_parts();
+    let (target_id, subject_type, subject_id, method, rendered_url) = target.into_parts();
+    let (response_status, response_headers, response_body_preview) = response.into_parts();
+    let (duration_ms, success, error) = outcome.into_parts();
+    NewRemoteCallResult {
+        task_id,
+        target_id,
+        subject_type,
+        subject_id,
+        method,
+        rendered_url,
+        response_status,
+        response_headers,
+        response_body_preview,
+        duration_ms,
+        success,
+        error,
     }
 }
 
@@ -285,9 +314,15 @@ impl TaskExecutionStorage for PostgresStorage {
             .map_err(map_postgres_error)?;
         let artifact_matches_kind = matches!(
             (&artifact, stored_kind),
-            (StorageTaskCompletionArtifact::None, _)
-                | (StorageTaskCompletionArtifact::Export(_), TaskKind::Export)
+            (
+                StorageTaskCompletionArtifact::None,
+                TaskKind::Import | TaskKind::Reindex
+            ) | (StorageTaskCompletionArtifact::Export(_), TaskKind::Export)
                 | (StorageTaskCompletionArtifact::Backup(_), TaskKind::Backup)
+                | (
+                    StorageTaskCompletionArtifact::RemoteCall(_),
+                    TaskKind::RemoteCall
+                )
         );
         if !artifact_matches_kind {
             return Err(map_postgres_error(ApiError::BadRequest(format!(
@@ -315,6 +350,15 @@ impl TaskExecutionStorage for PostgresStorage {
                     update,
                     event,
                     backup_artifact_from_storage(task_id, artifact),
+                )
+                .await
+            }
+            StorageTaskCompletionArtifact::RemoteCall(artifact) => {
+                task.finalize_remote_call_with_result(
+                    self.pool(),
+                    update,
+                    event,
+                    remote_call_artifact_from_storage(task_id, artifact),
                 )
                 .await
             }
@@ -346,15 +390,26 @@ impl TaskExecutionStorage for PostgresStorage {
         let update = TaskStateUpdate::new(TaskStatus::Failed, counts)
             .with_summary(summary.clone())
             .with_started_at(record.started_at);
-        let finalized = task
-            .finalize_terminal(self.pool(), update, event_from_storage(record.id, event))
+        let event = event_from_storage(record.id, event);
+        let finalized = if kind == TaskKind::Reindex {
+            let finalized = with_transaction(self.pool(), async |conn| {
+                live_claimed_task_conn(conn, task.task_id, task.token).await?;
+                mark_computed_reindex_failed_conn(conn, &record, &summary).await?;
+                finalize_terminal_conn(conn, task.task_id, Some(task.token), update, event).await
+            })
             .await
             .map_err(map_postgres_error)?;
-        if kind == TaskKind::Reindex {
-            mark_computed_reindex_failed(self.pool(), &record, &summary)
+            record_task_terminal(&finalized);
+            crate::observability::metrics::computed_rebuild_finished(
+                "failed",
+                std::time::Duration::ZERO,
+            );
+            finalized
+        } else {
+            task.finalize_terminal(self.pool(), update, event)
                 .await
-                .map_err(map_postgres_error)?;
-        }
+                .map_err(map_postgres_error)?
+        };
         task_to_storage(finalized).map_err(map_postgres_error)
     }
 

--- a/src/tasks/remote_call.rs
+++ b/src/tasks/remote_call.rs
@@ -16,14 +16,16 @@ use crate::config::{
 };
 use crate::errors::ApiError;
 use crate::models::{
-    NewRemoteCallResult, NewTaskEventRecord, RemoteAuthConfig, RemoteHttpMethod,
-    RemoteInvocationBodyOverride, RemoteInvocationParameters, RemoteTemplateContext,
-    StoredRemoteCallTaskPayload, TaskResultCounts, TaskStatus, authorize_remote_invocation,
+    NewTaskEventRecord, RemoteAuthConfig, RemoteHttpMethod, RemoteInvocationBodyOverride,
+    RemoteInvocationParameters, RemoteTemplateContext, StoredRemoteCallTaskPayload,
+    TaskResultCounts, TaskStatus, authorize_remote_invocation,
 };
 use crate::observability::metrics;
 use crate::services::tasks::{ClaimedTask, TaskStateChange, complete_task, update_task_state};
-use crate::storage::capabilities::remote_target::insert_remote_call_result;
-use crate::storage::{StorageContext, StorageTaskCompletionArtifact};
+use crate::storage::{
+    StorageContext, StorageRemoteCallArtifactOutcome, StorageRemoteCallArtifactResponse,
+    StorageRemoteCallArtifactTarget, StorageRemoteCallTaskArtifact, StorageTaskCompletionArtifact,
+};
 use crate::traits::AuthzSubject;
 
 #[cfg(feature = "integration-test-support")]
@@ -59,7 +61,6 @@ pub(super) async fn execute_remote_call_task<C>(
 where
     C: StorageContext,
 {
-    let pool = backend;
     let payload = task
         .request_payload
         .clone()
@@ -67,7 +68,7 @@ where
     let request: StoredRemoteCallTaskPayload = serde_json::from_value(payload)?;
 
     update_task_state(
-        pool,
+        backend,
         task,
         TaskStateChange::new(TaskStatus::Running, TaskResultCounts::default())
             .started_at(task.started_at),
@@ -76,36 +77,32 @@ where
 
     let result = execute_remote_call(backend, task.id, user, scopes, &request).await;
     match result {
-        Ok(success) => finalize_remote_task(pool, task, success).await,
+        Ok(success) => finalize_remote_task(backend, task, success).await,
         Err(error) => {
             let sanitized = crate::tasks::helpers::sanitize_error_for_storage(&error);
-            let fallback = NewRemoteCallResult {
-                task_id: task.id,
-                target_id: Some(request.target_id.id()),
-                subject_type: request.subject.subject_type().as_str().to_string(),
-                subject_id: request.subject.subject_id(),
-                method: "unknown".to_string(),
-                rendered_url: "".to_string(),
-                response_status: None,
-                response_headers: None,
-                response_body_preview: None,
-                duration_ms: 0,
-                success: false,
-                error: Some(sanitized.clone()),
-            };
-            insert_remote_call_result(pool, fallback).await?;
             warn!(
                 message = "Remote call task failed before HTTP execution",
                 task_id = task.id,
                 error = %error
             );
             finalize_remote_task(
-                pool,
+                backend,
                 task,
                 RemoteExecutionOutcome {
                     success: false,
-                    summary: sanitized,
+                    summary: sanitized.clone(),
                     event_data: None,
+                    artifact: StorageRemoteCallTaskArtifact::new(
+                        StorageRemoteCallArtifactTarget::new(
+                            None,
+                            request.subject.subject_type().as_str(),
+                            request.subject.subject_id(),
+                            "unknown",
+                            "",
+                        ),
+                        StorageRemoteCallArtifactResponse::new(None, None, None),
+                        StorageRemoteCallArtifactOutcome::new(0, false, Some(sanitized)),
+                    ),
                 },
             )
             .await
@@ -117,10 +114,10 @@ struct RemoteExecutionOutcome {
     success: bool,
     summary: String,
     event_data: Option<serde_json::Value>,
+    artifact: StorageRemoteCallTaskArtifact,
 }
 
-struct RemoteFailureContext<'a, C> {
-    storage: &'a C,
+struct RemoteFailureContext<'a> {
     task_id: i32,
     target_id: i32,
     subject_type: &'a str,
@@ -138,8 +135,7 @@ async fn execute_remote_call<C>(
 where
     C: StorageContext,
 {
-    let pool = backend;
-    let target = request.target_id.instance(pool).await?;
+    let target = request.target_id.instance(backend).await?;
     let resolved =
         authorize_remote_invocation(backend, user, scopes, &target, &request.subject).await?;
 
@@ -152,7 +148,6 @@ where
     let rendered_url = render_template("url_template", &target.url_template, &context)?;
     let start = Instant::now();
     let failure_context = RemoteFailureContext {
-        storage: pool,
         task_id,
         target_id: target.id,
         subject_type: resolved.subject_type.as_str(),
@@ -162,7 +157,12 @@ where
     let normalized_rendered_url = match validate_outbound_url(&rendered_url) {
         Ok(parts) => parts.url().to_string(),
         Err(error) => {
-            return record_remote_call_failure(&failure_context, rendered_url, 0, error).await;
+            return Ok(remote_call_failure(
+                &failure_context,
+                rendered_url,
+                0,
+                error,
+            ));
         }
     };
 
@@ -212,25 +212,6 @@ where
                     u64::try_from(response.duration_ms()).unwrap_or(0),
                 ),
             );
-            insert_remote_call_result(
-                pool,
-                NewRemoteCallResult {
-                    task_id,
-                    target_id: Some(target.id),
-                    subject_type: resolved.subject_type.as_str().to_string(),
-                    subject_id: resolved.subject_id,
-                    method: target.method.as_str().to_string(),
-                    rendered_url: response.url().to_string(),
-                    response_status: Some(i32::from(response.status_code())),
-                    response_headers: Some(response.headers().clone()),
-                    response_body_preview: Some(response.body_preview().to_string()),
-                    duration_ms: response.duration_ms(),
-                    success,
-                    error: (!success).then(|| format!("Remote returned HTTP {status}")),
-                },
-            )
-            .await?;
-
             let summary = if success {
                 format!("Remote call succeeded with HTTP {status}")
             } else {
@@ -243,27 +224,45 @@ where
                     "status": i32::from(response.status_code()),
                     "duration_ms": response.duration_ms(),
                 })),
+                artifact: StorageRemoteCallTaskArtifact::new(
+                    StorageRemoteCallArtifactTarget::new(
+                        Some(target.id),
+                        resolved.subject_type.as_str(),
+                        resolved.subject_id,
+                        target.method.as_str(),
+                        response.url(),
+                    ),
+                    StorageRemoteCallArtifactResponse::new(
+                        Some(i32::from(response.status_code())),
+                        Some(response.headers().clone()),
+                        Some(response.body_preview().to_string()),
+                    ),
+                    StorageRemoteCallArtifactOutcome::new(
+                        response.duration_ms(),
+                        success,
+                        (!success).then(|| format!("Remote returned HTTP {status}")),
+                    ),
+                ),
             })
         }
         Err(error) => {
             let duration_ms = i32::try_from(start.elapsed().as_millis()).unwrap_or(i32::MAX);
-            record_remote_call_failure(
+            Ok(remote_call_failure(
                 &failure_context,
                 normalized_rendered_url,
                 duration_ms,
                 error,
-            )
-            .await
+            ))
         }
     }
 }
 
-async fn record_remote_call_failure<C: StorageContext>(
-    context: &RemoteFailureContext<'_, C>,
+fn remote_call_failure(
+    context: &RemoteFailureContext<'_>,
     rendered_url: String,
     duration_ms: i32,
     error: OutboundHttpError,
-) -> Result<RemoteExecutionOutcome, ApiError> {
+) -> RemoteExecutionOutcome {
     let metric_outcome = remote_error_outcome(&error);
     warn!(
         message = "Remote target call failed",
@@ -283,29 +282,22 @@ async fn record_remote_call_failure<C: StorageContext>(
         metric_outcome,
         std::time::Duration::from_millis(u64::try_from(duration_ms).unwrap_or(0)),
     );
-    insert_remote_call_result(
-        context.storage,
-        NewRemoteCallResult {
-            task_id: context.task_id,
-            target_id: Some(context.target_id),
-            subject_type: context.subject_type.to_string(),
-            subject_id: context.subject_id,
-            method: context.method.to_string(),
-            rendered_url,
-            response_status: None,
-            response_headers: None,
-            response_body_preview: None,
-            duration_ms,
-            success: false,
-            error: Some(message.clone()),
-        },
-    )
-    .await?;
-    Ok(RemoteExecutionOutcome {
+    RemoteExecutionOutcome {
         success: false,
-        summary: message,
+        summary: message.clone(),
         event_data: Some(serde_json::json!({ "duration_ms": duration_ms })),
-    })
+        artifact: StorageRemoteCallTaskArtifact::new(
+            StorageRemoteCallArtifactTarget::new(
+                Some(context.target_id),
+                context.subject_type,
+                context.subject_id,
+                context.method,
+                rendered_url,
+            ),
+            StorageRemoteCallArtifactResponse::new(None, None, None),
+            StorageRemoteCallArtifactOutcome::new(duration_ms, false, Some(message)),
+        ),
+    }
 }
 
 fn status_family(status_code: u16) -> &'static str {
@@ -341,7 +333,7 @@ fn remote_error_outcome(error: &OutboundHttpError) -> &'static str {
 }
 
 async fn finalize_remote_task(
-    pool: &impl crate::storage::StorageContext,
+    backend: &impl crate::storage::StorageContext,
     task: &ClaimedTask,
     outcome: RemoteExecutionOutcome,
 ) -> Result<(), ApiError> {
@@ -351,7 +343,7 @@ async fn finalize_remote_task(
         TaskStatus::Failed
     };
     complete_task(
-        pool,
+        backend,
         task,
         TaskStateChange::new(
             status,
@@ -368,7 +360,7 @@ async fn finalize_remote_task(
             message: outcome.summary,
             data: outcome.event_data,
         },
-        StorageTaskCompletionArtifact::None,
+        StorageTaskCompletionArtifact::RemoteCall(outcome.artifact),
     )
     .await?;
     Ok(())

--- a/src/tasks/worker.rs
+++ b/src/tasks/worker.rs
@@ -600,7 +600,7 @@ where
 }
 
 async fn maybe_recover_expired_task_leases(
-    pool: &impl crate::storage::StorageContext,
+    backend: &impl crate::storage::StorageContext,
 ) -> Result<(), ApiError> {
     let recovery_interval = task_worker_settings().recovery_interval();
     let previous_last_run = {
@@ -616,7 +616,7 @@ async fn maybe_recover_expired_task_leases(
         }
     };
 
-    match recover_expired_task_leases(pool, 100).await {
+    match recover_expired_task_leases(backend, 100).await {
         Ok(recovered) => {
             for task in recovered {
                 metrics::task_lease_recovered(&task.kind);
@@ -641,7 +641,7 @@ async fn maybe_recover_expired_task_leases(
 }
 
 async fn maybe_cleanup_expired_task_outputs(
-    pool: &impl crate::storage::StorageContext,
+    backend: &impl crate::storage::StorageContext,
 ) -> Result<(), ApiError> {
     let cleanup_interval = task_worker_settings().export_output_cleanup_interval();
     let Some(reservation) = CleanupReservation::reserve(cleanup_state(), cleanup_interval)? else {
@@ -649,7 +649,7 @@ async fn maybe_cleanup_expired_task_outputs(
     };
 
     metrics::task_output_cleanup_run(metrics::TaskOutputKind::Export);
-    let deleted_exports = match purge_expired_export_outputs(pool).await {
+    let deleted_exports = match purge_expired_export_outputs(backend).await {
         Ok(deleted) => deleted,
         Err(error) => {
             metrics::task_output_cleanup_failed(metrics::TaskOutputKind::Export);
@@ -659,7 +659,7 @@ async fn maybe_cleanup_expired_task_outputs(
     metrics::task_output_cleanup_deleted(metrics::TaskOutputKind::Export, deleted_exports);
 
     metrics::task_output_cleanup_run(metrics::TaskOutputKind::Backup);
-    let deleted_backups = match purge_expired_backup_outputs(pool).await {
+    let deleted_backups = match purge_expired_backup_outputs(backend).await {
         Ok(deleted) => deleted,
         Err(error) => {
             metrics::task_output_cleanup_failed(metrics::TaskOutputKind::Backup);
@@ -685,10 +685,10 @@ async fn process_claimed_task(
     task: &ClaimedTask,
     backup_settings: &BackupSettings,
 ) -> Result<(), ApiError> {
-    let pool = context;
     let task_kind = TaskKind::from_db(&task.kind)?;
     if task_kind == TaskKind::Reindex {
-        return crate::storage::postgres::operations::computed_field::execute_computed_reindex_task(pool, task).await;
+        crate::services::tasks::execute_computed_field_rebuild(context, task).await?;
+        return Ok(());
     }
     let submitted_by = task.submitted_by.ok_or_else(|| {
         ApiError::BadRequest(
@@ -742,7 +742,7 @@ async fn process_claimed_task(
 }
 
 pub(super) async fn mark_claimed_task_failed(
-    pool: &impl crate::storage::StorageContext,
+    backend: &impl crate::storage::StorageContext,
     task: &ClaimedTask,
     err: &ApiError,
 ) -> Result<(), ApiError> {
@@ -757,7 +757,7 @@ pub(super) async fn mark_claimed_task_failed(
     );
 
     fail_task(
-        pool,
+        backend,
         task,
         summary.clone(),
         NewTaskEventRecord {

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -244,6 +244,7 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         "UnifiedSearchStorage",
         "TaskQueueStorage",
         "TaskExecutionStorage",
+        "BackupSnapshotStorage",
         "WorkflowStorage",
         "OperationalStorage",
         "sealed::CertifiedStorageBackend",
@@ -290,12 +291,17 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         "update_personal",
         "delete_personal",
         "request_rebuild",
+        "execute_rebuild",
     ] {
         assert!(
             compact_context.contains(&format!("\"computed_fields\",\"{operation}\"")),
             "computed-field lifecycle operation {operation} must use the common storage observer"
         );
     }
+    assert!(
+        compact_context.contains("\"backup_snapshots\",\"snapshot\""),
+        "backup snapshot creation must use the common storage observer"
+    );
     for operation in [
         "claim",
         "renew_lease",
@@ -376,6 +382,9 @@ fn task_execution_consumers_do_not_import_postgres_task_state_helpers() {
             "storage::capabilities::task",
             "storage::postgres::operations::task::{",
             "storage::postgres::operations::task::purge_expired_",
+            "snapshot_backup_db",
+            "insert_remote_call_result",
+            "execute_computed_reindex_task",
         ] {
             assert!(
                 !source.contains(forbidden),

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::{Arc, LazyLock};
 
 use actix_web::web::Data;
@@ -27,30 +28,34 @@ use crate::storage::{
     AuthenticationStorage, AuthenticationTokenScopeQuery, AuthorizationCollectionAccessQuery,
     AuthorizationCollectionGrantListQuery, AuthorizationCollectionsQuery, AuthorizationGrantKey,
     AuthorizationGrantMutation, AuthorizationGroupMembershipQuery, AuthorizationPermission,
-    AuthorizationStorage, BidirectionalRelatedObjectsQuery, CatalogListQuery, CatalogStorage,
-    ComputedFieldLifecycleStorage, ComputedObjectEnrichmentQuery, ComputedObjectListQuery,
-    ComputedObjectProjection, ComputedObjectStorage, ComputedObjectVisibility, EventArchive,
-    EventDeliveryStorage, EventFanoutStorage, EventHealthStorage, EventRetentionStorage,
-    HistoryAsOfQuery, HistoryCollectionScope, HistoryListQuery, HistoryStorage, MetricsStorage,
-    ObjectAggregateAuthorizationMode, ObjectAggregateAuthorizer, ObjectAggregateStorage,
-    ObjectAggregateStorageQuery, ObjectHistoryAsOfQuery, ObjectHistoryListQuery,
-    ObjectRelationsTouchingIdsQuery, OperationalStateStorage, RelatedObjectsForRootsQuery,
-    RelationGraphQuery, RelationIdsQuery, RelationListQuery, RelationQueryStorage,
-    RelationTouchingQuery, RetainedEvent, STORAGE_CONTRACT_VERSION, StorageBackendKind,
+    AuthorizationStorage, BackupSnapshotStorage, BidirectionalRelatedObjectsQuery,
+    CatalogListQuery, CatalogStorage, ComputedFieldLifecycleStorage, ComputedObjectEnrichmentQuery,
+    ComputedObjectListQuery, ComputedObjectProjection, ComputedObjectStorage,
+    ComputedObjectVisibility, EventArchive, EventDeliveryStorage, EventFanoutStorage,
+    EventHealthStorage, EventRetentionStorage, HistoryAsOfQuery, HistoryCollectionScope,
+    HistoryListQuery, HistoryStorage, MetricsStorage, ObjectAggregateAuthorizationMode,
+    ObjectAggregateAuthorizer, ObjectAggregateStorage, ObjectAggregateStorageQuery,
+    ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectRelationsTouchingIdsQuery,
+    OperationalStateStorage, RelatedObjectsForRootsQuery, RelationGraphQuery, RelationIdsQuery,
+    RelationListQuery, RelationQueryStorage, RelationTouchingQuery, RetainedEvent,
+    STORAGE_CONTRACT_VERSION, StorageBackendKind, StorageBackupTaskArtifact,
     StorageComputedFieldDefinitionInput, StorageComputedFieldDefinitionPatch,
     StorageComputedFieldRebuildRequest, StorageComputedFieldVisibility, StorageError,
-    StorageObject, StorageObjectAggregateAuthorizationCandidate,
+    StorageExportTaskArtifact, StorageObject, StorageObjectAggregateAuthorizationCandidate,
     StorageObjectAggregateAuthorizationTarget, StorageObjectAggregateSort,
     StorageObjectAggregateSpec, StorageObjectAggregateTarget, StoragePersonalComputedFieldCreate,
     StoragePersonalComputedFieldDelete, StoragePersonalComputedFieldListQuery,
     StoragePersonalComputedFieldUpdate, StorageRelatedDirection, StorageRelatedSort,
+    StorageRemoteCallArtifactOutcome, StorageRemoteCallArtifactResponse,
+    StorageRemoteCallArtifactTarget, StorageRemoteCallTaskArtifact,
     StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
-    StorageSharedComputedFieldUpdate, StorageTaskCompletion, StorageTaskCompletionArtifact,
-    StorageTaskCreateRequest, StorageTaskEventAppend, StorageTaskEventInput, StorageTaskFailure,
-    StorageTaskKind, StorageTaskLeaseDuration, StorageTaskListQuery, StorageTaskOutputLookup,
-    StorageTaskPageQuery, StorageTaskResultCounts, StorageTaskScopeSnapshot,
-    StorageTaskStateUpdate, StorageTaskStatus, StorageVisibility, TaskExecutionStorage,
-    TaskQueueStorage, TokenRetentionStorage, UnifiedSearchQuery, UnifiedSearchStorage,
+    StorageSharedComputedFieldUpdate, StorageTaskClaimToken, StorageTaskCompletion,
+    StorageTaskCompletionArtifact, StorageTaskCreateRequest, StorageTaskEventAppend,
+    StorageTaskEventInput, StorageTaskFailure, StorageTaskKind, StorageTaskLease,
+    StorageTaskLeaseDuration, StorageTaskListQuery, StorageTaskOutputLookup, StorageTaskPageQuery,
+    StorageTaskResultCounts, StorageTaskScopeSnapshot, StorageTaskStateUpdate, StorageTaskStatus,
+    StorageVisibility, TaskExecutionStorage, TaskQueueStorage, TokenRetentionStorage,
+    UnifiedSearchQuery, UnifiedSearchStorage,
 };
 use crate::traits::CanSave;
 
@@ -354,57 +359,123 @@ async fn every_available_storage_backend_supplies_the_complete_task_state_machin
                         .is_empty()
                 );
 
-                let first = backend
-                    .claim_next_task(lease_duration)
-                    .await
-                    .expect("certified backend should claim the next task")
-                    .expect("a compatibility task should be claimable");
-                assert!(fixture_ids.contains(&first.task().id()));
-                assert!(
-                    backend
-                        .renew_task_lease(first.lease().clone(), lease_duration)
+                let mut completed_ids = HashSet::new();
+                let mut completed_kinds = HashSet::new();
+                for completed_index in 0..StorageTaskKind::ALL.len() {
+                    let claimed = backend
+                        .claim_next_task(lease_duration)
                         .await
-                        .expect("certified backend should renew a live claim")
-                );
-                backend
-                    .append_task_event(StorageTaskEventAppend::new(
-                        first.lease().clone(),
-                        StorageTaskEventInput::new("running", "Compatibility event"),
-                    ))
-                    .await
-                    .expect("certified backend should append a claim-owned event");
-                backend
-                    .update_task_state(StorageTaskStateUpdate::new(
-                        first.lease().clone(),
-                        StorageTaskStatus::Running,
-                        StorageTaskResultCounts::new(0, 0, 0),
-                    ))
-                    .await
-                    .expect("certified backend should update claimed task state");
-                backend
-                    .complete_task(
-                        StorageTaskCompletion::new(
-                            StorageTaskStateUpdate::new(
-                                first.lease().clone(),
-                                StorageTaskStatus::Succeeded,
-                                StorageTaskResultCounts::new(1, 1, 0),
-                            ),
-                            StorageTaskEventInput::new("succeeded", "Compatibility completed"),
+                        .expect("certified backend should claim the next task")
+                        .expect("a compatibility task should be claimable");
+                    assert!(fixture_ids.contains(&claimed.task().id()));
+                    assert!(completed_ids.insert(claimed.task().id()));
+                    assert!(completed_kinds.insert(claimed.task().kind()));
+                    if completed_index == 0 {
+                        assert!(
+                            backend
+                                .renew_task_lease(claimed.lease().clone(), lease_duration)
+                                .await
+                                .expect("certified backend should renew a live claim")
+                        );
+                        backend
+                            .append_task_event(StorageTaskEventAppend::new(
+                                claimed.lease().clone(),
+                                StorageTaskEventInput::new("running", "Compatibility event"),
+                            ))
+                            .await
+                            .expect("certified backend should append a claim-owned event");
+                    }
+                    backend
+                        .update_task_state(StorageTaskStateUpdate::new(
+                            claimed.lease().clone(),
+                            StorageTaskStatus::Running,
+                            StorageTaskResultCounts::new(0, 0, 0),
+                        ))
+                        .await
+                        .expect("certified backend should update claimed task state");
+                    let artifact = compatibility_completion_artifact(claimed.task().kind());
+                    backend
+                        .complete_task(
+                            StorageTaskCompletion::new(
+                                StorageTaskStateUpdate::new(
+                                    claimed.lease().clone(),
+                                    StorageTaskStatus::Succeeded,
+                                    StorageTaskResultCounts::new(1, 1, 0),
+                                ),
+                                StorageTaskEventInput::new("succeeded", "Compatibility completed"),
+                            )
+                            .artifact(artifact),
                         )
-                        .artifact(StorageTaskCompletionArtifact::None),
-                    )
-                    .await
-                    .expect("certified backend should complete a claimed task");
+                        .await
+                        .expect("certified backend should complete a claimed task");
+                    match claimed.task().kind() {
+                        StorageTaskKind::Export => assert!(matches!(
+                            backend.get_export_output(claimed.task().id()).await,
+                            Ok(StorageTaskOutputLookup::Available(_))
+                        )),
+                        StorageTaskKind::Backup => assert!(matches!(
+                            backend.get_backup_output(claimed.task().id()).await,
+                            Ok(StorageTaskOutputLookup::Available(_))
+                        )),
+                        StorageTaskKind::Import
+                        | StorageTaskKind::Reindex
+                        | StorageTaskKind::RemoteCall => {}
+                    }
+                }
+                assert_eq!(completed_kinds.len(), StorageTaskKind::ALL.len());
 
-                let second = backend
+                let mut failure_fixture_ids = Vec::new();
+                for task_kind in StorageTaskKind::ALL {
+                    let task = backend
+                        .create_task(
+                            StorageTaskCreateRequest::builder(
+                                task_kind,
+                                user.id,
+                                serde_json::json!({"compatibility_failure": true}),
+                                1,
+                            )
+                            .idempotency_key(Some(
+                                IdempotencyKey::new(prefix(&format!(
+                                    "task_execution_failure_{}",
+                                    task_kind.as_str()
+                                )))
+                                .expect("compatibility idempotency key should be valid"),
+                            ))
+                            .request_hash(Some(prefix(&format!(
+                                "task_execution_failure_hash_{}",
+                                task_kind.as_str()
+                            ))))
+                            .scope_snapshot(StorageTaskScopeSnapshot::unscoped())
+                            .build(10),
+                        )
+                        .await
+                        .expect("certified backend should create a failure fixture");
+                    failure_fixture_ids.push(task.id());
+                    fixture_ids.push(task.id());
+                }
+                crate::storage::postgres::with_connection(pool.get_ref(), async |conn| {
+                    use crate::schema::tasks::dsl::{created_at, id, tasks};
+                    diesel::update(tasks.filter(id.eq_any(&failure_fixture_ids)))
+                        .set(
+                            created_at.eq(chrono::NaiveDate::from_ymd_opt(1999, 1, 1)
+                                .expect("compatibility date")
+                                .and_hms_opt(0, 0, 0)
+                                .expect("compatibility time")),
+                        )
+                        .execute(conn)
+                        .await
+                })
+                .await
+                .expect("failure fixtures should be made claim-first");
+                let failed = backend
                     .claim_next_task(lease_duration)
                     .await
-                    .expect("certified backend should claim another task")
-                    .expect("another compatibility task should be claimable");
-                assert!(fixture_ids.contains(&second.task().id()));
+                    .expect("certified backend should claim a failure fixture")
+                    .expect("a compatibility failure fixture should be claimable");
+                assert!(failure_fixture_ids.contains(&failed.task().id()));
                 backend
                     .fail_task(StorageTaskFailure::new(
-                        second.lease().clone(),
+                        failed.lease().clone(),
                         "Compatibility failure",
                         StorageTaskEventInput::new("failed", "Compatibility failure"),
                     ))
@@ -439,6 +510,92 @@ async fn every_available_storage_backend_supplies_the_complete_task_state_machin
     user.delete_without_events(pool.get_ref())
         .await
         .expect("task execution compatibility user should be removed");
+}
+
+fn compatibility_completion_artifact(kind: StorageTaskKind) -> StorageTaskCompletionArtifact {
+    let output_expires_at =
+        chrono::Utc::now().naive_utc() + chrono::Duration::try_hours(1).expect("valid duration");
+    match kind {
+        StorageTaskKind::Import | StorageTaskKind::Reindex => StorageTaskCompletionArtifact::None,
+        StorageTaskKind::Export => StorageTaskCompletionArtifact::Export(
+            StorageExportTaskArtifact::builder(
+                "application/json",
+                serde_json::json!({"compatibility": true}),
+                serde_json::json!([]),
+                output_expires_at,
+            )
+            .output(Some(serde_json::json!({"compatible": true})), None)
+            .build(),
+        ),
+        StorageTaskKind::Backup => StorageTaskCompletionArtifact::Backup(
+            StorageBackupTaskArtifact::new(b"{}".to_vec(), 2, "0".repeat(64), output_expires_at),
+        ),
+        StorageTaskKind::RemoteCall => {
+            StorageTaskCompletionArtifact::RemoteCall(StorageRemoteCallTaskArtifact::new(
+                StorageRemoteCallArtifactTarget::new(
+                    None,
+                    "collection",
+                    1,
+                    "GET",
+                    "https://compatibility.invalid",
+                ),
+                StorageRemoteCallArtifactResponse::new(
+                    Some(200),
+                    Some(serde_json::json!({})),
+                    Some("compatible".to_string()),
+                ),
+                StorageRemoteCallArtifactOutcome::new(1, true, None),
+            ))
+        }
+    }
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_supplies_backup_snapshots() {
+    let _permit = postgres_permit().await;
+    let pool = pool();
+
+    for kind in StorageBackendKind::ALL {
+        match kind {
+            StorageBackendKind::Postgresql => {
+                let backend = StorageHandle::postgres(pool.get_ref().clone());
+                let (state, history) = backend
+                    .snapshot_backup(false)
+                    .await
+                    .expect("certified backend should supply a state-only backup snapshot")
+                    .into_parts();
+                assert_eq!(
+                    state.len(),
+                    crate::models::backup::BACKUP_STATE_SECTIONS.len()
+                );
+                for section in crate::models::backup::BACKUP_STATE_SECTIONS {
+                    assert!(state.contains_key(*section));
+                }
+                assert!(history.is_none());
+
+                let (state, history) = backend
+                    .snapshot_backup(true)
+                    .await
+                    .expect("certified backend should supply a history-inclusive backup snapshot")
+                    .into_parts();
+                assert_eq!(
+                    state.len(),
+                    crate::models::backup::BACKUP_STATE_SECTIONS.len()
+                );
+                for section in crate::models::backup::BACKUP_STATE_SECTIONS {
+                    assert!(state.contains_key(*section));
+                }
+                let history = history.expect("history was requested");
+                assert_eq!(
+                    history.len(),
+                    crate::models::backup::backup_history_sections().count()
+                );
+                for section in crate::models::backup::backup_history_sections() {
+                    assert!(history.contains_key(section));
+                }
+            }
+        }
+    }
 }
 
 #[actix_web::test]
@@ -1087,6 +1244,43 @@ async fn every_available_storage_backend_supplies_computed_field_lifecycle() {
                     .await
                     .expect("certified backend should request a computed-field rebuild");
                 assert_eq!(rebuild_state.class_id(), class_id);
+                let rebuild_task_id = rebuild_state
+                    .active_task_id()
+                    .expect("rebuild request should identify its task");
+                let claim_token = uuid::Uuid::new_v4();
+                crate::storage::postgres::with_connection(pool.get_ref(), async |conn| {
+                    use crate::schema::tasks::dsl::{
+                        id, lease_expires_at, lease_token, status, tasks,
+                    };
+                    diesel::update(tasks.filter(id.eq(rebuild_task_id)))
+                        .set((
+                            status.eq(StorageTaskStatus::Validating.as_str()),
+                            lease_token.eq(Some(claim_token)),
+                            lease_expires_at.eq(Some(
+                                chrono::Utc::now().naive_utc()
+                                    + chrono::Duration::try_minutes(1)
+                                        .expect("valid compatibility lease"),
+                            )),
+                        ))
+                        .execute(conn)
+                        .await
+                })
+                .await
+                .expect("compatibility rebuild should receive a live backend claim");
+                let rebuilt = backend
+                    .execute_computed_field_rebuild(StorageTaskLease::new(
+                        rebuild_task_id,
+                        StorageTaskClaimToken::new(claim_token.to_string()),
+                    ))
+                    .await
+                    .expect("certified backend should execute a claimed computed-field rebuild");
+                assert_eq!(rebuilt.status(), StorageTaskStatus::Succeeded);
+                let ready_state = backend
+                    .computed_field_state(class_id)
+                    .await
+                    .expect("certified backend should expose the completed rebuild state");
+                assert_eq!(ready_state.rebuild_status(), "ready");
+                assert_eq!(ready_state.active_task_id(), None);
 
                 let personal = backend
                     .create_personal_computed_field(StoragePersonalComputedFieldCreate::new(

--- a/tests/api_core_data_suite/computed_fields.rs
+++ b/tests/api_core_data_suite/computed_fields.rs
@@ -9,7 +9,7 @@ mod tests {
     use crate::models::search::parse_query_parameter;
     use crate::models::{
         ComputedFieldDefinitionRequest, GroupID, HubuumClassID, NewHubuumClass, NewHubuumObject,
-        Permissions, TaskID, TaskStatus,
+        Permissions, TaskStatus,
     };
     use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER, finalize_page};
     use crate::permissions::test_support::mock_treetop::{MockAllowRule, MockTreetopBackend};
@@ -19,7 +19,9 @@ mod tests {
         enrich_objects_with_computed_query_snapshot, execute_computed_reindex_task,
         request_class_rebuild, resolve_computed_query_fields, source_data_sha256,
     };
-    use crate::storage::postgres::operations::task::recover_expired_task_leases;
+    use crate::storage::postgres::operations::task::{
+        claim_task_for_backend_test, recover_expired_task_leases,
+    };
     use crate::storage::postgres::{capture_queries, with_connection};
     use crate::tests::api_operations::{
         get_request, get_request_with_permission_backend, patch_request,
@@ -139,7 +141,7 @@ mod tests {
                     .expect("manual rebuild task")
                 }
             };
-            if let Ok(task) = TaskID::new(task_id).unwrap().instance(&context.pool).await {
+            if let Ok(task) = claim_task_for_backend_test(&context.pool, task_id).await {
                 return task;
             }
             tokio::task::yield_now().await;

--- a/tests/api_core_data_suite/object_aggregates/mod.rs
+++ b/tests/api_core_data_suite/object_aggregates/mod.rs
@@ -8,7 +8,7 @@ use crate::events::EventContext;
 use crate::models::{
     ComputedFieldDefinitionPatch, ComputedFieldDefinitionRequest, GroupID, HubuumObject,
     HubuumObjectID, MAX_OBJECT_AGGREGATE_CURSOR_LENGTH, NewHubuumClass, NewHubuumObject,
-    Permissions, ServiceAccountID, TaskID, TokenResourceScope, UpdateHubuumObject,
+    Permissions, ServiceAccountID, TokenResourceScope, UpdateHubuumObject,
 };
 use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER};
 use crate::permissions::test_support::mock_treetop::{MockAllowRule, MockTreetopBackend};
@@ -17,13 +17,14 @@ use crate::storage::postgres::operations::computed_field::{
     class_computation_state_for, create_personal_definition, create_shared_definition,
     execute_computed_reindex_task, update_shared_definition,
 };
+use crate::storage::postgres::operations::task::claim_task_for_backend_test;
 use crate::tests::api_operations::get_request;
 use crate::tests::asserts::{assert_response_status, header_value};
 use crate::tests::{
     ObjectFixture, TestContext, create_test_group, create_test_service_account,
     resource_scoped_token, scoped_token, service_account_token, test_context,
 };
-use crate::traits::{CanDelete, CanUpdate, PermissionController, SelfAccessors};
+use crate::traits::{CanDelete, CanUpdate, PermissionController};
 
 async fn fixture(context: &TestContext, label: &str) -> ObjectFixture {
     let object = |name: &str, description: &str, data: serde_json::Value| NewHubuumObject {
@@ -197,9 +198,7 @@ async fn finish_active_rebuild(context: &TestContext, class_id: i32) {
         if state.active_task_id.is_none() {
             return;
         }
-        let task = TaskID::new(state.active_task_id.unwrap())
-            .unwrap()
-            .instance(&context.pool)
+        let task = claim_task_for_backend_test(&context.pool, state.active_task_id.unwrap())
             .await
             .unwrap();
         let _ = execute_computed_reindex_task(&context.pool, &task).await;

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -133,7 +133,7 @@ async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() 
 
     assert!(
         body.contains(
-            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"10\"} 1"
+            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"11\"} 1"
         )
     );
     assert!(body.contains(

--- a/tests/api_platform_suite/runtime_config.rs
+++ b/tests/api_platform_suite/runtime_config.rs
@@ -37,7 +37,7 @@ mod tests {
         let serialized = serde_json::to_string(&body).unwrap();
 
         assert_eq!(body["database"]["backend"], "postgresql");
-        assert_eq!(body["database"]["contract_version"], 10);
+        assert_eq!(body["database"]["contract_version"], 11);
         assert_eq!(
             body["database"]["capabilities"],
             serde_json::json!([
@@ -52,6 +52,7 @@ mod tests {
                 "unified_search",
                 "task_queue",
                 "task_execution",
+                "backup_snapshots",
                 "workflows",
                 "operations"
             ])


### PR DESCRIPTION
## Summary

- add mandatory backend-neutral backup snapshot and computed rebuild execution contracts
- make remote-call results a typed task completion artifact stored atomically with the terminal task transition
- enforce live opaque claims inside every computed materialization batch and atomically finalize class and task state
- route backup and worker consumers through application services and the observed storage handle
- expand the shared compatibility suite across every task kind, backup mode, and computed rebuild execution

## Rationale

The task state-machine boundary still left three workflow-shaped holes: backup reads called a PostgreSQL snapshot helper directly, computed rebuild workers invoked PostgreSQL execution code, and remote-call workers stored their result before separately finalizing the task. Those paths made backend behavior partial and let application workers depend on adapter operations.

This layer makes those behaviors part of the mandatory storage contract. Application code now carries private-field DTOs and opaque leases, while PostgreSQL owns repeatable-read snapshots, result upserts, row locks, materialization transactions, durable timestamps, and atomic terminal state changes.

## Behavior and compatibility

- `StorageBackend` now requires `BackupSnapshotStorage`; both state-only and history-inclusive canonical snapshots are compatibility tested.
- Computed rebuild execution is required by `ComputedFieldLifecycleStorage` and observed as `computed_fields/execute_rebuild`.
- Every materialization batch locks and revalidates the live claim in the same transaction as its writes.
- Computed class readiness or failure and the task terminal event/state are committed atomically.
- Remote-call response artifacts and terminal task state are committed in one transaction; a stale worker rolls back the result.
- Import/reindex, export, backup, and remote-call completions must supply the artifact shape appropriate to their task kind.
- Export, backup, remote-call, and generic terminal paths use one shared finalizer and consistent terminal logs and metrics.
- The administrator-visible storage contract advances from version `10` to `11` and reports the required `backup_snapshots` capability.

## Breaking change

Administration and monitoring clients that match the storage contract version or exact capability list must accept contract version `11` and the new `backup_snapshots` capability. No data migration or operator configuration change is required.

Part of #27.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- generated OpenAPI is byte-identical to `docs/openapi.json`
- Rust API, supply-chain, and CI change-classifier policy checks
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg "CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release" --tag hubuum-server:verify .`
