### PR TITLE
Enforce event subscription persistence boundary

### DIFF
--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -113,12 +113,13 @@ and revision-precondition scopes used across requests and workers.
 considered complete merely because a marker exists.
 
 PostgreSQL query implementations live in
-`src/storage/postgres/operations/*`. Export-template and remote-target
-lifecycle, history, and remote-call result persistence rows are adapter-owned;
-remaining mixed persistence rows move there as their backend-neutral DTOs are
-extracted. Their current locations are implementation details, not partial
-backend support. `StorageHandle` selects one certified PostgreSQL adapter, and
-only the storage implementation can recover its pool.
+`src/storage/postgres/operations/*`. Export-template, remote-target, event-sink,
+and event-subscription lifecycle rows are adapter-owned, as are remote-target
+history and remote-call result persistence rows. Remaining mixed persistence
+rows move there as their backend-neutral DTOs are extracted. Their current
+locations are implementation details, not partial backend support.
+`StorageHandle` selects one certified PostgreSQL adapter, and only the storage
+implementation can recover its pool.
 Application consumers use `StorageContext`, lifecycle traits, mandatory
 capability traits, or application services. No second backend can be added to
 composition without implementing every operation behind those contracts.
@@ -556,6 +557,13 @@ paging; enrich durable provenance; and redact payloads that are visible only
 through related collections. Sink and subscription writes are atomic with
 their lifecycle events, and subscription point and mutation operations are
 collection-scoped at the contract boundary.
