### PR TITLE
Extract mandatory import storage contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
-- **Breaking (administrator API):** the storage contract version is now `13`,
+- **Breaking (administrator API):** the storage contract version is now `14`,
   and the redacted administrator configuration reports independently enforced
   `catalog_queries`, `computed_object_queries`, `computed_field_lifecycle`,
   `object_aggregates`, `relation_queries`, `temporal_history`, and
   `unified_search`, `remote_targets`, `task_queue`, `task_execution`,
-  `backup_snapshots`, and `restores`
+  `backup_snapshots`, `restores`, and `imports`
   capabilities instead of
   the broader provisional `queries_and_history` label. Monitoring or
   administration clients matching the version or capability list must accept
@@ -48,8 +48,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   destructive apply, recovery, and provenance now form another mandatory
   compatibility-tested backend contract; restore application code no longer
   imports PostgreSQL/Diesel records or operations. Administration and monitoring
-  clients matching contract version `12` must upgrade to version `13` and
-  accept the required `restores` capability.
+  clients matching contract version `13` must upgrade to version `14` and
+  accept the required `imports` capability. Import planning lookups,
+  rollback-only preflight, strict atomic apply, best-effort per-item apply, and
+  result persistence now form one mandatory backend trait; application import
+  code no longer imports PostgreSQL connections, transactions, or query
+  operations.
 - Event worker and retention configuration validation now uses backend-neutral
   policy terminology, matching the storage traits and DTOs used by application
   workers instead of exposing database implementation language.

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -137,7 +137,7 @@ use std::fmt;
 ///
 /// Increment this when a selectable backend must implement a new capability
 /// family or when an existing family's externally observable semantics change.
-pub const STORAGE_CONTRACT_VERSION: u16 = 13;
+pub const STORAGE_CONTRACT_VERSION: u16 = 14;
 
 /// Stable identity of a selectable storage backend.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -174,12 +174,13 @@ pub enum StorageCapability {
     TaskExecution,
     BackupSnapshots,
     Restores,
