### PR TITLE
Publish SHA-addressed main container builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1545,32 +1545,6 @@ jobs:
           name: main-${{ matrix.platform.os_name }}-${{ matrix.feature.ext }}
           path: dist/*
 
-  publish-main-release:
-    name: Publish main-latest artifacts
-    if: github.ref == 'refs/heads/main'
-    needs:
-      - build-main-linux-artifacts
-      - build-main-native-artifacts
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    steps:
-      - name: Download main artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          pattern: main-*
-          merge-multiple: true
-          path: dist
-      - name: Publish main-latest release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        with:
-          tag_name: main-latest
-          name: Main build
-          body: Automatically published build for the `main` branch.
-          draft: false
-          prerelease: false
-          files: dist/*
-
   publish-main-container-images:
     name: Build main container (${{ matrix.platform.arch }})
     if: github.ref == 'refs/heads/main' && needs.changes.outputs.artifacts == 'true'
@@ -1608,11 +1582,11 @@ jobs:
           file: Dockerfile
           platforms: linux/${{ matrix.platform.arch }}
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/hubuum-server:main-full-${{ matrix.platform.arch }}
+          tags: ghcr.io/${{ github.repository_owner }}/hubuum-server:sha-${{ github.sha }}-${{ matrix.platform.arch }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.version=sha-${{ github.sha }}
           build-args: |
             CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release
             HUBUUM_BUILD_GIT_SHA=${{ github.sha }}
@@ -1661,14 +1635,13 @@ jobs:
         run: |
           owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           image="ghcr.io/${owner}/hubuum-server"
-          final_tags=("${image}:main" "${image}:main-full")
-          
-          # Create and push manifest for each tag
-          for tag in "${final_tags[@]}"; do
-            docker buildx imagetools create -t "$tag" \
-              "${image}:main-full-amd64" \
-              "${image}:main-full-arm64"
-          done
+          sha_tag="${image}:sha-${GITHUB_SHA}"
+          docker buildx imagetools create \
+            --tag "$sha_tag" \
+            --tag "${image}:main" \
+            --tag "${image}:main-full" \
+            "${sha_tag}-amd64" \
+            "${sha_tag}-arm64"
 
   publish-tag-container-images:
     name: Build release container (${{ matrix.platform.arch }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- Main-branch CI no longer updates a rolling GitHub Release. Native binaries
+  remain available as per-run Actions artifacts, while multi-architecture GHCR
+  images receive a commit-SHA tag before the movable `main` and `main-full`
+  tags are advanced to the same manifest.
 - **Breaking (Rust API support policy):** the root `hubuum` library and every
   current workspace crate are explicitly internal and non-publishable. Their
   Rust `pub` items are workspace construction details rather than supported

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -828,3 +828,47 @@ fn tagged_release_attestors_can_persist_artifact_metadata() {
         );
     }
 }
+
+#[test]
+fn main_builds_remain_run_artifacts_without_a_rolling_github_release() {
+    let workflow = read_repository_text(".github/workflows/ci.yml");
+
+    assert!(workflow.contains("\n  build-main-linux-artifacts:"));
+    assert!(workflow.contains("\n  build-main-native-artifacts:"));
+    assert!(
+        workflow.contains("name: main-${{ matrix.platform.os_name }}-${{ matrix.feature.ext }}")
+    );
+    assert!(!workflow.contains("\n  publish-main-release:"));
+    assert!(!workflow.contains("main-latest"));
+}
+
+#[test]
+fn main_container_manifest_is_sha_addressed_before_channel_promotion() {
+    let workflow = read_repository_text(".github/workflows/ci.yml");
+    let job_start = workflow
+        .find("\n  publish-main-container-images:")
+        .expect("CI should define main container publication");
+    let job_end = workflow[job_start + 1..]
+        .find("\n  publish-tag-container-images:")
+        .map(|offset| job_start + 1 + offset)
+        .expect("main container publication should precede tagged publication");
+    let jobs = &workflow[job_start..job_end];
+
+    assert!(jobs.contains(
+        "tags: ghcr.io/${{ github.repository_owner }}/hubuum-server:sha-${{ github.sha }}-${{ matrix.platform.arch }}"
+    ));
+    assert!(jobs.contains("org.opencontainers.image.version=sha-${{ github.sha }}"));
+    assert!(jobs.contains("sha_tag=\"${image}:sha-${GITHUB_SHA}\""));
+    for tag in ["$sha_tag", "${image}:main", "${image}:main-full"] {
+        assert!(
+            jobs.contains(&format!("--tag \"{tag}\"")),
+            "main manifest publication should create {tag}"
+        );
+    }
+    for platform in ["amd64", "arm64"] {
+        assert!(
+            jobs.contains(&format!("\"${{sha_tag}}-{platform}\"")),
+            "main manifest should use the SHA-addressed {platform} image"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- stop publishing native `main` builds through the rolling `main-latest` GitHub Release
- retain native binaries and checksums as per-run GitHub Actions artifacts
- publish platform images as `sha-<commit>-amd64` and `sha-<commit>-arm64`
- create the multi-architecture `sha-<commit>` manifest first, then advance `main` and `main-full` to that same manifest
- add regression coverage and document the behavior in the Unreleased changelog

## Rationale

GitHub Release immutability is desirable for proper versioned releases, but it prevents CI from safely replacing assets in a rolling `main-latest` release. GHCR channel tags are the better fit for the rolling build: each build remains addressable by commit SHA, while `main` and `main-full` provide convenient movable aliases.

The obsolete `main-latest` GitHub Release and Git tag have already been removed. Versioned releases and tags were not changed.

## User impact

Consumers that need reproducibility can pin `ghcr.io/hubuum/hubuum-server:sha-<commit>`. Consumers that want the latest successful main build can continue using `:main` or `:main-full`. Native main binaries remain available from the corresponding Actions run instead of a GitHub Release.

This is not a breaking change to a versioned release or API.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --bin hubuum-server main_ --locked`
- `env PATH=/tmp/hubuum-ci-python312/bin:/mn/sarpanitu/drift-u1/terjekv/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin bash scripts/test-classify-ci-changes.sh`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `git diff --check`

The full suite was attempted twice before rebasing. Both runs passed the unit and workflow sections, then late `api_jobs` export/import cases timed out while their tasks remained queued (15 failures on the second run). The changed production surface is limited to the GitHub Actions workflow; the two new workflow regressions pass on the updated `main` base.