+
+Event-sink and event-subscription API models contain no Diesel derives, schema
+bindings, persistence changesets, or SQL cursor mappings. Those rows and
+mappings stay in the PostgreSQL adapter, which converts them to backend-neutral
+storage DTOs. Handlers and request-level compatibility tests use application or
+test-support entry points rather than importing adapter rows or opening SQL
+connections.
 
 Delivery administration returns claim-free projections. Opaque worker claim
 tokens never cross into handlers, logs, or administrator responses. Listing

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -27,11 +27,10 @@ use crate::models::token::{renew_token_by_id_for_principal, revoke_token_by_id_f
 use crate::models::{
     CollectionID, EventDelivery, EventDeliveryID, EventDeliveryStatus, EventSinkKind,
     ExportContentType, ExportTemplateID, ExportTemplateKind, GroupID, HubuumClassID,
-    HubuumClassRelationID, HubuumObjectID, NewEventSinkRow, NewEventSubscriptionRow,
-    NewExportTemplate, NewHubuumClassRelation, NewHubuumObjectRelation, NewUser,
-    ObjectRelationLimit, Permissions, PermissionsList, PrincipalID, PrincipalToken,
-    PrincipalTokenCreateRequest, RemoteTargetID, Token, TokenID, TokenScope, UpdateExportTemplate,
-    UpdateUser, UserID,
+    HubuumClassRelationID, HubuumObjectID, NewExportTemplate, NewHubuumClassRelation,
+    NewHubuumObjectRelation, NewUser, ObjectRelationLimit, Permissions, PermissionsList,
+    PrincipalID, PrincipalToken, PrincipalTokenCreateRequest, RemoteTargetID, Token, TokenID,
+    TokenScope, UpdateExportTemplate, UpdateUser, UserID,
 };
 use crate::schema::events::dsl::events;
 use crate::storage::postgres::operations::event_delivery::{
@@ -45,7 +44,7 @@ use crate::storage::postgres::operations::event_retention::{
     purge_event_retention_without_archive, try_acquire_event_retention_lock,
 };
 use crate::storage::postgres::operations::event_subscription::{
-    SaveEventSinkRecord, SaveEventSubscriptionRecord,
+    NewEventSinkRow, NewEventSubscriptionRow, SaveEventSinkRecord, SaveEventSubscriptionRecord,
 };
 use crate::storage::postgres::operations::events::{
     EventListFilters, list_events_with_total_count,

--- a/src/models/event_subscription.rs
+++ b/src/models/event_subscription.rs
@@ -1,6 +1,5 @@
 use std::{fmt, str::FromStr};
 
-use crate::storage::postgres::prelude::*;
 use chrono::NaiveDateTime;
 use hubuum_events_core::EventSubscriptionFilter;
 use serde::{Deserialize, Serialize, Serializer};
@@ -9,10 +8,7 @@ use utoipa::ToSchema;
 use crate::errors::ApiError;
 use crate::models::search::{FilterField, SortParam};
 use crate::models::{REDACTED_DEBUG_VALUE, ResourceRevision};
-use crate::pagination::{
-    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
-};
-use crate::schema::{event_sinks, event_subscriptions};
+use crate::pagination::{CursorPaginated, CursorValue};
 
 crate::int_id_newtype! {
     /// Identifier wrapper for an event sink.
@@ -103,30 +99,6 @@ macro_rules! impl_redacted_event_subscription_debug {
     };
 }
 
-#[derive(Clone, Queryable, Selectable)]
-#[diesel(table_name = event_sinks)]
-pub(crate) struct EventSinkRow {
-    pub id: i32,
-    pub name: String,
-    pub kind: String,
-    pub config: serde_json::Value,
-    pub secret_ref: Option<String>,
-    pub enabled: bool,
-    pub created_at: NaiveDateTime,
-    pub updated_at: NaiveDateTime,
-    pub revision: ResourceRevision,
-}
-
-impl_redacted_event_sink_debug!(
-    EventSinkRow,
-    id,
-    name,
-    kind,
-    enabled,
-    created_at,
-    updated_at,
-);
-
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct EventSink {
     pub id: i32,
@@ -172,84 +144,6 @@ pub struct UpdateEventSink {
 }
 
 impl_redacted_event_sink_debug!(UpdateEventSink, name, kind, enabled);
-
-#[derive(Clone, Insertable)]
-#[diesel(table_name = event_sinks)]
-pub(crate) struct NewEventSinkRow {
-    pub name: String,
-    pub kind: String,
-    pub config: serde_json::Value,
-    pub secret_ref: Option<String>,
-    pub enabled: bool,
-}
-
-impl_redacted_event_sink_debug!(NewEventSinkRow, name, kind, enabled);
-
-#[derive(Clone, AsChangeset)]
-#[diesel(table_name = event_sinks)]
-pub(crate) struct UpdateEventSinkRow {
-    pub name: Option<String>,
-    pub kind: Option<String>,
-    pub config: Option<serde_json::Value>,
-    pub secret_ref: Option<Option<String>>,
-    pub enabled: Option<bool>,
-}
-
-impl_redacted_event_sink_debug!(UpdateEventSinkRow, name, kind, enabled);
-
-impl UpdateEventSinkRow {
-    pub(crate) fn has_changes(&self, current: &EventSinkRow) -> bool {
-        self.name
-            .as_ref()
-            .is_some_and(|value| value != &current.name)
-            || self
-                .kind
-                .as_ref()
-                .is_some_and(|value| value != &current.kind)
-            || self
-                .config
-                .as_ref()
-                .is_some_and(|value| value != &current.config)
-            || self
-                .secret_ref
-                .as_ref()
-                .is_some_and(|value| value != &current.secret_ref)
-            || self.enabled.is_some_and(|value| value != current.enabled)
-    }
-}
-
-#[derive(Clone, Queryable, Selectable)]
-#[diesel(table_name = event_subscriptions)]
-pub(crate) struct EventSubscriptionRow {
-    pub id: i32,
-    pub collection_id: i32,
-    pub sink_id: i32,
-    pub name: String,
-    pub description: String,
-    pub entity_types: serde_json::Value,
-    pub actions: serde_json::Value,
-    pub filter: serde_json::Value,
-    pub routing: serde_json::Value,
-    pub enabled: bool,
-    pub created_at: NaiveDateTime,
-    pub updated_at: NaiveDateTime,
-    pub revision: ResourceRevision,
-}
-
-impl_redacted_event_subscription_debug!(
-    EventSubscriptionRow,
-    id,
-    collection_id,
-    sink_id,
-    name,
-    description,
-    entity_types,
-    actions,
-    filter,
-    enabled,
-    created_at,
-    updated_at,
-);
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct EventSubscription {
@@ -334,127 +228,6 @@ impl_redacted_event_subscription_debug!(
     filter,
     enabled,
 );
-
-#[derive(Clone, Insertable)]
-#[diesel(table_name = event_subscriptions)]
-pub(crate) struct NewEventSubscriptionRow {
-    pub collection_id: i32,
-    pub sink_id: i32,
-    pub name: String,
-    pub description: String,
-    pub entity_types: serde_json::Value,
-    pub actions: serde_json::Value,
-    pub filter: serde_json::Value,
-    pub routing: serde_json::Value,
-    pub enabled: bool,
-}
-
-impl_redacted_event_subscription_debug!(
-    NewEventSubscriptionRow,
-    collection_id,
-    sink_id,
-    name,
-    description,
-    entity_types,
-    actions,
-    filter,
-    enabled,
-);
-
-#[derive(Clone, AsChangeset)]
-#[diesel(table_name = event_subscriptions)]
-pub(crate) struct UpdateEventSubscriptionRow {
-    pub sink_id: Option<i32>,
-    pub name: Option<String>,
-    pub description: Option<String>,
-    pub entity_types: Option<serde_json::Value>,
-    pub actions: Option<serde_json::Value>,
-    pub filter: Option<serde_json::Value>,
-    pub routing: Option<serde_json::Value>,
-    pub enabled: Option<bool>,
-}
-
-impl_redacted_event_subscription_debug!(
-    UpdateEventSubscriptionRow,
-    sink_id,
-    name,
-    description,
-    entity_types,
-    actions,
-    filter,
-    enabled,
-);
-
-impl UpdateEventSubscriptionRow {
-    pub(crate) fn has_changes(&self, current: &EventSubscriptionRow) -> bool {
-        self.sink_id.is_some_and(|value| value != current.sink_id)
-            || self
-                .name
-                .as_ref()
-                .is_some_and(|value| value != &current.name)
-            || self
-                .description
-                .as_ref()
-                .is_some_and(|value| value != &current.description)
-            || self
-                .entity_types
-                .as_ref()
-                .is_some_and(|value| value != &current.entity_types)
-            || self
-                .actions
-                .as_ref()
-                .is_some_and(|value| value != &current.actions)
-            || self
-                .filter
-                .as_ref()
-                .is_some_and(|value| value != &current.filter)
-            || self
-                .routing
-                .as_ref()
-                .is_some_and(|value| value != &current.routing)
-            || self.enabled.is_some_and(|value| value != current.enabled)
-    }
-}
-
-impl TryFrom<EventSinkRow> for EventSink {
-    type Error = ApiError;
-
-    fn try_from(row: EventSinkRow) -> Result<Self, Self::Error> {
-        Ok(Self {
-            id: row.id,
-            name: row.name,
-            kind: EventSinkKind::from_str(&row.kind)?,
-            config: row.config,
-            secret_ref: row.secret_ref,
-            enabled: row.enabled,
-            created_at: row.created_at,
-            updated_at: row.updated_at,
-            revision: row.revision,
-        })
-    }
-}
-
-impl TryFrom<EventSubscriptionRow> for EventSubscription {
-    type Error = ApiError;
-
-    fn try_from(row: EventSubscriptionRow) -> Result<Self, Self::Error> {
-        Ok(Self {
-            id: row.id,
-            collection_id: row.collection_id,
-            sink_id: row.sink_id,
-            name: row.name,
-            description: row.description,
-            entity_types: serde_json::from_value(row.entity_types)?,
-            actions: serde_json::from_value(row.actions)?,
-            filter: serde_json::from_value(row.filter)?,
-            routing: row.routing,
-            enabled: row.enabled,
-            created_at: row.created_at,
-            updated_at: row.updated_at,
-            revision: row.revision,
-        })
-    }
-}
 
 impl UpdateEventSink {
     pub fn is_empty(&self) -> bool {
@@ -729,44 +502,6 @@ impl CursorPaginated for EventSink {
     }
 }
 
-impl CursorSqlMapping for EventSink {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id => CursorSqlField {
-                column: "event_sinks.id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Name => CursorSqlField {
-                column: "event_sinks.name",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::Kind => CursorSqlField {
-                column: "event_sinks.kind",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::CreatedAt => CursorSqlField {
-                column: "event_sinks.created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::Revision => CursorSqlField {
-                column: "event_sinks.revision",
-                sql_type: CursorSqlType::BigInt,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for event sinks",
-                    field
-                )));
-            }
-        })
-    }
-}
-
 impl CursorPaginated for EventSubscription {
     fn supports_sort(field: &FilterField) -> bool {
         matches!(
@@ -800,39 +535,6 @@ impl CursorPaginated for EventSubscription {
             field: FilterField::Id,
             descending: false,
         }]
-    }
-}
-
-impl CursorSqlMapping for EventSubscription {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id => CursorSqlField {
-                column: "event_subscriptions.id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Name => CursorSqlField {
-                column: "event_subscriptions.name",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::CreatedAt => CursorSqlField {
-                column: "event_subscriptions.created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::Revision => CursorSqlField {
-                column: "event_subscriptions.revision",
-                sql_type: CursorSqlType::BigInt,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for event subscriptions",
-                    field
-                )));
-            }
-        })
     }
 }
 
