### PR TITLE
Move permission persistence into adapter

### DIFF
--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -123,14 +123,14 @@ considered complete merely because a marker exists.
 PostgreSQL query implementations live in
 `src/storage/postgres/operations/*`. Export-template, remote-target, event,
 event-sink, event-subscription, and event-delivery lifecycle rows are
-adapter-owned, as are collection, class, and object lifecycle and history rows,
-class- and object-relation rows, relation graph query rows, remote-target
-history, and remote-call result persistence rows. Domain collection, class,
-object, and relation values contain no Diesel derives, schema bindings, or SQL
-cursor mappings. Those mappings and explicit conversions live in the PostgreSQL
-adapter. Remaining mixed persistence rows move there as their backend-neutral
-DTOs are extracted. Their current locations are implementation details, not
-partial backend support.
+adapter-owned, as are permission query, insert, update, collection, class, and
+object lifecycle and history rows, class- and object-relation rows, relation
+graph query rows, remote-target history, and remote-call result persistence
+rows. Domain permission, collection, class, object, and relation values contain
+no Diesel derives, schema bindings, or SQL cursor mappings. Those mappings and
+explicit conversions live in the PostgreSQL adapter. Remaining mixed
+persistence rows move there as their backend-neutral DTOs are extracted. Their
+current locations are implementation details, not partial backend support.
 `StorageHandle` selects one certified PostgreSQL adapter, and only the storage
 implementation can recover its pool.
 Application consumers use `StorageContext`, lifecycle traits, mandatory

--- a/src/models/output.rs
+++ b/src/models/output.rs
@@ -1,7 +1,4 @@
-// These are models that are used to serialize the output of the API
-// They are not used to interact with the database
-
-// A typical use is to combine the output of multiple models into a single response
+// API output DTOs assembled from one or more domain values.
 
 use crate::models::{Collection, Group, HubuumClass, Permission, ResourceRevision};
 use serde::{Deserialize, Serialize};
@@ -13,15 +10,15 @@ pub struct GroupPermission {
     pub permission: Permission,
 }
 
-/// The revisioned, SQL-owned authorization state for a collection.
+/// The revisioned authorization grant set for a collection.
 ///
-/// Individual permission rows are implementation details of this aggregate;
+/// Individual grants are implementation details of this aggregate;
 /// callers condition mutations on the revision of the complete set.
 #[derive(Serialize, Deserialize, Clone, ToSchema)]
 pub struct CollectionPermissionSet {
     pub collection_id: i32,
     pub revision: ResourceRevision,
-    /// ACL rows contain stable group identifiers without embedding mutable
+    /// ACL entries contain stable group identifiers without embedding mutable
     /// group representations that are outside this aggregate's revision.
     pub permissions: Vec<Permission>,
 }

--- a/src/models/permissions.rs
+++ b/src/models/permissions.rs
@@ -1,10 +1,9 @@
-use crate::storage::postgres::prelude::*;
 use std::{fmt, fmt::Display, slice};
 
 use serde::{Deserialize, Deserializer, Serialize};
 use utoipa::ToSchema;
 
-use crate::{errors::ApiError, schema::permissions};
+use crate::errors::ApiError;
 
 use super::search::ParsedQueryParam;
 
@@ -315,53 +314,7 @@ impl<'a> IntoIterator for &'a PermissionsList {
     }
 }
 
