### PR TITLE
Enforce relation persistence boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Breaking (administrator API):** the storage contract version is now `23`.
+  Class- and object-relation point operations, lifecycle writes, and deliberately
+  event-suppressed compatibility writes now cross the same mandatory, uniformly
+  observed backend contract. Relation persistence rows, graph query rows,
+  Diesel mappings, and SQL cursor mappings are owned by the PostgreSQL adapter;
+  domain models and application adapters exchange backend-neutral values.
+  Required capability labels and public HTTP request and response shapes are
+  unchanged. Administration and monitoring clients matching contract version
+  `22` must accept version `23`.
 - **Breaking (administrator API):** the storage contract version is now `22`
   and the required capability list includes `inventory_queries`. Inventory
   totals and per-class object counts are now a mandatory, compatibility-tested

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -182,7 +182,7 @@ use std::fmt;
 ///
 /// Increment this when a selectable backend must implement a new capability
 /// family or when an existing family's externally observable semantics change.
-pub const STORAGE_CONTRACT_VERSION: u16 = 22;
+pub const STORAGE_CONTRACT_VERSION: u16 = 23;
 
 /// Stable identity of a selectable storage backend.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -119,13 +119,13 @@ considered complete merely because a marker exists.
 PostgreSQL query implementations live in
 `src/storage/postgres/operations/*`. Export-template, remote-target, event,
 event-sink, event-subscription, and event-delivery lifecycle rows are
-adapter-owned, as are object lifecycle and object-history rows, remote-target
-history, and remote-call result persistence rows. Domain object, create, update,
-history, and per-class count values contain no Diesel derives, schema bindings,
-or SQL cursor mappings. Those mappings and explicit conversions live in the
-PostgreSQL adapter. Remaining mixed persistence rows move there as their
-backend-neutral DTOs are extracted. Their current locations are implementation
-details, not partial backend support.
+adapter-owned, as are object lifecycle and object-history rows, class- and
+object-relation rows, relation graph query rows, remote-target history, and
+remote-call result persistence rows. Domain object and relation values contain
+no Diesel derives, schema bindings, or SQL cursor mappings. Those mappings and
+explicit conversions live in the PostgreSQL adapter. Remaining mixed
+persistence rows move there as their backend-neutral DTOs are extracted. Their
+current locations are implementation details, not partial backend support.
 `StorageHandle` selects one certified PostgreSQL adapter, and only the storage
 implementation can recover its pool.
 Application consumers use `StorageContext`, lifecycle traits, mandatory
@@ -135,10 +135,14 @@ composition without implementing every operation behind those contracts.
 The storage contract version changes when a required family is added or when
 observable semantics change. The selected backend and contract version are
 reported in startup logs, process metrics, and the redacted admin configuration.
-Version 22 additionally requires consistent administrative inventory queries,
-the `inventory_queries` capability label, and mandatory object point-operation
-abstraction. Version 21 required the complete export-template lifecycle and a
-new `export_template_lifecycle` capability label. Version 20 required
+Version 23 additionally requires class- and object-relation point operations,
+lifecycle writes, and event-suppressed compatibility writes to cross the same
+mandatory, observed storage contract. Relation persistence and graph query rows,
+Diesel mappings, and SQL cursor mappings are adapter-owned. Version 22 required
+consistent administrative inventory queries, the `inventory_queries`
+capability label, and mandatory object point-operation abstraction. Version 21
+required the complete export-template lifecycle and a new
+`export_template_lifecycle` capability label. Version 20 required
 coordinated initial-administrator bootstrap,
 atomic local-password replacement with token revocation, the complete stored
 template set for administrator audits, and backend-aggregated export-template

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -454,7 +454,7 @@ mod tests {
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
         assert!(json.contains("\"backend\":\"postgresql\""));
-        assert!(json.contains("\"contract_version\":22"));
+        assert!(json.contains("\"contract_version\":23"));
         assert!(json.contains("\"catalog_queries\""));
         assert!(json.contains("\"computed_object_queries\""));
         assert!(json.contains("\"computed_field_lifecycle\""));

--- a/src/models/relation.rs
+++ b/src/models/relation.rs
@@ -1,11 +1,4 @@
-use crate::storage::postgres::prelude::*;
 use async_trait::async_trait;
-use diesel::deserialize::{self, FromSql, FromSqlRow};
-use diesel::expression::AsExpression;
-use diesel::pg::{Pg, PgValue};
-use diesel::serialize::{self, Output, ToSql};
-use diesel::sql_types::{Array, BigInt, Bool, Integer, Jsonb, Nullable, Text, Timestamp};
-
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use utoipa::openapi::schema::{Schema, Type};
@@ -19,7 +12,6 @@ use crate::models::{
 use crate::permissions::{AuthzTarget, ResourceAttrs, ResourceKind, ResourceRef};
 use crate::traits::SelfAccessors;
 use crate::utilities::aliases::normalize_template_alias;
-use crate::{schema::hubuumclass_relation, schema::hubuumobject_relation};
 
 crate::int_id_newtype! {
     /// Identifier wrapper for a [`HubuumClassRelation`].
@@ -29,8 +21,7 @@ crate::int_id_newtype! {
 
 /// Maximum number of object relations allowed for one object on one side of a
 /// class relation.
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, AsExpression, FromSqlRow)]
-#[diesel(sql_type = Integer)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub struct ObjectRelationLimit(i32);
 
 impl ObjectRelationLimit {
@@ -60,19 +51,6 @@ impl<'de> Deserialize<'de> for ObjectRelationLimit {
     }
 }
 
-impl FromSql<Integer, Pg> for ObjectRelationLimit {
-    fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
-        let value = i32::from_sql(value)?;
-        Self::new(value).map_err(|error| error.to_string().into())
-    }
-}
-
-impl ToSql<Integer, Pg> for ObjectRelationLimit {
-    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
-        <i32 as ToSql<Integer, Pg>>::to_sql(&self.0, out)
-    }
-}
-
 impl utoipa::PartialSchema for ObjectRelationLimit {
     fn schema() -> RefOr<Schema> {
         ObjectBuilder::new()
@@ -88,8 +66,7 @@ impl utoipa::PartialSchema for ObjectRelationLimit {
 
 impl ToSchema for ObjectRelationLimit {}
 
-#[derive(Debug, Serialize, Deserialize, Queryable, Clone, PartialEq, Eq, ToSchema)]
-#[diesel(table_name = hubuumclass_relation)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema)]
 pub struct HubuumClassRelation {
     pub id: i32,
     pub from_hubuum_class_id: i32,
@@ -107,9 +84,8 @@ pub struct HubuumClassRelation {
     pub revision: ResourceRevision,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Insertable, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[schema(example = new_hubuum_class_relation_example)]
-#[diesel(table_name = hubuumclass_relation)]
 pub struct NewHubuumClassRelation {
     pub from_hubuum_class_id: i32,
     pub to_hubuum_class_id: i32,
@@ -317,8 +293,7 @@ crate::int_id_newtype! {
     noun = "object relation id";
 }
 
-#[derive(Debug, Serialize, Deserialize, Queryable, Clone, Copy, PartialEq, Eq, ToSchema)]
-#[diesel(table_name = hubuumobject_relation)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, ToSchema)]
 pub struct HubuumObjectRelation {
     pub id: i32,
     pub from_hubuum_object_id: i32,
@@ -329,9 +304,8 @@ pub struct HubuumObjectRelation {
     pub revision: ResourceRevision,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Insertable, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[schema(example = new_hubuum_object_relation_example)]
-#[diesel(table_name = hubuumobject_relation)]
 pub struct NewHubuumObjectRelation {
     pub from_hubuum_object_id: i32,
     pub to_hubuum_object_id: i32,
@@ -605,77 +579,59 @@ impl ResolvedObjectRelationTarget {
 /// To create new relations between objects from within a
 /// path where we already provide the class and object IDs
 /// we only need the destination object ID.
-#[derive(Debug, Serialize, Deserialize, Insertable, Clone, ToSchema)]
-#[diesel(table_name = hubuumobject_relation)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct NewHubuumObjectRelationFromClassAndObject {
     pub to_hubuum_object_id: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize, QueryableByName, Clone, PartialEq, Eq, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema)]
 pub struct HubuumClassRelationTransitive {
-    #[diesel(sql_type = Integer)]
     pub ancestor_class_id: i32,
-    #[diesel(sql_type = Integer)]
     pub descendant_class_id: i32,
-    #[diesel(sql_type = Integer)]
     pub depth: i32,
-    #[diesel(sql_type = Array<Nullable<Integer>>)]
     pub path: Vec<Option<i32>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, QueryableByName, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct HubuumObjectTransitiveLink {
-    #[diesel(sql_type = Integer)]
     target_object_id: i32,
-    #[diesel(sql_type = Array<Integer>)]
     path: Vec<i32>,
 }
 
-#[derive(Debug, Queryable, QueryableByName, Serialize, Deserialize, Clone)]
+impl HubuumObjectTransitiveLink {
+    pub(crate) fn new(target_object_id: i32, path: Vec<i32>) -> Self {
+        Self {
+            target_object_id,
+            path,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ClassGraphRow {
-    #[diesel(sql_type = Integer)]
     pub ancestor_class_id: i32,
-    #[diesel(sql_type = Integer)]
     pub descendant_class_id: i32,
-    #[diesel(sql_type = Integer)]
     pub depth: i32,
-    #[diesel(sql_type = Array<Integer>)]
     pub path: Vec<i32>,
-    #[diesel(sql_type = Text)]
     pub ancestor_name: String,
-    #[diesel(sql_type = Text)]
     pub descendant_name: String,
-    #[diesel(sql_type = Integer)]
     pub ancestor_collection_id: i32,
-    #[diesel(sql_type = Integer)]
     pub descendant_collection_id: i32,
-    #[diesel(sql_type = Nullable<Jsonb>)]
     pub ancestor_json_schema: Option<serde_json::Value>,
-    #[diesel(sql_type = Nullable<Jsonb>)]
     pub descendant_json_schema: Option<serde_json::Value>,
-    #[diesel(sql_type = Bool)]
     pub ancestor_validate_schema: bool,
-    #[diesel(sql_type = Bool)]
     pub descendant_validate_schema: bool,
-    #[diesel(sql_type = Text)]
     pub ancestor_description: String,
-    #[diesel(sql_type = Text)]
     pub descendant_description: String,
-    #[diesel(sql_type = Timestamp)]
     pub ancestor_created_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = Timestamp)]
     pub descendant_created_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = Timestamp)]
     pub ancestor_updated_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = Timestamp)]
     pub descendant_updated_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = BigInt)]
     pub ancestor_revision: ResourceRevision,
-    #[diesel(sql_type = BigInt)]
     pub descendant_revision: ResourceRevision,
 }
 
-#[derive(Debug, Queryable, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ObjectGraphRow {
     pub ancestor_object_id: i32,
     pub descendant_object_id: i32,
@@ -699,121 +655,68 @@ pub struct ObjectGraphRow {
     pub descendant_revision: ResourceRevision,
 }
 
-#[derive(Debug, QueryableByName, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RelatedObjectGraphRow {
-    #[diesel(sql_type = Integer)]
     pub ancestor_object_id: i32,
-    #[diesel(sql_type = Integer)]
     pub descendant_object_id: i32,
-    #[diesel(sql_type = Integer)]
     pub depth: i32,
-    #[diesel(sql_type = Array<Integer>)]
     pub path: Vec<i32>,
-    #[diesel(sql_type = Text)]
     pub ancestor_name: String,
-    #[diesel(sql_type = Text)]
     pub descendant_name: String,
-    #[diesel(sql_type = Integer)]
     pub ancestor_collection_id: i32,
-    #[diesel(sql_type = Integer)]
     pub descendant_collection_id: i32,
-    #[diesel(sql_type = Integer)]
     pub ancestor_class_id: i32,
-    #[diesel(sql_type = Integer)]
     pub descendant_class_id: i32,
-    #[diesel(sql_type = Text)]
     pub ancestor_description: String,
-    #[diesel(sql_type = Text)]
     pub descendant_description: String,
-    #[diesel(sql_type = Jsonb)]
     pub ancestor_data: serde_json::Value,
-    #[diesel(sql_type = Jsonb)]
     pub descendant_data: serde_json::Value,
-    #[diesel(sql_type = Timestamp)]
     pub ancestor_created_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = Timestamp)]
     pub descendant_created_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = Timestamp)]
     pub ancestor_updated_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = Timestamp)]
     pub descendant_updated_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = BigInt)]
     pub ancestor_revision: ResourceRevision,
-    #[diesel(sql_type = BigInt)]
     pub descendant_revision: ResourceRevision,
 }
 
-#[derive(Debug, QueryableByName, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RelatedObjectIncludeRow {
-    #[diesel(sql_type = Integer)]
     pub root_object_id: i32,
-    #[diesel(sql_type = Integer)]
     pub ancestor_object_id: i32,
-    #[diesel(sql_type = Integer)]
     pub descendant_object_id: i32,
-    #[diesel(sql_type = Integer)]
     pub depth: i32,
-    #[diesel(sql_type = Array<Integer>)]
     pub path: Vec<i32>,
-    #[diesel(sql_type = Text)]
     pub ancestor_name: String,
-    #[diesel(sql_type = Text)]
     pub descendant_name: String,
-    #[diesel(sql_type = Integer)]
     pub ancestor_collection_id: i32,
-    #[diesel(sql_type = Integer)]
     pub descendant_collection_id: i32,
-    #[diesel(sql_type = Integer)]
     pub ancestor_class_id: i32,
-    #[diesel(sql_type = Integer)]
     pub descendant_class_id: i32,
-    #[diesel(sql_type = Text)]
     pub ancestor_description: String,
-    #[diesel(sql_type = Text)]
     pub descendant_description: String,
-    #[diesel(sql_type = Jsonb)]
     pub ancestor_data: serde_json::Value,
-    #[diesel(sql_type = Jsonb)]
     pub descendant_data: serde_json::Value,
-    #[diesel(sql_type = Timestamp)]
     pub ancestor_created_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = Timestamp)]
     pub descendant_created_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = Timestamp)]
     pub ancestor_updated_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = Timestamp)]
     pub descendant_updated_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = BigInt)]
     pub ancestor_revision: ResourceRevision,
-    #[diesel(sql_type = BigInt)]
     pub descendant_revision: ResourceRevision,
 }
 
-#[derive(Debug, QueryableByName, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RelatedObjectForRootRow {
-    #[diesel(sql_type = Integer)]
     pub root_object_id: i32,
-    #[diesel(sql_type = Integer)]
     pub descendant_object_id: i32,
-    #[diesel(sql_type = Integer)]
     pub depth: i32,
-    #[diesel(sql_type = Array<Integer>)]
     pub path: Vec<i32>,
-    #[diesel(sql_type = Text)]
     pub descendant_name: String,
-    #[diesel(sql_type = Integer)]
     pub descendant_collection_id: i32,
-    #[diesel(sql_type = Integer)]
     pub descendant_class_id: i32,
-    #[diesel(sql_type = Text)]
     pub descendant_description: String,
-    #[diesel(sql_type = Jsonb)]
     pub descendant_data: serde_json::Value,
-    #[diesel(sql_type = Timestamp)]
     pub descendant_created_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = Timestamp)]
     pub descendant_updated_at: chrono::NaiveDateTime,
-    #[diesel(sql_type = BigInt)]
     pub descendant_revision: ResourceRevision,
 }
 

--- a/src/models/traits/class_relation.rs
+++ b/src/models/traits/class_relation.rs
@@ -1,24 +1,91 @@
 use crate::errors::ApiError;
 use crate::events::EventContext;
-use crate::storage::postgres::operations::relations::{
-    DeleteClassRelationRecord, LoadClassRelationRecord, SaveClassRelationRecord,
-};
 
 use crate::models::search::{FilterField, SortParam};
 use crate::models::{
     ClassGraphRow, Collection, CollectionID, HubuumClass, HubuumClassID, HubuumClassRelation,
     HubuumClassRelationID, HubuumClassRelationTransitive, HubuumClassWithPath, HubuumObject,
     HubuumObjectID, HubuumObjectRelation, HubuumObjectRelationID, NewHubuumClassRelation,
-    NewHubuumObjectRelation, ObjectGraphRow, RelatedObjectGraphRow,
+    NewHubuumObjectRelation, ObjectGraphRow, ObjectRelationCreateSelector, ObjectRelationSelector,
+    PreparedClassRelation, PreparedObjectRelation, RelatedObjectGraphRow,
+    ResolvedClassRelationTarget, ResolvedObjectRelationTarget,
 };
+use crate::storage::{StorageContext, storage_handle};
 use crate::traits::accessors::{
     ClassAdapter, CollectionAdapter, IdAccessor, InstanceAdapter, ObjectAdapter,
 };
 use crate::traits::crud::{DeleteAdapter, SaveAdapter};
 use crate::traits::{
-    ClassAccessors, CollectionAccessors, CursorPaginated, CursorSqlField, CursorSqlMapping,
-    CursorSqlType, CursorValue, ObjectAccessors, SelfAccessors,
+    ClassAccessors, CollectionAccessors, CursorPaginated, CursorValue, ObjectAccessors,
+    SelfAccessors,
 };
