### PR TITLE
Enforce event delivery persistence boundary

### DIFF
--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -114,10 +114,10 @@ considered complete merely because a marker exists.
 
 PostgreSQL query implementations live in
 `src/storage/postgres/operations/*`. Export-template, remote-target, event-sink,
-and event-subscription lifecycle rows are adapter-owned, as are remote-target
-history and remote-call result persistence rows. Remaining mixed persistence
-rows move there as their backend-neutral DTOs are extracted. Their current
-locations are implementation details, not partial backend support.
+event-subscription, and event-delivery lifecycle rows are adapter-owned, as are
+remote-target history and remote-call result persistence rows. Remaining mixed
+persistence rows move there as their backend-neutral DTOs are extracted. Their
+current locations are implementation details, not partial backend support.
 `StorageHandle` selects one certified PostgreSQL adapter, and only the storage
 implementation can recover its pool.
 Application consumers use `StorageContext`, lifecycle traits, mandatory
@@ -558,12 +558,12 @@ through related collections. Sink and subscription writes are atomic with
 their lifecycle events, and subscription point and mutation operations are
 collection-scoped at the contract boundary.
 
-Event-sink and event-subscription API models contain no Diesel derives, schema
-bindings, persistence changesets, or SQL cursor mappings. Those rows and
-mappings stay in the PostgreSQL adapter, which converts them to backend-neutral
-storage DTOs. Handlers and request-level compatibility tests use application or
-test-support entry points rather than importing adapter rows or opening SQL
-connections.
+Event-sink, event-subscription, and event-delivery API models contain no Diesel
+derives, schema bindings, persistence changesets, claim tokens, or SQL cursor
+mappings. Those rows and mappings stay in the PostgreSQL adapter, which converts
+them to backend-neutral storage DTOs. Handlers and request-level tests use
+application or test-support entry points rather than importing adapter rows,
+opening SQL connections, or mutating delivery tables directly.
 
 Delivery administration returns claim-free projections. Opaque worker claim
 tokens never cross into handlers, logs, or administrator responses. Listing

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -25,16 +25,16 @@ use crate::models::object::{NewHubuumObject, UpdateHubuumObject};
 use crate::models::search::{QueryOptions, parse_query_parameter};
 use crate::models::token::{renew_token_by_id_for_principal, revoke_token_by_id_for_principal};
 use crate::models::{
-    CollectionID, EventDelivery, EventDeliveryID, EventDeliveryStatus, EventSinkKind,
-    ExportContentType, ExportTemplateID, ExportTemplateKind, GroupID, HubuumClassID,
-    HubuumClassRelationID, HubuumObjectID, NewExportTemplate, NewHubuumClassRelation,
-    NewHubuumObjectRelation, NewUser, ObjectRelationLimit, Permissions, PermissionsList,
-    PrincipalID, PrincipalToken, PrincipalTokenCreateRequest, RemoteTargetID, Token, TokenID,
-    TokenScope, UpdateExportTemplate, UpdateUser, UserID,
+    CollectionID, EventDeliveryID, EventDeliveryStatus, EventSinkKind, ExportContentType,
+    ExportTemplateID, ExportTemplateKind, GroupID, HubuumClassID, HubuumClassRelationID,
+    HubuumObjectID, NewExportTemplate, NewHubuumClassRelation, NewHubuumObjectRelation, NewUser,
+    ObjectRelationLimit, Permissions, PermissionsList, PrincipalID, PrincipalToken,
+    PrincipalTokenCreateRequest, RemoteTargetID, Token, TokenID, TokenScope, UpdateExportTemplate,
+    UpdateUser, UserID,
 };
 use crate::schema::events::dsl::events;
 use crate::storage::postgres::operations::event_delivery::{
-    claim_event_deliveries, claim_event_delivery_by_id, mark_event_delivery_dead,
+    EventDeliveryRow, claim_event_deliveries, claim_event_delivery_by_id, mark_event_delivery_dead,
     mark_event_delivery_failed, next_event_delivery_wakeup_in_db,
 };
 use crate::storage::postgres::operations::event_fanout::{
@@ -475,13 +475,13 @@ async fn mark_event_dispatched(scope: &TestScope, event_id_value: i64) {
     .unwrap();
 }
 
-async fn delivery_for_event(scope: &TestScope, event_id_value: i64) -> EventDelivery {
+async fn delivery_for_event(scope: &TestScope, event_id_value: i64) -> EventDeliveryRow {
     use crate::schema::event_deliveries::dsl::{event_deliveries, event_id};
 
     with_connection(&scope.pool, async |conn| {
         event_deliveries
             .filter(event_id.eq(event_id_value))
-            .first::<EventDelivery>(conn)
+            .first::<EventDeliveryRow>(conn)
             .await
     })
     .await

--- a/src/models/event_delivery.rs
+++ b/src/models/event_delivery.rs
@@ -1,18 +1,12 @@
-use std::{fmt, str::FromStr};
+use std::str::FromStr;
 
-use crate::storage::postgres::prelude::*;
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use uuid::Uuid;
 
 use crate::errors::ApiError;
-use crate::models::redacted_debug_option;
 use crate::models::search::{FilterField, SortParam};
-use crate::pagination::{
-    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
-};
-use crate::schema::event_deliveries;
+use crate::pagination::{CursorPaginated, CursorValue};
 
 /// Identifier wrapper for an event delivery.
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, ToSchema)]
@@ -82,41 +76,6 @@ impl FromStr for EventDeliveryStatus {
     }
 }
 