-pub trait PermissionFilter<'a, Q> {
-    /// ## Create a boxed filter to check if a permission is set to true or false.
-    ///
-    /// ### Arguments
-    ///
-    /// * `query` - The query to add the filter to.
-    /// * `target` - The value to check for.
-    ///
-    /// ### Returns
-    ///
-    /// * `BoxedQuery` - The query with the filter added.
-    ///
-    /// ## Example
-    ///
-    /// ```text
-    /// use crate::models::Permissions;
-    /// use crate::models::PermissionFilter;
-    /// use crate::schema::permissions::dsl::{permissions, group_id, collection_id};
-    ///
-    /// let permissions_list = vec![
-    ///  Permissions::ReadCollection,
-    ///  Permissions::UpdateCollection
-    /// ];
-    /// let mut base_query = permissions
-    ///   .into_boxed()
-    ///   .filter(collection_id.eq_any(vec![1, 2, 3]))
-    ///
-    /// for perm in permissions_list {
-    ///   base_query = perm.create_boxed_filter(base_query, true);
-    /// }
-    /// ```
-    fn create_boxed_filter(self, query: Q, target: bool) -> Q;
-}
-
-impl<'a> PermissionFilter<'a, permissions::BoxedQuery<'a, diesel::pg::Pg>> for Permissions {
-    fn create_boxed_filter(
-        self,
-        mut query: permissions::BoxedQuery<diesel::pg::Pg>,
-        target: bool,
-    ) -> permissions::BoxedQuery<diesel::pg::Pg> {
-        crate::apply_permission_filter!(query, self, target);
-        query
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Queryable, Selectable, Clone, Copy, ToSchema)]
-#[diesel(table_name = permissions)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, ToSchema)]
 pub struct Permission {
     pub id: i32,
     pub collection_id: i32,
@@ -402,8 +355,8 @@ pub struct Permission {
 }
 
 impl Permission {
-    /// The set of permissions this row grants — the `has_*` flags that are `true`,
-    /// mapped to their [`Permissions`] variant.
+    /// The set of capabilities carried by this grant: each enabled `has_*`
+    /// flag mapped to its [`Permissions`] variant.
     pub fn granted(&self) -> Vec<Permissions> {
         [
             (self.has_read_collection, Permissions::ReadCollection),
@@ -483,87 +436,9 @@ impl Permission {
     }
 }
 
-// Insertable permission models.
-#[derive(Debug, Serialize, Deserialize, Insertable)]
-#[diesel(table_name = permissions)]
-pub struct NewPermission {
-    pub collection_id: i32,
-    pub group_id: i32,
-    pub has_read_collection: bool,
-    pub has_update_collection: bool,
-    pub has_delete_collection: bool,
-    pub has_delegate_collection: bool,
-    pub has_create_class: bool,
-    pub has_read_class: bool,
-    pub has_update_class: bool,
-    pub has_delete_class: bool,
-    pub has_create_object: bool,
-    pub has_read_object: bool,
-    pub has_update_object: bool,
-    pub has_delete_object: bool,
-    pub has_create_class_relation: bool,
-    pub has_read_class_relation: bool,
-    pub has_update_class_relation: bool,
-    pub has_delete_class_relation: bool,
-    pub has_create_object_relation: bool,
-    pub has_read_object_relation: bool,
-    pub has_update_object_relation: bool,
-    pub has_delete_object_relation: bool,
-    pub has_read_template: bool,
-    pub has_create_template: bool,
-    pub has_update_template: bool,
-    pub has_delete_template: bool,
-    pub has_read_remote_target: bool,
-    pub has_create_remote_target: bool,
-    pub has_update_remote_target: bool,
-    pub has_delete_remote_target: bool,
-    pub has_execute_remote_target: bool,
-    pub has_read_audit: bool,
-    pub has_manage_event_subscription: bool,
-}
-
-#[derive(Debug, Serialize, Deserialize, AsChangeset, Default)]
-#[diesel(table_name = permissions)]
-pub struct UpdatePermission {
-    pub has_read_collection: Option<bool>,
-    pub has_update_collection: Option<bool>,
-    pub has_delete_collection: Option<bool>,
-    pub has_delegate_collection: Option<bool>,
-    pub has_create_class: Option<bool>,
-    pub has_read_class: Option<bool>,
-    pub has_update_class: Option<bool>,
-    pub has_delete_class: Option<bool>,
-    pub has_create_object: Option<bool>,
-    pub has_read_object: Option<bool>,
-    pub has_update_object: Option<bool>,
-    pub has_delete_object: Option<bool>,
-    pub has_create_class_relation: Option<bool>,
-    pub has_read_class_relation: Option<bool>,
-    pub has_update_class_relation: Option<bool>,
-    pub has_delete_class_relation: Option<bool>,
-    pub has_create_object_relation: Option<bool>,
-    pub has_read_object_relation: Option<bool>,
-    pub has_update_object_relation: Option<bool>,
-    pub has_delete_object_relation: Option<bool>,
-    pub has_read_template: Option<bool>,
-    pub has_create_template: Option<bool>,
-    pub has_update_template: Option<bool>,
-    pub has_delete_template: Option<bool>,
-    pub has_read_remote_target: Option<bool>,
-    pub has_create_remote_target: Option<bool>,
-    pub has_update_remote_target: Option<bool>,
-    pub has_delete_remote_target: Option<bool>,
-    pub has_execute_remote_target: Option<bool>,
-    pub has_read_audit: Option<bool>,
-    pub has_manage_event_subscription: Option<bool>,
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::storage::postgres::prelude::*;
-
-    use super::{PermissionFilter, Permissions, PermissionsList};
-    use crate::schema::permissions::dsl::permissions;
+    use super::{Permissions, PermissionsList};
 
     #[test]
     fn template_permissions_parse_and_display_round_trip() {
@@ -604,25 +479,5 @@ mod tests {
             permission_list.as_slice(),
             &[Permissions::ReadCollection, Permissions::UpdateCollection]
         );
-    }
-
-    #[test]
-    fn template_permissions_filter_map_to_expected_columns() {
-        let fixtures = [
-            (Permissions::ReadTemplate, "has_read_template"),
-            (Permissions::CreateTemplate, "has_create_template"),
-            (Permissions::UpdateTemplate, "has_update_template"),
-            (Permissions::DeleteTemplate, "has_delete_template"),
-        ];
-
-        for (permission, expected_column) in fixtures {
-            let base_query = permissions.into_boxed();
-            let filtered = permission.create_boxed_filter(base_query, true);
-            let sql = diesel::debug_query::<diesel::pg::Pg, _>(&filtered).to_string();
-            assert!(
-                sql.contains(expected_column),
-                "Expected SQL to contain '{expected_column}', got: {sql}"
-            );
-        }
     }
 }

--- a/src/models/traits/output.rs
+++ b/src/models/traits/output.rs
@@ -8,9 +8,7 @@ use crate::models::{
     Collection, CollectionID, GroupPermission, HubuumClass, HubuumClassExpanded, Permission,
 };
 use crate::storage::StorageContext;
-use crate::traits::{
-    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue, SelfAccessors,
-};
+use crate::traits::{CursorPaginated, CursorValue, SelfAccessors};
 
 /// Convert a `(Group, T)` tuple into a richer output type.
 pub trait FromTuple<T> {
@@ -200,38 +198,5 @@ impl CursorPaginated for GroupPermission {
 
     fn tie_breaker_sort() -> Vec<SortParam> {
         Self::default_sort()
-    }
-}
-
-impl CursorSqlMapping for GroupPermission {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id => CursorSqlField {
-                column: "permissions.id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Name | FilterField::Groupname => CursorSqlField {
-                column: "groups.groupname",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::CreatedAt => CursorSqlField {
-                column: "permissions.created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAt => CursorSqlField {
-                column: "permissions.updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for group permissions",
-                    field
-                )));
-            }
-        })
     }
 }

