### PR TITLE
Enforce remote-target persistence boundary

### DIFF
--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -113,11 +113,12 @@ and revision-precondition scopes used across requests and workers.
 considered complete merely because a marker exists.
 
 PostgreSQL query implementations live in
-`src/storage/postgres/operations/*`. Export-template persistence rows are
-adapter-owned; remaining mixed persistence rows move there as their
-backend-neutral DTOs are extracted. Their current locations are implementation
-details, not partial backend support. `StorageHandle` selects one certified
-PostgreSQL adapter, and only the storage implementation can recover its pool.
+`src/storage/postgres/operations/*`. Export-template and remote-target
+lifecycle, history, and remote-call result persistence rows are adapter-owned;
+remaining mixed persistence rows move there as their backend-neutral DTOs are
+extracted. Their current locations are implementation details, not partial
+backend support. `StorageHandle` selects one certified PostgreSQL adapter, and
+only the storage implementation can recover its pool.
 Application consumers use `StorageContext`, lifecycle traits, mandatory
 capability traits, or application services. No second backend can be added to
 composition without implementing every operation behind those contracts.
@@ -434,12 +435,14 @@ real matching rows.
 `RemoteTargetStorage` owns remote-target point and list reads, atomic audited
 create/update/delete behavior, and invocation provenance. Transport templates,
 authentication configuration, and subject policy cross the boundary only in
-private-field, redacted-debug storage DTOs; Diesel rows stay in the PostgreSQL
-adapter. The application service performs public-model validation and converts
-between API/domain models and storage DTOs. Handlers and remote-call workers do
-not import adapter operations or recover a pool. Every entry point is observed
-under bounded `remote_targets/*` labels, and the available-backend compatibility
-test exercises all six operations.
+private-field, redacted-debug storage DTOs. Lifecycle, temporal-history, and
+remote-call result persistence rows, SQL cursor mappings, and query construction
+stay in the PostgreSQL adapter. The application service performs public-model
+validation and converts between API/domain models and storage DTOs. Handlers,
+remote-call workers, and request-level compatibility tests do not import adapter
+operations or recover a pool. Every entry point is observed under bounded
+`remote_targets/*` labels, and the available-backend compatibility test exercises
+all six operations.
 
 `CatalogStorage` owns the ordinary collection, class, and object query surface.
 Each operation applies backend-neutral filters, stable cursor state, local

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -28,10 +28,10 @@ use crate::models::{
     CollectionID, EventDelivery, EventDeliveryID, EventDeliveryStatus, EventSinkKind,
     ExportContentType, ExportTemplateID, ExportTemplateKind, GroupID, HubuumClassID,
     HubuumClassRelationID, HubuumObjectID, NewEventSinkRow, NewEventSubscriptionRow,
-    NewExportTemplate, NewHubuumClassRelation, NewHubuumObjectRelation, NewRemoteTargetRow,
-    NewUser, ObjectRelationLimit, Permissions, PermissionsList, PrincipalID, PrincipalToken,
+    NewExportTemplate, NewHubuumClassRelation, NewHubuumObjectRelation, NewUser,
+    ObjectRelationLimit, Permissions, PermissionsList, PrincipalID, PrincipalToken,
     PrincipalTokenCreateRequest, RemoteTargetID, Token, TokenID, TokenScope, UpdateExportTemplate,
-    UpdateRemoteTargetRow, UpdateUser, UserID,
+    UpdateUser, UserID,
 };
 use crate::schema::events::dsl::events;
 use crate::storage::postgres::operations::event_delivery::{
@@ -51,8 +51,8 @@ use crate::storage::postgres::operations::events::{
     EventListFilters, list_events_with_total_count,
 };
 use crate::storage::postgres::operations::remote_target::{
-    DeleteRemoteTargetRecord, SaveRemoteTargetRecord, UpdateRemoteTargetRecord,
-    emit_remote_target_invoked_event,
+    DeleteRemoteTargetRecord, NewRemoteTargetRow, SaveRemoteTargetRecord, UpdateRemoteTargetRecord,
+    UpdateRemoteTargetRow, emit_remote_target_invoked_event,
 };
 use crate::storage::postgres::{capture_queries, with_connection, with_transaction};
 use crate::storage::{EventDeliverySink, EventDeliverySubscription};

--- a/src/models/remote_target.rs
+++ b/src/models/remote_target.rs
@@ -1,7 +1,6 @@
 use crate::models::token_scope::TokenScope;
 use std::{fmt, str::FromStr};
 
-use crate::storage::postgres::prelude::*;
 use chrono::NaiveDateTime;
 use hubuum_outbound_http::OutboundHeaderName;
 use hubuum_templates::prepare_template;
@@ -18,10 +17,7 @@ use crate::models::{
     HubuumObjectRelationID, Permissions, REDACTED_DEBUG_VALUE, ResourceRevision,
     redacted_debug_option,
 };
-use crate::pagination::{
-    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
-};
-use crate::schema::{remote_call_results, remote_targets};
+use crate::pagination::{CursorPaginated, CursorValue};
 use crate::traits::UserPermissions;
 use crate::traits::{ClassAccessors, CollectionAccessors, ObjectAccessors, SelfAccessors};
 
@@ -177,65 +173,6 @@ macro_rules! impl_redacted_remote_call_result_debug {
     };
 }
 