-#[derive(Clone, Queryable, Selectable, PartialEq, Eq)]
-#[diesel(table_name = event_deliveries)]
-pub struct EventDelivery {
-    pub id: i64,
-    pub event_id: i64,
-    pub subscription_id: i32,
-    pub status: String,
-    pub attempts: i32,
-    pub next_attempt_at: NaiveDateTime,
-    pub last_error: Option<String>,
-    pub locked_until: Option<NaiveDateTime>,
-    pub(crate) claim_token: Option<Uuid>,
-    pub created_at: NaiveDateTime,
-    pub updated_at: NaiveDateTime,
-}
-
-impl fmt::Debug for EventDelivery {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("EventDelivery")
-            .field("id", &self.id)
-            .field("event_id", &self.event_id)
-            .field("subscription_id", &self.subscription_id)
-            .field("status", &self.status)
-            .field("attempts", &self.attempts)
-            .field("next_attempt_at", &self.next_attempt_at)
-            .field("last_error", &redacted_debug_option(&self.last_error))
-            .field("locked_until", &self.locked_until)
-            .field("claim_token", &redacted_debug_option(&self.claim_token))
-            .field("created_at", &self.created_at)
-            .field("updated_at", &self.updated_at)
-            .finish()
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct EventDeliveryResponse {
     pub id: i64,
@@ -129,23 +88,6 @@ pub struct EventDeliveryResponse {
     pub locked_until: Option<NaiveDateTime>,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
-}
-
-impl From<EventDelivery> for EventDeliveryResponse {
-    fn from(delivery: EventDelivery) -> Self {
-        Self {
-            id: delivery.id,
-            event_id: delivery.event_id,
-            subscription_id: delivery.subscription_id,
-            status: delivery.status,
-            attempts: delivery.attempts,
-            next_attempt_at: delivery.next_attempt_at,
-            last_error: delivery.last_error,
-            locked_until: delivery.locked_until,
-            created_at: delivery.created_at,
-            updated_at: delivery.updated_at,
-        }
-    }
 }
 
 impl CursorPaginated for EventDeliveryResponse {
@@ -192,14 +134,6 @@ impl CursorPaginated for EventDeliveryResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct EventDeliveryUpdateResponse {
     pub delivery: EventDeliveryResponse,
-}
-
-impl From<EventDelivery> for EventDeliveryUpdateResponse {
-    fn from(delivery: EventDelivery) -> Self {
-        Self {
-            delivery: delivery.into(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default, ToSchema)]
@@ -360,89 +294,9 @@ impl EventDeliveryHealthResponse {
     }
 }
 
-impl CursorPaginated for EventDelivery {
-    fn supports_sort(field: &FilterField) -> bool {
-        matches!(
-            field,
-            FilterField::Id
-                | FilterField::Status
-                | FilterField::CreatedAt
-                | FilterField::UpdatedAt
-                | FilterField::NextAttemptAt
-        )
-    }
-
-    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
-        match field {
-            FilterField::Id => Ok(CursorValue::Integer(self.id)),
-            FilterField::Status => Ok(CursorValue::String(self.status.clone())),
-            FilterField::CreatedAt => Ok(CursorValue::DateTime(self.created_at)),
-            FilterField::UpdatedAt => Ok(CursorValue::DateTime(self.updated_at)),
-            FilterField::NextAttemptAt => Ok(CursorValue::DateTime(self.next_attempt_at)),
-            _ => Err(ApiError::BadRequest(format!(
-                "Unsupported sort field '{}' for event deliveries",
-                field
-            ))),
-        }
-    }
-
-    fn default_sort() -> Vec<SortParam> {
-        vec![SortParam {
-            field: FilterField::Id,
-            descending: false,
-        }]
-    }
-
-    fn tie_breaker_sort() -> Vec<SortParam> {
-        vec![SortParam {
-            field: FilterField::Id,
-            descending: false,
-        }]
-    }
-}
-
-impl CursorSqlMapping for EventDelivery {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id => CursorSqlField {
-                column: "event_deliveries.id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Status => CursorSqlField {
-                column: "event_deliveries.status",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::CreatedAt => CursorSqlField {
-                column: "event_deliveries.created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAt => CursorSqlField {
-                column: "event_deliveries.updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::NextAttemptAt => CursorSqlField {
-                column: "event_deliveries.next_attempt_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for event deliveries",
-                    field
-                )));
-            }
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::REDACTED_DEBUG_VALUE;
     use crate::storage::{
         EventDeliveryHealthSnapshot, EventDeliveryStatusSnapshot, EventFanoutSnapshot,
         EventQueueSnapshot, EventSinkHealthSnapshot, EventSinkSnapshot,
@@ -461,59 +315,6 @@ mod tests {
                 poll_wakeups: 5,
             },
         }
-    }
-
-    #[test]
-    fn event_delivery_response_omits_internal_claim_token() {
-        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0)
-            .unwrap()
-            .naive_utc();
-        let claim_token = Uuid::parse_str("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").unwrap();
-        let delivery = EventDelivery {
-            id: 1,
-            event_id: 2,
-            subscription_id: 3,
-            status: EventDeliveryStatus::InFlight.as_str().to_string(),
-            attempts: 1,
-            next_attempt_at: timestamp,
-            last_error: None,
-            locked_until: Some(timestamp),
-            claim_token: Some(claim_token),
-            created_at: timestamp,
-            updated_at: timestamp,
-        };
-
-        let serialized = serde_json::to_value(EventDeliveryResponse::from(delivery)).unwrap();
-
-        assert!(serialized.get("claim_token").is_none());
-        assert!(!serialized.to_string().contains(&claim_token.to_string()));
-    }
-
-    #[test]
-    fn event_delivery_debug_redacts_claim_token_and_error() {
-        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0)
-            .unwrap()
-            .naive_utc();
-        let claim_token = Uuid::parse_str("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").unwrap();
-        let delivery = EventDelivery {
-            id: 1,
-            event_id: 2,
-            subscription_id: 3,
-            status: EventDeliveryStatus::InFlight.as_str().to_string(),
-            attempts: 1,
-            next_attempt_at: timestamp,
-            last_error: Some("delivery-error-secret".to_string()),
-            locked_until: Some(timestamp),
-            claim_token: Some(claim_token),
-            created_at: timestamp,
-            updated_at: timestamp,
-        };
-
-        let debug = format!("{delivery:?}");
-
-        assert!(debug.contains(REDACTED_DEBUG_VALUE));
-        assert!(!debug.contains("delivery-error-secret"));
-        assert!(!debug.contains(&claim_token.to_string()));
     }
 
     #[test]