--- a/src/storage/postgres/operations/authorization.rs
+++ b/src/storage/postgres/operations/authorization.rs
@@ -9,6 +9,7 @@ use crate::models::{
 use crate::storage::postgres::operations::collection as collection_backend;
 use crate::storage::postgres::operations::collection::CollectionRow;
 use crate::storage::postgres::operations::permissions as permission_backend;
+use crate::storage::postgres::operations::permissions::PermissionRow;
 use crate::storage::postgres::prelude::*;
 use crate::storage::postgres::{PostgresPool, with_connection};
 use crate::storage::{
@@ -178,7 +179,8 @@ fn group_to_storage(group: Group) -> AuthorizationGroup {
     )
 }
 
-fn grant_to_storage(grant: Permission) -> AuthorizationGrant {
+fn grant_to_storage(grant: impl Into<Permission>) -> AuthorizationGrant {
+    let grant = grant.into();
     AuthorizationGrant::new(
         grant.id,
         grant.collection_id,
@@ -244,8 +246,8 @@ pub(crate) async fn authorize_local_collection(
     pool: &PostgresPool,
     query: AuthorizationCollectionAccessQuery,
 ) -> Result<bool, ApiError> {
-    use crate::models::permissions::PermissionFilter;
     use crate::schema::{group_memberships, permissions};
+    use crate::storage::postgres::operations::permissions::PermissionFilter;
 
     let group_ids = group_memberships::table
         .filter(group_memberships::principal_id.eq(query.principal_id()))
@@ -447,7 +449,7 @@ pub(crate) async fn authorization_policy_snapshot(
                 permissions::collection_id.asc(),
                 permissions::group_id.asc(),
             ))
-            .load::<(Permission, Group, CollectionRow)>(conn)
+            .load::<(PermissionRow, Group, CollectionRow)>(conn)
             .await
     })
     .await?;
@@ -497,7 +499,7 @@ pub(crate) async fn get_local_collection_grant(
         permissions::table
             .filter(permissions::collection_id.eq(key.collection_id()))
             .filter(permissions::group_id.eq(key.group_id()))
-            .first(conn)
+            .first::<PermissionRow>(conn)
             .await
             .optional()
     })
@@ -522,9 +524,9 @@ pub(crate) async fn load_local_collection_permission_set(
                 .filter(collection_authorization_state::collection_id.eq(query.collection_id()))
                 .select((
                     collection_authorization_state::revision,
-                    Option::<Permission>::as_select(),
+                    Option::<PermissionRow>::as_select(),
                 ))
-                .load::<(crate::models::ResourceRevision, Option<Permission>)>(conn)
+                .load::<(crate::models::ResourceRevision, Option<PermissionRow>)>(conn)
                 .await
         } else {
             collection_authorization_state::table
@@ -534,9 +536,9 @@ pub(crate) async fn load_local_collection_permission_set(
                 .filter(collection_authorization_state::collection_id.eq(query.collection_id()))
                 .select((
                     collection_authorization_state::revision,
-                    Option::<Permission>::as_select(),
+                    Option::<PermissionRow>::as_select(),
                 ))
-                .load::<(crate::models::ResourceRevision, Option<Permission>)>(conn)
+                .load::<(crate::models::ResourceRevision, Option<PermissionRow>)>(conn)
                 .await
         }
     })

--- a/src/storage/postgres/operations/collection/mod.rs
+++ b/src/storage/postgres/operations/collection/mod.rs
@@ -4,7 +4,6 @@ use tracing::{debug, trace};
 use crate::errors::ApiError;
 use crate::models::group::Group;
 use crate::models::output::{EffectiveGroupPermission, GroupPermission};
-use crate::models::permissions::PermissionFilter;
 use crate::models::search::{FilterField, QueryOptions, QueryParamsExt};
 use crate::models::{
     Collection, CollectionID, HubuumObjectRelationID, NewCollection, NewCollectionWithAssignee,
@@ -13,6 +12,7 @@ use crate::models::{
 use crate::models::{HubuumClassRelation, NewHubuumObjectRelation};
 use crate::models::{HubuumObjectRelation, NewHubuumClassRelation};
 use crate::storage::postgres::operations::GetCollection;
+use crate::storage::postgres::operations::permissions::{PermissionFilter, PermissionRow};
 use crate::storage::postgres::{with_connection, with_transaction};
 use crate::traits::{
     ClassAccessors, CollectionAccessors, GroupAccessors, ObjectAccessors, SelfAccessors,

--- a/src/storage/postgres/operations/collection/permissions.rs
+++ b/src/storage/postgres/operations/collection/permissions.rs
@@ -1,13 +1,70 @@
 use super::*;
+use crate::models::search::SortParam;
 use crate::models::token_scope::TokenScope;
 use crate::storage::postgres::operations::authz::AuthzSubject;
+use crate::traits::{
+    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
+};
 use diesel_async::RunQueryDsl;
 use std::collections::HashMap;
+
+struct GroupPermissionQueryRow(GroupPermission);
+
+impl CursorPaginated for GroupPermissionQueryRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        GroupPermission::supports_sort(field)
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        self.0.cursor_value(field)
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        GroupPermission::default_sort()
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        GroupPermission::tie_breaker_sort()
+    }
+}
+
+impl CursorSqlMapping for GroupPermissionQueryRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorSqlField {
+                column: "permissions.id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Name | FilterField::Groupname => CursorSqlField {
+                column: "groups.groupname",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::CreatedAt => CursorSqlField {
+                column: "permissions.created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAt => CursorSqlField {
+                column: "permissions.updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for group permissions",
+                    field
+                )));
+            }
+        })
+    }
+}
 
 async fn build_effective_group_permissions(
     conn: &mut crate::storage::postgres::PostgresConnection,
     target_collection_id: i32,
-    rows: Vec<(i32, i32, Group, Permission)>,
+    rows: Vec<(i32, i32, Group, PermissionRow)>,
 ) -> Result<Vec<EffectiveGroupPermission>, ApiError> {
     use crate::schema::collections::dsl::{collections, id};
 
@@ -55,7 +112,7 @@ async fn build_effective_group_permissions(
                     depth,
                     inherited: depth > 0,
                     group,
-                    permission,
+                    permission: permission.into(),
                 })
             },
         )
@@ -67,7 +124,6 @@ pub async fn principal_on_from_backend<S: AuthzSubject, T: CollectionAccessors>(
     principal: S,
     collection_ref: T,
 ) -> Result<Vec<GroupPermission>, ApiError> {
-    use crate::models::traits::output::FromTuple;
     use crate::schema::groups::dsl::{groups, id as group_table_id};
     use crate::schema::permissions::dsl::{collection_id, group_id, permissions};
 
@@ -79,12 +135,18 @@ pub async fn principal_on_from_backend<S: AuthzSubject, T: CollectionAccessors>(
             .filter(collection_id.eq(collection_target_id))
             .filter(group_id.eq_any(group_ids_subquery))
             .select((groups::all_columns(), permissions::all_columns()))
-            .load::<(Group, Permission)>(conn)
+            .load::<(Group, PermissionRow)>(conn)
             .await
     })
     .await?;
 