@@ -930,10 +632,10 @@ mod tests {
             secret_ref: Some("request-secret-reference".to_string()),
             enabled: true,
         };
-        let row = EventSinkRow {
+        let persisted = EventSink {
             id: 1,
             name: "webhook".to_string(),
-            kind: "webhook".to_string(),
+            kind: EventSinkKind::Webhook,
             config: serde_json::json!({
                 "headers": {"authorization": "stored-config-secret"}
             }),
@@ -949,7 +651,7 @@ mod tests {
             &["request-config-secret", "request-secret-reference"],
         );
         assert_omits(
-            &format!("{row:?}"),
+            &format!("{persisted:?}"),
             &["stored-config-secret", "stored-secret-reference"],
         );
     }
@@ -968,15 +670,15 @@ mod tests {
             }),
             enabled: true,
         };
-        let row = EventSubscriptionRow {
+        let persisted = EventSubscription {
             id: 2,
             collection_id: 3,
             sink_id: 1,
             name: "subscription".to_string(),
             description: String::new(),
-            entity_types: serde_json::json!(["object"]),
-            actions: serde_json::json!(["updated"]),
-            filter: serde_json::json!({}),
+            entity_types: vec!["object".to_string()],
+            actions: vec!["updated".to_string()],
+            filter: EventSubscriptionFilter::default(),
             routing: serde_json::json!({
                 "url": "https://example.invalid/hook?key=stored-routing-secret"
             }),
@@ -987,6 +689,6 @@ mod tests {
         };
 
         assert_omits(&format!("{request:?}"), &["request-routing-secret"]);
-        assert_omits(&format!("{row:?}"), &["stored-routing-secret"]);
+        assert_omits(&format!("{persisted:?}"), &["stored-routing-secret"]);
     }
 }