--- a/src/storage/postgres/operations/event_administration.rs
+++ b/src/storage/postgres/operations/event_administration.rs
@@ -10,11 +10,11 @@ use hubuum_storage_core::{
 use crate::errors::ApiError;
 use crate::events::EventResponse;
 use crate::models::{
-    EventDelivery as EventDeliveryRow, EventDeliveryID, EventSink, EventSinkID, EventSubscription,
-    EventSubscriptionID,
+    EventDeliveryID, EventSink, EventSinkID, EventSubscription, EventSubscriptionID,
 };
 use crate::storage::postgres::PostgresPool;
 
+use super::event_delivery::EventDeliveryRow;
 use super::event_subscription::{
     DeleteEventSinkRecord, DeleteEventSubscriptionRecord, EventSinkRow, EventSubscriptionRow,
     NewEventSinkRow, NewEventSubscriptionRow, SaveEventSinkRecord, SaveEventSubscriptionRecord,

--- a/src/storage/postgres/operations/event_delivery.rs
+++ b/src/storage/postgres/operations/event_delivery.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::time::Duration as StdDuration;
 
 use crate::storage::postgres::operations::maintenance::maintenance_state_conn;
@@ -9,9 +10,14 @@ use uuid::Uuid;
 
 use crate::errors::ApiError;
 use crate::events::{EntityType, Event, EventDeliverySettings};
-use crate::models::search::{FilterField, Operator, ParsedQueryParamExt, QueryOptions};
+#[cfg(feature = "integration-test-support")]
+use crate::models::EventDeliveryResponse;
+use crate::models::search::{FilterField, Operator, ParsedQueryParamExt, QueryOptions, SortParam};
 use crate::models::{
-    EventDelivery, EventDeliveryID, EventDeliveryStatus, EventSink, EventSubscription,
+    EventDeliveryID, EventDeliveryStatus, EventSink, EventSubscription, redacted_debug_option,
+};
+use crate::pagination::{
+    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
 };
 use crate::storage::postgres::{with_connection, with_transaction};
 use crate::storage::{
@@ -21,9 +27,120 @@ use crate::storage::{
 
 use super::event_subscription::{EventSinkRow, EventSubscriptionRow};
 
+#[derive(Clone, Queryable, Selectable, PartialEq, Eq)]
+#[diesel(table_name = crate::schema::event_deliveries)]
+pub(crate) struct EventDeliveryRow {
+    pub(crate) id: i64,
+    pub(crate) event_id: i64,
+    pub(crate) subscription_id: i32,
+    pub(crate) status: String,
+    pub(crate) attempts: i32,
+    pub(crate) next_attempt_at: NaiveDateTime,
+    pub(crate) last_error: Option<String>,
+    pub(crate) locked_until: Option<NaiveDateTime>,
+    pub(crate) claim_token: Option<Uuid>,
+    pub(crate) created_at: NaiveDateTime,
+    pub(crate) updated_at: NaiveDateTime,
+}
+
+impl fmt::Debug for EventDeliveryRow {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EventDeliveryRow")
+            .field("id", &self.id)
+            .field("event_id", &self.event_id)
+            .field("subscription_id", &self.subscription_id)
+            .field("status", &self.status)
+            .field("attempts", &self.attempts)
+            .field("next_attempt_at", &self.next_attempt_at)
+            .field("last_error", &redacted_debug_option(&self.last_error))
+            .field("locked_until", &self.locked_until)
+            .field("claim_token", &redacted_debug_option(&self.claim_token))
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .finish()
+    }
+}
+
+impl CursorPaginated for EventDeliveryRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        matches!(
+            field,
+            FilterField::Id
+                | FilterField::Status
+                | FilterField::CreatedAt
+                | FilterField::UpdatedAt
+                | FilterField::NextAttemptAt
+        )
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        match field {
+            FilterField::Id => Ok(CursorValue::Integer(self.id)),
+            FilterField::Status => Ok(CursorValue::String(self.status.clone())),
+            FilterField::CreatedAt => Ok(CursorValue::DateTime(self.created_at)),
+            FilterField::UpdatedAt => Ok(CursorValue::DateTime(self.updated_at)),
+            FilterField::NextAttemptAt => Ok(CursorValue::DateTime(self.next_attempt_at)),
+            _ => Err(ApiError::BadRequest(format!(
+                "Unsupported sort field '{}' for event deliveries",
+                field
+            ))),
+        }
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        vec![SortParam {
+            field: FilterField::Id,
+            descending: false,
+        }]
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        Self::default_sort()
+    }
+}
+
+impl CursorSqlMapping for EventDeliveryRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorSqlField {
+                column: "event_deliveries.id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Status => CursorSqlField {
+                column: "event_deliveries.status",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::CreatedAt => CursorSqlField {
+                column: "event_deliveries.created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAt => CursorSqlField {
+                column: "event_deliveries.updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::NextAttemptAt => CursorSqlField {
+                column: "event_deliveries.next_attempt_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for event deliveries",
+                    field
+                )));
+            }
+        })
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ClaimedEventDelivery {
-    pub delivery: EventDelivery,
+    pub delivery: EventDeliveryRow,
     pub event: Event,
     pub subscription: EventSubscriptionRow,
     pub sink: EventSinkRow,
@@ -151,7 +268,7 @@ pub(crate) async fn claim_event_delivery_batch(
                         locked_until.eq(Some(lock_deadline)),
                         claim_token.eq(Some(claim)),
                     ))