-    Ok(rows.into_iter().map(GroupPermission::from_tuple).collect())
+    Ok(rows
+        .into_iter()
+        .map(|(group, permission)| GroupPermission {
+            group,
+            permission: permission.into(),
+        })
+        .collect())
 }
 
 /// All of a principal's direct permission rows across every collection, as
@@ -107,15 +169,15 @@ pub async fn principal_all_permissions_from_backend<S: AuthzSubject>(
             .select((
                 CollectionRow::as_select(),
                 Group::as_select(),
-                Permission::as_select(),
+                PermissionRow::as_select(),
             ))
-            .load::<(CollectionRow, Group, Permission)>(conn)
+            .load::<(CollectionRow, Group, PermissionRow)>(conn)
             .await
     })
     .await
     .map(|rows| {
         rows.into_iter()
-            .map(|(collection, group, permission)| (collection.into(), group, permission))
+            .map(|(collection, group, permission)| (collection.into(), group, permission.into()))
             .collect()
     })
 }
@@ -129,7 +191,6 @@ pub async fn principal_on_paginated_with_total_count_from_backend<
     collection_ref: T,
     query_options: &QueryOptions,
 ) -> Result<(Vec<GroupPermission>, i64), ApiError> {
-    use crate::models::traits::output::FromTuple;
     use crate::schema::groups::dsl::{groupname, groups, id as group_table_id};
     use crate::schema::permissions::dsl::{
         collection_id, created_at as permission_created_at, group_id, id as permission_id,
@@ -186,14 +247,19 @@ pub async fn principal_on_paginated_with_total_count_from_backend<
     .await?;
 
     let mut query = build_query()?;
-    crate::apply_query_options!(query, query_options, GroupPermission);
+    crate::apply_query_options!(query, query_options, GroupPermissionQueryRow);
     let rows = with_connection(pool, async |conn| {
-        query.load::<(Group, Permission)>(conn).await
+        query.load::<(Group, PermissionRow)>(conn).await
     })
     .await?;
 
     Ok((
-        rows.into_iter().map(GroupPermission::from_tuple).collect(),
+        rows.into_iter()
+            .map(|(group, permission)| GroupPermission {
+                group,
+                permission: permission.into(),
+            })
+            .collect(),
         total_count,
     ))
 }
@@ -231,7 +297,7 @@ pub async fn effective_principal_on_from_backend<S: AuthzSubject, T: CollectionA
                 groups::all_columns(),
                 permissions::all_columns(),
             ))
-            .load::<(i32, i32, Group, Permission)>(conn)
+            .load::<(i32, i32, Group, PermissionRow)>(conn)
             .await?;
 
         build_effective_group_permissions(conn, target_collection_id, rows).await
@@ -372,7 +438,7 @@ pub async fn effective_group_on_from_backend(
                 groups::all_columns(),
                 permissions::all_columns(),
             ))
-            .load::<(i32, i32, Group, Permission)>(conn)
+            .load::<(i32, i32, Group, PermissionRow)>(conn)
             .await?;
 
         build_effective_group_permissions(conn, target_collection_id, rows).await
@@ -502,7 +568,6 @@ pub async fn groups_on_from_backend<T: CollectionAccessors>(
     permissions_filter: Vec<Permissions>,
     query_options: QueryOptions,
 ) -> Result<Vec<GroupPermission>, ApiError> {
-    use crate::models::traits::output::FromTuple;
     use crate::schema::groups::dsl::{groups, id as group_table_id};
     use crate::schema::permissions::dsl::{
         collection_id, created_at as permission_created_at, group_id, id as permission_id,
@@ -577,12 +642,18 @@ pub async fn groups_on_from_backend<T: CollectionAccessors>(
         base_query
             .inner_join(groups.on(group_table_id.eq(group_id)))
             .select((groups::all_columns(), permissions::all_columns()))
-            .load::<(Group, Permission)>(conn)
+            .load::<(Group, PermissionRow)>(conn)
             .await
     })
     .await?;
 
-    Ok(rows.into_iter().map(GroupPermission::from_tuple).collect())
+    Ok(rows
+        .into_iter()
+        .map(|(group, permission)| GroupPermission {
+            group,
+            permission: permission.into(),
+        })
+        .collect())
 }
 
 pub async fn groups_on_paginated_from_backend<T: CollectionAccessors>(
@@ -607,7 +678,6 @@ pub async fn groups_on_paginated_with_total_count_from_backend<T: CollectionAcce
     permissions_filter: Vec<Permissions>,
     query_options: &QueryOptions,
 ) -> Result<(Vec<GroupPermission>, i64), ApiError> {
-    use crate::models::traits::output::FromTuple;
     use crate::schema::groups::dsl::{groupname, groups, id as group_table_id};
     use crate::schema::permissions::dsl::{
         collection_id, created_at as permission_created_at, group_id, id as permission_id,
@@ -665,17 +735,22 @@ pub async fn groups_on_paginated_with_total_count_from_backend<T: CollectionAcce
     .await?;
 
     let mut query = build_query()?;
-    crate::apply_query_options!(query, query_options, GroupPermission);
+    crate::apply_query_options!(query, query_options, GroupPermissionQueryRow);
     let rows = with_connection(pool, async |conn| {
         query
             .select((groups::all_columns(), permissions::all_columns()))
-            .load::<(Group, Permission)>(conn)
+            .load::<(Group, PermissionRow)>(conn)
             .await
     })
     .await?;
 
     Ok((
-        rows.into_iter().map(GroupPermission::from_tuple).collect(),
+        rows.into_iter()
+            .map(|(group, permission)| GroupPermission {
+                group,
+                permission: permission.into(),
+            })
+            .collect(),
         total_count,
     ))
 }
@@ -707,8 +782,9 @@ pub async fn group_on_from_backend(
         permissions
             .filter(collection_id.eq(target_collection_id))
             .filter(group_id.eq(gid))
-            .first::<Permission>(conn)
+            .first::<PermissionRow>(conn)
             .await
+            .map(Into::into)
     })
     .await
 }