-#[derive(Clone, Queryable, Selectable)]
-#[diesel(table_name = remote_targets)]
-pub(crate) struct RemoteTargetRow {
-    pub id: i32,
-    pub collection_id: i32,
-    pub class_id: Option<i32>,
-    pub name: String,
-    pub description: String,
-    pub method: String,
-    pub url_template: String,
-    pub headers_template: serde_json::Value,
-    pub body_template: Option<String>,
-    pub auth_config: serde_json::Value,
-    pub allowed_subject_types: serde_json::Value,
-    pub timeout_ms: i32,
-    pub enabled: bool,
-    pub created_at: NaiveDateTime,
-    pub updated_at: NaiveDateTime,
-    pub revision: ResourceRevision,
-}
-
-impl_redacted_remote_target_debug!(
-    RemoteTargetRow,
-    id,
-    collection_id,
-    class_id,
-    name,
-    description,
-    method,
-    allowed_subject_types,
-    timeout_ms,
-    enabled,
-    created_at,
-    updated_at,
-);
-
-impl RemoteTargetRow {
-    pub(crate) fn audit_snapshot(&self) -> serde_json::Value {
-        serde_json::json!({
-            "id": self.id,
-            "collection_id": self.collection_id,
-            "class_id": self.class_id,
-            "name": self.name,
-            "description": self.description,
-            "method": self.method,
-            "url_template": self.url_template,
-            "headers_template": self.headers_template,
-            "body_template": self.body_template,
-            "auth_config": "<redacted>",
-            "allowed_subject_types": self.allowed_subject_types,
-            "timeout_ms": self.timeout_ms,
-            "enabled": self.enabled,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
-            "revision": self.revision,
-        })
-    }
-}
-
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct RemoteTarget {
     pub id: i32,
@@ -342,111 +279,6 @@ impl_redacted_remote_target_debug!(
     timeout_ms,
     enabled,
 );
-
-#[derive(Clone, Insertable)]
-#[diesel(table_name = remote_targets)]
-pub(crate) struct NewRemoteTargetRow {
-    pub collection_id: i32,
-    pub class_id: Option<i32>,
-    pub name: String,
-    pub description: String,
-    pub method: String,
-    pub url_template: String,
-    pub headers_template: serde_json::Value,
-    pub body_template: Option<String>,
-    pub auth_config: serde_json::Value,
-    pub allowed_subject_types: serde_json::Value,
-    pub timeout_ms: i32,
-    pub enabled: bool,
-}
-
-impl_redacted_remote_target_debug!(
-    NewRemoteTargetRow,
-    collection_id,
-    class_id,
-    name,
-    description,
-    method,
-    allowed_subject_types,
-    timeout_ms,
-    enabled,
-);
-
-#[derive(Clone, AsChangeset)]
-#[diesel(table_name = remote_targets)]
-pub(crate) struct UpdateRemoteTargetRow {
-    pub collection_id: Option<i32>,
-    pub class_id: Option<Option<i32>>,
-    pub name: Option<String>,
-    pub description: Option<String>,
-    pub method: Option<String>,
-    pub url_template: Option<String>,
-    pub headers_template: Option<serde_json::Value>,
-    pub body_template: Option<Option<String>>,
-    pub auth_config: Option<serde_json::Value>,
-    pub allowed_subject_types: Option<serde_json::Value>,
-    pub timeout_ms: Option<i32>,
-    pub enabled: Option<bool>,
-}
-
-impl_redacted_remote_target_debug!(
-    UpdateRemoteTargetRow,
-    collection_id,
-    class_id,
-    name,
-    description,
-    method,
-    allowed_subject_types,
-    timeout_ms,
-    enabled,
-);
-
-impl UpdateRemoteTargetRow {
-    pub(crate) fn has_changes(&self, current: &RemoteTargetRow) -> bool {
-        self.collection_id
-            .is_some_and(|value| value != current.collection_id)
-            || self
-                .class_id
-                .as_ref()
-                .is_some_and(|value| value != &current.class_id)
-            || self
-                .name
-                .as_ref()
-                .is_some_and(|value| value != &current.name)
-            || self
-                .description
-                .as_ref()
-                .is_some_and(|value| value != &current.description)
-            || self
-                .method
-                .as_ref()
-                .is_some_and(|value| value != &current.method)
-            || self
-                .url_template
-                .as_ref()
-                .is_some_and(|value| value != &current.url_template)
-            || self
-                .headers_template
-                .as_ref()
-                .is_some_and(|value| value != &current.headers_template)
-            || self
-                .body_template
-                .as_ref()
-                .is_some_and(|value| value != &current.body_template)
-            || self
-                .auth_config
-                .as_ref()
-                .is_some_and(|value| value != &current.auth_config)
-            || self
-                .allowed_subject_types
-                .as_ref()
-                .is_some_and(|value| value != &current.allowed_subject_types)
-            || self
-                .timeout_ms
-                .is_some_and(|value| value != current.timeout_ms)
-            || self.enabled.is_some_and(|value| value != current.enabled)
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct RemoteTargetInvokeRequest {
@@ -647,8 +479,7 @@ impl RemoteTemplateContext {
     }
 }
 
-#[derive(Clone, Queryable, Selectable, Serialize, Deserialize, PartialEq, ToSchema)]
-#[diesel(table_name = remote_call_results)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct RemoteCallResult {
     pub id: i32,
     pub task_id: i32,
@@ -678,35 +509,6 @@ impl_redacted_remote_call_result_debug!(
     duration_ms,
     success,
     created_at,
-);
-
-#[derive(Clone, Insertable)]
-#[diesel(table_name = remote_call_results)]
-pub struct NewRemoteCallResult {
-    pub task_id: i32,
-    pub target_id: Option<i32>,
-    pub subject_type: String,
-    pub subject_id: i32,
-    pub method: String,
-    pub rendered_url: String,
-    pub response_status: Option<i32>,
-    pub response_headers: Option<serde_json::Value>,
-    pub response_body_preview: Option<String>,
-    pub duration_ms: i32,
-    pub success: bool,
-    pub error: Option<String>,
-}
-
-impl_redacted_remote_call_result_debug!(
-    NewRemoteCallResult,
-    task_id,
-    target_id,
-    subject_type,
-    subject_id,
-    method,
-    response_status,
-    duration_ms,
-    success,
 );
 
 impl UpdateRemoteTarget {
@@ -1125,54 +927,6 @@ impl CursorPaginated for RemoteTarget {
     }
 }
 
-impl CursorSqlMapping for RemoteTarget {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id => CursorSqlField {
-                column: "remote_targets.id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Name => CursorSqlField {
-                column: "remote_targets.name",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::Description => CursorSqlField {
-                column: "remote_targets.description",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::CollectionId => CursorSqlField {
-                column: "remote_targets.collection_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::CreatedAt => CursorSqlField {
-                column: "remote_targets.created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAt => CursorSqlField {
-                column: "remote_targets.updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::Revision => CursorSqlField {
-                column: "remote_targets.revision",
-                sql_type: CursorSqlType::BigInt,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for remote targets",
-                    field
-                )));
-            }
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -1442,7 +1196,8 @@ mod tests {
 
     #[test]
     fn remote_call_result_debug_redacts_url_headers_and_body() {
-        let result = NewRemoteCallResult {
+        let result = RemoteCallResult {
+            id: 1,
             task_id: 1,
             target_id: Some(2),
             subject_type: "object".to_string(),
@@ -1457,6 +1212,9 @@ mod tests {
             duration_ms: 12,
             success: true,
             error: Some("result-error-secret".to_string()),
+            created_at: chrono::NaiveDate::from_ymd_opt(2026, 8, 10)
+                .and_then(|date| date.and_hms_opt(12, 0, 0))
+                .expect("static test timestamp must be valid"),
         };
 
         let debug = format!("{result:?}");
@@ -1470,8 +1228,7 @@ mod tests {
     }
 }
 
-#[derive(serde::Serialize, diesel::Queryable, Clone, ToSchema)]
-#[diesel(table_name = crate::schema::remote_targets_history)]
+#[derive(serde::Serialize, Clone, ToSchema)]
 pub struct RemoteTargetHistory {
     pub id: i32,
     pub collection_id: i32,
@@ -1522,4 +1279,31 @@ impl_redacted_remote_target_debug!(
     task_id,
 );
 
-crate::impl_history_pagination!(RemoteTargetHistory, "remote_targets_history");
+impl CursorPaginated for RemoteTargetHistory {
+    fn supports_sort(field: &FilterField) -> bool {
+        matches!(field, FilterField::HistoryId | FilterField::Revision)
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        Ok(match field {
+            FilterField::HistoryId => CursorValue::Integer(self.history_id),
+            FilterField::Revision => CursorValue::Integer(self.revision.get()),
+            other => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{other}' is not orderable for history"
+                )));
+            }
+        })
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        vec![SortParam {
+            field: FilterField::HistoryId,
+            descending: true,
+        }]
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        Self::default_sort()
+    }
+}

--- a/src/storage/postgres/operations/history.rs
+++ b/src/storage/postgres/operations/history.rs
@@ -1,10 +1,7 @@
 use crate::errors::ApiError;
 use crate::events::PrincipalNames;
 use crate::models::search::QueryOptions;
-use crate::models::{
-    CollectionHistory, HubuumClassHistory, HubuumObjectHistory, RemoteTargetHistory,
-    ResourceRevision,
-};
+use crate::models::{CollectionHistory, HubuumClassHistory, HubuumObjectHistory, ResourceRevision};
 use crate::storage::postgres::prelude::*;
 use crate::storage::postgres::with_connection;
 use crate::storage::{
@@ -52,6 +49,37 @@ pub(crate) struct ExportTemplateHistoryRow {
 }
 
 crate::impl_history_pagination!(ExportTemplateHistoryRow, "export_templates_history");
+
+#[derive(Queryable)]
+#[diesel(table_name = crate::schema::remote_targets_history)]
+pub(crate) struct RemoteTargetHistoryRow {
+    id: i32,
+    collection_id: i32,
+    class_id: Option<i32>,
+    name: String,
+    description: String,
+    method: String,
+    url_template: String,
+    headers_template: serde_json::Value,
+    body_template: Option<String>,
+    auth_config: serde_json::Value,
+    allowed_subject_types: serde_json::Value,
+    timeout_ms: i32,
+    enabled: bool,
+    created_at: chrono::NaiveDateTime,
+    updated_at: chrono::NaiveDateTime,
+    op: String,
+    valid_from: chrono::DateTime<chrono::Utc>,
+    valid_to: Option<chrono::DateTime<chrono::Utc>>,
+    actor_id: Option<i32>,
+    history_id: i64,
+    actor_kind: Option<String>,
+    initiator_user_id: Option<i32>,
+    task_id: Option<i32>,
+    revision: ResourceRevision,
+}
+
+crate::impl_history_pagination!(RemoteTargetHistoryRow, "remote_targets_history");
 
 /// Batch-resolve principal ids for provenance responses (anonymized users keep
 /// their tombstoned principal name; ids with no matching principal are absent).
@@ -170,7 +198,7 @@ pub(crate) fn export_template_history_to_storage(
 }
 
 pub(crate) fn remote_target_history_to_storage(
-    row: RemoteTargetHistory,
+    row: RemoteTargetHistoryRow,
 ) -> RemoteTargetHistoryRecord {
     RemoteTargetHistoryRecord::new(
         row.id,
@@ -315,7 +343,7 @@ history_db_fns!(
     remote_target_as_of,
     crate::schema::remote_targets_history,
     collection_id,
-    crate::models::RemoteTargetHistory
+    RemoteTargetHistoryRow
 );
 
 pub async fn object_history_paginated_with_total_count(

--- a/src/storage/postgres/operations/remote_target.rs
+++ b/src/storage/postgres/operations/remote_target.rs
@@ -1,16 +1,364 @@
+use std::fmt;
+
 use crate::storage::postgres::prelude::*;
 
 use crate::api::etag::RevisionOwner;
 use crate::apply_query_options;
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
-use crate::models::remote_target::{
-    NewRemoteCallResult, NewRemoteTargetRow, RemoteCallResult, RemoteTarget, RemoteTargetID,
-    RemoteTargetRow, UpdateRemoteTargetRow,
+#[cfg(feature = "integration-test-support")]
+use crate::models::remote_target::RemoteCallResult;
+use crate::models::remote_target::RemoteTargetID;
+use crate::models::search::{FilterField, QueryOptions, SortParam};
+use crate::models::{REDACTED_DEBUG_VALUE, ResourceRevision, redacted_debug_option};
+use crate::pagination::{
+    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
 };
-use crate::models::search::{FilterField, QueryOptions};
 use crate::storage::postgres::{with_connection, with_transaction};
 use crate::{date_search, numeric_search, revision_search, string_search};
+
+macro_rules! impl_redacted_remote_target_row_debug {
+    ($target:ty, $($field:ident),+ $(,)?) => {
+        impl fmt::Debug for $target {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let mut debug = formatter.debug_struct(stringify!($target));
+                $(debug.field(stringify!($field), &self.$field);)+
+                debug
+                    .field("configuration", &REDACTED_DEBUG_VALUE)
+                    .finish()
+            }
+        }
+    };
+}
+
+#[derive(Clone, Queryable, Selectable)]
+#[diesel(table_name = crate::schema::remote_targets)]
+pub(crate) struct RemoteTargetRow {
+    pub(crate) id: i32,
+    pub(crate) collection_id: i32,
+    pub(crate) class_id: Option<i32>,
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) method: String,
+    pub(crate) url_template: String,
+    pub(crate) headers_template: serde_json::Value,
+    pub(crate) body_template: Option<String>,
+    pub(crate) auth_config: serde_json::Value,
+    pub(crate) allowed_subject_types: serde_json::Value,
+    pub(crate) timeout_ms: i32,
+    pub(crate) enabled: bool,
+    pub(crate) created_at: chrono::NaiveDateTime,
+    pub(crate) updated_at: chrono::NaiveDateTime,
+    pub(crate) revision: ResourceRevision,
+}
+
+impl_redacted_remote_target_row_debug!(
+    RemoteTargetRow,
+    id,
+    collection_id,
+    class_id,
+    name,
+    description,
+    method,
+    allowed_subject_types,
+    timeout_ms,
+    enabled,
+    created_at,
+    updated_at,
+);
+
+impl RemoteTargetRow {
+    pub(crate) fn audit_snapshot(&self) -> serde_json::Value {
+        serde_json::json!({
+            "id": self.id,
+            "collection_id": self.collection_id,
+            "class_id": self.class_id,
+            "name": self.name,
+            "description": self.description,
+            "method": self.method,
+            "url_template": self.url_template,
+            "headers_template": self.headers_template,
+            "body_template": self.body_template,
+            "auth_config": "<redacted>",
+            "allowed_subject_types": self.allowed_subject_types,
+            "timeout_ms": self.timeout_ms,
+            "enabled": self.enabled,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "revision": self.revision,
+        })
+    }
+}
+
+impl CursorPaginated for RemoteTargetRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        matches!(
+            field,
+            FilterField::Id
+                | FilterField::Name
+                | FilterField::Description
+                | FilterField::CollectionId
+                | FilterField::CreatedAt
+                | FilterField::UpdatedAt
+                | FilterField::Revision
+        )
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        match field {
+            FilterField::Id => Ok(CursorValue::Integer(self.id.into())),
+            FilterField::Name => Ok(CursorValue::String(self.name.clone())),
+            FilterField::Description => Ok(CursorValue::String(self.description.clone())),
+            FilterField::CollectionId => Ok(CursorValue::Integer(self.collection_id.into())),
+            FilterField::CreatedAt => Ok(CursorValue::DateTime(self.created_at)),
+            FilterField::UpdatedAt => Ok(CursorValue::DateTime(self.updated_at)),
+            FilterField::Revision => Ok(CursorValue::Integer(self.revision.get())),
+            _ => Err(ApiError::BadRequest(format!(
+                "Unsupported sort field '{field}' for remote targets"
+            ))),
+        }
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        vec![SortParam {
+            field: FilterField::Id,
+            descending: false,
+        }]
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        Self::default_sort()
+    }
+}
+
+impl CursorSqlMapping for RemoteTargetRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorSqlField {
+                column: "remote_targets.id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Name => CursorSqlField {
+                column: "remote_targets.name",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::Description => CursorSqlField {
+                column: "remote_targets.description",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::CollectionId => CursorSqlField {
+                column: "remote_targets.collection_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::CreatedAt => CursorSqlField {
+                column: "remote_targets.created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAt => CursorSqlField {
+                column: "remote_targets.updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::Revision => CursorSqlField {
+                column: "remote_targets.revision",
+                sql_type: CursorSqlType::BigInt,
+                nullable: false,
+            },
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{field}' is not orderable for remote targets"
+                )));
+            }
+        })
+    }
+}
+
+#[derive(Clone, Insertable)]
+#[diesel(table_name = crate::schema::remote_targets)]
+pub(crate) struct NewRemoteTargetRow {
+    pub(crate) collection_id: i32,
+    pub(crate) class_id: Option<i32>,
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) method: String,
+    pub(crate) url_template: String,
+    pub(crate) headers_template: serde_json::Value,
+    pub(crate) body_template: Option<String>,
+    pub(crate) auth_config: serde_json::Value,
+    pub(crate) allowed_subject_types: serde_json::Value,
+    pub(crate) timeout_ms: i32,
+    pub(crate) enabled: bool,
+}
+
+impl_redacted_remote_target_row_debug!(
+    NewRemoteTargetRow,
+    collection_id,
+    class_id,
+    name,
+    description,
+    method,
+    allowed_subject_types,
+    timeout_ms,
+    enabled,
+);
+
+#[derive(Clone, AsChangeset)]
+#[diesel(table_name = crate::schema::remote_targets)]
+pub(crate) struct UpdateRemoteTargetRow {
+    pub(crate) collection_id: Option<i32>,
+    pub(crate) class_id: Option<Option<i32>>,
+    pub(crate) name: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) method: Option<String>,
+    pub(crate) url_template: Option<String>,
+    pub(crate) headers_template: Option<serde_json::Value>,
+    pub(crate) body_template: Option<Option<String>>,
+    pub(crate) auth_config: Option<serde_json::Value>,
+    pub(crate) allowed_subject_types: Option<serde_json::Value>,
+    pub(crate) timeout_ms: Option<i32>,
+    pub(crate) enabled: Option<bool>,
+}
+
+impl_redacted_remote_target_row_debug!(
+    UpdateRemoteTargetRow,
+    collection_id,
+    class_id,
+    name,
+    description,
+    method,
+    allowed_subject_types,
+    timeout_ms,
+    enabled,
+);
+
+impl UpdateRemoteTargetRow {
+    pub(crate) fn has_changes(&self, current: &RemoteTargetRow) -> bool {
+        self.collection_id
+            .is_some_and(|value| value != current.collection_id)
+            || self
+                .class_id
+                .as_ref()
+                .is_some_and(|value| value != &current.class_id)
+            || self
+                .name
+                .as_ref()
+                .is_some_and(|value| value != &current.name)
+            || self
+                .description
+                .as_ref()
+                .is_some_and(|value| value != &current.description)
+            || self
+                .method
+                .as_ref()
+                .is_some_and(|value| value != &current.method)
+            || self
+                .url_template
+                .as_ref()
+                .is_some_and(|value| value != &current.url_template)
+            || self
+                .headers_template
+                .as_ref()
+                .is_some_and(|value| value != &current.headers_template)
+            || self
+                .body_template
+                .as_ref()
+                .is_some_and(|value| value != &current.body_template)
+            || self
+                .auth_config
+                .as_ref()
+                .is_some_and(|value| value != &current.auth_config)
+            || self
+                .allowed_subject_types
+                .as_ref()
+                .is_some_and(|value| value != &current.allowed_subject_types)
+            || self
+                .timeout_ms
+                .is_some_and(|value| value != current.timeout_ms)
+            || self.enabled.is_some_and(|value| value != current.enabled)
+    }
+}
+
+#[cfg(feature = "integration-test-support")]
+#[derive(Clone, Queryable, Selectable)]
+#[diesel(table_name = crate::schema::remote_call_results)]
+struct RemoteCallResultRow {
+    id: i32,
+    task_id: i32,
+    target_id: Option<i32>,
+    subject_type: String,
+    subject_id: i32,
+    method: String,
+    rendered_url: String,
+    response_status: Option<i32>,
+    response_headers: Option<serde_json::Value>,
+    response_body_preview: Option<String>,
+    duration_ms: i32,
+    success: bool,
+    error: Option<String>,
+    created_at: chrono::NaiveDateTime,
+}
+
+#[derive(Clone, Insertable)]
+#[diesel(table_name = crate::schema::remote_call_results)]
+pub(crate) struct NewRemoteCallResultRow {
+    pub(crate) task_id: i32,
+    pub(crate) target_id: Option<i32>,
+    pub(crate) subject_type: String,
+    pub(crate) subject_id: i32,
+    pub(crate) method: String,
+    pub(crate) rendered_url: String,
+    pub(crate) response_status: Option<i32>,
+    pub(crate) response_headers: Option<serde_json::Value>,
+    pub(crate) response_body_preview: Option<String>,
+    pub(crate) duration_ms: i32,
+    pub(crate) success: bool,
+    pub(crate) error: Option<String>,
+}
+
+impl fmt::Debug for NewRemoteCallResultRow {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NewRemoteCallResultRow")
+            .field("task_id", &self.task_id)
+            .field("target_id", &self.target_id)
+            .field("subject_type", &self.subject_type)
+            .field("subject_id", &self.subject_id)
+            .field("method", &self.method)
+            .field("response_status", &self.response_status)
+            .field("duration_ms", &self.duration_ms)
+            .field("success", &self.success)
+            .field("rendered_url", &REDACTED_DEBUG_VALUE)
+            .field("response_headers", &REDACTED_DEBUG_VALUE)
+            .field("response_body_preview", &REDACTED_DEBUG_VALUE)
+            .field("error", &redacted_debug_option(&self.error))
+            .finish()
+    }
+}
+
+#[cfg(feature = "integration-test-support")]
+fn remote_call_result_to_model(row: RemoteCallResultRow) -> RemoteCallResult {
+    RemoteCallResult {
+        id: row.id,
+        task_id: row.task_id,
+        target_id: row.target_id,
+        subject_type: row.subject_type,
+        subject_id: row.subject_id,
+        method: row.method,
+        rendered_url: row.rendered_url,
+        response_status: row.response_status,
+        response_headers: row.response_headers,
+        response_body_preview: row.response_body_preview,
+        duration_ms: row.duration_ms,
+        success: row.success,
+        error: row.error,
+        created_at: row.created_at,
+    }
+}
 
 fn remote_target_event(
     row: &RemoteTargetRow,
@@ -321,7 +669,7 @@ pub(crate) async fn list_rows_with_total_count(
     .await?;
 
     let mut query = build_list_query(allowed_collection_ids, query_options)?;
-    apply_query_options!(query, query_options, RemoteTarget);
+    apply_query_options!(query, query_options, RemoteTargetRow);
     let rows =
         with_connection(pool, async |conn| query.load::<RemoteTargetRow>(conn).await).await?;
 
@@ -369,11 +717,11 @@ fn build_list_query<'a>(
 
 pub(crate) async fn upsert_remote_call_result_conn(
     conn: &mut crate::storage::postgres::PostgresConnection,
-    entry: NewRemoteCallResult,
-) -> Result<RemoteCallResult, ApiError> {
+    entry: NewRemoteCallResultRow,
+) -> Result<(), ApiError> {
     use crate::schema::remote_call_results::dsl::{remote_call_results, task_id};
 
-    Ok(diesel::insert_into(remote_call_results)
+    diesel::insert_into(remote_call_results)
         .values(&entry)
         .on_conflict(task_id)
         .do_update()
@@ -391,6 +739,24 @@ pub(crate) async fn upsert_remote_call_result_conn(
             crate::schema::remote_call_results::success.eq(entry.success),
             crate::schema::remote_call_results::error.eq(entry.error.clone()),
         ))
-        .get_result::<RemoteCallResult>(conn)
-        .await?)
+        .execute(conn)
+        .await?;
+    Ok(())
+}
+
+#[cfg(feature = "integration-test-support")]
+pub(crate) async fn load_remote_call_result_for_task(
+    pool: &impl crate::storage::StorageContext,
+    task_id_value: i32,
+) -> Result<RemoteCallResult, ApiError> {
+    use crate::schema::remote_call_results::dsl::{remote_call_results, task_id};
+
+    with_connection(pool, async |conn| {
+        remote_call_results
+            .filter(task_id.eq(task_id_value))
+            .first::<RemoteCallResultRow>(conn)
+            .await
+    })
+    .await
+    .map(remote_call_result_to_model)
 }

--- a/src/storage/postgres/operations/task.rs
+++ b/src/storage/postgres/operations/task.rs
@@ -21,8 +21,8 @@ use crate::models::{
     BackupOutputLookup, BackupTaskOutputRecord, BackupTaskOutputSummaryRecord, ExportOutputLookup,
     ExportTaskOutputRecord, ExportTaskOutputSummaryRecord, ImportTaskResultRecord,
     NewBackupTaskOutputRecord, NewExportTaskOutputRecord, NewImportTaskResultRecord,
-    NewRemoteCallResult, NewTaskEventRecord, NewTaskRecord, PrincipalID, TaskEventRecord, TaskID,
-    TaskKind, TaskRecord, TaskResponse, TaskResultCounts, TaskStatus, TokenID,
+    NewTaskEventRecord, NewTaskRecord, PrincipalID, TaskEventRecord, TaskID, TaskKind, TaskRecord,
+    TaskResponse, TaskResultCounts, TaskStatus, TokenID,
 };
 use crate::observability::metrics;
 use crate::pagination::{CursorValue, decode_cursor_values, page_limits_or_defaults};
@@ -31,6 +31,8 @@ use crate::storage::postgres::operations::history::resolve_principal_names;
 use crate::storage::postgres::operations::maintenance::maintenance_state_conn;
 use crate::storage::postgres::{with_connection, with_transaction};
 use crate::tasks::TaskLeaseDuration;
+
+use super::remote_target::NewRemoteCallResultRow;
 
 const DATABASE_UTC_NOW_SQL: &str = "clock_timestamp() AT TIME ZONE 'UTC'";
 const DATABASE_UTC_NOW_QUERY: &str = "SELECT clock_timestamp() AT TIME ZONE 'UTC' AS now";
@@ -773,13 +775,17 @@ pub trait TaskBackend: TaskIdentifier {
         record_task_terminal(&record);
         Ok(record)
     }
+}
 
