### PR TITLE
Enforce collection persistence boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Breaking (administrator API):** the storage contract version is now `25`.
+  Collection point and compatibility writes, hierarchy operations, and
+  collection-permission projections now cross mandatory, uniformly observed
+  backend contracts. Collection, collection-history, insert, and update
+  persistence rows and SQL cursor mappings are owned by the PostgreSQL adapter;
+  collection domain models contain no Diesel or PostgreSQL implementation
+  details. Required capability labels and public HTTP request and response
+  shapes are unchanged. Administration and monitoring clients matching
+  contract version `24` must accept version `25`.
 - **Breaking (administrator API):** the storage contract version is now `24`.
   Class point persistence, bulk name resolution, and event-suppressed
   compatibility writes now cross a mandatory, uniformly observed backend

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -182,7 +182,7 @@ use std::fmt;
 ///
 /// Increment this when a selectable backend must implement a new capability
 /// family or when an existing family's externally observable semantics change.
-pub const STORAGE_CONTRACT_VERSION: u16 = 24;
+pub const STORAGE_CONTRACT_VERSION: u16 = 25;
 
 /// Stable identity of a selectable storage backend.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -93,9 +93,13 @@ complete contract includes `AuthenticationStorage`, `IdentityStorage`,
 `AuthorizationStorage`, `HistoryStorage`, `CatalogStorage`,
 `ComputedObjectStorage`, `ComputedFieldLifecycleStorage`,
 `ObjectAggregateStorage`, `RelationQueryStorage`, `InventoryStorage`, and
-`UnifiedSearchStorage` contracts. `ObjectRecordStorage` keeps transitional
-point-load, validation, and event-suppressed fixture operations behind the same
-mandatory backend boundary; it does not expose rows or connections.
+`UnifiedSearchStorage` contracts. `CollectionRecordStorage` keeps deliberately
+event-suppressed collection writes behind the mandatory lifecycle boundary,
+while `CollectionPermissionStorage` exposes operation-shaped grant projections
+without leaking a query builder. `ClassRecordStorage` and `ObjectRecordStorage`
+keep transitional point-load, validation, bulk lookup, and event-suppressed
+fixture operations behind the same mandatory backend boundary. None of these
+contracts exposes rows or connections.
 `TaskQueueStorage` replaces task submission and reads, while
 `TaskExecutionStorage` owns the complete worker claim and state machine.
 `BackupSnapshotStorage` owns consistent full-system reads, and computed rebuild
@@ -119,13 +123,14 @@ considered complete merely because a marker exists.
 PostgreSQL query implementations live in
 `src/storage/postgres/operations/*`. Export-template, remote-target, event,
 event-sink, event-subscription, and event-delivery lifecycle rows are
-adapter-owned, as are class and object lifecycle and history rows, class- and
-object-relation rows, relation graph query rows, remote-target history, and
-remote-call result persistence rows. Domain class, object, and relation values
-contain no Diesel derives, schema bindings, or SQL cursor mappings. Those
-mappings and explicit conversions live in the PostgreSQL adapter. Remaining mixed
-persistence rows move there as their backend-neutral DTOs are extracted. Their
-current locations are implementation details, not partial backend support.
+adapter-owned, as are collection, class, and object lifecycle and history rows,
+class- and object-relation rows, relation graph query rows, remote-target
+history, and remote-call result persistence rows. Domain collection, class,
+object, and relation values contain no Diesel derives, schema bindings, or SQL
+cursor mappings. Those mappings and explicit conversions live in the PostgreSQL
+adapter. Remaining mixed persistence rows move there as their backend-neutral
+DTOs are extracted. Their current locations are implementation details, not
+partial backend support.
 `StorageHandle` selects one certified PostgreSQL adapter, and only the storage
 implementation can recover its pool.
 Application consumers use `StorageContext`, lifecycle traits, mandatory
@@ -135,14 +140,17 @@ composition without implementing every operation behind those contracts.
 The storage contract version changes when a required family is added or when
 observable semantics change. The selected backend and contract version are
 reported in startup logs, process metrics, and the redacted admin configuration.