--- a/src/storage/postgres/operations/permissions.rs
+++ b/src/storage/postgres/operations/permissions.rs
@@ -3,9 +3,183 @@ use crate::storage::postgres::prelude::*;
 use crate::api::etag::RevisionOwner;
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, EventContext, NewEvent};
-use crate::models::{NewPermission, Permission, Permissions, PermissionsList, UpdatePermission};
+use crate::models::{Permission, Permissions, PermissionsList};
+use crate::schema::permissions;
 use crate::storage::postgres::operations::event_record::emit_event;
 use crate::storage::postgres::with_transaction;
+
+#[derive(Debug, Queryable, Selectable, Clone, Copy)]
+#[diesel(table_name = permissions)]
+pub(crate) struct PermissionRow {
+    pub(crate) id: i32,
+    pub(crate) collection_id: i32,
+    pub(crate) group_id: i32,
+    pub(crate) has_read_collection: bool,
+    pub(crate) has_update_collection: bool,
+    pub(crate) has_delete_collection: bool,
+    pub(crate) has_delegate_collection: bool,
+    pub(crate) has_create_class: bool,
+    pub(crate) has_read_class: bool,
+    pub(crate) has_update_class: bool,
+    pub(crate) has_delete_class: bool,
+    pub(crate) has_create_object: bool,
+    pub(crate) has_read_object: bool,
+    pub(crate) has_update_object: bool,
+    pub(crate) has_delete_object: bool,
+    pub(crate) has_create_class_relation: bool,
+    pub(crate) has_read_class_relation: bool,
+    pub(crate) has_update_class_relation: bool,
+    pub(crate) has_delete_class_relation: bool,
+    pub(crate) has_create_object_relation: bool,
+    pub(crate) has_read_object_relation: bool,
+    pub(crate) has_update_object_relation: bool,
+    pub(crate) has_delete_object_relation: bool,
+    pub(crate) has_read_template: bool,
+    pub(crate) has_create_template: bool,
+    pub(crate) has_update_template: bool,
+    pub(crate) has_delete_template: bool,
+    pub(crate) has_read_remote_target: bool,
+    pub(crate) has_create_remote_target: bool,
+    pub(crate) has_update_remote_target: bool,
+    pub(crate) has_delete_remote_target: bool,
+    pub(crate) has_execute_remote_target: bool,
+    pub(crate) created_at: chrono::NaiveDateTime,
+    pub(crate) updated_at: chrono::NaiveDateTime,
+    pub(crate) has_read_audit: bool,
+    pub(crate) has_manage_event_subscription: bool,
+}
+
+impl From<PermissionRow> for Permission {
+    fn from(row: PermissionRow) -> Self {
+        Self {
+            id: row.id,
+            collection_id: row.collection_id,
+            group_id: row.group_id,
+            has_read_collection: row.has_read_collection,
+            has_update_collection: row.has_update_collection,
+            has_delete_collection: row.has_delete_collection,
+            has_delegate_collection: row.has_delegate_collection,
+            has_create_class: row.has_create_class,
+            has_read_class: row.has_read_class,
+            has_update_class: row.has_update_class,
+            has_delete_class: row.has_delete_class,
+            has_create_object: row.has_create_object,
+            has_read_object: row.has_read_object,
+            has_update_object: row.has_update_object,
+            has_delete_object: row.has_delete_object,
+            has_create_class_relation: row.has_create_class_relation,
+            has_read_class_relation: row.has_read_class_relation,
+            has_update_class_relation: row.has_update_class_relation,
+            has_delete_class_relation: row.has_delete_class_relation,
+            has_create_object_relation: row.has_create_object_relation,
+            has_read_object_relation: row.has_read_object_relation,
+            has_update_object_relation: row.has_update_object_relation,
+            has_delete_object_relation: row.has_delete_object_relation,
+            has_read_template: row.has_read_template,
+            has_create_template: row.has_create_template,
+            has_update_template: row.has_update_template,
+            has_delete_template: row.has_delete_template,
+            has_read_remote_target: row.has_read_remote_target,
+            has_create_remote_target: row.has_create_remote_target,
+            has_update_remote_target: row.has_update_remote_target,
+            has_delete_remote_target: row.has_delete_remote_target,
+            has_execute_remote_target: row.has_execute_remote_target,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            has_read_audit: row.has_read_audit,
+            has_manage_event_subscription: row.has_manage_event_subscription,
+        }
+    }
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = permissions)]
+pub(crate) struct NewPermission {
+    pub(crate) collection_id: i32,
+    pub(crate) group_id: i32,
+    pub(crate) has_read_collection: bool,
+    pub(crate) has_update_collection: bool,
+    pub(crate) has_delete_collection: bool,
+    pub(crate) has_delegate_collection: bool,
+    pub(crate) has_create_class: bool,
+    pub(crate) has_read_class: bool,
+    pub(crate) has_update_class: bool,
+    pub(crate) has_delete_class: bool,
+    pub(crate) has_create_object: bool,
+    pub(crate) has_read_object: bool,
+    pub(crate) has_update_object: bool,
+    pub(crate) has_delete_object: bool,
+    pub(crate) has_create_class_relation: bool,
+    pub(crate) has_read_class_relation: bool,
+    pub(crate) has_update_class_relation: bool,
+    pub(crate) has_delete_class_relation: bool,
+    pub(crate) has_create_object_relation: bool,
+    pub(crate) has_read_object_relation: bool,
+    pub(crate) has_update_object_relation: bool,
+    pub(crate) has_delete_object_relation: bool,
+    pub(crate) has_read_template: bool,
+    pub(crate) has_create_template: bool,
+    pub(crate) has_update_template: bool,
+    pub(crate) has_delete_template: bool,
+    pub(crate) has_read_remote_target: bool,
+    pub(crate) has_create_remote_target: bool,
+    pub(crate) has_update_remote_target: bool,
+    pub(crate) has_delete_remote_target: bool,
+    pub(crate) has_execute_remote_target: bool,
+    pub(crate) has_read_audit: bool,
+    pub(crate) has_manage_event_subscription: bool,
+}
+
+#[derive(Debug, AsChangeset, Default)]
+#[diesel(table_name = permissions)]
+pub(crate) struct UpdatePermission {
+    pub(crate) has_read_collection: Option<bool>,
+    pub(crate) has_update_collection: Option<bool>,
+    pub(crate) has_delete_collection: Option<bool>,
+    pub(crate) has_delegate_collection: Option<bool>,
+    pub(crate) has_create_class: Option<bool>,
+    pub(crate) has_read_class: Option<bool>,
+    pub(crate) has_update_class: Option<bool>,
+    pub(crate) has_delete_class: Option<bool>,
+    pub(crate) has_create_object: Option<bool>,
+    pub(crate) has_read_object: Option<bool>,
+    pub(crate) has_update_object: Option<bool>,
+    pub(crate) has_delete_object: Option<bool>,
+    pub(crate) has_create_class_relation: Option<bool>,
+    pub(crate) has_read_class_relation: Option<bool>,
+    pub(crate) has_update_class_relation: Option<bool>,
+    pub(crate) has_delete_class_relation: Option<bool>,
+    pub(crate) has_create_object_relation: Option<bool>,
+    pub(crate) has_read_object_relation: Option<bool>,
+    pub(crate) has_update_object_relation: Option<bool>,
+    pub(crate) has_delete_object_relation: Option<bool>,
+    pub(crate) has_read_template: Option<bool>,
+    pub(crate) has_create_template: Option<bool>,
+    pub(crate) has_update_template: Option<bool>,
+    pub(crate) has_delete_template: Option<bool>,
+    pub(crate) has_read_remote_target: Option<bool>,
+    pub(crate) has_create_remote_target: Option<bool>,
+    pub(crate) has_update_remote_target: Option<bool>,
+    pub(crate) has_delete_remote_target: Option<bool>,
+    pub(crate) has_execute_remote_target: Option<bool>,
+    pub(crate) has_read_audit: Option<bool>,
+    pub(crate) has_manage_event_subscription: Option<bool>,
+}
+
+pub(crate) trait PermissionFilter<'a, Q> {
+    fn create_boxed_filter(self, query: Q, target: bool) -> Q;
+}
+
+impl<'a> PermissionFilter<'a, permissions::BoxedQuery<'a, diesel::pg::Pg>> for Permissions {
+    fn create_boxed_filter(
+        self,
+        mut query: permissions::BoxedQuery<'a, diesel::pg::Pg>,
+        target: bool,
+    ) -> permissions::BoxedQuery<'a, diesel::pg::Pg> {
+        crate::apply_permission_filter!(query, self, target);
+        query
+    }
+}
 
 async fn permission_owner_revision(
     conn: &mut crate::storage::postgres::PostgresConnection,
@@ -357,9 +531,10 @@ pub(crate) async fn apply_permission_grant_without_event(
             .filter(collection_id.eq(target_collection_id))
             .filter(group_id.eq(group_id_for_grant))
             .for_update()
-            .first::<Permission>(conn)
+            .first::<PermissionRow>(conn)
             .await
-            .optional()?;
+            .optional()?
+            .map(Into::into);
 
         match existing_entry {
             Some(existing) => {
@@ -506,8 +681,9 @@ pub(crate) async fn apply_permission_grant_without_event(
                     .filter(collection_id.eq(target_collection_id))
                     .filter(group_id.eq(group_id_for_grant))
                     .set(&update_perm)
-                    .get_result(conn)
-                    .await?)
+                    .get_result::<PermissionRow>(conn)
+                    .await?
+                    .into())
             }
             None => {
                 let new_entry = NewPermission {
@@ -563,8 +739,9 @@ pub(crate) async fn apply_permission_grant_without_event(
 
                 Ok(diesel::insert_into(permissions)
                     .values(&new_entry)
-                    .get_result(conn)
-                    .await?)
+                    .get_result::<PermissionRow>(conn)
+                    .await?
+                    .into())
             }
         }
     })