+impl<T: TaskIdentifier + ?Sized> TaskBackend for T {}
+
+pub(crate) trait RemoteCallTaskBackend: TaskIdentifier {
     async fn finalize_remote_call_with_result(
         &self,
         pool: &impl crate::storage::StorageContext,
         update: TaskStateUpdate,
         event: NewTaskEventRecord,
-        result: NewRemoteCallResult,
+        result: NewRemoteCallResultRow,
     ) -> Result<TaskRecord, ApiError> {
         let task_id_value = self.task_id();
         let task_lease_token = self.task_lease_token();
@@ -794,7 +800,7 @@ pub trait TaskBackend: TaskIdentifier {
     }
 }
 
-impl<T: TaskIdentifier + ?Sized> TaskBackend for T {}
+impl<T: TaskIdentifier + ?Sized> RemoteCallTaskBackend for T {}
 
 pub(crate) async fn finalize_terminal_conn(
     conn: &mut crate::storage::postgres::PostgresConnection,
@@ -1940,21 +1946,22 @@ mod tests {
     use uuid::Uuid;
 
     use super::{
-        CLAIM_NEXT_QUEUED_TASK_SQL, TaskBackend, TaskCreateRequest, TaskScopeSnapshot,
-        TaskStateUpdate, claim_next_queued_task, database_now, insert_import_results,
-        insert_internal_queued_task, recover_expired_task_lease, renew_task_lease,
-        task_capacity_lock_key, task_event_responses, task_kind_claim_order,
+        CLAIM_NEXT_QUEUED_TASK_SQL, RemoteCallTaskBackend, TaskBackend, TaskCreateRequest,
+        TaskScopeSnapshot, TaskStateUpdate, claim_next_queued_task, database_now,
+        insert_import_results, insert_internal_queued_task, recover_expired_task_lease,
+        renew_task_lease, task_capacity_lock_key, task_event_responses, task_kind_claim_order,
     };
     use crate::errors::ApiError;
     use crate::events::{Action, ActorKind, EntityType, NewEvent, emit_event};
     use crate::models::search::QueryOptions;
     use crate::models::{
-        CollectionID, NewBackupTaskOutputRecord, NewImportTaskResultRecord, NewRemoteCallResult,
-        NewTaskEventRecord, NewTaskRecord, Permissions, PrincipalID, RemoteInvocationBodyOverride,
+        CollectionID, NewBackupTaskOutputRecord, NewImportTaskResultRecord, NewTaskEventRecord,
+        NewTaskRecord, Permissions, PrincipalID, RemoteInvocationBodyOverride,
         RemoteInvocationParameters, RemoteInvocationSubject, RemoteTargetID,
         StoredRemoteCallTaskPayload, TaskID, TaskKind, TaskResultCounts, TaskStatus, TokenID,
         TokenScope,
     };
+    use crate::storage::postgres::operations::remote_target::NewRemoteCallResultRow;
     use crate::storage::postgres::operations::user::DeleteUserRecord;
     use crate::storage::postgres::{capture_queries, with_connection, with_transaction};
     use crate::tasks::TaskLeaseDuration;
@@ -2657,7 +2664,7 @@ mod tests {
                     message: "stale remote-call completion".to_string(),
                     data: None,
                 },
-                NewRemoteCallResult {
+                NewRemoteCallResultRow {
                     task_id: leased.id,
                     target_id: None,
                     subject_type: "collection".to_string(),

--- a/src/storage/postgres/remote_targets.rs
+++ b/src/storage/postgres/remote_targets.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 
 use crate::errors::ApiError;
-use crate::models::{NewRemoteTargetRow, RemoteTargetID, RemoteTargetRow, UpdateRemoteTargetRow};
+use crate::models::RemoteTargetID;
 use crate::pagination::SKIPPED_TOTAL_COUNT;
 use crate::storage::{
     RemoteTargetStorage, StorageError, StorageRecordMetadata, StorageRemoteTarget,
@@ -14,8 +14,9 @@ use crate::storage::{
 use super::PostgresStorage;
 use super::error::map_postgres_error;
 use super::operations::remote_target::{
-    DeleteRemoteTargetRecord, LoadRemoteTargetRecord, SaveRemoteTargetRecord,
-    UpdateRemoteTargetRecord, emit_remote_target_invoked_event, list_rows_with_total_count,
+    DeleteRemoteTargetRecord, LoadRemoteTargetRecord, NewRemoteTargetRow, RemoteTargetRow,
+    SaveRemoteTargetRecord, UpdateRemoteTargetRecord, UpdateRemoteTargetRow,
+    emit_remote_target_invoked_event, list_rows_with_total_count,
 };
 
 fn target_to_storage(row: RemoteTargetRow) -> Result<StorageRemoteTarget, ApiError> {

--- a/src/storage/postgres/task_execution.rs
+++ b/src/storage/postgres/task_execution.rs
@@ -8,8 +8,8 @@ use uuid::Uuid;
 use crate::config::get_config;
 use crate::errors::ApiError;
 use crate::models::{
-    NewBackupTaskOutputRecord, NewExportTaskOutputRecord, NewRemoteCallResult, NewTaskEventRecord,
-    TaskKind, TaskResultCounts, TaskStatus,
+    NewBackupTaskOutputRecord, NewExportTaskOutputRecord, NewTaskEventRecord, TaskKind,
+    TaskResultCounts, TaskStatus,
 };
 use crate::storage::{
     StorageBackupTaskArtifact, StorageError, StorageExportTaskArtifact,
@@ -23,11 +23,12 @@ use crate::tasks::TaskLeaseDuration;
 use super::PostgresStorage;
 use super::error::map_postgres_error;
 use super::operations::computed_field::mark_computed_reindex_failed_conn;
+use super::operations::remote_target::NewRemoteCallResultRow;
 use super::operations::task::{
-    TaskBackend, TaskIdentifier, TaskStateUpdate, append_task_event_while_claimed,
-    claim_next_queued_task, finalize_terminal_conn, live_claimed_task_conn,
-    purge_expired_backup_outputs, purge_expired_export_outputs, record_task_terminal,
-    recover_expired_task_leases, renew_task_lease,
+    RemoteCallTaskBackend, TaskBackend, TaskIdentifier, TaskStateUpdate,
+    append_task_event_while_claimed, claim_next_queued_task, finalize_terminal_conn,
+    live_claimed_task_conn, purge_expired_backup_outputs, purge_expired_export_outputs,
+    record_task_terminal, recover_expired_task_leases, renew_task_lease,
 };
 use super::task_queue::task_to_storage;
 use super::{
@@ -185,12 +186,12 @@ fn backup_artifact_from_storage(
 fn remote_call_artifact_from_storage(
     task_id: i32,
     artifact: StorageRemoteCallTaskArtifact,
-) -> NewRemoteCallResult {
+) -> NewRemoteCallResultRow {
     let (target, response, outcome) = artifact.into_parts();
     let (target_id, subject_type, subject_id, method, rendered_url) = target.into_parts();
     let (response_status, response_headers, response_body_preview) = response.into_parts();
     let (duration_ms, success, error) = outcome.into_parts();
-    NewRemoteCallResult {
+    NewRemoteCallResultRow {
         task_id,
         target_id,
         subject_type,

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -14,13 +14,14 @@ use crate::errors::ApiError;
 use crate::models::user::User;
 use crate::models::{
     CollectionID, NewEventSink, NewEventSinkRow, NewEventSubscription, NewEventSubscriptionRow,
-    TaskKind, validate_sink_parts, validate_subscription_parts,
+    RemoteCallResult, TaskKind, validate_sink_parts, validate_subscription_parts,
 };
 use crate::services::Services;
 use crate::storage::postgres::PostgresPool;
 use crate::storage::postgres::operations::event_subscription::{
     SaveEventSinkRecord, SaveEventSubscriptionRecord,
 };
+use crate::storage::postgres::operations::remote_target::load_remote_call_result_for_task;
 use crate::storage::{DynLifecycleStorage, PostgresStorage};
 
 pub use crate::logger::test_support::JsonLogWriter;
@@ -107,6 +108,14 @@ pub fn services_for_postgres(pool: PostgresPool) -> Services {
     Services::from_lifecycle_storage(DynLifecycleStorage::from_backend(PostgresStorage::new(
         pool,
     )))
+}
+
+/// Load the adapter-owned remote-call result projection for request-level tests.
+pub async fn remote_call_result(
+    pool: &PostgresPool,
+    task_id: i32,
+) -> Result<RemoteCallResult, ApiError> {
+    load_remote_call_result_for_task(pool, task_id).await
 }
 
 pub async fn save_event_sink(pool: &PostgresPool, sink: NewEventSink) -> Result<i32, ApiError> {

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -757,8 +757,10 @@ fn export_template_consumers_use_only_the_backend_neutral_lifecycle_contract() {
 fn remote_target_consumers_use_the_backend_neutral_application_service() {
     let root = repository_root();
     for file in [
+        "src/models/remote_target.rs",
         "src/api/v1/handlers/remote_targets.rs",
         "src/tasks/remote_call.rs",
+        "tests/api_jobs_suite/remote_targets.rs",
     ] {
         let path = root.join(file);
         let source = fs::read_to_string(&path)
@@ -772,6 +774,16 @@ fn remote_target_consumers_use_the_backend_neutral_application_service() {
             ".instance(&context)",
             ".instance(backend)",
             "RemoteTarget::list_with_total_count",
+            "storage::postgres",
+            "diesel::",
+            "diesel_async",
+            "crate::schema",
+            "CursorSql",
+            "impl_history_pagination!",
+            "RemoteTargetRow",
+            "NewRemoteTargetRow",
+            "UpdateRemoteTargetRow",
+            "NewRemoteCallResult",
         ] {
             assert!(
                 !source.contains(forbidden),

--- a/tests/api_jobs_suite/remote_targets.rs
+++ b/tests/api_jobs_suite/remote_targets.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod tests {
-    use crate::storage::postgres::prelude::*;
     use actix_rt::time::sleep;
     use actix_web::{
         http::{StatusCode, header},
@@ -25,7 +24,6 @@ mod tests {
         NewHubuumObject, NewHubuumObjectRelation, Permissions, PermissionsList, RemoteCallResult,
         RemoteTarget, TaskResponse, TaskStatus,
     };
-    use crate::storage::postgres::with_connection;
     use crate::tests::TestContext;
     use crate::tests::api_operations::{
         delete_request, get_request, patch_request, post_request, post_request_with_headers,
@@ -348,16 +346,9 @@ mod tests {
     }
 
     async fn remote_call_result(context: &TestContext, task_id_value: i32) -> RemoteCallResult {
-        use crate::schema::remote_call_results::dsl::{remote_call_results, task_id};
-
-        with_connection(&context.pool, async |conn| {
-            remote_call_results
-                .filter(task_id.eq(task_id_value))
-                .first::<RemoteCallResult>(conn)
-                .await
-        })
-        .await
-        .unwrap()
+        crate::test_support::remote_call_result(&context.pool, task_id_value)
+            .await
+            .unwrap()
     }
 
     #[actix_web::test]


### PR DESCRIPTION
## Summary

- move remote-target lifecycle, temporal-history, and remote-call result persistence rows into the PostgreSQL adapter
- keep public remote-target and remote-call types backend-neutral by removing Diesel derives, schema bindings, and SQL cursor mappings
- route request-level result inspection through explicit test support instead of allowing integration tests to query PostgreSQL directly
- strengthen the application-boundary regression guard and storage-boundary documentation

## Architecture

`RemoteTargetStorage` remains a mandatory, compatibility-tested storage capability. This layer completes the physical boundary around its PostgreSQL implementation: API/domain models carry only backend-neutral behavior, while Diesel rows, changesets, insert records, history projections, SQL cursor metadata, and query construction are owned by `src/storage/postgres`.

The remote-call task finalizer is split from the public test-support task trait so an adapter-private insert row cannot leak through a public trait signature. Request tests receive the public `RemoteCallResult` DTO through an explicit feature-gated test helper.

There is no storage contract-version change because the mandatory capability and its observable semantics are unchanged.

## Behavior and compatibility

- HTTP request and response shapes are unchanged.
- Remote-target lifecycle, history, invocation provenance, and remote-call result behavior are unchanged.
- Available backend compatibility requirements are unchanged.
- No PostgreSQL or Diesel type is exposed to application consumers by this layer.
- No migration or administrator action is required.

## Changelog

No changelog-worthy impact: this is an internal architecture refactor with no user-facing API, configuration, storage-contract, or operational behavior change.

## OpenAPI

No regeneration was required because endpoint schemas and public DTO shapes are unchanged.

## Verification

- `source .env && ./run_tests.sh`
- `cargo check --all-targets`
- `cargo check --all-targets --features integration-test-support`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `scripts/test-classify-ci-changes.sh`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`
- `git diff --check`

## Stack

This is the next layer above #324 in stack #286.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>