--- a/src/storage/postgres/operations/event_administration.rs
+++ b/src/storage/postgres/operations/event_administration.rs
@@ -10,15 +10,16 @@ use hubuum_storage_core::{
 use crate::errors::ApiError;
 use crate::events::EventResponse;
 use crate::models::{
-    EventDelivery as EventDeliveryRow, EventDeliveryID, EventSink, EventSinkID, EventSinkRow,
-    EventSubscription, EventSubscriptionID, EventSubscriptionRow, NewEventSinkRow,
-    NewEventSubscriptionRow, UpdateEventSinkRow, UpdateEventSubscriptionRow,
+    EventDelivery as EventDeliveryRow, EventDeliveryID, EventSink, EventSinkID, EventSubscription,
+    EventSubscriptionID,
 };
 use crate::storage::postgres::PostgresPool;
 
 use super::event_subscription::{
-    DeleteEventSinkRecord, DeleteEventSubscriptionRecord, SaveEventSinkRecord,
-    SaveEventSubscriptionRecord, UpdateEventSinkRecord, UpdateEventSubscriptionRecord,
+    DeleteEventSinkRecord, DeleteEventSubscriptionRecord, EventSinkRow, EventSubscriptionRow,
+    NewEventSinkRow, NewEventSubscriptionRow, SaveEventSinkRecord, SaveEventSubscriptionRecord,
+    UpdateEventSinkRecord, UpdateEventSinkRow, UpdateEventSubscriptionRecord,
+    UpdateEventSubscriptionRow,
 };
 
 fn storage_audit_event(event: EventResponse) -> StorageAuditEvent {

--- a/src/storage/postgres/operations/event_delivery.rs
+++ b/src/storage/postgres/operations/event_delivery.rs
@@ -9,7 +9,6 @@ use uuid::Uuid;
 
 use crate::errors::ApiError;
 use crate::events::{EntityType, Event, EventDeliverySettings};
-use crate::models::event_subscription::{EventSinkRow, EventSubscriptionRow};
 use crate::models::search::{FilterField, Operator, ParsedQueryParamExt, QueryOptions};
 use crate::models::{
     EventDelivery, EventDeliveryID, EventDeliveryStatus, EventSink, EventSubscription,
@@ -19,6 +18,8 @@ use crate::storage::{
     EventDeliveryBatch, EventDeliveryClaim, EventDeliverySink, EventDeliverySubscription,
     EventDeliveryWorkItem,
 };
+
+use super::event_subscription::{EventSinkRow, EventSubscriptionRow};
 
 #[derive(Debug, Clone)]
 pub(crate) struct ClaimedEventDelivery {

--- a/src/storage/postgres/operations/event_fanout.rs
+++ b/src/storage/postgres/operations/event_fanout.rs
@@ -12,6 +12,8 @@ use crate::models::EventDeliveryStatus;
 use crate::storage::postgres::with_connection;
 use crate::storage::postgres::with_transaction;
 
+use super::event_subscription::EventSubscriptionRow;
+
 pub(crate) async fn process_event_fanout_batch(
     pool: &crate::storage::postgres::PostgresPool,
     settings: EventFanoutSettings,
@@ -139,7 +141,7 @@ pub async fn fanout_events(
 async fn load_enabled_subscriptions(
     conn: &mut crate::storage::postgres::PostgresConnection,
     collection_ids: &[i32],
-) -> Result<Vec<crate::models::event_subscription::EventSubscriptionRow>, ApiError> {
+) -> Result<Vec<EventSubscriptionRow>, ApiError> {
     use crate::schema::{event_sinks, event_subscriptions};
 
     if collection_ids.is_empty() {
@@ -152,7 +154,7 @@ async fn load_enabled_subscriptions(
         .filter(event_sinks::enabled.eq(true))
         .filter(event_subscriptions::collection_id.eq_any(collection_ids))
         .select(event_subscriptions::all_columns)
-        .load::<crate::models::event_subscription::EventSubscriptionRow>(conn)
+        .load::<EventSubscriptionRow>(conn)
         .await
         .map_err(ApiError::from)
 }
@@ -190,14 +192,10 @@ struct CompiledEventSubscription {
     filter: hubuum_events_core::EventSubscriptionFilter,
 }
 
-impl TryFrom<crate::models::event_subscription::EventSubscriptionRow>
-    for CompiledEventSubscription
-{
+impl TryFrom<EventSubscriptionRow> for CompiledEventSubscription {
     type Error = ApiError;
 
-    fn try_from(
-        subscription: crate::models::event_subscription::EventSubscriptionRow,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(subscription: EventSubscriptionRow) -> Result<Self, Self::Error> {
         let entity_types = serde_json::from_value::<Vec<String>>(subscription.entity_types)
             .map_err(|error| ApiError::InternalServerError(error.to_string()))?;
         let actions = serde_json::from_value::<Vec<String>>(subscription.actions)

--- a/src/storage/postgres/operations/event_subscription.rs
+++ b/src/storage/postgres/operations/event_subscription.rs
@@ -1,4 +1,7 @@
+use std::{fmt, str::FromStr};
+
 use crate::storage::postgres::prelude::*;
+use chrono::NaiveDateTime;
 use serde_json::json;
 
 use crate::api::etag::RevisionOwner;
@@ -6,12 +9,405 @@ use crate::apply_query_options;
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, EventContext, NewEvent, emit_event};
 use crate::models::event_subscription::{
-    EventSink, EventSinkID, EventSinkRow, EventSubscription, EventSubscriptionID,
-    EventSubscriptionRow, NewEventSinkRow, NewEventSubscriptionRow, UpdateEventSinkRow,
-    UpdateEventSubscriptionRow,
+    EventSink, EventSinkID, EventSinkKind, EventSubscription, EventSubscriptionID,
 };
-use crate::models::search::{FilterField, QueryOptions};
+use crate::models::search::{FilterField, QueryOptions, SortParam};
+use crate::models::{REDACTED_DEBUG_VALUE, ResourceRevision};
+use crate::pagination::{
+    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
+};
 use crate::storage::postgres::{with_connection, with_transaction};
+
+macro_rules! impl_redacted_event_sink_row_debug {
+    ($target:ty, $($field:ident),+ $(,)?) => {
+        impl fmt::Debug for $target {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let mut debug = formatter.debug_struct(stringify!($target));
+                $(debug.field(stringify!($field), &self.$field);)+
+                debug
+                    .field("configuration", &REDACTED_DEBUG_VALUE)
+                    .finish()
+            }
+        }
+    };
+}
+
+macro_rules! impl_redacted_event_subscription_row_debug {
+    ($target:ty, $($field:ident),+ $(,)?) => {
+        impl fmt::Debug for $target {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let mut debug = formatter.debug_struct(stringify!($target));
+                $(debug.field(stringify!($field), &self.$field);)+
+                debug.field("routing", &REDACTED_DEBUG_VALUE).finish()
+            }
+        }
+    };
+}
+
+#[derive(Clone, Queryable, Selectable)]
+#[diesel(table_name = crate::schema::event_sinks)]
+pub(crate) struct EventSinkRow {
+    pub(crate) id: i32,
+    pub(crate) name: String,
+    pub(crate) kind: String,
+    pub(crate) config: serde_json::Value,
+    pub(crate) secret_ref: Option<String>,
+    pub(crate) enabled: bool,
+    pub(crate) created_at: NaiveDateTime,
+    pub(crate) updated_at: NaiveDateTime,
+    pub(crate) revision: ResourceRevision,
+}
+
+impl_redacted_event_sink_row_debug!(
+    EventSinkRow,
+    id,
+    name,
+    kind,
+    enabled,
+    created_at,
+    updated_at,
+);
+
+#[derive(Clone, Insertable)]
+#[diesel(table_name = crate::schema::event_sinks)]
+pub(crate) struct NewEventSinkRow {
+    pub(crate) name: String,
+    pub(crate) kind: String,
+    pub(crate) config: serde_json::Value,
+    pub(crate) secret_ref: Option<String>,
+    pub(crate) enabled: bool,
+}
+
+impl_redacted_event_sink_row_debug!(NewEventSinkRow, name, kind, enabled);
+
+#[derive(Clone, AsChangeset)]
+#[diesel(table_name = crate::schema::event_sinks)]
+pub(crate) struct UpdateEventSinkRow {
+    pub(crate) name: Option<String>,
+    pub(crate) kind: Option<String>,
+    pub(crate) config: Option<serde_json::Value>,
+    pub(crate) secret_ref: Option<Option<String>>,
+    pub(crate) enabled: Option<bool>,
+}
+
+impl_redacted_event_sink_row_debug!(UpdateEventSinkRow, name, kind, enabled);
+
+impl UpdateEventSinkRow {
+    fn has_changes(&self, current: &EventSinkRow) -> bool {
+        self.name
+            .as_ref()
+            .is_some_and(|value| value != &current.name)
+            || self
+                .kind
+                .as_ref()
+                .is_some_and(|value| value != &current.kind)
+            || self
+                .config
+                .as_ref()
+                .is_some_and(|value| value != &current.config)
+            || self
+                .secret_ref
+                .as_ref()
+                .is_some_and(|value| value != &current.secret_ref)
+            || self.enabled.is_some_and(|value| value != current.enabled)
+    }
+}
+
+#[derive(Clone, Queryable, Selectable)]
+#[diesel(table_name = crate::schema::event_subscriptions)]
+pub(crate) struct EventSubscriptionRow {
+    pub(crate) id: i32,
+    pub(crate) collection_id: i32,
+    pub(crate) sink_id: i32,
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) entity_types: serde_json::Value,
+    pub(crate) actions: serde_json::Value,
+    pub(crate) filter: serde_json::Value,
+    pub(crate) routing: serde_json::Value,
+    pub(crate) enabled: bool,
+    pub(crate) created_at: NaiveDateTime,
+    pub(crate) updated_at: NaiveDateTime,
+    pub(crate) revision: ResourceRevision,
+}
+
+impl_redacted_event_subscription_row_debug!(
+    EventSubscriptionRow,
+    id,
+    collection_id,
+    sink_id,
+    name,
+    description,
+    entity_types,
+    actions,
+    filter,
+    enabled,
+    created_at,
+    updated_at,
+);
+
+#[derive(Clone, Insertable)]
+#[diesel(table_name = crate::schema::event_subscriptions)]
+pub(crate) struct NewEventSubscriptionRow {
+    pub(crate) collection_id: i32,
+    pub(crate) sink_id: i32,
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) entity_types: serde_json::Value,
+    pub(crate) actions: serde_json::Value,
+    pub(crate) filter: serde_json::Value,
+    pub(crate) routing: serde_json::Value,
+    pub(crate) enabled: bool,
+}
+
+impl_redacted_event_subscription_row_debug!(
+    NewEventSubscriptionRow,
+    collection_id,
+    sink_id,
+    name,
+    description,
+    entity_types,
+    actions,
+    filter,
+    enabled,
+);
+
+#[derive(Clone, AsChangeset)]
+#[diesel(table_name = crate::schema::event_subscriptions)]
+pub(crate) struct UpdateEventSubscriptionRow {
+    pub(crate) sink_id: Option<i32>,
+    pub(crate) name: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) entity_types: Option<serde_json::Value>,
+    pub(crate) actions: Option<serde_json::Value>,
+    pub(crate) filter: Option<serde_json::Value>,
+    pub(crate) routing: Option<serde_json::Value>,
+    pub(crate) enabled: Option<bool>,
+}
+
+impl_redacted_event_subscription_row_debug!(
+    UpdateEventSubscriptionRow,
+    sink_id,
+    name,
+    description,
+    entity_types,
+    actions,
+    filter,
+    enabled,
+);
+
+impl UpdateEventSubscriptionRow {
+    fn has_changes(&self, current: &EventSubscriptionRow) -> bool {
+        self.sink_id.is_some_and(|value| value != current.sink_id)
+            || self
+                .name
+                .as_ref()
+                .is_some_and(|value| value != &current.name)
+            || self
+                .description
+                .as_ref()
+                .is_some_and(|value| value != &current.description)
+            || self
+                .entity_types
+                .as_ref()
+                .is_some_and(|value| value != &current.entity_types)
+            || self
+                .actions
+                .as_ref()
+                .is_some_and(|value| value != &current.actions)
+            || self
+                .filter
+                .as_ref()
+                .is_some_and(|value| value != &current.filter)
+            || self
+                .routing
+                .as_ref()
+                .is_some_and(|value| value != &current.routing)
+            || self.enabled.is_some_and(|value| value != current.enabled)
+    }
+}
+
+impl TryFrom<EventSinkRow> for EventSink {
+    type Error = ApiError;
+
+    fn try_from(row: EventSinkRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: row.id,
+            name: row.name,
+            kind: EventSinkKind::from_str(&row.kind)?,
+            config: row.config,
+            secret_ref: row.secret_ref,
+            enabled: row.enabled,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            revision: row.revision,
+        })
+    }
+}
+
+impl TryFrom<EventSubscriptionRow> for EventSubscription {
+    type Error = ApiError;
+
+    fn try_from(row: EventSubscriptionRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: row.id,
+            collection_id: row.collection_id,
+            sink_id: row.sink_id,
+            name: row.name,
+            description: row.description,
+            entity_types: serde_json::from_value(row.entity_types)?,
+            actions: serde_json::from_value(row.actions)?,
+            filter: serde_json::from_value(row.filter)?,
+            routing: row.routing,
+            enabled: row.enabled,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            revision: row.revision,
+        })
+    }
+}
+
+impl CursorPaginated for EventSinkRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        matches!(
+            field,
+            FilterField::Id
+                | FilterField::Name
+                | FilterField::Kind
+                | FilterField::CreatedAt
+                | FilterField::Revision
+        )
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        match field {
+            FilterField::Id => Ok(CursorValue::Integer(i64::from(self.id))),
+            FilterField::Name => Ok(CursorValue::String(self.name.clone())),
+            FilterField::Kind => Ok(CursorValue::String(self.kind.clone())),
+            FilterField::CreatedAt => Ok(CursorValue::DateTime(self.created_at)),
+            FilterField::Revision => Ok(CursorValue::Integer(self.revision.get())),
+            _ => Err(ApiError::BadRequest(format!(
+                "Unsupported sort field '{}' for event sinks",
+                field
+            ))),
+        }
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        vec![SortParam {
+            field: FilterField::Id,
+            descending: false,
+        }]
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        Self::default_sort()
+    }
+}
+
+impl CursorSqlMapping for EventSinkRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorSqlField {
+                column: "event_sinks.id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Name => CursorSqlField {
+                column: "event_sinks.name",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::Kind => CursorSqlField {
+                column: "event_sinks.kind",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::CreatedAt => CursorSqlField {
+                column: "event_sinks.created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::Revision => CursorSqlField {
+                column: "event_sinks.revision",
+                sql_type: CursorSqlType::BigInt,
+                nullable: false,
+            },
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for event sinks",
+                    field
+                )));
+            }
+        })
+    }
+}
+
+impl CursorPaginated for EventSubscriptionRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        matches!(
+            field,
+            FilterField::Id | FilterField::Name | FilterField::CreatedAt | FilterField::Revision
+        )
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        match field {
+            FilterField::Id => Ok(CursorValue::Integer(i64::from(self.id))),
+            FilterField::Name => Ok(CursorValue::String(self.name.clone())),
+            FilterField::CreatedAt => Ok(CursorValue::DateTime(self.created_at)),
+            FilterField::Revision => Ok(CursorValue::Integer(self.revision.get())),
+            _ => Err(ApiError::BadRequest(format!(
+                "Unsupported sort field '{}' for event subscriptions",
+                field
+            ))),
+        }
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        vec![SortParam {
+            field: FilterField::Id,
+            descending: false,
+        }]
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        Self::default_sort()
+    }
+}
+
+impl CursorSqlMapping for EventSubscriptionRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorSqlField {
+                column: "event_subscriptions.id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Name => CursorSqlField {
+                column: "event_subscriptions.name",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::CreatedAt => CursorSqlField {
+                column: "event_subscriptions.created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::Revision => CursorSqlField {
+                column: "event_subscriptions.revision",
+                sql_type: CursorSqlType::BigInt,
+                nullable: false,
+            },
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for event subscriptions",
+                    field
+                )));
+            }
+        })
+    }
+}
 
 pub(crate) trait LoadEventSinkRecord {
     async fn load_event_sink_record(
@@ -499,7 +895,7 @@ pub(crate) async fn list_event_sink_rows_with_total_count(
     })
     .await?;
     let mut query = build_event_sink_query(query_options)?;
-    apply_query_options!(query, query_options, EventSink);
+    apply_query_options!(query, query_options, EventSinkRow);
     let rows = with_connection(pool, async |conn| query.load::<EventSinkRow>(conn).await).await?;
     Ok((rows, total_count))
 }