@@ -596,13 +773,14 @@ pub(crate) async fn apply_permission_grant(
 
     with_transaction(pool, async |conn| -> Result<Permission, ApiError> {
         let before_owner_revision = lock_permission_owner(conn, target_collection_id).await?;
-        let before = permissions
+        let before: Option<Permission> = permissions
             .filter(collection_id.eq(target_collection_id))
             .filter(group_id.eq(group_id_for_grant))
             .for_update()
-            .first::<Permission>(conn)
+            .first::<PermissionRow>(conn)
             .await
-            .optional()?;
+            .optional()?
+            .map(Into::into);
 
         if let Some(current) = before
             && !grant_changes_permission(&current, &permission_list, replace_existing)
@@ -617,8 +795,9 @@ pub(crate) async fn apply_permission_grant(
                     .filter(collection_id.eq(target_collection_id))
                     .filter(group_id.eq(group_id_for_grant))
                     .set(&update_perm)
-                    .get_result::<Permission>(conn)
+                    .get_result::<PermissionRow>(conn)
                     .await?
+                    .into()
             }
             None => {
                 let new_entry = new_permission_from_list(
@@ -628,8 +807,9 @@ pub(crate) async fn apply_permission_grant(
                 );
                 diesel::insert_into(permissions)
                     .values(&new_entry)
-                    .get_result::<Permission>(conn)
+                    .get_result::<PermissionRow>(conn)
                     .await?
+                    .into()
             }
         };
         let after_owner_revision = permission_owner_revision(conn, target_collection_id).await?;
@@ -675,8 +855,9 @@ pub(crate) async fn revoke_permission_grant_without_event(
             .filter(collection_id.eq(target_collection_id))
             .filter(group_id.eq(group_id_for_revoke))
             .for_update()
-            .first::<Permission>(conn)
-            .await?;
+            .first::<PermissionRow>(conn)
+            .await?
+            .into();
 
         if !revoke_changes_permission(&before, &permission_list) {
             return Ok(before);
@@ -785,8 +966,9 @@ pub(crate) async fn revoke_permission_grant_without_event(
             .filter(collection_id.eq(target_collection_id))
             .filter(group_id.eq(group_id_for_revoke))
             .set(&update_perm)
-            .get_result(conn)
-            .await?)
+            .get_result::<PermissionRow>(conn)
+            .await?
+            .into())
     })
     .await
 }
@@ -818,8 +1000,9 @@ pub(crate) async fn revoke_permission_grant(
             .filter(collection_id.eq(target_collection_id))
             .filter(group_id.eq(group_id_for_revoke))
             .for_update()
-            .first::<Permission>(conn)
-            .await?;
+            .first::<PermissionRow>(conn)
+            .await?
+            .into();
 
         if !revoke_changes_permission(&before, &permission_list) {
             return Ok(before);
@@ -830,8 +1013,9 @@ pub(crate) async fn revoke_permission_grant(
             .filter(collection_id.eq(target_collection_id))
             .filter(group_id.eq(group_id_for_revoke))
             .set(&update_perm)
-            .get_result::<Permission>(conn)
-            .await?;
+            .get_result::<PermissionRow>(conn)
+            .await?
+            .into();
         let after_owner_revision = permission_owner_revision(conn, target_collection_id).await?;
 
         let event = permission_event(
@@ -891,13 +1075,14 @@ pub(crate) async fn revoke_all_permission_grants(
     use crate::schema::permissions::dsl::*;
     with_transaction(pool, async |conn| -> Result<(), ApiError> {
         let before_owner_revision = lock_permission_owner(conn, collection_id_for_revoke).await?;
-        let before = permissions
+        let before: Option<Permission> = permissions
             .filter(collection_id.eq(collection_id_for_revoke))
             .filter(group_id.eq(group_id_for_revoke))
             .for_update()
-            .first::<Permission>(conn)
+            .first::<PermissionRow>(conn)
             .await
-            .optional()?;
+            .optional()?
+            .map(Into::into);
 
         diesel::delete(permissions)
             .filter(collection_id.eq(collection_id_for_revoke))
@@ -932,4 +1117,31 @@ pub(crate) async fn revoke_all_permission_grants(
         Ok(())
     })
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PermissionFilter, Permissions};
+    use crate::schema::permissions::dsl::permissions;
+    use crate::storage::postgres::prelude::*;
+
+    #[test]
+    fn template_permissions_filter_map_to_expected_columns() {
+        let fixtures = [
+            (Permissions::ReadTemplate, "has_read_template"),
+            (Permissions::CreateTemplate, "has_create_template"),
+            (Permissions::UpdateTemplate, "has_update_template"),
+            (Permissions::DeleteTemplate, "has_delete_template"),
+        ];
+
+        for (permission, expected_column) in fixtures {
+            let base_query = permissions.into_boxed();
+            let filtered = permission.create_boxed_filter(base_query, true);
+            let sql = diesel::debug_query::<diesel::pg::Pg, _>(&filtered).to_string();
+            assert!(
+                sql.contains(expected_column),
+                "Expected SQL to contain '{expected_column}', got: {sql}"
+            );
+        }
+    }
 }

--- a/src/storage/postgres/operations/task_import.rs
+++ b/src/storage/postgres/operations/task_import.rs
@@ -11,10 +11,9 @@ use crate::models::{
     ImportEventSinkInput, ImportEventSubscriptionInput, ImportExportTemplateInput,
     ImportGroupInput, ImportGroupMembershipInput, ImportIdentityScopeInput, ImportObjectInput,
     ImportPrincipalInput, ImportPrincipalSubtype, ImportRemoteTargetInput, ImportWriteCondition,
-    NewHubuumClass, NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation,
-    NewPermission, Permission, Permissions, PermissionsList, Principal, ResourceRevision,
-    RestoreTimestamps, ServiceAccount, UpdateCollection, UpdateHubuumClass, UpdateHubuumObject,
-    UpdatePermission, User,
+    NewHubuumClass, NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, Permission,
+    Permissions, PermissionsList, Principal, ResourceRevision, RestoreTimestamps, ServiceAccount,
+    UpdateCollection, UpdateHubuumClass, UpdateHubuumObject, User,
 };
 use crate::storage::postgres::operations::class::{
     HubuumClassRow, NewHubuumClassRow, UpdateHubuumClassRow,
@@ -24,6 +23,9 @@ use crate::storage::postgres::operations::collection::{
 };
 use crate::storage::postgres::operations::object::{
     HubuumObjectRow, NewHubuumObjectRow, UpdateHubuumObjectRow,
+};
+use crate::storage::postgres::operations::permissions::{
+    NewPermission, PermissionRow, UpdatePermission,
 };
 use crate::storage::postgres::operations::relation_rows::{
     HubuumClassRelationRow, HubuumObjectRelationRow, NewHubuumClassRelationRow,
@@ -2011,7 +2013,7 @@ pub async fn apply_permissions_db(
     let existing = permissions_table
         .filter(collection_id.eq(collection_id_value))
         .filter(group_id.eq(group_id_value))
-        .first::<Permission>(conn)
+        .first::<PermissionRow>(conn)
         .await
         .optional()?;
     if existing.is_some() && !overwrite {
@@ -2021,7 +2023,7 @@ pub async fn apply_permissions_db(
     }
 
     let permission_list = PermissionsList::new(permissions.to_vec());
-    match existing {
+    let permission = match existing {
         Some(existing) => {
             let mut update = if replace_existing {
                 UpdatePermission {
@@ -2069,13 +2071,13 @@ pub async fn apply_permissions_db(
                         .filter(group_id.eq(group_id_value)),
                 )
                 .set(&update)
-                .get_result::<Permission>(conn)
+                .get_result::<PermissionRow>(conn)
                 .await
                 .optional(),
                 async move || Ok(existing),
             )
             .await
-            .map_err(ApiError::from)
+            .map_err(ApiError::from)?
         }
         None => {
             let new_entry = NewPermission {
@@ -2128,11 +2130,12 @@ pub async fn apply_permissions_db(
 
             diesel::insert_into(permissions_table)
                 .values(&new_entry)
-                .get_result::<Permission>(conn)
+                .get_result::<PermissionRow>(conn)
                 .await
-                .map_err(ApiError::from)
+                .map_err(ApiError::from)?
         }
-    }
+    };
+    Ok(permission.into())
 }
 
 fn normalize_pair(left: i32, right: i32) -> (i32, i32) {

--- a/src/storage/postgres/operations/user/membership.rs
+++ b/src/storage/postgres/operations/user/membership.rs
@@ -162,7 +162,6 @@ where
     where
         &'a I: IntoIterator<Item = &'a Permissions>,
     {
-        use crate::models::PermissionFilter;
         use crate::schema::collection_closure::dsl::{
             ancestor_collection_id, collection_closure, descendant_collection_id,
         };
@@ -170,6 +169,7 @@ where
         use crate::schema::permissions::dsl::{
             collection_id as permission_collection_id, group_id, permissions,
         };
+        use crate::storage::postgres::operations::permissions::PermissionFilter;
 
         let requested: Vec<Permissions> = permissions_list.into_iter().copied().collect();
 

--- a/src/storage/postgres/operations/user/search.rs
+++ b/src/storage/postgres/operations/user/search.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::models::RelatedObjectForRootRow;
-use crate::models::permissions::PermissionFilter;
 use crate::models::search::{
     DEFAULT_RELATED_FILTER_DEPTH, Operator, ParsedQueryParamExt, ParsedQueryParamSqlExt,
     RelatedClassField, RelatedFilterTarget, RelatedObjectField, SQLComponent, SQLValue,
@@ -16,6 +15,7 @@ use crate::storage::postgres::operations::computed_field::{
     ComputedQuerySnapshot, computed_filter_predicate, object_cursor_sql_fields,
 };
 use crate::storage::postgres::operations::object::HubuumObjectRow;
+use crate::storage::postgres::operations::permissions::PermissionFilter;
 use crate::storage::postgres::operations::relation_rows::{
     ClassGraphQueryRow, HubuumClassRelationRow, HubuumObjectRelationRow,
     RelatedObjectForRootQueryRow, RelatedObjectGraphQueryRow, RelatedObjectIncludeQueryRow,

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -214,6 +214,67 @@ fn backend_neutral_layers_do_not_import_database_implementation_details() {
 }
 
 #[test]
+fn permission_domain_types_are_free_of_persistence_implementation_details() {
+    let root = repository_root();
+    let mut violations = Vec::new();
+
+    for relative_path in [
+        "src/models/permissions.rs",
+        "src/models/output.rs",
+        "src/models/traits/output.rs",
+    ] {
+        let path = root.join(relative_path);
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(&source);
+        for forbidden in [
+            "diesel::",
+            "diesel(",
+            "crate::schema",
+            "storage::postgres",
+            "CursorSqlMapping",
+            "CursorSqlField",
+            "CursorSqlType",
+            "PermissionFilter",
+        ] {
+            if production_source.contains(forbidden) {
+                violations.push(format!("{} contains {forbidden}", path.display()));
+            }
+        }
+    }
+
+    let adapter_path = root.join("src/storage/postgres/operations/permissions.rs");
+    let adapter_source = fs::read_to_string(&adapter_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", adapter_path.display()));
+    for required in [
+        "struct PermissionRow",
+        "struct NewPermission",
+        "struct UpdatePermission",
+        "impl From<PermissionRow> for Permission",
+        "trait PermissionFilter",
+    ] {
+        assert!(
+            adapter_source.contains(required),
+            "PostgreSQL permission adapter is missing {required}"
+        );
+    }
+
+    let query_path = root.join("src/storage/postgres/operations/collection/permissions.rs");
+    let query_source = fs::read_to_string(&query_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", query_path.display()));
+    assert!(
+        query_source.contains("impl CursorSqlMapping for GroupPermissionQueryRow"),
+        "PostgreSQL adapter must own the group-permission SQL cursor mapping"
+    );
+
+    assert!(
+        violations.is_empty(),
+        "permission domain types crossed into persistence details:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
 fn collection_domain_types_are_free_of_persistence_implementation_details() {
     let root = repository_root();
     let mut violations = Vec::new();


### PR DESCRIPTION
## Summary

- make Permission and GroupPermission backend-neutral domain/API DTOs with no Diesel derives, schema bindings, PostgreSQL imports, or SQL cursor mappings
- move permission query, insert, update, filter, and group-permission cursor representations into the PostgreSQL adapter
- convert adapter rows explicitly at authorization, collection projection, import, and mutation boundaries
- add an architecture regression test that keeps permission domain/output sources free of persistence details

## Architecture

The Permissions policy enum and Permission grant DTO remain shared domain types. PostgreSQL now owns PermissionRow, its insert/update records, permission-column filter construction, and the joined group-permission SQL cursor mapping. Application and storage-contract consumers receive domain grants and never load or select those domain types as database rows.

This is a representation-ownership refactor. It does not add or remove a selectable-backend capability, change StorageError or ApiError behavior, alter public HTTP schemas, change the database schema, or change the storage contract version.

## Changelog

No changelog entry is warranted: this layer has no user-visible behavior, configuration, schema, or compatibility change.

## Verification

- source .env && ./run_tests.sh
- cargo clippy --all-targets --features integration-test-support -- -D warnings
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"
- scripts/test-classify-ci-changes.sh
- cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked

Part of #27.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