-                    .get_results::<EventDelivery>(conn)
+                    .get_results::<EventDeliveryRow>(conn)
                     .await?;
 
             Ok(EventDeliveryClaimBatch {
@@ -307,7 +424,7 @@ pub(crate) async fn claim_event_delivery_by_id(
                 locked_until.eq(Some(lock_deadline)),
                 claim_token.eq(Some(claim)),
             ))
-            .get_result::<EventDelivery>(conn)
+            .get_result::<EventDeliveryRow>(conn)
             .await?;
 
             load_claimed_delivery_context(conn, delivery).await
@@ -319,7 +436,7 @@ pub(crate) async fn claim_event_delivery_by_id(
 #[cfg(test)]
 async fn load_claimed_delivery_context(
     conn: &mut crate::storage::postgres::PostgresConnection,
-    delivery: EventDelivery,
+    delivery: EventDeliveryRow,
 ) -> Result<ClaimedEventDelivery, ApiError> {
     load_claimed_delivery_contexts(conn, vec![delivery])
         .await?
@@ -330,7 +447,7 @@ async fn load_claimed_delivery_context(
 
 async fn load_claimed_delivery_contexts(
     conn: &mut crate::storage::postgres::PostgresConnection,
-    deliveries: Vec<EventDelivery>,
+    deliveries: Vec<EventDeliveryRow>,
 ) -> Result<Vec<ClaimedEventDelivery>, ApiError> {
     use crate::schema::{event_sinks, event_subscriptions, events};
 
@@ -406,7 +523,7 @@ pub(crate) async fn mark_event_delivery_succeeded(
     pool: &impl crate::storage::StorageContext,
     delivery_id_value: i64,
     claim_token_value: Uuid,
-) -> Result<EventDelivery, ApiError> {
+) -> Result<EventDeliveryRow, ApiError> {
     use crate::schema::event_deliveries::dsl::{
         claim_token, event_deliveries, id, last_error, locked_until, status,
     };
@@ -424,7 +541,7 @@ pub(crate) async fn mark_event_delivery_succeeded(
             claim_token.eq::<Option<Uuid>>(None),
             last_error.eq::<Option<String>>(None),
         ))
-        .get_result::<EventDelivery>(conn)
+        .get_result::<EventDeliveryRow>(conn)
         .await
     })
     .await
@@ -442,10 +559,10 @@ pub(crate) async fn mark_event_delivery_claim_succeeded(
 #[cfg(test)]
 pub(crate) async fn mark_event_delivery_failed(
     pool: &impl crate::storage::StorageContext,
-    delivery: &EventDelivery,
+    delivery: &EventDeliveryRow,
     settings: EventDeliverySettings,
     error: &str,
-) -> Result<EventDelivery, ApiError> {
+) -> Result<EventDeliveryRow, ApiError> {
     mark_event_delivery_failed_values(
         pool,
         delivery.id,
@@ -482,7 +599,7 @@ async fn mark_event_delivery_failed_values(
     delivery_attempts: i32,
     settings: EventDeliverySettings,
     error: &str,
-) -> Result<EventDelivery, ApiError> {
+) -> Result<EventDeliveryRow, ApiError> {
     use crate::schema::event_deliveries::dsl::{
         attempts, claim_token, event_deliveries, id, last_error, locked_until, next_attempt_at,
         status,
@@ -518,7 +635,7 @@ async fn mark_event_delivery_failed_values(
             locked_until.eq::<Option<chrono::NaiveDateTime>>(None),
             claim_token.eq::<Option<Uuid>>(None),
         ))
-        .get_result::<EventDelivery>(conn)
+        .get_result::<EventDeliveryRow>(conn)
         .await
     })
     .await
@@ -537,26 +654,95 @@ fn truncate_delivery_error(error: &str) -> String {
     error[..end].to_string()
 }
 
-pub async fn load_event_delivery(
+pub(crate) async fn load_event_delivery(
     pool: &impl crate::storage::StorageContext,
     delivery_id: EventDeliveryID,
-) -> Result<EventDelivery, ApiError> {
+) -> Result<EventDeliveryRow, ApiError> {
     use crate::schema::event_deliveries::dsl::{event_deliveries, id};
 
     with_connection(pool, async |conn| {
         event_deliveries
             .filter(id.eq(delivery_id.id()))
-            .first::<EventDelivery>(conn)
+            .first::<EventDeliveryRow>(conn)
             .await
     })
     .await
 }
 
-pub async fn list_event_deliveries_with_total_count(
+#[cfg(feature = "integration-test-support")]
+fn event_delivery_response(delivery: EventDeliveryRow) -> EventDeliveryResponse {
+    EventDeliveryResponse {
+        id: delivery.id,
+        event_id: delivery.event_id,
+        subscription_id: delivery.subscription_id,
+        status: delivery.status,
+        attempts: delivery.attempts,
+        next_attempt_at: delivery.next_attempt_at,
+        last_error: delivery.last_error,
+        locked_until: delivery.locked_until,
+        created_at: delivery.created_at,
+        updated_at: delivery.updated_at,
+    }
+}
+
+#[cfg(feature = "integration-test-support")]
+pub(crate) async fn load_event_delivery_for_event(
+    pool: &impl crate::storage::StorageContext,
+    event_id_value: i64,
+) -> Result<EventDeliveryResponse, ApiError> {
+    use crate::schema::event_deliveries::dsl::{event_deliveries, event_id};
+
+    with_connection(pool, async |conn| {
+        event_deliveries
+            .filter(event_id.eq(event_id_value))
+            .first::<EventDeliveryRow>(conn)
+            .await
+    })
+    .await
+    .map(event_delivery_response)
+}
+
+#[cfg(feature = "integration-test-support")]
+pub(crate) async fn set_event_delivery_status_for_test(
+    pool: &impl crate::storage::StorageContext,
+    delivery_id: i64,
+    delivery_status: EventDeliveryStatus,
+) -> Result<(), ApiError> {
+    use crate::schema::event_deliveries::dsl::{event_deliveries, id, status};
+
+    with_connection(pool, async |conn| {
+        diesel::update(event_deliveries.filter(id.eq(delivery_id)))
+            .set(status.eq(delivery_status.as_str()))
+            .execute(conn)
+            .await
+    })
+    .await?;
+    Ok(())
+}
+
+#[cfg(feature = "integration-test-support")]
+pub(crate) async fn set_event_delivery_claim_token_for_test(
+    pool: &impl crate::storage::StorageContext,
+    delivery_id: i64,
+    delivery_claim_token: Uuid,
+) -> Result<(), ApiError> {
+    use crate::schema::event_deliveries::dsl::{claim_token, event_deliveries, id};
+
+    with_connection(pool, async |conn| {
+        diesel::update(event_deliveries.filter(id.eq(delivery_id)))
+            .set(claim_token.eq(Some(delivery_claim_token)))
+            .execute(conn)
+            .await
+    })
+    .await?;
+    Ok(())
+}
+
+pub(crate) async fn list_event_deliveries_with_total_count(
     pool: &impl crate::storage::StorageContext,
     subscription_id_filter: Option<i32>,
     query_options: &QueryOptions,
-) -> Result<(Vec<EventDelivery>, i64), ApiError> {
+) -> Result<(Vec<EventDeliveryRow>, i64), ApiError> {
     let query = build_event_delivery_query(subscription_id_filter, query_options)?;
     let total_count = crate::pagination::exact_count_or_skipped(query_options, async || {
         with_connection(pool, async |conn| {
@@ -566,9 +752,11 @@ pub async fn list_event_deliveries_with_total_count(
     })
     .await?;
     let mut query = build_event_delivery_query(subscription_id_filter, query_options)?;
-    crate::apply_query_options!(query, query_options, EventDelivery);
-    let deliveries =
-        with_connection(pool, async |conn| query.load::<EventDelivery>(conn).await).await?;
+    crate::apply_query_options!(query, query_options, EventDeliveryRow);
+    let deliveries = with_connection(pool, async |conn| {
+        query.load::<EventDeliveryRow>(conn).await
+    })
+    .await?;
     Ok((deliveries, total_count))
 }
 
@@ -626,17 +814,17 @@ fn build_event_delivery_query(
     Ok(query)
 }
 
-pub async fn release_event_delivery_for_retry(
+pub(crate) async fn release_event_delivery_for_retry(
     pool: &impl crate::storage::StorageContext,
     delivery_id: EventDeliveryID,
-) -> Result<EventDelivery, ApiError> {
+) -> Result<EventDeliveryRow, ApiError> {
     use crate::schema::event_deliveries::dsl::{
         claim_token, event_deliveries, id, last_error, locked_until, next_attempt_at, status,
     };
 
     with_connection(
         pool,
-        async |conn| -> Result<EventDelivery, diesel::result::Error> {
+        async |conn| -> Result<EventDeliveryRow, diesel::result::Error> {
             let delivery = diesel::update(event_deliveries.filter(id.eq(delivery_id.id())).filter(
                 status.eq_any([
                     EventDeliveryStatus::Failed.as_str(),
@@ -650,7 +838,7 @@ pub async fn release_event_delivery_for_retry(
                 claim_token.eq::<Option<Uuid>>(None),
                 last_error.eq::<Option<String>>(None),
             ))
-            .get_result::<EventDelivery>(conn)
+            .get_result::<EventDeliveryRow>(conn)
             .await?;
             crate::events::notify_event_delivery(conn).await?;
             Ok(delivery)
@@ -659,10 +847,10 @@ pub async fn release_event_delivery_for_retry(
     .await
 }
 
-pub async fn mark_event_delivery_dead(
+pub(crate) async fn mark_event_delivery_dead(
     pool: &impl crate::storage::StorageContext,
     delivery_id: EventDeliveryID,
-) -> Result<EventDelivery, ApiError> {
+) -> Result<EventDeliveryRow, ApiError> {
     use crate::schema::event_deliveries::dsl::{
         claim_token, event_deliveries, id, last_error, locked_until, status,
     };
@@ -679,8 +867,40 @@ pub async fn mark_event_delivery_dead(
             claim_token.eq::<Option<Uuid>>(None),
             last_error.eq(Some("marked dead by operator".to_string())),
         ))
-        .get_result::<EventDelivery>(conn)
+        .get_result::<EventDeliveryRow>(conn)
         .await
     })
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_delivery_row_debug_redacts_claim_token_and_error() {
+        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0)
+            .unwrap()
+            .naive_utc();
+        let claim_token = Uuid::parse_str("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").unwrap();
+        let delivery = EventDeliveryRow {
+            id: 1,
+            event_id: 2,
+            subscription_id: 3,
+            status: EventDeliveryStatus::InFlight.as_str().to_string(),
+            attempts: 1,
+            next_attempt_at: timestamp,
+            last_error: Some("delivery-error-secret".to_string()),
+            locked_until: Some(timestamp),
+            claim_token: Some(claim_token),
+            created_at: timestamp,
+            updated_at: timestamp,
+        };
+
+        let debug = format!("{delivery:?}");
+
+        assert!(debug.contains(crate::models::REDACTED_DEBUG_VALUE));
+        assert!(!debug.contains("delivery-error-secret"));
+        assert!(!debug.contains(&claim_token.to_string()));
+    }
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -11,13 +11,19 @@ use tracing_subscriber::layer::SubscriberExt;
 
 use crate::auth::ConfiguredLdapScope;
 use crate::errors::ApiError;
+use crate::events::{Action, ActorKind, EntityType, NewEvent, emit_event};
 use crate::models::user::User;
 use crate::models::{
-    CollectionID, NewEventSink, NewEventSubscription, RemoteCallResult, TaskKind,
-    validate_sink_parts, validate_subscription_parts,
+    CollectionID, EventDeliveryResponse, EventDeliveryStatus, NewEventSink, NewEventSubscription,
+    RemoteCallResult, TaskKind, validate_sink_parts, validate_subscription_parts,
 };
 use crate::services::Services;
 use crate::storage::postgres::PostgresPool;
+use crate::storage::postgres::operations::event_delivery::{
+    load_event_delivery_for_event, set_event_delivery_claim_token_for_test,
+    set_event_delivery_status_for_test,
+};
+use crate::storage::postgres::operations::event_fanout::fanout_event;
 use crate::storage::postgres::operations::event_subscription::{
     NewEventSinkRow, NewEventSubscriptionRow, SaveEventSinkRecord, SaveEventSubscriptionRecord,
 };
@@ -139,6 +145,46 @@ pub async fn audit_event_count(
             .await
     })
     .await
+}
+
+/// Emit, fan out, and load one collection event delivery for request tests.
+pub async fn create_collection_event_delivery(
+    pool: &PostgresPool,
+    collection_id: i32,
+    entity_name: &str,
+) -> Result<EventDeliveryResponse, ApiError> {
+    use crate::storage::postgres::with_connection;
+
+    let event = NewEvent::new(
+        EntityType::Collection,
+        Action::Created,
+        ActorKind::System,
+        "delivery api test",
+    )?
+    .with_collection_id(collection_id)
+    .with_entity_id(collection_id)
+    .with_entity_name(entity_name);
+    let event = with_connection(pool, async |conn| emit_event(conn, &event).await).await?;
+    fanout_event(pool, event.id).await?;
+    load_event_delivery_for_event(pool, event.id).await
+}
+
+/// Set a delivery status through adapter-owned test support.
+pub async fn set_event_delivery_status(
+    pool: &PostgresPool,
+    delivery_id: i64,
+    status: EventDeliveryStatus,
+) -> Result<(), ApiError> {
+    set_event_delivery_status_for_test(pool, delivery_id, status).await
+}
+
+/// Set a delivery claim token through adapter-owned test support.
+pub async fn set_event_delivery_claim_token(
+    pool: &PostgresPool,
+    delivery_id: i64,
+    claim_token: uuid::Uuid,
+) -> Result<(), ApiError> {
+    set_event_delivery_claim_token_for_test(pool, delivery_id, claim_token).await
 }
 
 pub async fn save_event_sink(pool: &PostgresPool, sink: NewEventSink) -> Result<i32, ApiError> {

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -628,7 +628,9 @@ fn event_administration_consumers_use_the_backend_neutral_application_service() 
     }
 
     for file in [
+        "src/models/event_delivery.rs",
         "src/models/event_subscription.rs",
+        "tests/api_platform_suite/event_deliveries.rs",
         "tests/api_platform_suite/event_subscriptions.rs",
     ] {
         let path = root.join(file);
@@ -646,6 +648,7 @@ fn event_administration_consumers_use_the_backend_neutral_application_service() 
             "EventSubscriptionRow",
             "NewEventSubscriptionRow",
             "UpdateEventSubscriptionRow",
+            "EventDeliveryRow",
         ] {
             assert!(
                 !source.contains(forbidden),

--- a/tests/api_platform_suite/event_deliveries.rs
+++ b/tests/api_platform_suite/event_deliveries.rs
@@ -1,19 +1,19 @@
 #[cfg(test)]
 mod tests {
-    use crate::storage::postgres::prelude::*;
     use actix_web::{http::StatusCode, test};
     use serde_json::json;
 
-    use crate::events::{Action, ActorKind, EntityType, NewEvent, emit_event};
+    use crate::events::{Action, EntityType};
     use crate::models::{
-        CollectionID, EventDelivery, EventDeliveryHealthResponse, EventDeliveryResponse,
-        EventDeliveryStatus, EventDeliveryUpdateResponse, EventSinkID, EventSinkKind, NewEventSink,
+        CollectionID, EventDeliveryHealthResponse, EventDeliveryResponse, EventDeliveryStatus,
+        EventDeliveryUpdateResponse, EventSinkID, EventSinkKind, NewEventSink,
         NewEventSubscription,
     };
     use crate::pagination::TOTAL_COUNT_HEADER;
-    use crate::storage::postgres::operations::event_fanout::fanout_event;
-    use crate::storage::postgres::with_connection;
-    use crate::test_support::{save_event_sink, save_event_subscription};
+    use crate::test_support::{
+        create_collection_event_delivery, save_event_sink, save_event_subscription,
+        set_event_delivery_claim_token, set_event_delivery_status,
+    };
     use crate::tests::TestContext;
     use crate::tests::api_operations::{get_request, post_request};
     use crate::tests::asserts::assert_response_status;
@@ -21,7 +21,7 @@ mod tests {
     const DELIVERIES_ENDPOINT: &str = "/api/v1/event-deliveries";
 
     struct DeliveryFixture {
-        delivery: EventDelivery,
+        delivery: EventDeliveryResponse,
         sink_id: i32,
         sink_name: String,
         subscription_id: i32,
@@ -64,29 +64,11 @@ mod tests {
         .await
         .unwrap();
 
-        let event = NewEvent::new(
-            EntityType::Collection,
-            Action::Created,
-            ActorKind::System,
-            "delivery api test",
+        let delivery = create_collection_event_delivery(
+            &context.pool,
+            fixture.collection.id,
+            &fixture.collection.name,
         )
-        .unwrap()
-        .with_collection_id(fixture.collection.id)
-        .with_entity_id(fixture.collection.id)
-        .with_entity_name(&fixture.collection.name);
-        let event = with_connection(&context.pool, async |conn| emit_event(conn, &event).await)
-            .await
-            .unwrap();
-        fanout_event(&context.pool, event.id).await.unwrap();
-
-        let delivery = with_connection(&context.pool, async |conn| {
-            use crate::schema::event_deliveries::dsl::{event_deliveries, event_id};
-
-            event_deliveries
-                .filter(event_id.eq(event.id))
-                .first::<EventDelivery>(conn)
-                .await
-        })
         .await
         .unwrap();
 
@@ -171,16 +153,9 @@ mod tests {
     async fn test_event_delivery_dead_letter_does_not_rewrite_succeeded_delivery() {
         let context = TestContext::new().await;
         let delivery = create_delivery(&context).await.delivery;
-        with_connection(&context.pool, async |conn| {
-            use crate::schema::event_deliveries::dsl::{event_deliveries, id, status};
-
-            diesel::update(event_deliveries.filter(id.eq(delivery.id)))
-                .set(status.eq(EventDeliveryStatus::Succeeded.as_str()))
-                .execute(conn)
-                .await
-        })
-        .await
-        .unwrap();
+        set_event_delivery_status(&context.pool, delivery.id, EventDeliveryStatus::Succeeded)
+            .await
+            .unwrap();
 
         let resp = post_request(
             &context.pool,
@@ -196,16 +171,9 @@ mod tests {
     async fn test_event_delivery_list_applies_status_filter_to_rows_and_total() {
         let context = TestContext::new().await;
         let dead = create_delivery(&context).await.delivery;
-        with_connection(&context.pool, async |conn| {
-            use crate::schema::event_deliveries::dsl::{event_deliveries, id, status};
-
-            diesel::update(event_deliveries.filter(id.eq(dead.id)))
-                .set(status.eq(EventDeliveryStatus::Dead.as_str()))
-                .execute(conn)
-                .await
-        })
-        .await
-        .unwrap();
+        set_event_delivery_status(&context.pool, dead.id, EventDeliveryStatus::Dead)
+            .await
+            .unwrap();
 
         let resp = get_request(
             &context.pool,
@@ -238,18 +206,9 @@ mod tests {
         let context = TestContext::new().await;
         let delivery = create_delivery(&context).await.delivery;
         let claim_token = uuid::Uuid::new_v4();
-        with_connection(&context.pool, async |conn| {
-            use crate::schema::event_deliveries::dsl::{
-                claim_token as token, event_deliveries, id,
-            };
-
-            diesel::update(event_deliveries.filter(id.eq(delivery.id)))
-                .set(token.eq(Some(claim_token)))
-                .execute(conn)
-                .await
-        })
-        .await
-        .unwrap();
+        set_event_delivery_claim_token(&context.pool, delivery.id, claim_token)
+            .await
+            .unwrap();
 
         let resp = get_request(
             &context.pool,


### PR DESCRIPTION
## Summary

- move the event-delivery persistence row, Diesel mappings, SQL cursor mapping,
  and internal claim token into the PostgreSQL adapter
- keep the application-facing delivery DTOs backend-neutral while retaining the
  mandatory event-delivery administration and worker storage contracts
- route platform-suite fixture setup through explicit test-support APIs instead
  of opening PostgreSQL connections or mutating delivery tables directly
- add architectural guards and documentation for the completed event-delivery
  persistence boundary

## Architecture

`EventDeliveryResponse`, `EventDeliveryUpdateResponse`, health projections, IDs,
and statuses remain public storage-neutral DTOs. The PostgreSQL adapter now owns
`EventDeliveryRow`, including its Diesel/schema integration, SQL cursor behavior,
and claim token. Row-returning query helpers are crate-private, and the few
fixture-only operations are compiled only with `integration-test-support`.

This preserves the required `EventDeliveryAdministrationStorage` and worker
capabilities: a backend must still implement the complete lifecycle rather than
silently exposing a partial event-delivery feature set. No storage contract
version change is needed because the mandatory trait surface and DTO semantics
are unchanged.

The HTTP behavior is unchanged, including list/filter/cursor responses, retry
and dead-letter transitions, fanout, claiming, and health reporting. Internal
claim tokens remain absent from API responses and are now physically confined
to the adapter.

## Compatibility and operations

- PostgreSQL remains behaviorally unchanged.
- Platform compatibility tests now exercise delivery behavior through the same
  application/test boundary available to backend suites.
- Adapter-row debug output redacts both claim tokens and recorded delivery
  errors.
- Boundary tests reject future Diesel, schema, SQL cursor, PostgreSQL row, and
  direct-connection leakage into the public model and platform request tests.

## Changelog and API schema

This is an internal architecture refactor with no user-facing behavior change,
so no changelog entry is warranted. The HTTP schema is unchanged, so OpenAPI
regeneration is not required.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `scripts/test-classify-ci-changes.sh`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`

Stacked above #326.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
