### PR TITLE
Remove provisional storage certification markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   Authorization resource hydration and all-permissions-on-all-collections
   decisions now use mandatory backend-neutral DTOs and operations; application
   traits, export code, and handlers no longer import PostgreSQL authorization
-  query helpers.
+  query helpers. Backend certification no longer contains provisional workflow
+  or operational markers: all advertised families are enforced through
+  operation-shaped traits and shared available-backend tests.
 - Event worker and retention configuration validation now uses backend-neutral
   policy terminology, matching the storage traits and DTOs used by application
   workers instead of exposing database implementation language.

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -83,12 +83,10 @@ The families are not feature flags and the admin configuration does not report
 optional support. Every selectable backend implements the entire list. The
 sealed composition in `src/storage/contract.rs` makes adding a backend an
 explicit architecture change rather than an incidental trait implementation.
-During extraction, the remaining operational family retains a temporary central
-migration gate. That gate prevents another backend from becoming selectable,
-but it is not behavioral proof and must be replaced by mandatory operation-shaped
-traits and shared tests. The former
-identity, catalog-query, relation-query, history, and unified-search gates have
-now been replaced by the real `AuthenticationStorage`,
+Backend certification contains no empty capability markers. Identity,
+catalog-query, relation-query, history, unified-search, workflow, and operational
+responsibilities are enforced by operation-shaped traits and shared tests. The
+complete contract includes `AuthenticationStorage`,
 `AuthorizationStorage`, `HistoryStorage`, `CatalogStorage`,
 `ComputedObjectStorage`, `ComputedFieldLifecycleStorage`,
 `ObjectAggregateStorage`, `RelationQueryStorage`, and `UnifiedSearchStorage`
@@ -99,8 +97,11 @@ execution is part of `ComputedFieldLifecycleStorage`. `RemoteTargetStorage`
 owns target reads, lifecycle mutations, and invocation provenance.
 `RestoreStorage` owns the complete staged-restore lifecycle and coordinator.
 `ImportStorage` owns the complete import workflow. `ExportQueryStorage` owns the
-backend read-budget scope used by selection, includes, and hydration. No family
-is considered complete merely because a marker exists.
+backend read-budget scope used by selection, includes, and hydration.
+`OperationalStateStorage`, `MetricsStorage`, `EventHealthStorage`,
+`TokenRetentionStorage`, `EventDeliveryStorage`, `EventFanoutStorage`, and
+`EventRetentionStorage` jointly enforce the operations family. No family is
+considered complete merely because a marker exists.
 
 PostgreSQL query implementations live in
 `src/storage/postgres/operations/*`. Separating their persistence rows from

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -44,15 +44,6 @@ impl<T> LifecycleStorage for T where
 {
 }
 
-/// Temporary migration gate for the operational capability family whose
-/// operation-shaped traits have not yet been fully extracted.
-///
-/// These gates prevent another implementation from becoming selectable during
-/// the refactor, but they do not certify behavior. Each one must be replaced by
-/// mandatory operation-shaped traits and shared compatibility tests, as the
-/// authentication gate has been in this layer.
-pub(crate) trait OperationalStorage: Send + Sync {}
-
 mod sealed {
     pub trait CertifiedStorageBackend {}
 }
@@ -86,13 +77,11 @@ pub(crate) trait StorageBackend:
     + RestoreStorage
     + ImportStorage
     + ExportQueryStorage
-    + OperationalStorage
     + sealed::CertifiedStorageBackend
 {
     fn descriptor(&self) -> StorageBackendDescriptor;
 }
 
-impl OperationalStorage for PostgresStorage {}
 impl sealed::CertifiedStorageBackend for PostgresStorage {}
 
 impl StorageBackend for PostgresStorage {

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -252,7 +252,6 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         "RestoreStorage",
         "ImportStorage",
         "ExportQueryStorage",
-        "OperationalStorage",
         "sealed::CertifiedStorageBackend",
     ] {
         assert!(
@@ -268,6 +267,12 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         !contract_source.contains("CertifiedStorageBackend for MemoryStorageModel"),
         "the focused memory contract model must not be selectable as a full backend"
     );
+    for forbidden_marker in ["WorkflowStorage", "OperationalStorage"] {
+        assert!(
+            !contract_source.contains(forbidden_marker),
+            "complete storage certification must not rely on marker {forbidden_marker}"
+        );
+    }
     assert!(
         context_source.contains("assert_complete_storage_backend(&backend)"),
         "application composition must enforce the complete storage contract"


### PR DESCRIPTION
## Summary

- remove the final empty `OperationalStorage` certification marker;
- certify selectable backends exclusively through operation-shaped traits; and
- add an architecture guard that rejects the former workflow and operational
  markers if either is reintroduced.

This advances #27 and is stacked on #315.

## Why this is complete

The marker did not supply behavior. The advertised operations family is already
mandatory through:

- `OperationalStateStorage`;
- `MetricsStorage`;
- `EventHealthStorage`;
- `TokenRetentionStorage`;
- `EventDeliveryStorage`;
- `EventFanoutStorage`; and
- `EventRetentionStorage`.

Each trait has an implementation on the selected adapter, dispatch through the
opaque `StorageHandle`, common bounded observability, and shared
available-backend compatibility coverage. Removing the marker therefore makes
the type-level certification honest: no backend can satisfy `StorageBackend`
through an empty placeholder.

## Changelog

The `[Unreleased]` entry now explicitly states that all advertised storage
families are enforced by behavior-bearing traits and compatibility tests.

## Verification

- `cargo test --lib tests::application_boundary::selectable_storage_backends_are_complete_and_test_models_are_not_selectable --locked -- --exact`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`

The immediately preceding stack layer also passed the complete repository test
harness and required production container build.