+    Imports,
     Workflows,
     Operations,
 }
 
 impl StorageCapability {
-    pub const ALL: [Self; 16] = [
+    pub const ALL: [Self; 17] = [
         Self::DomainLifecycle,
         Self::CatalogQueries,
         Self::ComputedObjectQueries,
@@ -194,6 +195,7 @@ impl StorageCapability {
         Self::TaskExecution,
         Self::BackupSnapshots,
         Self::Restores,
+        Self::Imports,
         Self::Workflows,
         Self::Operations,
     ];
@@ -215,6 +217,7 @@ impl StorageCapability {
             Self::TaskExecution => "task_execution",
             Self::BackupSnapshots => "backup_snapshots",
             Self::Restores => "restores",
+            Self::Imports => "imports",
             Self::Workflows => "workflows",
             Self::Operations => "operations",
         }
@@ -254,6 +257,7 @@ pub enum StorageErrorKind {
     BadRequest,
     Conflict,
     Database,
+    Forbidden,
     Internal,
     NotFound,
     NotAcceptable,
@@ -261,6 +265,7 @@ pub enum StorageErrorKind {
     PreconditionFailed,
     TooManyRequests,
     Unavailable,
+    Unauthorized,
     Validation,
 }
 
@@ -272,6 +277,7 @@ impl StorageErrorKind {
             Self::BadRequest => "bad_request",
             Self::Conflict => "conflict",
             Self::Database => "database",
+            Self::Forbidden => "forbidden",
             Self::Internal => "internal",
             Self::NotFound => "not_found",
             Self::NotAcceptable => "not_acceptable",
@@ -279,6 +285,7 @@ impl StorageErrorKind {
             Self::PreconditionFailed => "precondition_failed",
             Self::TooManyRequests => "too_many_requests",
             Self::Unavailable => "unavailable",
+            Self::Unauthorized => "unauthorized",
             Self::Validation => "validation",
         }
     }
@@ -385,6 +392,7 @@ mod tests {
                 "task_execution",
                 "backup_snapshots",
                 "restores",
+                "imports",
                 "workflows",
                 "operations",
             ]

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -75,7 +75,8 @@ satisfy every capability family below before `StorageHandle` can compose it:
 | Task execution | Opaque claims, lease renewal and recovery, claim-checked events and state changes, atomic terminal artifacts, failure accounting, and output retention |
 | Backup snapshots | Canonical state and optional history sections read from one consistent backend snapshot |
 | Restores | Durable artifact staging, lifecycle transitions, global drain coordination, rollback-safe snapshot replacement, provenance, and recovery |
-| Workflows | Remaining import and export-hydration operations with backend-owned atomic mutations |
+| Imports | Planning lookups, rollback-only preflight, strict and best-effort application, and durable item results |
+| Workflows | Remaining export-hydration operations with backend-owned atomic reads |
 | Operations | Probes, metrics snapshots, retention, event delivery, locking, and worker coordination |
 
 The families are not feature flags and the admin configuration does not report
@@ -97,8 +98,9 @@ contracts. `TaskQueueStorage` replaces task submission and reads, while
 execution is part of `ComputedFieldLifecycleStorage`. `RemoteTargetStorage`
 owns target reads, lifecycle mutations, and invocation provenance.
 `RestoreStorage` owns the complete staged-restore lifecycle and coordinator.
-Remaining import and export-hydration workflow operations stay behind the
-workflow gate until their complete contracts and compatibility tests land. No
+`ImportStorage` owns the complete import workflow. Remaining export-hydration
+operations stay behind the workflow gate until their complete contract and
+compatibility tests land. No
 family is considered complete merely because a marker exists.
 
 PostgreSQL query implementations live in
@@ -113,6 +115,28 @@ composition without implementing every operation behind those contracts.
 The storage contract version changes when a required family is added or when
 observable semantics change. The selected backend and contract version are
 reported in startup logs, process metrics, and the redacted admin configuration.
+
+## Import Semantics
+
+Every selectable backend implements the complete `ImportStorage` trait. Import
+support is indivisible: a backend must provide planning lookups for collections,
+classes, objects, relations, and groups; rollback-only dry-run preflight; strict
+atomic application; best-effort per-item transactions; and durable result
+recording. A lookup-only or write-only adapter cannot satisfy `StorageBackend`.
+
+The application owns request validation, authorization decisions, collision
+policy, result presentation, and task lifecycle. It produces an exhaustive,
+typed `StorageImportOperation` plan and receives indexed preflight or apply
+outcomes containing only `StorageError`. The adapter owns runtime reference
+resolution, row locking, optimistic-revision rechecks, savepoints, and commit or
+rollback behavior. Consequently task planning and execution never receive a
+connection or transaction object and cannot select PostgreSQL operations.
+
+The opaque handle observes every import entry point under bounded `imports/*`
+labels. Labels contain operation names only; imported identifiers, names,
+payloads, and errors are excluded. PostgreSQL-specific tests retain responsibility
+for transaction isolation, history triggers, and timestamp behavior, while the
+available-backend compatibility registry exercises the mandatory contract.
 
 ## Restore Semantics
 

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -453,7 +453,7 @@ mod tests {
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
         assert!(json.contains("\"backend\":\"postgresql\""));
-        assert!(json.contains("\"contract_version\":13"));
+        assert!(json.contains("\"contract_version\":14"));
         assert!(json.contains("\"catalog_queries\""));
         assert!(json.contains("\"computed_object_queries\""));
         assert!(json.contains("\"computed_field_lifecycle\""));
@@ -466,6 +466,7 @@ mod tests {
         assert!(json.contains("\"task_execution\""));
         assert!(json.contains("\"backup_snapshots\""));
         assert!(json.contains("\"restores\""));
+        assert!(json.contains("\"imports\""));
         assert!(!debug.contains("secret-password"));
         assert!(!debug.contains("correct horse battery staple"));
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -174,6 +174,7 @@ impl From<StorageError> for ApiError {
             StorageErrorKind::BadRequest => Self::BadRequest(message),
             StorageErrorKind::Conflict => Self::Conflict(message),
             StorageErrorKind::Database => Self::DatabaseError(message),
+            StorageErrorKind::Forbidden => Self::Forbidden(message),
             StorageErrorKind::Internal => Self::InternalServerError(message),
             StorageErrorKind::NotFound => Self::NotFound(message),
             StorageErrorKind::NotAcceptable => Self::NotAcceptable(message),
@@ -181,6 +182,7 @@ impl From<StorageError> for ApiError {
             StorageErrorKind::PreconditionFailed => Self::PreconditionFailed(message, current_etag),
             StorageErrorKind::TooManyRequests => Self::TooManyRequests(message),
             StorageErrorKind::Unavailable => Self::ServiceUnavailable(message),
+            StorageErrorKind::Unauthorized => Self::Unauthorized(message),
             StorageErrorKind::Validation => Self::ValidationError(message),
         }
     }
@@ -488,6 +490,10 @@ mod tests {
                 "conflict",
             ),
             (
+                StorageError::new(StorageErrorKind::Forbidden, "access denied", None),
+                "forbidden",
+            ),
+            (
                 StorageError::new(StorageErrorKind::NotFound, "collection missing", None),
                 "not_found",
             ),
@@ -518,6 +524,10 @@ mod tests {
                     None,
                 ),
                 "too_many_requests",
+            ),
+            (
+                StorageError::new(StorageErrorKind::Unauthorized, "login required", None),
+                "unauthorized",
             ),
         ] {
             assert_eq!(ApiError::from(error).class(), expected_class);

--- a/src/storage/capabilities.rs
+++ b/src/storage/capabilities.rs
@@ -90,17 +90,6 @@ pub(crate) mod service_account {
     };
 }
 
-pub(crate) mod task {
-    pub(crate) use crate::storage::postgres::operations::task::insert_import_results;
-}
-
-pub(crate) mod task_import {
-    pub(crate) use crate::storage::postgres::operations::task_import::{
-        lookup_classes_by_collection_and_names, lookup_collections_by_name,
-        lookup_objects_by_class_and_names,
-    };
-}
-
 pub(crate) use crate::storage::postgres::{
     StorageCallSite, with_mutation_provenance_scope, with_revision_precondition_scope,
     with_statement_timeout_scope, with_storage_call_site,

--- a/src/storage/context.rs
+++ b/src/storage/context.rs
@@ -4,7 +4,10 @@ use uuid::Uuid;
 
 use crate::events::{EventDeliverySettings, EventFanoutSettings, EventRetentionSettings};
 use crate::models::search::QueryOptions;
-use crate::models::{MaintenanceState, TokenRetentionSettings};
+use crate::models::{
+    Collection, CollectionKey, HubuumClass, HubuumObject, ImportMode, MaintenanceState,
+    TokenRetentionSettings,
+};
 use crate::permissions::{AppContext, PermissionBackend};
 use crate::storage::observed::observe_storage_call;
 use crate::storage::postgres::PostgresPool;
@@ -21,8 +24,8 @@ use crate::storage::{
     EventDeliveryBatch, EventDeliveryClaim, EventDeliveryHealthSnapshot, EventDeliveryStorage,
     EventFanoutStorage, EventHealthStorage, EventMetricsSnapshot, EventRetentionStorage,
     EventRetentionSummary, ExportTemplateHistoryRecord, HistoryAsOfQuery, HistoryListQuery,
-    HistoryPage, HistoryPrincipalName, HistoryStorage, InventoryGaugeSnapshot, MetricsStorage,
-    ObjectAggregateAuthorizer, ObjectAggregateStorage, ObjectAggregateStorageQuery,
+    HistoryPage, HistoryPrincipalName, HistoryStorage, ImportStorage, InventoryGaugeSnapshot,
+    MetricsStorage, ObjectAggregateAuthorizer, ObjectAggregateStorage, ObjectAggregateStorageQuery,
     ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectHistoryRecord,
     ObjectRelationsTouchingIdsQuery, OperationalStateStorage, PostgresStorage, ReadinessSnapshot,
     RelatedObjectsForRootsQuery, RelationGraphQuery, RelationIdsQuery, RelationListQuery,
@@ -32,16 +35,17 @@ use crate::storage::{
     StorageClassComputationState, StorageClassGraphRow, StorageClassRelation, StorageCollection,
     StorageComputedFieldDefinition, StorageComputedFieldMutation, StorageComputedFieldPage,
     StorageComputedFieldRebuildRequest, StorageComputedObject, StorageError, StorageExportOutput,
-    StorageExportOutputSummary, StorageImportTaskResultPage, StorageObject,
-    StorageObjectAggregatePage, StorageObjectGraphRow, StorageObjectRelation,
-    StoragePersonalComputedFieldCreate, StoragePersonalComputedFieldDelete,
-    StoragePersonalComputedFieldListQuery, StoragePersonalComputedFieldUpdate, StoragePoolState,
-    StorageRelatedObjectForRootRow, StorageRelatedObjectIncludeRow, StorageRemoteTarget,
-    StorageRemoteTargetCreate, StorageRemoteTargetDelete, StorageRemoteTargetInvocation,
-    StorageRemoteTargetListQuery, StorageRemoteTargetPage, StorageRemoteTargetUpdate,
-    StorageRestoreApply, StorageRestoreCompletion, StorageRestoreCoordinatorSnapshot,
-    StorageRestoreDrainState, StorageRestoreFailure, StorageRestoreJob, StorageRestoreStageCreate,
-    StorageRestoreStatus, StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
+    StorageExportOutputSummary, StorageImportApply, StorageImportPlanItem, StorageImportPreflight,
+    StorageImportResult, StorageImportTaskResultPage, StorageObject, StorageObjectAggregatePage,
+    StorageObjectGraphRow, StorageObjectRelation, StoragePersonalComputedFieldCreate,
+    StoragePersonalComputedFieldDelete, StoragePersonalComputedFieldListQuery,
+    StoragePersonalComputedFieldUpdate, StoragePoolState, StorageRelatedObjectForRootRow,
+    StorageRelatedObjectIncludeRow, StorageRemoteTarget, StorageRemoteTargetCreate,
+    StorageRemoteTargetDelete, StorageRemoteTargetInvocation, StorageRemoteTargetListQuery,
+    StorageRemoteTargetPage, StorageRemoteTargetUpdate, StorageRestoreApply,
+    StorageRestoreCompletion, StorageRestoreCoordinatorSnapshot, StorageRestoreDrainState,
+    StorageRestoreFailure, StorageRestoreJob, StorageRestoreStageCreate, StorageRestoreStatus,
+    StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
     StorageSharedComputedFieldUpdate, StorageTask, StorageTaskAccess, StorageTaskClaim,
     StorageTaskCompletion, StorageTaskCreateRequest, StorageTaskEventAppend, StorageTaskEventPage,
     StorageTaskFailure, StorageTaskLease, StorageTaskLeaseDuration, StorageTaskListQuery,
@@ -1522,6 +1526,268 @@ impl RemoteTargetStorage for StorageHandle {
                 }
             },
         )
+        .await
+    }
+}
+
+#[async_trait]
+impl ImportStorage for StorageHandle {
+    async fn import_root_collection(&self) -> Result<Collection, StorageError> {
+        observe_storage_call(self.backend_name(), "imports", "root_collection", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.import_root_collection().await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn import_collection_by_id(
+        &self,
+        collection_id: i32,
+    ) -> Result<Option<Collection>, StorageError> {
+        observe_storage_call(self.backend_name(), "imports", "collection_by_id", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.import_collection_by_id(collection_id).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn import_collection_by_key(
+        &self,
+        key: &CollectionKey,
+    ) -> Result<Option<Collection>, StorageError> {
+        observe_storage_call(self.backend_name(), "imports", "collection_by_key", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.import_collection_by_key(key).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn import_collections_by_name(
+        &self,
+        name: &str,
+    ) -> Result<Vec<Collection>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "imports",
+            "collections_by_name",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.import_collections_by_name(name).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn import_collection_child_by_name(
+        &self,
+        parent_collection_id: i32,
+        name: &str,
+    ) -> Result<Option<Collection>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "imports",
+            "collection_child_by_name",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend
+                            .import_collection_child_by_name(parent_collection_id, name)
+                            .await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn import_class_by_name(
+        &self,
+        collection_id: i32,
+        name: &str,
+    ) -> Result<Option<HubuumClass>, StorageError> {
+        observe_storage_call(self.backend_name(), "imports", "class_by_name", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.import_class_by_name(collection_id, name).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn import_classes_by_names(
+        &self,
+        collection_id: i32,
+        names: &[String],
+    ) -> Result<Vec<HubuumClass>, StorageError> {
+        observe_storage_call(self.backend_name(), "imports", "classes_by_names", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.import_classes_by_names(collection_id, names).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn import_object_by_name(
+        &self,
+        class_id: i32,
+        name: &str,
+    ) -> Result<Option<HubuumObject>, StorageError> {
+        observe_storage_call(self.backend_name(), "imports", "object_by_name", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.import_object_by_name(class_id, name).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn import_objects_by_names(
+        &self,
+        class_id: i32,
+        names: &[String],
+    ) -> Result<Vec<HubuumObject>, StorageError> {
+        observe_storage_call(self.backend_name(), "imports", "objects_by_names", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.import_objects_by_names(class_id, names).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn import_class_relation_exists(
+        &self,
+        left_class_id: i32,
+        right_class_id: i32,
+    ) -> Result<bool, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "imports",
+            "class_relation_exists",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend
+                            .import_class_relation_exists(left_class_id, right_class_id)
+                            .await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn import_object_relation_exists(
+        &self,
+        left_object_id: i32,
+        right_object_id: i32,
+    ) -> Result<bool, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "imports",
+            "object_relation_exists",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend
+                            .import_object_relation_exists(left_object_id, right_object_id)
+                            .await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn import_group_exists(
+        &self,
+        identity_scope: &str,
+        group_name: &str,
+    ) -> Result<bool, StorageError> {
+        observe_storage_call(self.backend_name(), "imports", "group_exists", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend
+                        .import_group_exists(identity_scope, group_name)
+                        .await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn preflight_import(
+        &self,
+        items: Vec<StorageImportPlanItem>,
+        mode: ImportMode,
+    ) -> Result<StorageImportPreflight, StorageError> {
+        observe_storage_call(self.backend_name(), "imports", "preflight", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.preflight_import(items, mode).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn apply_import_strict(
+        &self,
+        items: Vec<StorageImportPlanItem>,
+    ) -> Result<(), StorageError> {
+        observe_storage_call(self.backend_name(), "imports", "apply_strict", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.apply_import_strict(items).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn apply_import_best_effort(
+        &self,
+        items: Vec<StorageImportPlanItem>,
+        mode: ImportMode,
+    ) -> Result<StorageImportApply, StorageError> {
+        observe_storage_call(self.backend_name(), "imports", "apply_best_effort", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.apply_import_best_effort(items, mode).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn record_import_results(
+        &self,
+        results: Vec<StorageImportResult>,
+    ) -> Result<(), StorageError> {
+        observe_storage_call(self.backend_name(), "imports", "record_results", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.record_import_results(results).await
+                }
+            }
+        })
         .await
     }
 }

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -4,7 +4,7 @@ use super::{
     AuthenticationStorage, AuthorizationStorage, BackupSnapshotStorage, CatalogStorage,
     ClassRelationStore, ClassStore, CollectionStore, ComputedFieldLifecycleStorage,
     ComputedObjectStorage, EventDeliveryStorage, EventFanoutStorage, EventHealthStorage,
-    EventRetentionStorage, HistoryStorage, MetricsStorage, ObjectAggregateStorage,
+    EventRetentionStorage, HistoryStorage, ImportStorage, MetricsStorage, ObjectAggregateStorage,
     ObjectRelationStore, ObjectStore, OperationalStateStorage, PostgresStorage,
     RelationQueryStorage, RemoteTargetStorage, RestoreStorage, TaskExecutionStorage,
     TaskQueueStorage, TokenRetentionStorage, UnifiedSearchStorage,
@@ -85,6 +85,7 @@ pub(crate) trait StorageBackend:
     + TaskExecutionStorage
     + BackupSnapshotStorage
     + RestoreStorage
+    + ImportStorage
     + WorkflowStorage
     + OperationalStorage
     + sealed::CertifiedStorageBackend
@@ -159,6 +160,7 @@ mod tests {
                 "task_execution",
                 "backup_snapshots",
                 "restores",
+                "imports",
                 "workflows",
                 "operations",
             ]

--- a/src/storage/imports.rs
+++ b/src/storage/imports.rs
@@ -1,0 +1,492 @@
+use async_trait::async_trait;
+
+use crate::models::{
+    Collection, CollectionKey, HubuumClass, HubuumObject, ImportClassInput,
+    ImportClassRelationInput, ImportCollectionInput, ImportCollectionPermissionInput,
+    ImportComputedFieldInput, ImportEventSinkInput, ImportEventSubscriptionInput,
+    ImportExportTemplateInput, ImportGroupInput, ImportGroupMembershipInput,
+    ImportIdentityScopeInput, ImportMode, ImportObjectInput, ImportObjectRelationInput,
+    ImportPrincipalInput, ImportRemoteTargetInput, RestoreTimestamps,
+};
+
+use super::StorageError;
+
+/// Durable import result supplied by the application after planning or apply.
+#[derive(Clone, PartialEq)]
+pub(crate) struct StorageImportResult {
+    task_id: i32,
+    item_ref: Option<String>,
+    entity_kind: String,
+    action: String,
+    identifier: Option<String>,
+    outcome: String,
+    error: Option<String>,
+    details: Option<serde_json::Value>,
+}
+
+impl StorageImportResult {
+    pub(crate) fn builder(
+        task_id: i32,
+        entity_kind: impl Into<String>,
+        action: impl Into<String>,
+        outcome: impl Into<String>,
+    ) -> StorageImportResultBuilder {
+        StorageImportResultBuilder {
+            result: Self {
+                task_id,
+                item_ref: None,
+                entity_kind: entity_kind.into(),
+                action: action.into(),
+                identifier: None,
+                outcome: outcome.into(),
+                error: None,
+                details: None,
+            },
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn error(&self) -> Option<&str> {
+        self.error.as_deref()
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        i32,
+        Option<String>,
+        String,
+        String,
+        Option<String>,
+        String,
+        Option<String>,
+        Option<serde_json::Value>,
+    ) {
+        (
+            self.task_id,
+            self.item_ref,
+            self.entity_kind,
+            self.action,
+            self.identifier,
+            self.outcome,
+            self.error,
+            self.details,
+        )
+    }
+}
+
+impl std::fmt::Debug for StorageImportResult {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("StorageImportResult")
+            .field("task_id", &"[redacted]")
+            .field("has_item_ref", &self.item_ref.is_some())
+            .field("entity_kind", &self.entity_kind)
+            .field("action", &self.action)
+            .field("outcome", &self.outcome)
+            .field("has_identifier", &self.identifier.is_some())
+            .field("has_error", &self.error.is_some())
+            .field("has_details", &self.details.is_some())
+            .finish()
+    }
+}
+
+pub(crate) struct StorageImportResultBuilder {
+    result: StorageImportResult,
+}
+
+impl StorageImportResultBuilder {
+    pub(crate) fn item_ref(mut self, item_ref: Option<String>) -> Self {
+        self.result.item_ref = item_ref;
+        self
+    }
+
+    pub(crate) fn identifier(mut self, identifier: Option<String>) -> Self {
+        self.result.identifier = identifier;
+        self
+    }
+
+    pub(crate) fn error(mut self, error: Option<String>) -> Self {
+        self.result.error = error;
+        self
+    }
+
+    pub(crate) fn details(mut self, details: Option<serde_json::Value>) -> Self {
+        self.result.details = details;
+        self
+    }
+
+    pub(crate) fn build(self) -> StorageImportResult {
+        self.result
+    }
+}
+
+/// A backend-neutral import command produced by application planning.
+///
+/// The enum is intentionally exhaustive: a selectable backend cannot claim
+/// import compatibility without handling every import entity and mutation.
+#[derive(Clone)]
+pub(crate) enum StorageImportOperation {
+    UpsertIdentityScope {
+        input: ImportIdentityScopeInput,
+        overwrite: bool,
+    },
+    UpsertGroup {
+        input: ImportGroupInput,
+        overwrite: bool,
+    },
+    UpsertPrincipal {
+        input: ImportPrincipalInput,
+        overwrite: bool,
+    },
+    UpsertGroupMembership {
+        input: ImportGroupMembershipInput,
+        overwrite: bool,
+    },
+    CreateCollection(ImportCollectionInput),
+    UpdateCollection {
+        collection_id: i32,
+        input: ImportCollectionInput,
+    },
+    CreateClass(ImportClassInput),
+    UpdateClass {
+        class_id: i32,
+        input: ImportClassInput,
+    },
+    CreateObject(ImportObjectInput),
+    UpdateObject {
+        object_id: i32,
+        input: ImportObjectInput,
+    },
+    UpsertComputedField {
+        input: ImportComputedFieldInput,
+        overwrite: bool,
+    },
+    CreateClassRelation(ImportClassRelationInput),
+    UpdateClassRelationTimestamps {
+        input: ImportClassRelationInput,
+        timestamps: RestoreTimestamps,
+    },
+    CheckClassRelationCondition(ImportClassRelationInput),
+    CreateObjectRelation(ImportObjectRelationInput),
+    UpdateObjectRelationTimestamps {
+        input: ImportObjectRelationInput,
+        timestamps: RestoreTimestamps,
+    },
+    CheckObjectRelationCondition(ImportObjectRelationInput),
+    ApplyCollectionPermissions {
+        input: ImportCollectionPermissionInput,
+        overwrite: bool,
+    },
+    UpsertExportTemplate {
+        input: ImportExportTemplateInput,
+        overwrite: bool,
+    },
+    UpsertRemoteTarget {
+        input: ImportRemoteTargetInput,
+        overwrite: bool,
+    },
+    UpsertEventSink {
+        input: ImportEventSinkInput,
+        overwrite: bool,
+    },
+    UpsertEventSubscription {
+        input: ImportEventSubscriptionInput,
+        overwrite: bool,
+    },
+}
+
+impl StorageImportOperation {
+    pub(crate) const fn kind(&self) -> &'static str {
+        match self {
+            Self::UpsertIdentityScope { .. } => "upsert_identity_scope",
+            Self::UpsertGroup { .. } => "upsert_group",
+            Self::UpsertPrincipal { .. } => "upsert_principal",
+            Self::UpsertGroupMembership { .. } => "upsert_group_membership",
+            Self::CreateCollection(_) => "create_collection",
+            Self::UpdateCollection { .. } => "update_collection",
+            Self::CreateClass(_) => "create_class",
+            Self::UpdateClass { .. } => "update_class",
+            Self::CreateObject(_) => "create_object",
+            Self::UpdateObject { .. } => "update_object",
+            Self::UpsertComputedField { .. } => "upsert_computed_field",
+            Self::CreateClassRelation(_) => "create_class_relation",
+            Self::UpdateClassRelationTimestamps { .. } => "update_class_relation_timestamps",
+            Self::CheckClassRelationCondition(_) => "check_class_relation_condition",
+            Self::CreateObjectRelation(_) => "create_object_relation",
+            Self::UpdateObjectRelationTimestamps { .. } => "update_object_relation_timestamps",
+            Self::CheckObjectRelationCondition(_) => "check_object_relation_condition",
+            Self::ApplyCollectionPermissions { .. } => "apply_collection_permissions",
+            Self::UpsertExportTemplate { .. } => "upsert_export_template",
+            Self::UpsertRemoteTarget { .. } => "upsert_remote_target",
+            Self::UpsertEventSink { .. } => "upsert_event_sink",
+            Self::UpsertEventSubscription { .. } => "upsert_event_subscription",
+        }
+    }
+
+    const fn overwrite(&self) -> Option<bool> {
+        match self {
+            Self::UpsertIdentityScope { overwrite, .. }
+            | Self::UpsertGroup { overwrite, .. }
+            | Self::UpsertPrincipal { overwrite, .. }
+            | Self::UpsertGroupMembership { overwrite, .. }
+            | Self::UpsertComputedField { overwrite, .. }
+            | Self::ApplyCollectionPermissions { overwrite, .. }
+            | Self::UpsertExportTemplate { overwrite, .. }
+            | Self::UpsertRemoteTarget { overwrite, .. }
+            | Self::UpsertEventSink { overwrite, .. }
+            | Self::UpsertEventSubscription { overwrite, .. } => Some(*overwrite),
+            Self::CreateCollection(_)
+            | Self::UpdateCollection { .. }
+            | Self::CreateClass(_)
+            | Self::UpdateClass { .. }
+            | Self::CreateObject(_)
+            | Self::UpdateObject { .. }
+            | Self::CreateClassRelation(_)
+            | Self::UpdateClassRelationTimestamps { .. }
+            | Self::CheckClassRelationCondition(_)
+            | Self::CreateObjectRelation(_)
+            | Self::UpdateObjectRelationTimestamps { .. }
+            | Self::CheckObjectRelationCondition(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Debug for StorageImportOperation {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("StorageImportOperation")
+            .field("kind", &self.kind())
+            .field("overwrite", &self.overwrite())
+            .field("payload", &"[redacted]")
+            .finish()
+    }
+}
+
+/// One indexed operation in an import plan.
+#[derive(Clone, Debug)]
+pub(crate) struct StorageImportPlanItem {
+    index: usize,
+    operation: StorageImportOperation,
+}
+
+impl StorageImportPlanItem {
+    pub(crate) const fn new(index: usize, operation: StorageImportOperation) -> Self {
+        Self { index, operation }
+    }
+
+    pub(crate) const fn index(&self) -> usize {
+        self.index
+    }
+
+    pub(crate) const fn operation(&self) -> &StorageImportOperation {
+        &self.operation
+    }
+}
+
+/// Per-item dry-run result returned from a rollback-only backend transaction.
+#[derive(Debug)]
+pub(crate) struct StorageImportPreflightItem {
+    index: usize,
+    observed_revision: Option<crate::models::ResourceRevision>,
+    error: Option<StorageError>,
+}
+
+impl StorageImportPreflightItem {
+    pub(crate) const fn success(
+        index: usize,
+        observed_revision: Option<crate::models::ResourceRevision>,
+    ) -> Self {
+        Self {
+            index,
+            observed_revision,
+            error: None,
+        }
+    }
+
+    pub(crate) const fn failure(
+        index: usize,
+        observed_revision: Option<crate::models::ResourceRevision>,
+        error: StorageError,
+    ) -> Self {
+        Self {
+            index,
+            observed_revision,
+            error: Some(error),
+        }
+    }
+
+    pub(crate) const fn index(&self) -> usize {
+        self.index
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        usize,
+        Option<crate::models::ResourceRevision>,
+        Option<StorageError>,
+    ) {
+        (self.index, self.observed_revision, self.error)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct StorageImportPreflight {
+    items: Vec<StorageImportPreflightItem>,
+    aborted: bool,
+}
+
+impl StorageImportPreflight {
+    pub(crate) const fn new(items: Vec<StorageImportPreflightItem>, aborted: bool) -> Self {
+        Self { items, aborted }
+    }
+
+    pub(crate) fn into_parts(self) -> (Vec<StorageImportPreflightItem>, bool) {
+        (self.items, self.aborted)
+    }
+}
+
+/// Per-item result from a best-effort import transaction.
+#[derive(Debug)]
+pub(crate) struct StorageImportApplyItem {
+    index: usize,
+    error: Option<StorageError>,
+}
+
+impl StorageImportApplyItem {
+    pub(crate) const fn success(index: usize) -> Self {
+        Self { index, error: None }
+    }
+
+    pub(crate) const fn failure(index: usize, error: StorageError) -> Self {
+        Self {
+            index,
+            error: Some(error),
+        }
+    }
+
+    pub(crate) const fn index(&self) -> usize {
+        self.index
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn error(&self) -> Option<&StorageError> {
+        self.error.as_ref()
+    }
+
+    pub(crate) fn into_parts(self) -> (usize, Option<StorageError>) {
+        (self.index, self.error)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct StorageImportApply {
+    items: Vec<StorageImportApplyItem>,
+    aborted: bool,
+}
+
+impl StorageImportApply {
+    pub(crate) const fn new(items: Vec<StorageImportApplyItem>, aborted: bool) -> Self {
+        Self { items, aborted }
+    }
+
+    pub(crate) fn into_parts(self) -> (Vec<StorageImportApplyItem>, bool) {
+        (self.items, self.aborted)
+    }
+}
+
+/// Complete import capability required from every selectable backend.
+///
+/// Planning lookups, rollback-only preflight, strict atomic application,
+/// best-effort per-item application, and durable result recording form one
+/// indivisible capability. Implementing only the lookup subset is not enough
+/// to satisfy [`crate::storage::StorageBackend`].
+#[async_trait]
+pub(crate) trait ImportStorage: Send + Sync {
+    async fn import_root_collection(&self) -> Result<Collection, StorageError>;
+
+    async fn import_collection_by_id(
+        &self,
+        collection_id: i32,
+    ) -> Result<Option<Collection>, StorageError>;
+
+    async fn import_collection_by_key(
+        &self,
+        key: &CollectionKey,
+    ) -> Result<Option<Collection>, StorageError>;
+
+    async fn import_collections_by_name(&self, name: &str)
+    -> Result<Vec<Collection>, StorageError>;
+
+    async fn import_collection_child_by_name(
+        &self,
+        parent_collection_id: i32,
+        name: &str,
+    ) -> Result<Option<Collection>, StorageError>;
+
+    async fn import_class_by_name(
+        &self,
+        collection_id: i32,
+        name: &str,
+    ) -> Result<Option<HubuumClass>, StorageError>;
+
+    async fn import_classes_by_names(
+        &self,
+        collection_id: i32,
+        names: &[String],
+    ) -> Result<Vec<HubuumClass>, StorageError>;
+
+    async fn import_object_by_name(
+        &self,
+        class_id: i32,
+        name: &str,
+    ) -> Result<Option<HubuumObject>, StorageError>;
+
+    async fn import_objects_by_names(
+        &self,
+        class_id: i32,
+        names: &[String],
+    ) -> Result<Vec<HubuumObject>, StorageError>;
+
+    async fn import_class_relation_exists(
+        &self,
+        left_class_id: i32,
+        right_class_id: i32,
+    ) -> Result<bool, StorageError>;
+
+    async fn import_object_relation_exists(
+        &self,
+        left_object_id: i32,
+        right_object_id: i32,
+    ) -> Result<bool, StorageError>;
+
+    async fn import_group_exists(
+        &self,
+        identity_scope: &str,
+        group_name: &str,
+    ) -> Result<bool, StorageError>;
+
+    async fn preflight_import(
+        &self,
+        items: Vec<StorageImportPlanItem>,
+        mode: ImportMode,
+    ) -> Result<StorageImportPreflight, StorageError>;
+
+    async fn apply_import_strict(
+        &self,
+        items: Vec<StorageImportPlanItem>,
+    ) -> Result<(), StorageError>;
+
+    async fn apply_import_best_effort(
+        &self,
+        items: Vec<StorageImportPlanItem>,
+        mode: ImportMode,
+    ) -> Result<StorageImportApply, StorageError>;
+
+    async fn record_import_results(
+        &self,
+        results: Vec<StorageImportResult>,
+    ) -> Result<(), StorageError>;
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,6 +4,7 @@ mod classes;
 mod collections;
 mod context;
 mod contract;
+mod imports;
 #[cfg(test)]
 mod memory;
 mod metrics;
@@ -88,6 +89,10 @@ pub(crate) use hubuum_storage_core::{
 };
 pub(crate) use hubuum_storage_core::{ClassHistoryRecord, CollectionHistoryRecord};
 pub(crate) use hubuum_storage_core::{StorageError, StorageErrorKind};
+pub(crate) use imports::{
+    ImportStorage, StorageImportApply, StorageImportApplyItem, StorageImportOperation,
+    StorageImportPlanItem, StorageImportPreflight, StorageImportPreflightItem, StorageImportResult,
+};
 #[cfg(test)]
 pub(crate) use memory::MemoryStorageModel;
 pub(crate) use metrics::{

--- a/src/storage/postgres/error.rs
+++ b/src/storage/postgres/error.rs
@@ -51,6 +51,7 @@ impl From<PostgresStorageError> for StorageError {
                 Self::new(StorageErrorKind::PayloadTooLarge, message, None)
             }
             ApiError::Conflict(message) => Self::new(StorageErrorKind::Conflict, message, None),
+            ApiError::Forbidden(message) => Self::new(StorageErrorKind::Forbidden, message, None),
             ApiError::DatabaseError(message) | ApiError::DbConnectionError(message) => {
                 Self::new(StorageErrorKind::Database, message, None)
             }
@@ -65,6 +66,9 @@ impl From<PostgresStorageError> for StorageError {
             }
             ApiError::ServiceUnavailable(message) => {
                 Self::new(StorageErrorKind::Unavailable, message, None)
+            }
+            ApiError::Unauthorized(message) => {
+                Self::new(StorageErrorKind::Unauthorized, message, None)
             }
             error => Self::new(
                 StorageErrorKind::Internal,
@@ -106,6 +110,14 @@ mod tests {
         assert_eq!(
             map_postgres_error(ApiError::TooManyRequests("capacity reached".to_string())).kind(),
             StorageErrorKind::TooManyRequests
+        );
+        assert_eq!(
+            map_postgres_error(ApiError::Forbidden("access denied".to_string())).kind(),
+            StorageErrorKind::Forbidden
+        );
+        assert_eq!(
+            map_postgres_error(ApiError::Unauthorized("login required".to_string())).kind(),
+            StorageErrorKind::Unauthorized
         );
     }
 }

--- a/src/storage/postgres/imports.rs
+++ b/src/storage/postgres/imports.rs
@@ -1,0 +1,1295 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use diesel_async::AsyncConnection;
+
+use crate::errors::ApiError;
+use crate::models::{
+    ClassKey, Collection, CollectionKey, EventSinkKey, GroupKey, HubuumClass, HubuumObject,
+    IdentityScopeKey, ImportAtomicity, ImportClassRelationInput, ImportCollectionInput,
+    ImportCollisionPolicy, ImportComputedFieldVisibility, ImportExportTemplateInput, ImportMode,
+    ImportObjectRelationInput, ImportPermissionPolicy, ImportPrincipalSubtype,
+    NewHubuumClassRelation, NewImportTaskResultRecord, ObjectKey, PrincipalKey,
+};
+use crate::storage::{
+    ImportStorage, StorageError, StorageImportApply, StorageImportApplyItem,
+    StorageImportOperation, StorageImportPlanItem, StorageImportPreflight,
+    StorageImportPreflightItem, StorageImportResult,
+};
+
+use super::error::map_postgres_error;
+use super::operations::task::insert_import_results;
+use super::operations::task_import::{
+    apply_permissions_db, check_class_relation_import_condition_db,
+    check_object_relation_import_condition_db, create_class_db, create_class_relation_db,
+    create_collection_db, create_object_db, create_object_relation_db,
+    load_export_template_sources_db, lookup_class_by_collection_and_name,
+    lookup_class_by_collection_and_name_db, lookup_classes_by_collection_and_names,
+    lookup_collection_by_id, lookup_collection_by_key, lookup_collection_by_key_db,
+    lookup_collection_child_by_name_db, lookup_collections_by_name, lookup_direct_class_relation,
+    lookup_event_sink_id_by_name_db, lookup_group_by_name, lookup_group_by_name_db,
+    lookup_identity_scope_id_by_name_db, lookup_object_by_class_and_name,
+    lookup_object_by_class_and_name_db, lookup_object_relation, lookup_objects_by_class_and_names,
+    lookup_principal_id_by_name_db, lookup_root_collection, lookup_root_collection_db,
+    update_class_db, update_class_relation_timestamps_db, update_collection_db, update_object_db,
+    update_object_relation_timestamps_db, upsert_computed_field_db, upsert_event_sink_db,
+    upsert_event_subscription_db, upsert_export_template_db, upsert_group_db,
+    upsert_group_membership_db, upsert_identity_scope_db, upsert_principal_db,
+    upsert_remote_target_db,
+};
+use super::{PostgresConnection, PostgresStorage, with_connection, with_transaction};
+
+#[derive(Default)]
+pub(crate) struct RuntimeState {
+    pub(crate) identity_scopes_by_ref: HashMap<String, i32>,
+    pub(crate) groups_by_ref: HashMap<String, i32>,
+    pub(crate) principals_by_ref: HashMap<String, i32>,
+    pub(crate) collections_by_ref: HashMap<String, Collection>,
+    pub(crate) classes_by_ref: HashMap<String, HubuumClass>,
+    pub(crate) objects_by_ref: HashMap<String, HubuumObject>,
+    pub(crate) event_sinks_by_ref: HashMap<String, i32>,
+    pub(crate) import_export_templates: Vec<ImportExportTemplateInput>,
+}
+
+impl RuntimeState {
+    fn for_plan(items: &[StorageImportPlanItem]) -> Self {
+        let import_export_templates = items
+            .iter()
+            .filter_map(|item| match item.operation() {
+                StorageImportOperation::UpsertExportTemplate { input, .. } => Some(input.clone()),
+                _ => None,
+            })
+            .collect();
+        Self {
+            import_export_templates,
+            ..Self::default()
+        }
+    }
+}
+
+fn collection_key_label(key: &CollectionKey) -> String {
+    match &key.path {
+        Some(path) => format!("/{}", path.join("/")),
+        None => key.name.clone(),
+    }
+}
+
+async fn resolve_collection_runtime(
+    conn: &mut PostgresConnection,
+    runtime: &RuntimeState,
+    reference: Option<&str>,
+    key: Option<&CollectionKey>,
+) -> Result<Collection, ApiError> {
+    match (reference, key) {
+        (Some(reference), None) => runtime
+            .collections_by_ref
+            .get(reference)
+            .cloned()
+            .ok_or_else(|| ApiError::BadRequest(format!("Unknown collection ref '{reference}'"))),
+        (None, Some(key)) => lookup_collection_by_key_db(conn, key)
+            .await?
+            .ok_or_else(|| {
+                ApiError::NotFound(format!(
+                    "Collection '{}' not found during execution",
+                    collection_key_label(key)
+                ))
+            }),
+        _ => Err(ApiError::BadRequest(
+            "Exactly one of collection_ref or collection_key must be provided".to_string(),
+        )),
+    }
+}
+
+async fn resolve_collection_parent_runtime(
+    conn: &mut PostgresConnection,
+    runtime: &RuntimeState,
+    input: &ImportCollectionInput,
+) -> Result<Collection, ApiError> {
+    match (
+        input.parent_collection_ref.as_deref(),
+        input.parent_collection_key.as_ref(),
+    ) {
+        (None, None) => lookup_root_collection_db(conn).await,
+        (Some(reference), None) => runtime
+            .collections_by_ref
+            .get(reference)
+            .cloned()
+            .ok_or_else(|| ApiError::BadRequest(format!("Unknown collection ref '{reference}'"))),
+        (None, Some(key)) => lookup_collection_by_key_db(conn, key)
+            .await?
+            .ok_or_else(|| {
+                ApiError::NotFound(format!(
+                    "Collection '{}' not found during execution",
+                    collection_key_label(key)
+                ))
+            }),
+        (Some(_), Some(_)) => Err(ApiError::BadRequest(
+            "At most one of parent_collection_ref or parent_collection_key may be provided"
+                .to_string(),
+        )),
+    }
+}
+
+async fn resolve_class_runtime(
+    conn: &mut PostgresConnection,
+    runtime: &RuntimeState,
+    reference: Option<&str>,
+    key: Option<&ClassKey>,
+) -> Result<HubuumClass, ApiError> {
+    match (reference, key) {
+        (Some(reference), None) => runtime
+            .classes_by_ref
+            .get(reference)
+            .cloned()
+            .ok_or_else(|| ApiError::BadRequest(format!("Unknown class ref '{reference}'"))),
+        (None, Some(key)) => {
+            let collection = resolve_collection_runtime(
+                conn,
+                runtime,
+                key.collection_ref.as_deref(),
+                key.collection_key.as_ref(),
+            )
+            .await?;
+            lookup_class_by_collection_and_name_db(conn, collection.id, &key.name)
+                .await?
+                .ok_or_else(|| {
+                    ApiError::NotFound(format!(
+                        "Class '{}' not found in collection '{}' during execution",
+                        key.name, collection.name
+                    ))
+                })
+        }
+        _ => Err(ApiError::BadRequest(
+            "Exactly one of class_ref or class_key must be provided".to_string(),
+        )),
+    }
+}
+
+pub(crate) async fn resolve_object_runtime(
+    conn: &mut PostgresConnection,
+    runtime: &RuntimeState,
+    reference: Option<&str>,
+    key: Option<&ObjectKey>,
+) -> Result<HubuumObject, ApiError> {
+    match (reference, key) {
+        (Some(reference), None) => runtime
+            .objects_by_ref
+            .get(reference)
+            .cloned()
+            .ok_or_else(|| ApiError::BadRequest(format!("Unknown object ref '{reference}'"))),
+        (None, Some(key)) => {
+            let class = resolve_class_runtime(
+                conn,
+                runtime,
+                key.class_ref.as_deref(),
+                key.class_key.as_ref(),
+            )
+            .await?;
+            lookup_object_by_class_and_name_db(conn, class.id, &key.name)
+                .await?
+                .ok_or_else(|| {
+                    ApiError::NotFound(format!(
+                        "Object '{}' not found in class '{}' during execution",
+                        key.name, class.name
+                    ))
+                })
+        }
+        _ => Err(ApiError::BadRequest(
+            "Exactly one of object_ref or object_key must be provided".to_string(),
+        )),
+    }
+}
+
+async fn resolve_identity_scope_runtime(
+    conn: &mut PostgresConnection,
+    runtime: &RuntimeState,
+    reference: Option<&str>,
+    key: Option<&IdentityScopeKey>,
+) -> Result<i32, ApiError> {
+    if let Some(reference) = reference
+        && let Some(found_id) = runtime.identity_scopes_by_ref.get(reference)
+    {
+        return Ok(*found_id);
+    }
+    let name = key.map(|key| key.name.as_str()).ok_or_else(|| {
+        ApiError::BadRequest(
+            "Identity-scope reference was not resolved and no identity_scope_key was supplied"
+                .to_string(),
+        )
+    })?;
+    lookup_identity_scope_id_by_name_db(conn, name)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Identity scope '{name}' not found")))
+}
+
+async fn validate_import_template_composition(
+    conn: &mut PostgresConnection,
+    runtime: &RuntimeState,
+    input: &ImportExportTemplateInput,
+    collection: &Collection,
+) -> Result<(), ApiError> {
+    let mut sources = load_export_template_sources_db(conn, collection.id).await?;
+    for candidate in &runtime.import_export_templates {
+        let candidate_collection = resolve_collection_runtime(
+            conn,
+            runtime,
+            candidate.collection_ref.as_deref(),
+            candidate.collection_key.as_ref(),
+        )
+        .await;
+        match candidate_collection {
+            Ok(candidate_collection) if candidate_collection.id == collection.id => {
+                sources.push((candidate.name.clone(), candidate.template.clone()));
+            }
+            Ok(_) | Err(ApiError::BadRequest(_) | ApiError::NotFound(_)) => {}
+            Err(error) => return Err(error),
+        }
+    }
+
+    input.validate_composition(&sources)
+}
+
+async fn resolve_group_runtime(
+    conn: &mut PostgresConnection,
+    runtime: &RuntimeState,
+    reference: Option<&str>,
+    key: Option<&GroupKey>,
+) -> Result<i32, ApiError> {
+    if let Some(reference) = reference
+        && let Some(id) = runtime.groups_by_ref.get(reference)
+    {
+        return Ok(*id);
+    }
+    let key = key.ok_or_else(|| {
+        ApiError::BadRequest(
+            "Group reference was not resolved and no group_key was supplied".to_string(),
+        )
+    })?;
+    let scope = key.identity_scope_name();
+    lookup_group_by_name_db(conn, scope, &key.groupname)
+        .await?
+        .map(|group| group.id)
+        .ok_or_else(|| ApiError::NotFound(format!("Group '{scope}/{}' not found", key.groupname)))
+}
+
+async fn resolve_principal_runtime(
+    conn: &mut PostgresConnection,
+    runtime: &RuntimeState,
+    reference: Option<&str>,
+    key: Option<&PrincipalKey>,
+) -> Result<i32, ApiError> {
+    if let Some(reference) = reference
+        && let Some(id) = runtime.principals_by_ref.get(reference)
+    {
+        return Ok(*id);
+    }
+    let key = key.ok_or_else(|| {
+        ApiError::BadRequest(
+            "Principal reference was not resolved and no principal_key was supplied".to_string(),
+        )
+    })?;
+    let scope = key.identity_scope_name();
+    lookup_principal_id_by_name_db(conn, scope, &key.name)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Principal '{scope}/{}' not found", key.name)))
+}
+
+async fn resolve_event_sink_runtime(
+    conn: &mut PostgresConnection,
+    runtime: &RuntimeState,
+    reference: Option<&str>,
+    key: Option<&EventSinkKey>,
+) -> Result<i32, ApiError> {
+    if let Some(reference) = reference
+        && let Some(found_id) = runtime.event_sinks_by_ref.get(reference)
+    {
+        return Ok(*found_id);
+    }
+    let name = key.map(|key| key.name.as_str()).ok_or_else(|| {
+        ApiError::BadRequest(
+            "Event-sink reference was not resolved and no sink_key was supplied".to_string(),
+        )
+    })?;
+    lookup_event_sink_id_by_name_db(conn, name)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Event sink '{name}' not found")))
+}
+
+async fn resolve_class_relation_runtime(
+    conn: &mut PostgresConnection,
+    runtime: &RuntimeState,
+    input: &ImportClassRelationInput,
+) -> Result<(HubuumClass, HubuumClass), ApiError> {
+    let from_class = resolve_class_runtime(
+        conn,
+        runtime,
+        input.from_class_ref.as_deref(),
+        input.from_class_key.as_ref(),
+    )
+    .await?;
+    let to_class = resolve_class_runtime(
+        conn,
+        runtime,
+        input.to_class_ref.as_deref(),
+        input.to_class_key.as_ref(),
+    )
+    .await?;
+    Ok((from_class, to_class))
+}
+
+async fn resolve_object_relation_runtime(
+    conn: &mut PostgresConnection,
+    runtime: &RuntimeState,
+    input: &ImportObjectRelationInput,
+) -> Result<(HubuumObject, HubuumObject), ApiError> {
+    let from_object = resolve_object_runtime(
+        conn,
+        runtime,
+        input.from_object_ref.as_deref(),
+        input.from_object_key.as_ref(),
+    )
+    .await?;
+    let to_object = resolve_object_runtime(
+        conn,
+        runtime,
+        input.to_object_ref.as_deref(),
+        input.to_object_key.as_ref(),
+    )
+    .await?;
+    Ok((from_object, to_object))
+}
+
+async fn observed_revision_for_planned_item(
+    conn: &mut PostgresConnection,
+    runtime: &RuntimeState,
+    execution: &StorageImportOperation,
+) -> Result<Option<crate::models::ResourceRevision>, ApiError> {
+    use crate::models::ImportComputedFieldVisibility;
+    use crate::storage::postgres::prelude::*;
+
+    let revision = match execution {
+        StorageImportOperation::UpsertIdentityScope { input, .. } => {
+            use crate::schema::identity_scopes::dsl as s;
+            s::identity_scopes
+                .filter(s::name.eq(&input.name))
+                .select(s::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::UpsertGroup { input, .. } => {
+            use crate::schema::groups::dsl as g;
+            let scope_id = resolve_identity_scope_runtime(
+                conn,
+                runtime,
+                input.identity_scope_ref.as_deref(),
+                input.identity_scope_key.as_ref(),
+            )
+            .await?;
+            g::groups
+                .filter(g::identity_scope_id.eq(scope_id))
+                .filter(g::groupname.eq(&input.groupname))
+                .select(g::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::UpsertPrincipal { input, .. } => {
+            use crate::schema::principals::dsl as p;
+            let scope_id = resolve_identity_scope_runtime(
+                conn,
+                runtime,
+                input.identity_scope_ref.as_deref(),
+                input.identity_scope_key.as_ref(),
+            )
+            .await?;
+            p::principals
+                .filter(p::identity_scope_id.eq(scope_id))
+                .filter(p::name.eq(&input.name))
+                .select(p::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::UpsertGroupMembership { input, .. } => {
+            use crate::schema::group_memberships::dsl as m;
+            let principal_id = resolve_principal_runtime(
+                conn,
+                runtime,
+                input.principal_ref.as_deref(),
+                input.principal_key.as_ref(),
+            )
+            .await?;
+            let group_id = resolve_group_runtime(
+                conn,
+                runtime,
+                input.group_ref.as_deref(),
+                input.group_key.as_ref(),
+            )
+            .await?;
+            m::group_memberships
+                .filter(m::principal_id.eq(principal_id))
+                .filter(m::group_id.eq(group_id))
+                .select(m::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::UpdateCollection { collection_id, .. } => {
+            use crate::schema::collections::dsl as c;
+            c::collections
+                .filter(c::id.eq(collection_id))
+                .select(c::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::UpdateClass { class_id, .. } => {
+            use crate::schema::hubuumclass::dsl as c;
+            c::hubuumclass
+                .filter(c::id.eq(class_id))
+                .select(c::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::UpdateObject { object_id, .. } => {
+            use crate::schema::hubuumobject::dsl as o;
+            o::hubuumobject
+                .filter(o::id.eq(object_id))
+                .select(o::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::UpsertComputedField { input, .. } => {
+            use crate::schema::computed_field_definitions::dsl as d;
+            let class = resolve_class_runtime(
+                conn,
+                runtime,
+                input.class_ref.as_deref(),
+                input.class_key.as_ref(),
+            )
+            .await?;
+            let owner_id = match input.visibility {
+                ImportComputedFieldVisibility::Shared => None,
+                ImportComputedFieldVisibility::Personal => Some(
+                    resolve_principal_runtime(
+                        conn,
+                        runtime,
+                        input.owner_ref.as_deref(),
+                        input.owner_key.as_ref(),
+                    )
+                    .await?,
+                ),
+            };
+            let visibility = match input.visibility {
+                ImportComputedFieldVisibility::Shared => "shared",
+                ImportComputedFieldVisibility::Personal => "personal",
+            };
+            d::computed_field_definitions
+                .filter(d::class_id.eq(class.id))
+                .filter(d::visibility.eq(visibility))
+                .filter(d::key.eq(&input.key))
+                .filter(d::owner_user_id.is_not_distinct_from(owner_id))
+                .select(d::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::UpdateClassRelationTimestamps { input, .. }
+        | StorageImportOperation::CheckClassRelationCondition(input) => {
+            use crate::schema::hubuumclass_relation::dsl as r;
+            let (from, to) = resolve_class_relation_runtime(conn, runtime, input).await?;
+            r::hubuumclass_relation
+                .filter(
+                    r::from_hubuum_class_id
+                        .eq(from.id)
+                        .and(r::to_hubuum_class_id.eq(to.id))
+                        .or(r::from_hubuum_class_id
+                            .eq(to.id)
+                            .and(r::to_hubuum_class_id.eq(from.id))),
+                )
+                .select(r::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::UpdateObjectRelationTimestamps { input, .. }
+        | StorageImportOperation::CheckObjectRelationCondition(input) => {
+            use crate::schema::hubuumobject_relation::dsl as r;
+            let (from, to) = resolve_object_relation_runtime(conn, runtime, input).await?;
+            r::hubuumobject_relation
+                .filter(
+                    r::from_hubuum_object_id
+                        .eq(from.id)
+                        .and(r::to_hubuum_object_id.eq(to.id))
+                        .or(r::from_hubuum_object_id
+                            .eq(to.id)
+                            .and(r::to_hubuum_object_id.eq(from.id))),
+                )
+                .select(r::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::ApplyCollectionPermissions { input, .. } => {
+            use crate::schema::collection_authorization_state::dsl as a;
+            let collection = resolve_collection_runtime(
+                conn,
+                runtime,
+                input.collection_ref.as_deref(),
+                input.collection_key.as_ref(),
+            )
+            .await?;
+            a::collection_authorization_state
+                .filter(a::collection_id.eq(collection.id))
+                .select(a::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::UpsertExportTemplate { input, .. } => {
+            use crate::schema::export_templates::dsl as t;
+            let collection = resolve_collection_runtime(
+                conn,
+                runtime,
+                input.collection_ref.as_deref(),
+                input.collection_key.as_ref(),
+            )
+            .await?;
+            t::export_templates
+                .filter(t::collection_id.eq(collection.id))
+                .filter(t::name.eq(&input.name))
+                .select(t::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::UpsertRemoteTarget { input, .. } => {
+            use crate::schema::remote_targets::dsl as r;
+            let collection = resolve_collection_runtime(
+                conn,
+                runtime,
+                input.collection_ref.as_deref(),
+                input.collection_key.as_ref(),
+            )
+            .await?;
+            r::remote_targets
+                .filter(r::collection_id.eq(collection.id))
+                .filter(r::name.eq(&input.name))
+                .select(r::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::UpsertEventSink { input, .. } => {
+            use crate::schema::event_sinks::dsl as s;
+            s::event_sinks
+                .filter(s::name.eq(&input.name))
+                .select(s::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::UpsertEventSubscription { input, .. } => {
+            use crate::schema::event_subscriptions::dsl as s;
+            let collection = resolve_collection_runtime(
+                conn,
+                runtime,
+                input.collection_ref.as_deref(),
+                input.collection_key.as_ref(),
+            )
+            .await?;
+            s::event_subscriptions
+                .filter(s::collection_id.eq(collection.id))
+                .filter(s::name.eq(&input.name))
+                .select(s::revision)
+                .first(conn)
+                .await
+                .optional()?
+        }
+        StorageImportOperation::CreateCollection(_)
+        | StorageImportOperation::CreateClass(_)
+        | StorageImportOperation::CreateObject(_)
+        | StorageImportOperation::CreateClassRelation(_)
+        | StorageImportOperation::CreateObjectRelation(_) => None,
+    };
+    Ok(revision)
+}
+
+pub(crate) async fn execute_planned_item(
+    conn: &mut PostgresConnection,
+    runtime: &mut RuntimeState,
+    execution: &StorageImportOperation,
+) -> Result<(), ApiError> {
+    match execution {
+        StorageImportOperation::UpsertIdentityScope { input, overwrite } => {
+            let id = upsert_identity_scope_db(conn, input, *overwrite).await?;
+            if let Some(reference) = &input.ref_ {
+                runtime.identity_scopes_by_ref.insert(reference.clone(), id);
+            }
+        }
+        StorageImportOperation::UpsertGroup { input, overwrite } => {
+            let scope_id = resolve_identity_scope_runtime(
+                conn,
+                runtime,
+                input.identity_scope_ref.as_deref(),
+                input.identity_scope_key.as_ref(),
+            )
+            .await?;
+            let id = upsert_group_db(conn, input, scope_id, *overwrite).await?;
+            if let Some(reference) = &input.ref_ {
+                runtime.groups_by_ref.insert(reference.clone(), id);
+            }
+        }
+        StorageImportOperation::UpsertPrincipal { input, overwrite } => {
+            let scope_id = resolve_identity_scope_runtime(
+                conn,
+                runtime,
+                input.identity_scope_ref.as_deref(),
+                input.identity_scope_key.as_ref(),
+            )
+            .await?;
+            let (owner_group_id, created_by) = match &input.subtype {
+                ImportPrincipalSubtype::Human { .. } => (None, None),
+                ImportPrincipalSubtype::ServiceAccount {
+                    owner_group_ref,
+                    owner_group_key,
+                    created_by_ref,
+                    created_by_key,
+                    ..
+                } => (
+                    Some(
+                        resolve_group_runtime(
+                            conn,
+                            runtime,
+                            owner_group_ref.as_deref(),
+                            owner_group_key.as_ref(),
+                        )
+                        .await?,
+                    ),
+                    if created_by_ref.is_some() || created_by_key.is_some() {
+                        Some(
+                            resolve_principal_runtime(
+                                conn,
+                                runtime,
+                                created_by_ref.as_deref(),
+                                created_by_key.as_ref(),
+                            )
+                            .await?,
+                        )
+                    } else {
+                        None
+                    },
+                ),
+            };
+            let id = upsert_principal_db(
+                conn,
+                input,
+                scope_id,
+                owner_group_id,
+                created_by,
+                *overwrite,
+            )
+            .await?;
+            if let Some(reference) = &input.ref_ {
+                runtime.principals_by_ref.insert(reference.clone(), id);
+            }
+        }
+        StorageImportOperation::UpsertGroupMembership { input, overwrite } => {
+            let principal_id = resolve_principal_runtime(
+                conn,
+                runtime,
+                input.principal_ref.as_deref(),
+                input.principal_key.as_ref(),
+            )
+            .await?;
+            let group_id = resolve_group_runtime(
+                conn,
+                runtime,
+                input.group_ref.as_deref(),
+                input.group_key.as_ref(),
+            )
+            .await?;
+            let mut source_scope_ids = Vec::with_capacity(input.sources.len());
+            for source in &input.sources {
+                source_scope_ids.push(
+                    resolve_identity_scope_runtime(
+                        conn,
+                        runtime,
+                        source.source_scope_ref.as_deref(),
+                        source.source_scope_key.as_ref(),
+                    )
+                    .await?,
+                );
+            }
+            upsert_group_membership_db(
+                conn,
+                input,
+                principal_id,
+                group_id,
+                &source_scope_ids,
+                *overwrite,
+            )
+            .await?;
+        }
+        StorageImportOperation::CreateCollection(input) => {
+            let parent = resolve_collection_parent_runtime(conn, runtime, input).await?;
+            let created = create_collection_db(conn, input, Some(parent.id)).await?;
+            if let Some(reference) = &input.ref_ {
+                runtime
+                    .collections_by_ref
+                    .insert(reference.clone(), created);
+            }
+        }
+        StorageImportOperation::UpdateCollection {
+            collection_id,
+            input,
+        } => {
+            let updated = update_collection_db(conn, *collection_id, input).await?;
+            if let Some(reference) = &input.ref_ {
+                runtime
+                    .collections_by_ref
+                    .insert(reference.clone(), updated);
+            }
+        }
+        StorageImportOperation::CreateClass(input) => {
+            let collection = resolve_collection_runtime(
+                conn,
+                runtime,
+                input.collection_ref.as_deref(),
+                input.collection_key.as_ref(),
+            )
+            .await?;
+            let created = create_class_db(conn, input, collection.id).await?;
+            if let Some(reference) = &input.ref_ {
+                runtime.classes_by_ref.insert(reference.clone(), created);
+            }
+        }
+        StorageImportOperation::UpdateClass { class_id, input } => {
+            let updated = update_class_db(conn, *class_id, input).await?;
+            if let Some(reference) = &input.ref_ {
+                runtime.classes_by_ref.insert(reference.clone(), updated);
+            }
+        }
+        StorageImportOperation::CreateObject(input) => {
+            let class = resolve_class_runtime(
+                conn,
+                runtime,
+                input.class_ref.as_deref(),
+                input.class_key.as_ref(),
+            )
+            .await?;
+            let created = create_object_db(conn, input, &class).await?;
+            if let Some(reference) = &input.ref_ {
+                runtime.objects_by_ref.insert(reference.clone(), created);
+            }
+        }
+        StorageImportOperation::UpdateObject { object_id, input } => {
+            let updated = update_object_db(conn, *object_id, input).await?;
+            if let Some(reference) = &input.ref_ {
+                runtime.objects_by_ref.insert(reference.clone(), updated);
+            }
+        }
+        StorageImportOperation::UpsertComputedField { input, overwrite } => {
+            let class = resolve_class_runtime(
+                conn,
+                runtime,
+                input.class_ref.as_deref(),
+                input.class_key.as_ref(),
+            )
+            .await?;
+            let owner_id = match input.visibility {
+                ImportComputedFieldVisibility::Shared => None,
+                ImportComputedFieldVisibility::Personal => Some(
+                    resolve_principal_runtime(
+                        conn,
+                        runtime,
+                        input.owner_ref.as_deref(),
+                        input.owner_key.as_ref(),
+                    )
+                    .await?,
+                ),
+            };
+            upsert_computed_field_db(conn, input, class.id, owner_id, *overwrite).await?;
+        }
+        StorageImportOperation::CreateClassRelation(input) => {
+            let (from_class, to_class) =
+                resolve_class_relation_runtime(conn, runtime, input).await?;
+            create_class_relation_db(
+                conn,
+                NewHubuumClassRelation {
+                    from_hubuum_class_id: from_class.id,
+                    to_hubuum_class_id: to_class.id,
+                    forward_template_alias: input.forward_template_alias.clone(),
+                    reverse_template_alias: input.reverse_template_alias.clone(),
+                    from_max_relations: input.from_max_relations,
+                    to_max_relations: input.to_max_relations,
+                },
+                input.timestamps.as_ref(),
+                input.condition,
+            )
+            .await?;
+        }
+        StorageImportOperation::UpdateClassRelationTimestamps { input, timestamps } => {
+            let (from_class, to_class) =
+                resolve_class_relation_runtime(conn, runtime, input).await?;
+            update_class_relation_timestamps_db(
+                conn,
+                from_class.id,
+                to_class.id,
+                timestamps,
+                input.condition,
+            )
+            .await?;
+        }
+        StorageImportOperation::CheckClassRelationCondition(input) => {
+            let (from_class, to_class) =
+                resolve_class_relation_runtime(conn, runtime, input).await?;
+            check_class_relation_import_condition_db(
+                conn,
+                from_class.id,
+                to_class.id,
+                input.condition,
+            )
+            .await?;
+        }
+        StorageImportOperation::CreateObjectRelation(input) => {
+            let (from_object, to_object) =
+                resolve_object_relation_runtime(conn, runtime, input).await?;
+            create_object_relation_db(
+                conn,
+                &from_object,
+                &to_object,
+                input.timestamps.as_ref(),
+                input.condition,
+            )
+            .await?;
+        }
+        StorageImportOperation::UpdateObjectRelationTimestamps { input, timestamps } => {
+            let (from_object, to_object) =
+                resolve_object_relation_runtime(conn, runtime, input).await?;
+            update_object_relation_timestamps_db(
+                conn,
+                &from_object,
+                &to_object,
+                timestamps,
+                input.condition,
+            )
+            .await?;
+        }
+        StorageImportOperation::CheckObjectRelationCondition(input) => {
+            let (from_object, to_object) =
+                resolve_object_relation_runtime(conn, runtime, input).await?;
+            check_object_relation_import_condition_db(
+                conn,
+                &from_object,
+                &to_object,
+                input.condition,
+            )
+            .await?;
+        }
+        StorageImportOperation::ApplyCollectionPermissions { input, overwrite } => {
+            let collection = resolve_collection_runtime(
+                conn,
+                runtime,
+                input.collection_ref.as_deref(),
+                input.collection_key.as_ref(),
+            )
+            .await?;
+            let identity_scope = input.group_key.identity_scope_name();
+            let group = lookup_group_by_name_db(conn, identity_scope, &input.group_key.groupname)
+                .await?
+                .ok_or_else(|| {
+                    ApiError::NotFound(format!(
+                        "Group '{}/{}' not found",
+                        identity_scope, input.group_key.groupname
+                    ))
+                })?;
+            apply_permissions_db(
+                conn,
+                collection.id,
+                group.id,
+                &input.permissions,
+                input.replace_existing.unwrap_or(false),
+                input.condition,
+                *overwrite,
+            )
+            .await?;
+        }
+        StorageImportOperation::UpsertExportTemplate { input, overwrite } => {
+            let collection = resolve_collection_runtime(
+                conn,
+                runtime,
+                input.collection_ref.as_deref(),
+                input.collection_key.as_ref(),
+            )
+            .await?;
+            let class_id = if input.class_ref.is_some() || input.class_key.is_some() {
+                let class = resolve_class_runtime(
+                    conn,
+                    runtime,
+                    input.class_ref.as_deref(),
+                    input.class_key.as_ref(),
+                )
+                .await?;
+                class.ensure_in_collection(collection.id, "Export template")?;
+                Some(class.id)
+            } else {
+                None
+            };
+            validate_import_template_composition(conn, runtime, input, &collection).await?;
+            upsert_export_template_db(conn, input, collection.id, class_id, *overwrite).await?;
+        }
+        StorageImportOperation::UpsertRemoteTarget { input, overwrite } => {
+            let collection = resolve_collection_runtime(
+                conn,
+                runtime,
+                input.collection_ref.as_deref(),
+                input.collection_key.as_ref(),
+            )
+            .await?;
+            let class_id = if input.class_ref.is_some() || input.class_key.is_some() {
+                let class = resolve_class_runtime(
+                    conn,
+                    runtime,
+                    input.class_ref.as_deref(),
+                    input.class_key.as_ref(),
+                )
+                .await?;
+                class.ensure_in_collection(collection.id, "Remote target")?;
+                Some(class.id)
+            } else {
+                None
+            };
+            upsert_remote_target_db(conn, input, collection.id, class_id, *overwrite).await?;
+        }
+        StorageImportOperation::UpsertEventSink { input, overwrite } => {
+            let id = upsert_event_sink_db(conn, input, *overwrite).await?;
+            if let Some(reference) = &input.ref_ {
+                runtime.event_sinks_by_ref.insert(reference.clone(), id);
+            }
+        }
+        StorageImportOperation::UpsertEventSubscription { input, overwrite } => {
+            let collection = resolve_collection_runtime(
+                conn,
+                runtime,
+                input.collection_ref.as_deref(),
+                input.collection_key.as_ref(),
+            )
+            .await?;
+            let sink_id = resolve_event_sink_runtime(
+                conn,
+                runtime,
+                input.sink_ref.as_deref(),
+                input.sink_key.as_ref(),
+            )
+            .await?;
+            upsert_event_subscription_db(conn, input, collection.id, sink_id, *overwrite).await?;
+        }
+    }
+
+    Ok(())
+}
+
+const DRY_RUN_ROLLBACK: &str = "hubuum import dry-run rollback";
+
+fn should_abort_preflight(error: &ApiError, mode: &ImportMode) -> bool {
+    if matches!(
+        mode.atomicity.unwrap_or(ImportAtomicity::Strict),
+        ImportAtomicity::Strict
+    ) {
+        return true;
+    }
+
+    match error {
+        ApiError::Forbidden(_) | ApiError::Unauthorized(_) => matches!(
+            mode.permission_policy
+                .unwrap_or(ImportPermissionPolicy::Abort),
+            ImportPermissionPolicy::Abort
+        ),
+        ApiError::Conflict(_) | ApiError::PreconditionFailed(_, _) => matches!(
+            mode.collision_policy
+                .unwrap_or(ImportCollisionPolicy::Abort),
+            ImportCollisionPolicy::Abort
+        ),
+        _ => false,
+    }
+}
+
+fn should_abort_best_effort(error: &ApiError, mode: &ImportMode) -> bool {
+    match error {
+        ApiError::Forbidden(_) | ApiError::Unauthorized(_) => matches!(
+            mode.permission_policy
+                .unwrap_or(ImportPermissionPolicy::Abort),
+            ImportPermissionPolicy::Abort
+        ),
+        ApiError::Conflict(_) => matches!(
+            mode.collision_policy
+                .unwrap_or(ImportCollisionPolicy::Abort),
+            ImportCollisionPolicy::Abort
+        ),
+        _ => false,
+    }
+}
+
+#[async_trait]
+impl ImportStorage for PostgresStorage {
+    async fn import_root_collection(&self) -> Result<Collection, StorageError> {
+        lookup_root_collection(self.pool())
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn import_collection_by_id(
+        &self,
+        collection_id: i32,
+    ) -> Result<Option<Collection>, StorageError> {
+        lookup_collection_by_id(self.pool(), collection_id)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn import_collection_by_key(
+        &self,
+        key: &CollectionKey,
+    ) -> Result<Option<Collection>, StorageError> {
+        lookup_collection_by_key(self.pool(), key)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn import_collections_by_name(
+        &self,
+        name: &str,
+    ) -> Result<Vec<Collection>, StorageError> {
+        lookup_collections_by_name(self.pool(), name)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn import_collection_child_by_name(
+        &self,
+        parent_collection_id: i32,
+        name: &str,
+    ) -> Result<Option<Collection>, StorageError> {
+        with_connection(self.pool(), async |conn| {
+            lookup_collection_child_by_name_db(conn, parent_collection_id, name).await
+        })
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn import_class_by_name(
+        &self,
+        collection_id: i32,
+        name: &str,
+    ) -> Result<Option<HubuumClass>, StorageError> {
+        lookup_class_by_collection_and_name(self.pool(), collection_id, name)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn import_classes_by_names(
+        &self,
+        collection_id: i32,
+        names: &[String],
+    ) -> Result<Vec<HubuumClass>, StorageError> {
+        lookup_classes_by_collection_and_names(self.pool(), collection_id, names)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn import_object_by_name(
+        &self,
+        class_id: i32,
+        name: &str,
+    ) -> Result<Option<HubuumObject>, StorageError> {
+        lookup_object_by_class_and_name(self.pool(), class_id, name)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn import_objects_by_names(
+        &self,
+        class_id: i32,
+        names: &[String],
+    ) -> Result<Vec<HubuumObject>, StorageError> {
+        lookup_objects_by_class_and_names(self.pool(), class_id, names)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn import_class_relation_exists(
+        &self,
+        left_class_id: i32,
+        right_class_id: i32,
+    ) -> Result<bool, StorageError> {
+        lookup_direct_class_relation(self.pool(), left_class_id, right_class_id)
+            .await
+            .map(|relation| relation.is_some())
+            .map_err(map_postgres_error)
+    }
+
+    async fn import_object_relation_exists(
+        &self,
+        left_object_id: i32,
+        right_object_id: i32,
+    ) -> Result<bool, StorageError> {
+        lookup_object_relation(self.pool(), left_object_id, right_object_id)
+            .await
+            .map(|relation| relation.is_some())
+            .map_err(map_postgres_error)
+    }
+
+    async fn import_group_exists(
+        &self,
+        identity_scope: &str,
+        group_name: &str,
+    ) -> Result<bool, StorageError> {
+        lookup_group_by_name(self.pool(), identity_scope, group_name)
+            .await
+            .map(|group| group.is_some())
+            .map_err(map_postgres_error)
+    }
+
+    async fn preflight_import(
+        &self,
+        items: Vec<StorageImportPlanItem>,
+        mode: ImportMode,
+    ) -> Result<StorageImportPreflight, StorageError> {
+        with_connection(self.pool(), async move |conn| {
+            let mut outcomes = Vec::with_capacity(items.len());
+            let mut aborted = false;
+            let mut runtime = RuntimeState::for_plan(&items);
+            let transaction = conn
+                .transaction::<(), ApiError, _>(async |conn| {
+                    for item in items {
+                        let index = item.index();
+                        let observed_revision =
+                            observed_revision_for_planned_item(conn, &runtime, item.operation())
+                                .await;
+                        let (revision, result) = match observed_revision {
+                            Ok(revision) => {
+                                let result = conn
+                                    .transaction::<(), ApiError, _>(async |conn| {
+                                        execute_planned_item(conn, &mut runtime, item.operation())
+                                            .await
+                                    })
+                                    .await;
+                                (revision, result)
+                            }
+                            Err(error) => (None, Err(error)),
+                        };
+                        match result {
+                            Ok(()) => {
+                                outcomes.push(StorageImportPreflightItem::success(index, revision))
+                            }
+                            Err(error) => {
+                                aborted = should_abort_preflight(&error, &mode);
+                                outcomes.push(StorageImportPreflightItem::failure(
+                                    index,
+                                    revision,
+                                    map_postgres_error(error),
+                                ));
+                                if aborted {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    Err(ApiError::InternalServerError(DRY_RUN_ROLLBACK.to_string()))
+                })
+                .await;
+
+            match transaction {
+                Err(ApiError::InternalServerError(message)) if message == DRY_RUN_ROLLBACK => {
+                    Ok(StorageImportPreflight::new(outcomes, aborted))
+                }
+                Err(error) => Err(error),
+                Ok(()) => Err(ApiError::InternalServerError(
+                    "Import dry run unexpectedly committed".to_string(),
+                )),
+            }
+        })
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn apply_import_strict(
+        &self,
+        items: Vec<StorageImportPlanItem>,
+    ) -> Result<(), StorageError> {
+        with_transaction(self.pool(), async move |conn| {
+            let mut runtime = RuntimeState::for_plan(&items);
+            for item in &items {
+                execute_planned_item(conn, &mut runtime, item.operation()).await?;
+            }
+            Ok::<(), ApiError>(())
+        })
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn apply_import_best_effort(
+        &self,
+        items: Vec<StorageImportPlanItem>,
+        mode: ImportMode,
+    ) -> Result<StorageImportApply, StorageError> {
+        let mut runtime = RuntimeState::for_plan(&items);
+        let mut outcomes = Vec::with_capacity(items.len());
+        let mut aborted = false;
+
+        for item in items {
+            let index = item.index();
+            let result = with_transaction(self.pool(), async |conn| {
+                execute_planned_item(conn, &mut runtime, item.operation()).await
+            })
+            .await;
+            match result {
+                Ok(()) => outcomes.push(StorageImportApplyItem::success(index)),
+                Err(error) => {
+                    aborted = should_abort_best_effort(&error, &mode);
+                    outcomes.push(StorageImportApplyItem::failure(
+                        index,
+                        map_postgres_error(error),
+                    ));
+                    if aborted {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(StorageImportApply::new(outcomes, aborted))
+    }
+
+    async fn record_import_results(
+        &self,
+        results: Vec<StorageImportResult>,
+    ) -> Result<(), StorageError> {
+        let results = results
+            .into_iter()
+            .map(|result| {
+                let (task_id, item_ref, entity_kind, action, identifier, outcome, error, details) =
+                    result.into_parts();
+                NewImportTaskResultRecord {
+                    task_id,
+                    item_ref,
+                    entity_kind,
+                    action,
+                    identifier,
+                    outcome,
+                    error,
+                    details,
+                }
+            })
+            .collect::<Vec<_>>();
+        insert_import_results(self.pool(), &results)
+            .await
+            .map(|_| ())
+            .map_err(map_postgres_error)
+    }
+}

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -1,6 +1,9 @@
 mod backup_snapshot;
 mod computed_fields;
 mod error;
+mod imports;
+#[cfg(test)]
+pub(crate) use imports::{RuntimeState, execute_planned_item, resolve_object_runtime};
 #[doc(hidden)]
 pub mod operations;
 mod remote_targets;

--- a/src/tasks/execution.rs
+++ b/src/tasks/execution.rs
@@ -1,206 +1,21 @@
-use tracing::{Instrument, error, info, info_span, warn};
+use tracing::{Instrument, info, info_span, warn};
 
 use crate::errors::ApiError;
 use crate::models::{
-    Collection, EventSinkKey, GroupKey, HubuumClass, HubuumObject, IdentityScopeKey,
-    ImportAtomicity, ImportClassRelationInput, ImportCollisionPolicy,
-    ImportComputedFieldVisibility, ImportExportTemplateInput, ImportMode,
-    ImportObjectRelationInput, ImportPermissionPolicy, ImportPrincipalSubtype, ImportRequest,
-    NewHubuumClassRelation, NewTaskEventRecord, PrincipalKey, TaskResultCounts, TaskStatus,
-    TokenScope,
+    ImportAtomicity, ImportCollisionPolicy, ImportMode, ImportPermissionPolicy, ImportRequest,
+    NewTaskEventRecord, TaskResultCounts, TaskStatus, TokenScope,
 };
 use crate::observability::metrics;
 use crate::services::tasks::{
     ClaimedTask, TaskStateChange, append_task_event, complete_task, update_task_state,
 };
-use crate::storage::StorageContext;
-use crate::storage::StorageTaskCompletionArtifact;
-use crate::storage::postgres::with_transaction;
+use crate::storage::{ImportStorage, StorageContext, StorageTaskCompletionArtifact};
 
 use super::helpers::{
     flush_import_result_batches, import_failure_outcome, sanitize_error_for_storage,
-    should_abort_best_effort_execution,
 };
 use super::planning::plan_import;
-use super::resolution::{
-    resolve_class_runtime, resolve_collection_parent_runtime, resolve_collection_runtime,
-    resolve_object_runtime,
-};
-use super::types::{
-    ExecutionAccumulator, PlannedExecution, PlannedItem, PlannedTaskResult, RuntimeState,
-    TerminalTaskUpdate,
-};
-use crate::storage::postgres::operations::task_import::{
-    apply_permissions_db, check_class_relation_import_condition_db,
-    check_object_relation_import_condition_db, create_class_db, create_class_relation_db,
-    create_collection_db, create_object_db, create_object_relation_db,
-    load_export_template_sources_db, lookup_event_sink_id_by_name_db, lookup_group_by_name_db,
-    lookup_identity_scope_id_by_name_db, lookup_principal_id_by_name_db, update_class_db,
-    update_class_relation_timestamps_db, update_collection_db, update_object_db,
-    update_object_relation_timestamps_db, upsert_computed_field_db, upsert_event_sink_db,
-    upsert_event_subscription_db, upsert_export_template_db, upsert_group_db,
-    upsert_group_membership_db, upsert_identity_scope_db, upsert_principal_db,
-    upsert_remote_target_db,
-};
-
-async fn resolve_identity_scope_runtime(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    runtime: &RuntimeState,
-    reference: Option<&str>,
-    key: Option<&IdentityScopeKey>,
-) -> Result<i32, ApiError> {
-    if let Some(reference) = reference
-        && let Some(found_id) = runtime.identity_scopes_by_ref.get(reference)
-    {
-        return Ok(*found_id);
-    }
-    let name = key.map(|key| key.name.as_str()).ok_or_else(|| {
-        ApiError::BadRequest(
-            "Identity-scope reference was not resolved and no identity_scope_key was supplied"
-                .to_string(),
-        )
-    })?;
-    lookup_identity_scope_id_by_name_db(conn, name)
-        .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Identity scope '{name}' not found")))
-}
-
-async fn validate_import_template_composition(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    runtime: &RuntimeState,
-    input: &ImportExportTemplateInput,
-    collection: &Collection,
-) -> Result<(), ApiError> {
-    let mut sources = load_export_template_sources_db(conn, collection.id).await?;
-    for candidate in &runtime.import_export_templates {
-        let candidate_collection = resolve_collection_runtime(
-            conn,
-            runtime,
-            candidate.collection_ref.as_deref(),
-            candidate.collection_key.as_ref(),
-        )
-        .await;
-        match candidate_collection {
-            Ok(candidate_collection) if candidate_collection.id == collection.id => {
-                sources.push((candidate.name.clone(), candidate.template.clone()));
-            }
-            Ok(_) | Err(ApiError::BadRequest(_) | ApiError::NotFound(_)) => {}
-            Err(error) => return Err(error),
-        }
-    }
-
-    input.validate_composition(&sources)
-}
-
-async fn resolve_group_runtime(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    runtime: &RuntimeState,
-    reference: Option<&str>,
-    key: Option<&GroupKey>,
-) -> Result<i32, ApiError> {
-    if let Some(reference) = reference
-        && let Some(id) = runtime.groups_by_ref.get(reference)
-    {
-        return Ok(*id);
-    }
-    let key = key.ok_or_else(|| {
-        ApiError::BadRequest(
-            "Group reference was not resolved and no group_key was supplied".to_string(),
-        )
-    })?;
-    let scope = key.identity_scope_name();
-    lookup_group_by_name_db(conn, scope, &key.groupname)
-        .await?
-        .map(|group| group.id)
-        .ok_or_else(|| ApiError::NotFound(format!("Group '{scope}/{}' not found", key.groupname)))
-}
-
-async fn resolve_principal_runtime(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    runtime: &RuntimeState,
-    reference: Option<&str>,
-    key: Option<&PrincipalKey>,
-) -> Result<i32, ApiError> {
-    if let Some(reference) = reference
-        && let Some(id) = runtime.principals_by_ref.get(reference)
-    {
-        return Ok(*id);
-    }
-    let key = key.ok_or_else(|| {
-        ApiError::BadRequest(
-            "Principal reference was not resolved and no principal_key was supplied".to_string(),
-        )
-    })?;
-    let scope = key.identity_scope_name();
-    lookup_principal_id_by_name_db(conn, scope, &key.name)
-        .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Principal '{scope}/{}' not found", key.name)))
-}
-
-async fn resolve_event_sink_runtime(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    runtime: &RuntimeState,
-    reference: Option<&str>,
-    key: Option<&EventSinkKey>,
-) -> Result<i32, ApiError> {
-    if let Some(reference) = reference
-        && let Some(found_id) = runtime.event_sinks_by_ref.get(reference)
-    {
-        return Ok(*found_id);
-    }
-    let name = key.map(|key| key.name.as_str()).ok_or_else(|| {
-        ApiError::BadRequest(
-            "Event-sink reference was not resolved and no sink_key was supplied".to_string(),
-        )
-    })?;
-    lookup_event_sink_id_by_name_db(conn, name)
-        .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Event sink '{name}' not found")))
-}
-
-async fn resolve_class_relation_runtime(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    runtime: &RuntimeState,
-    input: &ImportClassRelationInput,
-) -> Result<(HubuumClass, HubuumClass), ApiError> {
-    let from_class = resolve_class_runtime(
-        conn,
-        runtime,
-        input.from_class_ref.as_deref(),
-        input.from_class_key.as_ref(),
-    )
-    .await?;
-    let to_class = resolve_class_runtime(
-        conn,
-        runtime,
-        input.to_class_ref.as_deref(),
-        input.to_class_key.as_ref(),
-    )
-    .await?;
-    Ok((from_class, to_class))
-}
-
-async fn resolve_object_relation_runtime(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    runtime: &RuntimeState,
-    input: &ImportObjectRelationInput,
-) -> Result<(HubuumObject, HubuumObject), ApiError> {
-    let from_object = resolve_object_runtime(
-        conn,
-        runtime,
-        input.from_object_ref.as_deref(),
-        input.from_object_key.as_ref(),
-    )
-    .await?;
-    let to_object = resolve_object_runtime(
-        conn,
-        runtime,
-        input.to_object_ref.as_deref(),
-        input.to_object_key.as_ref(),
-    )
-    .await?;
-    Ok((from_object, to_object))
-}
+use super::types::{ExecutionAccumulator, PlannedItem, TerminalTaskUpdate};
 
 pub(super) async fn execute_import_task<C>(
     backend: &C,
@@ -276,7 +91,8 @@ where
                 planning_time = ?planning_time,
                 total_time = ?total_timer.elapsed()
             );
-            crate::storage::postgres::operations::task::insert_import_results(pool, &results)
+            crate::storage::storage_handle(pool)
+                .record_import_results(results)
                 .await?;
             let summary = format!("Import validation failed for {failed_count} item(s)");
             finalize_task(
@@ -472,52 +288,35 @@ async fn finalize_task(
     Ok(())
 }
 
+fn import_storage_plan(
+    planned_items: &[PlannedItem],
+) -> Vec<crate::storage::StorageImportPlanItem> {
+    planned_items
+        .iter()
+        .enumerate()
+        .filter_map(|(index, item)| {
+            item.execution
+                .clone()
+                .map(|execution| crate::storage::StorageImportPlanItem::new(index, execution))
+        })
+        .collect()
+}
+
 pub(super) async fn execute_import_strict(
     pool: &impl crate::storage::StorageContext,
     task_id: i32,
     planned_items: &[PlannedItem],
     accumulator: &mut ExecutionAccumulator,
 ) -> Result<(), ApiError> {
-    let execution = with_transaction(
-        pool,
-        async |conn| -> Result<Vec<PlannedTaskResult>, ApiError> {
-            let mut runtime = RuntimeState::for_planned_items(planned_items);
-            let mut completed = Vec::with_capacity(planned_items.len());
+    crate::storage::storage_handle(pool)
+        .apply_import_strict(import_storage_plan(planned_items))
+        .await?;
 
-            for item in planned_items {
-                if let Some(execution) = &item.execution {
-                    let identifier = item
-                        .result
-                        .identifier
-                        .clone()
-                        .unwrap_or_else(|| item.result.entity_kind.clone());
-                    if let Err(err) = execute_planned_item(conn, &mut runtime, execution).await {
-                        error!(
-                            message = "Import execution failed during strict transaction",
-                            identifier = %identifier,
-                            error = %err
-                        );
-                        return Err(err);
-                    }
-                }
-                completed.push(item.result.clone());
-            }
-
-            Ok(completed)
-        },
-    )
-    .await;
-
-    match execution {
-        Ok(completed) => {
-            for result in &completed {
-                accumulator.push_success(task_id, result, "succeeded");
-                flush_import_result_batches(pool, accumulator, false).await?;
-            }
-            Ok(())
-        }
-        Err(err) => Err(err),
+    for item in planned_items {
+        accumulator.push_success(task_id, &item.result, "succeeded");
+        flush_import_result_batches(pool, accumulator, false).await?;
     }
+    Ok(())
 }
 
 pub(super) async fn execute_import_best_effort(
@@ -527,678 +326,51 @@ pub(super) async fn execute_import_best_effort(
     mode: &ImportMode,
     accumulator: &mut ExecutionAccumulator,
 ) -> Result<(), ApiError> {
-    let mut runtime = RuntimeState::for_planned_items(planned_items);
+    let (outcomes, aborted) = crate::storage::storage_handle(pool)
+        .apply_import_best_effort(import_storage_plan(planned_items), mode.clone())
+        .await?
+        .into_parts();
+    let cutoff = aborted
+        .then(|| outcomes.last().map(|item| item.index()))
+        .flatten();
+    let mut outcomes = outcomes
+        .into_iter()
+        .map(|item| {
+            let (index, error) = item.into_parts();
+            (index, error)
+        })
+        .collect::<std::collections::HashMap<_, _>>();
 
-    for item in planned_items {
-        let result = if let Some(execution) = &item.execution {
-            with_transaction(pool, async |conn| {
-                execute_planned_item(conn, &mut runtime, execution).await
-            })
-            .await
-            .map(|_| ())
-        } else {
-            Ok(())
-        };
-
-        match result {
-            Ok(()) => {
-                accumulator.push_success(task_id, &item.result, "succeeded");
-                flush_import_result_batches(pool, accumulator, false).await?;
-            }
-            Err(err) => {
-                let outcome = import_failure_outcome(&err);
-                let sanitized_error = sanitize_error_for_storage(&err);
-                accumulator.push_failure(task_id, &item.result, sanitized_error, outcome);
-                flush_import_result_batches(pool, accumulator, false).await?;
-                if should_abort_best_effort_execution(&err, mode) {
-                    warn!(
-                        message = "Import best-effort execution aborted early",
-                        task_id = task_id,
-                        processed_items = accumulator.processed,
-                        success_items = accumulator.success,
-                        failed_items = accumulator.failed,
-                        error = %err
-                    );
-                    break;
-                }
-            }
+    for (index, item) in planned_items.iter().enumerate() {
+        if cutoff.is_some_and(|cutoff| index > cutoff) {
+            break;
         }
+        match outcomes.remove(&index) {
+            Some(Some(error)) => {
+                let error = ApiError::from(error);
+                let outcome = import_failure_outcome(&error);
+                let sanitized_error = sanitize_error_for_storage(&error);
+                accumulator.push_failure(task_id, &item.result, sanitized_error, outcome);
+            }
+            Some(None) | None if item.execution.is_none() => {
+                accumulator.push_success(task_id, &item.result, "succeeded");
+            }
+            Some(None) => {
+                accumulator.push_success(task_id, &item.result, "succeeded");
+            }
+            None => continue,
+        }
+        flush_import_result_batches(pool, accumulator, false).await?;
     }
 
-    Ok(())
-}
-
-/// Observe the current owner revision for dry-run reporting. The value is
-/// advisory; the subsequent execution path still locks and rechecks the row.
-pub(super) async fn observed_revision_for_planned_item(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    runtime: &RuntimeState,
-    execution: &PlannedExecution,
-) -> Result<Option<crate::models::ResourceRevision>, ApiError> {
-    use crate::models::ImportComputedFieldVisibility;
-    use crate::storage::postgres::prelude::*;
-
-    let revision = match execution {
-        PlannedExecution::UpsertIdentityScope { input, .. } => {
-            use crate::schema::identity_scopes::dsl as s;
-            s::identity_scopes
-                .filter(s::name.eq(&input.name))
-                .select(s::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::UpsertGroup { input, .. } => {
-            use crate::schema::groups::dsl as g;
-            let scope_id = resolve_identity_scope_runtime(
-                conn,
-                runtime,
-                input.identity_scope_ref.as_deref(),
-                input.identity_scope_key.as_ref(),
-            )
-            .await?;
-            g::groups
-                .filter(g::identity_scope_id.eq(scope_id))
-                .filter(g::groupname.eq(&input.groupname))
-                .select(g::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::UpsertPrincipal { input, .. } => {
-            use crate::schema::principals::dsl as p;
-            let scope_id = resolve_identity_scope_runtime(
-                conn,
-                runtime,
-                input.identity_scope_ref.as_deref(),
-                input.identity_scope_key.as_ref(),
-            )
-            .await?;
-            p::principals
-                .filter(p::identity_scope_id.eq(scope_id))
-                .filter(p::name.eq(&input.name))
-                .select(p::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::UpsertGroupMembership { input, .. } => {
-            use crate::schema::group_memberships::dsl as m;
-            let principal_id = resolve_principal_runtime(
-                conn,
-                runtime,
-                input.principal_ref.as_deref(),
-                input.principal_key.as_ref(),
-            )
-            .await?;
-            let group_id = resolve_group_runtime(
-                conn,
-                runtime,
-                input.group_ref.as_deref(),
-                input.group_key.as_ref(),
-            )
-            .await?;
-            m::group_memberships
-                .filter(m::principal_id.eq(principal_id))
-                .filter(m::group_id.eq(group_id))
-                .select(m::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::UpdateCollection { collection_id, .. } => {
-            use crate::schema::collections::dsl as c;
-            c::collections
-                .filter(c::id.eq(collection_id))
-                .select(c::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::UpdateClass { class_id, .. } => {
-            use crate::schema::hubuumclass::dsl as c;
-            c::hubuumclass
-                .filter(c::id.eq(class_id))
-                .select(c::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::UpdateObject { object_id, .. } => {
-            use crate::schema::hubuumobject::dsl as o;
-            o::hubuumobject
-                .filter(o::id.eq(object_id))
-                .select(o::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::UpsertComputedField { input, .. } => {
-            use crate::schema::computed_field_definitions::dsl as d;
-            let class = resolve_class_runtime(
-                conn,
-                runtime,
-                input.class_ref.as_deref(),
-                input.class_key.as_ref(),
-            )
-            .await?;
-            let owner_id = match input.visibility {
-                ImportComputedFieldVisibility::Shared => None,
-                ImportComputedFieldVisibility::Personal => Some(
-                    resolve_principal_runtime(
-                        conn,
-                        runtime,
-                        input.owner_ref.as_deref(),
-                        input.owner_key.as_ref(),
-                    )
-                    .await?,
-                ),
-            };
-            let visibility = match input.visibility {
-                ImportComputedFieldVisibility::Shared => "shared",
-                ImportComputedFieldVisibility::Personal => "personal",
-            };
-            d::computed_field_definitions
-                .filter(d::class_id.eq(class.id))
-                .filter(d::visibility.eq(visibility))
-                .filter(d::key.eq(&input.key))
-                .filter(d::owner_user_id.is_not_distinct_from(owner_id))
-                .select(d::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::UpdateClassRelationTimestamps { input, .. }
-        | PlannedExecution::CheckClassRelationCondition(input) => {
-            use crate::schema::hubuumclass_relation::dsl as r;
-            let (from, to) = resolve_class_relation_runtime(conn, runtime, input).await?;
-            r::hubuumclass_relation
-                .filter(
-                    r::from_hubuum_class_id
-                        .eq(from.id)
-                        .and(r::to_hubuum_class_id.eq(to.id))
-                        .or(r::from_hubuum_class_id
-                            .eq(to.id)
-                            .and(r::to_hubuum_class_id.eq(from.id))),
-                )
-                .select(r::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::UpdateObjectRelationTimestamps { input, .. }
-        | PlannedExecution::CheckObjectRelationCondition(input) => {
-            use crate::schema::hubuumobject_relation::dsl as r;
-            let (from, to) = resolve_object_relation_runtime(conn, runtime, input).await?;
-            r::hubuumobject_relation
-                .filter(
-                    r::from_hubuum_object_id
-                        .eq(from.id)
-                        .and(r::to_hubuum_object_id.eq(to.id))
-                        .or(r::from_hubuum_object_id
-                            .eq(to.id)
-                            .and(r::to_hubuum_object_id.eq(from.id))),
-                )
-                .select(r::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::ApplyCollectionPermissions { input, .. } => {
-            use crate::schema::collection_authorization_state::dsl as a;
-            let collection = resolve_collection_runtime(
-                conn,
-                runtime,
-                input.collection_ref.as_deref(),
-                input.collection_key.as_ref(),
-            )
-            .await?;
-            a::collection_authorization_state
-                .filter(a::collection_id.eq(collection.id))
-                .select(a::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::UpsertExportTemplate { input, .. } => {
-            use crate::schema::export_templates::dsl as t;
-            let collection = resolve_collection_runtime(
-                conn,
-                runtime,
-                input.collection_ref.as_deref(),
-                input.collection_key.as_ref(),
-            )
-            .await?;
-            t::export_templates
-                .filter(t::collection_id.eq(collection.id))
-                .filter(t::name.eq(&input.name))
-                .select(t::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::UpsertRemoteTarget { input, .. } => {
-            use crate::schema::remote_targets::dsl as r;
-            let collection = resolve_collection_runtime(
-                conn,
-                runtime,
-                input.collection_ref.as_deref(),
-                input.collection_key.as_ref(),
-            )
-            .await?;
-            r::remote_targets
-                .filter(r::collection_id.eq(collection.id))
-                .filter(r::name.eq(&input.name))
-                .select(r::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::UpsertEventSink { input, .. } => {
-            use crate::schema::event_sinks::dsl as s;
-            s::event_sinks
-                .filter(s::name.eq(&input.name))
-                .select(s::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::UpsertEventSubscription { input, .. } => {
-            use crate::schema::event_subscriptions::dsl as s;
-            let collection = resolve_collection_runtime(
-                conn,
-                runtime,
-                input.collection_ref.as_deref(),
-                input.collection_key.as_ref(),
-            )
-            .await?;
-            s::event_subscriptions
-                .filter(s::collection_id.eq(collection.id))
-                .filter(s::name.eq(&input.name))
-                .select(s::revision)
-                .first(conn)
-                .await
-                .optional()?
-        }
-        PlannedExecution::CreateCollection(_)
-        | PlannedExecution::CreateClass(_)
-        | PlannedExecution::CreateObject(_)
-        | PlannedExecution::CreateClassRelation(_)
-        | PlannedExecution::CreateObjectRelation(_) => None,
-    };
-    Ok(revision)
-}
-
-pub(super) async fn execute_planned_item(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    runtime: &mut RuntimeState,
-    execution: &PlannedExecution,
-) -> Result<(), ApiError> {
-    match execution {
-        PlannedExecution::UpsertIdentityScope { input, overwrite } => {
-            let id = upsert_identity_scope_db(conn, input, *overwrite).await?;
-            if let Some(reference) = &input.ref_ {
-                runtime.identity_scopes_by_ref.insert(reference.clone(), id);
-            }
-        }
-        PlannedExecution::UpsertGroup { input, overwrite } => {
-            let scope_id = resolve_identity_scope_runtime(
-                conn,
-                runtime,
-                input.identity_scope_ref.as_deref(),
-                input.identity_scope_key.as_ref(),
-            )
-            .await?;
-            let id = upsert_group_db(conn, input, scope_id, *overwrite).await?;
-            if let Some(reference) = &input.ref_ {
-                runtime.groups_by_ref.insert(reference.clone(), id);
-            }
-        }
-        PlannedExecution::UpsertPrincipal { input, overwrite } => {
-            let scope_id = resolve_identity_scope_runtime(
-                conn,
-                runtime,
-                input.identity_scope_ref.as_deref(),
-                input.identity_scope_key.as_ref(),
-            )
-            .await?;
-            let (owner_group_id, created_by) = match &input.subtype {
-                ImportPrincipalSubtype::Human { .. } => (None, None),
-                ImportPrincipalSubtype::ServiceAccount {
-                    owner_group_ref,
-                    owner_group_key,
-                    created_by_ref,
-                    created_by_key,
-                    ..
-                } => (
-                    Some(
-                        resolve_group_runtime(
-                            conn,
-                            runtime,
-                            owner_group_ref.as_deref(),
-                            owner_group_key.as_ref(),
-                        )
-                        .await?,
-                    ),
-                    if created_by_ref.is_some() || created_by_key.is_some() {
-                        Some(
-                            resolve_principal_runtime(
-                                conn,
-                                runtime,
-                                created_by_ref.as_deref(),
-                                created_by_key.as_ref(),
-                            )
-                            .await?,
-                        )
-                    } else {
-                        None
-                    },
-                ),
-            };
-            let id = upsert_principal_db(
-                conn,
-                input,
-                scope_id,
-                owner_group_id,
-                created_by,
-                *overwrite,
-            )
-            .await?;
-            if let Some(reference) = &input.ref_ {
-                runtime.principals_by_ref.insert(reference.clone(), id);
-            }
-        }
-        PlannedExecution::UpsertGroupMembership { input, overwrite } => {
-            let principal_id = resolve_principal_runtime(
-                conn,
-                runtime,
-                input.principal_ref.as_deref(),
-                input.principal_key.as_ref(),
-            )
-            .await?;
-            let group_id = resolve_group_runtime(
-                conn,
-                runtime,
-                input.group_ref.as_deref(),
-                input.group_key.as_ref(),
-            )
-            .await?;
-            let mut source_scope_ids = Vec::with_capacity(input.sources.len());
-            for source in &input.sources {
-                source_scope_ids.push(
-                    resolve_identity_scope_runtime(
-                        conn,
-                        runtime,
-                        source.source_scope_ref.as_deref(),
-                        source.source_scope_key.as_ref(),
-                    )
-                    .await?,
-                );
-            }
-            upsert_group_membership_db(
-                conn,
-                input,
-                principal_id,
-                group_id,
-                &source_scope_ids,
-                *overwrite,
-            )
-            .await?;
-        }
-        PlannedExecution::CreateCollection(input) => {
-            let parent = resolve_collection_parent_runtime(conn, runtime, input).await?;
-            let created = create_collection_db(conn, input, Some(parent.id)).await?;
-            if let Some(reference) = &input.ref_ {
-                runtime
-                    .collections_by_ref
-                    .insert(reference.clone(), created);
-            }
-        }
-        PlannedExecution::UpdateCollection {
-            collection_id,
-            input,
-        } => {
-            let updated = update_collection_db(conn, *collection_id, input).await?;
-            if let Some(reference) = &input.ref_ {
-                runtime
-                    .collections_by_ref
-                    .insert(reference.clone(), updated);
-            }
-        }
-        PlannedExecution::CreateClass(input) => {
-            let collection = resolve_collection_runtime(
-                conn,
-                runtime,
-                input.collection_ref.as_deref(),
-                input.collection_key.as_ref(),
-            )
-            .await?;
-            let created = create_class_db(conn, input, collection.id).await?;
-            if let Some(reference) = &input.ref_ {
-                runtime.classes_by_ref.insert(reference.clone(), created);
-            }
-        }
-        PlannedExecution::UpdateClass { class_id, input } => {
-            let updated = update_class_db(conn, *class_id, input).await?;
-            if let Some(reference) = &input.ref_ {
-                runtime.classes_by_ref.insert(reference.clone(), updated);
-            }
-        }
-        PlannedExecution::CreateObject(input) => {
-            let class = resolve_class_runtime(
-                conn,
-                runtime,
-                input.class_ref.as_deref(),
-                input.class_key.as_ref(),
-            )
-            .await?;
-            let created = create_object_db(conn, input, &class).await?;
-            if let Some(reference) = &input.ref_ {
-                runtime.objects_by_ref.insert(reference.clone(), created);
-            }
-        }
-        PlannedExecution::UpdateObject { object_id, input } => {
-            let updated = update_object_db(conn, *object_id, input).await?;
-            if let Some(reference) = &input.ref_ {
-                runtime.objects_by_ref.insert(reference.clone(), updated);
-            }
-        }
-        PlannedExecution::UpsertComputedField { input, overwrite } => {
-            let class = resolve_class_runtime(
-                conn,
-                runtime,
-                input.class_ref.as_deref(),
-                input.class_key.as_ref(),
-            )
-            .await?;
-            let owner_id = match input.visibility {
-                ImportComputedFieldVisibility::Shared => None,
-                ImportComputedFieldVisibility::Personal => Some(
-                    resolve_principal_runtime(
-                        conn,
-                        runtime,
-                        input.owner_ref.as_deref(),
-                        input.owner_key.as_ref(),
-                    )
-                    .await?,
-                ),
-            };
-            upsert_computed_field_db(conn, input, class.id, owner_id, *overwrite).await?;
-        }
-        PlannedExecution::CreateClassRelation(input) => {
-            let (from_class, to_class) =
-                resolve_class_relation_runtime(conn, runtime, input).await?;
-            create_class_relation_db(
-                conn,
-                NewHubuumClassRelation {
-                    from_hubuum_class_id: from_class.id,
-                    to_hubuum_class_id: to_class.id,
-                    forward_template_alias: input.forward_template_alias.clone(),
-                    reverse_template_alias: input.reverse_template_alias.clone(),
-                    from_max_relations: input.from_max_relations,
-                    to_max_relations: input.to_max_relations,
-                },
-                input.timestamps.as_ref(),
-                input.condition,
-            )
-            .await?;
-        }
-        PlannedExecution::UpdateClassRelationTimestamps { input, timestamps } => {
-            let (from_class, to_class) =
-                resolve_class_relation_runtime(conn, runtime, input).await?;
-            update_class_relation_timestamps_db(
-                conn,
-                from_class.id,
-                to_class.id,
-                timestamps,
-                input.condition,
-            )
-            .await?;
-        }
-        PlannedExecution::CheckClassRelationCondition(input) => {
-            let (from_class, to_class) =
-                resolve_class_relation_runtime(conn, runtime, input).await?;
-            check_class_relation_import_condition_db(
-                conn,
-                from_class.id,
-                to_class.id,
-                input.condition,
-            )
-            .await?;
-        }
-        PlannedExecution::CreateObjectRelation(input) => {
-            let (from_object, to_object) =
-                resolve_object_relation_runtime(conn, runtime, input).await?;
-            create_object_relation_db(
-                conn,
-                &from_object,
-                &to_object,
-                input.timestamps.as_ref(),
-                input.condition,
-            )
-            .await?;
-        }
-        PlannedExecution::UpdateObjectRelationTimestamps { input, timestamps } => {
-            let (from_object, to_object) =
-                resolve_object_relation_runtime(conn, runtime, input).await?;
-            update_object_relation_timestamps_db(
-                conn,
-                &from_object,
-                &to_object,
-                timestamps,
-                input.condition,
-            )
-            .await?;
-        }
-        PlannedExecution::CheckObjectRelationCondition(input) => {
-            let (from_object, to_object) =
-                resolve_object_relation_runtime(conn, runtime, input).await?;
-            check_object_relation_import_condition_db(
-                conn,
-                &from_object,
-                &to_object,
-                input.condition,
-            )
-            .await?;
-        }
-        PlannedExecution::ApplyCollectionPermissions { input, overwrite } => {
-            let collection = resolve_collection_runtime(
-                conn,
-                runtime,
-                input.collection_ref.as_deref(),
-                input.collection_key.as_ref(),
-            )
-            .await?;
-            let identity_scope = input.group_key.identity_scope_name();
-            let group = lookup_group_by_name_db(conn, identity_scope, &input.group_key.groupname)
-                .await?
-                .ok_or_else(|| {
-                    ApiError::NotFound(format!(
-                        "Group '{}/{}' not found",
-                        identity_scope, input.group_key.groupname
-                    ))
-                })?;
-            apply_permissions_db(
-                conn,
-                collection.id,
-                group.id,
-                &input.permissions,
-                input.replace_existing.unwrap_or(false),
-                input.condition,
-                *overwrite,
-            )
-            .await?;
-        }
-        PlannedExecution::UpsertExportTemplate { input, overwrite } => {
-            let collection = resolve_collection_runtime(
-                conn,
-                runtime,
-                input.collection_ref.as_deref(),
-                input.collection_key.as_ref(),
-            )
-            .await?;
-            let class_id = if input.class_ref.is_some() || input.class_key.is_some() {
-                let class = resolve_class_runtime(
-                    conn,
-                    runtime,
-                    input.class_ref.as_deref(),
-                    input.class_key.as_ref(),
-                )
-                .await?;
-                class.ensure_in_collection(collection.id, "Export template")?;
-                Some(class.id)
-            } else {
-                None
-            };
-            validate_import_template_composition(conn, runtime, input, &collection).await?;
-            upsert_export_template_db(conn, input, collection.id, class_id, *overwrite).await?;
-        }
-        PlannedExecution::UpsertRemoteTarget { input, overwrite } => {
-            let collection = resolve_collection_runtime(
-                conn,
-                runtime,
-                input.collection_ref.as_deref(),
-                input.collection_key.as_ref(),
-            )
-            .await?;
-            let class_id = if input.class_ref.is_some() || input.class_key.is_some() {
-                let class = resolve_class_runtime(
-                    conn,
-                    runtime,
-                    input.class_ref.as_deref(),
-                    input.class_key.as_ref(),
-                )
-                .await?;
-                class.ensure_in_collection(collection.id, "Remote target")?;
-                Some(class.id)
-            } else {
-                None
-            };
-            upsert_remote_target_db(conn, input, collection.id, class_id, *overwrite).await?;
-        }
-        PlannedExecution::UpsertEventSink { input, overwrite } => {
-            let id = upsert_event_sink_db(conn, input, *overwrite).await?;
-            if let Some(reference) = &input.ref_ {
-                runtime.event_sinks_by_ref.insert(reference.clone(), id);
-            }
-        }
-        PlannedExecution::UpsertEventSubscription { input, overwrite } => {
-            let collection = resolve_collection_runtime(
-                conn,
-                runtime,
-                input.collection_ref.as_deref(),
-                input.collection_key.as_ref(),
-            )
-            .await?;
-            let sink_id = resolve_event_sink_runtime(
-                conn,
-                runtime,
-                input.sink_ref.as_deref(),
-                input.sink_key.as_ref(),
-            )
-            .await?;
-            upsert_event_subscription_db(conn, input, collection.id, sink_id, *overwrite).await?;
-        }
+    if aborted {
+        warn!(
+            message = "Import best-effort execution aborted early",
+            task_id = task_id,
+            processed_items = accumulator.processed,
+            success_items = accumulator.success,
+            failed_items = accumulator.failed
+        );
     }
 
     Ok(())

--- a/src/tasks/helpers.rs
+++ b/src/tasks/helpers.rs
@@ -4,11 +4,13 @@ use sha2::{Digest, Sha256};
 use tracing::debug;
 
 use crate::errors::ApiError;
+#[cfg(test)]
+use crate::models::ImportMode;
 use crate::models::{
-    Collection, HubuumClass, HubuumObject, ImportAtomicity, ImportCollisionPolicy, ImportMode,
+    Collection, HubuumClass, HubuumObject, ImportAtomicity, ImportCollisionPolicy,
     ImportPermissionPolicy,
 };
-use crate::storage::capabilities::task::insert_import_results;
+use crate::storage::{ImportStorage, storage_handle};
 
 use super::types::{
     ClassResolution, CollectionResolution, ExecutionAccumulator, FailureKind,
@@ -95,6 +97,7 @@ pub(super) fn sanitize_error_for_storage(err: &ApiError) -> String {
     }
 }
 
+#[cfg(test)]
 pub(super) fn should_abort_best_effort_execution(err: &ApiError, mode: &ImportMode) -> bool {
     match err {
         ApiError::Conflict(_) => matches!(
@@ -197,12 +200,12 @@ pub(super) async fn flush_import_result_batches(
             .results
             .drain(..IMPORT_RESULTS_BATCH_SIZE)
             .collect::<Vec<_>>();
-        insert_import_results(pool, &batch).await?;
+        storage_handle(pool).record_import_results(batch).await?;
     }
 
     if force && !accumulator.results.is_empty() {
         let batch = accumulator.results.drain(..).collect::<Vec<_>>();
-        insert_import_results(pool, &batch).await?;
+        storage_handle(pool).record_import_results(batch).await?;
     }
 
     Ok(())

--- a/src/tasks/planning.rs
+++ b/src/tasks/planning.rs
@@ -1,5 +1,5 @@
 use crate::models::token_scope::TokenScope;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use chrono::Utc;
@@ -11,8 +11,8 @@ use super::helpers::{
 };
 use super::preload::{preload_existing_classes, preload_existing_objects};
 use super::resolution::{
-    lookup_existing_collection_for_import_db, remember_class, remember_collection, remember_object,
-    resolve_class_planning, resolve_collection_by_id_planning, resolve_collection_parent_planning,
+    remember_class, remember_collection, remember_object, resolve_class_planning,
+    resolve_collection_by_id_planning, resolve_collection_parent_planning,
     resolve_collection_planning, resolve_object_planning,
 };
 use super::types::{
@@ -28,13 +28,8 @@ use crate::models::{
     ImportPermissionPolicy, ImportPrincipalSubtype, ImportRequest, ImportWriteCondition,
     Permissions, RestoreTimestamps,
 };
-use crate::storage::postgres::operations::UserPermissions;
-use crate::storage::postgres::operations::task_import::{
-    lookup_class_by_collection_and_name, lookup_direct_class_relation, lookup_group_by_name,
-    lookup_object_by_class_and_name, lookup_object_relation,
-};
-use crate::storage::postgres::prelude::AsyncConnection;
-use crate::storage::postgres::with_connection;
+use crate::storage::capabilities::UserPermissions;
+use crate::storage::{ImportStorage, StorageImportPlanItem, storage_handle};
 
 fn import_item_allows_overwrite(
     condition: Option<ImportWriteCondition>,
@@ -145,8 +140,6 @@ fn plan_system_item(
     }
 }
 
-const DRY_RUN_ROLLBACK: &str = "hubuum import dry-run rollback";
-
 fn preflight_failure_kind(error: &ApiError) -> FailureKind {
     match error {
         ApiError::Forbidden(_) | ApiError::Unauthorized(_) => FailureKind::Permission,
@@ -175,96 +168,60 @@ async fn preflight_dry_run(
     mode: &ImportMode,
     planned_items: Vec<PlannedItem>,
 ) -> Result<PlanningOutcome, ApiError> {
-    let atomicity = mode.atomicity.unwrap_or(ImportAtomicity::Strict);
-    let permission_policy = mode
-        .permission_policy
-        .unwrap_or(ImportPermissionPolicy::Abort);
-    let collision_policy = mode
-        .collision_policy
-        .unwrap_or(ImportCollisionPolicy::Abort);
+    let plan = planned_items
+        .iter()
+        .enumerate()
+        .filter_map(|(index, item)| {
+            item.execution
+                .clone()
+                .map(|execution| StorageImportPlanItem::new(index, execution))
+        })
+        .collect();
+    let (preflight_items, aborted) = storage_handle(pool)
+        .preflight_import(plan, mode.clone())
+        .await?
+        .into_parts();
+    let cutoff = aborted
+        .then(|| preflight_items.last().map(|item| item.index()))
+        .flatten();
+    let mut outcomes = preflight_items
+        .into_iter()
+        .map(|item| {
+            let (index, revision, error) = item.into_parts();
+            (index, (revision, error))
+        })
+        .collect::<HashMap<_, _>>();
+    let mut valid_items = Vec::with_capacity(planned_items.len());
+    let mut failures = Vec::new();
 
-    with_connection(
-        pool,
-        async move |conn| -> Result<PlanningOutcome, ApiError> {
-            let mut valid_items = Vec::with_capacity(planned_items.len());
-            let mut failures = Vec::new();
-            let mut aborted = false;
-            let mut runtime = super::types::RuntimeState::for_planned_items(&planned_items);
-
-            let transaction = conn
-                .transaction::<(), ApiError, _>(async |conn| {
-                    for mut item in planned_items {
-                        let observed_revision = match &item.execution {
-                            Some(execution) => {
-                                super::execution::observed_revision_for_planned_item(
-                                    conn, &runtime, execution,
-                                )
-                                .await
-                            }
-                            None => Ok(None),
-                        };
-                        let result = match observed_revision {
-                            Ok(observed_revision) => {
-                                item.result.set_observed_revision(observed_revision);
-                                match &item.execution {
-                                    Some(execution) => {
-                                        conn.transaction::<(), ApiError, _>(async |conn| {
-                                            super::execution::execute_planned_item(
-                                                conn,
-                                                &mut runtime,
-                                                execution,
-                                            )
-                                            .await
-                                        })
-                                        .await
-                                    }
-                                    None => Ok(()),
-                                }
-                            }
-                            Err(error) => Err(error),
-                        };
-                        match result {
-                            Ok(()) => valid_items.push(item),
-                            Err(error) => {
-                                let kind = preflight_failure_kind(&error);
-                                failures.push(PlanningFailure {
-                                    kind,
-                                    item: item.result,
-                                    message: sanitize_error_for_storage(&error),
-                                });
-                                if should_abort_import(
-                                    atomicity,
-                                    permission_policy,
-                                    collision_policy,
-                                    kind,
-                                ) {
-                                    aborted = true;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
-                    Err(ApiError::InternalServerError(DRY_RUN_ROLLBACK.to_string()))
-                })
-                .await;
-
-            match transaction {
-                Err(ApiError::InternalServerError(message)) if message == DRY_RUN_ROLLBACK => {
-                    Ok(PlanningOutcome {
-                        planned_items: valid_items,
-                        failures,
-                        aborted,
-                    })
-                }
-                Err(error) => Err(error),
-                Ok(()) => Err(ApiError::InternalServerError(
-                    "Import dry run unexpectedly committed".to_string(),
-                )),
+    for (index, mut item) in planned_items.into_iter().enumerate() {
+        if cutoff.is_some_and(|cutoff| index > cutoff) {
+            break;
+        }
+        let Some((revision, error)) = outcomes.remove(&index) else {
+            if item.execution.is_none() {
+                valid_items.push(item);
             }
-        },
-    )
-    .await
+            continue;
+        };
+        item.result.set_observed_revision(revision);
+        if let Some(error) = error {
+            let error = ApiError::from(error);
+            failures.push(PlanningFailure {
+                kind: preflight_failure_kind(&error),
+                item: item.result,
+                message: sanitize_error_for_storage(&error),
+            });
+        } else {
+            valid_items.push(item);
+        }
+    }
+
+    Ok(PlanningOutcome {
+        planned_items: valid_items,
+        failures,
+        aborted,
+    })
 }
 
 async fn is_import_admin<C>(
@@ -347,10 +304,10 @@ async fn class_relation_exists_cached(
         return Ok(*exists);
     }
 
-    let exists = lookup_direct_class_relation(pool, pair.0, pair.1)
+    let exists = storage_handle(pool)
+        .import_class_relation_exists(pair.0, pair.1)
         .await
-        .map_err(|err| sanitize_error_for_storage(&err))?
-        .is_some();
+        .map_err(|err| sanitize_error_for_storage(&err.into()))?;
     state.class_relation_exists_cache.insert(pair, exists);
     Ok(exists)
 }
@@ -369,10 +326,10 @@ async fn object_relation_exists_cached(
         return Ok(*exists);
     }
 
-    let exists = lookup_object_relation(pool, pair.0, pair.1)
+    let exists = storage_handle(pool)
+        .import_object_relation_exists(pair.0, pair.1)
         .await
-        .map_err(|err| sanitize_error_for_storage(&err))?
-        .is_some();
+        .map_err(|err| sanitize_error_for_storage(&err.into()))?;
     state.object_relation_exists_cache.insert(pair, exists);
     Ok(exists)
 }
@@ -1008,20 +965,19 @@ where
                 revision: crate::models::ResourceRevision::INITIAL,
             })
         } else {
-            with_connection(pool, async |conn| {
-                lookup_existing_collection_for_import_db(conn, parent.id, &input.name).await
-            })
-            .await
-            .map_err(|message| PlanningFailure {
-                kind: FailureKind::Runtime,
-                item: planned_result(
-                    "collection",
-                    "lookup",
-                    input.ref_.clone(),
-                    Some(input.name.clone()),
-                ),
-                message: sanitize_error_for_storage(&message),
-            })?
+            storage_handle(pool)
+                .import_collection_child_by_name(parent.id, &input.name)
+                .await
+                .map_err(|message| PlanningFailure {
+                    kind: FailureKind::Runtime,
+                    item: planned_result(
+                        "collection",
+                        "lookup",
+                        input.ref_.clone(),
+                        Some(input.name.clone()),
+                    ),
+                    message: sanitize_error_for_storage(&message.into()),
+                })?
         }
     } else {
         None
@@ -1237,7 +1193,8 @@ where
     } else if state.missing_class_keys.contains(&class_key) {
         None
     } else {
-        lookup_class_by_collection_and_name(pool, collection.id, &input.name)
+        storage_handle(pool)
+            .import_class_by_name(collection.id, &input.name)
             .await
             .map_err(|err| PlanningFailure {
                 kind: FailureKind::Runtime,
@@ -1247,7 +1204,7 @@ where
                     input.ref_.clone(),
                     Some(input.name.clone()),
                 ),
-                message: sanitize_error_for_storage(&err),
+                message: sanitize_error_for_storage(&err.into()),
             })?
             .map(class_to_resolution)
     };
@@ -1464,7 +1421,8 @@ where
     } else if state.missing_object_keys.contains(&object_key) {
         None
     } else {
-        lookup_object_by_class_and_name(pool, class.id, &input.name)
+        storage_handle(pool)
+            .import_object_by_name(class.id, &input.name)
             .await
             .map_err(|err| PlanningFailure {
                 kind: FailureKind::Runtime,
@@ -1474,7 +1432,7 @@ where
                     input.ref_.clone(),
                     Some(input.name.clone()),
                 ),
-                message: sanitize_error_for_storage(&err),
+                message: sanitize_error_for_storage(&err.into()),
             })?
             .map(object_to_resolution)
     };
@@ -1959,7 +1917,8 @@ where
     })?;
 
     let identity_scope = input.group_key.identity_scope_name();
-    let group = lookup_group_by_name(pool, identity_scope, &input.group_key.groupname)
+    let group_exists = storage_handle(pool)
+        .import_group_exists(identity_scope, &input.group_key.groupname)
         .await
         .map_err(|err| PlanningFailure {
             kind: FailureKind::Runtime,
@@ -1969,30 +1928,14 @@ where
                 input.ref_.clone(),
                 Some(input.group_key.groupname.clone()),
             ),
-            message: sanitize_error_for_storage(&err),
+            message: sanitize_error_for_storage(&err.into()),
         })?
-        .or_else(|| {
-            state
-                .planned_group_keys
-                .contains(&(
-                    identity_scope.to_string(),
-                    input.group_key.groupname.clone(),
-                ))
-                .then(|| crate::models::Group {
-                    id: state.next_temp_id,
-                    groupname: input.group_key.groupname.clone(),
-                    description: String::new(),
-                    created_at: Utc::now().naive_utc(),
-                    updated_at: Utc::now().naive_utc(),
-                    identity_scope_id: state.next_temp_id,
-                    managed_by: "local".to_string(),
-                    external_key: None,
-                    last_sync_attempted_at: None,
-                    last_sync_success_at: None,
-                    revision: crate::models::ResourceRevision::INITIAL,
-                })
-        })
-        .ok_or_else(|| PlanningFailure {
+        || state.planned_group_keys.contains(&(
+            identity_scope.to_string(),
+            input.group_key.groupname.clone(),
+        ));
+    if !group_exists {
+        return Err(PlanningFailure {
             kind: FailureKind::Resolution,
             item: planned_result(
                 "collection_permission",
@@ -2004,7 +1947,8 @@ where
                 "Group '{}/{}' not found",
                 identity_scope, input.group_key.groupname
             ),
-        })?;
+        });
+    }
 
     Ok(PlannedItem {
         result: planned_result(
@@ -2015,7 +1959,10 @@ where
                 "grant"
             },
             input.ref_.clone(),
-            Some(format!("{}::{}", collection.name, group.groupname)),
+            Some(format!(
+                "{}::{}",
+                collection.name, input.group_key.groupname
+            )),
         ),
         execution: Some(PlannedExecution::ApplyCollectionPermissions {
             input: input.clone(),

--- a/src/tasks/preload.rs
+++ b/src/tasks/preload.rs
@@ -7,10 +7,7 @@ use super::resolution::{
 };
 use super::types::{CollectionResolution, PlanningState};
 use crate::models::{ClassKey, ImportRequest, ObjectKey};
-use crate::storage::capabilities::task_import::{
-    lookup_classes_by_collection_and_names, lookup_collections_by_name,
-    lookup_objects_by_class_and_names,
-};
+use crate::storage::{ImportStorage, storage_handle};
 
 fn collect_request_class_keys(request: &ImportRequest) -> Vec<ClassKey> {
     let mut keys = Vec::new();
@@ -92,7 +89,8 @@ async fn preload_collections_for_class_keys(
         .collect::<Vec<_>>();
 
     for name in names {
-        let collections = lookup_collections_by_name(pool, &name)
+        let collections = storage_handle(pool)
+            .import_collections_by_name(&name)
             .await
             .map_err(|err| err.to_string())?;
         if collections.is_empty() {
@@ -155,7 +153,8 @@ pub(super) async fn preload_existing_classes(
 
     for (collection_id, names) in requested {
         let names = names.into_iter().collect::<Vec<_>>();
-        let classes = lookup_classes_by_collection_and_names(pool, collection_id, &names)
+        let classes = storage_handle(pool)
+            .import_classes_by_names(collection_id, &names)
             .await
             .map_err(|err| err.to_string())?;
         let found_names = classes
@@ -237,7 +236,8 @@ pub(super) async fn preload_existing_objects(
 
     for (class_id, names) in requested {
         let names = names.into_iter().collect::<Vec<_>>();
-        let objects = lookup_objects_by_class_and_names(pool, class_id, &names)
+        let objects = storage_handle(pool)
+            .import_objects_by_names(class_id, &names)
             .await
             .map_err(|err| err.to_string())?;
         let found_names = objects

--- a/src/tasks/resolution.rs
+++ b/src/tasks/resolution.rs
@@ -1,19 +1,7 @@
 use super::helpers::{class_to_resolution, collection_to_resolution, object_to_resolution};
-use super::types::{
-    ClassResolution, CollectionResolution, ObjectResolution, PlanningState, RuntimeState,
-};
-use crate::errors::ApiError;
-use crate::models::{
-    ClassKey, Collection, CollectionKey, HubuumClass, HubuumObject, ImportCollectionInput,
-    ObjectKey,
-};
-use crate::storage::postgres::operations::task_import::{
-    lookup_class_by_collection_and_name, lookup_class_by_collection_and_name_db,
-    lookup_collection_by_id, lookup_collection_by_key, lookup_collection_by_key_db,
-    lookup_collection_child_by_name_db, lookup_collections_by_name,
-    lookup_object_by_class_and_name, lookup_object_by_class_and_name_db, lookup_root_collection,
-    lookup_root_collection_db,
-};
+use super::types::{ClassResolution, CollectionResolution, ObjectResolution, PlanningState};
+use crate::models::{ClassKey, CollectionKey, ImportCollectionInput, ObjectKey};
+use crate::storage::{ImportStorage, storage_handle};
 
 fn validate_collection_key_path(key: &CollectionKey) -> Result<(), String> {
     if let Some(path) = &key.path {
@@ -48,7 +36,8 @@ async fn find_collection_by_key_planning(
     validate_collection_key_path(key)?;
 
     if key.path.is_some() {
-        let collection = lookup_collection_by_key(pool, key)
+        let collection = storage_handle(pool)
+            .import_collection_by_key(key)
             .await
             .map_err(|err| err.to_string())?
             .map(collection_to_resolution);
@@ -67,7 +56,8 @@ async fn find_collection_by_key_planning(
         .get(&key.name)
         .cloned()
         .unwrap_or_default();
-    for collection in lookup_collections_by_name(pool, &key.name)
+    for collection in storage_handle(pool)
+        .import_collections_by_name(&key.name)
         .await
         .map_err(|err| err.to_string())?
         .into_iter()
@@ -107,7 +97,8 @@ async fn resolve_root_collection_planning(
         return Ok(collection);
     }
 
-    let collection = lookup_root_collection(pool)
+    let collection = storage_handle(pool)
+        .import_root_collection()
         .await
         .map_err(|err| err.to_string())
         .map(collection_to_resolution)?;
@@ -166,7 +157,8 @@ pub(super) async fn resolve_collection_by_id_planning(
         return Ok(collection.clone());
     }
 
-    let collection = lookup_collection_by_id(pool, collection_id)
+    let collection = storage_handle(pool)
+        .import_collection_by_id(collection_id)
         .await
         .map_err(|err| err.to_string())?
         .map(collection_to_resolution)
@@ -208,7 +200,8 @@ pub(super) async fn resolve_class_planning(
                 ));
             }
 
-            let class = lookup_class_by_collection_and_name(pool, collection.id, &key.name)
+            let class = storage_handle(pool)
+                .import_class_by_name(collection.id, &key.name)
                 .await
                 .map_err(|err| err.to_string())?
                 .map(class_to_resolution)
@@ -258,7 +251,8 @@ pub(super) async fn resolve_object_planning(
                 ));
             }
 
-            let object = lookup_object_by_class_and_name(pool, class.id, &key.name)
+            let object = storage_handle(pool)
+                .import_object_by_name(class.id, &key.name)
                 .await
                 .map_err(|err| err.to_string())?
                 .map(object_to_resolution)
@@ -269,140 +263,6 @@ pub(super) async fn resolve_object_planning(
             Ok(object)
         }
         _ => Err("Exactly one of object_ref or object_key must be provided".to_string()),
-    }
-}
-
-pub(super) async fn resolve_collection_runtime(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    runtime: &RuntimeState,
-    reference: Option<&str>,
-    key: Option<&CollectionKey>,
-) -> Result<Collection, ApiError> {
-    match (reference, key) {
-        (Some(reference), None) => runtime
-            .collections_by_ref
-            .get(reference)
-            .cloned()
-            .ok_or_else(|| ApiError::BadRequest(format!("Unknown collection ref '{reference}'"))),
-        (None, Some(key)) => lookup_collection_by_key_db(conn, key)
-            .await?
-            .ok_or_else(|| {
-                ApiError::NotFound(format!(
-                    "Collection '{}' not found during execution",
-                    collection_key_label(key)
-                ))
-            }),
-        _ => Err(ApiError::BadRequest(
-            "Exactly one of collection_ref or collection_key must be provided".to_string(),
-        )),
-    }
-}
-
-pub(super) async fn resolve_collection_parent_runtime(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    runtime: &RuntimeState,
-    input: &ImportCollectionInput,
-) -> Result<Collection, ApiError> {
-    match (
-        input.parent_collection_ref.as_deref(),
-        input.parent_collection_key.as_ref(),
-    ) {
-        (None, None) => lookup_root_collection_db(conn).await,
-        (Some(reference), None) => runtime
-            .collections_by_ref
-            .get(reference)
-            .cloned()
-            .ok_or_else(|| ApiError::BadRequest(format!("Unknown collection ref '{reference}'"))),
-        (None, Some(key)) => lookup_collection_by_key_db(conn, key)
-            .await?
-            .ok_or_else(|| {
-                ApiError::NotFound(format!(
-                    "Collection '{}' not found during execution",
-                    collection_key_label(key)
-                ))
-            }),
-        (Some(_), Some(_)) => Err(ApiError::BadRequest(
-            "At most one of parent_collection_ref or parent_collection_key may be provided"
-                .to_string(),
-        )),
-    }
-}
-
-pub(super) async fn lookup_existing_collection_for_import_db(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    parent_collection_id: i32,
-    name: &str,
-) -> Result<Option<Collection>, ApiError> {
-    lookup_collection_child_by_name_db(conn, parent_collection_id, name).await
-}
-
-pub(super) async fn resolve_class_runtime(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    runtime: &RuntimeState,
-    reference: Option<&str>,
-    key: Option<&ClassKey>,
-) -> Result<HubuumClass, ApiError> {
-    match (reference, key) {
-        (Some(reference), None) => runtime
-            .classes_by_ref
-            .get(reference)
-            .cloned()
-            .ok_or_else(|| ApiError::BadRequest(format!("Unknown class ref '{reference}'"))),
-        (None, Some(key)) => {
-            let collection = resolve_collection_runtime(
-                conn,
-                runtime,
-                key.collection_ref.as_deref(),
-                key.collection_key.as_ref(),
-            )
-            .await?;
-            lookup_class_by_collection_and_name_db(conn, collection.id, &key.name)
-                .await?
-                .ok_or_else(|| {
-                    ApiError::NotFound(format!(
-                        "Class '{}' not found in collection '{}' during execution",
-                        key.name, collection.name
-                    ))
-                })
-        }
-        _ => Err(ApiError::BadRequest(
-            "Exactly one of class_ref or class_key must be provided".to_string(),
-        )),
-    }
-}
-
-pub(super) async fn resolve_object_runtime(
-    conn: &mut crate::storage::postgres::PostgresConnection,
-    runtime: &RuntimeState,
-    reference: Option<&str>,
-    key: Option<&ObjectKey>,
-) -> Result<HubuumObject, ApiError> {
-    match (reference, key) {
-        (Some(reference), None) => runtime
-            .objects_by_ref
-            .get(reference)
-            .cloned()
-            .ok_or_else(|| ApiError::BadRequest(format!("Unknown object ref '{reference}'"))),
-        (None, Some(key)) => {
-            let class = resolve_class_runtime(
-                conn,
-                runtime,
-                key.class_ref.as_deref(),
-                key.class_key.as_ref(),
-            )
-            .await?;
-            lookup_object_by_class_and_name_db(conn, class.id, &key.name)
-                .await?
-                .ok_or_else(|| {
-                    ApiError::NotFound(format!(
-                        "Object '{}' not found in class '{}' during execution",
-                        key.name, class.name
-                    ))
-                })
-        }
-        _ => Err(ApiError::BadRequest(
-            "Exactly one of object_ref or object_key must be provided".to_string(),
-        )),
     }
 }
 

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -5,7 +5,7 @@ use diesel_async::RunQueryDsl;
 use rstest::rstest;
 use std::sync::Arc;
 
-use super::execution::{execute_import_best_effort, execute_import_strict, execute_planned_item};
+use super::execution::{execute_import_best_effort, execute_import_strict};
 use super::helpers::{
     class_to_resolution, planned_result, sanitize_error_for_storage,
     should_abort_best_effort_execution,
@@ -16,11 +16,11 @@ use super::planning::{
 use super::request_hash;
 use super::resolution::{
     remember_class, remember_collection, resolve_class_planning, resolve_collection_by_id_planning,
-    resolve_collection_planning, resolve_object_planning, resolve_object_runtime,
+    resolve_collection_planning, resolve_object_planning,
 };
 use super::types::{
     CollectionResolution, ExecutionAccumulator, FailureKind, PlannedExecution, PlannedItem,
-    PlanningFailure, PlanningState, RuntimeState, WorkerLoopAction,
+    PlanningFailure, PlanningState, WorkerLoopAction,
 };
 use super::worker::{background_worker_action, mark_claimed_task_failed, process_one_task};
 use crate::errors::ApiError;
@@ -52,6 +52,7 @@ use crate::storage::postgres::operations::task_import::{
     upsert_export_template_db, upsert_group_membership_db, upsert_identity_scope_db,
     upsert_remote_target_db,
 };
+use crate::storage::postgres::{RuntimeState, execute_planned_item, resolve_object_runtime};
 use crate::storage::postgres::{capture_queries, with_connection, with_transaction};
 use crate::tests::{TestContext, create_test_group};
 use crate::traits::CanSave;
@@ -2799,7 +2800,7 @@ fn test_runtime_planning_failures_are_sanitized_for_storage() {
     assert_eq!(failure.message_for_storage(), "An internal error occurred");
 
     let stored = failure.into_result(1);
-    assert_eq!(stored.error.as_deref(), Some("An internal error occurred"));
+    assert_eq!(stored.error(), Some("An internal error occurred"));
 }
 
 #[test]

--- a/src/tasks/types.rs
+++ b/src/tasks/types.rs
@@ -1,13 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::models::{
-    Collection, HubuumClass, HubuumObject, ImportClassInput, ImportClassRelationInput,
-    ImportCollectionInput, ImportCollectionPermissionInput, ImportComputedFieldInput,
-    ImportEventSinkInput, ImportEventSubscriptionInput, ImportExportTemplateInput,
-    ImportGroupInput, ImportGroupMembershipInput, ImportIdentityScopeInput, ImportObjectInput,
-    ImportObjectRelationInput, ImportPrincipalInput, ImportRemoteTargetInput,
-    NewImportTaskResultRecord, Permissions, RestoreTimestamps, TaskResultCounts, TaskStatus,
-};
+use crate::models::{Permissions, TaskResultCounts, TaskStatus};
+use crate::storage::StorageImportResult;
+
+pub(super) use crate::storage::StorageImportOperation as PlannedExecution;
 
 #[derive(Clone, Debug)]
 pub(super) struct CollectionResolution {
@@ -98,18 +94,6 @@ impl PlanningState {
     }
 }
 
-#[derive(Default)]
-pub(super) struct RuntimeState {
-    pub(super) identity_scopes_by_ref: HashMap<String, i32>,
-    pub(super) groups_by_ref: HashMap<String, i32>,
-    pub(super) principals_by_ref: HashMap<String, i32>,
-    pub(super) collections_by_ref: HashMap<String, Collection>,
-    pub(super) classes_by_ref: HashMap<String, HubuumClass>,
-    pub(super) objects_by_ref: HashMap<String, HubuumObject>,
-    pub(super) event_sinks_by_ref: HashMap<String, i32>,
-    pub(super) import_export_templates: Vec<ImportExportTemplateInput>,
-}
-
 pub(super) struct TerminalTaskUpdate {
     pub(super) status: TaskStatus,
     pub(super) summary: String,
@@ -121,77 +105,6 @@ pub(super) struct TerminalTaskUpdate {
 pub(super) enum WorkerLoopAction {
     Continue,
     Sleep,
-}
-
-#[derive(Clone, Debug)]
-pub(super) enum PlannedExecution {
-    UpsertIdentityScope {
-        input: ImportIdentityScopeInput,
-        overwrite: bool,
-    },
-    UpsertGroup {
-        input: ImportGroupInput,
-        overwrite: bool,
-    },
-    UpsertPrincipal {
-        input: ImportPrincipalInput,
-        overwrite: bool,
-    },
-    UpsertGroupMembership {
-        input: ImportGroupMembershipInput,
-        overwrite: bool,
-    },
-    CreateCollection(ImportCollectionInput),
-    UpdateCollection {
-        collection_id: i32,
-        input: ImportCollectionInput,
-    },
-    CreateClass(ImportClassInput),
-    UpdateClass {
-        class_id: i32,
-        input: ImportClassInput,
-    },
-    CreateObject(ImportObjectInput),
-    UpdateObject {
-        object_id: i32,
-        input: ImportObjectInput,
-    },
-    UpsertComputedField {
-        input: ImportComputedFieldInput,
-        overwrite: bool,
-    },
-    CreateClassRelation(ImportClassRelationInput),
-    UpdateClassRelationTimestamps {
-        input: ImportClassRelationInput,
-        timestamps: RestoreTimestamps,
-    },
-    CheckClassRelationCondition(ImportClassRelationInput),
-    CreateObjectRelation(ImportObjectRelationInput),
-    UpdateObjectRelationTimestamps {
-        input: ImportObjectRelationInput,
-        timestamps: RestoreTimestamps,
-    },
-    CheckObjectRelationCondition(ImportObjectRelationInput),
-    ApplyCollectionPermissions {
-        input: ImportCollectionPermissionInput,
-        overwrite: bool,
-    },
-    UpsertExportTemplate {
-        input: ImportExportTemplateInput,
-        overwrite: bool,
-    },
-    UpsertRemoteTarget {
-        input: ImportRemoteTargetInput,
-        overwrite: bool,
-    },
-    UpsertEventSink {
-        input: ImportEventSinkInput,
-        overwrite: bool,
-    },
-    UpsertEventSubscription {
-        input: ImportEventSubscriptionInput,
-        overwrite: bool,
-    },
 }
 
 #[derive(Clone, Debug)]
@@ -226,26 +139,9 @@ pub(super) struct PlannedItem {
     pub(super) execution: Option<PlannedExecution>,
 }
 
-impl RuntimeState {
-    pub(super) fn for_planned_items(planned_items: &[PlannedItem]) -> Self {
-        let import_export_templates = planned_items
-            .iter()
-            .filter_map(|item| match &item.execution {
-                Some(PlannedExecution::UpsertExportTemplate { input, .. }) => Some(input.clone()),
-                _ => None,
-            })
-            .collect();
-
-        Self {
-            import_export_templates,
-            ..Self::default()
-        }
-    }
-}
-
 #[derive(Default)]
 pub(super) struct ExecutionAccumulator {
-    pub(super) results: Vec<NewImportTaskResultRecord>,
+    pub(super) results: Vec<StorageImportResult>,
     pub(super) processed: i32,
     pub(super) success: i32,
     pub(super) failed: i32,
@@ -262,16 +158,18 @@ impl ExecutionAccumulator {
     ) {
         self.processed += 1;
         self.success += 1;
-        self.results.push(NewImportTaskResultRecord {
-            task_id,
-            item_ref: planned.item_ref.clone(),
-            entity_kind: planned.entity_kind.clone(),
-            action: planned.action.clone(),
-            identifier: planned.identifier.clone(),
-            outcome: outcome.to_string(),
-            error: None,
-            details: planned.details.clone(),
-        });
+        self.results.push(
+            StorageImportResult::builder(
+                task_id,
+                planned.entity_kind.clone(),
+                planned.action.clone(),
+                outcome,
+            )
+            .item_ref(planned.item_ref.clone())
+            .identifier(planned.identifier.clone())
+            .details(planned.details.clone())
+            .build(),
+        );
     }
 
     pub(super) fn push_failure(
@@ -283,16 +181,19 @@ impl ExecutionAccumulator {
     ) {
         self.processed += 1;
         self.failed += 1;
-        self.results.push(NewImportTaskResultRecord {
-            task_id,
-            item_ref: planned.item_ref.clone(),
-            entity_kind: planned.entity_kind.clone(),
-            action: planned.action.clone(),
-            identifier: planned.identifier.clone(),
-            outcome: outcome.to_string(),
-            error: Some(error.into()),
-            details: planned.details.clone(),
-        });
+        self.results.push(
+            StorageImportResult::builder(
+                task_id,
+                planned.entity_kind.clone(),
+                planned.action.clone(),
+                outcome,
+            )
+            .item_ref(planned.item_ref.clone())
+            .identifier(planned.identifier.clone())
+            .error(Some(error.into()))
+            .details(planned.details.clone())
+            .build(),
+        );
     }
 }
 
@@ -335,18 +236,14 @@ impl PlanningFailure {
         }
     }
 
-    pub(super) fn into_result(self, task_id: i32) -> NewImportTaskResultRecord {
+    pub(super) fn into_result(self, task_id: i32) -> StorageImportResult {
         let error = self.message_for_storage();
         let outcome = self.outcome();
-        NewImportTaskResultRecord {
-            task_id,
-            item_ref: self.item.item_ref,
-            entity_kind: self.item.entity_kind,
-            action: self.item.action,
-            identifier: self.item.identifier,
-            outcome: outcome.to_string(),
-            error: Some(error),
-            details: self.item.details,
-        }
+        StorageImportResult::builder(task_id, self.item.entity_kind, self.item.action, outcome)
+            .item_ref(self.item.item_ref)
+            .identifier(self.item.identifier)
+            .error(Some(error))
+            .details(self.item.details)
+            .build()
     }
 }

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -117,7 +117,10 @@ fn application_consumers_do_not_import_database_implementation_details() {
         "src/exports/mod.rs",
         "src/restores/mod.rs",
         "src/tasks/helpers.rs",
+        "src/tasks/execution.rs",
+        "src/tasks/planning.rs",
         "src/tasks/preload.rs",
+        "src/tasks/resolution.rs",
         "src/tasks/remote_call.rs",
         "src/token_retention.rs",
         "src/traits/mod.rs",
@@ -247,6 +250,7 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         "TaskExecutionStorage",
         "BackupSnapshotStorage",
         "RestoreStorage",
+        "ImportStorage",
         "WorkflowStorage",
         "OperationalStorage",
         "sealed::CertifiedStorageBackend",
@@ -322,6 +326,29 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         assert!(
             compact_context.contains(&format!("\"restores\",\"{operation}\"")),
             "restore operation {operation} must use the common storage observer"
+        );
+    }
+    for operation in [
+        "root_collection",
+        "collection_by_id",
+        "collection_by_key",
+        "collections_by_name",
+        "collection_child_by_name",
+        "class_by_name",
+        "classes_by_names",
+        "object_by_name",
+        "objects_by_names",
+        "class_relation_exists",
+        "object_relation_exists",
+        "group_exists",
+        "preflight",
+        "apply_strict",
+        "apply_best_effort",
+        "record_results",
+    ] {
+        assert!(
+            compact_context.contains(&format!("\"imports\",\"{operation}\"")),
+            "import operation {operation} must use the common storage observer"
         );
     }
     for operation in [

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -16,9 +16,10 @@ use crate::models::search::{
     parse_query_parameter_with_computed_filters_and_passthrough,
 };
 use crate::models::{
-    CollectionHistory, CollectionID, ExportTemplateHistory, HubuumClassHistory,
-    HubuumObjectHistory, NewComputedFieldDefinition, NewHubuumClass, NewHubuumClassRelation,
-    NewHubuumObject, NewHubuumObjectRelation, RemoteTargetHistory,
+    CollectionHistory, CollectionID, CollectionKey, ExportTemplateHistory, HubuumClassHistory,
+    HubuumObjectHistory, ImportAtomicity, ImportClassInput, ImportCollectionInput, ImportMode,
+    NewComputedFieldDefinition, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
+    NewHubuumObjectRelation, RemoteTargetHistory,
 };
 use crate::pagination::prepare_db_pagination;
 use crate::services::Services;
@@ -33,27 +34,28 @@ use crate::storage::{
     ComputedObjectListQuery, ComputedObjectProjection, ComputedObjectStorage,
     ComputedObjectVisibility, EventArchive, EventDeliveryStorage, EventFanoutStorage,
     EventHealthStorage, EventRetentionStorage, HistoryAsOfQuery, HistoryCollectionScope,
-    HistoryListQuery, HistoryStorage, MetricsStorage, ObjectAggregateAuthorizationMode,
-    ObjectAggregateAuthorizer, ObjectAggregateStorage, ObjectAggregateStorageQuery,
-    ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectRelationsTouchingIdsQuery,
-    OperationalStateStorage, RelatedObjectsForRootsQuery, RelationGraphQuery, RelationIdsQuery,
-    RelationListQuery, RelationQueryStorage, RelationTouchingQuery, RemoteTargetStorage,
-    RestoreStorage, RetainedEvent, STORAGE_CONTRACT_VERSION, StorageBackendKind,
-    StorageBackupTaskArtifact, StorageComputedFieldDefinitionInput,
-    StorageComputedFieldDefinitionPatch, StorageComputedFieldRebuildRequest,
-    StorageComputedFieldVisibility, StorageError, StorageExportTaskArtifact, StorageObject,
-    StorageObjectAggregateAuthorizationCandidate, StorageObjectAggregateAuthorizationTarget,
-    StorageObjectAggregateSort, StorageObjectAggregateSpec, StorageObjectAggregateTarget,
-    StoragePersonalComputedFieldCreate, StoragePersonalComputedFieldDelete,
-    StoragePersonalComputedFieldListQuery, StoragePersonalComputedFieldUpdate,
-    StorageRelatedDirection, StorageRelatedSort, StorageRemoteCallArtifactOutcome,
-    StorageRemoteCallArtifactResponse, StorageRemoteCallArtifactTarget,
-    StorageRemoteCallTaskArtifact, StorageRemoteTargetCreate, StorageRemoteTargetDefinition,
-    StorageRemoteTargetDelete, StorageRemoteTargetInvocation, StorageRemoteTargetListQuery,
-    StorageRemoteTargetPatch, StorageRemoteTargetPolicy, StorageRemoteTargetTransport,
-    StorageRemoteTargetUpdate, StorageRestoreArtifactSummary, StorageRestoreFailure,
-    StorageRestoreInitiator, StorageRestoreJobStatus, StorageRestoreStageCreate,
-    StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
+    HistoryListQuery, HistoryStorage, ImportStorage, MetricsStorage,
+    ObjectAggregateAuthorizationMode, ObjectAggregateAuthorizer, ObjectAggregateStorage,
+    ObjectAggregateStorageQuery, ObjectHistoryAsOfQuery, ObjectHistoryListQuery,
+    ObjectRelationsTouchingIdsQuery, OperationalStateStorage, RelatedObjectsForRootsQuery,
+    RelationGraphQuery, RelationIdsQuery, RelationListQuery, RelationQueryStorage,
+    RelationTouchingQuery, RemoteTargetStorage, RestoreStorage, RetainedEvent,
+    STORAGE_CONTRACT_VERSION, StorageBackendKind, StorageBackupTaskArtifact,
+    StorageComputedFieldDefinitionInput, StorageComputedFieldDefinitionPatch,
+    StorageComputedFieldRebuildRequest, StorageComputedFieldVisibility, StorageError,
+    StorageExportTaskArtifact, StorageImportOperation, StorageImportPlanItem, StorageImportResult,
+    StorageObject, StorageObjectAggregateAuthorizationCandidate,
+    StorageObjectAggregateAuthorizationTarget, StorageObjectAggregateSort,
+    StorageObjectAggregateSpec, StorageObjectAggregateTarget, StoragePersonalComputedFieldCreate,
+    StoragePersonalComputedFieldDelete, StoragePersonalComputedFieldListQuery,
+    StoragePersonalComputedFieldUpdate, StorageRelatedDirection, StorageRelatedSort,
+    StorageRemoteCallArtifactOutcome, StorageRemoteCallArtifactResponse,
+    StorageRemoteCallArtifactTarget, StorageRemoteCallTaskArtifact, StorageRemoteTargetCreate,
+    StorageRemoteTargetDefinition, StorageRemoteTargetDelete, StorageRemoteTargetInvocation,
+    StorageRemoteTargetListQuery, StorageRemoteTargetPatch, StorageRemoteTargetPolicy,
+    StorageRemoteTargetTransport, StorageRemoteTargetUpdate, StorageRestoreArtifactSummary,
+    StorageRestoreFailure, StorageRestoreInitiator, StorageRestoreJobStatus,
+    StorageRestoreStageCreate, StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
     StorageSharedComputedFieldUpdate, StorageTaskClaimToken, StorageTaskCompletion,
     StorageTaskCompletionArtifact, StorageTaskCreateRequest, StorageTaskEventAppend,
     StorageTaskEventInput, StorageTaskFailure, StorageTaskKind, StorageTaskLease,
@@ -62,7 +64,7 @@ use crate::storage::{
     StorageVisibility, TaskExecutionStorage, TaskQueueStorage, TokenRetentionStorage,
     UnifiedSearchQuery, UnifiedSearchStorage,
 };
-use crate::traits::CanSave;
+use crate::traits::{CanDelete, CanSave};
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum LifecycleContractImplementation {
@@ -166,6 +168,234 @@ async fn every_available_storage_backend_supplies_authentication_projections() {
 }
 
 #[actix_web::test]
+async fn every_available_storage_backend_supplies_the_complete_import_contract() {
+    let _permit = postgres_permit().await;
+    let pool = pool();
+    let preflight_name = prefix("import_preflight_collection");
+    let best_effort_name = prefix("import_best_effort_collection");
+    let rollback_name = prefix("import_rollback_collection");
+    let collection_input = |name: &str, reference: &str| ImportCollectionInput {
+        ref_: Some(reference.to_string()),
+        name: name.to_string(),
+        description: "storage compatibility import".to_string(),
+        parent_collection_ref: None,
+        parent_collection_key: None,
+        condition: None,
+        timestamps: None,
+    };
+
+    for kind in StorageBackendKind::ALL {
+        match kind {
+            StorageBackendKind::Postgresql => {
+                let backend = StorageHandle::postgres(pool.get_ref().clone());
+                let root = backend
+                    .import_root_collection()
+                    .await
+                    .expect("certified backend should resolve the import root");
+                assert_eq!(
+                    backend
+                        .import_collection_by_id(root.id)
+                        .await
+                        .expect("certified backend should look up import collections by id")
+                        .map(|collection| collection.id),
+                    Some(root.id)
+                );
+                assert!(
+                    backend
+                        .import_collection_by_key(&CollectionKey {
+                            name: root.name.clone(),
+                            path: Some(Vec::new()),
+                        })
+                        .await
+                        .expect("certified backend should look up import collections by path")
+                        .is_some()
+                );
+                assert!(
+                    backend
+                        .import_collections_by_name(&root.name)
+                        .await
+                        .expect("certified backend should look up import collections by name")
+                        .iter()
+                        .any(|collection| collection.id == root.id)
+                );
+                assert!(
+                    backend
+                        .import_collection_child_by_name(root.id, &preflight_name)
+                        .await
+                        .expect("certified backend should look up import children")
+                        .is_none()
+                );
+                assert!(
+                    backend
+                        .import_class_by_name(root.id, &prefix("missing_import_class"))
+                        .await
+                        .expect("certified backend should look up import classes")
+                        .is_none()
+                );
+                assert!(
+                    backend
+                        .import_classes_by_names(root.id, &[])
+                        .await
+                        .expect("certified backend should batch import class lookups")
+                        .is_empty()
+                );
+                assert!(
+                    backend
+                        .import_object_by_name(i32::MAX, &prefix("missing_import_object"))
+                        .await
+                        .expect("certified backend should look up import objects")
+                        .is_none()
+                );
+                assert!(
+                    backend
+                        .import_objects_by_names(i32::MAX, &[])
+                        .await
+                        .expect("certified backend should batch import object lookups")
+                        .is_empty()
+                );
+                assert!(
+                    !backend
+                        .import_class_relation_exists(i32::MAX - 1, i32::MAX)
+                        .await
+                        .expect("certified backend should look up import class relations")
+                );
+                assert!(
+                    !backend
+                        .import_object_relation_exists(i32::MAX - 1, i32::MAX)
+                        .await
+                        .expect("certified backend should look up import object relations")
+                );
+                assert!(
+                    !backend
+                        .import_group_exists(LOCAL_IDENTITY_SCOPE, &prefix("missing_import_group"),)
+                        .await
+                        .expect("certified backend should look up import groups")
+                );
+
+                let preflight_plan = vec![StorageImportPlanItem::new(
+                    0,
+                    StorageImportOperation::CreateCollection(collection_input(
+                        &preflight_name,
+                        "collection:preflight",
+                    )),
+                )];
+                let (preflight, aborted) = backend
+                    .preflight_import(preflight_plan.clone(), ImportMode::default())
+                    .await
+                    .expect("certified backend should preflight an import")
+                    .into_parts();
+                assert!(!aborted);
+                assert_eq!(preflight.len(), 1);
+                assert!(
+                    preflight
+                        .into_iter()
+                        .next()
+                        .unwrap()
+                        .into_parts()
+                        .2
+                        .is_none()
+                );
+                assert!(
+                    backend
+                        .import_collection_child_by_name(root.id, &preflight_name)
+                        .await
+                        .expect("preflight rollback should remain queryable")
+                        .is_none(),
+                    "import preflight must roll back every mutation"
+                );
+
+                backend
+                    .apply_import_strict(preflight_plan)
+                    .await
+                    .expect("certified backend should atomically apply a strict import");
+
+                let rollback_plan = vec![
+                    StorageImportPlanItem::new(
+                        0,
+                        StorageImportOperation::CreateCollection(collection_input(
+                            &rollback_name,
+                            "collection:rollback",
+                        )),
+                    ),
+                    StorageImportPlanItem::new(
+                        1,
+                        StorageImportOperation::CreateClass(ImportClassInput {
+                            ref_: Some("class:rollback_failure".to_string()),
+                            name: prefix("import_rollback_class"),
+                            description: "must fail".to_string(),
+                            json_schema: None,
+                            validate_schema: Some(false),
+                            collection_ref: Some("collection:missing".to_string()),
+                            collection_key: None,
+                            condition: None,
+                            timestamps: None,
+                        }),
+                    ),
+                ];
+                assert!(backend.apply_import_strict(rollback_plan).await.is_err());
+                assert!(
+                    backend
+                        .import_collection_child_by_name(root.id, &rollback_name)
+                        .await
+                        .expect("strict rollback should remain queryable")
+                        .is_none(),
+                    "strict import must roll back earlier successful items"
+                );
+
+                let best_effort = backend
+                    .apply_import_best_effort(
+                        vec![
+                            StorageImportPlanItem::new(
+                                0,
+                                StorageImportOperation::CreateCollection(collection_input(
+                                    &best_effort_name,
+                                    "collection:best_effort",
+                                )),
+                            ),
+                            StorageImportPlanItem::new(
+                                1,
+                                StorageImportOperation::CreateClass(ImportClassInput {
+                                    ref_: Some("class:best_effort_failure".to_string()),
+                                    name: prefix("import_best_effort_class"),
+                                    description: "must fail".to_string(),
+                                    json_schema: None,
+                                    validate_schema: Some(false),
+                                    collection_ref: Some("collection:missing".to_string()),
+                                    collection_key: None,
+                                    condition: None,
+                                    timestamps: None,
+                                }),
+                            ),
+                        ],
+                        ImportMode {
+                            atomicity: Some(ImportAtomicity::BestEffort),
+                            ..ImportMode::default()
+                        },
+                    )
+                    .await
+                    .expect("certified backend should apply a best-effort import");
+                let (best_effort, aborted) = best_effort.into_parts();
+                assert!(!aborted);
+                assert_eq!(best_effort.len(), 2);
+                assert!(best_effort[0].error().is_none());
+                assert!(best_effort[1].error().is_some());
+
+                for name in [&preflight_name, &best_effort_name] {
+                    backend
+                        .import_collection_child_by_name(root.id, name)
+                        .await
+                        .expect("committed import collection should remain queryable")
+                        .expect("committed import collection should exist")
+                        .delete_without_events(pool.get_ref())
+                        .await
+                        .expect("import compatibility fixture should be removed");
+                }
+            }
+        }
+    }
+}
+
+#[actix_web::test]
 async fn every_available_storage_backend_supplies_the_complete_task_queue() {
     let _permit = postgres_permit().await;
     let pool = pool();
@@ -243,6 +473,27 @@ async fn every_available_storage_backend_supplies_the_complete_task_queue() {
                     .into_parts();
                 assert_eq!(result_total, Some(0));
                 assert!(results.is_empty());
+
+                backend
+                    .record_import_results(vec![
+                        StorageImportResult::builder(
+                            task_id,
+                            "compatibility",
+                            "verify",
+                            "succeeded",
+                        )
+                        .item_ref(Some("compatibility:item".to_string()))
+                        .build(),
+                    ])
+                    .await
+                    .expect("certified backend should persist import results");
+                let (results, result_total) = backend
+                    .list_import_task_results(StorageTaskPageQuery::new(task_id, options()))
+                    .await
+                    .expect("certified backend should return persisted import results")
+                    .into_parts();
+                assert_eq!(result_total, Some(1));
+                assert_eq!(results.len(), 1);
 
                 assert!(
                     backend

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -133,7 +133,7 @@ async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() 
 
     assert!(
         body.contains(
-            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"13\"} 1"
+            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"14\"} 1"
         )
     );
     assert!(body.contains(

--- a/tests/api_platform_suite/runtime_config.rs
+++ b/tests/api_platform_suite/runtime_config.rs
@@ -37,7 +37,7 @@ mod tests {
         let serialized = serde_json::to_string(&body).unwrap();
 
         assert_eq!(body["database"]["backend"], "postgresql");
-        assert_eq!(body["database"]["contract_version"], 13);
+        assert_eq!(body["database"]["contract_version"], 14);
         assert_eq!(
             body["database"]["capabilities"],
             serde_json::json!([
@@ -55,6 +55,7 @@ mod tests {
                 "task_execution",
                 "backup_snapshots",
                 "restores",
+                "imports",
                 "workflows",
                 "operations"
             ])


### PR DESCRIPTION
## Summary

- make import support a mandatory `ImportStorage` capability of every selectable storage backend
- define exhaustive, backend-neutral plan, preflight, apply, and result DTOs
- move PostgreSQL runtime reference resolution, revision observation, savepoints, transaction ownership, and Diesel row conversion into the PostgreSQL adapter
- route import planning and execution through consistently observed `StorageHandle` entry points
- add shared available-backend compatibility coverage for all import lookups, rollback-only preflight, strict rollback, best-effort partial commit, and durable results

## Rationale

Import application code previously selected PostgreSQL operations and managed connections and transactions directly. That made the application layer aware of backend mechanics and allowed a future backend to appear selectable without implementing the complete import workflow.

This layer makes import support indivisible. `StorageBackend` now requires `ImportStorage`, so lookups alone are insufficient: every selectable backend must implement planning, dry-run rollback, strict and best-effort writes, and result persistence. Application code now owns validation, authorization policy, and task/result presentation, while the adapter owns persistence semantics.

The import contract remains root-internal for now because its typed commands contain domain import models that have not yet moved into a workspace crate. It exposes no PostgreSQL, Diesel, connection, or transaction types; it can move into `hubuum-storage-core` once those domain DTOs are independently extractable.

## Behavior and compatibility

- the redacted administrator configuration and storage metrics now report the required `imports` capability
- storage contract version advances from `13` to `14`
- PostgreSQL adapter errors preserve forbidden and unauthorized categories across `PostgresStorageError` -> `StorageError` -> `ApiError`
- bounded `imports/*` observability labels cover every entry point without including imported names, identifiers, payloads, or error text

This is a breaking administrator API change for consumers that match the storage contract version or exact capability list. They must accept version `14` and the `imports` capability. The upgrade is documented in `[Unreleased]` in `CHANGELOG.md`.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- OpenAPI regeneration comparison (no document change)
- Rust API policy and policy fixture tests
- CI change-classifier tests
- Docker workspace-manifest parity test
- production Docker build with `tls-rustls`, `tls-openssl`, `--locked`, and `--release`

Stacked on #313.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
