### PR TITLE
Enforce class persistence boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Breaking (administrator API):** the storage contract version is now `24`.
+  Class point persistence, bulk name resolution, and event-suppressed
+  compatibility writes now cross a mandatory, uniformly observed backend
+  contract. Class, class-history, create, and update persistence rows and SQL
+  cursor mappings are owned by the PostgreSQL adapter; domain models and output
+  DTOs contain no Diesel or PostgreSQL mapping details. Required capability
+  labels and public HTTP request and response shapes are unchanged.
+  Administration and monitoring clients matching contract version `23` must
+  accept version `24`.
 - **Breaking (administrator API):** the storage contract version is now `23`.
   Class- and object-relation point operations, lifecycle writes, and deliberately
   event-suppressed compatibility writes now cross the same mandatory, uniformly

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -182,7 +182,7 @@ use std::fmt;
 ///
 /// Increment this when a selectable backend must implement a new capability
 /// family or when an existing family's externally observable semantics change.
-pub const STORAGE_CONTRACT_VERSION: u16 = 23;
+pub const STORAGE_CONTRACT_VERSION: u16 = 24;
 
 /// Stable identity of a selectable storage backend.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -119,11 +119,11 @@ considered complete merely because a marker exists.
 PostgreSQL query implementations live in
 `src/storage/postgres/operations/*`. Export-template, remote-target, event,
 event-sink, event-subscription, and event-delivery lifecycle rows are
-adapter-owned, as are object lifecycle and object-history rows, class- and
+adapter-owned, as are class and object lifecycle and history rows, class- and
 object-relation rows, relation graph query rows, remote-target history, and
-remote-call result persistence rows. Domain object and relation values contain
-no Diesel derives, schema bindings, or SQL cursor mappings. Those mappings and
-explicit conversions live in the PostgreSQL adapter. Remaining mixed
+remote-call result persistence rows. Domain class, object, and relation values
+contain no Diesel derives, schema bindings, or SQL cursor mappings. Those
+mappings and explicit conversions live in the PostgreSQL adapter. Remaining mixed
 persistence rows move there as their backend-neutral DTOs are extracted. Their
 current locations are implementation details, not partial backend support.
 `StorageHandle` selects one certified PostgreSQL adapter, and only the storage
@@ -135,10 +135,14 @@ composition without implementing every operation behind those contracts.
 The storage contract version changes when a required family is added or when
 observable semantics change. The selected backend and contract version are
 reported in startup logs, process metrics, and the redacted admin configuration.