@@ -562,7 +958,7 @@ pub(crate) async fn list_event_subscription_rows_with_total_count(
     })
     .await?;
     let mut query = build_event_subscription_query(collection, query_options)?;
-    apply_query_options!(query, query_options, EventSubscription);
+    apply_query_options!(query, query_options, EventSubscriptionRow);
     let rows = with_connection(pool, async |conn| {
         query.load::<EventSubscriptionRow>(conn).await
     })
@@ -652,13 +1048,68 @@ impl EventSubscription {
 mod tests {
     use super::*;
 
+    fn timestamp() -> NaiveDateTime {
+        chrono::DateTime::from_timestamp(1_700_000_000, 0)
+            .unwrap()
+            .naive_utc()
+    }
+
+    fn assert_omits(debug: &str, secrets: &[&str]) {
+        assert!(debug.contains(REDACTED_DEBUG_VALUE));
+        for secret in secrets {
+            assert!(!debug.contains(secret));
+        }
+    }
+
+    #[test]
+    fn event_sink_row_debug_redacts_configuration() {
+        let row = EventSinkRow {
+            id: 1,
+            name: "webhook".to_string(),
+            kind: "webhook".to_string(),
+            config: serde_json::json!({
+                "headers": {"authorization": "stored-config-secret"}
+            }),
+            secret_ref: Some("stored-secret-reference".to_string()),
+            enabled: true,
+            created_at: timestamp(),
+            updated_at: timestamp(),
+            revision: ResourceRevision::INITIAL,
+        };
+
+        assert_omits(
+            &format!("{row:?}"),
+            &["stored-config-secret", "stored-secret-reference"],
+        );
+    }
+
+    #[test]
+    fn event_subscription_row_debug_redacts_routing() {
+        let row = EventSubscriptionRow {
+            id: 1,
+            collection_id: 2,
+            sink_id: 3,
+            name: "webhook".to_string(),
+            description: String::new(),
+            entity_types: serde_json::json!(["collection"]),
+            actions: serde_json::json!(["created"]),
+            filter: serde_json::json!({}),
+            routing: serde_json::json!({
+                "url": "https://example.invalid/hook?key=stored-routing-secret"
+            }),
+            enabled: true,
+            created_at: timestamp(),
+            updated_at: timestamp(),
+            revision: ResourceRevision::INITIAL,
+        };
+
+        assert_omits(&format!("{row:?}"), &["stored-routing-secret"]);
+    }
+
     #[test]
     fn event_subscription_audit_snapshot_redacts_routing_credentials() {
         let credential = "audit-password";
         let api_key = "audit-api-key";
-        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0)
-            .unwrap()
-            .naive_utc();
         let row = EventSubscriptionRow {
             id: 1,
             collection_id: 2,
@@ -673,8 +1124,8 @@ mod tests {
                 "headers": {"X-API-Key": api_key}
             }),
             enabled: true,
-            created_at: timestamp,
-            updated_at: timestamp,
+            created_at: timestamp(),
+            updated_at: timestamp(),
             revision: crate::models::ResourceRevision::INITIAL,
         };
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -13,13 +13,13 @@ use crate::auth::ConfiguredLdapScope;
 use crate::errors::ApiError;
 use crate::models::user::User;
 use crate::models::{
-    CollectionID, NewEventSink, NewEventSinkRow, NewEventSubscription, NewEventSubscriptionRow,
-    RemoteCallResult, TaskKind, validate_sink_parts, validate_subscription_parts,
+    CollectionID, NewEventSink, NewEventSubscription, RemoteCallResult, TaskKind,
+    validate_sink_parts, validate_subscription_parts,
 };
 use crate::services::Services;
 use crate::storage::postgres::PostgresPool;
 use crate::storage::postgres::operations::event_subscription::{
-    SaveEventSinkRecord, SaveEventSubscriptionRecord,
+    NewEventSinkRow, NewEventSubscriptionRow, SaveEventSinkRecord, SaveEventSubscriptionRecord,
 };
 use crate::storage::postgres::operations::remote_target::load_remote_call_result_for_task;
 use crate::storage::{DynLifecycleStorage, PostgresStorage};
@@ -116,6 +116,29 @@ pub async fn remote_call_result(
     task_id: i32,
 ) -> Result<RemoteCallResult, ApiError> {
     load_remote_call_result_for_task(pool, task_id).await
+}
+
+/// Count audit events through the PostgreSQL test adapter boundary.
+pub async fn audit_event_count(
+    pool: &PostgresPool,
+    entity_type_value: crate::events::EntityType,
+    action_value: crate::events::Action,
+    entity_id_value: i32,
+) -> Result<i64, ApiError> {
+    use crate::schema::events::dsl::{action, entity_id, entity_type, events};
+    use crate::storage::postgres::prelude::*;
+    use crate::storage::postgres::with_connection;
+
+    with_connection(pool, async |conn| {
+        events
+            .filter(entity_type.eq(entity_type_value.as_str()))
+            .filter(action.eq(action_value.as_str()))
+            .filter(entity_id.eq(entity_id_value))
+            .count()
+            .get_result::<i64>(conn)
+            .await
+    })
+    .await
 }
 
 pub async fn save_event_sink(pool: &PostgresPool, sink: NewEventSink) -> Result<i32, ApiError> {

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -594,11 +594,13 @@ fn process_entry_points_compose_only_through_backend_neutral_storage() {
 fn event_administration_consumers_use_the_backend_neutral_application_service() {
     let root = repository_root();
     for file in [
+        "src/models/event_subscription.rs",
         "src/application.rs",
         "src/api/v1/handlers/events.rs",
         "src/api/v1/handlers/event_sinks.rs",
         "src/api/v1/handlers/event_subscriptions.rs",
         "src/api/v1/handlers/event_deliveries.rs",
+        "tests/api_platform_suite/event_subscriptions.rs",
     ] {
         let path = root.join(file);
         let source = fs::read_to_string(&path)
@@ -620,6 +622,34 @@ fn event_administration_consumers_use_the_backend_neutral_application_service() 
             assert!(
                 !source.contains(forbidden),
                 "{} still uses event adapter detail {forbidden}",
+                path.display()
+            );
+        }
+    }
+
+    for file in [
+        "src/models/event_subscription.rs",
+        "tests/api_platform_suite/event_subscriptions.rs",
+    ] {
+        let path = root.join(file);
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+        for forbidden in [
+            "storage::postgres",
+            "diesel::",
+            "diesel_async",
+            "crate::schema",
+            "CursorSql",
+            "EventSinkRow",
+            "NewEventSinkRow",
+            "UpdateEventSinkRow",
+            "EventSubscriptionRow",
+            "NewEventSubscriptionRow",
+            "UpdateEventSubscriptionRow",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{} still uses event persistence detail {forbidden}",
                 path.display()
             );
         }

--- a/tests/api_platform_suite/event_subscriptions.rs
+++ b/tests/api_platform_suite/event_subscriptions.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod tests {
-    use crate::storage::postgres::prelude::*;
     use actix_web::{http::StatusCode, test};
     use serde_json::json;
 
@@ -8,7 +7,6 @@ mod tests {
     use crate::models::{
         EventSink, EventSinkKind, EventSubscription, NewEventSink, NewEventSubscription,
     };
-    use crate::storage::postgres::with_connection;
     use crate::tests::TestContext;
     use crate::tests::api_operations::{delete_request, get_request, patch_request, post_request};
     use crate::tests::asserts::assert_response_status;
@@ -56,17 +54,12 @@ mod tests {
         action_value: Action,
         entity_id_value: i32,
     ) -> i64 {
-        with_connection(&context.pool, async |conn| {
-            use crate::schema::events::dsl::{action, entity_id, entity_type, events};
-
-            events
-                .filter(entity_type.eq(entity_type_value.as_str()))
-                .filter(action.eq(action_value.as_str()))
-                .filter(entity_id.eq(entity_id_value))
-                .count()
-                .get_result::<i64>(conn)
-                .await
-        })
+        crate::test_support::audit_event_count(
+            &context.pool,
+            entity_type_value,
+            action_value,
+            entity_id_value,
+        )
         .await
         .unwrap()
     }


### PR DESCRIPTION
## Summary

- move event-sink and event-subscription query, insert, update, and projection rows into the PostgreSQL adapter
- move sink/subscription SQL cursor mappings out of public API/domain models
- keep fanout, delivery, administration, fixtures, and conversions adapter-side
- route request-level audit inspection through explicit test support instead of direct SQL
- strengthen source-boundary and redaction regression coverage

## Architecture

`EventSubscriptionStorage` is already a mandatory, available-backend compatibility-tested capability. This layer completes its physical PostgreSQL boundary: `EventSink` and `EventSubscription` retain only backend-neutral API/domain behavior, while Diesel rows, insert records, changesets, row conversions, SQL cursor metadata, and query construction are owned by `src/storage/postgres/operations/event_subscription.rs`.

Event fanout and delivery import the shared persistence projections from the adapter module instead of the public model module. Request-level tests use an explicit feature-gated test-support entry point rather than opening a PostgreSQL connection or importing schema columns.

There is no storage contract-version change because the mandatory capability and its observable semantics are unchanged.

## Behavior and compatibility

- HTTP request and response shapes are unchanged.
- Sink/subscription lifecycle, filtering, cursor ordering, revision checks, lifecycle audit events, fanout, and delivery behavior are unchanged.
- Available backend compatibility requirements are unchanged.
- Redacted `Debug` behavior is tested independently for public DTOs and adapter rows.
- No migration or administrator action is required.

## Changelog

No changelog-worthy impact: this is an internal architecture refactor with no user-facing API, configuration, storage-contract, or operational behavior change.

## OpenAPI

No regeneration was required because endpoint schemas and public DTO shapes are unchanged.

## Verification

- `source .env && ./run_tests.sh`
- `cargo check --all-targets --features integration-test-support`
- `cargo test --lib tests::application_boundary`
- `cargo test --lib event_subscription::tests`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `scripts/test-classify-ci-changes.sh`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`
- `git diff --check`

## Stack

This is the next layer above #325 in stack #286.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>