+
+async fn prepare_class_relation(
+    backend: &impl StorageContext,
+    command: &NewHubuumClassRelation,
+) -> Result<PreparedClassRelation, ApiError> {
+    storage_handle(backend)
+        .lifecycle_storage()
+        .inner()
+        .prepare_class_relation(command.clone())
+        .await
+        .map_err(ApiError::from)
+}
+
+async fn resolve_class_relation(
+    backend: &impl StorageContext,
+    id: HubuumClassRelationID,
+) -> Result<ResolvedClassRelationTarget, ApiError> {
+    storage_handle(backend)
+        .lifecycle_storage()
+        .inner()
+        .resolve_class_relation(id)
+        .await
+        .map_err(ApiError::from)
+}
+
+async fn prepare_object_relation(
+    backend: &impl StorageContext,
+    command: &NewHubuumObjectRelation,
+) -> Result<PreparedObjectRelation, ApiError> {
+    storage_handle(backend)
+        .lifecycle_storage()
+        .inner()
+        .prepare_object_relation(ObjectRelationCreateSelector::explicit(command.clone()))
+        .await
+        .map_err(ApiError::from)
+}
+
+async fn resolve_object_relation(
+    backend: &impl StorageContext,
+    id: HubuumObjectRelationID,
+) -> Result<ResolvedObjectRelationTarget, ApiError> {
+    storage_handle(backend)
+        .lifecycle_storage()
+        .inner()
+        .resolve_object_relation(ObjectRelationSelector::by_id(id))
+        .await
+        .map_err(ApiError::from)
+}
+
+async fn relation_collections(
+    backend: &impl StorageContext,
+    from_collection_id: i32,
+    to_collection_id: i32,
+) -> Result<(Collection, Collection), ApiError> {
+    let storage = storage_handle(backend).lifecycle_storage();
+    let from_collection = storage
+        .inner()
+        .get_collection(CollectionID::new(from_collection_id)?)
+        .await
+        .map_err(ApiError::from)?;
+    let to_collection = storage
+        .inner()
+        .get_collection(CollectionID::new(to_collection_id)?)
+        .await
+        .map_err(ApiError::from)?;
+    Ok((from_collection, to_collection))
+}
 
 impl IdAccessor for HubuumClassRelationID {
     fn accessor_id(&self) -> i32 {
@@ -34,7 +101,10 @@ impl InstanceAdapter<HubuumClassRelation> for HubuumClassRelationID {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<HubuumClassRelation, ApiError> {
-        self.load_class_relation_record(pool).await
+        Ok(resolve_class_relation(pool, *self)
+            .await?
+            .relation()
+            .clone())
     }
 }
 impl IdAccessor for HubuumClassRelation {
@@ -57,7 +127,12 @@ impl DeleteAdapter for HubuumClassRelation {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(), ApiError> {
-        self.delete_class_relation_record_without_events(pool).await
+        storage_handle(pool)
+            .lifecycle_storage()
+            .inner()
+            .delete_class_relation_by_id(HubuumClassRelationID::new(self.id)?, None)
+            .await
+            .map_err(ApiError::from)
     }
 
     async fn delete_adapter(
@@ -65,7 +140,12 @@ impl DeleteAdapter for HubuumClassRelation {
         pool: &impl crate::storage::StorageContext,
         context: &EventContext,
     ) -> Result<(), ApiError> {
-        self.delete_class_relation_record(pool, Some(context)).await
+        storage_handle(pool)
+            .lifecycle_storage()
+            .inner()
+            .delete_class_relation_by_id(HubuumClassRelationID::new(self.id)?, Some(context))
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -76,7 +156,12 @@ impl SaveAdapter for NewHubuumClassRelation {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<HubuumClassRelation, ApiError> {
-        self.save_class_relation_record_without_events(pool).await
+        storage_handle(pool)
+            .lifecycle_storage()
+            .inner()
+            .create_class_relation_from_command(self.clone(), None)
+            .await
+            .map_err(ApiError::from)
     }
 
     async fn save_adapter(
@@ -84,7 +169,12 @@ impl SaveAdapter for NewHubuumClassRelation {
         pool: &impl crate::storage::StorageContext,
         context: &EventContext,
     ) -> Result<HubuumClassRelation, ApiError> {
-        self.save_class_relation_record(pool, Some(context)).await
+        storage_handle(pool)
+            .lifecycle_storage()
+            .inner()
+            .create_class_relation_from_command(self.clone(), Some(context))
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -93,7 +183,12 @@ impl DeleteAdapter for HubuumClassRelationID {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(), ApiError> {
-        self.delete_class_relation_record_without_events(pool).await
+        storage_handle(pool)
+            .lifecycle_storage()
+            .inner()
+            .delete_class_relation_by_id(*self, None)
+            .await
+            .map_err(ApiError::from)
     }
 
     async fn delete_adapter(
@@ -101,7 +196,12 @@ impl DeleteAdapter for HubuumClassRelationID {
         pool: &impl crate::storage::StorageContext,
         context: &EventContext,
     ) -> Result<(), ApiError> {
-        self.delete_class_relation_record(pool, Some(context)).await
+        storage_handle(pool)
+            .lifecycle_storage()
+            .inner()
+            .delete_class_relation_by_id(*self, Some(context))
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -112,8 +212,13 @@ impl CollectionAdapter<(Collection, Collection), (CollectionID, CollectionID)>
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(Collection, Collection), ApiError> {
-        use crate::storage::postgres::operations::GetCollection;
-        self.collection_from_backend(pool).await
+        let prepared = prepare_class_relation(pool, self).await?;
+        relation_collections(
+            pool,
+            prepared.from_class().collection_id,
+            prepared.to_class().collection_id,
+        )
+        .await
     }
 
     async fn collection_id_adapter(
@@ -135,8 +240,13 @@ impl CollectionAdapter<(Collection, Collection), (CollectionID, CollectionID)>
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(Collection, Collection), ApiError> {
-        use crate::storage::postgres::operations::GetCollection;
-        self.collection_from_backend(pool).await
+        let prepared = prepare_object_relation(pool, self).await?;
+        relation_collections(
+            pool,
+            prepared.from_object().collection_id,
+            prepared.to_object().collection_id,
+        )
+        .await
     }
 
     async fn collection_id_adapter(
@@ -176,8 +286,13 @@ impl CollectionAdapter<(Collection, Collection), (CollectionID, CollectionID)>
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(Collection, Collection), ApiError> {
-        use crate::storage::postgres::operations::GetCollection;
-        self.collection_from_backend(pool).await
+        let target = resolve_object_relation(pool, HubuumObjectRelationID::new(self.id)?).await?;
+        relation_collections(
+            pool,
+            target.from_object().collection_id,
+            target.to_object().collection_id,
+        )
+        .await
     }
 
     async fn collection_id_adapter(
@@ -199,8 +314,13 @@ impl CollectionAdapter<(Collection, Collection), (CollectionID, CollectionID)>
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(Collection, Collection), ApiError> {
-        use crate::storage::postgres::operations::GetCollection;
-        self.collection_from_backend(pool).await
+        let target = resolve_class_relation(pool, HubuumClassRelationID::new(self.id)?).await?;
+        relation_collections(
+            pool,
+            target.from_class().collection_id,
+            target.to_class().collection_id,
+        )
+        .await
     }
 
     async fn collection_id_adapter(
@@ -222,8 +342,8 @@ impl ClassAdapter<(HubuumClass, HubuumClass), (HubuumClassID, HubuumClassID)>
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(HubuumClass, HubuumClass), ApiError> {
-        use crate::storage::postgres::operations::GetClass;
-        self.class_from_backend(pool).await
+        let target = resolve_class_relation(pool, HubuumClassRelationID::new(self.id)?).await?;
+        Ok((target.from_class().clone(), target.to_class().clone()))
     }
 
     async fn class_id_adapter(
@@ -262,8 +382,8 @@ impl ClassAdapter<(HubuumClass, HubuumClass), (HubuumClassID, HubuumClassID)>
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(HubuumClass, HubuumClass), ApiError> {
-        use crate::storage::postgres::operations::GetClass;
-        self.class_from_backend(pool).await
+        let target = resolve_class_relation(pool, *self).await?;
+        Ok((target.from_class().clone(), target.to_class().clone()))
     }
 
     async fn class_id_adapter(
@@ -281,8 +401,8 @@ impl ClassAdapter<(HubuumClass, HubuumClass), (HubuumClassID, HubuumClassID)>
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(HubuumClass, HubuumClass), ApiError> {
-        use crate::storage::postgres::operations::GetClass;
-        self.class_from_backend(pool).await
+        let prepared = prepare_class_relation(pool, self).await?;
+        Ok((prepared.from_class().clone(), prepared.to_class().clone()))
     }
 
     async fn class_id_adapter(
@@ -303,8 +423,8 @@ impl ObjectAdapter<(HubuumObject, HubuumObject), (HubuumObjectID, HubuumObjectID
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(HubuumObject, HubuumObject), ApiError> {
-        use crate::storage::postgres::operations::GetObject;
-        self.object_from_backend(pool).await
+        let prepared = prepare_object_relation(pool, self).await?;
+        Ok((prepared.from_object().clone(), prepared.to_object().clone()))
     }
 
     async fn object_id_adapter(
@@ -325,8 +445,8 @@ impl ObjectAdapter<(HubuumObject, HubuumObject), (HubuumObjectID, HubuumObjectID
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(HubuumObject, HubuumObject), ApiError> {
-        use crate::storage::postgres::operations::GetObject;
-        self.object_from_backend(pool).await
+        let target = resolve_object_relation(pool, *self).await?;
+        Ok((target.from_object().clone(), target.to_object().clone()))
     }
 
     async fn object_id_adapter(
@@ -344,8 +464,8 @@ impl ObjectAdapter<(HubuumObject, HubuumObject), (HubuumObjectID, HubuumObjectID
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(HubuumObject, HubuumObject), ApiError> {
-        use crate::storage::postgres::operations::GetObject;
-        self.object_from_backend(pool).await
+        let target = resolve_object_relation(pool, HubuumObjectRelationID::new(self.id)?).await?;
+        Ok((target.from_object().clone(), target.to_object().clone()))
     }
 
     async fn object_id_adapter(
@@ -472,49 +592,6 @@ impl CursorPaginated for HubuumClassRelation {
     }
 }
 
-impl CursorSqlMapping for HubuumClassRelation {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id => CursorSqlField {
-                column: "hubuumclass_relation.id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::ClassFrom => CursorSqlField {
-                column: "hubuumclass_relation.from_hubuum_class_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::ClassTo => CursorSqlField {
-                column: "hubuumclass_relation.to_hubuum_class_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::CreatedAt => CursorSqlField {
-                column: "hubuumclass_relation.created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAt => CursorSqlField {
-                column: "hubuumclass_relation.updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::Revision => CursorSqlField {
-                column: "hubuumclass_relation.revision",
-                sql_type: CursorSqlType::BigInt,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for class relations",
-                    field
-                )));
-            }
-        })
-    }
-}
-
 impl CursorPaginated for HubuumObjectRelation {
     fn supports_sort(field: &FilterField) -> bool {
         matches!(
@@ -556,54 +633,6 @@ impl CursorPaginated for HubuumObjectRelation {
 
     fn tie_breaker_sort() -> Vec<SortParam> {
         Self::default_sort()
-    }
-}
-
-impl CursorSqlMapping for HubuumObjectRelation {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id => CursorSqlField {
-                column: "hubuumobject_relation.id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::ClassRelation => CursorSqlField {
-                column: "hubuumobject_relation.class_relation_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::ObjectFrom => CursorSqlField {
-                column: "hubuumobject_relation.from_hubuum_object_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::ObjectTo => CursorSqlField {
-                column: "hubuumobject_relation.to_hubuum_object_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::CreatedAt => CursorSqlField {
-                column: "hubuumobject_relation.created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAt => CursorSqlField {
-                column: "hubuumobject_relation.updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::Revision => CursorSqlField {
-                column: "hubuumobject_relation.revision",
-                sql_type: CursorSqlType::BigInt,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for object relations",
-                    field
-                )));
-            }
-        })
     }
 }
 
@@ -664,39 +693,6 @@ impl CursorPaginated for HubuumClassRelationTransitive {
                 descending: false,
             },
         ]
-    }
-}
-
-impl CursorSqlMapping for HubuumClassRelationTransitive {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::ClassFrom => CursorSqlField {
-                column: "ancestor_class_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::ClassTo => CursorSqlField {
-                column: "descendant_class_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Depth => CursorSqlField {
-                column: "depth",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Path => CursorSqlField {
-                column: "path",
-                sql_type: CursorSqlType::IntegerArray,
-                nullable: true,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for transitive class relations",
-                    field
-                )));
-            }
-        })
     }
 }
 
@@ -785,94 +781,6 @@ impl CursorPaginated for ClassGraphRow {
 
     fn tie_breaker_sort() -> Vec<SortParam> {
         Self::default_sort()
-    }
-}
-
-impl CursorSqlMapping for ClassGraphRow {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id
-            | FilterField::ClassTo
-            | FilterField::ClassId
-            | FilterField::Classes => CursorSqlField {
-                column: "related_classes.descendant_class_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::ClassFrom => CursorSqlField {
-                column: "related_classes.ancestor_class_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Name | FilterField::NameTo => CursorSqlField {
-                column: "related_classes.descendant_name",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::NameFrom => CursorSqlField {
-                column: "related_classes.ancestor_name",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::Description | FilterField::DescriptionTo => CursorSqlField {
-                column: "related_classes.descendant_description",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::DescriptionFrom => CursorSqlField {
-                column: "related_classes.ancestor_description",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::Collections | FilterField::CollectionId | FilterField::CollectionsTo => {
-                CursorSqlField {
-                    column: "related_classes.descendant_collection_id",
-                    sql_type: CursorSqlType::Integer,
-                    nullable: false,
-                }
-            }
-            FilterField::CollectionsFrom => CursorSqlField {
-                column: "related_classes.ancestor_collection_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::CreatedAt | FilterField::CreatedAtTo => CursorSqlField {
-                column: "related_classes.descendant_created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::CreatedAtFrom => CursorSqlField {
-                column: "related_classes.ancestor_created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAt | FilterField::UpdatedAtTo => CursorSqlField {
-                column: "related_classes.descendant_updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAtFrom => CursorSqlField {
-                column: "related_classes.ancestor_updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::Depth => CursorSqlField {
-                column: "related_classes.depth",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Path => CursorSqlField {
-                column: "related_classes.path",
-                sql_type: CursorSqlType::IntegerArray,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for related classes",
-                    field
-                )));
-            }
-        })
     }
 }
 
@@ -969,101 +877,6 @@ impl CursorPaginated for ObjectGraphRow {
     }
 }
 
-impl CursorSqlMapping for ObjectGraphRow {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id | FilterField::ObjectTo => CursorSqlField {
-                column: "descendant_object_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::ObjectFrom => CursorSqlField {
-                column: "ancestor_object_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Name | FilterField::NameTo => CursorSqlField {
-                column: "descendant_name",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::NameFrom => CursorSqlField {
-                column: "ancestor_name",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::Description | FilterField::DescriptionTo => CursorSqlField {
-                column: "descendant_description",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::DescriptionFrom => CursorSqlField {
-                column: "ancestor_description",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::Collections | FilterField::CollectionId | FilterField::CollectionsTo => {
-                CursorSqlField {
-                    column: "descendant_collection_id",
-                    sql_type: CursorSqlType::Integer,
-                    nullable: false,
-                }
-            }
-            FilterField::CollectionsFrom => CursorSqlField {
-                column: "ancestor_collection_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::ClassId | FilterField::Classes | FilterField::ClassTo => CursorSqlField {
-                column: "descendant_class_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::ClassFrom => CursorSqlField {
-                column: "ancestor_class_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::CreatedAt | FilterField::CreatedAtTo => CursorSqlField {
-                column: "descendant_created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::CreatedAtFrom => CursorSqlField {
-                column: "ancestor_created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAt | FilterField::UpdatedAtTo => CursorSqlField {
-                column: "descendant_updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAtFrom => CursorSqlField {
-                column: "ancestor_updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::Depth => CursorSqlField {
-                column: "depth",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Path => CursorSqlField {
-                column: "path",
-                sql_type: CursorSqlType::IntegerArray,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for related objects",
-                    field
-                )));
-            }
-        })
-    }
-}
-
 impl CursorPaginated for RelatedObjectGraphRow {
     fn supports_sort(field: &FilterField) -> bool {
         matches!(
@@ -1154,100 +967,5 @@ impl CursorPaginated for RelatedObjectGraphRow {
 
     fn tie_breaker_sort() -> Vec<SortParam> {
         Self::default_sort()
-    }
-}
-
-impl CursorSqlMapping for RelatedObjectGraphRow {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id | FilterField::ObjectTo => CursorSqlField {
-                column: "related_objects.descendant_object_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::ObjectFrom => CursorSqlField {
-                column: "related_objects.ancestor_object_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Name | FilterField::NameTo => CursorSqlField {
-                column: "related_objects.descendant_name",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::NameFrom => CursorSqlField {
-                column: "related_objects.ancestor_name",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::Description | FilterField::DescriptionTo => CursorSqlField {
-                column: "related_objects.descendant_description",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::DescriptionFrom => CursorSqlField {
-                column: "related_objects.ancestor_description",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::Collections | FilterField::CollectionId | FilterField::CollectionsTo => {
-                CursorSqlField {
-                    column: "related_objects.descendant_collection_id",
-                    sql_type: CursorSqlType::Integer,
-                    nullable: false,
-                }
-            }
-            FilterField::CollectionsFrom => CursorSqlField {
-                column: "related_objects.ancestor_collection_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::ClassId | FilterField::Classes | FilterField::ClassTo => CursorSqlField {
-                column: "related_objects.descendant_class_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::ClassFrom => CursorSqlField {
-                column: "related_objects.ancestor_class_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::CreatedAt | FilterField::CreatedAtTo => CursorSqlField {
-                column: "related_objects.descendant_created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::CreatedAtFrom => CursorSqlField {
-                column: "related_objects.ancestor_created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAt | FilterField::UpdatedAtTo => CursorSqlField {
-                column: "related_objects.descendant_updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAtFrom => CursorSqlField {
-                column: "related_objects.ancestor_updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::Depth => CursorSqlField {
-                column: "related_objects.depth",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Path => CursorSqlField {
-                column: "related_objects.path",
-                sql_type: CursorSqlType::IntegerArray,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for related objects",
-                    field
-                )));
-            }
-        })
     }
 }

--- a/src/models/traits/object_relation.rs
+++ b/src/models/traits/object_relation.rs
@@ -1,16 +1,26 @@
-use crate::storage::postgres::operations::relations::{
-    DeleteObjectRelationRecord, LoadObjectRelationRecord, SaveObjectRelationRecord,
-};
-
 use crate::errors::ApiError;
 use crate::events::EventContext;
 
 use crate::models::{
     HubuumObjectRelation, HubuumObjectRelationID, HubuumObjectWithPath, NewHubuumObjectRelation,
-    ObjectGraphRow, RelatedObjectForRootRow, RelatedObjectGraphRow, RelatedObjectIncludeRow,
+    ObjectGraphRow, ObjectRelationSelector, RelatedObjectForRootRow, RelatedObjectGraphRow,
+    RelatedObjectIncludeRow, ResolvedObjectRelationTarget,
 };
+use crate::storage::{StorageContext, storage_handle};
 use crate::traits::accessors::{IdAccessor, InstanceAdapter};
 use crate::traits::crud::{DeleteAdapter, SaveAdapter};
+
+async fn resolve_object_relation(
+    backend: &impl StorageContext,
+    id: HubuumObjectRelationID,
+) -> Result<ResolvedObjectRelationTarget, ApiError> {
+    storage_handle(backend)
+        .lifecycle_storage()
+        .inner()
+        .resolve_object_relation(ObjectRelationSelector::by_id(id))
+        .await
+        .map_err(ApiError::from)
+}
 
 impl IdAccessor for HubuumObjectRelationID {
     fn accessor_id(&self) -> i32 {
@@ -26,7 +36,7 @@ impl InstanceAdapter<HubuumObjectRelation> for HubuumObjectRelationID {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<HubuumObjectRelation, ApiError> {
-        self.load_object_relation_record(pool).await
+        Ok(*resolve_object_relation(pool, *self).await?.relation())
     }
 }
 impl IdAccessor for HubuumObjectRelation {
@@ -49,8 +59,12 @@ impl DeleteAdapter for HubuumObjectRelation {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(), ApiError> {
-        self.delete_object_relation_record_without_events(pool)
+        storage_handle(pool)
+            .lifecycle_storage()
+            .inner()
+            .delete_object_relation_by_id(HubuumObjectRelationID::new(self.id)?, None)
             .await
+            .map_err(ApiError::from)
     }
 
     async fn delete_adapter(
@@ -58,8 +72,12 @@ impl DeleteAdapter for HubuumObjectRelation {
         pool: &impl crate::storage::StorageContext,
         context: &EventContext,
     ) -> Result<(), ApiError> {
-        self.delete_object_relation_record(pool, Some(context))
+        storage_handle(pool)
+            .lifecycle_storage()
+            .inner()
+            .delete_object_relation_by_id(HubuumObjectRelationID::new(self.id)?, Some(context))
             .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -68,8 +86,12 @@ impl DeleteAdapter for HubuumObjectRelationID {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(), ApiError> {
-        self.delete_object_relation_record_without_events(pool)
+        storage_handle(pool)
+            .lifecycle_storage()
+            .inner()
+            .delete_object_relation_by_id(*self, None)
             .await
+            .map_err(ApiError::from)
     }
 
     async fn delete_adapter(
@@ -77,8 +99,12 @@ impl DeleteAdapter for HubuumObjectRelationID {
         pool: &impl crate::storage::StorageContext,
         context: &EventContext,
     ) -> Result<(), ApiError> {
-        self.delete_object_relation_record(pool, Some(context))
+        storage_handle(pool)
+            .lifecycle_storage()
+            .inner()
+            .delete_object_relation_by_id(*self, Some(context))
             .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -89,7 +115,12 @@ impl SaveAdapter for NewHubuumObjectRelation {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<HubuumObjectRelation, ApiError> {
-        self.save_object_relation_record_without_events(pool).await
+        storage_handle(pool)
+            .lifecycle_storage()
+            .inner()
+            .create_object_relation_from_command(self.clone(), None)
+            .await
+            .map_err(ApiError::from)
     }
 
     async fn save_adapter(
@@ -97,7 +128,12 @@ impl SaveAdapter for NewHubuumObjectRelation {
         pool: &impl crate::storage::StorageContext,
         context: &EventContext,
     ) -> Result<HubuumObjectRelation, ApiError> {
-        self.save_object_relation_record(pool, Some(context)).await
+        storage_handle(pool)
+            .lifecycle_storage()
+            .inner()
+            .create_object_relation_from_command(self.clone(), Some(context))
+            .await
+            .map_err(ApiError::from)
     }
 }
 

--- a/src/services/class_relations.rs
+++ b/src/services/class_relations.rs
@@ -46,7 +46,7 @@ impl ClassRelationService {
     ) -> Result<ResolvedClassRelationTarget, ApiError> {
         self.storage
             .inner()
-            .create_class_relation(prepared, context)
+            .create_class_relation(prepared, Some(context))
             .await
             .map_err(ApiError::from)
     }
@@ -58,7 +58,7 @@ impl ClassRelationService {
     ) -> Result<(), ApiError> {
         self.storage
             .inner()
-            .delete_class_relation(target, context)
+            .delete_class_relation(target, Some(context))
             .await
             .map_err(ApiError::from)
     }
@@ -290,6 +290,47 @@ mod tests {
         assert_eq!(resolved.relation().revision, ResourceRevision::INITIAL);
         assert_eq!(resolved.from_class(), &from_class);
         assert_eq!(resolved.to_class(), &to_class);
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
+    #[actix_web::test]
+    async fn class_relation_contract_supports_event_suppressed_compatibility_writes(
+        #[case] backend: ContractImplementation,
+    ) {
+        let harness = ContractHarness::new(backend, "event_suppressed").await;
+        let from_class = harness.create_class("from").await;
+        let to_class = harness.create_class("to").await;
+        let lifecycle = &harness.services.class_relations().storage;
+        let created = lifecycle
+            .inner()
+            .create_class_relation_from_command(harness.command(&from_class, &to_class), None)
+            .await
+            .expect("event-suppressed relation should create");
+        let relation_id = HubuumClassRelationID::new(created.id).expect("valid class relation id");
+        lifecycle
+            .inner()
+            .resolve_class_relation(relation_id)
+            .await
+            .expect("event-suppressed relation should resolve");
+        lifecycle
+            .inner()
+            .delete_class_relation_by_id(relation_id, None)
+            .await
+            .expect("event-suppressed relation should delete");
+
+        assert!(
+            lifecycle
+                .inner()
+                .resolve_class_relation(relation_id)
+                .await
+                .is_err()
+        );
+        if let Some(storage) = harness.storage.as_ref() {
+            assert!(storage.class_relation_events().await.is_empty());
+        }
         harness.finish().await;
     }
 

--- a/src/services/object_relations.rs
+++ b/src/services/object_relations.rs
@@ -46,7 +46,7 @@ impl ObjectRelationService {
     ) -> Result<ResolvedObjectRelationTarget, ApiError> {
         self.storage
             .inner()
-            .create_object_relation(prepared, context)
+            .create_object_relation(prepared, Some(context))
             .await
             .map_err(ApiError::from)
     }
@@ -58,7 +58,7 @@ impl ObjectRelationService {
     ) -> Result<(), ApiError> {
         self.storage
             .inner()
-            .delete_object_relation(target, context)
+            .delete_object_relation(target, Some(context))
             .await
             .map_err(ApiError::from)
     }
@@ -386,6 +386,54 @@ mod tests {
         assert_eq!(resolved.relation().revision, ResourceRevision::INITIAL);
         assert_eq!(resolved.from_object(), prepared.from_object());
         assert_eq!(resolved.to_object(), prepared.to_object());
+        harness.finish().await;
+    }
+
+    #[rstest]
+    #[case::postgres(ContractImplementation::PostgresAdapter)]
+    #[case::memory(ContractImplementation::MemoryModel)]
+    #[actix_web::test]
+    async fn object_relation_contract_supports_event_suppressed_compatibility_writes(
+        #[case] backend: ContractImplementation,
+    ) {
+        let harness = ContractHarness::new(backend, "event_suppressed").await;
+        let fixture = harness.fixture("event_suppressed").await;
+        let lifecycle = &harness.services.object_relations().storage;
+        let created = lifecycle
+            .inner()
+            .create_object_relation_from_command(
+                NewHubuumObjectRelation {
+                    from_hubuum_object_id: fixture.from_object.id,
+                    to_hubuum_object_id: fixture.to_object.id,
+                    class_relation_id: fixture.class_relation.relation().id,
+                },
+                None,
+            )
+            .await
+            .expect("event-suppressed relation should create");
+        let relation_id =
+            HubuumObjectRelationID::new(created.id).expect("valid object relation id");
+        lifecycle
+            .inner()
+            .resolve_object_relation(ObjectRelationSelector::by_id(relation_id))
+            .await
+            .expect("event-suppressed relation should resolve");
+        lifecycle
+            .inner()
+            .delete_object_relation_by_id(relation_id, None)
+            .await
+            .expect("event-suppressed relation should delete");
+
+        assert!(
+            lifecycle
+                .inner()
+                .resolve_object_relation(ObjectRelationSelector::by_id(relation_id))
+                .await
+                .is_err()
+        );
+        if let Some(storage) = harness.storage.as_ref() {
+            assert!(storage.object_relation_events().await.is_empty());
+        }
         harness.finish().await;
     }
 

--- a/src/storage/class_relations.rs
+++ b/src/storage/class_relations.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::events::EventContext;
 use crate::models::{
-    HubuumClassRelationID, NewHubuumClassRelation, PreparedClassRelation,
+    HubuumClassRelation, HubuumClassRelationID, NewHubuumClassRelation, PreparedClassRelation,
     ResolvedClassRelationTarget,
 };
 
@@ -12,6 +12,9 @@ use super::StorageError;
 ///
 /// Prepared and resolved aggregates include both endpoint classes so callers
 /// can authorize without depending on persistence-specific lookups.
+/// A missing event context deliberately suppresses audit-event emission for
+/// compatibility operations; selectable backends must still perform the same
+/// validation, persistence, and observation behavior.
 #[async_trait]
 pub(crate) trait ClassRelationStore: Send + Sync {
     async fn prepare_class_relation(
@@ -27,12 +30,28 @@ pub(crate) trait ClassRelationStore: Send + Sync {
     async fn create_class_relation(
         &self,
         prepared: &PreparedClassRelation,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<ResolvedClassRelationTarget, StorageError>;
 
     async fn delete_class_relation(
         &self,
         target: &ResolvedClassRelationTarget,
-        context: &EventContext,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError>;
+
+    /// Create directly from a command for compatibility callers that do not
+    /// require a separately authorized prepared aggregate.
+    async fn create_class_relation_from_command(
+        &self,
+        command: NewHubuumClassRelation,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumClassRelation, StorageError>;
+
+    /// Delete directly by identifier for compatibility callers that do not
+    /// require a separately authorized resolved aggregate.
+    async fn delete_class_relation_by_id(
+        &self,
+        id: HubuumClassRelationID,
+        context: Option<&EventContext>,
     ) -> Result<(), StorageError>;
 }

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -927,7 +927,7 @@ impl ClassRelationStore for MemoryStorageModel {
     async fn create_class_relation(
         &self,
         prepared: &PreparedClassRelation,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<ResolvedClassRelationTarget, StorageError> {
         let mut state = self.state.write().await;
         state.prepared_class_relation_endpoints(prepared)?;
@@ -957,7 +957,9 @@ impl ClassRelationStore for MemoryStorageModel {
             revision: ResourceRevision::INITIAL,
         };
         state.class_relations.insert(id, relation.clone());
-        state.record_class_relation_event(id, Action::Created, context);
+        if let Some(context) = context {
+            state.record_class_relation_event(id, Action::Created, context);
+        }
         ResolvedClassRelationTarget::new(
             relation,
             prepared.from_class().clone(),
@@ -969,7 +971,7 @@ impl ClassRelationStore for MemoryStorageModel {
     async fn delete_class_relation(
         &self,
         target: &ResolvedClassRelationTarget,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<(), StorageError> {
         let mut state = self.state.write().await;
         let relation_id = state.class_relation_target(target)?.id;
@@ -977,8 +979,32 @@ impl ClassRelationStore for MemoryStorageModel {
         state
             .object_relations
             .retain(|_, relation| relation.class_relation_id != relation_id);
-        state.record_class_relation_event(relation_id, Action::Deleted, context);
+        if let Some(context) = context {
+            state.record_class_relation_event(relation_id, Action::Deleted, context);
+        }
         Ok(())
+    }
+
+    async fn create_class_relation_from_command(
+        &self,
+        command: NewHubuumClassRelation,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumClassRelation, StorageError> {
+        let prepared = self.prepare_class_relation(command).await?;
+        Ok(self
+            .create_class_relation(&prepared, context)
+            .await?
+            .relation()
+            .clone())
+    }
+
+    async fn delete_class_relation_by_id(
+        &self,
+        id: HubuumClassRelationID,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError> {
+        let target = self.resolve_class_relation(id).await?;
+        self.delete_class_relation(&target, context).await
     }
 }
 
@@ -1095,7 +1121,7 @@ impl ObjectRelationStore for MemoryStorageModel {
     async fn create_object_relation(
         &self,
         prepared: &PreparedObjectRelation,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<ResolvedObjectRelationTarget, StorageError> {
         let mut state = self.state.write().await;
         state.validate_prepared_object_relation(prepared)?;
@@ -1143,7 +1169,9 @@ impl ObjectRelationStore for MemoryStorageModel {
             revision: ResourceRevision::INITIAL,
         };
         state.object_relations.insert(id, relation);
-        state.record_object_relation_event(id, Action::Created, context);
+        if let Some(context) = context {
+            state.record_object_relation_event(id, Action::Created, context);
+        }
         ResolvedObjectRelationTarget::new(
             relation,
             prepared.from_object().clone(),
@@ -1156,14 +1184,41 @@ impl ObjectRelationStore for MemoryStorageModel {
     async fn delete_object_relation(
         &self,
         target: &ResolvedObjectRelationTarget,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<(), StorageError> {
         let mut state = self.state.write().await;
         state.validate_resolved_object_relation(target)?;
         let relation_id = target.relation().id;
         state.object_relations.remove(&relation_id);
-        state.record_object_relation_event(relation_id, Action::Deleted, context);
+        if let Some(context) = context {
+            state.record_object_relation_event(relation_id, Action::Deleted, context);
+        }
         Ok(())
+    }
+
+    async fn create_object_relation_from_command(
+        &self,
+        command: NewHubuumObjectRelation,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumObjectRelation, StorageError> {
+        let prepared = self
+            .prepare_object_relation(ObjectRelationCreateSelector::explicit(command))
+            .await?;
+        Ok(*self
+            .create_object_relation(&prepared, context)
+            .await?
+            .relation())
+    }
+
+    async fn delete_object_relation_by_id(
+        &self,
+        id: HubuumObjectRelationID,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError> {
+        let target = self
+            .resolve_object_relation(ObjectRelationSelector::by_id(id))
+            .await?;
+        self.delete_object_relation(&target, context).await
     }
 }
 

--- a/src/storage/object_relations.rs
+++ b/src/storage/object_relations.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 
 use crate::events::EventContext;
 use crate::models::{
+    HubuumObjectRelation, HubuumObjectRelationID, NewHubuumObjectRelation,
     ObjectRelationCreateSelector, ObjectRelationSelector, PreparedObjectRelation,
     ResolvedObjectRelationTarget,
 };
@@ -9,6 +10,10 @@ use crate::models::{
 use super::StorageError;
 
 /// Persistence capability for object-relation resolution and lifecycle writes.
+///
+/// A missing event context deliberately suppresses audit-event emission for
+/// compatibility operations; selectable backends must still perform the same
+/// validation, persistence, and observation behavior.
 #[async_trait]
 pub(crate) trait ObjectRelationStore: Send + Sync {
     async fn prepare_object_relation(
@@ -24,12 +29,28 @@ pub(crate) trait ObjectRelationStore: Send + Sync {
     async fn create_object_relation(
         &self,
         prepared: &PreparedObjectRelation,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<ResolvedObjectRelationTarget, StorageError>;
 
     async fn delete_object_relation(
         &self,
         target: &ResolvedObjectRelationTarget,
-        context: &EventContext,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError>;
+
+    /// Create directly from a command for compatibility callers that do not
+    /// require a separately authorized prepared aggregate.
+    async fn create_object_relation_from_command(
+        &self,
+        command: NewHubuumObjectRelation,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumObjectRelation, StorageError>;
+
+    /// Delete directly by identifier for compatibility callers that do not
+    /// require a separately authorized resolved aggregate.
+    async fn delete_object_relation_by_id(
+        &self,
+        id: HubuumObjectRelationID,
+        context: Option<&EventContext>,
     ) -> Result<(), StorageError>;
 }

--- a/src/storage/observed.rs
+++ b/src/storage/observed.rs
@@ -7,12 +7,13 @@ use tracing::{Instrument, debug, debug_span, warn};
 
 use crate::events::EventContext;
 use crate::models::{
-    ClassSelector, Collection, CollectionID, HubuumClass, HubuumClassRelationID, HubuumObject,
+    ClassSelector, Collection, CollectionID, HubuumClass, HubuumClassRelation,
+    HubuumClassRelationID, HubuumObject, HubuumObjectRelation, HubuumObjectRelationID,
     NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
-    ObjectDataPatchDocument, ObjectRelationCreateSelector, ObjectRelationSelector, ObjectSelector,
-    PreparedClassRelation, PreparedObjectRelation, ResolvedClassRelationTarget,
-    ResolvedClassTarget, ResolvedObjectRelationTarget, ResolvedObjectTarget, UpdateCollection,
-    UpdateHubuumClass, UpdateHubuumObject,
+    NewHubuumObjectRelation, ObjectDataPatchDocument, ObjectRelationCreateSelector,
+    ObjectRelationSelector, ObjectSelector, PreparedClassRelation, PreparedObjectRelation,
+    ResolvedClassRelationTarget, ResolvedClassTarget, ResolvedObjectRelationTarget,
+    ResolvedObjectTarget, UpdateCollection, UpdateHubuumClass, UpdateHubuumObject,
 };
 
 use super::{
@@ -327,7 +328,7 @@ impl ClassRelationStore for ObservedLifecycleStorage {
     async fn create_class_relation(
         &self,
         prepared: &PreparedClassRelation,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<ResolvedClassRelationTarget, StorageError> {
         self.call(
             "class_relations",
@@ -340,12 +341,39 @@ impl ClassRelationStore for ObservedLifecycleStorage {
     async fn delete_class_relation(
         &self,
         target: &ResolvedClassRelationTarget,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<(), StorageError> {
         self.call(
             "class_relations",
             "delete",
             self.inner.delete_class_relation(target, context),
+        )
+        .await
+    }
+
+    async fn create_class_relation_from_command(
+        &self,
+        command: NewHubuumClassRelation,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumClassRelation, StorageError> {
+        self.call(
+            "class_relations",
+            "create_from_command",
+            self.inner
+                .create_class_relation_from_command(command, context),
+        )
+        .await
+    }
+
+    async fn delete_class_relation_by_id(
+        &self,
+        id: HubuumClassRelationID,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError> {
+        self.call(
+            "class_relations",
+            "delete_by_id",
+            self.inner.delete_class_relation_by_id(id, context),
         )
         .await
     }
@@ -380,7 +408,7 @@ impl ObjectRelationStore for ObservedLifecycleStorage {
     async fn create_object_relation(
         &self,
         prepared: &PreparedObjectRelation,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<ResolvedObjectRelationTarget, StorageError> {
         self.call(
             "object_relations",
@@ -393,12 +421,39 @@ impl ObjectRelationStore for ObservedLifecycleStorage {
     async fn delete_object_relation(
         &self,
         target: &ResolvedObjectRelationTarget,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<(), StorageError> {
         self.call(
             "object_relations",
             "delete",
             self.inner.delete_object_relation(target, context),
+        )
+        .await
+    }
+
+    async fn create_object_relation_from_command(
+        &self,
+        command: NewHubuumObjectRelation,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumObjectRelation, StorageError> {
+        self.call(
+            "object_relations",
+            "create_from_command",
+            self.inner
+                .create_object_relation_from_command(command, context),
+        )
+        .await
+    }
+
+    async fn delete_object_relation_by_id(
+        &self,
+        id: HubuumObjectRelationID,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError> {
+        self.call(
+            "object_relations",
+            "delete_by_id",
+            self.inner.delete_object_relation_by_id(id, context),
         )
         .await
     }

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -26,13 +26,14 @@ use crate::events::{
 };
 use crate::models::search::QueryOptions;
 use crate::models::{
-    ClassSelector, Collection, CollectionID, HubuumClass, HubuumClassRelationID, HubuumObject,
-    HubuumObjectID, MaintenanceState, NewCollectionWithAssignee, NewHubuumClass,
-    NewHubuumClassRelation, NewHubuumObject, ObjectDataPatchDocument, ObjectRelationCreateSelector,
-    ObjectRelationSelector, ObjectSelector, PreparedClassRelation, PreparedObjectRelation,
-    ResolvedClassRelationTarget, ResolvedClassTarget, ResolvedObjectRelationTarget,
-    ResolvedObjectTarget, TokenRetentionSettings, UpdateCollection, UpdateHubuumClass,
-    UpdateHubuumObject,
+    ClassSelector, Collection, CollectionID, HubuumClass, HubuumClassRelation,
+    HubuumClassRelationID, HubuumObject, HubuumObjectID, HubuumObjectRelation,
+    HubuumObjectRelationID, MaintenanceState, NewCollectionWithAssignee, NewHubuumClass,
+    NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, ObjectDataPatchDocument,
+    ObjectRelationCreateSelector, ObjectRelationSelector, ObjectSelector, PreparedClassRelation,
+    PreparedObjectRelation, ResolvedClassRelationTarget, ResolvedClassTarget,
+    ResolvedObjectRelationTarget, ResolvedObjectTarget, TokenRetentionSettings, UpdateCollection,
+    UpdateHubuumClass, UpdateHubuumObject,
 };
 use crate::storage::postgres::operations::GetCollection;
 use crate::storage::postgres::operations::class::{
@@ -52,9 +53,10 @@ use crate::storage::postgres::operations::object::{
 };
 use crate::storage::postgres::operations::relations::{
     CreatePreparedClassRelationRecord, CreatePreparedObjectRelationRecord,
-    DeleteResolvedClassRelationRecord, DeleteResolvedObjectRelationRecord,
-    PrepareClassRelationRecord, PrepareObjectRelationRecord, ResolveClassRelationTargetRecord,
-    ResolveObjectRelationTargetRecord,
+    DeleteClassRelationRecord, DeleteObjectRelationRecord, DeleteResolvedClassRelationRecord,
+    DeleteResolvedObjectRelationRecord, PrepareClassRelationRecord, PrepareObjectRelationRecord,
+    ResolveClassRelationTargetRecord, ResolveObjectRelationTargetRecord, SaveClassRelationRecord,
+    SaveObjectRelationRecord,
 };
 
 use super::{
@@ -1420,7 +1422,7 @@ impl ClassRelationStore for PostgresStorage {
     async fn create_class_relation(
         &self,
         prepared: &PreparedClassRelation,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<ResolvedClassRelationTarget, StorageError> {
         let relation = prepared
             .create_prepared_class_relation_record(&self.pool, context)
@@ -1437,10 +1439,31 @@ impl ClassRelationStore for PostgresStorage {
     async fn delete_class_relation(
         &self,
         target: &ResolvedClassRelationTarget,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<(), StorageError> {
         target
             .delete_resolved_class_relation_record(&self.pool, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn create_class_relation_from_command(
+        &self,
+        command: NewHubuumClassRelation,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumClassRelation, StorageError> {
+        command
+            .save_class_relation_record(&self.pool, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn delete_class_relation_by_id(
+        &self,
+        id: HubuumClassRelationID,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError> {
+        id.delete_class_relation_record(&self.pool, context)
             .await
             .map_err(map_postgres_error)
     }
@@ -1471,7 +1494,7 @@ impl ObjectRelationStore for PostgresStorage {
     async fn create_object_relation(
         &self,
         prepared: &PreparedObjectRelation,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<ResolvedObjectRelationTarget, StorageError> {
         let relation = prepared
             .create_prepared_object_relation_record(&self.pool, context)
@@ -1489,10 +1512,31 @@ impl ObjectRelationStore for PostgresStorage {
     async fn delete_object_relation(
         &self,
         target: &ResolvedObjectRelationTarget,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<(), StorageError> {
         target
             .delete_resolved_object_relation_record(&self.pool, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn create_object_relation_from_command(
+        &self,
+        command: NewHubuumObjectRelation,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumObjectRelation, StorageError> {
+        command
+            .save_object_relation_record(&self.pool, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn delete_object_relation_by_id(
+        &self,
+        id: HubuumObjectRelationID,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError> {
+        id.delete_object_relation_record(&self.pool, context)
             .await
             .map_err(map_postgres_error)
     }

--- a/src/storage/postgres/operations/class.rs
+++ b/src/storage/postgres/operations/class.rs
@@ -10,6 +10,7 @@ use crate::models::{
 };
 use crate::storage::postgres::operations::GetClass;
 use crate::storage::postgres::operations::event_record::emit_event;
+use crate::storage::postgres::operations::relation_rows::HubuumClassRelationRow;
 use crate::storage::postgres::{with_connection, with_transaction};
 
 fn class_snapshot(class: &HubuumClass) -> serde_json::Value {
@@ -118,7 +119,7 @@ impl GetClass<(HubuumClass, HubuumClass)> for HubuumClassRelationID {
             async |conn| -> Result<(HubuumClass, HubuumClass), diesel::result::Error> {
                 let relation = hubuumclass_relation
                     .filter(rel_id.eq(self.id()))
-                    .first::<HubuumClassRelation>(conn)
+                    .first::<HubuumClassRelationRow>(conn)
                     .await?;
 
                 let from_class = hubuumclass

--- a/src/storage/postgres/operations/mod.rs
+++ b/src/storage/postgres/operations/mod.rs
@@ -57,6 +57,7 @@ use crate::models::{
     HubuumObjectID, HubuumObjectRelation, HubuumObjectTransitiveLink, PrincipalToken,
     TokenListState, User,
 };
+use crate::storage::postgres::operations::relation_rows::HubuumClassRelationTransitiveRow;
 use crate::storage::postgres::operations::relations::{
     ObjectRelationMembershipsBackend, SelfRelationsBackend, max_transitive_depth_from_config,
     parse_transitive_filter_params,
@@ -194,7 +195,7 @@ where
         use diesel::sql_types::Integer;
 
         let filter = parse_transitive_filter_params(query_options)?;
-        let sorts = normalized_sorts::<HubuumClassRelationTransitive>(&query_options.sort)?;
+        let sorts = normalized_sorts::<HubuumClassRelationTransitiveRow>(&query_options.sort)?;
 
         let mut raw_sql = String::from(
             "SELECT ancestor_class_id, descendant_class_id, depth, path
@@ -204,7 +205,7 @@ where
              WHERE (ancestor_class_id = $1 OR descendant_class_id = $1)",
         );
 
-        if let Some(cursor_sql) = cursor_filter_sql::<HubuumClassRelationTransitive>(
+        if let Some(cursor_sql) = cursor_filter_sql::<HubuumClassRelationTransitiveRow>(
             &sorts,
             query_options.cursor.as_deref(),
         )? {
@@ -214,7 +215,7 @@ where
 
         let order_by = sorts
             .iter()
-            .map(order_sql_clause::<HubuumClassRelationTransitive>)
+            .map(order_sql_clause::<HubuumClassRelationTransitiveRow>)
             .collect::<Result<Vec<_>, _>>()?
             .join(", ");
         raw_sql.push_str(&format!("\nORDER BY {order_by}"));
@@ -223,7 +224,7 @@ where
             raw_sql.push_str(&format!("\nLIMIT {limit}"));
         }
 
-        with_connection(pool, async |conn| {
+        let rows = with_connection(pool, async |conn| {
             let query = bind_transitive_filter_params!(
                 sql_query(raw_sql)
                     .bind::<Integer, _>(self.id())
@@ -231,9 +232,10 @@ where
                 filter
             );
 
-            diesel_async::RunQueryDsl::load::<HubuumClassRelationTransitive>(query, conn).await
+            diesel_async::RunQueryDsl::load::<HubuumClassRelationTransitiveRow>(query, conn).await
         })
-        .await
+        .await?;
+        Ok(rows.into_iter().map(Into::into).collect())
     }
 
     // We typically end up searching, so this interface is rarely used.

--- a/src/storage/postgres/operations/relation_rows.rs
+++ b/src/storage/postgres/operations/relation_rows.rs
@@ -1,12 +1,807 @@
+use crate::errors::ApiError;
+use crate::models::search::{FilterField, SortParam};
 use crate::models::{
-    ClassGraphRow, HubuumClassRelation, HubuumObjectRelation, RelatedObjectForRootRow,
-    RelatedObjectGraphRow, RelatedObjectIncludeRow,
+    ClassGraphRow, HubuumClassRelation, HubuumClassRelationTransitive, HubuumObjectRelation,
+    HubuumObjectTransitiveLink, NewHubuumClassRelation, NewHubuumObjectRelation,
+    ObjectRelationLimit, RelatedObjectForRootRow, RelatedObjectGraphRow, RelatedObjectIncludeRow,
 };
+use crate::storage::postgres::prelude::*;
 use crate::storage::{
     StorageClassGraphRow, StorageClassRelation, StorageGraphClass, StorageGraphObject,
     StorageGraphResource, StorageObjectGraphRow, StorageObjectRelation, StorageRecordMetadata,
     StorageRelatedObjectForRootRow, StorageRelatedObjectIncludeRow,
 };
+use crate::traits::{
+    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
+};
+
+#[derive(Clone, Queryable, QueryableByName, Selectable)]
+#[diesel(table_name = crate::schema::hubuumclass_relation)]
+pub(crate) struct HubuumClassRelationRow {
+    pub(crate) id: i32,
+    pub(crate) from_hubuum_class_id: i32,
+    pub(crate) to_hubuum_class_id: i32,
+    pub(crate) forward_template_alias: Option<String>,
+    pub(crate) reverse_template_alias: Option<String>,
+    pub(crate) created_at: chrono::NaiveDateTime,
+    pub(crate) updated_at: chrono::NaiveDateTime,
+    pub(crate) from_max_relations: Option<i32>,
+    pub(crate) to_max_relations: Option<i32>,
+    pub(crate) revision: crate::models::ResourceRevision,
+}
+
+fn persisted_relation_limit(value: Option<i32>) -> Result<Option<ObjectRelationLimit>, ApiError> {
+    value
+        .map(|value| {
+            ObjectRelationLimit::new(value).map_err(|_| {
+                ApiError::InternalServerError(format!(
+                    "persisted object relation limit '{value}' is not positive"
+                ))
+            })
+        })
+        .transpose()
+}
+
+impl TryFrom<HubuumClassRelationRow> for HubuumClassRelation {
+    type Error = ApiError;
+
+    fn try_from(row: HubuumClassRelationRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: row.id,
+            from_hubuum_class_id: row.from_hubuum_class_id,
+            to_hubuum_class_id: row.to_hubuum_class_id,
+            forward_template_alias: row.forward_template_alias,
+            reverse_template_alias: row.reverse_template_alias,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            from_max_relations: persisted_relation_limit(row.from_max_relations)?,
+            to_max_relations: persisted_relation_limit(row.to_max_relations)?,
+            revision: row.revision,
+        })
+    }
+}
+
+impl CursorPaginated for HubuumClassRelationRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        <HubuumClassRelation as CursorPaginated>::supports_sort(field)
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorValue::Integer(self.id as i64),
+            FilterField::ClassFrom => CursorValue::Integer(self.from_hubuum_class_id as i64),
+            FilterField::ClassTo => CursorValue::Integer(self.to_hubuum_class_id as i64),
+            FilterField::CreatedAt => CursorValue::DateTime(self.created_at),
+            FilterField::UpdatedAt => CursorValue::DateTime(self.updated_at),
+            FilterField::Revision => CursorValue::Integer(self.revision.get()),
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for class relations",
+                    field
+                )));
+            }
+        })
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        <HubuumClassRelation as CursorPaginated>::default_sort()
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        <HubuumClassRelation as CursorPaginated>::tie_breaker_sort()
+    }
+}
+
+impl CursorSqlMapping for HubuumClassRelationRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorSqlField {
+                column: "hubuumclass_relation.id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::ClassFrom => CursorSqlField {
+                column: "hubuumclass_relation.from_hubuum_class_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::ClassTo => CursorSqlField {
+                column: "hubuumclass_relation.to_hubuum_class_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::CreatedAt => CursorSqlField {
+                column: "hubuumclass_relation.created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAt => CursorSqlField {
+                column: "hubuumclass_relation.updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::Revision => CursorSqlField {
+                column: "hubuumclass_relation.revision",
+                sql_type: CursorSqlType::BigInt,
+                nullable: false,
+            },
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for class relations",
+                    field
+                )));
+            }
+        })
+    }
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = crate::schema::hubuumclass_relation)]
+pub(crate) struct NewHubuumClassRelationRow<'a> {
+    from_hubuum_class_id: i32,
+    to_hubuum_class_id: i32,
+    forward_template_alias: Option<&'a str>,
+    reverse_template_alias: Option<&'a str>,
+    from_max_relations: Option<i32>,
+    to_max_relations: Option<i32>,
+}
+
+impl<'a> From<&'a NewHubuumClassRelation> for NewHubuumClassRelationRow<'a> {
+    fn from(relation: &'a NewHubuumClassRelation) -> Self {
+        Self {
+            from_hubuum_class_id: relation.from_hubuum_class_id,
+            to_hubuum_class_id: relation.to_hubuum_class_id,
+            forward_template_alias: relation.forward_template_alias.as_deref(),
+            reverse_template_alias: relation.reverse_template_alias.as_deref(),
+            from_max_relations: relation.from_max_relations.map(ObjectRelationLimit::value),
+            to_max_relations: relation.to_max_relations.map(ObjectRelationLimit::value),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Queryable, QueryableByName, Selectable)]
+#[diesel(table_name = crate::schema::hubuumobject_relation)]
+pub(crate) struct HubuumObjectRelationRow {
+    pub(crate) id: i32,
+    pub(crate) from_hubuum_object_id: i32,
+    pub(crate) to_hubuum_object_id: i32,
+    pub(crate) class_relation_id: i32,
+    pub(crate) created_at: chrono::NaiveDateTime,
+    pub(crate) updated_at: chrono::NaiveDateTime,
+    pub(crate) revision: crate::models::ResourceRevision,
+}
+
+impl From<HubuumObjectRelationRow> for HubuumObjectRelation {
+    fn from(row: HubuumObjectRelationRow) -> Self {
+        Self {
+            id: row.id,
+            from_hubuum_object_id: row.from_hubuum_object_id,
+            to_hubuum_object_id: row.to_hubuum_object_id,
+            class_relation_id: row.class_relation_id,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            revision: row.revision,
+        }
+    }
+}
+
+impl CursorPaginated for HubuumObjectRelationRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        <HubuumObjectRelation as CursorPaginated>::supports_sort(field)
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        HubuumObjectRelation::from(*self).cursor_value(field)
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        <HubuumObjectRelation as CursorPaginated>::default_sort()
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        <HubuumObjectRelation as CursorPaginated>::tie_breaker_sort()
+    }
+}
+
+impl CursorSqlMapping for HubuumObjectRelationRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorSqlField {
+                column: "hubuumobject_relation.id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::ClassRelation => CursorSqlField {
+                column: "hubuumobject_relation.class_relation_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::ObjectFrom => CursorSqlField {
+                column: "hubuumobject_relation.from_hubuum_object_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::ObjectTo => CursorSqlField {
+                column: "hubuumobject_relation.to_hubuum_object_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::CreatedAt => CursorSqlField {
+                column: "hubuumobject_relation.created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAt => CursorSqlField {
+                column: "hubuumobject_relation.updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::Revision => CursorSqlField {
+                column: "hubuumobject_relation.revision",
+                sql_type: CursorSqlType::BigInt,
+                nullable: false,
+            },
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for object relations",
+                    field
+                )));
+            }
+        })
+    }
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = crate::schema::hubuumobject_relation)]
+pub(crate) struct NewHubuumObjectRelationRow {
+    from_hubuum_object_id: i32,
+    to_hubuum_object_id: i32,
+    class_relation_id: i32,
+}
+
+impl From<&NewHubuumObjectRelation> for NewHubuumObjectRelationRow {
+    fn from(relation: &NewHubuumObjectRelation) -> Self {
+        Self {
+            from_hubuum_object_id: relation.from_hubuum_object_id,
+            to_hubuum_object_id: relation.to_hubuum_object_id,
+            class_relation_id: relation.class_relation_id,
+        }
+    }
+}
+
+#[derive(Clone, QueryableByName)]
+pub(crate) struct HubuumClassRelationTransitiveRow {
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) ancestor_class_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) descendant_class_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) depth: i32,
+    #[diesel(sql_type = diesel::sql_types::Array<diesel::sql_types::Nullable<diesel::sql_types::Integer>>)]
+    pub(crate) path: Vec<Option<i32>>,
+}
+
+impl From<HubuumClassRelationTransitiveRow> for HubuumClassRelationTransitive {
+    fn from(row: HubuumClassRelationTransitiveRow) -> Self {
+        Self {
+            ancestor_class_id: row.ancestor_class_id,
+            descendant_class_id: row.descendant_class_id,
+            depth: row.depth,
+            path: row.path,
+        }
+    }
+}
+
+impl CursorPaginated for HubuumClassRelationTransitiveRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        <HubuumClassRelationTransitive as CursorPaginated>::supports_sort(field)
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        HubuumClassRelationTransitive::from(self.clone()).cursor_value(field)
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        <HubuumClassRelationTransitive as CursorPaginated>::default_sort()
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        <HubuumClassRelationTransitive as CursorPaginated>::tie_breaker_sort()
+    }
+}
+
+impl CursorSqlMapping for HubuumClassRelationTransitiveRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::ClassFrom => CursorSqlField {
+                column: "ancestor_class_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::ClassTo => CursorSqlField {
+                column: "descendant_class_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Depth => CursorSqlField {
+                column: "depth",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Path => CursorSqlField {
+                column: "path",
+                sql_type: CursorSqlType::IntegerArray,
+                nullable: true,
+            },
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for transitive class relations",
+                    field
+                )));
+            }
+        })
+    }
+}
+
+#[derive(QueryableByName)]
+pub(crate) struct HubuumObjectTransitiveLinkRow {
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    target_object_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Array<diesel::sql_types::Integer>)]
+    path: Vec<i32>,
+}
+
+impl From<HubuumObjectTransitiveLinkRow> for HubuumObjectTransitiveLink {
+    fn from(row: HubuumObjectTransitiveLinkRow) -> Self {
+        Self::new(row.target_object_id, row.path)
+    }
+}
+
+#[derive(Clone, Queryable, QueryableByName)]
+pub(crate) struct ClassGraphQueryRow {
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) ancestor_class_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) descendant_class_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) depth: i32,
+    #[diesel(sql_type = diesel::sql_types::Array<diesel::sql_types::Integer>)]
+    pub(crate) path: Vec<i32>,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub(crate) ancestor_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub(crate) descendant_name: String,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) ancestor_collection_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) descendant_collection_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Jsonb>)]
+    pub(crate) ancestor_json_schema: Option<serde_json::Value>,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Jsonb>)]
+    pub(crate) descendant_json_schema: Option<serde_json::Value>,
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    pub(crate) ancestor_validate_schema: bool,
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    pub(crate) descendant_validate_schema: bool,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub(crate) ancestor_description: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub(crate) descendant_description: String,
+    #[diesel(sql_type = diesel::sql_types::Timestamp)]
+    pub(crate) ancestor_created_at: chrono::NaiveDateTime,
+    #[diesel(sql_type = diesel::sql_types::Timestamp)]
+    pub(crate) descendant_created_at: chrono::NaiveDateTime,
+    #[diesel(sql_type = diesel::sql_types::Timestamp)]
+    pub(crate) ancestor_updated_at: chrono::NaiveDateTime,
+    #[diesel(sql_type = diesel::sql_types::Timestamp)]
+    pub(crate) descendant_updated_at: chrono::NaiveDateTime,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub(crate) ancestor_revision: crate::models::ResourceRevision,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub(crate) descendant_revision: crate::models::ResourceRevision,
+}
+
+impl From<ClassGraphQueryRow> for ClassGraphRow {
+    fn from(row: ClassGraphQueryRow) -> Self {
+        Self {
+            ancestor_class_id: row.ancestor_class_id,
+            descendant_class_id: row.descendant_class_id,
+            depth: row.depth,
+            path: row.path,
+            ancestor_name: row.ancestor_name,
+            descendant_name: row.descendant_name,
+            ancestor_collection_id: row.ancestor_collection_id,
+            descendant_collection_id: row.descendant_collection_id,
+            ancestor_json_schema: row.ancestor_json_schema,
+            descendant_json_schema: row.descendant_json_schema,
+            ancestor_validate_schema: row.ancestor_validate_schema,
+            descendant_validate_schema: row.descendant_validate_schema,
+            ancestor_description: row.ancestor_description,
+            descendant_description: row.descendant_description,
+            ancestor_created_at: row.ancestor_created_at,
+            descendant_created_at: row.descendant_created_at,
+            ancestor_updated_at: row.ancestor_updated_at,
+            descendant_updated_at: row.descendant_updated_at,
+            ancestor_revision: row.ancestor_revision,
+            descendant_revision: row.descendant_revision,
+        }
+    }
+}
+
+impl CursorPaginated for ClassGraphQueryRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        <ClassGraphRow as CursorPaginated>::supports_sort(field)
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        ClassGraphRow::from(self.clone()).cursor_value(field)
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        <ClassGraphRow as CursorPaginated>::default_sort()
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        <ClassGraphRow as CursorPaginated>::tie_breaker_sort()
+    }
+}
+
+impl CursorSqlMapping for ClassGraphQueryRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::Id
+            | FilterField::ClassTo
+            | FilterField::ClassId
+            | FilterField::Classes => CursorSqlField {
+                column: "related_classes.descendant_class_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::ClassFrom => CursorSqlField {
+                column: "related_classes.ancestor_class_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Name | FilterField::NameTo => CursorSqlField {
+                column: "related_classes.descendant_name",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::NameFrom => CursorSqlField {
+                column: "related_classes.ancestor_name",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::Description | FilterField::DescriptionTo => CursorSqlField {
+                column: "related_classes.descendant_description",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::DescriptionFrom => CursorSqlField {
+                column: "related_classes.ancestor_description",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::Collections | FilterField::CollectionId | FilterField::CollectionsTo => {
+                CursorSqlField {
+                    column: "related_classes.descendant_collection_id",
+                    sql_type: CursorSqlType::Integer,
+                    nullable: false,
+                }
+            }
+            FilterField::CollectionsFrom => CursorSqlField {
+                column: "related_classes.ancestor_collection_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::CreatedAt | FilterField::CreatedAtTo => CursorSqlField {
+                column: "related_classes.descendant_created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::CreatedAtFrom => CursorSqlField {
+                column: "related_classes.ancestor_created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAt | FilterField::UpdatedAtTo => CursorSqlField {
+                column: "related_classes.descendant_updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAtFrom => CursorSqlField {
+                column: "related_classes.ancestor_updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::Depth => CursorSqlField {
+                column: "related_classes.depth",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Path => CursorSqlField {
+                column: "related_classes.path",
+                sql_type: CursorSqlType::IntegerArray,
+                nullable: false,
+            },
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for related classes",
+                    field
+                )));
+            }
+        })
+    }
+}
+
+#[derive(Clone, QueryableByName)]
+pub(crate) struct RelatedObjectGraphQueryRow {
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) ancestor_object_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) descendant_object_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) depth: i32,
+    #[diesel(sql_type = diesel::sql_types::Array<diesel::sql_types::Integer>)]
+    pub(crate) path: Vec<i32>,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub(crate) ancestor_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub(crate) descendant_name: String,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) ancestor_collection_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) descendant_collection_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) ancestor_class_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) descendant_class_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub(crate) ancestor_description: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub(crate) descendant_description: String,
+    #[diesel(sql_type = diesel::sql_types::Jsonb)]
+    pub(crate) ancestor_data: serde_json::Value,
+    #[diesel(sql_type = diesel::sql_types::Jsonb)]
+    pub(crate) descendant_data: serde_json::Value,
+    #[diesel(sql_type = diesel::sql_types::Timestamp)]
+    pub(crate) ancestor_created_at: chrono::NaiveDateTime,
+    #[diesel(sql_type = diesel::sql_types::Timestamp)]
+    pub(crate) descendant_created_at: chrono::NaiveDateTime,
+    #[diesel(sql_type = diesel::sql_types::Timestamp)]
+    pub(crate) ancestor_updated_at: chrono::NaiveDateTime,
+    #[diesel(sql_type = diesel::sql_types::Timestamp)]
+    pub(crate) descendant_updated_at: chrono::NaiveDateTime,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub(crate) ancestor_revision: crate::models::ResourceRevision,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub(crate) descendant_revision: crate::models::ResourceRevision,
+}
+
+impl From<RelatedObjectGraphQueryRow> for RelatedObjectGraphRow {
+    fn from(row: RelatedObjectGraphQueryRow) -> Self {
+        Self {
+            ancestor_object_id: row.ancestor_object_id,
+            descendant_object_id: row.descendant_object_id,
+            depth: row.depth,
+            path: row.path,
+            ancestor_name: row.ancestor_name,
+            descendant_name: row.descendant_name,
+            ancestor_collection_id: row.ancestor_collection_id,
+            descendant_collection_id: row.descendant_collection_id,
+            ancestor_class_id: row.ancestor_class_id,
+            descendant_class_id: row.descendant_class_id,
+            ancestor_description: row.ancestor_description,
+            descendant_description: row.descendant_description,
+            ancestor_data: row.ancestor_data,
+            descendant_data: row.descendant_data,
+            ancestor_created_at: row.ancestor_created_at,
+            descendant_created_at: row.descendant_created_at,
+            ancestor_updated_at: row.ancestor_updated_at,
+            descendant_updated_at: row.descendant_updated_at,
+            ancestor_revision: row.ancestor_revision,
+            descendant_revision: row.descendant_revision,
+        }
+    }
+}
+
+impl CursorPaginated for RelatedObjectGraphQueryRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        <RelatedObjectGraphRow as CursorPaginated>::supports_sort(field)
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        RelatedObjectGraphRow::from(self.clone()).cursor_value(field)
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        <RelatedObjectGraphRow as CursorPaginated>::default_sort()
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        <RelatedObjectGraphRow as CursorPaginated>::tie_breaker_sort()
+    }
+}
+
+impl CursorSqlMapping for RelatedObjectGraphQueryRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::Id | FilterField::ObjectTo => CursorSqlField {
+                column: "related_objects.descendant_object_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::ObjectFrom => CursorSqlField {
+                column: "related_objects.ancestor_object_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Name | FilterField::NameTo => CursorSqlField {
+                column: "related_objects.descendant_name",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::NameFrom => CursorSqlField {
+                column: "related_objects.ancestor_name",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::Description | FilterField::DescriptionTo => CursorSqlField {
+                column: "related_objects.descendant_description",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::DescriptionFrom => CursorSqlField {
+                column: "related_objects.ancestor_description",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::Collections | FilterField::CollectionId | FilterField::CollectionsTo => {
+                CursorSqlField {
+                    column: "related_objects.descendant_collection_id",
+                    sql_type: CursorSqlType::Integer,
+                    nullable: false,
+                }
+            }
+            FilterField::CollectionsFrom => CursorSqlField {
+                column: "related_objects.ancestor_collection_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::ClassId | FilterField::Classes | FilterField::ClassTo => CursorSqlField {
+                column: "related_objects.descendant_class_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::ClassFrom => CursorSqlField {
+                column: "related_objects.ancestor_class_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::CreatedAt | FilterField::CreatedAtTo => CursorSqlField {
+                column: "related_objects.descendant_created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::CreatedAtFrom => CursorSqlField {
+                column: "related_objects.ancestor_created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAt | FilterField::UpdatedAtTo => CursorSqlField {
+                column: "related_objects.descendant_updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAtFrom => CursorSqlField {
+                column: "related_objects.ancestor_updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::Depth => CursorSqlField {
+                column: "related_objects.depth",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Path => CursorSqlField {
+                column: "related_objects.path",
+                sql_type: CursorSqlType::IntegerArray,
+                nullable: false,
+            },
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for related objects",
+                    field
+                )));
+            }
+        })
+    }
+}
+
+#[derive(QueryableByName)]
+pub(crate) struct RelatedObjectIncludeQueryRow {
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    root_object_id: i32,
+    #[diesel(embed)]
+    graph: RelatedObjectGraphQueryRow,
+}
+
+impl From<RelatedObjectIncludeQueryRow> for RelatedObjectIncludeRow {
+    fn from(row: RelatedObjectIncludeQueryRow) -> Self {
+        let root_object_id = row.root_object_id;
+        let graph = RelatedObjectGraphRow::from(row.graph);
+        Self {
+            root_object_id,
+            ancestor_object_id: graph.ancestor_object_id,
+            descendant_object_id: graph.descendant_object_id,
+            depth: graph.depth,
+            path: graph.path,
+            ancestor_name: graph.ancestor_name,
+            descendant_name: graph.descendant_name,
+            ancestor_collection_id: graph.ancestor_collection_id,
+            descendant_collection_id: graph.descendant_collection_id,
+            ancestor_class_id: graph.ancestor_class_id,
+            descendant_class_id: graph.descendant_class_id,
+            ancestor_description: graph.ancestor_description,
+            descendant_description: graph.descendant_description,
+            ancestor_data: graph.ancestor_data,
+            descendant_data: graph.descendant_data,
+            ancestor_created_at: graph.ancestor_created_at,
+            descendant_created_at: graph.descendant_created_at,
+            ancestor_updated_at: graph.ancestor_updated_at,
+            descendant_updated_at: graph.descendant_updated_at,
+            ancestor_revision: graph.ancestor_revision,
+            descendant_revision: graph.descendant_revision,
+        }
+    }
+}
+
+#[derive(QueryableByName)]
+pub(crate) struct RelatedObjectForRootQueryRow {
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) root_object_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) descendant_object_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) depth: i32,
+    #[diesel(sql_type = diesel::sql_types::Array<diesel::sql_types::Integer>)]
+    pub(crate) path: Vec<i32>,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub(crate) descendant_name: String,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) descendant_collection_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub(crate) descendant_class_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub(crate) descendant_description: String,
+    #[diesel(sql_type = diesel::sql_types::Jsonb)]
+    pub(crate) descendant_data: serde_json::Value,
+    #[diesel(sql_type = diesel::sql_types::Timestamp)]
+    pub(crate) descendant_created_at: chrono::NaiveDateTime,
+    #[diesel(sql_type = diesel::sql_types::Timestamp)]
+    pub(crate) descendant_updated_at: chrono::NaiveDateTime,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub(crate) descendant_revision: crate::models::ResourceRevision,
+}
+
+impl From<RelatedObjectForRootQueryRow> for RelatedObjectForRootRow {
+    fn from(row: RelatedObjectForRootQueryRow) -> Self {
+        Self {
+            root_object_id: row.root_object_id,
+            descendant_object_id: row.descendant_object_id,
+            depth: row.depth,
+            path: row.path,
+            descendant_name: row.descendant_name,
+            descendant_collection_id: row.descendant_collection_id,
+            descendant_class_id: row.descendant_class_id,
+            descendant_description: row.descendant_description,
+            descendant_data: row.descendant_data,
+            descendant_created_at: row.descendant_created_at,
+            descendant_updated_at: row.descendant_updated_at,
+            descendant_revision: row.descendant_revision,
+        }
+    }
+}
 
 fn metadata(
     id: i32,

--- a/src/storage/postgres/operations/relations.rs
+++ b/src/storage/postgres/operations/relations.rs
@@ -16,6 +16,10 @@ use crate::models::{
 };
 use crate::storage::postgres::operations::event_record::emit_event;
 use crate::storage::postgres::operations::object::HubuumObjectRow;
+use crate::storage::postgres::operations::relation_rows::{
+    HubuumClassRelationRow, HubuumClassRelationTransitiveRow, HubuumObjectRelationRow,
+    HubuumObjectTransitiveLinkRow, NewHubuumClassRelationRow, NewHubuumObjectRelationRow,
+};
 use crate::storage::postgres::{PostgresConnection, with_connection, with_transaction};
 use crate::{
     apply_query_options, bind_transitive_filter_params, date_search, numeric_search,
@@ -25,6 +29,12 @@ use crate::{
 use crate::traits::{GroupAccessors, SelfAccessors};
 
 use super::{ObjectRelationsFromUser, Relations, SelfRelations};
+
+fn class_relations_from_rows(
+    rows: Vec<HubuumClassRelationRow>,
+) -> Result<Vec<HubuumClassRelation>, ApiError> {
+    rows.into_iter().map(TryInto::try_into).collect()
+}
 
 fn class_relation_snapshot(relation: &HubuumClassRelation) -> serde_json::Value {
     serde_json::json!({
@@ -243,8 +253,8 @@ where
         use diesel::sql_query;
         use diesel::sql_types::Integer;
 
-        with_connection(pool, async |conn| {
-            diesel_async::RunQueryDsl::load::<HubuumClassRelationTransitive>(
+        let rows = with_connection(pool, async |conn| {
+            diesel_async::RunQueryDsl::load::<HubuumClassRelationTransitiveRow>(
                 sql_query(
                     "SELECT ancestor_class_id, descendant_class_id, depth, path
                      FROM get_bidirectionally_related_classes($1, ARRAY[]::INT[], $2)
@@ -257,7 +267,8 @@ where
             )
             .await
         })
-        .await
+        .await?;
+        Ok(rows.into_iter().map(Into::into).collect())
     }
 
     async fn relations_from_backend(
@@ -266,14 +277,15 @@ where
     ) -> Result<Vec<HubuumClassRelation>, ApiError> {
         use crate::schema::hubuumclass_relation::dsl::*;
 
-        with_connection(pool, async |conn| {
+        let rows = with_connection(pool, async |conn| {
             hubuumclass_relation
                 .or_filter(from_hubuum_class_id.eq(self.id()))
                 .or_filter(to_hubuum_class_id.eq(self.id()))
-                .load::<HubuumClassRelation>(conn)
+                .load::<HubuumClassRelationRow>(conn)
                 .await
         })
-        .await
+        .await?;
+        class_relations_from_rows(rows)
     }
 
     async fn search_relations_from_backend(
@@ -315,18 +327,19 @@ where
             }
         }
 
-        apply_query_options!(base_query, query_options, HubuumClassRelation);
+        apply_query_options!(base_query, query_options, HubuumClassRelationRow);
 
         trace_query!(base_query, "Searching relations");
 
-        with_connection(pool, async |conn| {
+        let rows = with_connection(pool, async |conn| {
             base_query
                 .select(hubuumclass_relation::all_columns())
                 .distinct()
-                .load::<HubuumClassRelation>(conn)
+                .load::<HubuumClassRelationRow>(conn)
                 .await
         })
-        .await
+        .await?;
+        class_relations_from_rows(rows)
     }
 }
 
@@ -407,8 +420,8 @@ where
     let (from, to) = (from.id(), to.id());
     let (from, to) = if from > to { (to, from) } else { (from, to) };
 
-    with_connection(pool, async |conn| {
-        diesel_async::RunQueryDsl::first::<HubuumClassRelation>(
+    let row = with_connection(pool, async |conn| {
+        diesel_async::RunQueryDsl::first::<HubuumClassRelationRow>(
             hubuumclass_relation
                 .filter(from_hubuum_class_id.eq(from))
                 .filter(to_hubuum_class_id.eq(to)),
@@ -416,7 +429,8 @@ where
         )
         .await
     })
-    .await
+    .await?;
+    row.try_into()
 }
 
 async fn fetch_relations<C1, C2>(
@@ -434,8 +448,8 @@ where
     let (from, to) = (from.id(), to.id());
     let (from, to) = if from > to { (to, from) } else { (from, to) };
 
-    with_connection(pool, async |conn| {
-        diesel_async::RunQueryDsl::load::<HubuumClassRelationTransitive>(
+    let rows = with_connection(pool, async |conn| {
+        diesel_async::RunQueryDsl::load::<HubuumClassRelationTransitiveRow>(
             sql_query(
                 "SELECT ancestor_class_id, descendant_class_id, depth, path
                  FROM get_bidirectionally_related_classes($1, ARRAY[]::INT[], $2)
@@ -450,7 +464,8 @@ where
         )
         .await
     })
-    .await
+    .await?;
+    Ok(rows.into_iter().map(Into::into).collect())
 }
 
 async fn fetch_relations_paginated<C1, C2>(
@@ -471,7 +486,7 @@ where
     let (from, to) = if from > to { (to, from) } else { (from, to) };
 
     let filter = parse_transitive_filter_params(query_options)?;
-    let sorts = normalized_sorts::<HubuumClassRelationTransitive>(&query_options.sort)?;
+    let sorts = normalized_sorts::<HubuumClassRelationTransitiveRow>(&query_options.sort)?;
     let mut raw_sql = String::from(
         "SELECT ancestor_class_id, descendant_class_id, depth, path
          FROM get_bidirectionally_related_classes(
@@ -480,16 +495,17 @@ where
          WHERE ancestor_class_id = $9 AND descendant_class_id = $10",
     );
 
-    if let Some(cursor_sql) =
-        cursor_filter_sql::<HubuumClassRelationTransitive>(&sorts, query_options.cursor.as_deref())?
-    {
+    if let Some(cursor_sql) = cursor_filter_sql::<HubuumClassRelationTransitiveRow>(
+        &sorts,
+        query_options.cursor.as_deref(),
+    )? {
         raw_sql.push_str("\n  AND ");
         raw_sql.push_str(&cursor_sql);
     }
 
     let order_by = sorts
         .iter()
-        .map(order_sql_clause::<HubuumClassRelationTransitive>)
+        .map(order_sql_clause::<HubuumClassRelationTransitiveRow>)
         .collect::<Result<Vec<_>, _>>()?
         .join(", ");
     raw_sql.push_str(&format!("\nORDER BY {order_by}"));
@@ -498,7 +514,7 @@ where
         raw_sql.push_str(&format!("\nLIMIT {limit}"));
     }
 
-    with_connection(pool, async |conn| {
+    let rows = with_connection(pool, async |conn| {
         let query = bind_transitive_filter_params!(
             sql_query(raw_sql.clone())
                 .bind::<Integer, _>(from)
@@ -506,13 +522,14 @@ where
             filter
         );
 
-        diesel_async::RunQueryDsl::load::<HubuumClassRelationTransitive>(
+        diesel_async::RunQueryDsl::load::<HubuumClassRelationTransitiveRow>(
             query.bind::<Integer, _>(from).bind::<Integer, _>(to),
             conn,
         )
         .await
     })
-    .await
+    .await?;
+    Ok(rows.into_iter().map(Into::into).collect())
 }
 
 impl<U> ObjectRelationsFromUser for U
@@ -538,8 +555,8 @@ where
         // object endpoints go through the scope-aware `objects_related_to_page`),
         // so this runs with full principal authority.
         let collections = user_can_on_any(pool, self, Permissions::ReadObject, None).await?;
-        with_connection(pool, async |conn| {
-            diesel_async::RunQueryDsl::load::<HubuumObjectTransitiveLink>(
+        let rows = with_connection(pool, async |conn| {
+            diesel_async::RunQueryDsl::load::<HubuumObjectTransitiveLinkRow>(
                 sql_query("SELECT * FROM get_transitively_linked_objects($1, $2, $3, $4)")
                     .bind::<Integer, _>(source_object.id())
                     .bind::<Integer, _>(target_class.id())
@@ -551,7 +568,8 @@ where
             )
             .await
         })
-        .await
+        .await?;
+        Ok(rows.into_iter().map(Into::into).collect())
     }
 }
 
@@ -642,10 +660,11 @@ where
                         .or(class_rel::to_hubuum_class_id.eq(class.id())),
                 )
                 .select(obj_rel::hubuumobject_relation::all_columns())
-                .first::<HubuumObjectRelation>(conn)
+                .first::<HubuumObjectRelationRow>(conn)
                 .await
         })
         .await
+        .map(Into::into)
     }
 
     async fn related_objects_from_backend<C>(
@@ -739,13 +758,14 @@ impl LoadClassRelationRecord for HubuumClassRelationID {
     ) -> Result<HubuumClassRelation, ApiError> {
         use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
 
-        with_connection(pool, async |conn| {
+        let row = with_connection(pool, async |conn| {
             hubuumclass_relation
                 .filter(id.eq(self.id()))
-                .first::<HubuumClassRelation>(conn)
+                .first::<HubuumClassRelationRow>(conn)
                 .await
         })
-        .await
+        .await?;
+        row.try_into()
     }
 }
 
@@ -811,10 +831,11 @@ async fn load_resolved_class_relation_target_on_connection(
 ) -> Result<ResolvedClassRelationTarget, ApiError> {
     use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
 
-    let relation = hubuumclass_relation
+    let relation: HubuumClassRelation = hubuumclass_relation
         .filter(id.eq(relation_id))
-        .first::<HubuumClassRelation>(conn)
-        .await?;
+        .first::<HubuumClassRelationRow>(conn)
+        .await?
+        .try_into()?;
     let (from_class, to_class) = load_class_relation_endpoint_records(
         conn,
         relation.from_hubuum_class_id,
@@ -881,11 +902,12 @@ impl DeleteClassRelationRecord for HubuumClassRelation {
         use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let relation = hubuumclass_relation
+            let relation: HubuumClassRelation = hubuumclass_relation
                 .filter(id.eq(self.id))
                 .for_update()
-                .first::<HubuumClassRelation>(conn)
-                .await?;
+                .first::<HubuumClassRelationRow>(conn)
+                .await?
+                .try_into()?;
             let from_class = hubuumclass
                 .filter(class_id.eq(relation.from_hubuum_class_id))
                 .first::<HubuumClass>(conn)
@@ -947,11 +969,12 @@ impl DeleteClassRelationRecord for HubuumClassRelationID {
         use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let relation = hubuumclass_relation
+            let relation: HubuumClassRelation = hubuumclass_relation
                 .filter(id.eq(self.id()))
                 .for_update()
-                .first::<HubuumClassRelation>(conn)
-                .await?;
+                .first::<HubuumClassRelationRow>(conn)
+                .await?
+                .try_into()?;
             let from_class = hubuumclass
                 .filter(class_id.eq(relation.from_hubuum_class_id))
                 .first::<HubuumClass>(conn)
@@ -1009,13 +1032,14 @@ impl SaveClassRelationRecord for NewHubuumClassRelation {
 
         let normalized = self.clone().normalized()?;
 
-        with_connection(pool, async |conn| {
+        let row = with_connection(pool, async |conn| {
             diesel::insert_into(hubuumclass_relation)
-                .values(&normalized)
-                .get_result(conn)
+                .values(NewHubuumClassRelationRow::from(&normalized))
+                .get_result::<HubuumClassRelationRow>(conn)
                 .await
         })
-        .await
+        .await?;
+        row.try_into()
     }
 
     async fn save_class_relation_record(
@@ -1035,10 +1059,11 @@ impl SaveClassRelationRecord for NewHubuumClassRelation {
         with_transaction(
             pool,
             async |conn| -> Result<HubuumClassRelation, ApiError> {
-                let relation = diesel::insert_into(hubuumclass_relation)
-                    .values(&normalized)
-                    .get_result::<HubuumClassRelation>(conn)
-                    .await?;
+                let relation: HubuumClassRelation = diesel::insert_into(hubuumclass_relation)
+                    .values(NewHubuumClassRelationRow::from(&normalized))
+                    .get_result::<HubuumClassRelationRow>(conn)
+                    .await?
+                    .try_into()?;
                 let from_class = hubuumclass
                     .filter(id.eq(relation.from_hubuum_class_id))
                     .first::<HubuumClass>(conn)
@@ -1072,7 +1097,7 @@ pub(crate) trait CreatePreparedClassRelationRecord {
     async fn create_prepared_class_relation_record(
         &self,
         pool: &impl crate::storage::StorageContext,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<HubuumClassRelation, ApiError>;
 }
 
@@ -1080,7 +1105,7 @@ impl CreatePreparedClassRelationRecord for PreparedClassRelation {
     async fn create_prepared_class_relation_record(
         &self,
         pool: &impl crate::storage::StorageContext,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<HubuumClassRelation, ApiError> {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id};
         use crate::schema::hubuumclass_relation::dsl::hubuumclass_relation;
@@ -1104,24 +1129,27 @@ impl CreatePreparedClassRelationRecord for PreparedClassRelation {
                     ));
                 }
 
-                let relation = diesel::insert_into(hubuumclass_relation)
-                    .values(self.command())
-                    .get_result::<HubuumClassRelation>(conn)
-                    .await?;
-                let event = NewEvent::new(
-                    EntityType::ClassRelation,
-                    Action::Created,
-                    context.actor_kind(),
-                    format!(
-                        "Class relation {} -> {} created",
-                        relation.from_hubuum_class_id, relation.to_hubuum_class_id
-                    ),
-                )?
-                .with_context(context)
-                .with_entity_id(relation.id)
-                .with_after(class_relation_snapshot(&relation))
-                .with_metadata(class_relation_metadata(&from_class, &to_class));
-                emit_event(conn, &event).await?;
+                let relation: HubuumClassRelation = diesel::insert_into(hubuumclass_relation)
+                    .values(NewHubuumClassRelationRow::from(self.command()))
+                    .get_result::<HubuumClassRelationRow>(conn)
+                    .await?
+                    .try_into()?;
+                if let Some(context) = context {
+                    let event = NewEvent::new(
+                        EntityType::ClassRelation,
+                        Action::Created,
+                        context.actor_kind(),
+                        format!(
+                            "Class relation {} -> {} created",
+                            relation.from_hubuum_class_id, relation.to_hubuum_class_id
+                        ),
+                    )?
+                    .with_context(context)
+                    .with_entity_id(relation.id)
+                    .with_after(class_relation_snapshot(&relation))
+                    .with_metadata(class_relation_metadata(&from_class, &to_class));
+                    emit_event(conn, &event).await?;
+                }
                 Ok(relation)
             },
         )
@@ -1133,7 +1161,7 @@ pub(crate) trait DeleteResolvedClassRelationRecord {
     async fn delete_resolved_class_relation_record(
         &self,
         pool: &impl crate::storage::StorageContext,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<(), ApiError>;
 }
 
@@ -1141,17 +1169,18 @@ impl DeleteResolvedClassRelationRecord for ResolvedClassRelationTarget {
     async fn delete_resolved_class_relation_record(
         &self,
         pool: &impl crate::storage::StorageContext,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<(), ApiError> {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id as class_id};
         use crate::schema::hubuumclass_relation::dsl::{hubuumclass_relation, id};
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let relation = hubuumclass_relation
+            let relation: HubuumClassRelation = hubuumclass_relation
                 .filter(id.eq(self.relation().id))
                 .for_update()
-                .first::<HubuumClassRelation>(conn)
-                .await?;
+                .first::<HubuumClassRelationRow>(conn)
+                .await?
+                .try_into()?;
             let from_class = hubuumclass
                 .filter(class_id.eq(relation.from_hubuum_class_id))
                 .for_update()
@@ -1174,20 +1203,22 @@ impl DeleteResolvedClassRelationRecord for ResolvedClassRelationTarget {
             diesel::delete(hubuumclass_relation.filter(id.eq(relation.id)))
                 .execute(conn)
                 .await?;
-            let event = NewEvent::new(
-                EntityType::ClassRelation,
-                Action::Deleted,
-                context.actor_kind(),
-                format!(
-                    "Class relation {} -> {} deleted",
-                    relation.from_hubuum_class_id, relation.to_hubuum_class_id
-                ),
-            )?
-            .with_context(context)
-            .with_entity_id(relation.id)
-            .with_before(class_relation_snapshot(&relation))
-            .with_metadata(class_relation_metadata(&from_class, &to_class));
-            emit_event(conn, &event).await?;
+            if let Some(context) = context {
+                let event = NewEvent::new(
+                    EntityType::ClassRelation,
+                    Action::Deleted,
+                    context.actor_kind(),
+                    format!(
+                        "Class relation {} -> {} deleted",
+                        relation.from_hubuum_class_id, relation.to_hubuum_class_id
+                    ),
+                )?
+                .with_context(context)
+                .with_entity_id(relation.id)
+                .with_before(class_relation_snapshot(&relation))
+                .with_metadata(class_relation_metadata(&from_class, &to_class));
+                emit_event(conn, &event).await?;
+            }
             Ok(())
         })
         .await
@@ -1231,7 +1262,7 @@ async fn load_direct_class_relation_target_on_connection(
     let relation = hubuumclass_relation
         .filter(from_hubuum_class_id.eq(lower_class_id))
         .filter(to_hubuum_class_id.eq(higher_class_id))
-        .first::<HubuumClassRelation>(conn)
+        .first::<HubuumClassRelationRow>(conn)
         .await
         .map_err(|error| match error {
             diesel::result::Error::NotFound => ApiError::NotFound(format!(
@@ -1239,6 +1270,7 @@ async fn load_direct_class_relation_target_on_connection(
             )),
             error => ApiError::from(error),
         })?;
+    let relation: HubuumClassRelation = relation.try_into()?;
     let (from_class, to_class) = load_class_relation_endpoint_records(
         conn,
         relation.from_hubuum_class_id,
@@ -1350,10 +1382,11 @@ impl ResolveObjectRelationTargetRecord for ObjectRelationSelector {
         with_connection(pool, async |conn| {
             let (relation, from_object, to_object) = match self.kind() {
                 ObjectRelationSelectorKind::ById(relation_id) => {
-                    let relation = hubuumobject_relation
+                    let relation: HubuumObjectRelation = hubuumobject_relation
                         .filter(id.eq(relation_id.id()))
-                        .first::<HubuumObjectRelation>(conn)
-                        .await?;
+                        .first::<HubuumObjectRelationRow>(conn)
+                        .await?
+                        .into();
                     let (from_object, to_object) = load_object_relation_endpoint_records(
                         conn,
                         relation.from_hubuum_object_id,
@@ -1379,11 +1412,12 @@ impl ResolveObjectRelationTargetRecord for ObjectRelationSelector {
                     }
                     let lower_object_id = from.object_id().id().min(to.object_id().id());
                     let higher_object_id = from.object_id().id().max(to.object_id().id());
-                    let relation = hubuumobject_relation
+                    let relation: HubuumObjectRelation = hubuumobject_relation
                         .filter(from_hubuum_object_id.eq(lower_object_id))
                         .filter(to_hubuum_object_id.eq(higher_object_id))
-                        .first::<HubuumObjectRelation>(conn)
-                        .await?;
+                        .first::<HubuumObjectRelationRow>(conn)
+                        .await?
+                        .into();
                     let command = NewHubuumObjectRelation {
                         from_hubuum_object_id: relation.from_hubuum_object_id,
                         to_hubuum_object_id: relation.to_hubuum_object_id,
@@ -1416,7 +1450,7 @@ pub(crate) trait CreatePreparedObjectRelationRecord {
     async fn create_prepared_object_relation_record(
         &self,
         pool: &impl crate::storage::StorageContext,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<HubuumObjectRelation, ApiError>;
 }
 
@@ -1424,7 +1458,7 @@ impl CreatePreparedObjectRelationRecord for PreparedObjectRelation {
     async fn create_prepared_object_relation_record(
         &self,
         pool: &impl crate::storage::StorageContext,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<HubuumObjectRelation, ApiError> {
         use crate::schema::hubuumclass_relation::dsl::{
             hubuumclass_relation, id as class_relation_id,
@@ -1447,39 +1481,43 @@ impl CreatePreparedObjectRelationRecord for PreparedObjectRelation {
                         "Object relation endpoints no longer match the prepared target".to_string(),
                     ));
                 }
-                let class_relation = hubuumclass_relation
+                let class_relation: HubuumClassRelation = hubuumclass_relation
                     .filter(class_relation_id.eq(self.command().class_relation_id))
                     .for_share()
-                    .first::<HubuumClassRelation>(conn)
-                    .await?;
+                    .first::<HubuumClassRelationRow>(conn)
+                    .await?
+                    .try_into()?;
                 if &class_relation != self.class_relation().relation() {
                     return Err(ApiError::NotFound(
                         "Class relation no longer matches the prepared object relation".to_string(),
                     ));
                 }
 
-                let relation = diesel::insert_into(hubuumobject_relation)
-                    .values(self.command())
-                    .get_result::<HubuumObjectRelation>(conn)
-                    .await?;
-                let event = NewEvent::new(
-                    EntityType::ObjectRelation,
-                    Action::Created,
-                    context.actor_kind(),
-                    format!(
-                        "Object relation {} -> {} created",
-                        relation.from_hubuum_object_id, relation.to_hubuum_object_id
-                    ),
-                )?
-                .with_context(context)
-                .with_entity_id(relation.id)
-                .with_after(object_relation_snapshot(&relation))
-                .with_metadata(object_relation_metadata(
-                    &relation,
-                    &from_object,
-                    &to_object,
-                ));
-                emit_event(conn, &event).await?;
+                let relation: HubuumObjectRelation = diesel::insert_into(hubuumobject_relation)
+                    .values(NewHubuumObjectRelationRow::from(self.command()))
+                    .get_result::<HubuumObjectRelationRow>(conn)
+                    .await?
+                    .into();
+                if let Some(context) = context {
+                    let event = NewEvent::new(
+                        EntityType::ObjectRelation,
+                        Action::Created,
+                        context.actor_kind(),
+                        format!(
+                            "Object relation {} -> {} created",
+                            relation.from_hubuum_object_id, relation.to_hubuum_object_id
+                        ),
+                    )?
+                    .with_context(context)
+                    .with_entity_id(relation.id)
+                    .with_after(object_relation_snapshot(&relation))
+                    .with_metadata(object_relation_metadata(
+                        &relation,
+                        &from_object,
+                        &to_object,
+                    ));
+                    emit_event(conn, &event).await?;
+                }
                 Ok(relation)
             },
         )
@@ -1491,7 +1529,7 @@ pub(crate) trait DeleteResolvedObjectRelationRecord {
     async fn delete_resolved_object_relation_record(
         &self,
         pool: &impl crate::storage::StorageContext,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<(), ApiError>;
 }
 
@@ -1499,16 +1537,17 @@ impl DeleteResolvedObjectRelationRecord for ResolvedObjectRelationTarget {
     async fn delete_resolved_object_relation_record(
         &self,
         pool: &impl crate::storage::StorageContext,
-        context: &EventContext,
+        context: Option<&EventContext>,
     ) -> Result<(), ApiError> {
         use crate::schema::hubuumobject_relation::dsl::{hubuumobject_relation, id};
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let relation = hubuumobject_relation
+            let relation: HubuumObjectRelation = hubuumobject_relation
                 .filter(id.eq(self.relation().id))
                 .for_update()
-                .first::<HubuumObjectRelation>(conn)
-                .await?;
+                .first::<HubuumObjectRelationRow>(conn)
+                .await?
+                .into();
             let (from_object, to_object) = load_object_relation_endpoint_records(
                 conn,
                 relation.from_hubuum_object_id,
@@ -1527,24 +1566,26 @@ impl DeleteResolvedObjectRelationRecord for ResolvedObjectRelationTarget {
             diesel::delete(hubuumobject_relation.filter(id.eq(relation.id)))
                 .execute(conn)
                 .await?;
-            let event = NewEvent::new(
-                EntityType::ObjectRelation,
-                Action::Deleted,
-                context.actor_kind(),
-                format!(
-                    "Object relation {} -> {} deleted",
-                    relation.from_hubuum_object_id, relation.to_hubuum_object_id
-                ),
-            )?
-            .with_context(context)
-            .with_entity_id(relation.id)
-            .with_before(object_relation_snapshot(&relation))
-            .with_metadata(object_relation_metadata(
-                &relation,
-                &from_object,
-                &to_object,
-            ));
-            emit_event(conn, &event).await?;
+            if let Some(context) = context {
+                let event = NewEvent::new(
+                    EntityType::ObjectRelation,
+                    Action::Deleted,
+                    context.actor_kind(),
+                    format!(
+                        "Object relation {} -> {} deleted",
+                        relation.from_hubuum_object_id, relation.to_hubuum_object_id
+                    ),
+                )?
+                .with_context(context)
+                .with_entity_id(relation.id)
+                .with_before(object_relation_snapshot(&relation))
+                .with_metadata(object_relation_metadata(
+                    &relation,
+                    &from_object,
+                    &to_object,
+                ));
+                emit_event(conn, &event).await?;
+            }
             Ok(())
         })
         .await
@@ -1568,10 +1609,11 @@ impl LoadObjectRelationRecord for HubuumObjectRelationID {
         with_connection(pool, async |conn| {
             hubuumobject_relation
                 .filter(id.eq(self.id()))
-                .first::<HubuumObjectRelation>(conn)
+                .first::<HubuumObjectRelationRow>(conn)
                 .await
         })
         .await
+        .map(Into::into)
     }
 }
 
@@ -1623,11 +1665,12 @@ impl DeleteObjectRelationRecord for HubuumObjectRelation {
         use crate::schema::hubuumobject_relation::dsl::{hubuumobject_relation, id};
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let relation = hubuumobject_relation
+            let relation: HubuumObjectRelation = hubuumobject_relation
                 .filter(id.eq(self.id))
                 .for_update()
-                .first::<HubuumObjectRelation>(conn)
-                .await?;
+                .first::<HubuumObjectRelationRow>(conn)
+                .await?
+                .into();
             let from_object = hubuumobject
                 .filter(object_id.eq(relation.from_hubuum_object_id))
                 .first::<HubuumObjectRow>(conn)
@@ -1696,11 +1739,12 @@ impl DeleteObjectRelationRecord for HubuumObjectRelationID {
         use crate::schema::hubuumobject_relation::dsl::{hubuumobject_relation, id};
 
         with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            let relation = hubuumobject_relation
+            let relation: HubuumObjectRelation = hubuumobject_relation
                 .filter(id.eq(self.id()))
                 .for_update()
-                .first::<HubuumObjectRelation>(conn)
-                .await?;
+                .first::<HubuumObjectRelationRow>(conn)
+                .await?
+                .into();
             let from_object = hubuumobject
                 .filter(object_id.eq(relation.from_hubuum_object_id))
                 .first::<HubuumObjectRow>(conn)
@@ -1800,11 +1844,12 @@ impl SaveObjectRelationRecord for NewHubuumObjectRelation {
 
         with_connection(pool, async |conn| {
             diesel::insert_into(hubuumobject_relation)
-                .values(self)
-                .get_result(conn)
+                .values(NewHubuumObjectRelationRow::from(self))
+                .get_result::<HubuumObjectRelationRow>(conn)
                 .await
         })
         .await
+        .map(Into::into)
     }
 
     async fn save_object_relation_record(
@@ -1858,10 +1903,11 @@ impl SaveObjectRelationRecord for NewHubuumObjectRelation {
         with_transaction(
             pool,
             async |conn| -> Result<HubuumObjectRelation, ApiError> {
-                let relation = diesel::insert_into(hubuumobject_relation)
-                    .values(self)
-                    .get_result::<HubuumObjectRelation>(conn)
-                    .await?;
+                let relation: HubuumObjectRelation = diesel::insert_into(hubuumobject_relation)
+                    .values(NewHubuumObjectRelationRow::from(self))
+                    .get_result::<HubuumObjectRelationRow>(conn)
+                    .await?
+                    .into();
                 let event = NewEvent::new(
                     EntityType::ObjectRelation,
                     Action::Created,

--- a/src/storage/postgres/operations/task_import.rs
+++ b/src/storage/postgres/operations/task_import.rs
@@ -20,6 +20,10 @@ use crate::storage::postgres::operations::collection::CollectionRowInsert;
 use crate::storage::postgres::operations::object::{
     HubuumObjectRow, NewHubuumObjectRow, UpdateHubuumObjectRow,
 };
+use crate::storage::postgres::operations::relation_rows::{
+    HubuumClassRelationRow, HubuumObjectRelationRow, NewHubuumClassRelationRow,
+    NewHubuumObjectRelationRow,
+};
 use crate::storage::postgres::{SendAsyncFn, with_connection};
 
 fn assert_import_revision(
@@ -204,15 +208,16 @@ pub async fn lookup_direct_class_relation(
     };
     let pair = normalize_pair(left, right);
 
-    with_connection(pool, async |conn| {
+    let row = with_connection(pool, async |conn| {
         hubuumclass_relation
             .filter(from_hubuum_class_id.eq(pair.0))
             .filter(to_hubuum_class_id.eq(pair.1))
-            .first::<HubuumClassRelation>(conn)
+            .first::<HubuumClassRelationRow>(conn)
             .await
             .optional()
     })
-    .await
+    .await?;
+    row.map(TryInto::try_into).transpose()
 }
 
 pub async fn lookup_object_relation(
@@ -225,15 +230,16 @@ pub async fn lookup_object_relation(
     };
     let pair = normalize_pair(left, right);
 
-    with_connection(pool, async |conn| {
+    let row = with_connection(pool, async |conn| {
         hubuumobject_relation
             .filter(from_hubuum_object_id.eq(pair.0))
             .filter(to_hubuum_object_id.eq(pair.1))
-            .first::<HubuumObjectRelation>(conn)
+            .first::<HubuumObjectRelationRow>(conn)
             .await
             .optional()
     })
-    .await
+    .await?;
+    Ok(row.map(Into::into))
 }
 
 pub async fn lookup_group_by_name(
@@ -1755,22 +1761,23 @@ pub async fn create_class_relation_db(
     use crate::schema::hubuumclass_relation::dsl::{created_at, hubuumclass_relation, updated_at};
     let new_relation = new_relation.normalized()?;
 
-    match timestamps {
+    let row = match timestamps {
         Some(timestamps) => diesel::insert_into(hubuumclass_relation)
             .values((
-                &new_relation,
+                NewHubuumClassRelationRow::from(&new_relation),
                 created_at.eq(timestamps.created_at()),
                 updated_at.eq(timestamps.updated_at()),
             ))
-            .get_result::<HubuumClassRelation>(conn)
+            .get_result::<HubuumClassRelationRow>(conn)
             .await
             .map_err(ApiError::from),
         None => diesel::insert_into(hubuumclass_relation)
-            .values(&new_relation)
-            .get_result::<HubuumClassRelation>(conn)
+            .values(NewHubuumClassRelationRow::from(&new_relation))
+            .get_result::<HubuumClassRelationRow>(conn)
             .await
             .map_err(ApiError::from),
-    }
+    }?;
+    row.try_into()
 }
 
 pub async fn update_class_relation_timestamps_db(
@@ -1786,7 +1793,7 @@ pub async fn update_class_relation_timestamps_db(
     let pair = normalize_pair(left, right);
     check_class_relation_import_condition_db(conn, pair.0, pair.1, condition).await?;
 
-    with_imported_timestamp_override(conn, async |conn| {
+    let row = with_imported_timestamp_override(conn, async |conn| {
         crate::storage::postgres::updated_or_current(
             diesel::update(
                 hubuumclass_relation
@@ -1797,21 +1804,22 @@ pub async fn update_class_relation_timestamps_db(
                 created_at.eq(timestamps.created_at()),
                 updated_at.eq(timestamps.updated_at()),
             ))
-            .get_result::<HubuumClassRelation>(conn)
+            .get_result::<HubuumClassRelationRow>(conn)
             .await
             .optional(),
             async || {
                 hubuumclass_relation
                     .filter(from_hubuum_class_id.eq(pair.0))
                     .filter(to_hubuum_class_id.eq(pair.1))
-                    .first(conn)
+                    .first::<HubuumClassRelationRow>(conn)
                     .await
             },
         )
         .await
         .map_err(ApiError::from)
     })
-    .await
+    .await?;
+    row.try_into()
 }
 
 pub async fn check_class_relation_import_condition_db(
@@ -1851,11 +1859,12 @@ pub async fn create_object_relation_db(
         created_at, hubuumobject_relation, updated_at,
     };
     let class_pair = normalize_pair(from_object.hubuum_class_id, to_object.hubuum_class_id);
-    let relation = hubuumclass_relation
+    let relation: HubuumClassRelation = hubuumclass_relation
         .filter(from_hubuum_class_id.eq(class_pair.0))
         .filter(to_hubuum_class_id.eq(class_pair.1))
-        .first::<HubuumClassRelation>(conn)
-        .await?;
+        .first::<HubuumClassRelationRow>(conn)
+        .await?
+        .try_into()?;
 
     let object_pair = normalize_pair(from_object.id, to_object.id);
     let new_relation = NewHubuumObjectRelation {
@@ -1864,22 +1873,23 @@ pub async fn create_object_relation_db(
         class_relation_id: relation.id,
     };
 
-    match timestamps {
+    let row = match timestamps {
         Some(timestamps) => diesel::insert_into(hubuumobject_relation)
             .values((
-                &new_relation,
+                NewHubuumObjectRelationRow::from(&new_relation),
                 created_at.eq(timestamps.created_at()),
                 updated_at.eq(timestamps.updated_at()),
             ))
-            .get_result::<HubuumObjectRelation>(conn)
+            .get_result::<HubuumObjectRelationRow>(conn)
             .await
             .map_err(ApiError::from),
         None => diesel::insert_into(hubuumobject_relation)
-            .values(&new_relation)
-            .get_result::<HubuumObjectRelation>(conn)
+            .values(NewHubuumObjectRelationRow::from(&new_relation))
+            .get_result::<HubuumObjectRelationRow>(conn)
             .await
             .map_err(ApiError::from),
-    }
+    }?;
+    Ok(row.into())
 }
 
 pub async fn update_object_relation_timestamps_db(
@@ -1895,7 +1905,7 @@ pub async fn update_object_relation_timestamps_db(
     let pair = normalize_pair(from_object.id, to_object.id);
     check_object_relation_import_condition_db(conn, from_object, to_object, condition).await?;
 
-    with_imported_timestamp_override(conn, async |conn| {
+    let row = with_imported_timestamp_override(conn, async |conn| {
         crate::storage::postgres::updated_or_current(
             diesel::update(
                 hubuumobject_relation
@@ -1906,21 +1916,22 @@ pub async fn update_object_relation_timestamps_db(
                 created_at.eq(timestamps.created_at()),
                 updated_at.eq(timestamps.updated_at()),
             ))
-            .get_result::<HubuumObjectRelation>(conn)
+            .get_result::<HubuumObjectRelationRow>(conn)
             .await
             .optional(),
             async || {
                 hubuumobject_relation
                     .filter(from_hubuum_object_id.eq(pair.0))
                     .filter(to_hubuum_object_id.eq(pair.1))
-                    .first(conn)
+                    .first::<HubuumObjectRelationRow>(conn)
                     .await
             },
         )
         .await
         .map_err(ApiError::from)
     })
-    .await
+    .await?;
+    Ok(row.into())
 }
 
 pub async fn check_object_relation_import_condition_db(

--- a/src/storage/postgres/operations/user/search.rs
+++ b/src/storage/postgres/operations/user/search.rs
@@ -14,6 +14,10 @@ use crate::storage::postgres::operations::computed_field::{
     ComputedQuerySnapshot, computed_filter_predicate, object_cursor_sql_fields,
 };
 use crate::storage::postgres::operations::object::HubuumObjectRow;
+use crate::storage::postgres::operations::relation_rows::{
+    ClassGraphQueryRow, HubuumClassRelationRow, HubuumObjectRelationRow,
+    RelatedObjectForRootQueryRow, RelatedObjectGraphQueryRow, RelatedObjectIncludeQueryRow,
+};
 use crate::storage::postgres::operations::resource_scope::{
     class_scope_predicate, collection_scope_predicate, object_scope_predicate, resource_scope_ids,
 };
@@ -26,6 +30,12 @@ use crate::utilities::extensions::CustomStringExtensions;
 use diesel::BoolExpressionMethods;
 use diesel_async::RunQueryDsl;
 use std::collections::BTreeMap;
+
+fn class_relations_from_rows(
+    rows: Vec<HubuumClassRelationRow>,
+) -> Result<Vec<HubuumClassRelation>, ApiError> {
+    rows.into_iter().map(TryInto::try_into).collect()
+}
 
 #[derive(diesel::QueryableByName)]
 struct CountRow {
@@ -1376,7 +1386,7 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         .await?;
 
         let mut base_query = build_query()?;
-        crate::apply_query_options!(base_query, query_options, HubuumClassRelation);
+        crate::apply_query_options!(base_query, query_options, HubuumClassRelationRow);
 
         trace_query!(base_query, "Searching class relations");
 
@@ -1384,12 +1394,12 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             base_query
                 .select(hubuumclass_relation::all_columns())
                 .distinct()
-                .load::<HubuumClassRelation>(conn)
+                .load::<HubuumClassRelationRow>(conn)
                 .await
         })
         .await?;
 
-        Ok((items, total_count))
+        Ok((class_relations_from_rows(items)?, total_count))
     }
 
     async fn class_relations_touching_page_from_backend<K>(
@@ -1531,7 +1541,7 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         .await?;
 
         let mut base_query = build_query()?;
-        crate::apply_query_options!(base_query, query_options, HubuumClassRelation);
+        crate::apply_query_options!(base_query, query_options, HubuumClassRelationRow);
 
         trace_query!(
             base_query,
@@ -1542,12 +1552,12 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             base_query
                 .select(hubuumclass_relation::all_columns())
                 .distinct()
-                .load::<HubuumClassRelation>(conn)
+                .load::<HubuumClassRelationRow>(conn)
                 .await
         })
         .await?;
 
-        Ok((items, total_count))
+        Ok((class_relations_from_rows(items)?, total_count))
     }
 
     async fn search_class_relations_between_ids_from_backend(
@@ -1632,10 +1642,11 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             "Searching visible class relations touching class IDs"
         );
 
-        with_connection(pool, async |conn| {
-            base_query.load::<HubuumClassRelation>(conn).await
+        let rows = with_connection(pool, async |conn| {
+            base_query.load::<HubuumClassRelationRow>(conn).await
         })
-        .await
+        .await?;
+        class_relations_from_rows(rows)
     }
 
     async fn search_class_relations_between_ids_from_backend_with_admin_status(
@@ -1701,10 +1712,11 @@ pub trait UserSearchBackend: UserCollectionAccessors {
 
         trace_query!(base_query, "Searching class relations among class IDs");
 
-        with_connection(pool, async |conn| {
-            base_query.load::<HubuumClassRelation>(conn).await
+        let rows = with_connection(pool, async |conn| {
+            base_query.load::<HubuumClassRelationRow>(conn).await
         })
-        .await
+        .await?;
+        class_relations_from_rows(rows)
     }
 
     async fn search_classes_related_to_from_backend<K>(
@@ -1772,7 +1784,7 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         else {
             return Ok(vec![]);
         };
-        let spec = apply_raw_sql_pagination::<ClassGraphRow>(base_spec, &query_options)?;
+        let spec = apply_raw_sql_pagination::<ClassGraphQueryRow>(base_spec, &query_options)?;
 
         let query = bind_raw_sql_query!(spec.clone());
         debug!(
@@ -1783,9 +1795,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         trace_query!(query, "Searching related classes");
 
         with_connection(pool, async |conn| {
-            query.get_results::<ClassGraphRow>(conn).await
+            query.get_results::<ClassGraphQueryRow>(conn).await
         })
         .await
+        .map(|rows| rows.into_iter().map(Into::into).collect())
     }
 
     async fn classes_related_to_page_from_backend_with_admin_status<K>(
@@ -1815,7 +1828,7 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             ));
         };
         let total_count_spec = base_spec.clone().into_count_query("related_classes_count");
-        let spec = apply_raw_sql_pagination::<ClassGraphRow>(base_spec, &query_options)?;
+        let spec = apply_raw_sql_pagination::<ClassGraphQueryRow>(base_spec, &query_options)?;
 
         let total_count = crate::pagination::exact_count_or_skipped(&query_options, async || {
             with_connection(pool, async |conn| {
@@ -1836,11 +1849,11 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         );
         trace_query!(query, "Searching related classes");
         let items = with_connection(pool, async |conn| {
-            query.get_results::<ClassGraphRow>(conn).await
+            query.get_results::<ClassGraphQueryRow>(conn).await
         })
         .await?;
 
-        Ok((items, total_count))
+        Ok((items.into_iter().map(Into::into).collect(), total_count))
     }
 
     async fn search_object_relations_from_backend(
@@ -2018,7 +2031,7 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         .await?;
 
         let mut base_query = build_query()?;
-        crate::apply_query_options!(base_query, query_options, HubuumObjectRelation);
+        crate::apply_query_options!(base_query, query_options, HubuumObjectRelationRow);
 
         trace_query!(base_query, "Searching object relations");
 
@@ -2026,12 +2039,12 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             base_query
                 .select(hubuumobject_relation::all_columns())
                 .distinct()
-                .load::<HubuumObjectRelation>(conn)
+                .load::<HubuumObjectRelationRow>(conn)
                 .await
         })
         .await?;
 
-        Ok((items, total_count))
+        Ok((items.into_iter().map(Into::into).collect(), total_count))
     }
 
     async fn object_relations_touching_page_from_backend<O>(
@@ -2192,7 +2205,7 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         .await?;
 
         let mut base_query = build_query()?;
-        crate::apply_query_options!(base_query, query_options, HubuumObjectRelation);
+        crate::apply_query_options!(base_query, query_options, HubuumObjectRelationRow);
 
         trace_query!(
             base_query,
@@ -2203,12 +2216,12 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             base_query
                 .select(hubuumobject_relation::all_columns())
                 .distinct()
-                .load::<HubuumObjectRelation>(conn)
+                .load::<HubuumObjectRelationRow>(conn)
                 .await
         })
         .await?;
 
-        Ok((items, total_count))
+        Ok((items.into_iter().map(Into::into).collect(), total_count))
     }
 
     async fn search_object_relations_between_ids_from_backend(
@@ -2301,9 +2314,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             "Searching visible object relations touching object IDs"
         );
         with_connection(pool, async |connection| {
-            base_query.load::<HubuumObjectRelation>(connection).await
+            base_query.load::<HubuumObjectRelationRow>(connection).await
         })
         .await
+        .map(|rows| rows.into_iter().map(Into::into).collect())
     }
 
     async fn search_object_relations_between_ids_from_backend_with_admin_status(
@@ -2377,9 +2391,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         trace_query!(base_query, "Searching object relations among object IDs");
 
         with_connection(pool, async |conn| {
-            base_query.load::<HubuumObjectRelation>(conn).await
+            base_query.load::<HubuumObjectRelationRow>(conn).await
         })
         .await
+        .map(|rows| rows.into_iter().map(Into::into).collect())
     }
 
     async fn search_objects_related_to_from_backend<O>(
@@ -2447,7 +2462,8 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         else {
             return Ok(vec![]);
         };
-        let spec = apply_raw_sql_pagination::<RelatedObjectGraphRow>(base_spec, &query_options)?;
+        let spec =
+            apply_raw_sql_pagination::<RelatedObjectGraphQueryRow>(base_spec, &query_options)?;
 
         let query = bind_raw_sql_query!(spec.clone());
         debug!(
@@ -2458,9 +2474,10 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         trace_query!(query, "Searching source-relative related objects");
 
         with_connection(pool, async |conn| {
-            query.get_results::<RelatedObjectGraphRow>(conn).await
+            query.get_results::<RelatedObjectGraphQueryRow>(conn).await
         })
         .await
+        .map(|rows| rows.into_iter().map(Into::into).collect())
     }
 
     async fn objects_related_to_page_from_backend_with_admin_status<O>(
@@ -2490,7 +2507,8 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             ));
         };
         let total_count_spec = base_spec.clone().into_count_query("related_objects_count");
-        let spec = apply_raw_sql_pagination::<RelatedObjectGraphRow>(base_spec, &query_options)?;
+        let spec =
+            apply_raw_sql_pagination::<RelatedObjectGraphQueryRow>(base_spec, &query_options)?;
 
         let total_count = crate::pagination::exact_count_or_skipped(&query_options, async || {
             with_connection(pool, async |conn| {
@@ -2511,11 +2529,11 @@ pub trait UserSearchBackend: UserCollectionAccessors {
         );
         trace_query!(query, "Searching source-relative related objects");
         let items = with_connection(pool, async |conn| {
-            query.get_results::<RelatedObjectGraphRow>(conn).await
+            query.get_results::<RelatedObjectGraphQueryRow>(conn).await
         })
         .await?;
 
-        Ok((items, total_count))
+        Ok((items.into_iter().map(Into::into).collect(), total_count))
     }
 
     async fn related_objects_for_roots_from_backend(
@@ -2721,9 +2739,12 @@ where
     trace_query!(query, "Searching batched related objects");
 
     with_connection(pool, async |conn| {
-        query.get_results::<RelatedObjectIncludeRow>(conn).await
+        query
+            .get_results::<RelatedObjectIncludeQueryRow>(conn)
+            .await
     })
     .await
+    .map(|rows| rows.into_iter().map(Into::into).collect())
 }
 
 struct BidirectionalRootGraphQuery<'a> {
@@ -2789,9 +2810,12 @@ where
     trace_query!(query, "Searching batched bidirectionally related objects");
 
     with_connection(pool, async |conn| {
-        query.get_results::<RelatedObjectForRootRow>(conn).await
+        query
+            .get_results::<RelatedObjectForRootQueryRow>(conn)
+            .await
     })
     .await
+    .map(|rows| rows.into_iter().map(Into::into).collect())
 }
 
 fn related_include_object_edges_sql(

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -261,6 +261,65 @@ fn object_domain_types_are_free_of_persistence_implementation_details() {
 }
 
 #[test]
+fn relation_domain_types_are_free_of_persistence_implementation_details() {
+    let root = repository_root();
+    let mut violations = Vec::new();
+
+    for relative_path in [
+        "src/models/relation.rs",
+        "src/models/traits/class_relation.rs",
+        "src/models/traits/object_relation.rs",
+    ] {
+        let path = root.join(relative_path);
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(&source);
+        for forbidden in [
+            "diesel::",
+            "diesel(",
+            "crate::schema",
+            "storage::postgres",
+            "CursorSqlMapping",
+            "CursorSqlField",
+            "CursorSqlType",
+        ] {
+            if production_source.contains(forbidden) {
+                violations.push(format!("{} contains {forbidden}", path.display()));
+            }
+        }
+    }
+
+    let adapter_path = root.join("src/storage/postgres/operations/relation_rows.rs");
+    let adapter_source = fs::read_to_string(&adapter_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", adapter_path.display()));
+    for required in [
+        "struct HubuumClassRelationRow",
+        "struct NewHubuumClassRelationRow",
+        "struct HubuumObjectRelationRow",
+        "struct NewHubuumObjectRelationRow",
+        "struct HubuumClassRelationTransitiveRow",
+        "struct ClassGraphQueryRow",
+        "struct RelatedObjectGraphQueryRow",
+        "impl CursorSqlMapping for HubuumClassRelationRow",
+        "impl CursorSqlMapping for HubuumObjectRelationRow",
+        "impl CursorSqlMapping for HubuumClassRelationTransitiveRow",
+        "impl CursorSqlMapping for ClassGraphQueryRow",
+        "impl CursorSqlMapping for RelatedObjectGraphQueryRow",
+    ] {
+        assert!(
+            adapter_source.contains(required),
+            "PostgreSQL relation adapter is missing {required}"
+        );
+    }
+
+    assert!(
+        violations.is_empty(),
+        "relation domain types crossed into persistence details:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
 fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable() {
     let root = repository_root();
     let contract_path = root.join("src/storage/contract.rs");

--- a/tests/api_core_data_suite/relations.rs
+++ b/tests/api_core_data_suite/relations.rs
@@ -1020,10 +1020,17 @@ mod tests {
 
         let held_insert = actix_web::rt::spawn(async move {
             with_transaction(&insert_pool, async move |conn| -> Result<(), ApiError> {
-                use crate::schema::hubuumobject_relation;
+                use crate::schema::hubuumobject_relation::dsl::{
+                    class_relation_id, from_hubuum_object_id, hubuumobject_relation,
+                    to_hubuum_object_id,
+                };
 
-                diesel::insert_into(hubuumobject_relation::table)
-                    .values(&held_relation)
+                diesel::insert_into(hubuumobject_relation)
+                    .values((
+                        from_hubuum_object_id.eq(held_relation.from_hubuum_object_id),
+                        to_hubuum_object_id.eq(held_relation.to_hubuum_object_id),
+                        class_relation_id.eq(held_relation.class_relation_id),
+                    ))
                     .execute(conn)
                     .await?;
                 inserted_tx

--- a/tests/api_jobs_suite/imports.rs
+++ b/tests/api_jobs_suite/imports.rs
@@ -11,15 +11,14 @@ mod tests {
 
     use crate::models::{
         CURRENT_IMPORT_VERSION, ClassKey, CollectionKey, ComputedResultType, GroupID, GroupKey,
-        HubuumClass, HubuumClassRelation, IdentityScopeKey, ImportAtomicity, ImportClassInput,
-        ImportClassRelationInput, ImportCollectionInput, ImportCollectionPermissionInput,
-        ImportCollisionPolicy, ImportComputedFieldInput, ImportComputedFieldVisibility,
-        ImportEventSubscriptionInput, ImportGraph, ImportGroupInput, ImportGroupMembershipInput,
-        ImportIdentityScopeInput, ImportMode, ImportObjectInput, ImportObjectRelationInput,
-        ImportPermissionPolicy, ImportPrincipalInput, ImportPrincipalSubtype, ImportRequest,
-        ImportTaskResultResponse, ImportWriteCondition, NewHubuumClass, NewTaskRecord,
-        ObjectRelationLimit, Permissions, ResourceRevision, RestoreTimestamps, TaskEventResponse,
-        TaskKind, TaskResponse, TaskStatus,
+        HubuumClass, IdentityScopeKey, ImportAtomicity, ImportClassInput, ImportClassRelationInput,
+        ImportCollectionInput, ImportCollectionPermissionInput, ImportCollisionPolicy,
+        ImportComputedFieldInput, ImportComputedFieldVisibility, ImportEventSubscriptionInput,
+        ImportGraph, ImportGroupInput, ImportGroupMembershipInput, ImportIdentityScopeInput,
+        ImportMode, ImportObjectInput, ImportObjectRelationInput, ImportPermissionPolicy,
+        ImportPrincipalInput, ImportPrincipalSubtype, ImportRequest, ImportTaskResultResponse,
+        ImportWriteCondition, NewHubuumClass, NewTaskRecord, ObjectRelationLimit, Permissions,
+        ResourceRevision, RestoreTimestamps, TaskEventResponse, TaskKind, TaskResponse, TaskStatus,
     };
     use crate::pagination::{NEXT_CURSOR_HEADER, TOTAL_COUNT_HEADER};
     use crate::schema::collections::dsl::{
@@ -613,35 +612,44 @@ mod tests {
         let completed = wait_for_task(&context, task.id, &[TaskStatus::Succeeded]).await;
         assert_eq!(completed.progress.success_items, 4);
 
-        let (jack_id, room_id, relation) = with_connection(&context.pool, async |conn| {
-            let jack_id = hubuumclass
-                .filter(class_name.eq(jack_name))
-                .select(class_id)
-                .first::<i32>(conn)
-                .await?;
-            let room_id = hubuumclass
-                .filter(class_name.eq(room_name))
-                .select(class_id)
-                .first::<i32>(conn)
-                .await?;
-            let relation = hubuumclass_relation
-                .filter(from_hubuum_class_id.eq(jack_id.min(room_id)))
-                .filter(to_hubuum_class_id.eq(jack_id.max(room_id)))
-                .first::<HubuumClassRelation>(conn)
-                .await?;
-            Ok::<_, diesel::result::Error>((jack_id, room_id, relation))
-        })
-        .await
-        .unwrap();
-        let (jack_limit, room_limit) = if relation.from_hubuum_class_id == jack_id {
-            assert_eq!(relation.to_hubuum_class_id, room_id);
-            (relation.from_max_relations, relation.to_max_relations)
+        let (jack_id, room_id, relation_from, relation_to, from_limit, to_limit) =
+            with_connection(&context.pool, async |conn| {
+                let jack_id = hubuumclass
+                    .filter(class_name.eq(jack_name))
+                    .select(class_id)
+                    .first::<i32>(conn)
+                    .await?;
+                let room_id = hubuumclass
+                    .filter(class_name.eq(room_name))
+                    .select(class_id)
+                    .first::<i32>(conn)
+                    .await?;
+                let relation = hubuumclass_relation
+                    .filter(from_hubuum_class_id.eq(jack_id.min(room_id)))
+                    .filter(to_hubuum_class_id.eq(jack_id.max(room_id)))
+                    .select((
+                        from_hubuum_class_id,
+                        to_hubuum_class_id,
+                        class_relation::from_max_relations,
+                        class_relation::to_max_relations,
+                    ))
+                    .first::<(i32, i32, Option<i32>, Option<i32>)>(conn)
+                    .await?;
+                Ok::<_, diesel::result::Error>((
+                    jack_id, room_id, relation.0, relation.1, relation.2, relation.3,
+                ))
+            })
+            .await
+            .unwrap();
+        let (jack_limit, room_limit) = if relation_from == jack_id {
+            assert_eq!(relation_to, room_id);
+            (from_limit, to_limit)
         } else {
-            assert_eq!(relation.from_hubuum_class_id, room_id);
-            assert_eq!(relation.to_hubuum_class_id, jack_id);
-            (relation.to_max_relations, relation.from_max_relations)
+            assert_eq!(relation_from, room_id);
+            assert_eq!(relation_to, jack_id);
+            (to_limit, from_limit)
         };
-        assert_eq!(jack_limit, Some(ObjectRelationLimit::new(1).unwrap()));
+        assert_eq!(jack_limit, Some(1));
         assert_eq!(room_limit, None);
     }
 

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -133,7 +133,7 @@ async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() 
 
     assert!(
         body.contains(
-            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"22\"} 1"
+            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"23\"} 1"
         )
     );
     assert!(body.contains(

--- a/tests/api_platform_suite/runtime_config.rs
+++ b/tests/api_platform_suite/runtime_config.rs
@@ -37,7 +37,7 @@ mod tests {
         let serialized = serde_json::to_string(&body).unwrap();
 
         assert_eq!(body["database"]["backend"], "postgresql");
-        assert_eq!(body["database"]["contract_version"], 22);
+        assert_eq!(body["database"]["contract_version"], 23);
         assert_eq!(
             body["database"]["capabilities"],
             serde_json::json!([


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary

- Move class-relation, object-relation, transitive-link, and relation-graph
  Diesel rows and SQL cursor mappings into the PostgreSQL adapter, with explicit
  conversion to backend-neutral domain values.
- Route relation point operations, prepared lifecycle writes, and deliberately
  event-suppressed compatibility writes through mandatory `ClassRelationStore`
  and `ObjectRelationStore` contracts.
- Preserve native fixed-query point mutations through explicit command and
  identifier operations instead of making compatibility callers compose extra
  backend reads.
- Apply the shared bounded storage tracing, duration, and failure
  instrumentation to every relation storage entry point.
- Exercise the complete contract against both available backend models and add
  architecture guards that reject Diesel, schema, PostgreSQL, and SQL cursor
  details in the production relation domain boundary.
- Advance the selectable-backend contract to version 23 and expose the updated
  version through redacted administrator configuration and storage metrics.

## Rationale

Relation domain and graph types were still physical PostgreSQL query rows, and
legacy model adapters bypassed the mandatory storage lifecycle traits. This
made the boundary porous even though the higher-level relation capabilities
were nominally required.

This layer makes physical row decoding and SQL pagination adapter concerns.
Application and domain consumers exchange backend-neutral values, every
selectable backend must implement the same relation behavior, adapter failures
are translated to `StorageError`, and API callers continue to receive
`ApiError`. The direct command operations retain the existing bounded query and
pool-checkout behavior while remaining observable through the storage boundary.

## Behavior and compatibility

- Public HTTP request and response shapes are unchanged.
- The administrator-visible storage contract changes from version 22 to 23;
  monitoring and administration clients that match the exact version must
  accept version 23.
- Required capability labels are unchanged because relation lifecycle and query
  support were already mandatory; this change closes the remaining physical-row
  and compatibility-operation leaks in those capabilities.
- Omitting an event context remains an explicit compatibility behavior: writes
  perform the same validation and persistence semantics but deliberately do not
  emit an audit event.
- Existing relation limits, normalization, transaction semantics, cursor
  behavior, and fixed query budgets are preserved.
- No database migration, Cargo manifest, Docker input, or OpenAPI schema changed.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --features integration-test-support -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `scripts/test-classify-ci-changes.sh`
- `git diff --check`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg 'CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release' --tag hubuum-server:verify .`

`CHANGELOG.md` documents the breaking administrator contract-version change and
upgrade expectation.

Part of #27.