-Version 24 additionally requires class point persistence, bulk name resolution,
-and event-suppressed compatibility writes to cross one mandatory, observed
-storage contract. Class lifecycle and history rows, Diesel mappings, and SQL
-cursor mappings are adapter-owned. Version 23 required class- and object-relation
-point operations, lifecycle writes, and event-suppressed compatibility writes
-to cross the same mandatory, observed storage contract. Relation persistence
-and graph query rows, Diesel mappings, and SQL cursor mappings are adapter-owned.
-Version 22 required
+Version 25 additionally requires collection point and compatibility writes,
+hierarchy operations, and collection-permission projections to cross mandatory,
+observed storage contracts. Collection lifecycle and history rows, Diesel
+mappings, and SQL cursor mappings are adapter-owned. Version 24 required class
+point persistence, bulk name resolution, and event-suppressed compatibility
+writes to cross one mandatory, observed storage contract. Class lifecycle and
+history rows, Diesel mappings, and SQL cursor mappings are adapter-owned. Version
+23 required class- and object-relation point operations, lifecycle writes, and
+event-suppressed compatibility writes to cross the same mandatory, observed
+storage contract. Relation persistence and graph query rows, Diesel mappings,
+and SQL cursor mappings are adapter-owned. Version 22 required
 consistent administrative inventory queries, the `inventory_queries`
 capability label, and mandatory object point-operation abstraction. Version 21
 required the complete export-template lifecycle and a new

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -454,7 +454,7 @@ mod tests {
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
         assert!(json.contains("\"backend\":\"postgresql\""));
-        assert!(json.contains("\"contract_version\":24"));
+        assert!(json.contains("\"contract_version\":25"));
         assert!(json.contains("\"catalog_queries\""));
         assert!(json.contains("\"computed_object_queries\""));
         assert!(json.contains("\"computed_field_lifecycle\""));

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -1,5 +1,4 @@
 use crate::models::token_scope::TokenScope;
-use crate::storage::postgres::prelude::*;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -12,24 +11,16 @@ use crate::models::search::QueryOptions;
 use crate::models::traits::GroupAccessors;
 use crate::models::{Permission, Permissions, ResourceRevision};
 use crate::permissions::{AuthzTarget, ResourceAttrs, ResourceKind, ResourceRef};
-use crate::schema::collections;
-use crate::storage::StorageContext;
-use crate::storage::postgres::operations::collection as collection_backend;
+use crate::storage::{
+    CollectionGrantListQuery, CollectionGroupPermissionQuery, CollectionGroupsPageQuery,
+    CollectionGroupsQuery, CollectionPermissionStorage, CollectionPrincipalPageQuery,
+    CollectionPrincipalQuery, CollectionRecordStorage, CollectionVisibilityQuery, StorageContext,
+    storage_handle,
+};
 use crate::traits::AuthzSubject;
 use crate::traits::{CollectionAccessors, SelfAccessors};
 
-#[derive(
-    Serialize,
-    Deserialize,
-    Queryable,
-    QueryableByName,
-    PartialEq,
-    Debug,
-    Clone,
-    Selectable,
-    ToSchema,
-)]
-#[diesel(table_name = collections)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, ToSchema)]
 pub struct Collection {
     pub id: i32,
     pub name: String,
@@ -46,9 +37,8 @@ crate::int_id_newtype! {
     noun = "collection id";
 }
 
-#[derive(Serialize, Deserialize, Clone, AsChangeset, ToSchema)]
+#[derive(Serialize, Deserialize, Clone, ToSchema)]
 #[schema(example = update_collection_example)]
-#[diesel(table_name = collections)]
 pub struct UpdateCollection {
     pub name: Option<String>,
     pub description: Option<String>,
@@ -85,8 +75,7 @@ pub struct NewCollectionWithAssignee {
 /// into the database.
 ///
 /// Odds are pretty good that you want to use NewCollectionWithAssignee instead.
-#[derive(Serialize, Deserialize, Insertable, ToSchema)]
-#[diesel(table_name = collections)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct NewCollection {
     pub name: String,
     pub description: String,
@@ -134,7 +123,14 @@ where
     S: AuthzSubject,
     T: CollectionAccessors,
 {
-    collection_backend::principal_on_from_backend(backend, principal, collection_ref).await
+    let query = CollectionPrincipalQuery::new(
+        principal.principal_id(),
+        collection_ref.collection_id(backend).await?.id(),
+    );
+    storage_handle(backend)
+        .principal_collection_permissions(query)
+        .await
+        .map_err(ApiError::from)
 }
 
 /// All of a principal's direct permission rows across every collection, as
@@ -147,7 +143,10 @@ where
     C: StorageContext,
     S: AuthzSubject,
 {
-    collection_backend::principal_all_permissions_from_backend(backend, principal).await
+    storage_handle(backend)
+        .principal_all_collection_permissions(principal.principal_id())
+        .await
+        .map_err(ApiError::from)
 }
 
 pub async fn principal_on_paginated_with_total_count<C, S, T>(
@@ -161,13 +160,17 @@ where
     S: AuthzSubject,
     T: CollectionAccessors,
 {
-    collection_backend::principal_on_paginated_with_total_count_from_backend(
-        backend,
-        principal,
-        collection_ref,
-        query_options,
-    )
-    .await
+    let principal = CollectionPrincipalQuery::new(
+        principal.principal_id(),
+        collection_ref.collection_id(backend).await?.id(),
+    );
+    storage_handle(backend)
+        .principal_collection_permissions_page(CollectionPrincipalPageQuery::new(
+            principal,
+            query_options.clone(),
+        ))
+        .await
+        .map_err(ApiError::from)
 }
 
 pub async fn effective_principal_on<C, S, T>(
@@ -180,8 +183,14 @@ where
     S: AuthzSubject,
     T: CollectionAccessors,
 {
-    collection_backend::effective_principal_on_from_backend(backend, principal, collection_ref)
+    let query = CollectionPrincipalQuery::new(
+        principal.principal_id(),
+        collection_ref.collection_id(backend).await?.id(),
+    );
+    storage_handle(backend)
+        .effective_principal_collection_permissions(query)
         .await
+        .map_err(ApiError::from)
 }
 
 /// Check if a user has a specific permission to any collection
@@ -205,8 +214,14 @@ where
     C: StorageContext,
     U: GroupAccessors + AuthzSubject,
 {
-    collection_backend::user_can_on_any_from_backend(backend, user_id, permission_type, scopes)
+    storage_handle(backend)
+        .visible_collections(CollectionVisibilityQuery::new(
+            user_id.principal_id(),
+            permission_type,
+            scopes,
+        ))
         .await
+        .map_err(ApiError::from)
 }
 
 /// Check if a group has a specific permission to a given collection ID
@@ -230,8 +245,14 @@ where
     C: StorageContext,
     T: CollectionAccessors,
 {
-    collection_backend::group_can_on_from_backend(backend, gid, collection_ref, permission_type)
+    storage_handle(backend)
+        .group_has_collection_permission(CollectionGroupPermissionQuery::new(
+            collection_ref.collection_id(backend).await?.id(),
+            gid,
+            permission_type,
+        ))
         .await
+        .map_err(ApiError::from)
 }
 
 pub async fn effective_group_on<C>(
@@ -242,7 +263,10 @@ pub async fn effective_group_on<C>(
 where
     C: StorageContext,
 {
-    collection_backend::effective_group_on_from_backend(backend, target_collection_id, gid).await
+    storage_handle(backend)
+        .effective_group_collection_permissions(target_collection_id, gid)
+        .await
+        .map_err(ApiError::from)
 }
 
 /// Check what groups have a specific permission to a given collection ID
@@ -263,8 +287,13 @@ pub async fn groups_can_on<C>(
 where
     C: StorageContext,
 {
-    collection_backend::groups_can_on_from_backend(backend, target_collection_id, permission_type)
+    storage_handle(backend)
+        .groups_with_collection_permission(CollectionGroupsQuery::new(
+            target_collection_id,
+            permission_type,
+        ))
         .await
+        .map_err(ApiError::from)
 }
 
 pub async fn groups_can_on_paginated_with_total_count<C>(
@@ -276,13 +305,13 @@ pub async fn groups_can_on_paginated_with_total_count<C>(
 where
     C: StorageContext,
 {
-    collection_backend::groups_can_on_paginated_with_total_count_from_backend(
-        backend,
-        target_collection_id,
-        permission_type,
-        query_options,
-    )
-    .await
+    storage_handle(backend)
+        .groups_with_collection_permission_page(CollectionGroupsPageQuery::new(
+            CollectionGroupsQuery::new(target_collection_id, permission_type),
+            query_options.clone(),
+        ))
+        .await
+        .map_err(ApiError::from)
 }
 
 /// List all groups and their permissions for a collection
@@ -304,13 +333,14 @@ where
     C: StorageContext,
     T: CollectionAccessors,
 {
-    collection_backend::groups_on_from_backend(
-        backend,
-        collection_ref,
-        permissions_filter,
-        query_options,
-    )
-    .await
+    storage_handle(backend)
+        .list_collection_group_permissions(CollectionGrantListQuery::new(
+            collection_ref.collection_id(backend).await?.id(),
+            permissions_filter,
+            query_options,
+        ))
+        .await
+        .map_err(ApiError::from)
 }
 
 pub async fn groups_on_paginated<C, T>(
@@ -323,13 +353,15 @@ where
     C: StorageContext,
     T: CollectionAccessors,
 {
-    collection_backend::groups_on_paginated_from_backend(
-        backend,
-        collection_ref,
-        permissions_filter,
-        query_options,
-    )
-    .await
+    let (items, _) = storage_handle(backend)
+        .list_collection_group_permissions_page(CollectionGrantListQuery::new(
+            collection_ref.collection_id(backend).await?.id(),
+            permissions_filter,
+            query_options.clone(),
+        ))
+        .await
+        .map_err(ApiError::from)?;
+    Ok(items)
 }
 
 pub async fn groups_on_paginated_with_total_count<C, T>(
@@ -342,13 +374,14 @@ where
     C: StorageContext,
     T: CollectionAccessors,
 {
-    collection_backend::groups_on_paginated_with_total_count_from_backend(
-        backend,
-        collection_ref,
-        permissions_filter,
-        query_options,
-    )
-    .await
+    storage_handle(backend)
+        .list_collection_group_permissions_page(CollectionGrantListQuery::new(
+            collection_ref.collection_id(backend).await?.id(),
+            permissions_filter,
+            query_options.clone(),
+        ))
+        .await
+        .map_err(ApiError::from)
 }
 
 pub async fn count_groups_on_paginated<C, T>(
@@ -361,13 +394,15 @@ where
     C: StorageContext,
     T: CollectionAccessors,
 {
-    collection_backend::count_groups_on_paginated_from_backend(
-        backend,
-        collection_ref,
-        permissions_filter,
-        query_options,
-    )
-    .await
+    let (_, total) = storage_handle(backend)
+        .list_collection_group_permissions_page(CollectionGrantListQuery::new(
+            collection_ref.collection_id(backend).await?.id(),
+            permissions_filter,
+            query_options.clone(),
+        ))
+        .await
+        .map_err(ApiError::from)?;
+    Ok(total)
 }
 
 /// List all permissions for a given group on a collection
@@ -379,7 +414,10 @@ pub async fn group_on<C>(
 where
     C: StorageContext,
 {
-    collection_backend::group_on_from_backend(backend, target_collection_id, gid).await
+    storage_handle(backend)
+        .collection_group_permission(target_collection_id, gid)
+        .await
+        .map_err(ApiError::from)
 }
 
 pub async fn collection_children<C, T>(
@@ -390,7 +428,13 @@ where
     C: StorageContext,
     T: CollectionAccessors,
 {
-    collection_backend::collection_children_from_backend(backend, collection_ref).await
+    let collection_id = collection_ref.collection_id(backend).await?;
+    storage_handle(backend)
+        .lifecycle_storage()
+        .inner()
+        .collection_children(collection_id)
+        .await
+        .map_err(ApiError::from)
 }
 
 pub async fn collection_ancestors<C, T>(
@@ -401,7 +445,13 @@ where
     C: StorageContext,
     T: CollectionAccessors,
 {
-    collection_backend::collection_ancestors_from_backend(backend, collection_ref).await
+    let collection_id = collection_ref.collection_id(backend).await?;
+    storage_handle(backend)
+        .lifecycle_storage()
+        .inner()
+        .collection_ancestors(collection_id)
+        .await
+        .map_err(ApiError::from)
 }
 
 pub async fn move_collection<C>(
@@ -413,17 +463,13 @@ pub async fn move_collection<C>(
 where
     C: StorageContext,
 {
-    collection_backend::move_collection_record_from_backend(
-        backend,
-        collection_id,
-        new_parent_collection_id,
-        context,
-    )
-    .await
+    storage_handle(backend)
+        .move_collection_record(collection_id, new_parent_collection_id, context)
+        .await
+        .map_err(ApiError::from)
 }
 
-#[derive(serde::Serialize, diesel::Queryable, Clone, Debug, ToSchema)]
-#[diesel(table_name = crate::schema::collections_history)]
+#[derive(serde::Serialize, Clone, Debug, ToSchema)]
 pub struct CollectionHistory {
     pub id: i32,
     pub name: String,
@@ -442,7 +488,45 @@ pub struct CollectionHistory {
     pub revision: ResourceRevision,
 }
 
-crate::impl_history_pagination!(CollectionHistory, "collections_history");
+impl crate::traits::CursorPaginated for CollectionHistory {
+    fn supports_sort(field: &crate::models::search::FilterField) -> bool {
+        matches!(
+            field,
+            crate::models::search::FilterField::HistoryId
+                | crate::models::search::FilterField::Revision
+        )
+    }
+
+    fn cursor_value(
+        &self,
+        field: &crate::models::search::FilterField,
+    ) -> Result<crate::traits::CursorValue, ApiError> {
+        Ok(match field {
+            crate::models::search::FilterField::HistoryId => {
+                crate::traits::CursorValue::Integer(self.history_id)
+            }
+            crate::models::search::FilterField::Revision => {
+                crate::traits::CursorValue::Integer(self.revision.get())
+            }
+            other => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{other}' is not orderable for history"
+                )));
+            }
+        })
+    }
+
+    fn default_sort() -> Vec<crate::models::search::SortParam> {
+        vec![crate::models::search::SortParam {
+            field: crate::models::search::FilterField::HistoryId,
+            descending: true,
+        }]
+    }
+
+    fn tie_breaker_sort() -> Vec<crate::models::search::SortParam> {
+        Self::default_sort()
+    }
+}
 
 #[async_trait]
 impl AuthzTarget for Collection {
@@ -476,6 +560,7 @@ impl AuthzTarget for CollectionID {
 mod tests {
     use std::vec;
 
+    use crate::storage::postgres::prelude::*;
     use diesel::sql_query;
 
     use super::*;

--- a/src/models/traits/collection.rs
+++ b/src/models/traits/collection.rs
@@ -5,17 +5,10 @@ use crate::models::collection::{
 };
 use crate::models::group::GroupID;
 use crate::models::search::{FilterField, SortParam};
-use crate::storage::StorageContext;
-use crate::storage::postgres::operations::collection::{
-    DeleteCollectionRecord, SaveCollectionForGroupRecord, SaveCollectionWithAssigneeRecord,
-    UpdateCollectionRecord,
-};
+use crate::storage::{CollectionRecordStorage, StorageContext, storage_handle};
 use crate::traits::accessors::{CollectionAdapter, IdAccessor, InstanceAdapter};
 use crate::traits::crud::{DeleteAdapter, SaveAdapter, UpdateAdapter};
-use crate::traits::{
-    CanUpdate, CollectionAccessors, CursorPaginated, CursorSqlField, CursorSqlMapping,
-    CursorSqlType, PermissionController,
-};
+use crate::traits::{CollectionAccessors, CursorPaginated, PermissionController};
 
 impl SaveAdapter for Collection {
     type Output = Collection;
@@ -28,9 +21,10 @@ impl SaveAdapter for Collection {
             name: Some(self.name.clone()),
             description: Some(self.description.clone()),
         };
-        updated_collection
-            .update_without_events(pool, CollectionID::new(self.id)?)
+        storage_handle(pool)
+            .update_collection_record(&updated_collection, self.id, None)
             .await
+            .map_err(ApiError::from)
     }
 
     async fn save_adapter(
@@ -42,9 +36,10 @@ impl SaveAdapter for Collection {
             name: Some(self.name.clone()),
             description: Some(self.description.clone()),
         };
-        updated_collection
-            .update_collection_record(pool, self.id, Some(context))
+        storage_handle(pool)
+            .update_collection_record(&updated_collection, self.id, Some(context))
             .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -53,7 +48,10 @@ impl DeleteAdapter for Collection {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(), ApiError> {
-        self.delete_collection_record_without_events(pool).await
+        storage_handle(pool)
+            .delete_collection_record(self.id, None)
+            .await
+            .map_err(ApiError::from)
     }
 
     async fn delete_adapter(
@@ -61,7 +59,10 @@ impl DeleteAdapter for Collection {
         pool: &impl crate::storage::StorageContext,
         context: &EventContext,
     ) -> Result<(), ApiError> {
-        self.delete_collection_record(pool, Some(context)).await
+        storage_handle(pool)
+            .delete_collection_record(self.id, Some(context))
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -70,7 +71,10 @@ impl DeleteAdapter for CollectionID {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<(), ApiError> {
-        self.delete_collection_record_without_events(pool).await
+        storage_handle(pool)
+            .delete_collection_record(self.id(), None)
+            .await
+            .map_err(ApiError::from)
     }
 
     async fn delete_adapter(
@@ -78,7 +82,10 @@ impl DeleteAdapter for CollectionID {
         pool: &impl crate::storage::StorageContext,
         context: &EventContext,
     ) -> Result<(), ApiError> {
-        self.delete_collection_record(pool, Some(context)).await
+        storage_handle(pool)
+            .delete_collection_record(self.id(), Some(context))
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -91,8 +98,10 @@ impl UpdateAdapter for UpdateCollection {
         pool: &impl crate::storage::StorageContext,
         target_collection_id: CollectionID,
     ) -> Result<Self::Output, ApiError> {
-        self.update_collection_record_without_events(pool, target_collection_id.id())
+        storage_handle(pool)
+            .update_collection_record(self, target_collection_id.id(), None)
             .await
+            .map_err(ApiError::from)
     }
 
     async fn update_adapter(
@@ -101,8 +110,10 @@ impl UpdateAdapter for UpdateCollection {
         target_collection_id: CollectionID,
         context: &EventContext,
     ) -> Result<Self::Output, ApiError> {
-        self.update_collection_record(pool, target_collection_id.id(), Some(context))
+        storage_handle(pool)
+            .update_collection_record(self, target_collection_id.id(), Some(context))
             .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -113,8 +124,10 @@ impl SaveAdapter for NewCollectionWithAssignee {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<Collection, ApiError> {
-        self.save_collection_with_assignee_record_without_events(pool)
+        storage_handle(pool)
+            .create_collection_record(self, None)
             .await
+            .map_err(ApiError::from)
     }
 
     async fn save_adapter(
@@ -122,8 +135,10 @@ impl SaveAdapter for NewCollectionWithAssignee {
         pool: &impl crate::storage::StorageContext,
         context: &EventContext,
     ) -> Result<Collection, ApiError> {
-        self.save_collection_with_assignee_record(pool, Some(context))
+        storage_handle(pool)
+            .create_collection_record(self, Some(context))
             .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -188,8 +203,12 @@ impl CollectionAdapter for CollectionID {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<Collection, ApiError> {
-        use crate::storage::postgres::operations::GetCollection;
-        self.collection_from_backend(pool).await
+        storage_handle(pool)
+            .lifecycle_storage()
+            .inner()
+            .get_collection(*self)
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -206,8 +225,19 @@ impl NewCollection {
     where
         C: StorageContext,
     {
-        self.save_collection_for_group_record_without_events(backend, assignee.id())
+        let command = NewCollectionWithAssignee {
+            name: self.name,
+            description: self.description,
+            group_id: assignee,
+            parent_collection_id: self
+                .parent_collection_id
+                .map(CollectionID::new)
+                .transpose()?,
+        };
+        storage_handle(backend)
+            .create_collection_record(&command, None)
             .await
+            .map_err(ApiError::from)
     }
 
     /// Persist the collection and apply permissions using the assignee embedded in the supplied
@@ -223,11 +253,19 @@ impl NewCollection {
     where
         C: StorageContext,
     {
-        self.save_collection_for_group_record_without_events(
-            backend,
-            collection_with_assignee.group_id.id(),
-        )
-        .await
+        let command = NewCollectionWithAssignee {
+            name: self.name,
+            description: self.description,
+            group_id: collection_with_assignee.group_id,
+            parent_collection_id: self
+                .parent_collection_id
+                .map(CollectionID::new)
+                .transpose()?,
+        };
+        storage_handle(backend)
+            .create_collection_record(&command, None)
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -275,48 +313,5 @@ impl CursorPaginated for Collection {
 
     fn tie_breaker_sort() -> Vec<SortParam> {
         Self::default_sort()
-    }
-}
-
-impl CursorSqlMapping for Collection {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id => CursorSqlField {
-                column: "collections.id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Name => CursorSqlField {
-                column: "collections.name",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::Description => CursorSqlField {
-                column: "collections.description",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::CreatedAt => CursorSqlField {
-                column: "collections.created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAt => CursorSqlField {
-                column: "collections.updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::Revision => CursorSqlField {
-                column: "collections.revision",
-                sql_type: CursorSqlType::BigInt,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for collections",
-                    field
-                )));
-            }
-        })
     }
 }

--- a/src/pagination/tests.rs
+++ b/src/pagination/tests.rs
@@ -6,6 +6,7 @@ use rstest::rstest;
 
 use super::*;
 use crate::models::{Collection, UserWithName};
+use crate::storage::postgres::operations::collection::CollectionRow;
 
 #[derive(Clone, Debug)]
 struct JsonCursorItem {
@@ -148,7 +149,7 @@ fn test_paginate_collections_with_cursor() {
     .unwrap();
 
     let cursor_sql =
-        cursor_filter_sql::<Collection>(&prepared_query.sort, prepared_query.cursor.as_deref())
+        cursor_filter_sql::<CollectionRow>(&prepared_query.sort, prepared_query.cursor.as_deref())
             .unwrap();
 
     assert_eq!(cursor_sql, Some("((collections.id > 2))".to_string()));

--- a/src/storage/collections.rs
+++ b/src/storage/collections.rs
@@ -1,7 +1,13 @@
 use async_trait::async_trait;
 
 use crate::events::EventContext;
-use crate::models::{Collection, CollectionID, NewCollectionWithAssignee, UpdateCollection};
+use crate::models::group::Group;
+use crate::models::output::{EffectiveGroupPermission, GroupPermission};
+use crate::models::search::QueryOptions;
+use crate::models::{
+    Collection, CollectionID, NewCollectionWithAssignee, Permission, Permissions, TokenScope,
+    UpdateCollection,
+};
 
 use super::StorageError;
 
@@ -44,4 +50,299 @@ pub(crate) trait CollectionStore: Send + Sync {
         new_parent_id: CollectionID,
         context: &EventContext,
     ) -> Result<Collection, StorageError>;
+}
+
+/// Backend-neutral compatibility contract for collection record mutations.
+///
+/// Application services use [`CollectionStore`] for ordinary lifecycle behavior.
+/// Legacy domain adapters additionally require deliberately event-suppressed
+/// writes; every selectable backend must provide those paths without exposing
+/// adapter or database types to callers.
+#[async_trait]
+pub(crate) trait CollectionRecordStorage: Send + Sync {
+    async fn create_collection_record(
+        &self,
+        command: &NewCollectionWithAssignee,
+        context: Option<&EventContext>,
+    ) -> Result<Collection, StorageError>;
+
+    async fn update_collection_record(
+        &self,
+        update: &UpdateCollection,
+        collection_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<Collection, StorageError>;
+
+    async fn delete_collection_record(
+        &self,
+        collection_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError>;
+
+    async fn move_collection_record(
+        &self,
+        collection_id: i32,
+        new_parent_collection_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<Collection, StorageError>;
+}
+
+#[derive(Clone)]
+pub(crate) struct CollectionPrincipalQuery {
+    principal_id: i32,
+    collection_id: i32,
+}
+
+impl CollectionPrincipalQuery {
+    pub(crate) const fn new(principal_id: i32, collection_id: i32) -> Self {
+        Self {
+            principal_id,
+            collection_id,
+        }
+    }
+
+    pub(crate) const fn principal_id(&self) -> i32 {
+        self.principal_id
+    }
+
+    pub(crate) const fn collection_id(&self) -> i32 {
+        self.collection_id
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CollectionPrincipalPageQuery {
+    principal: CollectionPrincipalQuery,
+    query_options: QueryOptions,
+}
+
+impl CollectionPrincipalPageQuery {
+    pub(crate) const fn new(
+        principal: CollectionPrincipalQuery,
+        query_options: QueryOptions,
+    ) -> Self {
+        Self {
+            principal,
+            query_options,
+        }
+    }
+
+    pub(crate) const fn principal(&self) -> &CollectionPrincipalQuery {
+        &self.principal
+    }
+
+    pub(crate) const fn query_options(&self) -> &QueryOptions {
+        &self.query_options
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CollectionVisibilityQuery {
+    principal_id: i32,
+    permission: Permissions,
+    scopes: Option<TokenScope>,
+}
+
+impl CollectionVisibilityQuery {
+    pub(crate) fn new(
+        principal_id: i32,
+        permission: Permissions,
+        scopes: Option<&TokenScope>,
+    ) -> Self {
+        Self {
+            principal_id,
+            permission,
+            scopes: scopes.cloned(),
+        }
+    }
+
+    pub(crate) const fn principal_id(&self) -> i32 {
+        self.principal_id
+    }
+
+    pub(crate) const fn permission(&self) -> Permissions {
+        self.permission
+    }
+
+    pub(crate) const fn scopes(&self) -> Option<&TokenScope> {
+        self.scopes.as_ref()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CollectionGroupPermissionQuery {
+    collection_id: i32,
+    group_id: i32,
+    permission: Permissions,
+}
+
+impl CollectionGroupPermissionQuery {
+    pub(crate) const fn new(collection_id: i32, group_id: i32, permission: Permissions) -> Self {
+        Self {
+            collection_id,
+            group_id,
+            permission,
+        }
+    }
+
+    pub(crate) const fn collection_id(&self) -> i32 {
+        self.collection_id
+    }
+
+    pub(crate) const fn group_id(&self) -> i32 {
+        self.group_id
+    }
+
+    pub(crate) const fn permission(&self) -> Permissions {
+        self.permission
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CollectionGroupsQuery {
+    collection_id: i32,
+    permission: Permissions,
+}
+
+impl CollectionGroupsQuery {
+    pub(crate) const fn new(collection_id: i32, permission: Permissions) -> Self {
+        Self {
+            collection_id,
+            permission,
+        }
+    }
+
+    pub(crate) const fn collection_id(&self) -> i32 {
+        self.collection_id
+    }
+
+    pub(crate) const fn permission(&self) -> Permissions {
+        self.permission
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CollectionGroupsPageQuery {
+    groups: CollectionGroupsQuery,
+    query_options: QueryOptions,
+}
+
+impl CollectionGroupsPageQuery {
+    pub(crate) const fn new(groups: CollectionGroupsQuery, query_options: QueryOptions) -> Self {
+        Self {
+            groups,
+            query_options,
+        }
+    }
+
+    pub(crate) const fn groups(&self) -> &CollectionGroupsQuery {
+        &self.groups
+    }
+
+    pub(crate) const fn query_options(&self) -> &QueryOptions {
+        &self.query_options
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CollectionGrantListQuery {
+    collection_id: i32,
+    permissions: Vec<Permissions>,
+    query_options: QueryOptions,
+}
+
+impl CollectionGrantListQuery {
+    pub(crate) fn new(
+        collection_id: i32,
+        permissions: Vec<Permissions>,
+        query_options: QueryOptions,
+    ) -> Self {
+        Self {
+            collection_id,
+            permissions,
+            query_options,
+        }
+    }
+
+    pub(crate) const fn collection_id(&self) -> i32 {
+        self.collection_id
+    }
+
+    pub(crate) fn permissions(&self) -> &[Permissions] {
+        &self.permissions
+    }
+
+    pub(crate) const fn query_options(&self) -> &QueryOptions {
+        &self.query_options
+    }
+}
+
+/// Operation-shaped collection permission queries required by every selectable backend.
+///
+/// Policy decisions still live in the application permission layer. These
+/// methods expose the persisted grant projections needed by legacy endpoints
+/// without allowing callers to depend on PostgreSQL query construction.
+#[async_trait]
+pub(crate) trait CollectionPermissionStorage: Send + Sync {
+    async fn principal_collection_permissions(
+        &self,
+        query: CollectionPrincipalQuery,
+    ) -> Result<Vec<GroupPermission>, StorageError>;
+
+    async fn principal_all_collection_permissions(
+        &self,
+        principal_id: i32,
+    ) -> Result<Vec<(Collection, Group, Permission)>, StorageError>;
+
+    async fn principal_collection_permissions_page(
+        &self,
+        query: CollectionPrincipalPageQuery,
+    ) -> Result<(Vec<GroupPermission>, i64), StorageError>;
+
+    async fn effective_principal_collection_permissions(
+        &self,
+        query: CollectionPrincipalQuery,
+    ) -> Result<Vec<EffectiveGroupPermission>, StorageError>;
+
+    async fn visible_collections(
+        &self,
+        query: CollectionVisibilityQuery,
+    ) -> Result<Vec<Collection>, StorageError>;
+
+    async fn group_has_collection_permission(
+        &self,
+        query: CollectionGroupPermissionQuery,
+    ) -> Result<bool, StorageError>;
+
+    async fn effective_group_collection_permissions(
+        &self,
+        collection_id: i32,
+        group_id: i32,
+    ) -> Result<Vec<EffectiveGroupPermission>, StorageError>;
+
+    async fn groups_with_collection_permission(
+        &self,
+        query: CollectionGroupsQuery,
+    ) -> Result<Vec<Group>, StorageError>;
+
+    async fn groups_with_collection_permission_page(
+        &self,
+        query: CollectionGroupsPageQuery,
+    ) -> Result<(Vec<Group>, i64), StorageError>;
+
+    async fn list_collection_group_permissions(
+        &self,
+        query: CollectionGrantListQuery,
+    ) -> Result<Vec<GroupPermission>, StorageError>;
+
+    async fn list_collection_group_permissions_page(
+        &self,
+        query: CollectionGrantListQuery,
+    ) -> Result<(Vec<GroupPermission>, i64), StorageError>;
+
+    async fn collection_group_permission(
+        &self,
+        collection_id: i32,
+        group_id: i32,
+    ) -> Result<Permission, StorageError>;
 }

--- a/src/storage/context.rs
+++ b/src/storage/context.rs
@@ -8,11 +8,14 @@ use crate::events::{
     EventContext, EventDeliverySettings, EventFanoutSettings, EventRetentionSettings,
     MutationProvenance,
 };
+use crate::models::output::{EffectiveGroupPermission, GroupPermission};
 use crate::models::search::QueryOptions;
 use crate::models::{
     ClassIdSet, Collection, CollectionKey, HubuumClass, HubuumObject, ImportMode, MaintenanceState,
-    NewHubuumClass, NewHubuumObject, TokenRetentionSettings, UpdateHubuumClass, UpdateHubuumObject,
+    NewCollectionWithAssignee, NewHubuumClass, NewHubuumObject, TokenRetentionSettings,
+    UpdateCollection, UpdateHubuumClass, UpdateHubuumObject,
 };
+use crate::models::{Group, Permission};
 use crate::permissions::{AppContext, PermissionBackend};
 use crate::storage::observed::observe_storage_call;
 use crate::storage::postgres::PostgresPool;
@@ -27,7 +30,10 @@ use crate::storage::{
     AuthorizationPermissionSet, AuthorizationPermissionSetQuery, AuthorizationPolicySnapshotRow,
     AuthorizationPrincipal, AuthorizationResourceIds, AuthorizationStorage, BackupSnapshotStorage,
     BidirectionalRelatedObjectsQuery, CatalogListQuery, CatalogPage, CatalogStorage,
-    ClassRecordStorage, ComputedFieldLifecycleStorage, ComputedObjectEnrichmentQuery,
+    ClassRecordStorage, CollectionGrantListQuery, CollectionGroupPermissionQuery,
+    CollectionGroupsPageQuery, CollectionGroupsQuery, CollectionPermissionStorage,
+    CollectionPrincipalPageQuery, CollectionPrincipalQuery, CollectionRecordStorage,
+    CollectionVisibilityQuery, ComputedFieldLifecycleStorage, ComputedObjectEnrichmentQuery,
     ComputedObjectListQuery, ComputedObjectPage, ComputedObjectStorage, DynLifecycleStorage,
     EventArchive, EventDeliveryAdministrationStorage, EventDeliveryBatch, EventDeliveryClaim,
     EventDeliveryHealthSnapshot, EventDeliveryStorage, EventFanoutStorage, EventHealthStorage,
@@ -2688,6 +2694,318 @@ impl InventoryStorage for StorageHandle {
                 BackendImplementation::Postgresql(backend) => backend.inventory_counts().await,
             }
         })
+        .await
+    }
+}
+
+#[async_trait]
+impl CollectionRecordStorage for StorageHandle {
+    async fn create_collection_record(
+        &self,
+        command: &NewCollectionWithAssignee,
+        context: Option<&EventContext>,
+    ) -> Result<Collection, StorageError> {
+        observe_storage_call(self.backend_name(), "collection_records", "create", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.create_collection_record(command, context).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn update_collection_record(
+        &self,
+        update: &UpdateCollection,
+        collection_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<Collection, StorageError> {
+        observe_storage_call(self.backend_name(), "collection_records", "update", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend
+                        .update_collection_record(update, collection_id, context)
+                        .await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn delete_collection_record(
+        &self,
+        collection_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError> {
+        observe_storage_call(self.backend_name(), "collection_records", "delete", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend
+                        .delete_collection_record(collection_id, context)
+                        .await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn move_collection_record(
+        &self,
+        collection_id: i32,
+        new_parent_collection_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<Collection, StorageError> {
+        observe_storage_call(self.backend_name(), "collection_records", "move", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend
+                        .move_collection_record(collection_id, new_parent_collection_id, context)
+                        .await
+                }
+            }
+        })
+        .await
+    }
+}
+
+#[async_trait]
+impl CollectionPermissionStorage for StorageHandle {
+    async fn principal_collection_permissions(
+        &self,
+        query: CollectionPrincipalQuery,
+    ) -> Result<Vec<GroupPermission>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "collection_permissions",
+            "principal",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.principal_collection_permissions(query).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn principal_all_collection_permissions(
+        &self,
+        principal_id: i32,
+    ) -> Result<Vec<(Collection, Group, Permission)>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "collection_permissions",
+            "principal_all",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend
+                            .principal_all_collection_permissions(principal_id)
+                            .await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn principal_collection_permissions_page(
+        &self,
+        query: CollectionPrincipalPageQuery,
+    ) -> Result<(Vec<GroupPermission>, i64), StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "collection_permissions",
+            "principal_page",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.principal_collection_permissions_page(query).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn effective_principal_collection_permissions(
+        &self,
+        query: CollectionPrincipalQuery,
+    ) -> Result<Vec<EffectiveGroupPermission>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "collection_permissions",
+            "effective_principal",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend
+                            .effective_principal_collection_permissions(query)
+                            .await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn visible_collections(
+        &self,
+        query: CollectionVisibilityQuery,
+    ) -> Result<Vec<Collection>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "collection_permissions",
+            "visible",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.visible_collections(query).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn group_has_collection_permission(
+        &self,
+        query: CollectionGroupPermissionQuery,
+    ) -> Result<bool, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "collection_permissions",
+            "group_has",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.group_has_collection_permission(query).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn effective_group_collection_permissions(
+        &self,
+        collection_id: i32,
+        group_id: i32,
+    ) -> Result<Vec<EffectiveGroupPermission>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "collection_permissions",
+            "effective_group",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend
+                            .effective_group_collection_permissions(collection_id, group_id)
+                            .await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn groups_with_collection_permission(
+        &self,
+        query: CollectionGroupsQuery,
+    ) -> Result<Vec<Group>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "collection_permissions",
+            "groups",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.groups_with_collection_permission(query).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn groups_with_collection_permission_page(
+        &self,
+        query: CollectionGroupsPageQuery,
+    ) -> Result<(Vec<Group>, i64), StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "collection_permissions",
+            "groups_page",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.groups_with_collection_permission_page(query).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn list_collection_group_permissions(
+        &self,
+        query: CollectionGrantListQuery,
+    ) -> Result<Vec<GroupPermission>, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "collection_permissions",
+            "grants",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.list_collection_group_permissions(query).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn list_collection_group_permissions_page(
+        &self,
+        query: CollectionGrantListQuery,
+    ) -> Result<(Vec<GroupPermission>, i64), StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "collection_permissions",
+            "grants_page",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend.list_collection_group_permissions_page(query).await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn collection_group_permission(
+        &self,
+        collection_id: i32,
+        group_id: i32,
+    ) -> Result<Permission, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "collection_permissions",
+            "group_grant",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend
+                            .collection_group_permission(collection_id, group_id)
+                            .await
+                    }
+                }
+            },
+        )
         .await
     }
 }

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use super::{
     AuditEventStorage, AuthenticationStorage, AuthorizationStorage, BackupSnapshotStorage,
-    CatalogStorage, ClassRecordStorage, ClassRelationStore, ClassStore, CollectionStore,
+    CatalogStorage, ClassRecordStorage, ClassRelationStore, ClassStore,
+    CollectionPermissionStorage, CollectionRecordStorage, CollectionStore,
     ComputedFieldLifecycleStorage, ComputedObjectStorage, EventDeliveryAdministrationStorage,
     EventDeliveryStorage, EventFanoutStorage, EventHealthStorage, EventRetentionStorage,
     EventSubscriptionStorage, ExportQueryStorage, ExportTemplateStorage, HistoryStorage,
@@ -77,6 +78,8 @@ pub(crate) trait StorageBackend:
     + OperationalStateStorage
     + TokenRetentionStorage
     + UnifiedSearchStorage
+    + CollectionPermissionStorage
+    + CollectionRecordStorage
     + ClassRecordStorage
     + ObjectRecordStorage
     + RemoteTargetStorage

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -20,7 +20,11 @@ pub mod postgres;
 
 pub(crate) use class_relations::ClassRelationStore;
 pub(crate) use classes::{ClassRecordStorage, ClassStore};
-pub(crate) use collections::CollectionStore;
+pub(crate) use collections::{
+    CollectionGrantListQuery, CollectionGroupPermissionQuery, CollectionGroupsPageQuery,
+    CollectionGroupsQuery, CollectionPermissionStorage, CollectionPrincipalPageQuery,
+    CollectionPrincipalQuery, CollectionRecordStorage, CollectionStore, CollectionVisibilityQuery,
+};
 pub use context::StorageContext;
 pub(crate) use context::{StorageHandle, storage_handle};
 #[cfg(test)]

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -24,16 +24,17 @@ use std::pin::Pin;
 use crate::events::{
     EventContext, EventFanoutSettings, EventRetentionSettings, MutationProvenance,
 };
+use crate::models::output::{EffectiveGroupPermission, GroupPermission};
 use crate::models::search::QueryOptions;
 use crate::models::{
-    ClassIdSet, ClassSelector, Collection, CollectionID, HubuumClass, HubuumClassID,
+    ClassIdSet, ClassSelector, Collection, CollectionID, Group, HubuumClass, HubuumClassID,
     HubuumClassRelation, HubuumClassRelationID, HubuumObject, HubuumObjectID, HubuumObjectRelation,
     HubuumObjectRelationID, MaintenanceState, NewCollectionWithAssignee, NewHubuumClass,
     NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, ObjectDataPatchDocument,
-    ObjectRelationCreateSelector, ObjectRelationSelector, ObjectSelector, PreparedClassRelation,
-    PreparedObjectRelation, ResolvedClassRelationTarget, ResolvedClassTarget,
-    ResolvedObjectRelationTarget, ResolvedObjectTarget, TokenRetentionSettings, UpdateCollection,
-    UpdateHubuumClass, UpdateHubuumObject,
+    ObjectRelationCreateSelector, ObjectRelationSelector, ObjectSelector, Permission,
+    PreparedClassRelation, PreparedObjectRelation, PrincipalID, ResolvedClassRelationTarget,
+    ResolvedClassTarget, ResolvedObjectRelationTarget, ResolvedObjectTarget,
+    TokenRetentionSettings, UpdateCollection, UpdateHubuumClass, UpdateHubuumObject,
 };
 use crate::storage::postgres::operations::GetCollection;
 use crate::storage::postgres::operations::class::{
@@ -44,7 +45,12 @@ use crate::storage::postgres::operations::class::{
 use crate::storage::postgres::operations::collection::{
     DeleteCollectionRecord, SaveCollectionWithAssigneeRecord, UpdateCollectionRecord,
     collection_ancestors_from_backend, collection_children_from_backend,
-    move_collection_record_from_backend,
+    effective_group_on_from_backend, effective_principal_on_from_backend,
+    group_can_on_from_backend, group_on_from_backend, groups_can_on_from_backend,
+    groups_can_on_paginated_with_total_count_from_backend, groups_on_from_backend,
+    groups_on_paginated_with_total_count_from_backend, move_collection_record_from_backend,
+    principal_all_permissions_from_backend, principal_on_from_backend,
+    principal_on_paginated_with_total_count_from_backend, user_can_on_any_from_backend,
 };
 use crate::storage::postgres::operations::object::{
     CreateObjectInResolvedClassRecord, DeleteObjectRecord, DeleteResolvedObjectRecord,
@@ -71,7 +77,10 @@ use super::{
     AuthorizationPermissionSet, AuthorizationPermissionSetQuery, AuthorizationPolicySnapshotRow,
     AuthorizationPrincipal, AuthorizationResourceIds, AuthorizationStorage,
     BidirectionalRelatedObjectsQuery, CatalogListQuery, CatalogPage, CatalogStorage,
-    ClassRecordStorage, ClassRelationStore, ClassStore, CollectionStore,
+    ClassRecordStorage, ClassRelationStore, ClassStore, CollectionGrantListQuery,
+    CollectionGroupPermissionQuery, CollectionGroupsPageQuery, CollectionGroupsQuery,
+    CollectionPermissionStorage, CollectionPrincipalPageQuery, CollectionPrincipalQuery,
+    CollectionRecordStorage, CollectionStore, CollectionVisibilityQuery,
     ComputedObjectEnrichmentQuery, ComputedObjectListQuery, ComputedObjectPage,
     ComputedObjectStorage, EventArchive, EventDeliveryAdministrationStorage, EventDeliveryBatch,
     EventDeliveryClaim, EventDeliveryHealthSnapshot, EventDeliveryStorage, EventFanoutStorage,
@@ -1277,6 +1286,214 @@ impl TokenRetentionStorage for PostgresStorage {
         settings: TokenRetentionSettings,
     ) -> Result<usize, StorageError> {
         operations::token_retention::purge_expired_token_batch(&self.pool, settings)
+            .await
+            .map_err(map_postgres_error)
+    }
+}
+
+#[async_trait]
+impl CollectionRecordStorage for PostgresStorage {
+    async fn create_collection_record(
+        &self,
+        command: &NewCollectionWithAssignee,
+        context: Option<&EventContext>,
+    ) -> Result<Collection, StorageError> {
+        command
+            .save_collection_with_assignee_record(&self.pool, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn update_collection_record(
+        &self,
+        update: &UpdateCollection,
+        collection_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<Collection, StorageError> {
+        update
+            .update_collection_record(&self.pool, collection_id, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn delete_collection_record(
+        &self,
+        collection_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError> {
+        CollectionID::new(collection_id)
+            .map_err(map_postgres_error)?
+            .delete_collection_record(&self.pool, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn move_collection_record(
+        &self,
+        collection_id: i32,
+        new_parent_collection_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<Collection, StorageError> {
+        move_collection_record_from_backend(
+            &self.pool,
+            collection_id,
+            new_parent_collection_id,
+            context,
+        )
+        .await
+        .map_err(map_postgres_error)
+    }
+}
+
+#[async_trait]
+impl CollectionPermissionStorage for PostgresStorage {
+    async fn principal_collection_permissions(
+        &self,
+        query: CollectionPrincipalQuery,
+    ) -> Result<Vec<GroupPermission>, StorageError> {
+        principal_on_from_backend(
+            &self.pool,
+            PrincipalID::new(query.principal_id()).map_err(map_postgres_error)?,
+            CollectionID::new(query.collection_id()).map_err(map_postgres_error)?,
+        )
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn principal_all_collection_permissions(
+        &self,
+        principal_id: i32,
+    ) -> Result<Vec<(Collection, Group, Permission)>, StorageError> {
+        principal_all_permissions_from_backend(
+            &self.pool,
+            PrincipalID::new(principal_id).map_err(map_postgres_error)?,
+        )
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn principal_collection_permissions_page(
+        &self,
+        query: CollectionPrincipalPageQuery,
+    ) -> Result<(Vec<GroupPermission>, i64), StorageError> {
+        principal_on_paginated_with_total_count_from_backend(
+            &self.pool,
+            PrincipalID::new(query.principal().principal_id()).map_err(map_postgres_error)?,
+            CollectionID::new(query.principal().collection_id()).map_err(map_postgres_error)?,
+            query.query_options(),
+        )
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn effective_principal_collection_permissions(
+        &self,
+        query: CollectionPrincipalQuery,
+    ) -> Result<Vec<EffectiveGroupPermission>, StorageError> {
+        effective_principal_on_from_backend(
+            &self.pool,
+            PrincipalID::new(query.principal_id()).map_err(map_postgres_error)?,
+            CollectionID::new(query.collection_id()).map_err(map_postgres_error)?,
+        )
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn visible_collections(
+        &self,
+        query: CollectionVisibilityQuery,
+    ) -> Result<Vec<Collection>, StorageError> {
+        user_can_on_any_from_backend(
+            &self.pool,
+            PrincipalID::new(query.principal_id()).map_err(map_postgres_error)?,
+            query.permission(),
+            query.scopes(),
+        )
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn group_has_collection_permission(
+        &self,
+        query: CollectionGroupPermissionQuery,
+    ) -> Result<bool, StorageError> {
+        group_can_on_from_backend(
+            &self.pool,
+            query.group_id(),
+            CollectionID::new(query.collection_id()).map_err(map_postgres_error)?,
+            query.permission(),
+        )
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn effective_group_collection_permissions(
+        &self,
+        collection_id: i32,
+        group_id: i32,
+    ) -> Result<Vec<EffectiveGroupPermission>, StorageError> {
+        effective_group_on_from_backend(&self.pool, collection_id, group_id)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn groups_with_collection_permission(
+        &self,
+        query: CollectionGroupsQuery,
+    ) -> Result<Vec<Group>, StorageError> {
+        groups_can_on_from_backend(&self.pool, query.collection_id(), query.permission())
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn groups_with_collection_permission_page(
+        &self,
+        query: CollectionGroupsPageQuery,
+    ) -> Result<(Vec<Group>, i64), StorageError> {
+        groups_can_on_paginated_with_total_count_from_backend(
+            &self.pool,
+            query.groups().collection_id(),
+            query.groups().permission(),
+            query.query_options(),
+        )
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn list_collection_group_permissions(
+        &self,
+        query: CollectionGrantListQuery,
+    ) -> Result<Vec<GroupPermission>, StorageError> {
+        groups_on_from_backend(
+            &self.pool,
+            CollectionID::new(query.collection_id()).map_err(map_postgres_error)?,
+            query.permissions().to_vec(),
+            query.query_options().clone(),
+        )
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn list_collection_group_permissions_page(
+        &self,
+        query: CollectionGrantListQuery,
+    ) -> Result<(Vec<GroupPermission>, i64), StorageError> {
+        groups_on_paginated_with_total_count_from_backend(
+            &self.pool,
+            CollectionID::new(query.collection_id()).map_err(map_postgres_error)?,
+            query.permissions().to_vec(),
+            query.query_options(),
+        )
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn collection_group_permission(
+        &self,
+        collection_id: i32,
+        group_id: i32,
+    ) -> Result<Permission, StorageError> {
+        group_on_from_backend(&self.pool, collection_id, group_id)
             .await
             .map_err(map_postgres_error)
     }

--- a/src/storage/postgres/operations/authorization.rs
+++ b/src/storage/postgres/operations/authorization.rs
@@ -7,6 +7,7 @@ use crate::models::{
     PrincipalID,
 };
 use crate::storage::postgres::operations::collection as collection_backend;
+use crate::storage::postgres::operations::collection::CollectionRow;
 use crate::storage::postgres::operations::permissions as permission_backend;
 use crate::storage::postgres::prelude::*;
 use crate::storage::postgres::{PostgresPool, with_connection};
@@ -330,11 +331,15 @@ pub(crate) async fn local_authorized_collections(
             collections::table
                 .filter(collections::id.eq_any(collection_ids))
                 .distinct()
-                .load::<Collection>(conn)
+                .load::<CollectionRow>(conn)
                 .await
         })
         .await?;
-        return Ok(rows.into_iter().map(collection_to_storage).collect());
+        return Ok(rows
+            .into_iter()
+            .map(Into::into)
+            .map(collection_to_storage)
+            .collect());
     }
 
     let principal_id = PrincipalID::new(query.principal_id())?;
@@ -365,11 +370,15 @@ pub(crate) async fn local_authorized_collections(
     let rows = with_connection(pool, async |conn| {
         collections::table
             .filter(collections::id.eq_any(ids))
-            .load::<Collection>(conn)
+            .load::<CollectionRow>(conn)
             .await
     })
     .await?;
-    Ok(rows.into_iter().map(collection_to_storage).collect())
+    Ok(rows
+        .into_iter()
+        .map(Into::into)
+        .map(collection_to_storage)
+        .collect())
 }
 
 pub(crate) async fn list_authorization_collection_candidates(
@@ -380,11 +389,15 @@ pub(crate) async fn list_authorization_collection_candidates(
     let rows = with_connection(pool, async |conn| {
         collections::table
             .order_by(collections::id.asc())
-            .load::<Collection>(conn)
+            .load::<CollectionRow>(conn)
             .await
     })
     .await?;
-    Ok(rows.into_iter().map(collection_to_storage).collect())
+    Ok(rows
+        .into_iter()
+        .map(Into::into)
+        .map(collection_to_storage)
+        .collect())
 }
 
 pub(crate) async fn list_authorization_group_candidates(
@@ -434,7 +447,7 @@ pub(crate) async fn authorization_policy_snapshot(
                 permissions::collection_id.asc(),
                 permissions::group_id.asc(),
             ))
-            .load::<(Permission, Group, Collection)>(conn)
+            .load::<(Permission, Group, CollectionRow)>(conn)
             .await
     })
     .await?;
@@ -444,7 +457,7 @@ pub(crate) async fn authorization_policy_snapshot(
             AuthorizationPolicySnapshotRow::new(
                 grant_to_storage(grant),
                 group_to_storage(group),
-                collection_to_storage(collection),
+                collection_to_storage(collection.into()),
             )
         })
         .collect())

--- a/src/storage/postgres/operations/class.rs
+++ b/src/storage/postgres/operations/class.rs
@@ -9,6 +9,7 @@ use crate::models::{
     NewHubuumClassRelation, ResolvedClassTarget, UpdateHubuumClass,
 };
 use crate::storage::postgres::operations::GetClass;
+use crate::storage::postgres::operations::collection::CollectionRow;
 use crate::storage::postgres::operations::event_record::emit_event;
 use crate::storage::postgres::operations::relation_rows::HubuumClassRelationRow;
 use crate::storage::postgres::{with_connection, with_transaction};
@@ -754,10 +755,11 @@ impl ClassCollectionLookup for HubuumClass {
         with_connection(pool, async |conn| {
             collections
                 .filter(id.eq(self.collection_id))
-                .first::<Collection>(conn)
+                .first::<CollectionRow>(conn)
                 .await
         })
         .await
+        .map(Into::into)
     }
 }
 

--- a/src/storage/postgres/operations/collection/permissions.rs
+++ b/src/storage/postgres/operations/collection/permissions.rs
@@ -15,10 +15,11 @@ async fn build_effective_group_permissions(
         return Ok(Vec::new());
     }
 
-    let target_collection = collections
+    let target_collection: Collection = collections
         .filter(id.eq(target_collection_id))
-        .first::<Collection>(conn)
-        .await?;
+        .first::<CollectionRow>(conn)
+        .await?
+        .into();
     let mut source_ids: Vec<i32> = rows
         .iter()
         .map(|(source_collection_id, _, _, _)| *source_collection_id)
@@ -27,10 +28,13 @@ async fn build_effective_group_permissions(
     source_ids.dedup();
     let source_collections = collections
         .filter(id.eq_any(source_ids))
-        .load::<Collection>(conn)
+        .load::<CollectionRow>(conn)
         .await?
         .into_iter()
-        .map(|collection| (collection.id, collection))
+        .map(|row| {
+            let collection: Collection = row.into();
+            (collection.id, collection)
+        })
         .collect::<HashMap<_, _>>();
 
     rows.into_iter()
@@ -101,14 +105,19 @@ pub async fn principal_all_permissions_from_backend<S: AuthzSubject>(
             .inner_join(crate::schema::collections::table)
             .filter(group_id.eq_any(group_ids_subquery))
             .select((
-                Collection::as_select(),
+                CollectionRow::as_select(),
                 Group::as_select(),
                 Permission::as_select(),
             ))
-            .load::<(Collection, Group, Permission)>(conn)
+            .load::<(CollectionRow, Group, Permission)>(conn)
             .await
     })
     .await
+    .map(|rows| {
+        rows.into_iter()
+            .map(|(collection, group, permission)| (collection.into(), group, permission))
+            .collect()
+    })
 }
 
 pub async fn principal_on_paginated_with_total_count_from_backend<
@@ -261,7 +270,9 @@ pub async fn user_can_on_any_from_backend<U: GroupAccessors + AuthzSubject>(
         if let Some(scope) = resource_scope_ids(scopes) {
             query = query.filter(collection_scope_predicate(scope));
         }
-        return with_connection(pool, async |conn| query.load::<Collection>(conn).await).await;
+        return with_connection(pool, async |conn| query.load::<CollectionRow>(conn).await)
+            .await
+            .map(|rows| rows.into_iter().map(Into::into).collect());
     }
 
     let base_query = {
@@ -283,10 +294,11 @@ pub async fn user_can_on_any_from_backend<U: GroupAccessors + AuthzSubject>(
                 .filter(collection_scope_predicate(scope))
                 .select(collections::all_columns())
                 .distinct()
-                .load::<Collection>(conn)
+                .load::<CollectionRow>(conn)
                 .await
         })
-        .await;
+        .await
+        .map(|rows| rows.into_iter().map(Into::into).collect());
     }
     with_connection(pool, async |conn| {
         filtered_query
@@ -294,10 +306,11 @@ pub async fn user_can_on_any_from_backend<U: GroupAccessors + AuthzSubject>(
             .inner_join(collections.on(collection_table_id.eq(descendant_collection_id)))
             .select(collections::all_columns())
             .distinct()
-            .load::<Collection>(conn)
+            .load::<CollectionRow>(conn)
             .await
     })
     .await
+    .map(|rows| rows.into_iter().map(Into::into).collect())
 }
 
 pub async fn group_can_on_from_backend<T: CollectionAccessors>(

--- a/src/storage/postgres/operations/collection/records.rs
+++ b/src/storage/postgres/operations/collection/records.rs
@@ -2,8 +2,137 @@ use super::*;
 use crate::api::etag::RevisionOwner;
 use crate::events::{Action, EntityType, EventContext, NewEvent};
 use crate::storage::postgres::operations::event_record::emit_event;
+use crate::traits::{
+    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
+};
 use chrono::NaiveDateTime;
 use diesel_async::RunQueryDsl;
+
+/// PostgreSQL representation of a collection row.
+///
+/// The domain value is persistence-neutral; schema bindings and physical
+/// cursor columns remain private to the adapter.
+#[derive(Clone, Queryable, QueryableByName, Selectable)]
+#[diesel(table_name = crate::schema::collections)]
+pub(crate) struct CollectionRow {
+    pub(crate) id: i32,
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) created_at: chrono::NaiveDateTime,
+    pub(crate) updated_at: chrono::NaiveDateTime,
+    pub(crate) parent_collection_id: Option<i32>,
+    pub(crate) revision: crate::models::ResourceRevision,
+}
+
+impl From<CollectionRow> for Collection {
+    fn from(row: CollectionRow) -> Self {
+        Self {
+            id: row.id,
+            name: row.name,
+            description: row.description,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            parent_collection_id: row.parent_collection_id,
+            revision: row.revision,
+        }
+    }
+}
+
+impl CursorPaginated for CollectionRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        Collection::supports_sort(field)
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorValue::Integer(self.id.into()),
+            FilterField::Name => CursorValue::String(self.name.clone()),
+            FilterField::Description => CursorValue::String(self.description.clone()),
+            FilterField::CreatedAt => CursorValue::DateTime(self.created_at),
+            FilterField::UpdatedAt => CursorValue::DateTime(self.updated_at),
+            FilterField::Revision => CursorValue::Integer(self.revision.get()),
+            other => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{other}' is not orderable for collections"
+                )));
+            }
+        })
+    }
+
+    fn default_sort() -> Vec<crate::models::search::SortParam> {
+        Collection::default_sort()
+    }
+
+    fn tie_breaker_sort() -> Vec<crate::models::search::SortParam> {
+        Collection::tie_breaker_sort()
+    }
+}
+
+impl CursorSqlMapping for CollectionRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorSqlField {
+                column: "collections.id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Name => CursorSqlField {
+                column: "collections.name",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::Description => CursorSqlField {
+                column: "collections.description",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::CreatedAt => CursorSqlField {
+                column: "collections.created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAt => CursorSqlField {
+                column: "collections.updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::Revision => CursorSqlField {
+                column: "collections.revision",
+                sql_type: CursorSqlType::BigInt,
+                nullable: false,
+            },
+            other => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{other}' is not orderable for collections"
+                )));
+            }
+        })
+    }
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = crate::schema::collections)]
+struct NewCollectionRow<'a> {
+    name: &'a str,
+    description: &'a str,
+    parent_collection_id: Option<i32>,
+}
+
+#[derive(AsChangeset)]
+#[diesel(table_name = crate::schema::collections)]
+pub(crate) struct UpdateCollectionRow<'a> {
+    name: Option<&'a str>,
+    description: Option<&'a str>,
+}
+
+impl<'a> From<&'a UpdateCollection> for UpdateCollectionRow<'a> {
+    fn from(update: &'a UpdateCollection) -> Self {
+        Self {
+            name: update.name.as_deref(),
+            description: update.description.as_deref(),
+        }
+    }
+}
 
 fn collection_snapshot(collection: &Collection) -> serde_json::Value {
     serde_json::json!({
@@ -92,10 +221,11 @@ async fn lock_and_validate_collection_for_delete(
     let collection = collections
         .filter(id.eq(collection_id))
         .for_update()
-        .first::<Collection>(conn)
+        .first::<CollectionRow>(conn)
         .await
-        .optional()?;
-    let collection =
+        .optional()?
+        .map(Into::into);
+    let collection: Collection =
         crate::storage::postgres::require_existing_revision_target(collection, &owner_key)?;
     crate::storage::postgres::assert_locked_revision_precondition(
         conn,
@@ -164,35 +294,33 @@ pub(crate) async fn insert_collection_row_with_closure(
     conn: &mut crate::storage::postgres::PostgresConnection,
     input: CollectionRowInsert<'_>,
 ) -> Result<Collection, ApiError> {
-    use crate::schema::collections::dsl::{
-        collections, created_at, description, name, parent_collection_id, updated_at,
-    };
+    use crate::schema::collections::dsl::{collections, created_at, updated_at};
 
     let resolved_parent_id = resolve_parent_collection_id(conn, input.parent_collection_id).await?;
 
-    let collection = match input.timestamps {
-        Some((created, updated)) => {
-            diesel::insert_into(collections)
-                .values((
-                    name.eq(input.name),
-                    description.eq(input.description),
-                    parent_collection_id.eq(resolved_parent_id),
-                    created_at.eq(created),
-                    updated_at.eq(updated),
-                ))
-                .get_result::<Collection>(conn)
-                .await?
-        }
-        None => {
-            diesel::insert_into(collections)
-                .values((
-                    name.eq(input.name),
-                    description.eq(input.description),
-                    parent_collection_id.eq(resolved_parent_id),
-                ))
-                .get_result::<Collection>(conn)
-                .await?
-        }
+    let collection: Collection = match input.timestamps {
+        Some((created, updated)) => diesel::insert_into(collections)
+            .values((
+                NewCollectionRow {
+                    name: input.name,
+                    description: input.description,
+                    parent_collection_id: Some(resolved_parent_id),
+                },
+                created_at.eq(created),
+                updated_at.eq(updated),
+            ))
+            .get_result::<CollectionRow>(conn)
+            .await?
+            .into(),
+        None => diesel::insert_into(collections)
+            .values(NewCollectionRow {
+                name: input.name,
+                description: input.description,
+                parent_collection_id: Some(resolved_parent_id),
+            })
+            .get_result::<CollectionRow>(conn)
+            .await?
+            .into(),
     };
 
     insert_collection_closure_rows(conn, collection.id, resolved_parent_id).await?;
@@ -400,15 +528,21 @@ impl UpdateCollectionRecord for UpdateCollection {
             crate::storage::postgres::updated_or_current(
                 diesel::update(collections)
                     .filter(id.eq(collection_id))
-                    .set(self)
-                    .get_result::<Collection>(conn)
+                    .set(UpdateCollectionRow::from(self))
+                    .get_result::<CollectionRow>(conn)
                     .await
                     .optional(),
-                async || collections.filter(id.eq(collection_id)).first(conn).await,
+                async || {
+                    collections
+                        .filter(id.eq(collection_id))
+                        .first::<CollectionRow>(conn)
+                        .await
+                },
             )
             .await
         })
         .await
+        .map(Into::into)
     }
 
     async fn update_collection_record(
@@ -430,10 +564,11 @@ impl UpdateCollectionRecord for UpdateCollection {
             let before = collections
                 .filter(id.eq(collection_id))
                 .for_update()
-                .first::<Collection>(conn)
+                .first::<CollectionRow>(conn)
                 .await
-                .optional()?;
-            let before =
+                .optional()?
+                .map(Into::into);
+            let before: Collection =
                 crate::storage::postgres::require_existing_revision_target(before, &owner_key)?;
             crate::storage::postgres::assert_locked_revision_precondition(
                 conn,
@@ -445,9 +580,10 @@ impl UpdateCollectionRecord for UpdateCollection {
                 return Ok(before);
             }
             let updated = diesel::update(collections.filter(id.eq(collection_id)))
-                .set(self)
-                .get_result::<Collection>(conn)
-                .await?;
+                .set(UpdateCollectionRow::from(self))
+                .get_result::<CollectionRow>(conn)
+                .await?
+                .into();
             let event = collection_event(
                 &updated,
                 Action::Updated,
@@ -586,10 +722,11 @@ pub async fn collection_children_from_backend<T: CollectionAccessors>(
         collections
             .filter(parent_collection_id.eq(target_collection_id))
             .order(crate::schema::collections::name.asc())
-            .load::<Collection>(conn)
+            .load::<CollectionRow>(conn)
             .await
     })
     .await
+    .map(|rows| rows.into_iter().map(Into::into).collect())
 }
 
 pub async fn collection_ancestors_from_backend<T: CollectionAccessors>(
@@ -609,10 +746,11 @@ pub async fn collection_ancestors_from_backend<T: CollectionAccessors>(
             .filter(depth.gt(0))
             .order(depth.asc())
             .select(collections::all_columns())
-            .load::<Collection>(conn)
+            .load::<CollectionRow>(conn)
             .await
     })
     .await
+    .map(|rows| rows.into_iter().map(Into::into).collect())
 }
 
 pub async fn move_collection_record_from_backend(
@@ -627,11 +765,12 @@ pub async fn move_collection_record_from_backend(
     use crate::schema::collections::dsl::{collections, id, parent_collection_id};
 
     with_transaction(pool, async |conn| -> Result<Collection, ApiError> {
-        let before = collections
+        let before: Collection = collections
             .filter(id.eq(target_collection_id))
             .for_update()
-            .first::<Collection>(conn)
-            .await?;
+            .first::<CollectionRow>(conn)
+            .await?
+            .into();
 
         if before.parent_collection_id.is_none() {
             return Err(ApiError::Conflict(
@@ -678,8 +817,9 @@ pub async fn move_collection_record_from_backend(
 
         let updated = collections
             .filter(id.eq(target_collection_id))
-            .first::<Collection>(conn)
-            .await?;
+            .first::<CollectionRow>(conn)
+            .await?
+            .into();
 
         if let Some(context) = context {
             let event = collection_event(

--- a/src/storage/postgres/operations/collection/relations.rs
+++ b/src/storage/postgres/operations/collection/relations.rs
@@ -19,10 +19,13 @@ impl GetCollection<(Collection, Collection)> for HubuumClassRelation {
                 .filter(class_id.eq_any(&[from_id, to_id]))
                 .inner_join(collections.on(collection_id.eq(class_collection_id)))
                 .select(collections::all_columns())
-                .load::<Collection>(conn)
+                .load::<CollectionRow>(conn)
                 .await
         })
-        .await?;
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<Collection>>();
 
         if from_id == to_id && collection_list.len() == 1 {
             trace!("Found same collection for class relation, returning same collection twice");
@@ -60,10 +63,13 @@ impl GetCollection<(Collection, Collection)> for NewHubuumClassRelation {
                 .filter(class_id.eq_any(&[from_id, to_id]))
                 .inner_join(collections.on(collection_id.eq(class_collection_id)))
                 .select(collections::all_columns())
-                .load::<Collection>(conn)
+                .load::<CollectionRow>(conn)
                 .await
         })
-        .await?;
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<Collection>>();
 
         if collection_list.len() == 1 {
             trace!("Found same collection for class relation, returning same collection twice");
@@ -101,10 +107,13 @@ impl GetCollection<(Collection, Collection)> for HubuumObjectRelation {
                 .filter(object_id.eq_any(&[from_id, to_id]))
                 .inner_join(collections.on(collection_id.eq(object_collection_id)))
                 .select(collections::all_columns())
-                .load::<Collection>(conn)
+                .load::<CollectionRow>(conn)
                 .await
         })
-        .await?;
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<Collection>>();
 
         if collection_list.len() == 1 {
             trace!("Found same collection for object relation, returning same collection twice");
@@ -142,10 +151,13 @@ impl GetCollection<(Collection, Collection)> for NewHubuumObjectRelation {
                 .filter(object_id.eq_any(&[from_id, to_id]))
                 .inner_join(collections.on(collection_id.eq(object_collection_id)))
                 .select(collections::all_columns())
-                .load::<Collection>(conn)
+                .load::<CollectionRow>(conn)
                 .await
         })
-        .await?;
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<Collection>>();
 
         if collection_list.len() == 1 {
             trace!("Found same collection for object relation, returning same collection twice");
@@ -183,10 +195,13 @@ impl GetCollection<(Collection, Collection)> for HubuumObjectRelationID {
                 .filter(object_id.eq_any(&[from_id, to_id]))
                 .inner_join(collections.on(collection_id.eq(object_collection_id)))
                 .select(collections::all_columns())
-                .load::<Collection>(conn)
+                .load::<CollectionRow>(conn)
                 .await
         })
-        .await?;
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<Collection>>();
 
         if collection_list.len() == 1 {
             trace!("Found same collection for object relation, returning same collection twice");
@@ -218,10 +233,11 @@ where
         let collection = with_connection(pool, async |conn| {
             collections
                 .filter(id.eq(self.id()))
-                .first::<Collection>(conn)
+                .first::<CollectionRow>(conn)
                 .await
         })
-        .await?;
+        .await?
+        .into();
 
         Ok(collection)
     }

--- a/src/storage/postgres/operations/history.rs
+++ b/src/storage/postgres/operations/history.rs
@@ -1,7 +1,7 @@
 use crate::errors::ApiError;
 use crate::events::PrincipalNames;
+use crate::models::ResourceRevision;
 use crate::models::search::QueryOptions;
-use crate::models::{CollectionHistory, ResourceRevision};
 use crate::storage::postgres::prelude::*;
 use crate::storage::postgres::with_connection;
 use crate::storage::{
@@ -16,6 +16,35 @@ use std::num::NonZeroI64;
 pub enum HistoryCollectionFilter<'a> {
     All,
     Visible(&'a [i32]),
+}
+
+#[derive(Queryable)]
+#[diesel(table_name = crate::schema::collections_history)]
+pub(crate) struct CollectionHistoryRow {
+    id: i32,
+    name: String,
+    description: String,
+    created_at: chrono::NaiveDateTime,
+    updated_at: chrono::NaiveDateTime,
+    parent_collection_id: Option<i32>,
+    op: String,
+    valid_from: chrono::DateTime<chrono::Utc>,
+    valid_to: Option<chrono::DateTime<chrono::Utc>>,
+    actor_id: Option<i32>,
+    history_id: i64,
+    actor_kind: Option<String>,
+    initiator_user_id: Option<i32>,
+    task_id: Option<i32>,
+    revision: ResourceRevision,
+}
+
+crate::impl_history_pagination!(CollectionHistoryRow, "collections_history");
+
+#[cfg(test)]
+impl CollectionHistoryRow {
+    pub(crate) fn principal_ids(&self) -> [Option<i32>; 2] {
+        [self.actor_id, self.initiator_user_id]
+    }
 }
 
 #[derive(Queryable)]
@@ -181,7 +210,7 @@ macro_rules! metadata_to_storage {
     };
 }
 
-pub(crate) fn collection_history_to_storage(row: CollectionHistory) -> CollectionHistoryRecord {
+pub(crate) fn collection_history_to_storage(row: CollectionHistoryRow) -> CollectionHistoryRecord {
     CollectionHistoryRecord::new(
         row.id,
         row.name,
@@ -367,7 +396,7 @@ history_db_fns!(
     collection_as_of,
     crate::schema::collections_history,
     id,
-    crate::models::CollectionHistory
+    CollectionHistoryRow
 );
 
 history_db_fns!(

--- a/src/storage/postgres/operations/object.rs
+++ b/src/storage/postgres/operations/object.rs
@@ -12,6 +12,7 @@ use crate::models::{
 };
 use crate::storage::postgres::operations::GetObject;
 use crate::storage::postgres::operations::class::{HubuumClassRow, lock_resolved_class_target};
+use crate::storage::postgres::operations::collection::CollectionRow;
 use crate::storage::postgres::operations::computed_field::{
     acquire_computed_class_shared_lock, materialize_object_in_transaction,
 };
@@ -1080,10 +1081,11 @@ impl ObjectCollectionLookup for HubuumObject {
         with_connection(pool, async |conn| {
             collections
                 .filter(id.eq(self.collection_id))
-                .first::<Collection>(conn)
+                .first::<CollectionRow>(conn)
                 .await
         })
         .await
+        .map(Into::into)
     }
 }
 

--- a/src/storage/postgres/operations/task_import.rs
+++ b/src/storage/postgres/operations/task_import.rs
@@ -19,7 +19,9 @@ use crate::models::{
 use crate::storage::postgres::operations::class::{
     HubuumClassRow, NewHubuumClassRow, UpdateHubuumClassRow,
 };
-use crate::storage::postgres::operations::collection::CollectionRowInsert;
+use crate::storage::postgres::operations::collection::{
+    CollectionRow, CollectionRowInsert, UpdateCollectionRow,
+};
 use crate::storage::postgres::operations::object::{
     HubuumObjectRow, NewHubuumObjectRow, UpdateHubuumObjectRow,
 };
@@ -83,10 +85,11 @@ pub async fn lookup_collections_by_name(
         collections
             .filter(name.eq(value))
             .order(crate::schema::collections::id.asc())
-            .load::<Collection>(conn)
+            .load::<CollectionRow>(conn)
             .await
     })
     .await
+    .map(|rows| rows.into_iter().map(Into::into).collect())
 }
 
 pub async fn lookup_root_collection(
@@ -114,11 +117,12 @@ pub async fn lookup_collection_by_id(
     with_connection(pool, async |conn| {
         collections
             .filter(id.eq(collection_id))
-            .first::<Collection>(conn)
+            .first::<CollectionRow>(conn)
             .await
             .optional()
     })
     .await
+    .map(|row| row.map(Into::into))
 }
 
 pub async fn lookup_class_by_collection_and_name(
@@ -290,8 +294,9 @@ pub async fn lookup_collections_by_name_db(
     collections
         .filter(name.eq(value))
         .order(crate::schema::collections::id.asc())
-        .load::<Collection>(conn)
+        .load::<CollectionRow>(conn)
         .await
+        .map(|rows| rows.into_iter().map(Into::into).collect())
         .map_err(ApiError::from)
 }
 
@@ -302,8 +307,9 @@ pub async fn lookup_root_collection_db(
 
     collections
         .filter(parent_collection_id.is_null())
-        .first::<Collection>(conn)
+        .first::<CollectionRow>(conn)
         .await
+        .map(Into::into)
         .map_err(ApiError::from)
 }
 
@@ -317,9 +323,10 @@ pub async fn lookup_collection_child_by_name_db(
     collections
         .filter(parent_collection_id.eq(parent_id_value))
         .filter(name.eq(child_name))
-        .first::<Collection>(conn)
+        .first::<CollectionRow>(conn)
         .await
         .optional()
+        .map(|row| row.map(Into::into))
         .map_err(ApiError::from)
 }
 
@@ -514,21 +521,22 @@ pub async fn update_collection_db(
             crate::storage::postgres::updated_or_current(
                 diesel::update(collections.filter(id.eq(collection_id_value)))
                     .set((
-                        &update,
+                        UpdateCollectionRow::from(&update),
                         created_at.eq(timestamps.created_at()),
                         updated_at.eq(timestamps.updated_at()),
                     ))
-                    .get_result::<Collection>(conn)
+                    .get_result::<CollectionRow>(conn)
                     .await
                     .optional(),
                 async || {
                     collections
                         .filter(id.eq(collection_id_value))
-                        .first(conn)
+                        .first::<CollectionRow>(conn)
                         .await
                 },
             )
             .await
+            .map(Into::into)
             .map_err(ApiError::from)
         })
         .await;
@@ -536,18 +544,19 @@ pub async fn update_collection_db(
 
     crate::storage::postgres::updated_or_current(
         diesel::update(collections.filter(id.eq(collection_id_value)))
-            .set(&update)
-            .get_result::<Collection>(conn)
+            .set(UpdateCollectionRow::from(&update))
+            .get_result::<CollectionRow>(conn)
             .await
             .optional(),
         async || {
             collections
                 .filter(id.eq(collection_id_value))
-                .first(conn)
+                .first::<CollectionRow>(conn)
                 .await
         },
     )
     .await
+    .map(Into::into)
     .map_err(ApiError::from)
 }
 

--- a/src/storage/postgres/operations/user/membership.rs
+++ b/src/storage/postgres/operations/user/membership.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::models::token_scope::TokenScope;
 use crate::storage::postgres::operations::authz::{AuthzSubject, scope_allows};
+use crate::storage::postgres::operations::collection::CollectionRow;
 use diesel_async::RunQueryDsl;
 
 pub trait LoadUserGroups: AuthzSubject {
@@ -186,10 +187,11 @@ where
             return with_connection(pool, async |conn| {
                 collections
                     .select(collections::all_columns())
-                    .load::<Collection>(conn)
+                    .load::<CollectionRow>(conn)
                     .await
             })
-            .await;
+            .await
+            .map(|rows| rows.into_iter().map(Into::into).collect());
         }
 
         let groups_id_subquery = self.group_ids_subquery();
@@ -210,9 +212,10 @@ where
                 .inner_join(collections.on(descendant_collection_id.eq(collections_table_id)))
                 .select(collections::all_columns())
                 .distinct()
-                .load::<Collection>(conn)
+                .load::<CollectionRow>(conn)
                 .await
         })
         .await
+        .map(|rows| rows.into_iter().map(Into::into).collect())
     }
 }

--- a/src/storage/postgres/operations/user/search.rs
+++ b/src/storage/postgres/operations/user/search.rs
@@ -11,6 +11,7 @@ use crate::storage::postgres::operations::authz::{
     AuthzSubject as PostgresAuthzSubject, scope_allows,
 };
 use crate::storage::postgres::operations::class::HubuumClassRow;
+use crate::storage::postgres::operations::collection::CollectionRow;
 use crate::storage::postgres::operations::computed_field::{
     ComputedQuerySnapshot, computed_filter_predicate, object_cursor_sql_fields,
 };
@@ -465,15 +466,16 @@ pub trait UserSearchBackend: UserCollectionAccessors {
             }
         }
 
-        crate::apply_query_options!(base_query, query_options, Collection);
+        crate::apply_query_options!(base_query, query_options, CollectionRow);
 
         with_connection(pool, async |conn| {
             base_query
                 .select(collections::all_columns())
-                .load::<Collection>(conn)
+                .load::<CollectionRow>(conn)
                 .await
         })
         .await
+        .map(|rows| rows.into_iter().map(Into::into).collect())
     }
 
     async fn count_collections_from_backend_with_admin_status(

--- a/src/storage/postgres/operations/user/unified_search.rs
+++ b/src/storage/postgres/operations/user/unified_search.rs
@@ -12,6 +12,7 @@ use crate::models::{
 };
 use crate::storage::postgres::operations::authz::scope_allows;
 use crate::storage::postgres::operations::class::HubuumClassRow;
+use crate::storage::postgres::operations::collection::CollectionRow;
 use crate::storage::postgres::operations::object::HubuumObjectRow;
 use crate::storage::postgres::with_connection_async;
 
@@ -216,10 +217,11 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
                 .bind::<Text, _>(cursor_binds.name)
                 .bind::<Integer, _>(cursor_binds.id)
                 .bind::<BigInt, _>(limit)
-                .load::<Collection>(conn)
+                .load::<CollectionRow>(conn)
                 .await
         })
         .await
+        .map(|rows| rows.into_iter().map(Into::into).collect())
     }
 
     async fn search_unified_classes_from_backend(
@@ -288,10 +290,13 @@ pub trait UnifiedSearchBackend: UserCollectionAccessors {
             use crate::schema::collections::dsl::{collections, id};
             collections
                 .filter(id.eq_any(collection_ids))
-                .load::<Collection>(conn)
+                .load::<CollectionRow>(conn)
                 .await
         })
-        .await?;
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<Collection>>();
         let collection_map = collections
             .into_iter()
             .map(|collection| (collection.id, collection))

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -214,6 +214,65 @@ fn backend_neutral_layers_do_not_import_database_implementation_details() {
 }
 
 #[test]
+fn collection_domain_types_are_free_of_persistence_implementation_details() {
+    let root = repository_root();
+    let mut violations = Vec::new();
+
+    for relative_path in [
+        "src/models/collection.rs",
+        "src/models/traits/collection.rs",
+    ] {
+        let path = root.join(relative_path);
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(&source);
+        for forbidden in [
+            "diesel::",
+            "diesel(",
+            "crate::schema",
+            "storage::postgres",
+            "CursorSqlMapping",
+            "CursorSqlField",
+            "CursorSqlType",
+        ] {
+            if production_source.contains(forbidden) {
+                violations.push(format!("{} contains {forbidden}", path.display()));
+            }
+        }
+    }
+
+    let adapter_path = root.join("src/storage/postgres/operations/collection/records.rs");
+    let adapter_source = fs::read_to_string(&adapter_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", adapter_path.display()));
+    for required in [
+        "struct CollectionRow",
+        "struct NewCollectionRow",
+        "struct UpdateCollectionRow",
+        "impl From<CollectionRow> for Collection",
+        "impl CursorSqlMapping for CollectionRow",
+    ] {
+        assert!(
+            adapter_source.contains(required),
+            "PostgreSQL collection adapter is missing {required}"
+        );
+    }
+
+    let history_path = root.join("src/storage/postgres/operations/history.rs");
+    let history_source = fs::read_to_string(&history_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", history_path.display()));
+    assert!(
+        history_source.contains("struct CollectionHistoryRow"),
+        "PostgreSQL history adapter must own the collection-history row"
+    );
+
+    assert!(
+        violations.is_empty(),
+        "collection domain types crossed into persistence details:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
 fn class_domain_types_are_free_of_persistence_implementation_details() {
     let root = repository_root();
     let mut violations = Vec::new();
@@ -421,6 +480,8 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         "HistoryStorage",
         "InventoryStorage",
         "UnifiedSearchStorage",
+        "CollectionPermissionStorage",
+        "CollectionRecordStorage",
         "ClassRecordStorage",
         "ObjectRecordStorage",
         "RemoteTargetStorage",
@@ -587,6 +648,31 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         compact_context.contains("\"inventory\",\"counts\""),
         "inventory counts must use the common storage observer"
     );
+    for operation in ["create", "update", "delete", "move"] {
+        assert!(
+            compact_context.contains(&format!("\"collection_records\",\"{operation}\"")),
+            "collection record operation {operation} must use the common storage observer"
+        );
+    }
+    for operation in [
+        "principal",
+        "principal_all",
+        "principal_page",
+        "effective_principal",
+        "visible",
+        "group_has",
+        "effective_group",
+        "groups",
+        "groups_page",
+        "grants",
+        "grants_page",
+        "group_grant",
+    ] {
+        assert!(
+            compact_context.contains(&format!("\"collection_permissions\",\"{operation}\"")),
+            "collection permission operation {operation} must use the common storage observer"
+        );
+    }
     for operation in ["create", "update", "delete", "load", "collection", "names"] {
         assert!(
             compact_context.contains(&format!("\"class_records\",\"{operation}\"")),

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -20,10 +20,11 @@ use crate::models::search::{
     parse_query_parameter_with_computed_filters_and_passthrough,
 };
 use crate::models::{
-    CollectionHistory, CollectionID, CollectionKey, ExportTemplateHistory, HubuumClassHistory,
-    HubuumObjectHistory, ImportAtomicity, ImportClassInput, ImportCollectionInput, ImportMode,
-    NewComputedFieldDefinition, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject,
-    NewHubuumObjectRelation, RemoteTargetHistory,
+    CollectionHistory, CollectionID, CollectionKey, ExportTemplateHistory, GroupID,
+    HubuumClassHistory, HubuumObjectHistory, ImportAtomicity, ImportClassInput,
+    ImportCollectionInput, ImportMode, NewCollectionWithAssignee, NewComputedFieldDefinition,
+    NewHubuumClass, NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, Permissions,
+    RemoteTargetHistory, UpdateCollection,
 };
 use crate::pagination::prepare_db_pagination;
 use crate::services::Services;
@@ -37,6 +38,9 @@ use crate::storage::{
     AuthorizationGrantMutation, AuthorizationGroupMembershipQuery, AuthorizationPermission,
     AuthorizationPermissionSetQuery, AuthorizationResourceIds, AuthorizationStorage,
     BackupSnapshotStorage, BidirectionalRelatedObjectsQuery, CatalogListQuery, CatalogStorage,
+    CollectionGrantListQuery, CollectionGroupPermissionQuery, CollectionGroupsPageQuery,
+    CollectionGroupsQuery, CollectionPermissionStorage, CollectionPrincipalPageQuery,
+    CollectionPrincipalQuery, CollectionRecordStorage, CollectionVisibilityQuery,
     ComputedFieldLifecycleStorage, ComputedObjectEnrichmentQuery, ComputedObjectListQuery,
     ComputedObjectProjection, ComputedObjectStorage, ComputedObjectVisibility, EventArchive,
     EventDeliveryAdministrationStorage, EventDeliveryStorage, EventFanoutStorage,
@@ -1609,6 +1613,62 @@ async fn every_available_storage_backend_supplies_restore_lifecycle_and_coordina
 }
 
 #[actix_web::test]
+async fn every_available_storage_backend_supplies_collection_record_compatibility() {
+    let _permit = postgres_permit().await;
+    let pool = pool();
+    let group = crate::tests::create_test_group(pool.get_ref()).await;
+
+    for kind in StorageBackendKind::ALL {
+        match kind {
+            StorageBackendKind::Postgresql => {
+                let backend = StorageHandle::postgres(pool.get_ref().clone());
+                let command = NewCollectionWithAssignee {
+                    name: prefix("collection_record_compatibility"),
+                    description: "collection record compatibility".to_string(),
+                    group_id: GroupID::new(group.id).expect("valid compatibility group id"),
+                    parent_collection_id: None,
+                };
+                let created = backend
+                    .create_collection_record(&command, None)
+                    .await
+                    .expect("certified backend should create collection records");
+                let updated = backend
+                    .update_collection_record(
+                        &UpdateCollection {
+                            name: None,
+                            description: Some(
+                                "updated collection record compatibility".to_string(),
+                            ),
+                        },
+                        created.id,
+                        Some(&EventContext::system()),
+                    )
+                    .await
+                    .expect("certified backend should update collection records");
+                assert_eq!(
+                    updated.description,
+                    "updated collection record compatibility"
+                );
+                let moved = backend
+                    .move_collection_record(created.id, 1, None)
+                    .await
+                    .expect("certified backend should move collection records");
+                assert_eq!(moved.parent_collection_id, Some(1));
+                backend
+                    .delete_collection_record(created.id, Some(&EventContext::system()))
+                    .await
+                    .expect("certified backend should delete collection records");
+            }
+        }
+    }
+
+    group
+        .delete_without_events(pool.get_ref())
+        .await
+        .expect("collection record compatibility group should be removed");
+}
+
+#[actix_web::test]
 async fn every_available_storage_backend_supplies_local_authorization_data() {
     let _permit = postgres_permit().await;
     let pool = pool();
@@ -1770,6 +1830,130 @@ async fn every_available_storage_backend_supplies_local_authorization_data() {
                         .await
                         .expect("applied local grant should authorize the batch")
                 );
+
+                let page_options = || QueryOptions {
+                    filters: Vec::new(),
+                    sort: Vec::new(),
+                    limit: None,
+                    cursor: None,
+                    include_total: true,
+                };
+                let principal_query = || CollectionPrincipalQuery::new(user.id, collection_id);
+
+                let principal_permissions = backend
+                    .principal_collection_permissions(principal_query())
+                    .await
+                    .expect("certified backend should project principal collection grants");
+                assert!(
+                    principal_permissions
+                        .iter()
+                        .any(|row| row.group.id == group.id)
+                );
+
+                let all_permissions = backend
+                    .principal_all_collection_permissions(user.id)
+                    .await
+                    .expect("certified backend should project all principal collection grants");
+                assert!(all_permissions.iter().any(|(collection, row_group, _)| {
+                    collection.id == collection_id && row_group.id == group.id
+                }));
+
+                let (principal_page, principal_total) = backend
+                    .principal_collection_permissions_page(CollectionPrincipalPageQuery::new(
+                        principal_query(),
+                        page_options(),
+                    ))
+                    .await
+                    .expect("certified backend should page principal collection grants");
+                assert!(principal_total >= 1);
+                assert!(!principal_page.is_empty());
+
+                let effective_principal = backend
+                    .effective_principal_collection_permissions(principal_query())
+                    .await
+                    .expect("certified backend should project effective principal grants");
+                assert!(
+                    effective_principal
+                        .iter()
+                        .any(|row| row.group.id == group.id)
+                );
+
+                let visible = backend
+                    .visible_collections(CollectionVisibilityQuery::new(
+                        user.id,
+                        Permissions::ReadCollection,
+                        None,
+                    ))
+                    .await
+                    .expect("certified backend should project visible collections");
+                assert!(
+                    visible
+                        .iter()
+                        .any(|collection| collection.id == collection_id)
+                );
+
+                let group_query = CollectionGroupPermissionQuery::new(
+                    collection_id,
+                    group.id,
+                    Permissions::ReadCollection,
+                );
+                assert!(
+                    backend
+                        .group_has_collection_permission(group_query)
+                        .await
+                        .expect("certified backend should test group collection grants")
+                );
+
+                let effective_group = backend
+                    .effective_group_collection_permissions(collection_id, group.id)
+                    .await
+                    .expect("certified backend should project effective group grants");
+                assert!(!effective_group.is_empty());
+
+                let groups_query =
+                    || CollectionGroupsQuery::new(collection_id, Permissions::ReadCollection);
+                let groups = backend
+                    .groups_with_collection_permission(groups_query())
+                    .await
+                    .expect("certified backend should list groups with collection grants");
+                assert!(groups.iter().any(|candidate| candidate.id == group.id));
+
+                let (groups_page, groups_total) = backend
+                    .groups_with_collection_permission_page(CollectionGroupsPageQuery::new(
+                        groups_query(),
+                        page_options(),
+                    ))
+                    .await
+                    .expect("certified backend should page groups with collection grants");
+                assert!(groups_total >= 1);
+                assert!(!groups_page.is_empty());
+
+                let grant_query = || {
+                    CollectionGrantListQuery::new(
+                        collection_id,
+                        vec![Permissions::ReadCollection],
+                        page_options(),
+                    )
+                };
+                let grants = backend
+                    .list_collection_group_permissions(grant_query())
+                    .await
+                    .expect("certified backend should list collection grants");
+                assert!(grants.iter().any(|row| row.group.id == group.id));
+
+                let (grant_page, grant_total) = backend
+                    .list_collection_group_permissions_page(grant_query())
+                    .await
+                    .expect("certified backend should page collection grants");
+                assert!(grant_total >= 1);
+                assert!(!grant_page.is_empty());
+
+                let grant = backend
+                    .collection_group_permission(collection_id, group.id)
+                    .await
+                    .expect("certified backend should load a collection grant");
+                assert_eq!(grant.collection_id, collection_id);
+                assert_eq!(grant.group_id, group.id);
 
                 let collections = backend
                     .local_authorized_collections(AuthorizationCollectionsQuery::new(

--- a/src/tests/storage_performance.rs
+++ b/src/tests/storage_performance.rs
@@ -1326,7 +1326,7 @@ async fn collection_history_query_count_is_constant_with_page_size() {
             .await?;
             let principal_ids = rows
                 .iter()
-                .flat_map(|row| [row.actor_id, row.initiator_user_id])
+                .flat_map(|row| row.principal_ids())
                 .flatten()
                 .collect();
             let principal_names = resolve_principal_names(&pool, principal_ids).await?;

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -133,7 +133,7 @@ async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() 
 
     assert!(
         body.contains(
-            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"24\"} 1"
+            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"25\"} 1"
         )
     );
     assert!(body.contains(

--- a/tests/api_platform_suite/runtime_config.rs
+++ b/tests/api_platform_suite/runtime_config.rs
@@ -37,7 +37,7 @@ mod tests {
         let serialized = serde_json::to_string(&body).unwrap();
 
         assert_eq!(body["database"]["backend"], "postgresql");
-        assert_eq!(body["database"]["contract_version"], 24);
+        assert_eq!(body["database"]["contract_version"], 25);
         assert_eq!(
             body["database"]["capabilities"],
             serde_json::json!([


### PR DESCRIPTION
## Summary

- move collection lifecycle, insert, update, history, and cursor SQL rows into the PostgreSQL adapter with explicit domain conversions
- require every selectable backend to implement collection record mutations, hierarchy moves, and the complete collection-permission projection surface
- route collection model and compatibility APIs through backend-neutral, operation-shaped request DTOs instead of PostgreSQL helpers
- normalize adapter failures into StorageError, then preserve ApiError as the application and HTTP error surface
- apply the shared bounded storage observer to every new entry point and certify every registered backend through compatibility tests

## Architecture and compatibility

This raises the storage contract version to 25. Collection domain production code no longer contains Diesel derives, schema bindings, PostgreSQL imports, or SQL cursor mappings. Backends cannot be selected while omitting collection writes or permission projections because CollectionRecordStorage and CollectionPermissionStorage are mandatory StorageBackend supertraits.

The selected backend identity and redacted settings remain available through startup logs, metrics, and administrator configuration. Required capability labels and public HTTP request/response shapes are unchanged.

## Breaking changes

Administrator and monitoring consumers that require storage contract version 24 must accept version 25. There are no database migrations, public HTTP schema changes, or Cargo/workspace changes in this layer.

## Verification

- source .env && ./run_tests.sh
- cargo clippy --all-targets --features integration-test-support -- -D warnings
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"
- scripts/test-classify-ci-changes.sh
- cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked

Part of #27.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