-Version 23 additionally requires class- and object-relation point operations,
-lifecycle writes, and event-suppressed compatibility writes to cross the same
-mandatory, observed storage contract. Relation persistence and graph query rows,
-Diesel mappings, and SQL cursor mappings are adapter-owned. Version 22 required
+Version 24 additionally requires class point persistence, bulk name resolution,
+and event-suppressed compatibility writes to cross one mandatory, observed
+storage contract. Class lifecycle and history rows, Diesel mappings, and SQL
+cursor mappings are adapter-owned. Version 23 required class- and object-relation
+point operations, lifecycle writes, and event-suppressed compatibility writes
+to cross the same mandatory, observed storage contract. Relation persistence
+and graph query rows, Diesel mappings, and SQL cursor mappings are adapter-owned.
+Version 22 required
 consistent administrative inventory queries, the `inventory_queries`
 capability label, and mandatory object point-operation abstraction. Version 21
 required the complete export-template lifecycle and a new

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -454,7 +454,7 @@ mod tests {
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
         assert!(json.contains("\"backend\":\"postgresql\""));
-        assert!(json.contains("\"contract_version\":23"));
+        assert!(json.contains("\"contract_version\":24"));
         assert!(json.contains("\"catalog_queries\""));
         assert!(json.contains("\"computed_object_queries\""));
         assert!(json.contains("\"computed_field_lifecycle\""));

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -46,8 +46,9 @@ use crate::services::tasks::{
     task_scope_snapshot, update_task_state,
 };
 use crate::storage::{
-    ExportQueryStorage, StorageContext, StorageExportTaskArtifact, StorageQueryBudget,
-    StorageTaskCompletionArtifact, StorageTaskDurations, StorageTaskScopeSnapshot, storage_handle,
+    ClassRecordStorage, ExportQueryStorage, StorageContext, StorageExportTaskArtifact,
+    StorageQueryBudget, StorageTaskCompletionArtifact, StorageTaskDurations,
+    StorageTaskScopeSnapshot, storage_handle,
 };
 use crate::tasks::request_hash;
 use crate::traits::{
@@ -2112,7 +2113,11 @@ async fn ensure_class_name_ids(
         return Ok(());
     }
 
-    for (class_id, class_name) in missing.load_names(pool).await? {
+    for (class_id, class_name) in storage_handle(pool)
+        .class_names(&missing)
+        .await
+        .map_err(ApiError::from)?
+    {
         class_names.insert(class_id, class_name);
     }
 

--- a/src/models/class.rs
+++ b/src/models/class.rs
@@ -1,4 +1,3 @@
-use crate::storage::postgres::prelude::*;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -6,11 +5,9 @@ use utoipa::ToSchema;
 use crate::errors::ApiError;
 use crate::models::ResourceRevision;
 use crate::permissions::{AuthzTarget, ResourceAttrs, ResourceKind, ResourceRef};
-use crate::schema::hubuumclass;
 use crate::traits::SelfAccessors;
 
-#[derive(Serialize, Deserialize, Queryable, QueryableByName, Clone, PartialEq, Debug, ToSchema)]
-#[diesel(table_name = hubuumclass )]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, ToSchema)]
 pub struct HubuumClass {
     pub id: i32,
     pub name: String,
@@ -23,9 +20,8 @@ pub struct HubuumClass {
     pub revision: ResourceRevision,
 }
 
-#[derive(Serialize, Deserialize, Insertable, Clone, Debug, ToSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
 #[schema(example = new_hubuum_class_example)]
-#[diesel(table_name = hubuumclass)]
 pub struct NewHubuumClass {
     pub name: String,
     pub collection_id: i32,
@@ -34,9 +30,8 @@ pub struct NewHubuumClass {
     pub description: String,
 }
 
-#[derive(Serialize, Deserialize, AsChangeset, Clone, Debug, ToSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
 #[schema(example = update_hubuum_class_example)]
-#[diesel(table_name = hubuumclass)]
 pub struct UpdateHubuumClass {
     pub name: Option<String>,
     pub collection_id: Option<i32>,
@@ -198,8 +193,8 @@ impl ResolvedClassTarget {
 ///
 /// Construct via [`ClassIdSet::new`]; the inner vec stays private so the "sorted, deduped,
 /// positive" invariant holds for every consumer — including callers that `binary_search` the
-/// set and rely on the ordering. Bulk class-keyed backend lookups hang off this type (see
-/// `crate::storage::postgres::operations::class`).
+/// set and rely on the ordering. Storage contracts can accept this type without trusting callers
+/// to normalize class identifiers themselves.
 #[derive(Debug, Clone)]
 pub(crate) struct ClassIdSet(Vec<i32>);
 
@@ -247,8 +242,7 @@ fn update_hubuum_class_example() -> UpdateHubuumClass {
     }
 }
 
-#[derive(serde::Serialize, diesel::Queryable, Clone, Debug, ToSchema)]
-#[diesel(table_name = crate::schema::hubuumclass_history)]
+#[derive(serde::Serialize, Clone, Debug, ToSchema)]
 pub struct HubuumClassHistory {
     pub id: i32,
     pub name: String,
@@ -269,7 +263,45 @@ pub struct HubuumClassHistory {
     pub revision: ResourceRevision,
 }
 
-crate::impl_history_pagination!(HubuumClassHistory, "hubuumclass_history");
+impl crate::traits::CursorPaginated for HubuumClassHistory {
+    fn supports_sort(field: &crate::models::search::FilterField) -> bool {
+        matches!(
+            field,
+            crate::models::search::FilterField::HistoryId
+                | crate::models::search::FilterField::Revision
+        )
+    }
+
+    fn cursor_value(
+        &self,
+        field: &crate::models::search::FilterField,
+    ) -> Result<crate::traits::CursorValue, ApiError> {
+        Ok(match field {
+            crate::models::search::FilterField::HistoryId => {
+                crate::traits::CursorValue::Integer(self.history_id)
+            }
+            crate::models::search::FilterField::Revision => {
+                crate::traits::CursorValue::Integer(self.revision.get())
+            }
+            other => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{other}' is not orderable for history"
+                )));
+            }
+        })
+    }
+
+    fn default_sort() -> Vec<crate::models::search::SortParam> {
+        vec![crate::models::search::SortParam {
+            field: crate::models::search::FilterField::HistoryId,
+            descending: true,
+        }]
+    }
+
+    fn tie_breaker_sort() -> Vec<crate::models::search::SortParam> {
+        Self::default_sort()
+    }
+}
 
 #[async_trait]
 impl AuthzTarget for HubuumClass {

--- a/src/models/traits/class.rs
+++ b/src/models/traits/class.rs
@@ -1,12 +1,9 @@
 use crate::traits::accessors::{ClassAdapter, CollectionAdapter, IdAccessor, InstanceAdapter};
-use crate::traits::{CanUpdate, ClassAccessors, CollectionAccessors, PermissionController};
+use crate::traits::{ClassAccessors, CollectionAccessors, PermissionController};
 
 use crate::errors::ApiError;
 use crate::events::EventContext;
-use crate::storage::postgres::operations::class::{
-    ClassCollectionLookup, CreateClassRecord, DeleteClassRecord, DeleteResolvedClassRecord,
-    LoadClassRecord, ResolveClassSelectorRecord, UpdateClassRecord, UpdateResolvedClassRecord,
-};
+use crate::storage::{ClassRecordStorage, storage_handle};
 use crate::traits::crud::{DeleteAdapter, SaveAdapter, UpdateAdapter};
 
 use crate::models::{
@@ -25,8 +22,12 @@ impl ResolveClassTarget for ClassSelector {
     where
         C: crate::storage::StorageContext,
     {
-        let class = self.resolve_class_selector_record(backend).await?;
-        Ok(ResolvedClassTarget::new(self.clone(), class))
+        storage_handle(backend)
+            .lifecycle_storage()
+            .inner()
+            .resolve_class(self.clone())
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -51,8 +52,12 @@ impl UpdateResolvedClass for UpdateHubuumClass {
     where
         C: crate::storage::StorageContext,
     {
-        self.update_resolved_class_record(backend, target, context)
+        storage_handle(backend)
+            .lifecycle_storage()
+            .inner()
+            .update_class(target, self.clone(), context)
             .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -75,7 +80,12 @@ impl DeleteResolvedClass for ResolvedClassTarget {
     where
         C: crate::storage::StorageContext,
     {
-        self.delete_resolved_class_record(backend, context).await
+        storage_handle(backend)
+            .lifecycle_storage()
+            .inner()
+            .delete_class(self, context)
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -94,9 +104,10 @@ impl SaveAdapter for HubuumClass {
             description: Some(self.description.clone()),
         };
 
-        update
-            .update_without_events(pool, HubuumClassID::new(self.id)?)
+        storage_handle(pool)
+            .update_class_record(&update, self.id, None)
             .await
+            .map_err(ApiError::from)
     }
 
     async fn save_adapter(
@@ -112,9 +123,10 @@ impl SaveAdapter for HubuumClass {
             description: Some(self.description.clone()),
         };
 
-        update
-            .update_class_record(pool, self.id, Some(context))
+        storage_handle(pool)
+            .update_class_record(&update, self.id, Some(context))
             .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -123,7 +135,10 @@ impl DeleteAdapter for HubuumClass {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(), ApiError> {
-        self.delete_class_record_without_events(pool).await
+        storage_handle(pool)
+            .delete_class_record(self, None)
+            .await
+            .map_err(ApiError::from)
     }
 
     async fn delete_adapter(
@@ -131,7 +146,10 @@ impl DeleteAdapter for HubuumClass {
         pool: &impl crate::storage::StorageContext,
         context: &EventContext,
     ) -> Result<(), ApiError> {
-        self.delete_class_record(pool, Some(context)).await
+        storage_handle(pool)
+            .delete_class_record(self, Some(context))
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -142,8 +160,10 @@ impl SaveAdapter for NewHubuumClass {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<HubuumClass, ApiError> {
-        self.validate_schema()?;
-        self.create_class_record_without_events(pool).await
+        storage_handle(pool)
+            .create_class_record(self, None)
+            .await
+            .map_err(ApiError::from)
     }
 
     async fn save_adapter(
@@ -151,8 +171,10 @@ impl SaveAdapter for NewHubuumClass {
         pool: &impl crate::storage::StorageContext,
         context: &EventContext,
     ) -> Result<HubuumClass, ApiError> {
-        self.validate_schema()?;
-        self.create_class_record(pool, Some(context)).await
+        storage_handle(pool)
+            .create_class_record(self, Some(context))
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -165,8 +187,10 @@ impl UpdateAdapter for UpdateHubuumClass {
         pool: &impl crate::storage::StorageContext,
         class_id: HubuumClassID,
     ) -> Result<HubuumClass, ApiError> {
-        self.update_class_record_without_events(pool, class_id.id())
+        storage_handle(pool)
+            .update_class_record(self, class_id.id(), None)
             .await
+            .map_err(ApiError::from)
     }
 
     async fn update_adapter(
@@ -175,8 +199,10 @@ impl UpdateAdapter for UpdateHubuumClass {
         class_id: HubuumClassID,
         context: &EventContext,
     ) -> Result<HubuumClass, ApiError> {
-        self.update_class_record(pool, class_id.id(), Some(context))
+        storage_handle(pool)
+            .update_class_record(self, class_id.id(), Some(context))
             .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -216,7 +242,10 @@ impl CollectionAdapter for HubuumClass {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<Collection, ApiError> {
-        self.lookup_class_collection(pool).await
+        storage_handle(pool)
+            .class_collection(self.id)
+            .await
+            .map_err(ApiError::from)
     }
 
     async fn collection_id_adapter(
@@ -257,7 +286,10 @@ impl ClassAdapter for HubuumClassID {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<HubuumClass, ApiError> {
-        self.load_class_record(pool).await
+        storage_handle(pool)
+            .load_class_record(self.id())
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -266,7 +298,10 @@ impl CollectionAdapter for HubuumClassID {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<Collection, ApiError> {
-        self.lookup_class_collection(pool).await
+        storage_handle(pool)
+            .class_collection(self.id())
+            .await
+            .map_err(ApiError::from)
     }
 
     async fn collection_id_adapter(

--- a/src/models/traits/output.rs
+++ b/src/models/traits/output.rs
@@ -162,54 +162,6 @@ impl CursorPaginated for HubuumClassExpanded {
     }
 }
 
-impl CursorSqlMapping for HubuumClassExpanded {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id => CursorSqlField {
-                column: "hubuumclass.id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Name => CursorSqlField {
-                column: "hubuumclass.name",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::Description => CursorSqlField {
-                column: "hubuumclass.description",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::Collections | FilterField::CollectionId => CursorSqlField {
-                column: "hubuumclass.collection_id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::CreatedAt => CursorSqlField {
-                column: "hubuumclass.created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAt => CursorSqlField {
-                column: "hubuumclass.updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::Revision => CursorSqlField {
-                column: "hubuumclass.revision",
-                sql_type: CursorSqlType::BigInt,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for classes",
-                    field
-                )));
-            }
-        })
-    }
-}
-
 impl CursorPaginated for GroupPermission {
     fn supports_sort(field: &FilterField) -> bool {
         matches!(

--- a/src/storage/classes.rs
+++ b/src/storage/classes.rs
@@ -2,7 +2,8 @@ use async_trait::async_trait;
 
 use crate::events::EventContext;
 use crate::models::{
-    ClassSelector, HubuumClass, NewHubuumClass, ResolvedClassTarget, UpdateHubuumClass,
+    ClassIdSet, ClassSelector, Collection, HubuumClass, NewHubuumClass, ResolvedClassTarget,
+    UpdateHubuumClass,
 };
 
 use super::StorageError;
@@ -36,4 +37,39 @@ pub(crate) trait ClassStore: Send + Sync {
         target: &ResolvedClassTarget,
         context: &EventContext,
     ) -> Result<(), StorageError>;
+}
+
+/// Backend-neutral compatibility contract for point class persistence.
+///
+/// Application services use [`ClassStore`] for ordinary lifecycle behavior.
+/// Legacy domain adapters additionally require event-suppressed fixture writes,
+/// direct point loads, and collection access; selectable backends must provide
+/// those operations without exposing an adapter or database type to callers.
+#[async_trait]
+pub(crate) trait ClassRecordStorage: Send + Sync {
+    async fn create_class_record(
+        &self,
+        class: &NewHubuumClass,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumClass, StorageError>;
+
+    async fn update_class_record(
+        &self,
+        update: &UpdateHubuumClass,
+        class_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumClass, StorageError>;
+
+    async fn delete_class_record(
+        &self,
+        class: &HubuumClass,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError>;
+
+    async fn load_class_record(&self, class_id: i32) -> Result<HubuumClass, StorageError>;
+
+    async fn class_collection(&self, class_id: i32) -> Result<Collection, StorageError>;
+
+    async fn class_names(&self, class_ids: &ClassIdSet)
+    -> Result<Vec<(i32, String)>, StorageError>;
 }

--- a/src/storage/context.rs
+++ b/src/storage/context.rs
@@ -10,8 +10,8 @@ use crate::events::{
 };
 use crate::models::search::QueryOptions;
 use crate::models::{
-    Collection, CollectionKey, HubuumClass, HubuumObject, ImportMode, MaintenanceState,
-    NewHubuumObject, TokenRetentionSettings, UpdateHubuumObject,
+    ClassIdSet, Collection, CollectionKey, HubuumClass, HubuumObject, ImportMode, MaintenanceState,
+    NewHubuumClass, NewHubuumObject, TokenRetentionSettings, UpdateHubuumClass, UpdateHubuumObject,
 };
 use crate::permissions::{AppContext, PermissionBackend};
 use crate::storage::observed::observe_storage_call;
@@ -27,9 +27,9 @@ use crate::storage::{
     AuthorizationPermissionSet, AuthorizationPermissionSetQuery, AuthorizationPolicySnapshotRow,
     AuthorizationPrincipal, AuthorizationResourceIds, AuthorizationStorage, BackupSnapshotStorage,
     BidirectionalRelatedObjectsQuery, CatalogListQuery, CatalogPage, CatalogStorage,
-    ComputedFieldLifecycleStorage, ComputedObjectEnrichmentQuery, ComputedObjectListQuery,
-    ComputedObjectPage, ComputedObjectStorage, DynLifecycleStorage, EventArchive,
-    EventDeliveryAdministrationStorage, EventDeliveryBatch, EventDeliveryClaim,
+    ClassRecordStorage, ComputedFieldLifecycleStorage, ComputedObjectEnrichmentQuery,
+    ComputedObjectListQuery, ComputedObjectPage, ComputedObjectStorage, DynLifecycleStorage,
+    EventArchive, EventDeliveryAdministrationStorage, EventDeliveryBatch, EventDeliveryClaim,
     EventDeliveryHealthSnapshot, EventDeliveryStorage, EventFanoutStorage, EventHealthStorage,
     EventMetricsSnapshot, EventRetentionStorage, EventRetentionSummary, EventSubscriptionStorage,
     ExportQueryStorage, ExportTemplateHistoryRecord, ExportTemplateStorage, HistoryAsOfQuery,
@@ -2686,6 +2686,89 @@ impl InventoryStorage for StorageHandle {
         observe_storage_call(self.backend_name(), "inventory", "counts", async {
             match &self.implementation {
                 BackendImplementation::Postgresql(backend) => backend.inventory_counts().await,
+            }
+        })
+        .await
+    }
+}
+
+#[async_trait]
+impl ClassRecordStorage for StorageHandle {
+    async fn create_class_record(
+        &self,
+        class: &NewHubuumClass,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumClass, StorageError> {
+        observe_storage_call(self.backend_name(), "class_records", "create", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.create_class_record(class, context).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn update_class_record(
+        &self,
+        update: &UpdateHubuumClass,
+        class_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumClass, StorageError> {
+        observe_storage_call(self.backend_name(), "class_records", "update", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.update_class_record(update, class_id, context).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn delete_class_record(
+        &self,
+        class: &HubuumClass,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError> {
+        observe_storage_call(self.backend_name(), "class_records", "delete", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.delete_class_record(class, context).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn load_class_record(&self, class_id: i32) -> Result<HubuumClass, StorageError> {
+        observe_storage_call(self.backend_name(), "class_records", "load", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.load_class_record(class_id).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn class_collection(&self, class_id: i32) -> Result<Collection, StorageError> {
+        observe_storage_call(self.backend_name(), "class_records", "collection", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.class_collection(class_id).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn class_names(
+        &self,
+        class_ids: &ClassIdSet,
+    ) -> Result<Vec<(i32, String)>, StorageError> {
+        observe_storage_call(self.backend_name(), "class_records", "names", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => backend.class_names(class_ids).await,
             }
         })
         .await

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use super::{
     AuditEventStorage, AuthenticationStorage, AuthorizationStorage, BackupSnapshotStorage,
-    CatalogStorage, ClassRelationStore, ClassStore, CollectionStore, ComputedFieldLifecycleStorage,
-    ComputedObjectStorage, EventDeliveryAdministrationStorage, EventDeliveryStorage,
-    EventFanoutStorage, EventHealthStorage, EventRetentionStorage, EventSubscriptionStorage,
-    ExportQueryStorage, ExportTemplateStorage, HistoryStorage, IdentityStorage, ImportStorage,
-    InventoryStorage, MetricsStorage, ObjectAggregateStorage, ObjectRecordStorage,
-    ObjectRelationStore, ObjectStore, OperationalStateStorage, PostgresStorage,
-    RelationQueryStorage, RemoteTargetStorage, RestoreStorage, StorageExecution,
+    CatalogStorage, ClassRecordStorage, ClassRelationStore, ClassStore, CollectionStore,
+    ComputedFieldLifecycleStorage, ComputedObjectStorage, EventDeliveryAdministrationStorage,
+    EventDeliveryStorage, EventFanoutStorage, EventHealthStorage, EventRetentionStorage,
+    EventSubscriptionStorage, ExportQueryStorage, ExportTemplateStorage, HistoryStorage,
+    IdentityStorage, ImportStorage, InventoryStorage, MetricsStorage, ObjectAggregateStorage,
+    ObjectRecordStorage, ObjectRelationStore, ObjectStore, OperationalStateStorage,
+    PostgresStorage, RelationQueryStorage, RemoteTargetStorage, RestoreStorage, StorageExecution,
     TaskExecutionStorage, TaskQueueStorage, TokenRetentionStorage, UnifiedSearchStorage,
     observed::ObservedLifecycleStorage,
 };
@@ -77,6 +77,7 @@ pub(crate) trait StorageBackend:
     + OperationalStateStorage
     + TokenRetentionStorage
     + UnifiedSearchStorage
+    + ClassRecordStorage
     + ObjectRecordStorage
     + RemoteTargetStorage
     + TaskQueueStorage

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -19,7 +19,7 @@ mod operational;
 pub mod postgres;
 
 pub(crate) use class_relations::ClassRelationStore;
-pub(crate) use classes::ClassStore;
+pub(crate) use classes::{ClassRecordStorage, ClassStore};
 pub(crate) use collections::CollectionStore;
 pub use context::StorageContext;
 pub(crate) use context::{StorageHandle, storage_handle};

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -26,8 +26,8 @@ use crate::events::{
 };
 use crate::models::search::QueryOptions;
 use crate::models::{
-    ClassSelector, Collection, CollectionID, HubuumClass, HubuumClassRelation,
-    HubuumClassRelationID, HubuumObject, HubuumObjectID, HubuumObjectRelation,
+    ClassIdSet, ClassSelector, Collection, CollectionID, HubuumClass, HubuumClassID,
+    HubuumClassRelation, HubuumClassRelationID, HubuumObject, HubuumObjectID, HubuumObjectRelation,
     HubuumObjectRelationID, MaintenanceState, NewCollectionWithAssignee, NewHubuumClass,
     NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, ObjectDataPatchDocument,
     ObjectRelationCreateSelector, ObjectRelationSelector, ObjectSelector, PreparedClassRelation,
@@ -37,8 +37,9 @@ use crate::models::{
 };
 use crate::storage::postgres::operations::GetCollection;
 use crate::storage::postgres::operations::class::{
-    CreateClassRecord, DeleteResolvedClassRecord, ResolveClassSelectorRecord,
-    UpdateResolvedClassRecord,
+    ClassCollectionLookup, CreateClassRecord, DeleteClassRecord, DeleteResolvedClassRecord,
+    LoadClassRecord, ResolveClassSelectorRecord, UpdateClassRecord, UpdateResolvedClassRecord,
+    load_class_names,
 };
 use crate::storage::postgres::operations::collection::{
     DeleteCollectionRecord, SaveCollectionWithAssigneeRecord, UpdateCollectionRecord,
@@ -70,38 +71,38 @@ use super::{
     AuthorizationPermissionSet, AuthorizationPermissionSetQuery, AuthorizationPolicySnapshotRow,
     AuthorizationPrincipal, AuthorizationResourceIds, AuthorizationStorage,
     BidirectionalRelatedObjectsQuery, CatalogListQuery, CatalogPage, CatalogStorage,
-    ClassRelationStore, ClassStore, CollectionStore, ComputedObjectEnrichmentQuery,
-    ComputedObjectListQuery, ComputedObjectPage, ComputedObjectStorage, EventArchive,
-    EventDeliveryAdministrationStorage, EventDeliveryBatch, EventDeliveryClaim,
-    EventDeliveryHealthSnapshot, EventDeliveryStorage, EventFanoutStorage, EventHealthStorage,
-    EventMetricsSnapshot, EventRetentionStorage, EventRetentionSummary, EventSubscriptionStorage,
-    ExportQueryStorage, ExportTemplateHistoryRecord, HistoryAsOfQuery, HistoryCollectionScope,
-    HistoryListQuery, HistoryPage, HistoryPrincipalName, HistoryStorage, IdentityStorage,
-    InventoryGaugeSnapshot, InventoryStorage, MetricsStorage, ObjectAggregateAuthorizer,
-    ObjectAggregateStorage, ObjectAggregateStorageQuery, ObjectHistoryAsOfQuery,
-    ObjectHistoryListQuery, ObjectHistoryRecord, ObjectRecordStorage, ObjectRelationStore,
-    ObjectRelationsTouchingIdsQuery, ObjectStore, OperationalExportTemplateAuditEntry,
-    OperationalExportTemplateHealth, OperationalStateStorage, OperationalStorageSnapshot,
-    OperationalTaskQueueSnapshot, ReadinessSnapshot, RelatedObjectsForRootsQuery,
-    RelationGraphQuery, RelationIdsQuery, RelationListQuery, RelationPage, RelationQueryStorage,
-    RelationTouchingQuery, RemoteTargetHistoryRecord, StorageAuditEvent,
-    StorageAuditEventListQuery, StorageCallSite, StorageClass, StorageClassGraphRow,
-    StorageClassRelation, StorageCollection, StorageComputedObject, StorageDefaultAdminBootstrap,
-    StorageError, StorageEventDelivery, StorageEventDeliveryListQuery, StorageEventPage,
-    StorageEventSink, StorageEventSinkCreate, StorageEventSinkDelete, StorageEventSinkListQuery,
-    StorageEventSinkUpdate, StorageEventSubscription, StorageEventSubscriptionCreate,
-    StorageEventSubscriptionDelete, StorageEventSubscriptionListQuery,
-    StorageEventSubscriptionUpdate, StorageExecution, StorageExternalPrincipalState,
-    StorageExternalUserSync, StorageIdentity, StorageIdentityPage, StorageIdentityScope,
-    StorageIdentityScopeEnsure, StorageInventoryCounts, StorageLocalPasswordReset, StorageObject,
-    StorageObjectAggregatePage, StorageObjectGraphRow, StorageObjectRelation, StoragePoolState,
-    StoragePrincipalGroup, StorageQueryBudget, StorageRelatedObjectForRootRow,
-    StorageRelatedObjectIncludeRow, StorageRevisionPrecondition, StorageServiceAccount,
-    StorageServiceAccountCreate, StorageServiceAccountListItem, StorageServiceAccountListQuery,
-    StorageServiceAccountMutation, StorageServiceAccountPoint, StorageServiceAccountUpdate,
-    StorageSyncedHuman, StorageTokenListQuery, StorageTokenMetadata, TaskGaugeSnapshot,
-    TokenRetentionStorage, UnifiedSearchClass, UnifiedSearchCollection, UnifiedSearchObject,
-    UnifiedSearchQuery, UnifiedSearchStorage,
+    ClassRecordStorage, ClassRelationStore, ClassStore, CollectionStore,
+    ComputedObjectEnrichmentQuery, ComputedObjectListQuery, ComputedObjectPage,
+    ComputedObjectStorage, EventArchive, EventDeliveryAdministrationStorage, EventDeliveryBatch,
+    EventDeliveryClaim, EventDeliveryHealthSnapshot, EventDeliveryStorage, EventFanoutStorage,
+    EventHealthStorage, EventMetricsSnapshot, EventRetentionStorage, EventRetentionSummary,
+    EventSubscriptionStorage, ExportQueryStorage, ExportTemplateHistoryRecord, HistoryAsOfQuery,
+    HistoryCollectionScope, HistoryListQuery, HistoryPage, HistoryPrincipalName, HistoryStorage,
+    IdentityStorage, InventoryGaugeSnapshot, InventoryStorage, MetricsStorage,
+    ObjectAggregateAuthorizer, ObjectAggregateStorage, ObjectAggregateStorageQuery,
+    ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectHistoryRecord, ObjectRecordStorage,
+    ObjectRelationStore, ObjectRelationsTouchingIdsQuery, ObjectStore,
+    OperationalExportTemplateAuditEntry, OperationalExportTemplateHealth, OperationalStateStorage,
+    OperationalStorageSnapshot, OperationalTaskQueueSnapshot, ReadinessSnapshot,
+    RelatedObjectsForRootsQuery, RelationGraphQuery, RelationIdsQuery, RelationListQuery,
+    RelationPage, RelationQueryStorage, RelationTouchingQuery, RemoteTargetHistoryRecord,
+    StorageAuditEvent, StorageAuditEventListQuery, StorageCallSite, StorageClass,
+    StorageClassGraphRow, StorageClassRelation, StorageCollection, StorageComputedObject,
+    StorageDefaultAdminBootstrap, StorageError, StorageEventDelivery,
+    StorageEventDeliveryListQuery, StorageEventPage, StorageEventSink, StorageEventSinkCreate,
+    StorageEventSinkDelete, StorageEventSinkListQuery, StorageEventSinkUpdate,
+    StorageEventSubscription, StorageEventSubscriptionCreate, StorageEventSubscriptionDelete,
+    StorageEventSubscriptionListQuery, StorageEventSubscriptionUpdate, StorageExecution,
+    StorageExternalPrincipalState, StorageExternalUserSync, StorageIdentity, StorageIdentityPage,
+    StorageIdentityScope, StorageIdentityScopeEnsure, StorageInventoryCounts,
+    StorageLocalPasswordReset, StorageObject, StorageObjectAggregatePage, StorageObjectGraphRow,
+    StorageObjectRelation, StoragePoolState, StoragePrincipalGroup, StorageQueryBudget,
+    StorageRelatedObjectForRootRow, StorageRelatedObjectIncludeRow, StorageRevisionPrecondition,
+    StorageServiceAccount, StorageServiceAccountCreate, StorageServiceAccountListItem,
+    StorageServiceAccountListQuery, StorageServiceAccountMutation, StorageServiceAccountPoint,
+    StorageServiceAccountUpdate, StorageSyncedHuman, StorageTokenListQuery, StorageTokenMetadata,
+    TaskGaugeSnapshot, TokenRetentionStorage, UnifiedSearchClass, UnifiedSearchCollection,
+    UnifiedSearchObject, UnifiedSearchQuery, UnifiedSearchStorage,
 };
 use super::{ClassHistoryRecord, CollectionHistoryRecord};
 use error::map_postgres_error;
@@ -1344,6 +1345,69 @@ impl CollectionStore for PostgresStorage {
         context: &EventContext,
     ) -> Result<Collection, StorageError> {
         move_collection_record_from_backend(&self.pool, id.id(), new_parent_id.id(), Some(context))
+            .await
+            .map_err(map_postgres_error)
+    }
+}
+
+#[async_trait]
+impl ClassRecordStorage for PostgresStorage {
+    async fn create_class_record(
+        &self,
+        class: &NewHubuumClass,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumClass, StorageError> {
+        class.validate_schema().map_err(map_postgres_error)?;
+        class
+            .create_class_record(&self.pool, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn update_class_record(
+        &self,
+        update: &UpdateHubuumClass,
+        class_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<HubuumClass, StorageError> {
+        update
+            .update_class_record(&self.pool, class_id, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn delete_class_record(
+        &self,
+        class: &HubuumClass,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError> {
+        class
+            .delete_class_record(&self.pool, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn load_class_record(&self, class_id: i32) -> Result<HubuumClass, StorageError> {
+        HubuumClassID::new(class_id)
+            .map_err(map_postgres_error)?
+            .load_class_record(&self.pool)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn class_collection(&self, class_id: i32) -> Result<Collection, StorageError> {
+        HubuumClassID::new(class_id)
+            .map_err(map_postgres_error)?
+            .lookup_class_collection(&self.pool)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn class_names(
+        &self,
+        class_ids: &ClassIdSet,
+    ) -> Result<Vec<(i32, String)>, StorageError> {
+        load_class_names(&self.pool, class_ids)
             .await
             .map_err(map_postgres_error)
     }

--- a/src/storage/postgres/operations/class.rs
+++ b/src/storage/postgres/operations/class.rs
@@ -4,14 +4,182 @@ use crate::api::etag::RevisionOwner;
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, EventContext, NewEvent};
 use crate::models::{
-    ClassIdSet, ClassSelector, ClassSelectorKind, Collection, HubuumClass, HubuumClassID,
-    HubuumClassRelation, HubuumClassRelationID, NewHubuumClass, NewHubuumClassRelation,
-    ResolvedClassTarget, UpdateHubuumClass,
+    ClassIdSet, ClassSelector, ClassSelectorKind, Collection, HubuumClass, HubuumClassExpanded,
+    HubuumClassID, HubuumClassRelation, HubuumClassRelationID, NewHubuumClass,
+    NewHubuumClassRelation, ResolvedClassTarget, UpdateHubuumClass,
 };
 use crate::storage::postgres::operations::GetClass;
 use crate::storage::postgres::operations::event_record::emit_event;
 use crate::storage::postgres::operations::relation_rows::HubuumClassRelationRow;
 use crate::storage::postgres::{with_connection, with_transaction};
+use crate::traits::{
+    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
+};
+
+/// PostgreSQL representation of a class row.
+///
+/// Domain classes remain backend-neutral; Diesel schema bindings and physical
+/// cursor columns are confined to this adapter row.
+#[derive(Clone, Queryable, QueryableByName, Selectable)]
+#[diesel(table_name = crate::schema::hubuumclass)]
+pub(crate) struct HubuumClassRow {
+    pub(crate) id: i32,
+    pub(crate) name: String,
+    pub(crate) collection_id: i32,
+    pub(crate) json_schema: Option<serde_json::Value>,
+    pub(crate) validate_schema: bool,
+    pub(crate) description: String,
+    pub(crate) created_at: chrono::NaiveDateTime,
+    pub(crate) updated_at: chrono::NaiveDateTime,
+    pub(crate) revision: crate::models::ResourceRevision,
+}
+
+impl From<HubuumClassRow> for HubuumClass {
+    fn from(row: HubuumClassRow) -> Self {
+        Self {
+            id: row.id,
+            name: row.name,
+            collection_id: row.collection_id,
+            json_schema: row.json_schema,
+            validate_schema: row.validate_schema,
+            description: row.description,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            revision: row.revision,
+        }
+    }
+}
+
+impl CursorPaginated for HubuumClassRow {
+    fn supports_sort(field: &crate::models::search::FilterField) -> bool {
+        HubuumClassExpanded::supports_sort(field)
+    }
+
+    fn cursor_value(
+        &self,
+        field: &crate::models::search::FilterField,
+    ) -> Result<CursorValue, ApiError> {
+        use crate::models::search::FilterField;
+
+        Ok(match field {
+            FilterField::Id => CursorValue::Integer(self.id.into()),
+            FilterField::Name => CursorValue::String(self.name.clone()),
+            FilterField::Description => CursorValue::String(self.description.clone()),
+            FilterField::Collections | FilterField::CollectionId => {
+                CursorValue::Integer(self.collection_id.into())
+            }
+            FilterField::CreatedAt => CursorValue::DateTime(self.created_at),
+            FilterField::UpdatedAt => CursorValue::DateTime(self.updated_at),
+            FilterField::Revision => CursorValue::Integer(self.revision.get()),
+            other => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{other}' is not orderable for classes"
+                )));
+            }
+        })
+    }
+
+    fn default_sort() -> Vec<crate::models::search::SortParam> {
+        HubuumClassExpanded::default_sort()
+    }
+
+    fn tie_breaker_sort() -> Vec<crate::models::search::SortParam> {
+        HubuumClassExpanded::tie_breaker_sort()
+    }
+}
+
+impl CursorSqlMapping for HubuumClassRow {
+    fn sql_field(field: &crate::models::search::FilterField) -> Result<CursorSqlField, ApiError> {
+        use crate::models::search::FilterField;
+
+        Ok(match field {
+            FilterField::Id => CursorSqlField {
+                column: "hubuumclass.id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Name => CursorSqlField {
+                column: "hubuumclass.name",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::Description => CursorSqlField {
+                column: "hubuumclass.description",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::Collections | FilterField::CollectionId => CursorSqlField {
+                column: "hubuumclass.collection_id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::CreatedAt => CursorSqlField {
+                column: "hubuumclass.created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAt => CursorSqlField {
+                column: "hubuumclass.updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::Revision => CursorSqlField {
+                column: "hubuumclass.revision",
+                sql_type: CursorSqlType::BigInt,
+                nullable: false,
+            },
+            other => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{other}' is not orderable for classes"
+                )));
+            }
+        })
+    }
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = crate::schema::hubuumclass)]
+pub(crate) struct NewHubuumClassRow<'a> {
+    name: &'a str,
+    collection_id: i32,
+    json_schema: Option<&'a serde_json::Value>,
+    validate_schema: Option<bool>,
+    description: &'a str,
+}
+
+impl<'a> From<&'a NewHubuumClass> for NewHubuumClassRow<'a> {
+    fn from(class: &'a NewHubuumClass) -> Self {
+        Self {
+            name: &class.name,
+            collection_id: class.collection_id,
+            json_schema: class.json_schema.as_ref(),
+            validate_schema: class.validate_schema,
+            description: &class.description,
+        }
+    }
+}
+
+#[derive(AsChangeset)]
+#[diesel(table_name = crate::schema::hubuumclass)]
+pub(crate) struct UpdateHubuumClassRow<'a> {
+    name: Option<&'a str>,
+    collection_id: Option<i32>,
+    json_schema: Option<&'a serde_json::Value>,
+    validate_schema: Option<bool>,
+    description: Option<&'a str>,
+}
+
+impl<'a> From<&'a UpdateHubuumClass> for UpdateHubuumClassRow<'a> {
+    fn from(update: &'a UpdateHubuumClass) -> Self {
+        Self {
+            name: update.name.as_deref(),
+            collection_id: update.collection_id,
+            json_schema: update.json_schema.as_ref(),
+            validate_schema: update.validate_schema,
+            description: update.description.as_deref(),
+        }
+    }
+}
 
 fn class_snapshot(class: &HubuumClass) -> serde_json::Value {
     serde_json::json!({
@@ -53,8 +221,9 @@ impl GetClass for HubuumClass {
             async |conn| -> Result<HubuumClass, diesel::result::Error> {
                 let class = hubuumclass
                     .filter(id.eq(self.id))
-                    .first::<HubuumClass>(conn)
-                    .await?;
+                    .first::<HubuumClassRow>(conn)
+                    .await?
+                    .into();
                 Ok(class)
             },
         )
@@ -73,8 +242,9 @@ impl GetClass for HubuumClassID {
             async |conn| -> Result<HubuumClass, diesel::result::Error> {
                 let class = hubuumclass
                     .filter(id.eq(self.id()))
-                    .first::<HubuumClass>(conn)
-                    .await?;
+                    .first::<HubuumClassRow>(conn)
+                    .await?
+                    .into();
                 Ok(class)
             },
         )
@@ -93,12 +263,14 @@ impl GetClass<(HubuumClass, HubuumClass)> for HubuumClassRelation {
             async |conn| -> Result<(HubuumClass, HubuumClass), diesel::result::Error> {
                 let from_class = hubuumclass
                     .filter(id.eq(self.from_hubuum_class_id))
-                    .first::<HubuumClass>(conn)
-                    .await?;
+                    .first::<HubuumClassRow>(conn)
+                    .await?
+                    .into();
                 let to_class = hubuumclass
                     .filter(id.eq(self.to_hubuum_class_id))
-                    .first::<HubuumClass>(conn)
-                    .await?;
+                    .first::<HubuumClassRow>(conn)
+                    .await?
+                    .into();
                 Ok((from_class, to_class))
             },
         )
@@ -124,12 +296,14 @@ impl GetClass<(HubuumClass, HubuumClass)> for HubuumClassRelationID {
 
                 let from_class = hubuumclass
                     .filter(hid.eq(relation.from_hubuum_class_id))
-                    .first::<HubuumClass>(conn)
-                    .await?;
+                    .first::<HubuumClassRow>(conn)
+                    .await?
+                    .into();
                 let to_class = hubuumclass
                     .filter(hid.eq(relation.to_hubuum_class_id))
-                    .first::<HubuumClass>(conn)
-                    .await?;
+                    .first::<HubuumClassRow>(conn)
+                    .await?
+                    .into();
                 Ok((from_class, to_class))
             },
         )
@@ -149,12 +323,14 @@ impl GetClass<(HubuumClass, HubuumClass)> for NewHubuumClassRelation {
             async |conn| -> Result<(HubuumClass, HubuumClass), diesel::result::Error> {
                 let from_class = hubuumclass
                     .filter(hid.eq(self.from_hubuum_class_id))
-                    .first::<HubuumClass>(conn)
-                    .await?;
+                    .first::<HubuumClassRow>(conn)
+                    .await?
+                    .into();
                 let to_class = hubuumclass
                     .filter(hid.eq(self.to_hubuum_class_id))
-                    .first::<HubuumClass>(conn)
-                    .await?;
+                    .first::<HubuumClassRow>(conn)
+                    .await?
+                    .into();
                 Ok((from_class, to_class))
             },
         )
@@ -201,21 +377,22 @@ impl ResolveClassSelectorRecord for ClassSelector {
     ) -> Result<HubuumClass, ApiError> {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id, name};
 
-        with_connection(pool, async |conn| match self.kind() {
+        let row = with_connection(pool, async |conn| match self.kind() {
             ClassSelectorKind::ById(class_id) => {
                 hubuumclass
                     .filter(id.eq(class_id.id()))
-                    .first::<HubuumClass>(conn)
+                    .first::<HubuumClassRow>(conn)
                     .await
             }
             ClassSelectorKind::ByName(class_name) => {
                 hubuumclass
                     .filter(name.eq(class_name))
-                    .first::<HubuumClass>(conn)
+                    .first::<HubuumClassRow>(conn)
                     .await
             }
         })
-        .await
+        .await?;
+        Ok(row.into())
     }
 }
 
@@ -244,11 +421,12 @@ impl CreateClassRecord for NewHubuumClass {
 
         with_connection(pool, async |conn| {
             diesel::insert_into(hubuumclass)
-                .values(self)
-                .get_result(conn)
+                .values(NewHubuumClassRow::from(self))
+                .get_result::<HubuumClassRow>(conn)
                 .await
         })
         .await
+        .map(Into::into)
     }
 
     async fn create_class_record(
@@ -264,9 +442,10 @@ impl CreateClassRecord for NewHubuumClass {
 
         with_transaction(pool, async |conn| -> Result<HubuumClass, ApiError> {
             let class = diesel::insert_into(hubuumclass)
-                .values(self)
-                .get_result::<HubuumClass>(conn)
-                .await?;
+                .values(NewHubuumClassRow::from(self))
+                .get_result::<HubuumClassRow>(conn)
+                .await?
+                .into();
             let event = class_event(
                 &class,
                 Action::Created,
@@ -312,16 +491,18 @@ impl UpdateClassRecord for UpdateHubuumClass {
             let before = hubuumclass
                 .filter(id.eq(class_id))
                 .for_update()
-                .first::<HubuumClass>(conn)
-                .await?;
+                .first::<HubuumClassRow>(conn)
+                .await?
+                .into();
             self.validate_schema_update(&before)?;
             if !self.has_changes(&before) {
                 return Ok(before);
             }
             Ok(diesel::update(hubuumclass.filter(id.eq(class_id)))
-                .set(self)
-                .get_result::<HubuumClass>(conn)
-                .await?)
+                .set(UpdateHubuumClassRow::from(self))
+                .get_result::<HubuumClassRow>(conn)
+                .await?
+                .into())
         })
         .await
     }
@@ -344,16 +525,18 @@ impl UpdateClassRecord for UpdateHubuumClass {
             let before = hubuumclass
                 .filter(id.eq(class_id))
                 .for_update()
-                .first::<HubuumClass>(conn)
-                .await?;
+                .first::<HubuumClassRow>(conn)
+                .await?
+                .into();
             self.validate_schema_update(&before)?;
             if !self.has_changes(&before) {
                 return Ok(before);
             }
             let updated = diesel::update(hubuumclass.filter(id.eq(class_id)))
-                .set(self)
-                .get_result::<HubuumClass>(conn)
-                .await?;
+                .set(UpdateHubuumClassRow::from(self))
+                .get_result::<HubuumClassRow>(conn)
+                .await?
+                .into();
             let event = class_event(
                 &updated,
                 Action::Updated,
@@ -383,7 +566,7 @@ pub(crate) async fn lock_resolved_class_target(
             .filter(name.eq(&resolved.name))
             .filter(collection_id.eq(resolved.collection_id))
             .for_update()
-            .first::<HubuumClass>(conn)
+            .first::<HubuumClassRow>(conn)
             .await
             .optional()?,
         ClassSelectorKind::ByName(class_name) => hubuumclass
@@ -391,12 +574,14 @@ pub(crate) async fn lock_resolved_class_target(
             .filter(name.eq(class_name))
             .filter(collection_id.eq(resolved.collection_id))
             .for_update()
-            .first::<HubuumClass>(conn)
+            .first::<HubuumClassRow>(conn)
             .await
             .optional()?,
     };
+    let locked = locked.map(Into::into);
     let owner_key = RevisionOwner::Class.key(resolved.id);
-    let locked = crate::storage::postgres::require_existing_revision_target(locked, &owner_key)?;
+    let locked: HubuumClass =
+        crate::storage::postgres::require_existing_revision_target(locked, &owner_key)?;
     crate::storage::postgres::assert_locked_revision_precondition(
         conn,
         &owner_key,
@@ -431,9 +616,10 @@ impl UpdateResolvedClassRecord for UpdateHubuumClass {
                 return Ok(before);
             }
             let updated = diesel::update(hubuumclass.filter(id.eq(before.id)))
-                .set(self)
-                .get_result::<HubuumClass>(conn)
-                .await?;
+                .set(UpdateHubuumClassRow::from(self))
+                .get_result::<HubuumClassRow>(conn)
+                .await?
+                .into();
             let event = class_event(
                 &updated,
                 Action::Updated,
@@ -531,8 +717,9 @@ impl DeleteClassRecord for HubuumClass {
             let before = hubuumclass
                 .filter(id.eq(self.id))
                 .for_update()
-                .first::<HubuumClass>(conn)
-                .await?;
+                .first::<HubuumClassRow>(conn)
+                .await?
+                .into();
             diesel::delete(hubuumclass.filter(id.eq(self.id)))
                 .execute(conn)
                 .await?;
@@ -586,27 +773,25 @@ impl ClassCollectionLookup for HubuumClassID {
     }
 }
 
-impl ClassIdSet {
-    /// Load the `(id, name)` pairs for the classes in this set. Ids without a matching row are
-    /// simply absent from the result; callers that require completeness must check themselves.
-    pub(crate) async fn load_names(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-    ) -> Result<Vec<(i32, String)>, ApiError> {
-        use crate::schema::hubuumclass::dsl::{hubuumclass, id, name};
+/// Load `(id, name)` pairs for a normalized class set. Missing ids are absent;
+/// callers that require completeness must check the returned keys.
+pub(crate) async fn load_class_names(
+    pool: &impl crate::storage::StorageContext,
+    class_ids: &ClassIdSet,
+) -> Result<Vec<(i32, String)>, ApiError> {
+    use crate::schema::hubuumclass::dsl::{hubuumclass, id, name};
 
-        if self.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let ids = self.as_slice().to_vec();
-        with_connection(pool, async |conn| {
-            hubuumclass
-                .filter(id.eq_any(ids))
-                .select((id, name))
-                .load::<(i32, String)>(conn)
-                .await
-        })
-        .await
+    if class_ids.is_empty() {
+        return Ok(Vec::new());
     }
+
+    let ids = class_ids.as_slice().to_vec();
+    with_connection(pool, async |conn| {
+        hubuumclass
+            .filter(id.eq_any(ids))
+            .select((id, name))
+            .load::<(i32, String)>(conn)
+            .await
+    })
+    .await
 }

--- a/src/storage/postgres/operations/computed_field.rs
+++ b/src/storage/postgres/operations/computed_field.rs
@@ -26,6 +26,7 @@ use crate::models::{
     ValidatedComputedFieldPatch,
 };
 use crate::pagination::{CursorSqlField, CursorSqlMapping, CursorSqlType};
+use crate::storage::postgres::operations::class::HubuumClassRow;
 use crate::storage::postgres::operations::event_record::emit_event;
 use crate::storage::postgres::operations::object::HubuumObjectRow;
 use crate::storage::postgres::operations::search::{JsonSqlPredicate, dynamic_sql_predicate};
@@ -303,8 +304,9 @@ async fn class_record(
     use crate::schema::hubuumclass::dsl::{hubuumclass, id};
     Ok(hubuumclass
         .filter(id.eq(target_class_id))
-        .first::<HubuumClass>(conn)
-        .await?)
+        .first::<HubuumClassRow>(conn)
+        .await?
+        .into())
 }
 
 async fn locked_class_record_in_collection(
@@ -313,11 +315,12 @@ async fn locked_class_record_in_collection(
     authorized_collection_id: i32,
 ) -> Result<HubuumClass, ApiError> {
     use crate::schema::hubuumclass::dsl::{hubuumclass, id};
-    let class = hubuumclass
+    let class: HubuumClass = hubuumclass
         .filter(id.eq(target_class_id))
         .for_share()
-        .first::<HubuumClass>(conn)
-        .await?;
+        .first::<HubuumClassRow>(conn)
+        .await?
+        .into();
     if class.collection_id != authorized_collection_id {
         return Err(ApiError::Conflict(format!(
             "Class {target_class_id} moved from collection {authorized_collection_id}; authorize the request again"

--- a/src/storage/postgres/operations/history.rs
+++ b/src/storage/postgres/operations/history.rs
@@ -1,7 +1,7 @@
 use crate::errors::ApiError;
 use crate::events::PrincipalNames;
 use crate::models::search::QueryOptions;
-use crate::models::{CollectionHistory, HubuumClassHistory, ResourceRevision};
+use crate::models::{CollectionHistory, ResourceRevision};
 use crate::storage::postgres::prelude::*;
 use crate::storage::postgres::with_connection;
 use crate::storage::{
@@ -105,6 +105,30 @@ pub(crate) struct HubuumObjectHistoryRow {
 
 crate::impl_history_pagination!(HubuumObjectHistoryRow, "hubuumobject_history");
 
+#[derive(Queryable)]
+#[diesel(table_name = crate::schema::hubuumclass_history)]
+pub(crate) struct HubuumClassHistoryRow {
+    id: i32,
+    name: String,
+    collection_id: i32,
+    json_schema: Option<serde_json::Value>,
+    validate_schema: bool,
+    description: String,
+    created_at: chrono::NaiveDateTime,
+    updated_at: chrono::NaiveDateTime,
+    op: String,
+    valid_from: chrono::DateTime<chrono::Utc>,
+    valid_to: Option<chrono::DateTime<chrono::Utc>>,
+    actor_id: Option<i32>,
+    history_id: i64,
+    actor_kind: Option<String>,
+    initiator_user_id: Option<i32>,
+    task_id: Option<i32>,
+    revision: ResourceRevision,
+}
+
+crate::impl_history_pagination!(HubuumClassHistoryRow, "hubuumclass_history");
+
 /// Batch-resolve principal ids for provenance responses (anonymized users keep
 /// their tombstoned principal name; ids with no matching principal are absent).
 pub(crate) async fn resolve_principal_names(
@@ -169,7 +193,7 @@ pub(crate) fn collection_history_to_storage(row: CollectionHistory) -> Collectio
     )
 }
 
-pub(crate) fn class_history_to_storage(row: HubuumClassHistory) -> ClassHistoryRecord {
+pub(crate) fn class_history_to_storage(row: HubuumClassHistoryRow) -> ClassHistoryRecord {
     ClassHistoryRecord::new(
         row.id,
         row.name,
@@ -351,7 +375,7 @@ history_db_fns!(
     class_as_of,
     crate::schema::hubuumclass_history,
     collection_id,
-    crate::models::HubuumClassHistory
+    HubuumClassHistoryRow
 );
 
 history_db_fns!(

--- a/src/storage/postgres/operations/object.rs
+++ b/src/storage/postgres/operations/object.rs
@@ -11,7 +11,7 @@ use crate::models::{
     UpdateHubuumObject,
 };
 use crate::storage::postgres::operations::GetObject;
-use crate::storage::postgres::operations::class::lock_resolved_class_target;
+use crate::storage::postgres::operations::class::{HubuumClassRow, lock_resolved_class_target};
 use crate::storage::postgres::operations::computed_field::{
     acquire_computed_class_shared_lock, materialize_object_in_transaction,
 };
@@ -318,8 +318,9 @@ async fn lock_object_and_update_class_by_id(
     let class = class::hubuumclass
         .filter(class::id.eq(class_id))
         .for_update()
-        .first::<HubuumClass>(conn)
-        .await?;
+        .first::<HubuumClassRow>(conn)
+        .await?
+        .into();
     let object: HubuumObject = object::hubuumobject
         .filter(object::id.eq(object_id))
         .filter(object::hubuum_class_id.eq(current.hubuum_class_id))
@@ -840,7 +841,7 @@ impl ResolveObjectSelectorRecord for ObjectSelector {
                         class::hubuumclass::all_columns(),
                         object::hubuumobject::all_columns(),
                     ))
-                    .first::<(HubuumClass, HubuumObjectRow)>(conn)
+                    .first::<(HubuumClassRow, HubuumObjectRow)>(conn)
                     .await
             }
             ObjectSelectorKind::ByName {
@@ -855,12 +856,12 @@ impl ResolveObjectSelectorRecord for ObjectSelector {
                         class::hubuumclass::all_columns(),
                         object::hubuumobject::all_columns(),
                     ))
-                    .first::<(HubuumClass, HubuumObjectRow)>(conn)
+                    .first::<(HubuumClassRow, HubuumObjectRow)>(conn)
                     .await
             }
         })
         .await
-        .map(|(class, object)| (class, object.into()))
+        .map(|(class, object)| (class.into(), object.into()))
     }
 }
 
@@ -885,7 +886,7 @@ async fn lock_resolved_object_target(
             .filter(class::name.eq(&resolved_class.name))
             .filter(class::collection_id.eq(resolved_class.collection_id))
             .for_update()
-            .first::<HubuumClass>(conn)
+            .first::<HubuumClassRow>(conn)
             .await
             .optional()?,
         ObjectSelectorKind::ByName {
@@ -896,10 +897,11 @@ async fn lock_resolved_object_target(
             .filter(class::name.eq(class_name))
             .filter(class::collection_id.eq(resolved_class.collection_id))
             .for_update()
-            .first::<HubuumClass>(conn)
+            .first::<HubuumClassRow>(conn)
             .await
             .optional()?,
     };
+    let locked_class = locked_class.map(Into::into);
     let locked_class =
         crate::storage::postgres::require_existing_revision_target(locked_class, &owner_key)?;
 
@@ -1111,13 +1113,14 @@ impl ObjectClassLookup for HubuumObject {
     ) -> Result<HubuumClass, ApiError> {
         use crate::schema::hubuumclass::dsl::{hubuumclass, id};
 
-        with_connection(pool, async |conn| {
+        let row = with_connection(pool, async |conn| {
             hubuumclass
                 .filter(id.eq(self.hubuum_class_id))
-                .first::<HubuumClass>(conn)
+                .first::<HubuumClassRow>(conn)
                 .await
         })
-        .await
+        .await?;
+        Ok(row.into())
     }
 }
 

--- a/src/storage/postgres/operations/relations.rs
+++ b/src/storage/postgres/operations/relations.rs
@@ -14,6 +14,7 @@ use crate::models::{
     ObjectRelationSelectorKind, PreparedClassRelation, PreparedObjectRelation,
     ResolvedClassRelationTarget, ResolvedObjectRelationTarget, User, user_can_on_any,
 };
+use crate::storage::postgres::operations::class::HubuumClassRow;
 use crate::storage::postgres::operations::event_record::emit_event;
 use crate::storage::postgres::operations::object::HubuumObjectRow;
 use crate::storage::postgres::operations::relation_rows::{
@@ -778,8 +779,11 @@ async fn load_class_relation_endpoint_records(
 
     let classes = hubuumclass
         .filter(id.eq_any([from_class_id, to_class_id]))
-        .load::<HubuumClass>(conn)
-        .await?;
+        .load::<HubuumClassRow>(conn)
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<HubuumClass>>();
     let from_class = classes
         .iter()
         .find(|class| class.id == from_class_id)
@@ -910,12 +914,14 @@ impl DeleteClassRelationRecord for HubuumClassRelation {
                 .try_into()?;
             let from_class = hubuumclass
                 .filter(class_id.eq(relation.from_hubuum_class_id))
-                .first::<HubuumClass>(conn)
-                .await?;
+                .first::<HubuumClassRow>(conn)
+                .await?
+                .into();
             let to_class = hubuumclass
                 .filter(class_id.eq(relation.to_hubuum_class_id))
-                .first::<HubuumClass>(conn)
-                .await?;
+                .first::<HubuumClassRow>(conn)
+                .await?
+                .into();
 
             diesel::delete(hubuumclass_relation.filter(id.eq(self.id)))
                 .execute(conn)
@@ -977,12 +983,14 @@ impl DeleteClassRelationRecord for HubuumClassRelationID {
                 .try_into()?;
             let from_class = hubuumclass
                 .filter(class_id.eq(relation.from_hubuum_class_id))
-                .first::<HubuumClass>(conn)
-                .await?;
+                .first::<HubuumClassRow>(conn)
+                .await?
+                .into();
             let to_class = hubuumclass
                 .filter(class_id.eq(relation.to_hubuum_class_id))
-                .first::<HubuumClass>(conn)
-                .await?;
+                .first::<HubuumClassRow>(conn)
+                .await?
+                .into();
             diesel::delete(hubuumclass_relation.filter(id.eq(self.id())))
                 .execute(conn)
                 .await?;
@@ -1066,12 +1074,14 @@ impl SaveClassRelationRecord for NewHubuumClassRelation {
                     .try_into()?;
                 let from_class = hubuumclass
                     .filter(id.eq(relation.from_hubuum_class_id))
-                    .first::<HubuumClass>(conn)
-                    .await?;
+                    .first::<HubuumClassRow>(conn)
+                    .await?
+                    .into();
                 let to_class = hubuumclass
                     .filter(id.eq(relation.to_hubuum_class_id))
-                    .first::<HubuumClass>(conn)
-                    .await?;
+                    .first::<HubuumClassRow>(conn)
+                    .await?
+                    .into();
                 let event = NewEvent::new(
                     EntityType::ClassRelation,
                     Action::Created,
@@ -1116,13 +1126,15 @@ impl CreatePreparedClassRelationRecord for PreparedClassRelation {
                 let from_class = hubuumclass
                     .filter(id.eq(self.command().from_hubuum_class_id))
                     .for_update()
-                    .first::<HubuumClass>(conn)
-                    .await?;
+                    .first::<HubuumClassRow>(conn)
+                    .await?
+                    .into();
                 let to_class = hubuumclass
                     .filter(id.eq(self.command().to_hubuum_class_id))
                     .for_update()
-                    .first::<HubuumClass>(conn)
-                    .await?;
+                    .first::<HubuumClassRow>(conn)
+                    .await?
+                    .into();
                 if &from_class != self.from_class() || &to_class != self.to_class() {
                     return Err(ApiError::NotFound(
                         "Class relation endpoints no longer match the prepared target".to_string(),
@@ -1184,13 +1196,15 @@ impl DeleteResolvedClassRelationRecord for ResolvedClassRelationTarget {
             let from_class = hubuumclass
                 .filter(class_id.eq(relation.from_hubuum_class_id))
                 .for_update()
-                .first::<HubuumClass>(conn)
-                .await?;
+                .first::<HubuumClassRow>(conn)
+                .await?
+                .into();
             let to_class = hubuumclass
                 .filter(class_id.eq(relation.to_hubuum_class_id))
                 .for_update()
-                .first::<HubuumClass>(conn)
-                .await?;
+                .first::<HubuumClassRow>(conn)
+                .await?
+                .into();
             if &relation != self.relation()
                 || &from_class != self.from_class()
                 || &to_class != self.to_class()

--- a/src/storage/postgres/operations/task_import.rs
+++ b/src/storage/postgres/operations/task_import.rs
@@ -16,6 +16,9 @@ use crate::models::{
     RestoreTimestamps, ServiceAccount, UpdateCollection, UpdateHubuumClass, UpdateHubuumObject,
     UpdatePermission, User,
 };
+use crate::storage::postgres::operations::class::{
+    HubuumClassRow, NewHubuumClassRow, UpdateHubuumClassRow,
+};
 use crate::storage::postgres::operations::collection::CollectionRowInsert;
 use crate::storage::postgres::operations::object::{
     HubuumObjectRow, NewHubuumObjectRow, UpdateHubuumObjectRow,
@@ -129,11 +132,12 @@ pub async fn lookup_class_by_collection_and_name(
         hubuumclass
             .filter(collection_id.eq(collection_id_value))
             .filter(name.eq(class_name))
-            .first::<HubuumClass>(conn)
+            .first::<HubuumClassRow>(conn)
             .await
             .optional()
     })
     .await
+    .map(|row| row.map(Into::into))
 }
 
 pub async fn lookup_classes_by_collection_and_names(
@@ -151,10 +155,11 @@ pub async fn lookup_classes_by_collection_and_names(
         hubuumclass
             .filter(collection_id.eq(collection_id_value))
             .filter(name.eq_any(class_names))
-            .load::<HubuumClass>(conn)
+            .load::<HubuumClassRow>(conn)
             .await
     })
     .await
+    .map(|rows| rows.into_iter().map(Into::into).collect())
 }
 
 pub async fn lookup_object_by_class_and_name(
@@ -374,10 +379,11 @@ pub async fn lookup_class_by_collection_and_name_db(
     hubuumclass
         .filter(collection_id.eq(collection_id_value))
         .filter(name.eq(class_name))
-        .first::<HubuumClass>(conn)
+        .first::<HubuumClassRow>(conn)
         .await
         .optional()
         .map_err(ApiError::from)
+        .map(|row| row.map(Into::into))
 }
 
 pub async fn lookup_object_by_class_and_name_db(
@@ -564,17 +570,19 @@ pub async fn create_class_db(
     match input.timestamps.as_ref() {
         Some(timestamps) => diesel::insert_into(hubuumclass)
             .values((
-                &new_class,
+                NewHubuumClassRow::from(&new_class),
                 created_at.eq(timestamps.created_at()),
                 updated_at.eq(timestamps.updated_at()),
             ))
-            .get_result::<HubuumClass>(conn)
+            .get_result::<HubuumClassRow>(conn)
             .await
+            .map(Into::into)
             .map_err(ApiError::from),
         None => diesel::insert_into(hubuumclass)
-            .values(&new_class)
-            .get_result::<HubuumClass>(conn)
+            .values(NewHubuumClassRow::from(&new_class))
+            .get_result::<HubuumClassRow>(conn)
             .await
+            .map(Into::into)
             .map_err(ApiError::from),
     }
 }
@@ -609,16 +617,22 @@ pub async fn update_class_db(
             crate::storage::postgres::updated_or_current(
                 diesel::update(hubuumclass.filter(id.eq(class_id_value)))
                     .set((
-                        &update,
+                        UpdateHubuumClassRow::from(&update),
                         created_at.eq(timestamps.created_at()),
                         updated_at.eq(timestamps.updated_at()),
                     ))
-                    .get_result::<HubuumClass>(conn)
+                    .get_result::<HubuumClassRow>(conn)
                     .await
                     .optional(),
-                async || hubuumclass.filter(id.eq(class_id_value)).first(conn).await,
+                async || {
+                    hubuumclass
+                        .filter(id.eq(class_id_value))
+                        .first::<HubuumClassRow>(conn)
+                        .await
+                },
             )
             .await
+            .map(Into::into)
             .map_err(ApiError::from)
         })
         .await;
@@ -626,13 +640,19 @@ pub async fn update_class_db(
 
     crate::storage::postgres::updated_or_current(
         diesel::update(hubuumclass.filter(id.eq(class_id_value)))
-            .set(&update)
-            .get_result::<HubuumClass>(conn)
+            .set(UpdateHubuumClassRow::from(&update))
+            .get_result::<HubuumClassRow>(conn)
             .await
             .optional(),
-        async || hubuumclass.filter(id.eq(class_id_value)).first(conn).await,
+        async || {
+            hubuumclass
+                .filter(id.eq(class_id_value))
+                .first::<HubuumClassRow>(conn)
+                .await
+        },
     )
     .await
+    .map(Into::into)
     .map_err(ApiError::from)
 }
 

--- a/src/storage/postgres/operations/user/search.rs
+++ b/src/storage/postgres/operations/user/search.rs
@@ -10,6 +10,7 @@ use crate::permissions::visibility::AuthorizedObjectIds;
 use crate::storage::postgres::operations::authz::{
     AuthzSubject as PostgresAuthzSubject, scope_allows,
 };
+use crate::storage::postgres::operations::class::HubuumClassRow;
 use crate::storage::postgres::operations::computed_field::{
     ComputedQuerySnapshot, computed_filter_predicate, object_cursor_sql_fields,
 };
@@ -698,7 +699,7 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             }
         }
 
-        crate::apply_query_options!(base_query, query_options, HubuumClassExpanded);
+        crate::apply_query_options!(base_query, query_options, HubuumClassRow);
 
         trace_query!(base_query, "Searching classes");
 
@@ -706,10 +707,13 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             base_query
                 .select(hubuumclass::all_columns())
                 .distinct()
-                .load::<HubuumClass>(conn)
+                .load::<HubuumClassRow>(conn)
                 .await
         })
-        .await?;
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<HubuumClass>>();
 
         let collection_map: std::collections::HashMap<i32, Collection> =
             collections.into_iter().map(|n| (n.id, n)).collect();

--- a/src/storage/postgres/operations/user/unified_search.rs
+++ b/src/storage/postgres/operations/user/unified_search.rs
@@ -11,6 +11,7 @@ use crate::models::{
     UnifiedSearchCursorToken, UnifiedSearchSpec,
 };
 use crate::storage::postgres::operations::authz::scope_allows;
+use crate::storage::postgres::operations::class::HubuumClassRow;
 use crate::storage::postgres::operations::object::HubuumObjectRow;
 use crate::storage::postgres::with_connection_async;
 
@@ -267,10 +268,13 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
                 .bind::<Text, _>(cursor_binds.name)
                 .bind::<Integer, _>(cursor_binds.id)
                 .bind::<BigInt, _>(limit)
-                .load::<HubuumClass>(conn)
+                .load::<HubuumClassRow>(conn)
                 .await
         })
-        .await?;
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<HubuumClass>>();
 
         if classes.is_empty() {
             return Ok(Vec::new());

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -214,6 +214,70 @@ fn backend_neutral_layers_do_not_import_database_implementation_details() {
 }
 
 #[test]
+fn class_domain_types_are_free_of_persistence_implementation_details() {
+    let root = repository_root();
+    let mut violations = Vec::new();
+
+    for relative_path in ["src/models/class.rs", "src/models/traits/class.rs"] {
+        let path = root.join(relative_path);
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(&source);
+        for forbidden in [
+            "diesel::",
+            "diesel(",
+            "crate::schema",
+            "storage::postgres",
+            "CursorSqlMapping",
+            "CursorSqlField",
+            "CursorSqlType",
+        ] {
+            if production_source.contains(forbidden) {
+                violations.push(format!("{} contains {forbidden}", path.display()));
+            }
+        }
+    }
+
+    let adapter_path = root.join("src/storage/postgres/operations/class.rs");
+    let adapter_source = fs::read_to_string(&adapter_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", adapter_path.display()));
+    for required in [
+        "struct HubuumClassRow",
+        "struct NewHubuumClassRow",
+        "struct UpdateHubuumClassRow",
+        "impl From<HubuumClassRow> for HubuumClass",
+        "impl CursorSqlMapping for HubuumClassRow",
+    ] {
+        assert!(
+            adapter_source.contains(required),
+            "PostgreSQL class adapter is missing {required}"
+        );
+    }
+
+    let history_path = root.join("src/storage/postgres/operations/history.rs");
+    let history_source = fs::read_to_string(&history_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", history_path.display()));
+    assert!(
+        history_source.contains("struct HubuumClassHistoryRow"),
+        "PostgreSQL history adapter must own the class-history row"
+    );
+
+    let output_path = root.join("src/models/traits/output.rs");
+    let output_source = fs::read_to_string(&output_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", output_path.display()));
+    assert!(
+        !output_source.contains("impl CursorSqlMapping for HubuumClassExpanded"),
+        "expanded class output must not own PostgreSQL cursor mappings"
+    );
+
+    assert!(
+        violations.is_empty(),
+        "class domain types crossed into persistence details:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
 fn object_domain_types_are_free_of_persistence_implementation_details() {
     let root = repository_root();
     let mut violations = Vec::new();
@@ -357,6 +421,7 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         "HistoryStorage",
         "InventoryStorage",
         "UnifiedSearchStorage",
+        "ClassRecordStorage",
         "ObjectRecordStorage",
         "RemoteTargetStorage",
         "TaskQueueStorage",
@@ -522,6 +587,12 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         compact_context.contains("\"inventory\",\"counts\""),
         "inventory counts must use the common storage observer"
     );
+    for operation in ["create", "update", "delete", "load", "collection", "names"] {
+        assert!(
+            compact_context.contains(&format!("\"class_records\",\"{operation}\"")),
+            "class record operation {operation} must use the common storage observer"
+        );
+    }
     for operation in [
         "validate",
         "validate_new",

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -133,7 +133,7 @@ async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() 
 
     assert!(
         body.contains(
-            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"23\"} 1"
+            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"24\"} 1"
         )
     );
     assert!(body.contains(

--- a/tests/api_platform_suite/runtime_config.rs
+++ b/tests/api_platform_suite/runtime_config.rs
@@ -37,7 +37,7 @@ mod tests {
         let serialized = serde_json::to_string(&body).unwrap();
 
         assert_eq!(body["database"]["backend"], "postgresql");
-        assert_eq!(body["database"]["contract_version"], 23);
+        assert_eq!(body["database"]["contract_version"], 24);
         assert_eq!(
             body["database"]["capabilities"],
             serde_json::json!([


### PR DESCRIPTION
## Summary

- move class lifecycle, history, insert, update, and SQL cursor rows into the PostgreSQL adapter
- add a mandatory `ClassRecordStorage` contract for point persistence, collection lookup, bulk name resolution, and deliberately event-suppressed compatibility writes
- route domain adapters and export enrichment through backend-neutral storage contracts, with backend errors mapped to `StorageError` before the API boundary
- observe every class-record entry point using bounded backend, family, operation, and outcome labels
- enforce the boundary and selectable-backend completeness with architecture tests

## Boundary behavior

The class domain models and their public output DTOs no longer contain Diesel derives, schema bindings, PostgreSQL imports, or SQL cursor mappings. PostgreSQL owns its row representations and the explicit conversions into backend-neutral domain values.

`StorageBackend` now requires `ClassRecordStorage`, so a selectable backend cannot omit class point operations while claiming compatibility. The existing lifecycle contract remains the ordinary application-service path; the new record contract also captures legacy fixture and compatibility operations without exposing a pool, connection, Diesel query, or PostgreSQL error to consumers.

The storage contract version is now `24`. This is a breaking administrator API change for clients that pin the reported contract version. Required capability labels and public HTTP request and response shapes are unchanged.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --features integration-test-support -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `scripts/test-classify-ci-changes.sh`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `git diff --check`

Part of #27.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
