### PR TITLE
Enforce group persistence boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Breaking (administrator API):** the storage contract version is now `26`.
+  Group lifecycle, identity-scope resolution, membership mutation, listing,
+  paging, and counting now cross one mandatory, uniformly observed backend
+  contract. Group, membership, update, and SQL cursor rows are owned by the
+  PostgreSQL adapter; group and membership domain models contain no Diesel or
+  PostgreSQL implementation details. Required capability labels and public HTTP request
+  and response shapes are unchanged. Administration and monitoring clients
+  matching contract version `25` must accept version `26`.
 - **Breaking (administrator API):** the storage contract version is now `25`.
   Collection point and compatibility writes, hierarchy operations, and
   collection-permission projections now cross mandatory, uniformly observed

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -182,7 +182,7 @@ use std::fmt;
 ///
 /// Increment this when a selectable backend must implement a new capability
 /// family or when an existing family's externally observable semantics change.
-pub const STORAGE_CONTRACT_VERSION: u16 = 25;
+pub const STORAGE_CONTRACT_VERSION: u16 = 26;
 
 /// Stable identity of a selectable storage backend.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -99,7 +99,9 @@ while `CollectionPermissionStorage` exposes operation-shaped grant projections
 without leaking a query builder. `ClassRecordStorage` and `ObjectRecordStorage`
 keep transitional point-load, validation, bulk lookup, and event-suppressed
 fixture operations behind the same mandatory backend boundary. None of these
-contracts exposes rows or connections.
+contracts exposes rows or connections. `GroupStorage` owns group point reads,
+identity-scope resolution, lifecycle writes, membership mutation, listing,
+paging, and counting through backend-neutral domain values.
 `TaskQueueStorage` replaces task submission and reads, while
 `TaskExecutionStorage` owns the complete worker claim and state machine.
 `BackupSnapshotStorage` owns consistent full-system reads, and computed rebuild
@@ -123,11 +125,11 @@ considered complete merely because a marker exists.
 PostgreSQL query implementations live in
 `src/storage/postgres/operations/*`. Export-template, remote-target, event,
 event-sink, event-subscription, and event-delivery lifecycle rows are
-adapter-owned, as are permission query, insert, update, collection, class, and
-object lifecycle and history rows, class- and object-relation rows, relation
+adapter-owned, as are permission query, insert, update, group, membership, collection,
+class, and object lifecycle and history rows, class- and object-relation rows, relation
 graph query rows, remote-target history, and remote-call result persistence
-rows. Domain permission, collection, class, object, and relation values contain
-no Diesel derives, schema bindings, or SQL cursor mappings. Those mappings and
+rows. Domain permission, group, collection, class, object, and relation values
+contain no Diesel derives, schema bindings, or SQL cursor mappings. Those mappings and
 explicit conversions live in the PostgreSQL adapter. Remaining mixed
 persistence rows move there as their backend-neutral DTOs are extracted. Their
 current locations are implementation details, not partial backend support.
@@ -140,7 +142,10 @@ composition without implementing every operation behind those contracts.
 The storage contract version changes when a required family is added or when
 observable semantics change. The selected backend and contract version are
 reported in startup logs, process metrics, and the redacted admin configuration.
-Version 25 additionally requires collection point and compatibility writes,
+Version 26 additionally requires group point and lifecycle writes,
+identity-scope resolution, and complete membership mutation and query behavior
+to cross one mandatory, observed storage contract. Group, membership, update,
+and SQL cursor rows are adapter-owned. Version 25 required collection point and compatibility writes,
 hierarchy operations, and collection-permission projections to cross mandatory,
 observed storage contracts. Collection lifecycle and history rows, Diesel
 mappings, and SQL cursor mappings are adapter-owned. Version 24 required class

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -454,7 +454,7 @@ mod tests {
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
         assert!(json.contains("\"backend\":\"postgresql\""));
-        assert!(json.contains("\"contract_version\":25"));
+        assert!(json.contains("\"contract_version\":26"));
         assert!(json.contains("\"catalog_queries\""));
         assert!(json.contains("\"computed_object_queries\""));
         assert!(json.contains("\"computed_field_lifecycle\""));

--- a/src/models/group.rs
+++ b/src/models/group.rs
@@ -3,25 +3,15 @@
 use crate::errors::ApiError;
 use crate::events::EventContext;
 use crate::models::principal::Principal;
-use crate::models::principal_group::NewPrincipalGroup;
 use crate::models::search::{FilterField, QueryOptions, SortParam};
 use crate::models::{LOCAL_PROVIDER_KIND, ResourceRevision};
-use crate::schema::groups;
-use crate::storage::postgres::operations::group::{
-    DeleteGroupRecord, GroupMembersBackend, LoadGroupRecord, SaveGroupRecord,
-    SavePrincipalGroupRecord, UpdateGroupRecord, group_identity_scope_name,
-};
-
-use crate::storage::StorageContext;
-use crate::storage::postgres::prelude::*;
+use crate::storage::{GroupStorage, StorageContext, storage_handle};
 use crate::traits::PrincipalIdAccessor;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::traits::accessors::{IdAccessor, InstanceAdapter};
-use crate::traits::{
-    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
-};
+use crate::traits::{CursorPaginated, CursorValue};
 
 crate::int_id_newtype! {
     /// Identifier wrapper for a [`Group`].
@@ -49,7 +39,10 @@ impl GroupID {
     where
         C: StorageContext,
     {
-        self.load_group_record(backend).await
+        storage_handle(backend)
+            .load_group(self.id())
+            .await
+            .map_err(ApiError::from)
     }
 
     /// Delete this group without emitting domain events.
@@ -61,7 +54,10 @@ impl GroupID {
     where
         C: StorageContext,
     {
-        self.delete_group_record_without_events(backend).await
+        storage_handle(backend)
+            .delete_group(self.id(), None)
+            .await
+            .map_err(ApiError::from)
     }
 
     pub async fn delete<C>(
@@ -72,14 +68,14 @@ impl GroupID {
     where
         C: StorageContext,
     {
-        self.delete_group_record(backend, context).await
+        storage_handle(backend)
+            .delete_group(self.id(), context)
+            .await
+            .map_err(ApiError::from)
     }
 }
 
-#[derive(
-    Serialize, Deserialize, Queryable, Selectable, Insertable, PartialEq, Debug, Clone, ToSchema,
-)]
-#[diesel(table_name = groups)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, ToSchema)]
 pub struct Group {
     pub id: i32,
     pub groupname: String,
@@ -252,7 +248,10 @@ impl Group {
     where
         C: StorageContext,
     {
-        let identity_scope = group_identity_scope_name(backend, self.id).await?;
+        let identity_scope = storage_handle(backend)
+            .group_identity_scope_name(self.id)
+            .await
+            .map_err(ApiError::from)?;
         Ok(GroupResponse::from_parts(self, identity_scope))
     }
 
@@ -267,7 +266,10 @@ impl Group {
     where
         C: StorageContext,
     {
-        self.load_group_members(backend).await
+        storage_handle(backend)
+            .group_members(self.id)
+            .await
+            .map_err(ApiError::from)
     }
 
     pub async fn members_paginated<C>(
@@ -278,8 +280,10 @@ impl Group {
     where
         C: StorageContext,
     {
-        self.load_group_members_paginated(backend, query_options)
+        storage_handle(backend)
+            .group_members_page(self.id, query_options)
             .await
+            .map_err(ApiError::from)
     }
 
     pub async fn count_members_paginated<C>(
@@ -290,8 +294,10 @@ impl Group {
     where
         C: StorageContext,
     {
-        self.count_group_members_paginated(backend, query_options)
+        storage_handle(backend)
+            .count_group_members(self.id, query_options)
             .await
+            .map_err(ApiError::from)
     }
 
     /// Add a member to a group. If the user is already a member, do nothing.
@@ -319,12 +325,10 @@ impl Group {
         C: StorageContext,
         P: PrincipalIdAccessor,
     {
-        NewPrincipalGroup {
-            principal_id: member.principal_id(),
-            group_id: self.id,
-        }
-        .save_principal_group_record_without_events(backend)
-        .await?;
+        storage_handle(backend)
+            .add_group_member(member.principal_id(), self.id, None)
+            .await
+            .map_err(ApiError::from)?;
 
         Ok(())
     }
@@ -339,12 +343,10 @@ impl Group {
         C: StorageContext,
         P: PrincipalIdAccessor,
     {
-        NewPrincipalGroup {
-            principal_id: member.principal_id(),
-            group_id: self.id,
-        }
-        .save_principal_group_record(backend, context)
-        .await
+        storage_handle(backend)
+            .add_group_member(member.principal_id(), self.id, context)
+            .await
+            .map_err(ApiError::from)
     }
 
     /// Remove a member from this group without emitting domain events.
@@ -361,8 +363,10 @@ impl Group {
         C: StorageContext,
         P: PrincipalIdAccessor,
     {
-        self.remove_group_member_from_backend_without_events(member.principal_id(), backend)
+        storage_handle(backend)
+            .remove_group_member(member.principal_id(), self.id, None)
             .await
+            .map_err(ApiError::from)
     }
 
     pub async fn remove_member<C, P>(
@@ -375,8 +379,10 @@ impl Group {
         C: StorageContext,
         P: PrincipalIdAccessor,
     {
-        self.remove_group_member_from_backend(member.principal_id(), backend, context)
+        storage_handle(backend)
+            .remove_group_member(member.principal_id(), self.id, context)
             .await
+            .map_err(ApiError::from)
     }
 
     /// Delete this group without emitting domain events.
@@ -388,7 +394,10 @@ impl Group {
     where
         C: StorageContext,
     {
-        self.delete_group_record_without_events(backend).await
+        storage_handle(backend)
+            .delete_group(self.id, None)
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -410,7 +419,10 @@ impl NewGroup {
     where
         C: StorageContext,
     {
-        self.save_group_record_without_events(backend).await
+        storage_handle(backend)
+            .create_group(self, None)
+            .await
+            .map_err(ApiError::from)
     }
 
     pub async fn save<C>(
@@ -421,13 +433,15 @@ impl NewGroup {
     where
         C: StorageContext,
     {
-        self.save_group_record(backend, context).await
+        storage_handle(backend)
+            .create_group(self, context)
+            .await
+            .map_err(ApiError::from)
     }
 }
 
-#[derive(Deserialize, Serialize, AsChangeset, ToSchema)]
+#[derive(Deserialize, Serialize, ToSchema)]
 #[schema(example = update_group_example)]
-#[diesel(table_name = groups)]
 pub struct UpdateGroup {
     pub groupname: Option<String>,
 }
@@ -455,8 +469,10 @@ impl UpdateGroup {
     where
         C: StorageContext,
     {
-        self.update_group_record_without_events(group_id.id(), backend)
+        storage_handle(backend)
+            .update_group(group_id.id(), self, None)
             .await
+            .map_err(ApiError::from)
     }
 
     pub async fn save<C>(
@@ -468,8 +484,10 @@ impl UpdateGroup {
     where
         C: StorageContext,
     {
-        self.update_group_record(group_id.id(), backend, context)
+        storage_handle(backend)
+            .update_group(group_id.id(), self, context)
             .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -529,48 +547,5 @@ impl CursorPaginated for Group {
 
     fn tie_breaker_sort() -> Vec<SortParam> {
         Self::default_sort()
-    }
-}
-
-impl CursorSqlMapping for Group {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id => CursorSqlField {
-                column: "groups.id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Name | FilterField::Groupname => CursorSqlField {
-                column: "groups.groupname",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::Description => CursorSqlField {
-                column: "groups.description",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::CreatedAt => CursorSqlField {
-                column: "groups.created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAt => CursorSqlField {
-                column: "groups.updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::Revision => CursorSqlField {
-                column: "groups.revision",
-                sql_type: CursorSqlType::BigInt,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for groups",
-                    field
-                )));
-            }
-        })
     }
 }

--- a/src/models/principal_group.rs
+++ b/src/models/principal_group.rs
@@ -1,25 +1,16 @@
 use crate::models::ResourceRevision;
 use crate::models::group::Group;
 use crate::models::principal::Principal;
-use crate::storage::postgres::operations::group::{
-    DeletePrincipalGroupRecord, PrincipalGroupGroupLookup, PrincipalGroupPrincipalLookup,
-    SavePrincipalGroupRecord,
-};
 
 use crate::errors::ApiError;
-use crate::schema::group_memberships;
-use crate::storage::StorageContext;
+use crate::storage::{GroupStorage, StorageContext, storage_handle};
 
-use crate::storage::postgres::prelude::*;
 use crate::traits::crud::SaveAdapter;
 use serde::{Deserialize, Serialize};
 
 /// A principal's membership in a group. Both human users and service accounts
 /// participate through this single table.
-#[derive(Serialize, Deserialize, Queryable, Insertable, Associations)]
-#[diesel(belongs_to(Principal))]
-#[diesel(belongs_to(Group))]
-#[diesel(table_name = group_memberships)]
+#[derive(Serialize, Deserialize)]
 pub struct PrincipalGroup {
     pub principal_id: i32,
     pub group_id: i32,
@@ -28,8 +19,7 @@ pub struct PrincipalGroup {
     pub revision: ResourceRevision,
 }
 
-#[derive(Serialize, Deserialize, Insertable)]
-#[diesel(table_name = group_memberships)]
+#[derive(Serialize, Deserialize)]
 pub struct NewPrincipalGroup {
     pub principal_id: i32,
     pub group_id: i32,
@@ -42,7 +32,10 @@ impl SaveAdapter for NewPrincipalGroup {
         &self,
         pool: &impl crate::storage::StorageContext,
     ) -> Result<Self::Output, ApiError> {
-        self.save_principal_group_record_without_events(pool).await
+        storage_handle(pool)
+            .add_group_member(self.principal_id, self.group_id, None)
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -51,28 +44,39 @@ impl PrincipalGroup {
     where
         C: StorageContext,
     {
-        self.load_principal_group_principal(backend).await
+        storage_handle(backend)
+            .group_member_principal(self.principal_id)
+            .await
+            .map_err(ApiError::from)
     }
 
     pub async fn group<C>(&self, backend: &C) -> Result<Group, ApiError>
     where
         C: StorageContext,
     {
-        self.load_principal_group_group(backend).await
+        storage_handle(backend)
+            .load_group(self.group_id)
+            .await
+            .map_err(ApiError::from)
     }
 
     pub async fn save<C>(&self, backend: &C) -> Result<PrincipalGroup, ApiError>
     where
         C: StorageContext,
     {
-        self.save_principal_group_record_without_events(backend)
+        storage_handle(backend)
+            .add_group_member(self.principal_id, self.group_id, None)
             .await
+            .map_err(ApiError::from)
     }
 
     pub async fn delete<C>(&self, backend: &C) -> Result<(), ApiError>
     where
         C: StorageContext,
     {
-        self.delete_principal_group_record(backend).await
+        storage_handle(backend)
+            .remove_group_member(self.principal_id, self.group_id, None)
+            .await
+            .map_err(ApiError::from)
     }
 }

--- a/src/storage/context.rs
+++ b/src/storage/context.rs
@@ -12,8 +12,9 @@ use crate::models::output::{EffectiveGroupPermission, GroupPermission};
 use crate::models::search::QueryOptions;
 use crate::models::{
     ClassIdSet, Collection, CollectionKey, HubuumClass, HubuumObject, ImportMode, MaintenanceState,
-    NewCollectionWithAssignee, NewHubuumClass, NewHubuumObject, TokenRetentionSettings,
-    UpdateCollection, UpdateHubuumClass, UpdateHubuumObject,
+    NewCollectionWithAssignee, NewGroup, NewHubuumClass, NewHubuumObject, Principal,
+    PrincipalGroup, TokenRetentionSettings, UpdateCollection, UpdateGroup, UpdateHubuumClass,
+    UpdateHubuumObject,
 };
 use crate::models::{Group, Permission};
 use crate::permissions::{AppContext, PermissionBackend};
@@ -38,9 +39,9 @@ use crate::storage::{
     EventArchive, EventDeliveryAdministrationStorage, EventDeliveryBatch, EventDeliveryClaim,
     EventDeliveryHealthSnapshot, EventDeliveryStorage, EventFanoutStorage, EventHealthStorage,
     EventMetricsSnapshot, EventRetentionStorage, EventRetentionSummary, EventSubscriptionStorage,
-    ExportQueryStorage, ExportTemplateHistoryRecord, ExportTemplateStorage, HistoryAsOfQuery,
-    HistoryListQuery, HistoryPage, HistoryPrincipalName, HistoryStorage, IdentityStorage,
-    ImportStorage, InventoryGaugeSnapshot, InventoryStorage, MetricsStorage,
+    ExportQueryStorage, ExportTemplateHistoryRecord, ExportTemplateStorage, GroupStorage,
+    HistoryAsOfQuery, HistoryListQuery, HistoryPage, HistoryPrincipalName, HistoryStorage,
+    IdentityStorage, ImportStorage, InventoryGaugeSnapshot, InventoryStorage, MetricsStorage,
     ObjectAggregateAuthorizer, ObjectAggregateStorage, ObjectAggregateStorageQuery,
     ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectHistoryRecord, ObjectRecordStorage,
     ObjectRelationsTouchingIdsQuery, OperationalExportTemplateAuditEntry,
@@ -2692,6 +2693,161 @@ impl InventoryStorage for StorageHandle {
         observe_storage_call(self.backend_name(), "inventory", "counts", async {
             match &self.implementation {
                 BackendImplementation::Postgresql(backend) => backend.inventory_counts().await,
+            }
+        })
+        .await
+    }
+}
+
+#[async_trait]
+impl GroupStorage for StorageHandle {
+    async fn load_group(&self, group_id: i32) -> Result<Group, StorageError> {
+        observe_storage_call(self.backend_name(), "groups", "load", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => backend.load_group(group_id).await,
+            }
+        })
+        .await
+    }
+
+    async fn group_identity_scope_name(&self, group_id: i32) -> Result<String, StorageError> {
+        observe_storage_call(self.backend_name(), "groups", "identity_scope", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.group_identity_scope_name(group_id).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn create_group(
+        &self,
+        command: &NewGroup,
+        context: Option<&EventContext>,
+    ) -> Result<Group, StorageError> {
+        observe_storage_call(self.backend_name(), "groups", "create", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.create_group(command, context).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn update_group(
+        &self,
+        group_id: i32,
+        update: &UpdateGroup,
+        context: Option<&EventContext>,
+    ) -> Result<Group, StorageError> {
+        observe_storage_call(self.backend_name(), "groups", "update", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.update_group(group_id, update, context).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn delete_group(
+        &self,
+        group_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<usize, StorageError> {
+        observe_storage_call(self.backend_name(), "groups", "delete", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.delete_group(group_id, context).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn group_members(&self, group_id: i32) -> Result<Vec<Principal>, StorageError> {
+        observe_storage_call(self.backend_name(), "groups", "members", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => backend.group_members(group_id).await,
+            }
+        })
+        .await
+    }
+
+    async fn group_members_page(
+        &self,
+        group_id: i32,
+        query_options: &QueryOptions,
+    ) -> Result<Vec<(PrincipalGroup, Principal)>, StorageError> {
+        observe_storage_call(self.backend_name(), "groups", "members_page", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.group_members_page(group_id, query_options).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn count_group_members(
+        &self,
+        group_id: i32,
+        query_options: &QueryOptions,
+    ) -> Result<i64, StorageError> {
+        observe_storage_call(self.backend_name(), "groups", "members_count", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.count_group_members(group_id, query_options).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn group_member_principal(&self, principal_id: i32) -> Result<Principal, StorageError> {
+        observe_storage_call(self.backend_name(), "groups", "member_principal", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.group_member_principal(principal_id).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn add_group_member(
+        &self,
+        principal_id: i32,
+        group_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<PrincipalGroup, StorageError> {
+        observe_storage_call(self.backend_name(), "groups", "member_add", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend
+                        .add_group_member(principal_id, group_id, context)
+                        .await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn remove_group_member(
+        &self,
+        principal_id: i32,
+        group_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError> {
+        observe_storage_call(self.backend_name(), "groups", "member_remove", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend
+                        .remove_group_member(principal_id, group_id, context)
+                        .await
+                }
             }
         })
         .await

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -6,12 +6,12 @@ use super::{
     CollectionPermissionStorage, CollectionRecordStorage, CollectionStore,
     ComputedFieldLifecycleStorage, ComputedObjectStorage, EventDeliveryAdministrationStorage,
     EventDeliveryStorage, EventFanoutStorage, EventHealthStorage, EventRetentionStorage,
-    EventSubscriptionStorage, ExportQueryStorage, ExportTemplateStorage, HistoryStorage,
-    IdentityStorage, ImportStorage, InventoryStorage, MetricsStorage, ObjectAggregateStorage,
-    ObjectRecordStorage, ObjectRelationStore, ObjectStore, OperationalStateStorage,
-    PostgresStorage, RelationQueryStorage, RemoteTargetStorage, RestoreStorage, StorageExecution,
-    TaskExecutionStorage, TaskQueueStorage, TokenRetentionStorage, UnifiedSearchStorage,
-    observed::ObservedLifecycleStorage,
+    EventSubscriptionStorage, ExportQueryStorage, ExportTemplateStorage, GroupStorage,
+    HistoryStorage, IdentityStorage, ImportStorage, InventoryStorage, MetricsStorage,
+    ObjectAggregateStorage, ObjectRecordStorage, ObjectRelationStore, ObjectStore,
+    OperationalStateStorage, PostgresStorage, RelationQueryStorage, RemoteTargetStorage,
+    RestoreStorage, StorageExecution, TaskExecutionStorage, TaskQueueStorage,
+    TokenRetentionStorage, UnifiedSearchStorage, observed::ObservedLifecycleStorage,
 };
 
 #[cfg(test)]
@@ -78,6 +78,7 @@ pub(crate) trait StorageBackend:
     + OperationalStateStorage
     + TokenRetentionStorage
     + UnifiedSearchStorage
+    + GroupStorage
     + CollectionPermissionStorage
     + CollectionRecordStorage
     + ClassRecordStorage

--- a/src/storage/groups.rs
+++ b/src/storage/groups.rs
@@ -1,0 +1,67 @@
+use async_trait::async_trait;
+
+use crate::events::EventContext;
+use crate::models::search::QueryOptions;
+use crate::models::{Group, NewGroup, Principal, PrincipalGroup, UpdateGroup};
+
+use super::StorageError;
+
+/// Complete group lifecycle and membership behavior required from every backend.
+///
+/// The application owns group and membership DTOs. Backends own persistence,
+/// coordination, event atomicity, query construction, and implementation errors.
+#[async_trait]
+pub(crate) trait GroupStorage: Send + Sync {
+    async fn load_group(&self, group_id: i32) -> Result<Group, StorageError>;
+
+    async fn group_identity_scope_name(&self, group_id: i32) -> Result<String, StorageError>;
+
+    async fn create_group(
+        &self,
+        command: &NewGroup,
+        context: Option<&EventContext>,
+    ) -> Result<Group, StorageError>;
+
+    async fn update_group(
+        &self,
+        group_id: i32,
+        update: &UpdateGroup,
+        context: Option<&EventContext>,
+    ) -> Result<Group, StorageError>;
+
+    async fn delete_group(
+        &self,
+        group_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<usize, StorageError>;
+
+    async fn group_members(&self, group_id: i32) -> Result<Vec<Principal>, StorageError>;
+
+    async fn group_members_page(
+        &self,
+        group_id: i32,
+        query_options: &QueryOptions,
+    ) -> Result<Vec<(PrincipalGroup, Principal)>, StorageError>;
+
+    async fn count_group_members(
+        &self,
+        group_id: i32,
+        query_options: &QueryOptions,
+    ) -> Result<i64, StorageError>;
+
+    async fn group_member_principal(&self, principal_id: i32) -> Result<Principal, StorageError>;
+
+    async fn add_group_member(
+        &self,
+        principal_id: i32,
+        group_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<PrincipalGroup, StorageError>;
+
+    async fn remove_group_member(
+        &self,
+        principal_id: i32,
+        group_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError>;
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -7,6 +7,7 @@ mod context;
 mod contract;
 mod execution;
 mod factory;
+mod groups;
 mod imports;
 #[cfg(test)]
 mod memory;
@@ -40,6 +41,7 @@ pub use execution::{
 #[cfg(feature = "embedded-migrations")]
 pub(crate) use factory::run_storage_migrations;
 pub(crate) use factory::{StorageSettings, initialize_storage};
+pub(crate) use groups::GroupStorage;
 pub(crate) use hubuum_storage_core::{
     AuditEventStorage, AuthenticationCredential, AuthenticationHuman, AuthenticationIdentity,
     AuthenticationPrincipal, AuthenticationResourceScope, AuthenticationStorage,

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -27,14 +27,15 @@ use crate::events::{
 use crate::models::output::{EffectiveGroupPermission, GroupPermission};
 use crate::models::search::QueryOptions;
 use crate::models::{
-    ClassIdSet, ClassSelector, Collection, CollectionID, Group, HubuumClass, HubuumClassID,
-    HubuumClassRelation, HubuumClassRelationID, HubuumObject, HubuumObjectID, HubuumObjectRelation,
-    HubuumObjectRelationID, MaintenanceState, NewCollectionWithAssignee, NewHubuumClass,
-    NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, ObjectDataPatchDocument,
-    ObjectRelationCreateSelector, ObjectRelationSelector, ObjectSelector, Permission,
-    PreparedClassRelation, PreparedObjectRelation, PrincipalID, ResolvedClassRelationTarget,
-    ResolvedClassTarget, ResolvedObjectRelationTarget, ResolvedObjectTarget,
-    TokenRetentionSettings, UpdateCollection, UpdateHubuumClass, UpdateHubuumObject,
+    ClassIdSet, ClassSelector, Collection, CollectionID, Group, GroupID, HubuumClass,
+    HubuumClassID, HubuumClassRelation, HubuumClassRelationID, HubuumObject, HubuumObjectID,
+    HubuumObjectRelation, HubuumObjectRelationID, MaintenanceState, NewCollectionWithAssignee,
+    NewGroup, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation,
+    ObjectDataPatchDocument, ObjectRelationCreateSelector, ObjectRelationSelector, ObjectSelector,
+    Permission, PreparedClassRelation, PreparedObjectRelation, Principal, PrincipalGroup,
+    PrincipalID, ResolvedClassRelationTarget, ResolvedClassTarget, ResolvedObjectRelationTarget,
+    ResolvedObjectTarget, TokenRetentionSettings, UpdateCollection, UpdateGroup, UpdateHubuumClass,
+    UpdateHubuumObject,
 };
 use crate::storage::postgres::operations::GetCollection;
 use crate::storage::postgres::operations::class::{
@@ -51,6 +52,9 @@ use crate::storage::postgres::operations::collection::{
     groups_on_paginated_with_total_count_from_backend, move_collection_record_from_backend,
     principal_all_permissions_from_backend, principal_on_from_backend,
     principal_on_paginated_with_total_count_from_backend, user_can_on_any_from_backend,
+};
+use crate::storage::postgres::operations::group::{
+    DeleteGroupRecord, GroupMembersBackend, LoadGroupRecord, SaveGroupRecord, UpdateGroupRecord,
 };
 use crate::storage::postgres::operations::object::{
     CreateObjectInResolvedClassRecord, DeleteObjectRecord, DeleteResolvedObjectRecord,
@@ -85,9 +89,9 @@ use super::{
     ComputedObjectStorage, EventArchive, EventDeliveryAdministrationStorage, EventDeliveryBatch,
     EventDeliveryClaim, EventDeliveryHealthSnapshot, EventDeliveryStorage, EventFanoutStorage,
     EventHealthStorage, EventMetricsSnapshot, EventRetentionStorage, EventRetentionSummary,
-    EventSubscriptionStorage, ExportQueryStorage, ExportTemplateHistoryRecord, HistoryAsOfQuery,
-    HistoryCollectionScope, HistoryListQuery, HistoryPage, HistoryPrincipalName, HistoryStorage,
-    IdentityStorage, InventoryGaugeSnapshot, InventoryStorage, MetricsStorage,
+    EventSubscriptionStorage, ExportQueryStorage, ExportTemplateHistoryRecord, GroupStorage,
+    HistoryAsOfQuery, HistoryCollectionScope, HistoryListQuery, HistoryPage, HistoryPrincipalName,
+    HistoryStorage, IdentityStorage, InventoryGaugeSnapshot, InventoryStorage, MetricsStorage,
     ObjectAggregateAuthorizer, ObjectAggregateStorage, ObjectAggregateStorageQuery,
     ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectHistoryRecord, ObjectRecordStorage,
     ObjectRelationStore, ObjectRelationsTouchingIdsQuery, ObjectStore,
@@ -1286,6 +1290,126 @@ impl TokenRetentionStorage for PostgresStorage {
         settings: TokenRetentionSettings,
     ) -> Result<usize, StorageError> {
         operations::token_retention::purge_expired_token_batch(&self.pool, settings)
+            .await
+            .map_err(map_postgres_error)
+    }
+}
+
+#[async_trait]
+impl GroupStorage for PostgresStorage {
+    async fn load_group(&self, group_id: i32) -> Result<Group, StorageError> {
+        GroupID::new(group_id)
+            .map_err(map_postgres_error)?
+            .load_group_record(&self.pool)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn group_identity_scope_name(&self, group_id: i32) -> Result<String, StorageError> {
+        GroupID::new(group_id).map_err(map_postgres_error)?;
+        operations::group::group_identity_scope_name(&self.pool, group_id)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn create_group(
+        &self,
+        command: &NewGroup,
+        context: Option<&EventContext>,
+    ) -> Result<Group, StorageError> {
+        command
+            .save_group_record(&self.pool, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn update_group(
+        &self,
+        group_id: i32,
+        update: &UpdateGroup,
+        context: Option<&EventContext>,
+    ) -> Result<Group, StorageError> {
+        let group_id = GroupID::new(group_id).map_err(map_postgres_error)?;
+        update
+            .update_group_record(group_id.id(), &self.pool, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn delete_group(
+        &self,
+        group_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<usize, StorageError> {
+        GroupID::new(group_id)
+            .map_err(map_postgres_error)?
+            .delete_group_record(&self.pool, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn group_members(&self, group_id: i32) -> Result<Vec<Principal>, StorageError> {
+        let group = self.load_group(group_id).await?;
+        group
+            .load_group_members(&self.pool)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn group_members_page(
+        &self,
+        group_id: i32,
+        query_options: &QueryOptions,
+    ) -> Result<Vec<(PrincipalGroup, Principal)>, StorageError> {
+        let group = self.load_group(group_id).await?;
+        group
+            .load_group_members_paginated(&self.pool, query_options)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn count_group_members(
+        &self,
+        group_id: i32,
+        query_options: &QueryOptions,
+    ) -> Result<i64, StorageError> {
+        let group = self.load_group(group_id).await?;
+        group
+            .count_group_members_paginated(&self.pool, query_options)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn group_member_principal(&self, principal_id: i32) -> Result<Principal, StorageError> {
+        PrincipalID::new(principal_id).map_err(map_postgres_error)?;
+        operations::group::group_member_principal(&self.pool, principal_id)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn add_group_member(
+        &self,
+        principal_id: i32,
+        group_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<PrincipalGroup, StorageError> {
+        GroupID::new(group_id).map_err(map_postgres_error)?;
+        PrincipalID::new(principal_id).map_err(map_postgres_error)?;
+        operations::group::save_manual_membership(&self.pool, principal_id, group_id, context)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn remove_group_member(
+        &self,
+        principal_id: i32,
+        group_id: i32,
+        context: Option<&EventContext>,
+    ) -> Result<(), StorageError> {
+        PrincipalID::new(principal_id).map_err(map_postgres_error)?;
+        let group = self.load_group(group_id).await?;
+        group
+            .remove_group_member_from_backend(principal_id, &self.pool, context)
             .await
             .map_err(map_postgres_error)
     }

--- a/src/storage/postgres/operations/authorization.rs
+++ b/src/storage/postgres/operations/authorization.rs
@@ -8,6 +8,7 @@ use crate::models::{
 };
 use crate::storage::postgres::operations::collection as collection_backend;
 use crate::storage::postgres::operations::collection::CollectionRow;
+use crate::storage::postgres::operations::group::GroupRow;
 use crate::storage::postgres::operations::permissions as permission_backend;
 use crate::storage::postgres::operations::permissions::PermissionRow;
 use crate::storage::postgres::prelude::*;
@@ -160,7 +161,8 @@ fn collection_to_storage(collection: Collection) -> AuthorizationCollection {
     )
 }
 
-fn group_to_storage(group: Group) -> AuthorizationGroup {
+fn group_to_storage(group: impl Into<Group>) -> AuthorizationGroup {
+    let group = group.into();
     AuthorizationGroup::new(
         AuthorizationGroupIdentity::new(
             group.id,
@@ -432,7 +434,7 @@ pub(crate) async fn list_authorization_group_candidates(
             }
         }
     }
-    let rows = with_connection(pool, async |conn| query.load::<Group>(conn).await).await?;
+    let rows = with_connection(pool, async |conn| query.load::<GroupRow>(conn).await).await?;
     Ok(rows.into_iter().map(group_to_storage).collect())
 }
 
@@ -449,7 +451,7 @@ pub(crate) async fn authorization_policy_snapshot(
                 permissions::collection_id.asc(),
                 permissions::group_id.asc(),
             ))
-            .load::<(PermissionRow, Group, CollectionRow)>(conn)
+            .load::<(PermissionRow, GroupRow, CollectionRow)>(conn)
             .await
     })
     .await?;

--- a/src/storage/postgres/operations/bootstrap.rs
+++ b/src/storage/postgres/operations/bootstrap.rs
@@ -4,8 +4,9 @@ use crate::errors::ApiError;
 use crate::models::identity::{
     LOCAL_IDENTITY_SCOPE, LOCAL_PROVIDER_KIND, MANUAL_MEMBERSHIP_SOURCE,
 };
-use crate::models::{Group, NewPrincipal, PrincipalKind, User};
+use crate::models::{NewPrincipal, PrincipalKind, User};
 use crate::storage::StorageDefaultAdminBootstrap;
+use crate::storage::postgres::operations::group::GroupRow;
 use crate::storage::postgres::operations::identity::identity_scope_id_by_name_conn;
 use crate::storage::postgres::operations::principal::InsertPrincipalRecord;
 use crate::storage::postgres::prelude::*;
@@ -88,7 +89,7 @@ pub async fn bootstrap_default_admin(
                 crate::schema::groups::description.eq("Default admin group."),
                 crate::schema::groups::managed_by.eq(LOCAL_PROVIDER_KIND),
             ))
-            .get_result::<Group>(conn)
+            .get_result::<GroupRow>(conn)
             .await?;
         let principal = NewPrincipal {
             identity_scope_id: local_scope_id,

--- a/src/storage/postgres/operations/collection/mod.rs
+++ b/src/storage/postgres/operations/collection/mod.rs
@@ -12,6 +12,7 @@ use crate::models::{
 use crate::models::{HubuumClassRelation, NewHubuumObjectRelation};
 use crate::models::{HubuumObjectRelation, NewHubuumClassRelation};
 use crate::storage::postgres::operations::GetCollection;
+use crate::storage::postgres::operations::group::GroupRow;
 use crate::storage::postgres::operations::permissions::{PermissionFilter, PermissionRow};
 use crate::storage::postgres::{with_connection, with_transaction};
 use crate::traits::{

--- a/src/storage/postgres/operations/collection/permissions.rs
+++ b/src/storage/postgres/operations/collection/permissions.rs
@@ -64,7 +64,7 @@ impl CursorSqlMapping for GroupPermissionQueryRow {
 async fn build_effective_group_permissions(
     conn: &mut crate::storage::postgres::PostgresConnection,
     target_collection_id: i32,
-    rows: Vec<(i32, i32, Group, PermissionRow)>,
+    rows: Vec<(i32, i32, GroupRow, PermissionRow)>,
 ) -> Result<Vec<EffectiveGroupPermission>, ApiError> {
     use crate::schema::collections::dsl::{collections, id};
 
@@ -111,7 +111,7 @@ async fn build_effective_group_permissions(
                     source_collection,
                     depth,
                     inherited: depth > 0,
-                    group,
+                    group: group.into(),
                     permission: permission.into(),
                 })
             },
@@ -135,7 +135,7 @@ pub async fn principal_on_from_backend<S: AuthzSubject, T: CollectionAccessors>(
             .filter(collection_id.eq(collection_target_id))
             .filter(group_id.eq_any(group_ids_subquery))
             .select((groups::all_columns(), permissions::all_columns()))
-            .load::<(Group, PermissionRow)>(conn)
+            .load::<(GroupRow, PermissionRow)>(conn)
             .await
     })
     .await?;
@@ -143,7 +143,7 @@ pub async fn principal_on_from_backend<S: AuthzSubject, T: CollectionAccessors>(
     Ok(rows
         .into_iter()
         .map(|(group, permission)| GroupPermission {
-            group,
+            group: group.into(),
             permission: permission.into(),
         })
         .collect())
@@ -168,16 +168,18 @@ pub async fn principal_all_permissions_from_backend<S: AuthzSubject>(
             .filter(group_id.eq_any(group_ids_subquery))
             .select((
                 CollectionRow::as_select(),
-                Group::as_select(),
+                GroupRow::as_select(),
                 PermissionRow::as_select(),
             ))
-            .load::<(CollectionRow, Group, PermissionRow)>(conn)
+            .load::<(CollectionRow, GroupRow, PermissionRow)>(conn)
             .await
     })
     .await
     .map(|rows| {
         rows.into_iter()
-            .map(|(collection, group, permission)| (collection.into(), group, permission.into()))
+            .map(|(collection, group, permission)| {
+                (collection.into(), group.into(), permission.into())
+            })
             .collect()
     })
 }
@@ -249,14 +251,14 @@ pub async fn principal_on_paginated_with_total_count_from_backend<
     let mut query = build_query()?;
     crate::apply_query_options!(query, query_options, GroupPermissionQueryRow);
     let rows = with_connection(pool, async |conn| {
-        query.load::<(Group, PermissionRow)>(conn).await
+        query.load::<(GroupRow, PermissionRow)>(conn).await
     })
     .await?;
 
     Ok((
         rows.into_iter()
             .map(|(group, permission)| GroupPermission {
-                group,
+                group: group.into(),
                 permission: permission.into(),
             })
             .collect(),
@@ -297,7 +299,7 @@ pub async fn effective_principal_on_from_backend<S: AuthzSubject, T: CollectionA
                 groups::all_columns(),
                 permissions::all_columns(),
             ))
-            .load::<(i32, i32, Group, PermissionRow)>(conn)
+            .load::<(i32, i32, GroupRow, PermissionRow)>(conn)
             .await?;
 
         build_effective_group_permissions(conn, target_collection_id, rows).await
@@ -438,7 +440,7 @@ pub async fn effective_group_on_from_backend(
                 groups::all_columns(),
                 permissions::all_columns(),
             ))
-            .load::<(i32, i32, Group, PermissionRow)>(conn)
+            .load::<(i32, i32, GroupRow, PermissionRow)>(conn)
             .await?;
 
         build_effective_group_permissions(conn, target_collection_id, rows).await
@@ -481,10 +483,11 @@ pub async fn groups_can_on_from_backend(
         groups
             .filter(group_table_id.eq_any(group_ids))
             .order(group_table_id.asc())
-            .load::<Group>(conn)
+            .load::<GroupRow>(conn)
             .await
     })
     .await
+    .map(|rows| rows.into_iter().map(Into::into).collect())
 }
 
 pub async fn groups_can_on_paginated_with_total_count_from_backend(
@@ -556,8 +559,12 @@ pub async fn groups_can_on_paginated_with_total_count_from_backend(
     .await?;
 
     let mut query = build_query()?;
-    crate::apply_query_options!(query, query_options, Group);
-    let items = with_connection(pool, async |conn| query.load::<Group>(conn).await).await?;
+    crate::apply_query_options!(query, query_options, GroupRow);
+    let items = with_connection(pool, async |conn| query.load::<GroupRow>(conn).await)
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
 
     Ok((items, total_count))
 }
@@ -642,7 +649,7 @@ pub async fn groups_on_from_backend<T: CollectionAccessors>(
         base_query
             .inner_join(groups.on(group_table_id.eq(group_id)))
             .select((groups::all_columns(), permissions::all_columns()))
-            .load::<(Group, PermissionRow)>(conn)
+            .load::<(GroupRow, PermissionRow)>(conn)
             .await
     })
     .await?;
@@ -650,7 +657,7 @@ pub async fn groups_on_from_backend<T: CollectionAccessors>(
     Ok(rows
         .into_iter()
         .map(|(group, permission)| GroupPermission {
-            group,
+            group: group.into(),
             permission: permission.into(),
         })
         .collect())
@@ -739,7 +746,7 @@ pub async fn groups_on_paginated_with_total_count_from_backend<T: CollectionAcce
     let rows = with_connection(pool, async |conn| {
         query
             .select((groups::all_columns(), permissions::all_columns()))
-            .load::<(Group, PermissionRow)>(conn)
+            .load::<(GroupRow, PermissionRow)>(conn)
             .await
     })
     .await?;
@@ -747,7 +754,7 @@ pub async fn groups_on_paginated_with_total_count_from_backend<T: CollectionAcce
     Ok((
         rows.into_iter()
             .map(|(group, permission)| GroupPermission {
-                group,
+                group: group.into(),
                 permission: permission.into(),
             })
             .collect(),

--- a/src/storage/postgres/operations/external_identity.rs
+++ b/src/storage/postgres/operations/external_identity.rs
@@ -8,6 +8,7 @@ use crate::models::{
     EXTERNAL_MEMBERSHIP_SOURCE, LOCAL_PROVIDER_KIND, Principal, PrincipalKind, User,
 };
 use crate::storage::postgres::operations::event_record::emit_event;
+use crate::storage::postgres::operations::group::GroupRow;
 use crate::storage::postgres::operations::identity::ensure_identity_scope;
 use crate::storage::postgres::prelude::*;
 use crate::storage::postgres::{with_connection, with_transaction};
@@ -235,7 +236,7 @@ pub async fn sync_external_user(
                     groups_table::last_sync_attempted_at.eq(sync_time),
                     groups_table::last_sync_success_at.eq(sync_time),
                 ))
-                .get_result::<crate::models::Group>(conn)
+                .get_result::<GroupRow>(conn)
                 .await?;
             synced_group_ids.push(saved.id);
 

--- a/src/storage/postgres/operations/group.rs
+++ b/src/storage/postgres/operations/group.rs
@@ -6,18 +6,165 @@ use crate::events::{Action, EntityType, EventContext, NewEvent};
 use crate::models::identity::{
     LOCAL_IDENTITY_SCOPE, LOCAL_PROVIDER_KIND, MANUAL_MEMBERSHIP_SOURCE,
 };
-use crate::models::search::{FilterField, QueryOptions};
-use crate::models::{
-    Group, GroupID, NewGroup, NewPrincipalGroup, Principal, PrincipalGroup, UpdateGroup,
-};
+use crate::models::search::{FilterField, QueryOptions, SortParam};
+use crate::models::{Group, GroupID, NewGroup, Principal, PrincipalGroup, UpdateGroup};
 use crate::storage::postgres::operations::event_record::emit_event;
 use crate::storage::postgres::operations::identity::{
     identity_scope_by_name, identity_scope_id_by_name_conn,
 };
 use crate::storage::postgres::{PostgresConnection, with_connection, with_transaction};
+use crate::traits::{
+    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
+};
 use crate::{date_search, numeric_search, string_search};
 
 const OWNED_SERVICE_ACCOUNT_PREVIEW_LIMIT: i64 = 10;
+
+#[derive(Debug, Queryable, Selectable, Clone)]
+#[diesel(table_name = crate::schema::groups)]
+pub(crate) struct GroupRow {
+    pub(crate) id: i32,
+    pub(crate) groupname: String,
+    pub(crate) description: String,
+    pub(crate) created_at: chrono::NaiveDateTime,
+    pub(crate) updated_at: chrono::NaiveDateTime,
+    pub(crate) identity_scope_id: i32,
+    pub(crate) managed_by: String,
+    pub(crate) external_key: Option<String>,
+    pub(crate) last_sync_attempted_at: Option<chrono::NaiveDateTime>,
+    pub(crate) last_sync_success_at: Option<chrono::NaiveDateTime>,
+    pub(crate) revision: crate::models::ResourceRevision,
+}
+
+impl From<GroupRow> for Group {
+    fn from(row: GroupRow) -> Self {
+        Self {
+            id: row.id,
+            groupname: row.groupname,
+            description: row.description,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            identity_scope_id: row.identity_scope_id,
+            managed_by: row.managed_by,
+            external_key: row.external_key,
+            last_sync_attempted_at: row.last_sync_attempted_at,
+            last_sync_success_at: row.last_sync_success_at,
+            revision: row.revision,
+        }
+    }
+}
+
+#[derive(Debug, Queryable, Selectable, Clone)]
+#[diesel(table_name = crate::schema::group_memberships)]
+pub(crate) struct PrincipalGroupRow {
+    pub(crate) principal_id: i32,
+    pub(crate) group_id: i32,
+    pub(crate) created_at: chrono::NaiveDateTime,
+    pub(crate) updated_at: chrono::NaiveDateTime,
+    pub(crate) revision: crate::models::ResourceRevision,
+}
+
+impl From<PrincipalGroupRow> for PrincipalGroup {
+    fn from(row: PrincipalGroupRow) -> Self {
+        Self {
+            principal_id: row.principal_id,
+            group_id: row.group_id,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            revision: row.revision,
+        }
+    }
+}
+
+impl CursorPaginated for GroupRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        Group::supports_sort(field)
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorValue::Integer(self.id as i64),
+            FilterField::Name | FilterField::Groupname => {
+                CursorValue::String(self.groupname.clone())
+            }
+            FilterField::Description => CursorValue::String(self.description.clone()),
+            FilterField::CreatedAt => CursorValue::DateTime(self.created_at),
+            FilterField::UpdatedAt => CursorValue::DateTime(self.updated_at),
+            FilterField::Revision => CursorValue::Integer(self.revision.get()),
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for groups",
+                    field
+                )));
+            }
+        })
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        Group::default_sort()
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        Group::tie_breaker_sort()
+    }
+}
+
+impl CursorSqlMapping for GroupRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorSqlField {
+                column: "groups.id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Name | FilterField::Groupname => CursorSqlField {
+                column: "groups.groupname",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::Description => CursorSqlField {
+                column: "groups.description",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::CreatedAt => CursorSqlField {
+                column: "groups.created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAt => CursorSqlField {
+                column: "groups.updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::Revision => CursorSqlField {
+                column: "groups.revision",
+                sql_type: CursorSqlType::BigInt,
+                nullable: false,
+            },
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for groups",
+                    field
+                )));
+            }
+        })
+    }
+}
+
+#[derive(AsChangeset)]
+#[diesel(table_name = crate::schema::groups)]
+struct UpdateGroupRow<'a> {
+    groupname: Option<&'a str>,
+}
+
+impl<'a> From<&'a UpdateGroup> for UpdateGroupRow<'a> {
+    fn from(update: &'a UpdateGroup) -> Self {
+        Self {
+            groupname: update.groupname.as_deref(),
+        }
+    }
+}
 
 fn group_snapshot(group: &Group) -> serde_json::Value {
     serde_json::json!({
@@ -76,10 +223,10 @@ async fn insert_effective_membership(
         .filter(principal_id.eq(principal))
         .filter(group_id.eq(group))
         .for_update()
-        .first::<PrincipalGroup>(conn)
+        .first::<PrincipalGroupRow>(conn)
         .await
         .optional()?;
-    if let Some(membership) = current {
+    if let Some(membership) = current.map(PrincipalGroup::from) {
         crate::storage::postgres::assert_locked_revision_precondition(
             conn,
             &owner_key,
@@ -97,7 +244,7 @@ async fn insert_effective_membership(
             crate::schema::group_memberships::group_id.eq(group),
         ))
         .on_conflict_do_nothing()
-        .get_result::<PrincipalGroup>(conn)
+        .get_result::<PrincipalGroupRow>(conn)
         .await
         .optional()?;
     match inserted {
@@ -165,9 +312,10 @@ async fn remove_manual_membership_source(
         .filter(group_memberships::principal_id.eq(principal))
         .filter(group_memberships::group_id.eq(group))
         .for_update()
-        .first::<PrincipalGroup>(conn)
+        .first::<PrincipalGroupRow>(conn)
         .await
-        .optional()?;
+        .optional()?
+        .map(PrincipalGroup::from);
     let Some(membership) = membership else {
         crate::storage::postgres::assert_revision_precondition_allows_missing_target(&owner_key)?;
         return Ok(None);
@@ -270,11 +418,12 @@ async fn lock_group_for_delete(
 ) -> Result<Group, ApiError> {
     use crate::schema::groups::dsl::{groups, id};
 
-    let group = groups
+    let group: Group = groups
         .filter(id.eq(group_id))
         .for_update()
-        .first::<Group>(conn)
-        .await?;
+        .first::<GroupRow>(conn)
+        .await?
+        .into();
     crate::storage::postgres::assert_locked_revision_precondition(
         conn,
         &RevisionOwner::Group.key(group.id),
@@ -356,7 +505,11 @@ impl LoadGroupRecord for GroupID {
         use crate::schema::groups::dsl::{groups, id};
 
         with_connection(pool, async |conn| {
-            groups.filter(id.eq(self.id())).first::<Group>(conn).await
+            groups
+                .filter(id.eq(self.id()))
+                .first::<GroupRow>(conn)
+                .await
+                .map(Into::into)
         })
         .await
     }
@@ -456,8 +609,9 @@ impl SaveGroupRecord for NewGroup {
                     groups::description.eq(&description),
                     groups::managed_by.eq(LOCAL_PROVIDER_KIND),
                 ))
-                .get_result::<Group>(conn)
+                .get_result::<GroupRow>(conn)
                 .await
+                .map(Into::into)
         })
         .await
     }
@@ -493,8 +647,9 @@ impl SaveGroupRecord for NewGroup {
                     groups::description.eq(&description),
                     groups::managed_by.eq(LOCAL_PROVIDER_KIND),
                 ))
-                .get_result::<Group>(conn)
-                .await?;
+                .get_result::<GroupRow>(conn)
+                .await?
+                .into();
             let event = group_event(
                 &group,
                 Action::Created,
@@ -539,9 +694,10 @@ impl UpdateGroupRecord for UpdateGroup {
         with_connection(pool, async |conn| -> Result<Group, ApiError> {
             ensure_group_allows_local_write(conn, group_id).await?;
             Ok(diesel::update(groups.filter(id.eq(group_id)))
-                .set(self)
-                .get_result::<Group>(conn)
-                .await?)
+                .set(&UpdateGroupRow::from(self))
+                .get_result::<GroupRow>(conn)
+                .await?
+                .into())
         })
         .await
     }
@@ -561,11 +717,12 @@ impl UpdateGroupRecord for UpdateGroup {
         use crate::schema::groups::dsl::{groups, id};
 
         with_transaction(pool, async |conn| -> Result<Group, ApiError> {
-            let before = groups
+            let before: Group = groups
                 .filter(id.eq(group_id))
                 .for_update()
-                .first::<Group>(conn)
-                .await?;
+                .first::<GroupRow>(conn)
+                .await?
+                .into();
             crate::storage::postgres::assert_locked_revision_precondition(
                 conn,
                 &RevisionOwner::Group.key(before.id),
@@ -577,9 +734,10 @@ impl UpdateGroupRecord for UpdateGroup {
                 return Ok(before);
             }
             let after = diesel::update(groups.filter(id.eq(group_id)))
-                .set(self)
-                .get_result::<Group>(conn)
-                .await?;
+                .set(&UpdateGroupRow::from(self))
+                .get_result::<GroupRow>(conn)
+                .await?
+                .into();
             let event = group_event(
                 &after,
                 Action::Updated,
@@ -705,9 +863,16 @@ impl GroupMembersBackend for Group {
         );
 
         with_connection(pool, async |conn| {
-            base_query.load::<(PrincipalGroup, Principal)>(conn).await
+            base_query
+                .load::<(PrincipalGroupRow, Principal)>(conn)
+                .await
         })
         .await
+        .map(|rows| {
+            rows.into_iter()
+                .map(|(membership, principal)| (membership.into(), principal))
+                .collect()
+        })
     }
 
     async fn count_group_members_paginated(
@@ -811,7 +976,7 @@ impl GroupMembersBackend for Group {
     }
 }
 
-async fn save_manual_membership(
+pub(crate) async fn save_manual_membership(
     pool: &impl crate::storage::StorageContext,
     principal_id: i32,
     group_id: i32,
@@ -849,56 +1014,6 @@ async fn save_manual_membership(
     .await
 }
 
-pub trait SavePrincipalGroupRecord {
-    async fn save_principal_group_record_without_events(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-    ) -> Result<PrincipalGroup, ApiError>;
-
-    async fn save_principal_group_record(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-        context: Option<&EventContext>,
-    ) -> Result<PrincipalGroup, ApiError> {
-        let _ = context;
-        self.save_principal_group_record_without_events(pool).await
-    }
-}
-
-impl SavePrincipalGroupRecord for NewPrincipalGroup {
-    async fn save_principal_group_record_without_events(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-    ) -> Result<PrincipalGroup, ApiError> {
-        save_manual_membership(pool, self.principal_id, self.group_id, None).await
-    }
-
-    async fn save_principal_group_record(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-        context: Option<&EventContext>,
-    ) -> Result<PrincipalGroup, ApiError> {
-        save_manual_membership(pool, self.principal_id, self.group_id, context).await
-    }
-}
-
-impl SavePrincipalGroupRecord for PrincipalGroup {
-    async fn save_principal_group_record_without_events(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-    ) -> Result<PrincipalGroup, ApiError> {
-        save_manual_membership(pool, self.principal_id, self.group_id, None).await
-    }
-
-    async fn save_principal_group_record(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-        context: Option<&EventContext>,
-    ) -> Result<PrincipalGroup, ApiError> {
-        save_manual_membership(pool, self.principal_id, self.group_id, context).await
-    }
-}
-
 async fn load_principal_group(
     conn: &mut crate::storage::postgres::PostgresConnection,
     principal: i32,
@@ -908,8 +1023,9 @@ async fn load_principal_group(
     group_memberships
         .filter(principal_id.eq(principal))
         .filter(group_id.eq(group))
-        .first::<PrincipalGroup>(conn)
+        .first::<PrincipalGroupRow>(conn)
         .await
+        .map(Into::into)
 }
 
 pub async fn principal_group_by_ids(
@@ -923,71 +1039,17 @@ pub async fn principal_group_by_ids(
     .await
 }
 
-pub trait DeletePrincipalGroupRecord {
-    async fn delete_principal_group_record(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-    ) -> Result<(), ApiError>;
-}
+pub(crate) async fn group_member_principal(
+    pool: &impl crate::storage::StorageContext,
+    principal_id: i32,
+) -> Result<Principal, ApiError> {
+    use crate::schema::principals::dsl::{id, principals};
 
-impl DeletePrincipalGroupRecord for PrincipalGroup {
-    async fn delete_principal_group_record(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-    ) -> Result<(), ApiError> {
-        with_transaction(pool, async |conn| -> Result<(), ApiError> {
-            remove_manual_membership_source(conn, self.principal_id, self.group_id).await?;
-            Ok(())
-        })
-        .await?;
-        Ok(())
-    }
-}
-
-pub trait PrincipalGroupPrincipalLookup {
-    async fn load_principal_group_principal(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-    ) -> Result<Principal, ApiError>;
-}
-
-impl PrincipalGroupPrincipalLookup for PrincipalGroup {
-    async fn load_principal_group_principal(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-    ) -> Result<Principal, ApiError> {
-        use crate::schema::principals::dsl::{id, principals};
-
-        with_connection(pool, async |conn| {
-            principals
-                .filter(id.eq(self.principal_id))
-                .first::<Principal>(conn)
-                .await
-        })
-        .await
-    }
-}
-
-pub trait PrincipalGroupGroupLookup {
-    async fn load_principal_group_group(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-    ) -> Result<Group, ApiError>;
-}
-
-impl PrincipalGroupGroupLookup for PrincipalGroup {
-    async fn load_principal_group_group(
-        &self,
-        pool: &impl crate::storage::StorageContext,
-    ) -> Result<Group, ApiError> {
-        use crate::schema::groups::dsl::{groups, id};
-
-        with_connection(pool, async |conn| {
-            groups
-                .filter(id.eq(self.group_id))
-                .first::<Group>(conn)
-                .await
-        })
-        .await
-    }
+    with_connection(pool, async |conn| {
+        principals
+            .filter(id.eq(principal_id))
+            .first::<Principal>(conn)
+            .await
+    })
+    .await
 }

--- a/src/storage/postgres/operations/task_import.rs
+++ b/src/storage/postgres/operations/task_import.rs
@@ -21,6 +21,7 @@ use crate::storage::postgres::operations::class::{
 use crate::storage::postgres::operations::collection::{
     CollectionRow, CollectionRowInsert, UpdateCollectionRow,
 };
+use crate::storage::postgres::operations::group::GroupRow;
 use crate::storage::postgres::operations::object::{
     HubuumObjectRow, NewHubuumObjectRow, UpdateHubuumObjectRow,
 };
@@ -266,11 +267,12 @@ pub async fn lookup_group_by_name(
             .filter(groups::groupname.eq(value))
             .filter(identity_scopes::name.eq(identity_scope))
             .select(groups::all_columns)
-            .first::<Group>(conn)
+            .first::<GroupRow>(conn)
             .await
             .optional()
     })
     .await
+    .map(|row| row.map(Into::into))
 }
 
 pub async fn lookup_collection_by_name_db(
@@ -424,9 +426,10 @@ pub async fn lookup_group_by_name_db(
         .filter(groups::groupname.eq(value))
         .filter(identity_scopes::name.eq(identity_scope))
         .select(groups::all_columns)
-        .first::<Group>(conn)
+        .first::<GroupRow>(conn)
         .await
         .optional()
+        .map(|row| row.map(Into::into))
         .map_err(ApiError::from)
 }
 
@@ -904,7 +907,7 @@ pub async fn upsert_group_db(
         .filter(identity_scope_id.eq(identity_scope_id_value))
         .filter(groupname.eq(&input.groupname))
         .for_update()
-        .first::<Group>(conn)
+        .first::<GroupRow>(conn)
         .await
         .optional()?;
     let row = match existing {
@@ -934,10 +937,15 @@ pub async fn upsert_group_db(
                             created_at.eq(created),
                             updated_at.eq(updated),
                         ))
-                        .get_result::<Group>(conn)
+                        .get_result::<GroupRow>(conn)
                         .await
                         .optional(),
-                    async || groups.filter(id.eq(existing.id)).first(conn).await,
+                    async || {
+                        groups
+                            .filter(id.eq(existing.id))
+                            .first::<GroupRow>(conn)
+                            .await
+                    },
                 )
                 .await
                 .map_err(ApiError::from)
@@ -959,7 +967,7 @@ pub async fn upsert_group_db(
                     created_at.eq(created),
                     updated_at.eq(updated),
                 ))
-                .get_result::<Group>(conn)
+                .get_result::<GroupRow>(conn)
                 .await?
         }
     };
@@ -2228,7 +2236,7 @@ mod tests {
             ensure_identity_scope(&scope.pool, &external_scope_name, LDAP_PROVIDER_KIND)
                 .await
                 .unwrap();
-        let external_group = with_connection(&scope.pool, async |conn| {
+        let external_group: Group = with_connection(&scope.pool, async |conn| {
             use crate::schema::groups;
 
             diesel::insert_into(groups::table)
@@ -2239,10 +2247,11 @@ mod tests {
                     groups::managed_by.eq(LDAP_PROVIDER_KIND),
                     groups::external_key.eq(scope.scoped_name("external_group_key")),
                 ))
-                .get_result::<Group>(conn)
+                .get_result::<GroupRow>(conn)
                 .await
         })
         .await
+        .map(Into::into)
         .unwrap();
 
         let external_key = GroupKey {

--- a/src/storage/postgres/operations/user/membership.rs
+++ b/src/storage/postgres/operations/user/membership.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::models::token_scope::TokenScope;
 use crate::storage::postgres::operations::authz::{AuthzSubject, scope_allows};
 use crate::storage::postgres::operations::collection::CollectionRow;
+use crate::storage::postgres::operations::group::GroupRow;
 use diesel_async::RunQueryDsl;
 
 pub trait LoadUserGroups: AuthzSubject {
@@ -28,10 +29,11 @@ where
                 .inner_join(groups.on(id.eq(group_id)))
                 .filter(principal_id.eq(principal_id_value))
                 .select(groups::all_columns())
-                .load::<Group>(conn)
+                .load::<GroupRow>(conn)
                 .await
         })
         .await
+        .map(|rows| rows.into_iter().map(Into::into).collect())
     }
 }
 
@@ -101,9 +103,12 @@ where
         .await?;
 
         let mut base_query = build_query()?.select(groups::all_columns());
-        crate::apply_query_options!(base_query, query_options, Group);
-        let items =
-            with_connection(pool, async |conn| base_query.load::<Group>(conn).await).await?;
+        crate::apply_query_options!(base_query, query_options, GroupRow);
+        let items = with_connection(pool, async |conn| base_query.load::<GroupRow>(conn).await)
+            .await?
+            .into_iter()
+            .map(Into::into)
+            .collect();
 
         Ok((items, total_count))
     }

--- a/src/storage/postgres/operations/user/search.rs
+++ b/src/storage/postgres/operations/user/search.rs
@@ -14,6 +14,7 @@ use crate::storage::postgres::operations::collection::CollectionRow;
 use crate::storage::postgres::operations::computed_field::{
     ComputedQuerySnapshot, computed_filter_predicate, object_cursor_sql_fields,
 };
+use crate::storage::postgres::operations::group::GroupRow;
 use crate::storage::postgres::operations::object::HubuumObjectRow;
 use crate::storage::postgres::operations::permissions::PermissionFilter;
 use crate::storage::postgres::operations::relation_rows::{
@@ -4737,7 +4738,7 @@ impl User {
             }
         }
 
-        crate::apply_query_options!(base_query, query_options, Group);
+        crate::apply_query_options!(base_query, query_options, GroupRow);
 
         trace_query!(base_query, "Searching groups");
 
@@ -4745,12 +4746,12 @@ impl User {
             base_query
                 .select(groups::all_columns())
                 .distinct()
-                .load::<Group>(conn)
+                .load::<GroupRow>(conn)
                 .await
         })
         .await?;
 
-        Ok(result)
+        Ok(result.into_iter().map(Into::into).collect())
     }
 
     pub async fn count_groups(

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -214,6 +214,55 @@ fn backend_neutral_layers_do_not_import_database_implementation_details() {
 }
 
 #[test]
+fn group_domain_types_are_free_of_persistence_implementation_details() {
+    let root = repository_root();
+    let mut violations = Vec::new();
+
+    for relative_path in ["src/models/group.rs", "src/models/principal_group.rs"] {
+        let path = root.join(relative_path);
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(&source);
+        for forbidden in [
+            "diesel::",
+            "diesel(",
+            "crate::schema",
+            "storage::postgres",
+            "CursorSqlMapping",
+            "CursorSqlField",
+            "CursorSqlType",
+        ] {
+            if production_source.contains(forbidden) {
+                violations.push(format!("{} contains {forbidden}", path.display()));
+            }
+        }
+    }
+
+    let adapter_path = root.join("src/storage/postgres/operations/group.rs");
+    let adapter_source = fs::read_to_string(&adapter_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", adapter_path.display()));
+    for required in [
+        "struct GroupRow",
+        "struct PrincipalGroupRow",
+        "struct UpdateGroupRow",
+        "impl From<GroupRow> for Group",
+        "impl From<PrincipalGroupRow> for PrincipalGroup",
+        "impl CursorSqlMapping for GroupRow",
+    ] {
+        assert!(
+            adapter_source.contains(required),
+            "PostgreSQL group adapter is missing {required}"
+        );
+    }
+
+    assert!(
+        violations.is_empty(),
+        "group domain types crossed into persistence details:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
 fn permission_domain_types_are_free_of_persistence_implementation_details() {
     let root = repository_root();
     let mut violations = Vec::new();
@@ -544,6 +593,7 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         "CollectionPermissionStorage",
         "CollectionRecordStorage",
         "ClassRecordStorage",
+        "GroupStorage",
         "ObjectRecordStorage",
         "RemoteTargetStorage",
         "TaskQueueStorage",
@@ -585,13 +635,31 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
             "catalog operation {operation} must use the common storage observer"
         );
     }
+    let compact_context = context_source.split_whitespace().collect::<String>();
+    for operation in [
+        "load",
+        "identity_scope",
+        "create",
+        "update",
+        "delete",
+        "members",
+        "members_page",
+        "members_count",
+        "member_principal",
+        "member_add",
+        "member_remove",
+    ] {
+        assert!(
+            compact_context.contains(&format!("\"groups\",\"{operation}\"")),
+            "group operation {operation} must use the common storage observer"
+        );
+    }
     for operation in ["list", "enrich"] {
         assert!(
             context_source.contains(&format!("\"computed_objects\", \"{operation}\"")),
             "computed-object operation {operation} must use the common storage observer"
         );
     }
-    let compact_context = context_source.split_whitespace().collect::<String>();
     for operation in [
         "state",
         "list_shared",

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -62,6 +62,7 @@ use crate::models::{
     PrincipalTokenCreateRequest, TokenResourceScope, TokenScope,
 };
 use crate::storage::postgres::PostgresPool;
+use crate::storage::postgres::operations::group::GroupRow;
 use crate::storage::postgres::{init_postgres_pool, with_connection};
 
 use crate::utilities::auth::{generate_random_password, hash_password};
@@ -756,13 +757,13 @@ pub async fn ensure_admin_group(pool: &PostgresPool) -> Group {
     let result = with_connection(pool, async |conn| {
         groups
             .filter(groupname.eq(&admin_groupname))
-            .first::<Group>(conn)
+            .first::<GroupRow>(conn)
             .await
     })
     .await;
 
     if let Ok(group) = result {
-        return group;
+        return group.into();
     }
 
     let result = NewGroup {
@@ -779,10 +780,11 @@ pub async fn ensure_admin_group(pool: &PostgresPool) -> Group {
                 return with_connection(pool, async |conn| {
                     groups
                         .filter(groupname.eq(&admin_groupname))
-                        .first::<Group>(conn)
+                        .first::<GroupRow>(conn)
                         .await
                 })
                 .await
+                .map(Into::into)
                 .expect("Failed to fetch user after conflict");
             }
             _ => panic!("Failed to create admin group: {e:?}"),

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -23,8 +23,8 @@ use crate::models::{
     CollectionHistory, CollectionID, CollectionKey, ExportTemplateHistory, GroupID,
     HubuumClassHistory, HubuumObjectHistory, ImportAtomicity, ImportClassInput,
     ImportCollectionInput, ImportMode, NewCollectionWithAssignee, NewComputedFieldDefinition,
-    NewHubuumClass, NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation, Permissions,
-    RemoteTargetHistory, UpdateCollection,
+    NewGroup, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation,
+    Permissions, RemoteTargetHistory, UpdateCollection, UpdateGroup,
 };
 use crate::pagination::prepare_db_pagination;
 use crate::services::Services;
@@ -45,14 +45,14 @@ use crate::storage::{
     ComputedObjectProjection, ComputedObjectStorage, ComputedObjectVisibility, EventArchive,
     EventDeliveryAdministrationStorage, EventDeliveryStorage, EventFanoutStorage,
     EventHealthStorage, EventRetentionStorage, EventSubscriptionStorage, ExportQueryStorage,
-    ExportTemplateStorage, HistoryAsOfQuery, HistoryCollectionScope, HistoryListQuery,
-    HistoryStorage, IdentityStorage, ImportStorage, InventoryStorage, MetricsStorage,
-    ObjectAggregateAuthorizationMode, ObjectAggregateAuthorizer, ObjectAggregateStorage,
-    ObjectAggregateStorageQuery, ObjectHistoryAsOfQuery, ObjectHistoryListQuery,
-    ObjectRelationsTouchingIdsQuery, OperationalStateStorage, RelatedObjectsForRootsQuery,
-    RelationGraphQuery, RelationIdsQuery, RelationListQuery, RelationQueryStorage,
-    RelationTouchingQuery, RemoteTargetStorage, RestoreStorage, RetainedEvent,
-    STORAGE_CONTRACT_VERSION, StorageAuditEventFilters, StorageAuditEventListQuery,
+    ExportTemplateStorage, GroupStorage, HistoryAsOfQuery, HistoryCollectionScope,
+    HistoryListQuery, HistoryStorage, IdentityStorage, ImportStorage, InventoryStorage,
+    MetricsStorage, ObjectAggregateAuthorizationMode, ObjectAggregateAuthorizer,
+    ObjectAggregateStorage, ObjectAggregateStorageQuery, ObjectHistoryAsOfQuery,
+    ObjectHistoryListQuery, ObjectRelationsTouchingIdsQuery, OperationalStateStorage,
+    RelatedObjectsForRootsQuery, RelationGraphQuery, RelationIdsQuery, RelationListQuery,
+    RelationQueryStorage, RelationTouchingQuery, RemoteTargetStorage, RestoreStorage,
+    RetainedEvent, STORAGE_CONTRACT_VERSION, StorageAuditEventFilters, StorageAuditEventListQuery,
     StorageBackendKind, StorageBackupTaskArtifact, StorageCallSite,
     StorageComputedFieldDefinitionInput, StorageComputedFieldDefinitionPatch,
     StorageComputedFieldRebuildRequest, StorageComputedFieldVisibility,
@@ -169,6 +169,122 @@ async fn every_available_storage_backend_supplies_consistent_inventory_counts() 
                         .windows(2)
                         .all(|rows| rows[0].class_id() < rows[1].class_id()),
                     "per-class counts must use stable class-id ordering"
+                );
+            }
+        }
+    }
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_supplies_complete_group_behavior() {
+    let _permit = postgres_permit().await;
+    let pool = pool();
+
+    for kind in StorageBackendKind::ALL {
+        match kind {
+            StorageBackendKind::Postgresql => {
+                let backend = StorageHandle::postgres(pool.get_ref().clone());
+                let initial_name = prefix("group_contract");
+                let renamed = prefix("group_contract_renamed");
+                let created = backend
+                    .create_group(
+                        &NewGroup {
+                            identity_scope: None,
+                            groupname: initial_name,
+                            description: Some("storage compatibility group".to_string()),
+                        },
+                        None,
+                    )
+                    .await
+                    .expect("certified backend should create groups");
+
+                let loaded = backend
+                    .load_group(created.id)
+                    .await
+                    .expect("certified backend should load groups");
+                assert_eq!(loaded.id, created.id);
+                assert_eq!(
+                    backend
+                        .group_identity_scope_name(created.id)
+                        .await
+                        .expect("certified backend should resolve group identity scopes"),
+                    LOCAL_IDENTITY_SCOPE
+                );
+
+                let updated = backend
+                    .update_group(
+                        created.id,
+                        &UpdateGroup {
+                            groupname: Some(renamed.clone()),
+                        },
+                        None,
+                    )
+                    .await
+                    .expect("certified backend should update groups");
+                assert_eq!(updated.groupname, renamed);
+
+                let user = crate::tests::create_user_with_params(
+                    pool.get_ref(),
+                    &prefix("group_contract_user"),
+                    "testpassword",
+                )
+                .await;
+                backend
+                    .add_group_member(user.id, created.id, None)
+                    .await
+                    .expect("certified backend should add group members");
+
+                let members = backend
+                    .group_members(created.id)
+                    .await
+                    .expect("certified backend should list group members");
+                assert!(members.iter().any(|member| member.id == user.id));
+                assert_eq!(
+                    backend
+                        .group_member_principal(user.id)
+                        .await
+                        .expect("certified backend should load a membership principal")
+                        .id,
+                    user.id
+                );
+
+                let query_options = QueryOptions {
+                    filters: Vec::new(),
+                    sort: Vec::new(),
+                    limit: Some(10),
+                    cursor: None,
+                    include_total: true,
+                };
+                let page = backend
+                    .group_members_page(created.id, &query_options)
+                    .await
+                    .expect("certified backend should page group members");
+                assert!(page.iter().any(|(_, member)| member.id == user.id));
+                assert_eq!(
+                    backend
+                        .count_group_members(created.id, &query_options)
+                        .await
+                        .expect("certified backend should count group members"),
+                    1
+                );
+
+                backend
+                    .remove_group_member(user.id, created.id, None)
+                    .await
+                    .expect("certified backend should remove group members");
+                assert_eq!(
+                    backend
+                        .count_group_members(created.id, &query_options)
+                        .await
+                        .expect("certified backend should recount group members"),
+                    0
+                );
+                assert_eq!(
+                    backend
+                        .delete_group(created.id, None)
+                        .await
+                        .expect("certified backend should delete groups"),
+                    1
                 );
             }
         }

--- a/tests/api_identity_suite/groups.rs
+++ b/tests/api_identity_suite/groups.rs
@@ -6,11 +6,11 @@ mod tests {
     use chrono::SubsecRound;
     use rstest::rstest;
 
-    use crate::models::group::{Group, GroupResponse, NewGroup, UpdateGroup};
+    use crate::models::group::{Group, GroupID, GroupResponse, NewGroup, UpdateGroup};
     use crate::models::user::{NewUser, User};
     use crate::models::{
         IdentityScope, LDAP_PROVIDER_KIND, MembershipPrincipalResponse, NewIdentityScope,
-        Principal, PrincipalGroup, PrincipalID, PrincipalKind, PrincipalMemberResponse,
+        Principal, PrincipalID, PrincipalKind, PrincipalMemberResponse,
     };
     use crate::pagination::NEXT_CURSOR_HEADER;
     use crate::storage::postgres::operations::identity::ensure_identity_scope;
@@ -179,7 +179,7 @@ mod tests {
         .await
         .unwrap();
         let groupname = context.scoped_name("external_group");
-        let group = with_connection(&context.pool, async |conn| {
+        let group_id = with_connection(&context.pool, async |conn| {
             use crate::schema::groups;
 
             diesel::insert_into(groups::table)
@@ -190,11 +190,17 @@ mod tests {
                     groups::managed_by.eq(crate::models::LDAP_PROVIDER_KIND),
                     groups::external_key.eq(context.scoped_name("external_group_key")),
                 ))
-                .get_result::<Group>(conn)
+                .returning(groups::id)
+                .get_result::<i32>(conn)
                 .await
         })
         .await
         .unwrap();
+        let group = GroupID::new(group_id)
+            .unwrap()
+            .group(&context.pool)
+            .await
+            .unwrap();
         let group_url = format!("{GROUPS_ENDPOINT}/{}", group.id);
 
         let resp = get_request(&context.pool, &context.normal_token, &group_url).await;
@@ -237,7 +243,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let external_group = with_connection(&context.pool, async |conn| {
+        let external_group_id = with_connection(&context.pool, async |conn| {
             use crate::schema::groups;
 
             diesel::insert_into(groups::table)
@@ -248,11 +254,17 @@ mod tests {
                     groups::managed_by.eq(crate::models::LDAP_PROVIDER_KIND),
                     groups::external_key.eq(context.scoped_name("batch_external_group_key")),
                 ))
-                .get_result::<Group>(conn)
+                .returning(groups::id)
+                .get_result::<i32>(conn)
                 .await
         })
         .await
         .unwrap();
+        let external_group = GroupID::new(external_group_id)
+            .unwrap()
+            .group(&context.pool)
+            .await
+            .unwrap();
 
         let responses =
             GroupResponse::from_groups(&context.pool, vec![local_group, external_group])
@@ -591,16 +603,23 @@ mod tests {
         let context = test_context;
         let group = create_test_group(&context.pool).await;
         let user = create_test_user(&context.pool).await;
-        let initial = with_connection(&context.pool, async |conn| {
+        with_connection(&context.pool, async |conn| {
             use crate::schema::group_memberships;
             diesel::insert_into(group_memberships::table)
                 .values((
                     group_memberships::principal_id.eq(user.id),
                     group_memberships::group_id.eq(group.id),
                 ))
-                .get_result::<PrincipalGroup>(conn)
+                .execute(conn)
                 .await
         })
+        .await
+        .unwrap();
+        let initial = crate::storage::postgres::operations::group::principal_group_by_ids(
+            &context.pool,
+            user.id,
+            group.id,
+        )
         .await
         .unwrap();
 

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -133,7 +133,7 @@ async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() 
 
     assert!(
         body.contains(
-            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"25\"} 1"
+            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"26\"} 1"
         )
     );
     assert!(body.contains(

--- a/tests/api_platform_suite/runtime_config.rs
+++ b/tests/api_platform_suite/runtime_config.rs
@@ -37,7 +37,7 @@ mod tests {
         let serialized = serde_json::to_string(&body).unwrap();
 
         assert_eq!(body["database"]["backend"], "postgresql");
-        assert_eq!(body["database"]["contract_version"], 25);
+        assert_eq!(body["database"]["contract_version"], 26);
         assert_eq!(
             body["database"]["capabilities"],
             serde_json::json!([


### PR DESCRIPTION
## Summary\n\n- make group point reads, identity-scope resolution, lifecycle writes, and complete membership behavior mandatory through \n- route application and domain entry points through the opaque , with one bounded tracing/metrics wrapper for every operation\n- move group, membership, update, and SQL cursor persistence mappings into the PostgreSQL adapter\n- keep , , and their commands free of Diesel, schemas, connections, and PostgreSQL adapter traits\n- convert authorization, collection permissions, imports, bootstrap, external identity sync, user membership, search, and test fixtures to adapter-owned rows\n- certify the capability for every selectable backend and exercise every group operation in the shared compatibility suite\n- advance the administrator-visible storage contract to version 26 and update redacted config, metrics, documentation, and changelog coverage\n\n## Behavior and compatibility\n\nThis is a breaking administrator API change because the reported storage contract version changes from 25 to 26. Administration and monitoring clients that match version 25 must accept version 26.\n\nRequired capability labels and public HTTP request/response shapes are unchanged. PostgreSQL remains the only selectable complete backend; focused in-memory contract models remain non-selectable.\n\n## Changelog\n\nThe  section documents the version-26 contract change and its upgrade action.\n\n## Verification\n\n- Created test database: hubuum_test_db_1786470154_39408_102415807
Running migration 2023-12-27-011440_initial
Running migration 2026-07-13-000001_task_worker_leases
Running migration 2026-07-13-000002_backup_restore
Running migration 2026-07-14-000001_preserve_imported_timestamps
Running migration 2026-07-15-000001_task_active_capacity_index
Running migration 2026-07-15-000002_event_related_collections
Running migration 2026-07-15-000003_computed_fields
Running migration 2026-07-18-000001_computed_field_sorting
Running migration 2026-07-21-000001_event_retention_coordination
Running migration 2026-07-22-000001_token_resource_scopes
Running migration 2026-07-24-000001_task_provenance
Running migration 2026-07-25-000001_token_explicit_expiry_retention_index
Running migration 2026-07-25-000002_token_implicit_expiry_retention_index
Running migration 2026-07-25-000003_task_submitted_token_retention_index
Running migration 2026-07-29-000001_allow_imported_temporal_timestamp_updates
Running migration 2026-07-30-000001_object_relation_cardinality
Running migration 2026-08-03-000001_resource_revisions
Running migration 2026-08-04-000001_token_revoked_retention_index
Running migration 2026-08-04-000002_collections_history_revision_index
Running migration 2026-08-04-000003_classes_history_revision_index
Running migration 2026-08-04-000004_class_relations_history_revision_index
Running migration 2026-08-04-000005_objects_history_revision_index
Running migration 2026-08-04-000006_object_relations_history_revision_index
Running migration 2026-08-04-000007_export_templates_history_revision_index
Running migration 2026-08-04-000008_remote_targets_history_revision_index
Running migration 2026-08-04-000009_identity_scopes_revision_index
Running migration 2026-08-04-000010_principals_revision_index
Running migration 2026-08-04-000011_groups_revision_index
Running migration 2026-08-04-000012_collections_revision_index
Running migration 2026-08-04-000013_classes_revision_index
Running migration 2026-08-04-000014_objects_revision_index
Running migration 2026-08-04-000015_class_relations_revision_index
Running migration 2026-08-04-000016_object_relations_revision_index
Running migration 2026-08-04-000017_export_templates_revision_index
Running migration 2026-08-04-000018_remote_targets_revision_index
Running migration 2026-08-04-000019_event_sinks_revision_index
Running migration 2026-08-04-000020_event_subscriptions_revision_index
Running migration 2026-08-04-000021_computed_fields_revision_index
Running migration 2026-08-04-000022_tokens_revision_index
Running migration 2026-08-04-000023_group_memberships_revision_index
Running migration 2026-08-04-000024_events_before_revision_index
Running migration 2026-08-04-000025_events_after_revision_index

running 1240 tests
test api::handlers::auth::tests::logout_token_request_debug_redacts_raw_bearer_token ... ok
test api::etag::tests::strong_etag_round_trip ... ok
test api::etag::tests::weak_malformed_and_mixed_wildcards_are_rejected ... ok
test api::etag::tests::parser_enforces_bounds_and_resource_identity ... ok
test api::etag::tests::lists_and_wildcard_are_supported ... ok
test api::openapi::tests::object_relation_limits_document_positive_nullable_fields ... ok
test api::openapi::tests::login_schema_documents_credential_length_limits ... ok
test api::openapi::tests::creation_assignee_group_ids_document_positive_minimum ... ok
test api::openapi::tests::openapi_operations_have_metadata_unique_operation_ids_and_security ... ok
test api::openapi::tests::export_scope_ids_document_positive_minimum ... ok
test api::openapi::tests::object_data_json_patch_media_type_limits_and_statuses_are_documented ... ok
test api::openapi::tests::revision_operations_have_one_documentation_classification ... ok
test api::openapi::tests::openapi_excludes_persisted_token_storage_schema ... ok
test api::openapi::tests::openapi_documents_cursor_pagination_for_list_endpoints ... ok
test api::v1::handlers::backups::tests::digest_header_decodes_stored_sha256_hex ... ok
test api::v1::handlers::backups::tests::digest_header_rejects_invalid_stored_sha256 ... ok
test api::v1::handlers::classes::computed_objects::tests::raw_computed_page_selects_only_its_cursor_boundary ... ok
test api::openapi::tests::openapi_contains_expected_operations_and_security_scheme ... ok
test api::openapi::tests::conditional_operations_document_if_match_and_precondition_failure ... ok
test api::v1::handlers::exports::tests::text_export_output_headers_use_persisted_truncated_column ... ok
test api::response::tests::response_header_debug_log_omits_the_value ... ok
test api::openapi::tests::openapi_paths_match_mounted_routes ... ok
test api::v1::handlers::history::tests::parse_as_of_rejects_duplicate_timestamps ... ok
test api::v1::handlers::history::tests::parse_as_of_reads_rfc3339 ... ok
test api::v1::handlers::history::tests::parse_as_of_rejects_garbage ... ok
test api::v1::handlers::history::tests::parse_as_of_requires_param ... ok
test auth::tests::auth_config_parse_errors_do_not_disclose_source::case_1_syntax ... ok
test auth::tests::auth_config_parse_errors_do_not_disclose_source::case_2_type_mismatch ... ok
test auth::tests::auth_config_reader_rejects_invalid_utf8 ... ok
test auth::tests::auth_config_reader_rejects_non_regular_files ... ok
test auth::tests::auth_config_reader_rejects_oversized_files ... ok
test auth::tests::auth_config_source_positions_count_unicode_characters ... ok
test auth::tests::external_user_state_rejects_an_empty_provider_subject ... ok
test auth::tests::failed_refresh_enters_retry_backoff ... ok
test auth::tests::future_attempt_timestamp_does_not_create_retry_backoff ... ok
test auth::tests::future_success_timestamp_requires_external_refresh ... ok
test auth::tests::provider_names_include_local_and_sorted_external_scopes ... ok
test auth::tests::recent_success_keeps_external_state_fresh ... ok
test auth::tests::refresh_is_due_after_retry_backoff_expires ... ok
test auth::tests::refresh_lock_registry_reclaims_dropped_principal_locks ... ok
test auth::tests::refresh_lock_registry_reuses_live_principal_locks ... ok
test auth::tests::refresh_policy_rejects_a_non_positive_max_stale_window ... ok
test auth::tests::refresh_policy_rejects_a_non_positive_ttl ... ok
test auth::tests::refresh_policy_rejects_a_stale_window_below_the_refresh_ttl ... ok
test auth::tests::refresh_policy_rejects_unrepresentable_durations::case_1_refresh_ttl ... ok
test auth::tests::refresh_policy_rejects_unrepresentable_durations::case_2_max_stale ... ok
test auth::tests::retry_backoff_rejects_cache_beyond_max_stale ... ok
test auth::tests::successful_attempt_timestamp_does_not_trigger_backoff ... ok
test backups::tests::backup_settings_reject_unrepresentable_retention ... ok
test backups::tests::backup_settings_reject_zero_limits::case_1_retention ... ok
test backups::tests::backup_settings_reject_zero_limits::case_2_active_tasks ... ok
test backups::tests::backup_settings_reject_zero_limits::case_3_output_size ... ok
test api::v1::handlers::client_config::tests::client_config_exposes_effective_client_defaults_without_authentication ... ok
test application::tests::worker_metrics_service_instruments_scrape_requests ... ok
test config::environment::tests::administration_environment_access_stays_behind_the_library_boundary ... ok
test config::environment::tests::clap_environment_is_exactly_the_declared_app_config_set ... ok
test config::environment::tests::every_declared_variable_has_one_owner_and_unique_name ... ok
test api::openapi::tests::principal_settings_patch_media_types_limits_and_statuses_are_documented ... ok
test api::openapi::tests::related_filter_depth_documents_valid_range::case_1 ... ok
test config::environment::tests::undeclared_or_ambiguous_names_are_rejected ... ok
test config::running::tests::running_config_is_an_explicit_redacted_projection ... ok
test config::tests::artifact_retention_horizons_must_be_representable::case_1 ... ok
test config::tests::artifact_retention_horizons_must_be_representable::case_2 ... ok
test api::openapi::tests::restore_upload_schema_references_backup_document ... ok
test config::tests::artifact_retention_horizons_must_be_representable::case_3 ... ok
test config::tests::backoff_max_must_not_be_below_base ... ok
test api::openapi::tests::tagged_operations_document_etag_response_headers ... ok
test config::tests::db_pool_acquire_timeout_is_loaded_and_validated ... ok
test config::tests::event_delivery_transport_timeout_must_be_shorter_than_lock_timeout ... ok
test api::openapi::tests::related_filter_depth_documents_valid_range::case_2 ... ok
test config::tests::event_delivery_worker_settings_are_parsed_from_env ... ok
test config::tests::event_fanout_worker_settings_are_parsed_from_env ... ok
test config::tests::event_retention_file_archive_requires_path ... ok
test api::openapi::tests::restore_job_paths_document_positive_ids ... ok
test config::tests::event_retention_settings_are_parsed_from_env ... ok
test config::tests::event_retention_settings_are_validated ... ok
test config::tests::event_worker_durations_must_be_representable::case_1_fanout_timeout ... ok
test config::tests::event_worker_durations_must_be_representable::case_2_delivery_timeout ... ok
test config::tests::event_worker_durations_must_be_representable::case_3_delivery_retry ... ok
test config::tests::event_worker_durations_must_be_representable::case_4_retention_days ... ok
test config::tests::export_max_active_tasks_per_user_defaults_when_env_var_is_unset ... ok
test config::tests::export_max_active_tasks_per_user_is_parsed_from_env ... ok
test config::tests::export_max_active_tasks_per_user_is_validated ... ok
test config::tests::export_max_output_bytes_defaults_when_env_var_is_unset ... ok
test config::tests::export_max_output_bytes_is_parsed_from_env ... ok
test config::tests::export_max_output_bytes_is_validated ... ok
test config::tests::extended_login_rate_limit_settings_are_parsed_from_env ... ok
test config::environment::tests::every_hubuum_environment_reference_in_every_crate_is_declared ... ok
test config::tests::import_max_active_tasks_per_user_is_loaded_and_validated ... ok
test config::tests::login_rate_limit_settings_are_parsed_from_env ... ok
test config::tests::login_rate_limit_settings_are_validated ... ok
test config::tests::login_rate_limit_settings_default_when_env_vars_are_unset ... ok
test config::tests::max_token_lifetime_hours_are_parsed_from_env ... ok
test config::tests::max_token_lifetime_hours_are_validated ... ok
test config::tests::max_token_lifetime_hours_default_when_env_var_is_unset ... ok
test config::tests::max_token_lifetime_hours_must_cover_the_default_lifetime ... ok
test config::tests::metrics_config_parses_from_env ... ok
test config::tests::metrics_path_must_be_absolute_non_root_path ... ok
test config::tests::metrics_path_must_be_literal::case_1 ... ok
test config::tests::metrics_path_must_be_literal::case_2 ... ok
test config::tests::metrics_path_must_be_literal::case_3 ... ok
test config::tests::metrics_path_must_be_literal::case_4 ... ok
test config::tests::metrics_path_must_be_literal::case_5 ... ok
test config::tests::metrics_path_must_not_collide_with_existing_routes::case_1 ... ok
test config::tests::metrics_path_must_not_collide_with_existing_routes::case_2 ... ok
test config::tests::metrics_path_must_not_collide_with_existing_routes::case_3 ... ok
test config::tests::metrics_path_must_not_collide_with_existing_routes::case_4 ... ok
test config::tests::metrics_path_must_not_collide_with_existing_routes::case_5 ... ok
test config::tests::metrics_path_must_not_collide_with_existing_routes::case_6 ... ok
test config::tests::metrics_path_must_not_collide_with_existing_routes::case_7 ... ok
test config::tests::metrics_path_must_not_have_empty_segments::case_1 ... ok
test config::tests::metrics_path_must_not_have_empty_segments::case_2 ... ok
test config::tests::negative_token_lifetime_hours_are_rejected ... ok
test config::tests::page_limits_are_parsed_from_env ... ok
test config::tests::page_limits_are_validated ... ok
test config::tests::runtime_role_controls_effective_worker_count::case_1_all ... ok
test config::tests::runtime_role_controls_effective_worker_count::case_2_api ... ok
test config::tests::runtime_role_controls_effective_worker_count::case_3_worker ... ok
test config::tests::page_limits_default_when_env_vars_are_unset ... ok
test config::tests::per_scope_thresholds_may_be_zero_to_disable ... ok
test config::tests::remote_call_max_active_tasks_per_user_defaults_when_env_var_is_unset ... ok
test config::tests::remote_call_max_active_tasks_per_user_is_parsed_from_env ... ok
test config::tests::remote_call_max_active_tasks_per_user_is_validated ... ok
test config::tests::runtime_role_is_parsed_from_env ... ok
test config::tests::shared_login_rate_limit_requires_a_url ... ok
test config::tests::shared_login_rate_limit_settings_are_parsed_from_env ... ok
test config::tests::subnet_prefixes_are_validated ... ok
test config::tests::task_heartbeat_must_be_shorter_than_lease ... ok
test config::tests::task_lease_duration_must_fit_database_timestamps ... ok
test config::tests::token_hash_key_is_initialized_once ... ok
test config::tests::task_lease_settings_are_parsed_from_env ... ok
test config::tests::task_worker_settings_are_parsed_from_env ... ok
test config::tests::tls_backend_defaults_to_none_when_env_var_is_unset ... ok
test config::tests::tls_backend_env_var_is_parsed_by_clap_and_test_config_loader ... ok
test config::tests::tls_backend_invalid_env_var_is_rejected_by_clap_parser ... ok
test config::tests::token_lifetime_hours_above_the_supported_range_are_rejected ... ok
test config::tests::token_lifetime_hours_are_parsed_from_env ... ok
test config::tests::token_lifetime_hours_are_validated ... ok
test config::tests::token_lifetime_hours_defaults_when_env_var_is_unset ... ok
test config::tests::token_retention_settings_are_parsed_from_env ... ok
test config::tests::token_retention_settings_are_validated::case_1 ... ok
test config::tests::token_retention_settings_are_validated::case_2 ... ok
test config::tests::token_retention_settings_are_validated::case_3 ... ok
test api::openapi::tests::openapi_operations_resolve_to_mounted_routes ... ok
test errors::tests::internal_error_responses_do_not_expose_details ... ok
test errors::tests::service_unavailable_response_does_not_expose_details ... ok
test config::tests::token_retention_settings_default_when_env_is_unset ... ok
test errors::tests::storage_errors_preserve_public_failure_categories ... ok
test errors::tests::test_api_error_exit_code_mapping ... ok
test errors::tests::test_api_error_from_diesel_not_found ... ok
test errors::tests::test_api_error_http_status_codes ... ok
test errors::tests::test_exit_codes_are_distinct ... ok
test errors::tests::test_fatal_error_type_signature ... ok
test events::delivery::tests::delivery_worker_stops_after_empty_or_error_iteration ... ok
test events::delivery::tests::delivery_worker_waits_for_retry_or_safety_poll::case_1_no_retry ... ok
test events::delivery::tests::delivery_worker_waits_for_retry_or_safety_poll::case_2_earlier_retry ... ok
test events::delivery::tests::delivery_worker_waits_for_retry_or_safety_poll::case_3_later_retry ... ok
test config::tests::trusted_proxies_default_to_empty ... ok
test events::delivery::tests::resolver_passes_through_transport_error ... ok
test events::delivery::tests::resolver_exports_unsupported_sink_kind ... ok
test events::model::tests::new_event_debug_redacts_payload_snapshots ... ok
test config::tests::trusted_proxies_parse_from_env ... ok
test config::tests::worker_defaults_scale_from_detected_cpu_count ... ok
test config::tests::worker_runtime_role_requires_at_least_one_enabled_worker ... ok
test config::environment::tests::only_declared_adapters_read_hubuum_environment_variables ... ok
test events::retention::tests::append_event_archive_rejects_symbolic_link_path ... ok
test events::retention::tests::append_event_archive_restricts_existing_file_permissions ... ok
test events::retention::tests::append_event_archive_writes_json_lines ... ok
test events::retention::tests::event_archive_is_synced_after_writing ... ok
test events::retention::tests::event_archive_sync_failure_is_returned ... ok
test events::retention::tests::retention_worker_retries_immediately_after_deleting_rows ... ok
test events::retention::tests::secure_event_archive_rejects_non_regular_file ... ok
test events::sink::tests::default_resolver_rejects_unknown_sink_kinds ... ok
test events::sink::tests::sink_delivery_debug_omits_config_routing_and_secret_reference ... ok
test events::sink::tests::sink_trait_can_be_mocked_without_worker_storage ... ok
test events::sink::tests::uri_connection_pool_debug_omits_credential_bearing_keys ... ok
test events::sink::tests::uri_connection_pool_does_not_evict_an_initializer_in_flight ... ok
test events::sink::tests::uri_connection_pool_evicts_the_least_recently_used_key_at_capacity ... ok
test events::pg_notify::tests::shutdown_releases_postgres_notification_listener ... ok
test events::sink::tests::uri_connection_pool_retries_a_failed_initializer ... ok
test events::sink::tests::uri_connection_pool_initializes_each_key_once_under_concurrency ... ok
test events::pg_notify::tests::notification_listener_pool_is_isolated_from_the_execution_pool ... ok
test events::pg_notify::tests::fanout_trigger_notifies_only_after_commit::case_1_commit ... ok
test events::pg_notify::tests::task_queue_notification_is_delivered_only_after_commit::case_1_commit ... ok
test events::tests::audit_revision_is_null_filters_nullable_revisions::case_1 ... ok
test events::tests::emit_event_respects_transaction_outcome::case_1_commit_persists ... ok
test backups::tests::configured_backend_can_deny_a_sql_administrator_backup ... ok
test events::tests::audit_page_filters_and_enriches_legacy_task_initiators_in_bounded_queries ... ok
test backups::tests::configured_backend_can_allow_a_non_sql_administrator_backup ... ok
test events::pg_notify::tests::task_queue_notification_is_delivered_only_after_commit::case_2_rollback ... ok
test events::pg_notify::tests::fanout_trigger_notifies_only_after_commit::case_2_rollback ... ok
test api::v1::handlers::history::tests::deleted_history_admin_check_uses_the_configured_backend ... ok
test api::v1::handlers::history::tests::historical_resource_attributes_are_sent_to_external_backends ... ok
test events::tests::event_delivery_terminal_retention_index_exists ... ok
test events::tests::class_relation_writes_emit_lifecycle_events_in_transaction ... ok
test events::tests::class_writes_emit_lifecycle_events_in_transaction ... ok
test events::tests::collection_writes_emit_lifecycle_events_in_transaction ... ok
test events::tests::event_delivery_claims_expired_in_flight_rows_again ... ok
test events::tests::event_fanout_skips_disabled_subscriptions ... ok
test events::tests::event_fanout_applies_subscription_filter_before_creating_delivery ... ok
test events::tests::event_fanout_reclaims_expired_claims ... ok
test events::tests::event_fanout_creates_delivery_for_each_matching_subscription_once ... ok
test events::tests::event_retention_bounds_terminal_delivery_deletes_to_the_batch_size ... ok
test events::tests::fanout_backlog_index_exists ... ok
test events::tests::event_delivery_failed_mark_respects_claim_token ... ok
test events::tests::event_retention_purge_deletes_old_events_through_guarded_path ... ok
test events::tests::event_fanout_query_growth_is_bounded_to_one_insert_per_event ... ok
test events::tests::new_event_accepts_arbitrary_correlation_id ... ok
test events::tests::new_event_applies_event_context ... ok
test events::tests::new_event_rejects_invalid_action_for_type ... ok
test errors::tests::test_api_error_from_pool_error ... ok
test events::tests::export_template_writes_emit_lifecycle_events ... ok
test events::tests::group_writes_emit_lifecycle_events_in_transaction ... ok
test events::tests::event_retention_purge_deletes_old_terminal_deliveries_without_deleting_event ... ok
test events::tests::moving_a_collection_to_its_current_parent_is_a_noop ... ok
test events::tests::event_delivery_worker_marks_successful_delivery_succeeded ... ok
test events::tests::ordinary_event_delete_is_rejected_by_append_only_trigger ... ok
test events::tests::group_membership_writes_emit_added_removed_events_when_changed ... ok
test exports::tests::allows_relation_context_with_empty_related_object_includes ... ok
test exports::tests::authorization_candidates_reject_mismatched_resources ... ok
test events::tests::event_retention_purge_keeps_events_pending_fanout ... ok
test exports::tests::hydration_budget_rejects_when_export_budget_is_exhausted ... ok
test exports::tests::hydration_budget_reserves_capacity_for_root_object ... ok
test events::tests::object_relation_writes_emit_lifecycle_events_in_transaction ... ok
test exports::tests::infers_relation_aliases_from_class_names ... ok
test exports::tests::normalizes_relation_alias_segments_predictably ... ok
test exports::tests::object_graph_edge_is_independent_of_relation_direction ... ok
test events::tests::event_delivery_worker_retries_with_backoff_then_marks_dead ... ok
test events::tests::remote_target_writes_emit_lifecycle_and_invoked_events_with_redacted_auth ... ok
test exports::tests::pluralizes_relation_aliases_predictably ... ok
test exports::tests::rejects_export_output_limit_above_server_cap ... ok
test exports::tests::rejects_relation_context_with_related_object_includes ... ok
test exports::tests::rejects_zero_export_limits ... ok
test exports::tests::take_related_within_budget_allows_within_capacity ... ok
test exports::tests::take_related_within_budget_errors_when_exhausted ... ok
test exports::tests::take_related_within_budget_errors_when_second_root_exceeds_remaining ... ok
test lifecycle::tests::shutdown_cancels_an_in_progress_iteration ... ok
test lifecycle::tests::shutdown_interrupts_a_worker_in_polling_sleep ... ok
test lifecycle::tests::shutdown_joins_an_idle_worker ... ok
test lifecycle::tests::supervision_rejects_an_empty_worker_set ... ok
test events::tests::event_retention_purge_keeps_events_with_active_deliveries ... ok
test logger::tests::authorization_helpers_log_grant_and_denial_levels ... ok
test logger::tests::deferred_mutation_logs_are_discarded_after_failure ... ok
test logger::tests::deferred_mutation_logs_are_emitted_after_success ... ok
test logger::tests::event_fields_override_span_fields_without_duplicate_json_keys ... ok
test logger::tests::logging_format_emits_json_fields ... ok
test logger::tests::logging_format_inherits_span_fields ... ok
test logger::tests::logging_format_serializes_explicit_structured_fields_as_json_values ... ok
test logger::tests::operation_mutation_helper_uses_catalog_labels_without_payloads ... ok
test logger::tests::test_logging_format_handles_special_characters ... ok
test middlewares::actor_context::tests::public_paths_skip_authentication_resolution ... ok
test middlewares::client_allowlist::resolve_tests::allowlist_rejects_spoofed_prepended_client ... ok
test middlewares::client_allowlist::resolve_tests::allowlist_skips_trusted_proxy_and_takes_client ... ok
test middlewares::client_allowlist::resolve_tests::hop_count_skips_configured_hops_from_the_right ... ok
test middlewares::client_allowlist::resolve_tests::parse_ip_token_handles_socket_and_bracketed_forms ... ok
test middlewares::client_allowlist::resolve_tests::peer_only_ignores_forwarded_headers ... ok
test middlewares::client_allowlist::resolve_tests::rotating_spoofed_xff_cannot_change_resolved_client ... ok
test middlewares::client_allowlist::resolve_tests::trust_enabled_with_no_peer_fails_closed ... ok
test middlewares::client_allowlist::resolve_tests::trust_enabled_without_mechanism_falls_back_to_peer ... ok
test middlewares::maintenance::tests::maintenance_path_availability::case_1_health ... ok
test middlewares::maintenance::tests::maintenance_path_availability::case_2_readiness ... ok
test middlewares::maintenance::tests::maintenance_path_availability::case_3_default_metrics ... ok
test middlewares::maintenance::tests::maintenance_path_availability::case_4_custom_metrics ... ok
test middlewares::maintenance::tests::maintenance_path_availability::case_5_restore_status ... ok
test middlewares::maintenance::tests::maintenance_path_availability::case_6_restore_confirmation ... ok
test middlewares::maintenance::tests::maintenance_path_availability::case_7_ordinary_api ... ok
test middlewares::maintenance::tests::restore_initiation_paths::case_1_restore_confirmation ... ok
test middlewares::maintenance::tests::restore_initiation_paths::case_2_restore_status ... ok
test middlewares::maintenance::tests::restore_initiation_paths::case_3_ordinary_api ... ok
test middlewares::rate_limit::tests::backoff_escalates_when_sustained_but_resets_after_cooloff ... ok
test events::tests::object_writes_emit_lifecycle_events_in_transaction ... ok
test middlewares::rate_limit::tests::limiter_keys_have_bounded_metric_scope_kinds::case_1 ... ok
test middlewares::rate_limit::tests::limiter_keys_have_bounded_metric_scope_kinds::case_2 ... ok
test middlewares::rate_limit::tests::limiter_keys_have_bounded_metric_scope_kinds::case_3 ... ok
test middlewares::rate_limit::tests::limiter_keys_have_bounded_metric_scope_kinds::case_4 ... ok
test middlewares::rate_limit::tests::lockout_duration_doubles_and_caps ... ok
test middlewares::rate_limit::tests::concurrent_attempts_reserve_capacity_atomically ... ok
test middlewares::rate_limit::tests::memory_capacity_rejects_new_scope_without_evicting_active_lockout ... ok
test middlewares::rate_limit::tests::prune_map_keeps_locked_but_drops_expired ... ok
test middlewares::rate_limit::tests::memory_store_satisfies_limiter_contract ... ok
test middlewares::rate_limit::tests::prune_map_retains_expired_lockouts_within_cooloff ... ok
test middlewares::rate_limit::tests::repeated_lockouts_increase_backoff_level ... ok
test middlewares::rate_limit::tests::scope_locks_after_reaching_threshold ... ok
test middlewares::rate_limit::tests::scopes_cover_user_ip_and_subnet_when_enabled ... ok
test middlewares::rate_limit::tests::scopes_skip_disabled_and_unknown_ip ... ok
test middlewares::rate_limit::tests::shared_store_accepts_remote_admin_release_despite_stale_local_lockout ... ignored, requires Valkey or Redis at redis://127.0.0.1:6379/
test middlewares::rate_limit::tests::subnet_label_aggregates_by_prefix ... ok
test middlewares::rate_limit::tests::valkey_capacity_does_not_evict_active_lockouts ... ignored, requires Valkey or Redis at redis://127.0.0.1:6379/
test middlewares::rate_limit::tests::valkey_capacity_does_not_evict_in_flight_reservations ... ignored, requires Valkey or Redis at redis://127.0.0.1:6379/
test middlewares::rate_limit::tests::valkey_store_satisfies_limiter_contract ... ignored, requires Valkey or Redis at redis://127.0.0.1:6379/
test middlewares::rate_limit::tests::valkey_store_settings_debug_redacts_connection_url ... ok
test models::backup::sensitive_debug_tests::backup_debug_reports_shape_without_snapshot_rows ... ok
test models::backup::sensitive_debug_tests::restore_debug_redacts_capabilities_and_persisted_errors ... ok
test models::backup::tests::backup_requests_include_history_by_default ... ok
test lifecycle::tests::supervision_reports_a_worker_that_stops ... ok
test models::backup::tests::backup_requests_reject_non_backup_fields::case_1_scope ... ok
test models::backup::tests::backup_requests_reject_non_backup_fields::case_2_embedded_import ... ok
test models::backup::tests::restore_initiator_rejects_invalid_snapshots::case_1_non_positive_principal ... ok
test models::backup::tests::restore_initiator_rejects_invalid_snapshots::case_2_empty_scope ... ok
test models::backup::tests::restore_initiator_rejects_invalid_snapshots::case_3_empty_name ... ok
test models::backup::tests::restore_job_id_rejects_non_positive_values_at_deserialization ... ok
test models::backup::tests::restore_stage_request_rejects_an_empty_document ... ok
test middlewares::rate_limit::tests::unavailable_valkey_falls_back_to_local_enforcement ... ok
test events::tests::token_writes_emit_created_revoked_events_without_token_material ... ok
test events::tests::token_renewal_event_links_source_and_copies_hash_free_scope ... ok
test events::tests::permission_writes_emit_granted_revoked_events ... ok
test models::collection::tests::grant_to_nonexistent_group ... ok
test events::tests::event_retention_skips_a_batch_while_another_replica_holds_the_coordinator_lock ... ok
test events::tests::user_writes_emit_lifecycle_events_without_password_material ... ok
test models::collection::tests::database_rejects_direct_root_delete_and_reparent ... ok
test models::class::tests::test_creating_class_and_cascade_delete ... ok
test models::class::tests::test_saving_after_changing_class ... ok
test models::class::tests::test_updating_class_and_deleting_it ... ok
test exports::tests::hydration_metadata_hides_unauthorized_class_relations ... ok
test models::computed_field::tests::invalid_operation_shape_is_a_bad_request ... ok
test models::computed_field::tests::request_validation_uses_typed_evaluator_contract ... ok
test models::event_delivery::tests::storage_health_snapshot_projects_into_the_existing_api_shape ... ok
test models::event_subscription::tests::common_secret_key_spellings_are_sensitive::case_1_api_header ... ok
test models::event_subscription::tests::common_secret_key_spellings_are_sensitive::case_2_compact_api_header ... ok
test models::event_subscription::tests::common_secret_key_spellings_are_sensitive::case_3_auth_token_header ... ok
test models::event_subscription::tests::common_secret_key_spellings_are_sensitive::case_4_client_secret ... ok
test models::event_subscription::tests::common_secret_key_spellings_are_sensitive::case_5_authorization_header ... ok
test models::event_subscription::tests::common_secret_key_spellings_are_sensitive::case_6_credentials ... ok
test models::event_subscription::tests::common_secret_key_spellings_are_sensitive::case_7_private_key ... ok
test models::event_subscription::tests::event_sink_debug_redacts_request_and_persisted_configuration ... ok
test models::event_subscription::tests::event_subscription_debug_redacts_request_and_persisted_routing ... ok
test models::event_subscription::tests::event_subscription_serialization_redacts_routing_credentials ... ok
test models::event_subscription::tests::non_secret_keys_remain_visible::case_1_routing_key ... ok
test models::event_subscription::tests::non_secret_keys_remain_visible::case_2_ordinary_key_suffix ... ok
test models::event_subscription::tests::non_secret_keys_remain_visible::case_3_public_key ... ok
test models::export::tests::scope_validation_rejects_invalid_domain_state::case_1_ids_on_collection ... ok
test models::export::tests::scope_validation_rejects_invalid_domain_state::case_2_missing_class ... ok
test models::export::tests::scope_validation_rejects_invalid_domain_state::case_3_extra_object ... ok
test models::export::tests::scope_validation_rejects_invalid_domain_state::case_4_incomplete_relation ... ok
test models::export::tests::scope_validation_rejects_invalid_domain_state::case_5_invalid_class ... ok
test models::export::tests::scope_validation_rejects_invalid_domain_state::case_6_invalid_object ... ok
test models::export::tests::scope_validation_returns_typed_domain_state::case_1_collections ... ok
test models::export::tests::scope_validation_returns_typed_domain_state::case_2_objects_in_class ... ok
test models::export::tests::scope_validation_returns_typed_domain_state::case_3_related_objects ... ok
test models::import::tests::core_import_timestamps_are_validated::case_1_collection ... ok
test models::import::tests::core_import_timestamps_are_validated::case_2_class ... ok
test models::import::tests::core_import_timestamps_are_validated::case_3_object ... ok
test models::import::tests::core_import_timestamps_are_validated::case_4_class_relation ... ok
test models::import::tests::core_import_timestamps_are_validated::case_5_object_relation ... ok
test models::import::tests::import_debug_redacts_graph_and_integration_configuration ... ok
test models::import::tests::import_rejects_ambiguous_extended_selectors ... ok
test models::import::tests::import_rejects_invalid_event_sink_configuration ... ok
test models::import::tests::import_rejects_invalid_remote_target_auth ... ok
test models::import::tests::import_rejects_malformed_export_templates ... ok
test models::import::tests::import_v2_rejects_v1_and_parses_revision_conditions ... ok
test models::import::tests::imported_human_credentials_are_mutually_exclusive_and_argon2_only::case_1_plain_password ... ok
test models::import::tests::imported_human_credentials_are_mutually_exclusive_and_argon2_only::case_2_both ... ok
test models::import::tests::imported_human_credentials_are_mutually_exclusive_and_argon2_only::case_3_invalid_hash ... ok
test models::import::tests::imported_human_debug_redacts_credentials::case_1_plaintext ... ok
test models::import::tests::imported_human_debug_redacts_credentials::case_2_hash ... ok
test models::import::tests::imported_timestamps_follow_creation_order::case_1_same ... ok
test models::import::tests::imported_timestamps_follow_creation_order::case_2_later ... ok
test models::import::tests::imported_timestamps_follow_creation_order::case_3_earlier ... ok
test models::import::tests::optional_extended_selectors_are_exclusive::case_1_omitted ... ok
test models::import::tests::optional_extended_selectors_are_exclusive::case_2_reference ... ok
test models::import::tests::optional_extended_selectors_are_exclusive::case_3_key ... ok
test models::import::tests::optional_extended_selectors_are_exclusive::case_4_ambiguous ... ok
test models::import::tests::required_extended_selectors_are_exclusive::case_1_reference ... ok
test models::import::tests::required_extended_selectors_are_exclusive::case_2_key ... ok
test models::import::tests::required_extended_selectors_are_exclusive::case_3_missing ... ok
test models::import::tests::required_extended_selectors_are_exclusive::case_4_ambiguous ... ok
test models::import::tests::test_import_request_mode_fills_missing_fields_with_defaults ... ok
test models::json_patch::tests::test_operation_compares_numeric_representations_recursively ... ok
test models::object::tests::contextual_object_request_infers_path_ids::case_1_omitted ... ok
test models::object::tests::contextual_object_request_infers_path_ids::case_2_matching ... ok
test models::object::tests::contextual_object_request_rejects_conflicting_path_ids::case_1_collection ... ok
test models::object::tests::contextual_object_request_rejects_conflicting_path_ids::case_2_class ... ok
test exports::tests::external_graph_authorization_preserves_allowed_alternative_path ... ok
test models::object_aggregate::tests::accepts_cursor_with_correct_scalar_value_type::case_1 ... ok
test models::object_aggregate::tests::accepts_cursor_with_correct_scalar_value_type::case_2 ... ok
test models::object_aggregate::tests::accepts_cursor_with_correct_scalar_value_type::case_3 ... ok
test models::object_aggregate::tests::accepts_cursor_with_correct_scalar_value_type::case_4 ... ok
test models::object_aggregate::tests::accepts_cursor_with_correct_scalar_value_type::case_5 ... ok
test models::object_aggregate::tests::aggregate_authorization_requires_object_and_collection_access::case_1 ... ok
test models::object_aggregate::tests::aggregate_authorization_requires_object_and_collection_access::case_2 ... ok
test models::object_aggregate::tests::cursor_budget_accounts_for_the_complete_replay_target ... ok
test models::object_aggregate::tests::cursor_emission_uses_the_request_specific_budget ... ok
test models::object_aggregate::tests::cursor_is_bound_to_dimension_and_sort_spec ... ok
test models::object_aggregate::tests::cursor_is_bound_to_measure_spec ... ok
test models::object_aggregate::tests::database_measure_values_gain_typed_request_metadata ... ok
test models::object_aggregate::tests::existing_cursor_does_not_reduce_its_replacement_budget ... ok
test models::object_aggregate::tests::parses_computed_source_filters ... ok
test models::object_aggregate::tests::parses_global_numeric_measures_without_grouping ... ok
test models::object_aggregate::tests::parses_ordered_multidimensional_group_query ... ok
test models::object_aggregate::tests::refuses_to_emit_an_unreplayable_group_cursor ... ok
test models::object_aggregate::tests::rejects_an_oversized_group_cursor_before_decoding ... ok
test models::object_aggregate::tests::rejects_cursor_with_invalid_ordering_values::case_1 ... ok
test models::object_aggregate::tests::rejects_cursor_with_invalid_ordering_values::case_2 ... ok
test models::object_aggregate::tests::rejects_cursor_with_invalid_ordering_values::case_3 ... ok
test models::object_aggregate::tests::rejects_cursor_with_invalid_ordering_values::case_4 ... ok
test models::object_aggregate::tests::rejects_cursor_with_invalid_ordering_values::case_5 ... ok
test models::object_aggregate::tests::rejects_cursor_with_invalid_ordering_values::case_6 ... ok
test models::object_aggregate::tests::rejects_cursor_with_wrong_scalar_value_type::case_1 ... ok
test models::object_aggregate::tests::rejects_cursor_with_wrong_scalar_value_type::case_2 ... ok
test models::object_aggregate::tests::rejects_cursor_with_wrong_scalar_value_type::case_3 ... ok
test models::object_aggregate::tests::rejects_cursor_with_wrong_scalar_value_type::case_4 ... ok
test models::object_aggregate::tests::rejects_cursor_with_wrong_scalar_value_type::case_5 ... ok
test models::object_aggregate::tests::rejects_cursor_with_wrong_scalar_value_type::case_6 ... ok
test models::object_aggregate::tests::rejects_duplicate_or_excessive_measures ... ok
test models::object_aggregate::tests::rejects_empty_or_malformed_json_paths ... ok
test models::object_aggregate::tests::rejects_invalid_or_injection_shaped_aggregate_syntax::case_1 ... ok
test models::object_aggregate::tests::rejects_invalid_or_injection_shaped_aggregate_syntax::case_2 ... ok
test models::object_aggregate::tests::rejects_invalid_or_injection_shaped_aggregate_syntax::case_3 ... ok
test models::object_aggregate::tests::rejects_invalid_or_injection_shaped_aggregate_syntax::case_4 ... ok
test models::object_aggregate::tests::rejects_invalid_or_injection_shaped_aggregate_syntax::case_5 ... ok
test models::object_aggregate::tests::rejects_missing_group_dimensions ... ok
test models::object_aggregate::tests::rejects_more_than_three_group_dimensions ... ok
test models::object_aggregate::tests::rejects_non_positive_object_counts::case_1 ... ok
test models::object_aggregate::tests::rejects_non_positive_object_counts::case_2 ... ok
test models::object_aggregate::tests::rejects_object_list_sort_fields ... ok
test models::object_data_patch::tests::object_data_patch_add_replaces_a_complete_existing_member_without_merging ... ok
test models::collection::tests::inherited_permissions_apply_without_unioning_rows ... ok
test models::object_data_patch::tests::object_data_patch_decodes_json_pointer_escaping ... ok
test models::object_data_patch::tests::object_data_patch_empty_path_replaces_the_complete_document ... ok
test models::object_data_patch::tests::object_data_patch_failure_restores_prior_operations ... ok
test models::object_data_patch::tests::object_data_patch_preserves_array_add_behavior::case_1_insert ... ok
test models::object_data_patch::tests::object_data_patch_preserves_array_add_behavior::case_2_append ... ok
test models::object::tests::test_creating_object_manual_delete ... ok
test models::object_data_patch::tests::object_data_patch_rejects_a_result_with_excessive_nesting ... ok
test models::object_data_patch::tests::object_data_patch_rejects_excessive_operation_count ... ok
test models::object_data_patch::tests::object_data_patch_rejects_excessive_pointer_depth ... ok
test models::object_data_patch::tests::object_data_patch_rejects_invalid_array_indices::case_1_leading_zero ... ok
test models::object_data_patch::tests::object_data_patch_rejects_invalid_array_indices::case_2_past_end ... ok
test models::object_data_patch::tests::object_data_patch_rejects_invalid_array_indices::case_3_non_numeric ... ok
test models::object_data_patch::tests::object_data_patch_reports_each_failed_rfc_6902_operation::case_1_add_missing_parent ... ok
test models::object_data_patch::tests::object_data_patch_reports_each_failed_rfc_6902_operation::case_2_remove_missing_member ... ok
test models::object_data_patch::tests::object_data_patch_reports_each_failed_rfc_6902_operation::case_3_replace_missing_member ... ok
test models::object_data_patch::tests::object_data_patch_reports_each_failed_rfc_6902_operation::case_4_move_missing_source ... ok
test models::object_data_patch::tests::object_data_patch_reports_each_failed_rfc_6902_operation::case_5_copy_missing_source ... ok
test models::object_data_patch::tests::object_data_patch_reports_each_failed_rfc_6902_operation::case_6_test_mismatch ... ok
test models::object_data_patch::tests::object_data_patch_supports_each_rfc_6902_operation::case_1_add ... ok
test models::object_data_patch::tests::object_data_patch_supports_each_rfc_6902_operation::case_2_remove ... ok
test models::object_data_patch::tests::object_data_patch_supports_each_rfc_6902_operation::case_3_replace ... ok
test models::object_data_patch::tests::object_data_patch_supports_each_rfc_6902_operation::case_4_move_value ... ok
test models::object_data_patch::tests::object_data_patch_supports_each_rfc_6902_operation::case_5_copy ... ok
test models::object_data_patch::tests::object_data_patch_supports_each_rfc_6902_operation::case_6_test_success ... ok
test models::permissions::tests::permission_list_constructor_preserves_first_occurrences ... ok
test models::permissions::tests::permission_list_deserialization_canonicalizes_duplicates ... ok
test models::permissions::tests::template_permissions_parse_and_display_round_trip ... ok
test models::relation::tests::class_relation_normalization_keeps_directional_settings_with_their_classes ... ok
test models::collection::tests::test_template_permissions_set_grant_and_revoke ... ok
test models::collection::tests::moving_collections_updates_ancestors_and_rejects_cycles ... ok
test models::object_data_patch::tests::object_data_patch_rejects_a_result_larger_than_the_object_data_limit ... ok
test models::collection::tests::test_permission_grant_without_side_effects ... ok
test exports::tests::permission_aware_export_uses_external_backend_visibility ... ok
test models::collection::tests::test_template_permission_backfill_updates_only_delegators ... ok
test models::collection::tests::test_list_groups_who_can ... ok
test models::object_data_patch::tests::object_data_patch_bounds_cumulative_application_work ... ok
test models::relation::tests::test_bidirectional_transitive_class_relations ... ok
test models::relation::tests::test_creating_class_relation ... ok
test models::relation::tests::test_creating_class_relation_lowest_id_becomes_from ... ok
test models::relation::tests::test_class_reachability_rebuild_switches_to_remaining_shortest_path ... ok
test models::relation::tests::test_creating_class_relation_with_same_classes ... ok
test models::relation::tests::test_cleanup_scoped_to_deleted_class_relation ... ok
test models::relation::tests::test_cleanup_preserves_object_relations_with_alternative_path ... ok
test models::relation::tests::test_deleting_class_relation ... ok
test models::relation::tests::test_bidirectional_transitive_object_traversal ... ok
test models::remote_target::tests::api_key_header_name_is_validated ... ok
test models::remote_target::tests::curated_filters_are_accepted_in_templates ... ok
test models::remote_target::tests::object_targets_require_class_scope ... ok
test models::remote_target::tests::remote_auth_debug_redacts_secret_references ... ok
test models::remote_target::tests::remote_call_result_debug_redacts_url_headers_and_body ... ok
test models::remote_target::tests::remote_http_method_parses_supported_methods ... ok
test models::remote_target::tests::remote_invocation_debug_redacts_parameters_body_and_context ... ok
test models::remote_target::tests::remote_target_debug_redacts_all_outbound_configuration ... ok
test models::remote_target::tests::target_parts_validate_templates_and_auth_references ... ok
test models::remote_target::tests::transport_controlled_api_key_header_is_rejected ... ok
test models::remote_target::tests::transport_controlled_header_template_is_rejected ... ok
test models::retention::tests::computes_expiry_from_the_supplied_clock ... ok
test models::retention::tests::rejects_an_expiry_outside_the_timestamp_range ... ok
test models::retention::tests::rejects_non_positive_values::case_1_hours ... ok
test models::retention::tests::rejects_non_positive_values::case_2_minutes ... ok
test models::retention::tests::rejects_unrepresentable_durations::case_1_hours ... ok
test models::retention::tests::rejects_unrepresentable_durations::case_2_minutes ... ok
test models::revision::tests::revision_advancement_is_checked ... ok
test models::revision::tests::revision_is_a_transparent_json_integer ... ok
test models::revision::tests::revision_rejects_non_positive_values ... ok
test models::search::test::docs_json_data_aliases_map_to_object_data_column ... ok
test models::search::test::docs_parse_query_parameter_accepts_negated_between_filter ... ok
test models::search::test::docs_parse_query_parameter_accepts_order_by_alias ... ok
test models::search::test::docs_parse_query_parameter_clamps_limit_above_maximum ... ok
test models::search::test::docs_parse_query_parameter_plain_filter_defaults_to_equals ... ok
test models::search::test::json_filter_rejects_malformed_paths::case_1 ... ok
test models::search::test::json_filter_rejects_malformed_paths::case_2 ... ok
test models::search::test::json_filter_rejects_malformed_paths::case_3 ... ok
test models::search::test::json_filter_rejects_malformed_paths::case_4 ... ok
test models::search::test::json_filter_rejects_malformed_paths::case_5 ... ok
test models::search::test::json_is_null_filter_uses_the_shared_path_validation ... ok
test models::search::test::non_json_field_cannot_abort_json_sql_generation ... ok
test models::search::test::oversized_integer_range_maps_to_the_public_validation_error ... ok
test models::search::test::parse_query_parameter_preserves_total_count_opt_out ... ok
test models::search::test::test_empty_query_string_returns_empty_vec ... ok
test models::search::test::test_get_sql_mapped_type_from_value ... ok
test models::search::test::test_get_sql_mapped_type_from_value_and_operator ... ok
test models::search::test::test_is_applicable_to ... ok
test models::search::test::test_json_field_type_from_schema ... ok
test models::search::test::test_json_field_type_from_schema_failures ... ok
test models::search::test::test_json_schema_sql_generation_wrapping ... ok
test models::search::test::test_json_schema_sql_query_boolean_generation ... ok
test models::search::test::test_json_schema_sql_query_date_generation ... ok
test models::search::test::test_json_schema_sql_query_ip_generation ... ok
test models::search::test::test_json_schema_sql_query_ip_validation ... ok
test models::search::test::test_json_schema_sql_query_numerical_generation ... ok
test models::search::test::test_json_schema_sql_query_text_generation ... ok
test models::search::test::test_new_from_string ... ok
test models::search::test::test_parse_integer_list::case_01 ... ok
test models::search::test::test_parse_integer_list::case_02 ... ok
test models::search::test::test_parse_integer_list::case_03 ... ok
test models::search::test::test_parse_integer_list::case_04 ... ok
test models::search::test::test_parse_integer_list::case_05 ... ok
test models::search::test::test_parse_integer_list::case_06 ... ok
test models::search::test::test_parse_integer_list::case_07 ... ok
test models::search::test::test_parse_integer_list::case_08 ... ok
test models::search::test::test_parse_integer_list::case_09 ... ok
test models::search::test::test_parse_integer_list::case_10 ... ok
test models::search::test::test_parse_integer_list::case_11 ... ok
test models::search::test::test_parse_integer_list::case_12 ... ok
test models::search::test::test_parse_integer_list::case_13 ... ok
test models::search::test::test_parse_integer_list::case_14 ... ok
test models::search::test::test_parse_integer_list_failures::case_1 ... ok
test models::search::test::test_parse_integer_list_failures::case_2 ... ok
test models::search::test::test_parse_integer_list_failures::case_3 ... ok
test models::search::test::test_parse_query_parameter_decodes_keys_values_and_plus ... ok
test models::search::test::test_parse_query_parameter_rejects_duplicate_cursor ... ok
test models::search::test::test_parse_query_parameter_rejects_zero_limit ... ok
test models::search::test::test_parse_query_parameter_with_cursor ... ok
test models::search::test::test_parse_query_parameter_with_passthrough_extracts_endpoint_local_values ... ok
test models::search::test::test_parse_query_parameter_with_passthrough_preserves_repeated_local_keys ... ok
test models::search::test::test_query_string_bad_request::case_1 ... ok
test models::search::test::test_query_string_bad_request::case_2 ... ok
test models::search::test::test_query_string_bad_request::case_3 ... ok
test models::search::test::test_query_string_parsing::case_1 ... ok
test models::search::test::test_query_string_parsing::case_2 ... ok
test models::search::test::test_query_string_parsing::case_3 ... ok
test models::search::test::test_query_string_parsing::case_4 ... ok
test models::search::test::test_query_string_without_equal_sign_returns_error ... ok
test models::task::tests::active_task_statuses_are_stable ... ok
test models::task::tests::export_task_details_include_persisted_phase_timings ... ok
test models::task::tests::task_id_deserialize_routes_through_new ... ok
test models::task::tests::task_id_new_accepts_positive ... ok
test models::task::tests::task_id_new_rejects_non_positive ... ok
test models::task::tests::task_record_debug_redacts_request_and_lease_material ... ok
test models::task::tests::task_result_counts_derive_processed_from_terminal_outcomes ... ok
test models::task::tests::task_result_counts_reject_negative_stored_values ... ok
test models::task::tests::task_result_counts_reject_processed_overflow ... ok
test models::task::tests::terminal_task_statuses_are_stable ... ok
test models::token::tests::principal_token_debug_redacts_stored_digest ... ok
test models::token_scope::tests::class_scope_does_not_expose_parent_collection ... ok
test models::token_scope::tests::collection_candidates_are_intersected_with_resource_scope ... ok
test models::token_scope::tests::collection_scope_covers_descendant_resources ... ok
test models::token_scope::tests::empty_stored_resource_scope_denies_resources ... ok
test models::token_scope::tests::object_scope_covers_only_the_named_object ... ok
test models::token_scope::tests::permission_only_scope_does_not_filter_collection_candidates ... ok
test models::token_scope::tests::relation_requires_both_endpoints_inside_scope ... ok
test models::token_scope::tests::request_resource_scope_count_is_bounded ... ok
test models::token_scope::tests::resource_ids_are_grouped_by_kind ... ok
test models::token_scope::tests::resource_scope_uses_tagged_wire_format ... ok
test models::token_scope::tests::stored_resource_scope_count_is_bounded ... ok
test models::token_scope::tests::task_snapshot_round_trips_both_scope_dimensions ... ok
test models::relation::tests::test_creating_object_relation ... ok
test models::unified_search::tests::cursor_decoder_accepts_legacy_json_tokens ... ok
test models::unified_search::tests::cursor_round_trips_through_encode_and_decode ... ok
test models::unified_search::tests::parse_unified_search_decodes_form_encoded_query_text ... ok
test models::unified_search::tests::parse_unified_search_defaults ... ok
test models::unified_search::tests::parse_unified_search_flags_and_cursor ... ok
test models::unified_search::tests::parse_unified_search_rejects_oversized_query ... ok
test models::unified_search::tests::parse_unified_search_rejects_unknown_parameter ... ok
test models::unified_search::tests::parse_with_limits_uses_default_when_absent ... ok
test models::unified_search::tests::parse_with_limits_validates_against_provided_max ... ok
test models::unified_search::tests::unified_search_query_reduces_to_backend_spec ... ok
test models::user::tests::login_fields_accept_their_documented_character_limits ... ok
test models::user::tests::new_user_debug_redacts_plaintext_password ... ok
test models::user::tests::oversized_login_fields_are_rejected::case_1_identity_scope ... ok
test models::user::tests::oversized_login_fields_are_rejected::case_2_name ... ok
test models::user::tests::oversized_login_fields_are_rejected::case_3_password ... ok
test models::user::tests::user_debug_redacts_stored_password_hash ... ok
test observability::metrics::cache::tests::cached_snapshot_is_fresh_before_the_ttl ... ok
test observability::metrics::cache::tests::expired_snapshot_remains_available_as_a_stale_fallback ... ok
test observability::metrics::export::tests::export_phase_attributes_are_bounded ... ok
test observability::metrics::export::tests::export_timer_labels_are_stable_and_bounded ... ok
test observability::metrics::export::tests::template_duration_attributes_use_stable_template_id ... ok
test observability::metrics::export::tests::untemplated_duration_attributes_use_none_identity ... ok
test observability::metrics::import::tests::import_phase_attributes_are_bounded ... ok
test observability::metrics::import::tests::import_timer_labels_are_stable_and_bounded ... ok
test observability::metrics::process::tests::large_unsigned_values_saturate_at_signed_metric_limit ... ok
test observability::metrics::process::tests::supported_platform_exports_process_metrics ... ok
test observability::metrics::registry::tests::request_histograms_use_subsecond_latency_buckets ... ok
test observability::metrics::registry::tests::storage_histograms_use_subsecond_latency_buckets ... ok
test observability::metrics::registry::tests::task_histograms_cover_long_running_background_work ... ok
test observability::metrics::scrape::tests::refresh_sources_have_stable_bounded_labels ... ok
test observability::metrics::task::tests::missing_terminal_timestamp_exports_zero ... ok
test observability::metrics::task::tests::task_age_states_have_stable_bounded_labels ... ok
test observability::metrics::task::tests::task_output_kinds_have_stable_bounded_labels ... ok
test observability::metrics::task::tests::terminal_timestamp_preserves_millisecond_precision_in_seconds ... ok
test observability::metrics::timer::tests::finished_timer_is_not_reported_as_unfinished ... ok
test observability::runtime_behavior::tests::assessment_rejects_non_exact_readiness_checkout_count ... ok
test observability::runtime_behavior::tests::assessment_rejects_relative_rate_regression ... ok
test observability::runtime_behavior::tests::counter_reset_is_rejected ... ok
test observability::runtime_behavior::tests::idle_report_excludes_scrape_refresh_acquisitions ... ok
test observability::runtime_behavior::tests::prometheus_parser_handles_label_order_and_escapes ... ok
test pagination::tests::cursor_decoding_rejects_a_mismatched_value_count ... ok
test pagination::tests::cursor_decoding_rejects_an_oversized_token_before_parsing ... ok
test pagination::tests::cursor_encoding_rejects_a_string_with_an_embedded_nul ... ok
test pagination::tests::cursor_encoding_rejects_an_oversized_token ... ok
test pagination::tests::cursor_encoding_rejects_json_that_decoding_would_reject ... ok
test pagination::tests::exact_total_count_can_be_skipped ... ok
test pagination::tests::in_memory_pagination_accepts_non_clone_rows ... ok
test pagination::tests::in_memory_pagination_extracts_each_sort_key_once ... ok
test pagination::tests::in_memory_pagination_propagates_sort_key_errors ... ok
test pagination::tests::json_cursor_accepts_the_maximum_nesting_depth ... ok
test pagination::tests::json_cursor_rejects_nesting_above_the_maximum ... ok
test pagination::tests::json_cursor_sql_accepts_postgres_numeric_boundaries::case_1_maximum_integral_digits ... ok
test pagination::tests::json_cursor_sql_accepts_postgres_numeric_boundaries::case_2_normalized_maximum_integral_digits ... ok
test pagination::tests::json_cursor_sql_accepts_postgres_numeric_boundaries::case_3_maximum_fractional_digits ... ok
test pagination::tests::json_cursor_sql_rejects_values_postgres_jsonb_cannot_represent::case_1_nul_string ... ok
test pagination::tests::json_cursor_sql_rejects_values_postgres_jsonb_cannot_represent::case_2_nul_key ... ok
test pagination::tests::json_cursor_sql_rejects_values_postgres_jsonb_cannot_represent::case_3_integral_overflow ... ok
test pagination::tests::json_cursor_sql_rejects_values_postgres_jsonb_cannot_represent::case_4_fractional_overflow ... ok
test pagination::tests::numeric_cursor_sql_rejects_a_decimal_outside_evaluator_bounds ... ok
test pagination::tests::numeric_cursor_sql_uses_a_canonical_decimal_literal ... ok
test pagination::tests::page_limits_reject_a_zero_requested_limit ... ok
test pagination::tests::page_limits_reject_invalid_invariants::case_1 ... ok
test pagination::tests::page_limits_reject_invalid_invariants::case_2 ... ok
test pagination::tests::page_limits_reject_invalid_invariants::case_3 ... ok
test pagination::tests::page_limits_resolve_defaults_and_clamp::case_1 ... ok
test pagination::tests::page_limits_resolve_defaults_and_clamp::case_2 ... ok
test pagination::tests::page_limits_resolve_defaults_and_clamp::case_3 ... ok
test pagination::tests::page_limits_resolve_defaults_and_clamp::case_4 ... ok
test pagination::tests::sql_cursor_filter_rejects_a_value_with_the_wrong_resolved_type ... ok
test pagination::tests::sql_json_cursor_rejects_values_postgres_jsonb_cannot_represent::case_1_nul_string ... ok
test pagination::tests::sql_json_cursor_rejects_values_postgres_jsonb_cannot_represent::case_2_nul_key ... ok
test pagination::tests::sql_json_cursor_rejects_values_postgres_jsonb_cannot_represent::case_3_integral_overflow ... ok
test pagination::tests::sql_json_cursor_rejects_values_postgres_jsonb_cannot_represent::case_4_fractional_overflow ... ok
test pagination::tests::sql_string_cursor_rejects_an_embedded_nul ... ok
test pagination::tests::test_cursor_filter_sql_handles_nullable_descending_strings ... ok
test pagination::tests::test_paginate_collections_descending ... ok
test pagination::tests::test_paginate_collections_with_cursor ... ok
test pagination::tests::test_prepare_db_pagination_adds_limit_and_tie_breaker ... ok
test permissions::types::tests::collection_helper_sets_collection_id_attr ... ok
test permissions::types::tests::collection_target_is_normalized_to_schema_compatible_class ... ok
test permissions::types::tests::collection_target_is_normalized_to_schema_compatible_template ... ok
test permissions::types::tests::principal_new_handles_empty_groups ... ok
test permissions::types::tests::principal_new_sorts_and_deduplicates_group_ids ... ok
test permissions::types::tests::reverse_relation_check_uses_relation_resource_shape ... ok
test permissions::types::tests::system_resource_has_no_collection ... ok
test permissions::visibility::tests::candidate_decision_count_mismatch_fails_closed ... ok
test restores::tests::restore_accepts_revisioned_deletion_event_shapes::case_1_deleted ... ok
test restores::tests::restore_accepts_revisioned_deletion_event_shapes::case_2_removed ... ok
test restores::tests::restore_accepts_revisioned_deletion_event_shapes::case_3_purged ... ok
test restores::tests::restore_capability_validation_handles_present_and_missing_stages::case_1_exact_match ... ok
test restores::tests::restore_capability_validation_handles_present_and_missing_stages::case_2_mismatch ... ok
test restores::tests::restore_capability_validation_handles_present_and_missing_stages::case_3_missing_stage ... ok
test restores::tests::restore_confirmation_staleness_respects_grace_period::case_1_just_confirmed ... ok
test restores::tests::restore_confirmation_staleness_respects_grace_period::case_2_inside_grace_period ... ok
test restores::tests::restore_confirmation_staleness_respects_grace_period::case_3_at_grace_boundary ... ok
test restores::tests::restore_confirmation_staleness_respects_grace_period::case_4_past_grace_period ... ok
test restores::tests::restore_rejects_computed_definition_scope_over_capacity::case_1_shared ... ok
test restores::tests::restore_rejects_computed_definition_scope_over_capacity::case_2_personal ... ok
test restores::tests::restore_rejects_duplicate_computed_definition_keys ... ok
test restores::tests::restore_settings_reject_unrepresentable_retention ... ok
test restores::tests::restore_settings_reject_zero_limits::case_1_upload_limit ... ok
test restores::tests::restore_settings_reject_zero_limits::case_2_retention ... ok
test restores::tests::restore_status_internal_errors_do_not_expose_details::case_1_internal_server ... ok
test restores::tests::restore_status_internal_errors_do_not_expose_details::case_2_database ... ok
test restores::tests::restore_status_internal_errors_do_not_expose_details::case_3_connection ... ok
test restores::tests::restore_status_internal_errors_do_not_expose_details::case_4_hash ... ok
test restores::tests::restore_status_preserves_public_safe_errors::case_1_validation ... ok
test restores::tests::restore_status_preserves_public_safe_errors::case_2_conflict ... ok
test exports::tests::object_hydration_query_count_is_constant_with_root_count ... ok
test services::class_relations::tests::class_relation_contract_class_delete_cascades_the_relation::case_2_memory ... ok
test models::relation::tests::test_creating_object_relation_reverse_duplicate_conflicts ... ok
test services::class_relations::tests::class_relation_contract_creates_and_resolves_the_endpoint_aggregate::case_2_memory ... ok
test models::relation::tests::test_creating_object_relation_failure_class_mismatch ... ok
test services::class_relations::tests::class_relation_contract_deletes_the_resolved_relation::case_2_memory ... ok
test models::relation::tests::test_deleting_class_relation_cascade ... ok
test services::class_relations::tests::class_relation_contract_normalizes_directional_settings::case_2_memory ... ok
test models::relation::tests::test_deleting_object_relation ... ok
test services::class_relations::tests::class_relation_contract_rejects_a_stale_prepared_endpoint::case_2_memory ... ok
test models::relation::tests::test_transitive_class_relations_paginated_cursor_path_sort ... ok
test services::class_relations::tests::class_relation_contract_rejects_duplicate_endpoint_pairs::case_2_memory ... ok
test services::class_relations::tests::class_relation_contract_creates_and_resolves_the_endpoint_aggregate::case_1_postgres ... ok
test services::class_relations::tests::class_relation_contract_rejects_self_relations::case_2_memory ... ok
test services::class_relations::tests::class_relation_contract_class_delete_cascades_the_relation::case_1_postgres ... ok
test services::class_relations::tests::class_relation_contract_supports_event_suppressed_compatibility_writes::case_2_memory ... ok
test services::class_relations::tests::memory_class_relation_events_cover_explicit_lifecycle_writes ... ok
test services::class_relations::tests::class_relation_contract_normalizes_directional_settings::case_1_postgres ... ok
test services::classes::tests::class_contract_changed_update_advances_revision::case_2_memory ... ok
test services::class_relations::tests::class_relation_contract_deletes_the_resolved_relation::case_1_postgres ... ok
test services::classes::tests::class_contract_collection_delete_cascades_the_class::case_2_memory ... ok
test models::relation::tests::test_finding_object_relations ... ok
test services::classes::tests::class_contract_delete_removes_the_resolved_class::case_2_memory ... ok
test services::class_relations::tests::class_relation_contract_rejects_self_relations::case_1_postgres ... ok
test services::classes::tests::class_contract_no_op_update_preserves_revision::case_2_memory ... ok
test models::relation::tests::test_transitive_object_traversal_supports_same_class_target ... ok
test services::classes::tests::class_contract_rejects_a_stale_name_target::case_2_memory ... ok
test services::class_relations::tests::class_relation_contract_rejects_a_stale_prepared_endpoint::case_1_postgres ... ok
test services::classes::tests::class_contract_rejects_invalid_json_schema::case_2_memory ... ok
test services::class_relations::tests::class_relation_contract_rejects_duplicate_endpoint_pairs::case_1_postgres ... ok
test services::class_relations::tests::class_relation_contract_supports_event_suppressed_compatibility_writes::case_1_postgres ... ok
test services::classes::tests::class_contract_resolves_explicit_addresses::case_3_memory_id ... ok
test services::classes::tests::class_contract_resolves_explicit_addresses::case_4_memory_name ... ok
test services::classes::tests::class_contract_changed_update_advances_revision::case_1_postgres ... ok
test services::classes::tests::class_contract_update_moves_the_class_between_collections::case_2_memory ... ok
test services::classes::tests::memory_class_events_exclude_no_op_updates ... ok
test services::classes::tests::class_contract_delete_removes_the_resolved_class::case_1_postgres ... ok
test services::collections::tests::collection_contract_allows_matching_names_under_different_parents::case_2_memory ... ok
test models::traits::user::test::test_user_permissions_collection_and_class_listing ... ok
test services::collections::tests::collection_contract_changed_update_advances_revision::case_2_memory ... ok
test services::classes::tests::class_contract_collection_delete_cascades_the_class::case_1_postgres ... ok
test services::collections::tests::collection_contract_create_is_visible_to_point_reads::case_2_memory ... ok
test services::classes::tests::class_contract_no_op_update_preserves_revision::case_1_postgres ... ok
test services::collections::tests::collection_contract_lists_direct_children::case_2_memory ... ok
test services::classes::tests::class_contract_rejects_invalid_json_schema::case_1_postgres ... ok
test services::collections::tests::collection_contract_move_reparents_the_subtree::case_2_memory ... ok
test services::classes::tests::class_contract_resolves_explicit_addresses::case_1_postgres_id ... ok
test services::collections::tests::collection_contract_no_op_update_preserves_revision::case_2_memory ... ok
test services::classes::tests::class_contract_rejects_a_stale_name_target::case_1_postgres ... ok
test services::collections::tests::collection_contract_orders_ancestors_nearest_first::case_2_memory ... ok
test services::classes::tests::class_contract_resolves_explicit_addresses::case_2_postgres_name ... ok
test services::collections::tests::collection_contract_rejects_deleting_a_parent_with_children::case_2_memory ... ok
test services::collections::tests::collection_contract_create_is_visible_to_point_reads::case_1_postgres ... ok
test services::collections::tests::collection_contract_rejects_matching_sibling_names::case_2_memory ... ok
test services::collections::tests::collection_contract_changed_update_advances_revision::case_1_postgres ... ok
test services::collections::tests::collection_contract_rejects_move_into_matching_sibling_name::case_2_memory ... ok
test services::collections::tests::memory_collection_events_exclude_no_op_updates ... ok
test services::object_relations::tests::memory_object_relation_events_cover_explicit_lifecycle_writes ... ok
test services::classes::tests::class_contract_update_moves_the_class_between_collections::case_1_postgres ... ok
test services::object_relations::tests::object_relation_contract_between_preparation_validates_path_membership::case_2_memory ... ok
test services::collections::tests::collection_contract_allows_matching_names_under_different_parents::case_1_postgres ... ok
test services::object_relations::tests::object_relation_contract_class_relation_delete_cascades_the_relation::case_2_memory ... ok
test services::collections::tests::collection_contract_no_op_update_preserves_revision::case_1_postgres ... ok
test services::object_relations::tests::object_relation_contract_deletes_the_resolved_relation::case_2_memory ... ok
test services::collections::tests::collection_contract_lists_direct_children::case_1_postgres ... ok
test services::object_relations::tests::object_relation_contract_enforces_directional_cardinality::case_2_memory ... ok
test services::collections::tests::collection_contract_move_reparents_the_subtree::case_1_postgres ... ok
test services::object_relations::tests::object_relation_contract_object_delete_cascades_the_relation::case_2_memory ... ok
test services::collections::tests::collection_contract_orders_ancestors_nearest_first::case_1_postgres ... ok
test services::object_relations::tests::object_relation_contract_prepares_a_normalized_endpoint_aggregate::case_2_memory ... ok
test models::collection::tests::test_permission_grant_combinations ... ok
test services::object_relations::tests::object_relation_contract_rejects_a_mismatched_class_relation::case_2_memory ... ok
test services::collections::tests::collection_contract_rejects_deleting_a_parent_with_children::case_1_postgres ... ok
test services::object_relations::tests::object_relation_contract_rejects_objects_from_the_same_class::case_2_memory ... ok
test services::collections::tests::collection_contract_rejects_matching_sibling_names::case_1_postgres ... ok
test services::object_relations::tests::object_relation_contract_rejects_reverse_duplicates::case_2_memory ... ok
test models::collection::tests::test_permission_revoke_combinations ... ok
test services::object_relations::tests::object_relation_contract_rejects_self_relations::case_2_memory ... ok
test services::collections::tests::collection_contract_rejects_move_into_matching_sibling_name::case_1_postgres ... ok
test services::object_relations::tests::object_relation_contract_between_preparation_validates_path_membership::case_1_postgres ... ok
test services::object_relations::tests::object_relation_contract_resolves_explicit_addresses::case_3_memory_id ... ok
test services::object_relations::tests::object_relation_contract_resolves_explicit_addresses::case_4_memory_between ... ok
test services::object_relations::tests::object_relation_contract_class_relation_delete_cascades_the_relation::case_1_postgres ... ok
test services::object_relations::tests::object_relation_contract_supports_event_suppressed_compatibility_writes::case_2_memory ... ok
test services::objects::tests::memory_object_events_exclude_no_op_mutations ... ok
test services::object_relations::tests::object_relation_contract_deletes_the_resolved_relation::case_1_postgres ... ok
test services::objects::tests::object_contract_changed_update_advances_revision::case_2_memory ... ok
test services::object_relations::tests::object_relation_contract_object_delete_cascades_the_relation::case_1_postgres ... ok
test services::objects::tests::object_contract_class_delete_cascades_the_object::case_2_memory ... ok
test services::object_relations::tests::object_relation_contract_enforces_directional_cardinality::case_1_postgres ... ok
test services::objects::tests::object_contract_delete_removes_the_resolved_object::case_2_memory ... ok
test services::object_relations::tests::object_relation_contract_prepares_a_normalized_endpoint_aggregate::case_1_postgres ... ok
test services::objects::tests::object_contract_no_op_patch_preserves_revision::case_2_memory ... ok
test services::object_relations::tests::object_relation_contract_rejects_a_mismatched_class_relation::case_1_postgres ... ok
test services::objects::tests::object_contract_no_op_update_preserves_revision::case_2_memory ... ok
test services::object_relations::tests::object_relation_contract_rejects_objects_from_the_same_class::case_1_postgres ... ok
test services::objects::tests::object_contract_patch_updates_data_and_revision::case_2_memory ... ok
test services::object_relations::tests::object_relation_contract_rejects_self_relations::case_1_postgres ... ok
test services::objects::tests::object_contract_rejects_a_stale_name_target::case_2_memory ... ok
test services::object_relations::tests::object_relation_contract_rejects_reverse_duplicates::case_1_postgres ... ok
test services::objects::tests::object_contract_rejects_data_outside_the_class_schema::case_2_memory ... ok
test services::object_relations::tests::object_relation_contract_resolves_explicit_addresses::case_1_postgres_id ... ok
test services::objects::tests::object_contract_changed_update_advances_revision::case_1_postgres ... ok
test services::objects::tests::object_contract_resolves_explicit_addresses::case_3_memory_id ... ok
test services::objects::tests::object_contract_resolves_explicit_addresses::case_4_memory_name ... ok
test services::related_filter_authorization::tests::relation_query_limit_requests_the_first_over_budget_row ... ok
test services::related_filter_authorization::tests::traversal_budget_rejects_objects_beyond_the_safety_limit ... ok
test services::storage_boundary::tests::visibility_preserves_independent_token_dimensions ... ok
test storage::contract::tests::postgres_satisfies_the_complete_storage_backend_contract ... ok
test storage::contract::tests::required_capabilities_are_stable_and_complete ... ok
test storage::factory::tests::settings_debug_redacts_the_connection_url ... ok
test storage::factory::tests::settings_require_backend_neutral_pool_limits ... ok
test storage::memory::error::tests::memory_model_errors_are_classified_before_crossing_the_storage_boundary ... ok
test storage::postgres::error::tests::postgres_errors_are_classified_before_crossing_the_storage_boundary ... ok
test storage::postgres::operations::authentication::tests::rejects_unknown_persisted_principal_kind ... ok
test storage::postgres::operations::backup::tests::snapshot_filters_are_validated_for_their_table::case_1_all_collections ... ok
test storage::postgres::operations::backup::tests::snapshot_filters_are_validated_for_their_table::case_2_task_filter_on_collection ... ok
test storage::postgres::operations::backup::tests::snapshot_tables_use_a_closed_allowlist::case_1_known ... ok
test storage::postgres::operations::backup::tests::snapshot_tables_use_a_closed_allowlist::case_2_injected ... ok
test storage::postgres::operations::computed_field::tests::canonical_hash_ignores_object_key_order ... ok
test storage::postgres::operations::computed_field::tests::canonical_hash_preserves_array_order ... ok
test storage::postgres::operations::computed_field::tests::computed_filter_count_is_bounded_before_sql_resolution ... ok
test storage::postgres::operations::computed_field::tests::computed_query_request_size_is_bounded_before_sql_resolution ... ok
test storage::postgres::operations::computed_objects::tests::cursor_projection_is_empty_for_a_terminal_page ... ok
test storage::postgres::operations::computed_objects::tests::cursor_projection_is_empty_for_an_empty_page ... ok
test storage::postgres::operations::computed_objects::tests::cursor_projection_selects_the_last_returned_object ... ok
test storage::postgres::operations::event_delivery::tests::event_delivery_row_debug_redacts_claim_token_and_error ... ok
test storage::postgres::operations::event_record::tests::event_row_debug_redacts_payloads_and_fanout_claim_token ... ok
test storage::postgres::operations::event_subscription::tests::event_sink_row_debug_redacts_configuration ... ok
test storage::postgres::operations::event_subscription::tests::event_subscription_audit_snapshot_redacts_routing_credentials ... ok
test storage::postgres::operations::event_subscription::tests::event_subscription_row_debug_redacts_routing ... ok
test services::object_relations::tests::object_relation_contract_resolves_explicit_addresses::case_2_postgres_between ... ok
test services::object_relations::tests::object_relation_contract_supports_event_suppressed_compatibility_writes::case_1_postgres ... ok
test services::objects::tests::object_contract_class_delete_cascades_the_object::case_1_postgres ... ok
test storage::postgres::operations::external_identity::tests::sync_external_user_preserves_principal_when_source_name_changes ... ok
test storage::postgres::operations::identity_operations::tests::token_state_mapping_is_complete ... ok
test storage::postgres::operations::permissions::tests::template_permissions_filter_map_to_expected_columns ... ok
test storage::postgres::operations::external_identity::tests::sync_external_user_batches_stale_membership_removal ... ok
test storage::postgres::operations::restore::tests::restore_coordinator_does_not_sample_activity_before_observing_draining ... ok
test storage::postgres::operations::restore::tests::restore_sql_identifiers_come_from_closed_lists::case_1_known ... ok
test storage::postgres::operations::restore::tests::restore_sql_identifiers_come_from_closed_lists::case_2_unknown_table ... ok
test storage::postgres::operations::restore::tests::restore_sql_identifiers_come_from_closed_lists::case_3_unknown_column ... ok
test storage::postgres::operations::restore::tests::restore_status_projection_fields::case_1_document ... ok
test storage::postgres::operations::restore::tests::restore_status_projection_fields::case_2_capability_hash ... ok
test storage::postgres::operations::search::tests::bind_placeholders_ignore_question_marks_in_sql_strings ... ok
test storage::postgres::operations::search::tests::bind_placeholders_returns_each_unquoted_offset ... ok
test services::objects::tests::object_contract_no_op_patch_preserves_revision::case_1_postgres ... ok
test storage::postgres::operations::external_identity::tests::sync_external_user_preserves_principal_when_source_subject_changes ... ok
test storage::postgres::operations::restore::tests::restore_coordinator_tick_uses_one_pool_checkout ... ok
test services::objects::tests::object_contract_delete_removes_the_resolved_object::case_1_postgres ... ok
test storage::postgres::operations::external_identity::tests::sync_external_user_reconciles_external_memberships_and_keeps_manual_memberships ... ok
test services::objects::tests::object_contract_no_op_update_preserves_revision::case_1_postgres ... ok
test storage::postgres::operations::task::tests::active_task_capacity_index_matches_the_admission_query ... ok
test storage::postgres::operations::service_account::tests::cancelling_pending_tasks_records_a_terminal_timestamp ... ok
test services::objects::tests::object_contract_patch_updates_data_and_revision::case_1_postgres ... ok
test storage::postgres::operations::task::tests::concurrent_active_task_admission_preserves_the_per_kind_limit::case_1 ... ok
test storage::postgres::operations::task::tests::concurrent_active_task_admission_preserves_the_per_kind_limit::case_2 ... ok
test services::objects::tests::object_contract_rejects_data_outside_the_class_schema::case_1_postgres ... ok
test storage::postgres::operations::service_account::tests::disabling_service_account_atomically_revokes_tokens_and_cancels_tasks ... ok
test services::objects::tests::object_contract_rejects_a_stale_name_target::case_1_postgres ... ok
test storage::postgres::operations::task::tests::concurrent_active_task_admission_preserves_the_per_kind_limit::case_3 ... ok
test storage::postgres::operations::task::tests::concurrent_active_task_admission_preserves_the_per_kind_limit::case_4 ... ok
test services::objects::tests::object_contract_resolves_explicit_addresses::case_1_postgres_id ... ok
test storage::postgres::operations::task::tests::database_time_is_naive_utc_under_non_utc_session_timezone ... ok
test services::objects::tests::object_contract_resolves_explicit_addresses::case_2_postgres_name ... ok
test storage::postgres::operations::task::tests::expired_single_item_task_records_terminal_failure::case_1 ... ok
test storage::postgres::operations::task::tests::expired_import_task_recomputes_counts_from_durable_results ... ok
test storage::postgres::operations::task::tests::task_claim_order_rotates_every_executable_kind_to_the_front ... ok
test storage::postgres::operations::task::tests::task_claim_query_limits_each_kind_before_priority_ordering ... ok
test storage::postgres::operations::task::tests::expired_single_item_task_records_terminal_failure::case_2 ... ok
test storage::postgres::operations::task::tests::task_request_builder_derives_scoped_persistence_fields ... ok
test storage::postgres::operations::task::tests::task_request_builder_derives_unscoped_persistence_fields ... ok
test storage::postgres::operations::task::tests::legacy_task_insert_copies_submitter_to_initiator ... ok
test storage::postgres::operations::task::tests::expired_task_lease_cannot_be_renewed ... ok
test storage::postgres::operations::task::tests::expired_task_lease_cannot_update_state_before_recovery ... ok
test storage::postgres::operations::task::tests::expired_single_item_task_records_terminal_failure::case_3 ... ok
test storage::postgres::operations::task::tests::test_task_capacity_lock_keys_do_not_collide_between_kind_slots ... ok
test storage::postgres::operations::task::tests::legacy_task_event_page_uses_bounded_provenance_queries ... ok
test storage::postgres::operations::task_import::tests::conditional_import_reports_a_missing_execution_target_as_stale ... ok
test storage::postgres::operations::task::tests::expired_task_lease_is_failed_without_replay ... ok
test storage::postgres::operations::token_retention::tests::concurrent_index_migrations_do_not_accept_invalid_same_name_indexes ... ok
test storage::postgres::operations::task::tests::stale_remote_call_worker_cannot_persist_a_result ... ok
test storage::postgres::operations::task::tests::stale_backup_worker_cannot_finalize_recovered_task ... ok
test storage::postgres::operations::task::tests::system_owned_task_queue_event_has_system_provenance ... ok
test storage::postgres::operations::task_import::tests::group_lookup_disambiguates_identity_scopes ... ok
test storage::postgres::operations::task::tests::stale_worker_cannot_update_recovered_task ... ok
test storage::postgres::operations::task::tests::task_lease_renewal_requires_the_claim_token ... ok
test storage::postgres::operations::task::tests::test_export_task_active_limit_blocks_new_work_for_same_user ... ok
test storage::postgres::operations::task::tests::test_remote_call_task_active_limit_blocks_new_work_for_same_user ... ok
test storage::postgres::operations::task::tests::test_import_task_active_limit_blocks_new_work_for_same_user ... ok
test storage::postgres::operations::task::tests::test_task_history_survives_user_deletion ... ok
test storage::postgres::operations::task::tests::test_claim_next_queued_task_is_safe_under_concurrency ... ok
test storage::postgres::operations::token_retention::tests::token_retention_supporting_index_exists::case_1 ... ok
test storage::postgres::operations::token_retention::tests::token_retention_supporting_index_exists::case_2 ... ok
test storage::postgres::operations::token_retention::tests::purge_batch_advances_all_indexed_terminal_streams ... ok
test storage::postgres::operations::token_retention::tests::token_retention_supporting_index_exists::case_3 ... ok
test storage::postgres::operations::token_retention::tests::token_retention_supporting_index_exists::case_4 ... ok
test storage::postgres::operations::token_retention::tests::purge_cascades_scope_rows_after_persisting_an_exact_audit_snapshot ... ok
test storage::postgres::operations::user::auth::tests::profile_update_preserves_active_tokens ... ok
test storage::postgres::operations::user::object_aggregate::sql::tests::count_sort_always_uses_complete_dimension_tie_breaker ... ok
test storage::postgres::operations::user::object_aggregate::sql::tests::json_dimension_sql_distinguishes_value_null_and_missing ... ok
test storage::postgres::operations::user::search::related_filter_tests::related_revision_equality_rejects_multiple_values ... ok
test storage::postgres::operations::user::search::related_filter_tests::related_target_seed_applies_class_resource_scope ... ok
test storage::postgres::operations::token_retention::tests::purge_deletes_explicit_expiry_after_retention ... ok
test storage::postgres::operations::user::auth::tests::password_update_revokes_all_active_tokens ... ok
test storage::postgres::operations::user::auth::tests::setting_password_revokes_all_active_tokens ... ok
test storage::postgres::operations::token_retention::tests::purge_deletes_implicit_expiry_after_lifetime_and_retention ... ok
test storage::postgres::operations::token_retention::tests::purge_deletes_revoked_token_before_its_future_expiry ... ok
test storage::postgres::operations::user::tests::test_user_can::case_01_u1_collection1_classread_true ... ok
test storage::postgres::operations::user::tests::test_user_can::case_03_u1_collection1_classreadcreate_true ... ok
test storage::postgres::operations::user::tests::test_user_can::case_02_u1_collection1_classcreate_true ... ok
test storage::postgres::operations::user::tests::test_user_can::case_05_u1_collection2_classcreate_true ... ok
test storage::postgres::operations::user::tests::test_user_can::case_04_u1_collection2_classdelete_true ... ok
test storage::postgres::operations::token_retention::tests::purge_respects_batch_size ... ok
test storage::postgres::operations::user::tests::test_user_can::case_06_u1_collection2_classcreatedelete_true ... ok
test storage::postgres::operations::token_retention::tests::purge_retains_explicit_expiry_during_retention ... ok
test storage::postgres::operations::user::tests::test_user_can::case_07_u1_collection12_classcreate_true ... ok
test storage::postgres::operations::user::tests::test_user_can::case_08_u1_collection1_objectread_false ... ok
test storage::postgres::operations::user::tests::test_user_can::case_09_u1_collection1_collectioncreate_false ... ok
test storage::postgres::operations::token_retention::tests::purge_retains_recently_revoked_token_before_expiry ... ok
test storage::postgres::runtime::tests::ambient_statement_timeout_scope_bounds_with_connection ... ok
test storage::postgres::operations::user::tests::test_user_can::case_11_u1_collection12_classreadcreatedelete_false ... ok
test storage::postgres::runtime::tests::database_call_sites_have_stable_bounded_labels ... ok
test storage::postgres::operations::user::tests::test_user_can::case_10_u1_collection12_classreadcreate_false ... ok
test storage::postgres::runtime::tests::required_database_migration_matches_latest_migration_directory ... ok
test storage::postgres::runtime::tests::resource_revision_migration_has_explicit_phase_transactions ... ok
test storage::postgres::runtime::tests::resource_revision_rollback_drops_the_persistent_computed_field_index ... ok
test storage::postgres::runtime::tests::resource_scope_rollback_revokes_tokens_before_dropping_scope_tables ... ok
test storage::postgres::runtime::tests::database_schema_readiness_accepts_the_migrated_test_database ... ok
test storage::postgres::runtime::tests::statement_timeout_ms_new_treats_zero_as_disabled ... ok
test storage::postgres::runtime::tests::test_init_pool ... ok
test storage::postgres::operations::user::tests::test_user_can::case_12_u2_collection1_objectread_true ... ok
test storage::postgres::runtime::tests::test_with_connection_returns_error_on_invalid_pool ... ok
test storage::postgres::runtime::tests::cancelled_transaction_is_discarded_and_rolled_back ... ok
test storage::postgres::runtime::tests::test_with_connection_success_path ... ok
test storage::postgres::runtime::tests::test_with_transaction_rolls_back_on_error ... ok
test storage::postgres::runtime::tests::statement_timeout_cancels_slow_queries ... ok
test tasks::helpers::tests::idempotency_key_from_headers_rejects_an_empty_value ... ok
test tasks::helpers::tests::idempotency_key_from_headers_rejects_an_oversized_value ... ok
test tasks::helpers::tests::idempotency_key_from_headers_rejects_non_ascii_values ... ok
test tasks::helpers::tests::idempotency_key_from_headers_returns_valid_value ... ok
test tasks::remote_call::tests::internal_outbound_errors_are_sanitized_for_storage ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_01 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_02 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_03 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_04 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_05 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_06 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_07 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_08 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_09 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_10 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_11 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_12 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_13 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_14 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_15 ... ok
test tasks::remote_call::tests::remote_errors_use_lossless_metric_outcomes::case_16 ... ok
test tasks::remote_call::tests::render_template_is_fuel_bounded ... ok
test tasks::remote_call::tests::render_template_supports_curated_filters ... ok
test tasks::remote_call::tests::user_actionable_outbound_errors_remain_visible_for_storage ... ok
test tasks::settings::tests::task_worker_settings_preserve_validated_values ... ok
test tasks::settings::tests::task_worker_settings_reject_heartbeat_at_or_beyond_lease ... ok
test tasks::settings::tests::task_worker_settings_reject_unrepresentable_lease_duration ... ok
test tasks::settings::tests::task_worker_settings_reject_zero_durations::case_1_poll ... ok
test tasks::settings::tests::task_worker_settings_reject_zero_durations::case_2_lease ... ok
test tasks::settings::tests::task_worker_settings_reject_zero_durations::case_3_heartbeat ... ok
test tasks::settings::tests::task_worker_settings_reject_zero_durations::case_4_recovery ... ok
test tasks::settings::tests::task_worker_settings_reject_zero_durations::case_5_cleanup ... ok
test tasks::settings::tests::task_worker_settings_require_every_builder_field ... ok
test storage::postgres::operations::user::tests::test_user_can::case_13_u2_collection1_objectcreate_true ... ok
test storage::postgres::runtime::tests::test_with_transaction_commits_on_success ... ok
test storage::postgres::operations::token_retention::tests::retained_metadata_scope_projection_blocks_concurrent_purge::case_1_point ... ok
test storage::postgres::runtime::tests::with_connection_timeout_bounds_and_reverts ... ok
test storage::postgres::operations::user::tests::test_user_can::case_14_u2_collection1_objectreadcreate_true ... ok
test storage::postgres::task_execution::tests::lease_pool_remains_available_when_an_execution_pool_is_exhausted ... ok
test storage::postgres::operations::user::tests::test_user_can::case_15_u2_collection2_objectdelete_true ... ok
test storage::postgres::operations::user::tests::test_user_can::case_16_u2_collection2_objectcreate_true ... ok
test storage::postgres::operations::user::tests::test_user_can::case_17_u2_collection2_objectcreatedelete_true ... ok
test tasks::tests::identity_scope_import_rejects_a_stale_expected_revision ... ok
test tasks::tests::import_planning_uses_the_task_execution_permission_backend ... ok
test tasks::tests::imported_templates_use_effective_collection_loader::case_1_existing ... ok
test tasks::tests::imported_class_binding_must_match_target_collection::case_1_export_template ... ok
test tasks::tests::imported_templates_use_effective_collection_loader::case_2_same_import ... ok
test tasks::tests::imported_class_binding_must_match_target_collection::case_2_remote_target ... ok
test tasks::tests::core_imports_without_timestamps_use_database_transaction_time ... ok
test tasks::tests::test_background_worker_continues_immediately_after_processing_a_task ... ok
test tasks::tests::test_best_effort_execution_only_aborts_for_matching_policy_failures ... ok
test tasks::tests::membership_import_honors_collision_policy::case_1_abort ... ok
test storage::postgres::operations::token_retention::tests::retained_metadata_scope_projection_blocks_concurrent_purge::case_2_list ... ok
test tasks::tests::imported_templates_use_effective_collection_loader::case_3_missing ... ok
test tasks::tests::imported_collection_timestamps_are_written_in_the_initial_history_entry ... ok
test tasks::tests::test_execute_import_strict_preserves_underlying_error_variant ... ok
test tasks::tests::membership_import_honors_collision_policy::case_2_overwrite ... ok
test tasks::tests::test_count_import_results_summary_counts_success_and_failure_rows ... ok
test tasks::tests::test_execute_import_strict_rolls_back_on_runtime_failure ... ok
test tasks::tests::test_execute_import_best_effort_continues_after_non_policy_runtime_error ... ok
test tasks::tests::test_execute_import_best_effort_keeps_successful_items ... ok
test tasks::tests::test_extended_import_uses_backend_denial_for_sql_administrator ... ok
test storage::postgres::operations::token_retention::tests::retained_metadata_scope_projection_blocks_concurrent_purge::case_3_batch ... ok
test tasks::tests::test_extended_import_uses_backend_grant_for_non_sql_administrator ... ok
test tasks::tests::test_identity_scope_overwrite_preserves_imported_timestamps ... ok
test tasks::tests::relation_timestamp_overwrite_requires_update_permission::case_1_class_update ... ok
test tasks::tests::test_mark_claimed_task_failed_uses_recorded_result_counts ... ok
test tasks::tests::relation_timestamp_overwrite_requires_update_permission::case_2_class_create ... ok
test tasks::tests::test_plan_class_rejects_duplicate_name_against_virtual_planned_class ... ok
test tasks::tests::relation_timestamp_overwrite_requires_update_permission::case_3_object_update ... ok
test tasks::tests::test_remember_collection_populates_collection_id_index ... ok
test tasks::tests::test_request_hash_is_stable_for_reordered_json_objects ... ok
test tasks::tests::relation_timestamp_overwrite_requires_update_permission::case_4_object_create ... ok
test tasks::tests::test_plan_class_rejects_duplicate_ref_against_virtual_planned_class ... ok
test tasks::tests::test_plan_collection_rejects_duplicate_name_within_request ... ok
test tasks::tests::test_plan_class_update_preserves_existing_schema_for_following_objects ... ok
test tasks::tests::test_plan_object_rejects_duplicate_name_against_virtual_planned_object ... ok
test tasks::tests::test_plan_collection_allows_duplicate_names_under_different_parents ... ok
test tasks::tests::test_runtime_planning_failures_are_sanitized_for_storage ... ok
test tasks::tests::test_sanitize_error_for_storage_masks_database_details ... ok
test tasks::tests::test_reindex_failure_finalization_reloads_persisted_progress ... ok
test tasks::tests::test_plan_object_rejects_duplicate_ref_against_virtual_planned_object ... ok
test tasks::tests::test_resolve_collection_by_id_planning_backfills_caches_after_db_lookup ... ok
test tasks::tests::test_resolve_class_planning_backfills_cache_after_db_lookup ... ok
test tasks::tests::import_planning_query_growth_is_bounded_per_object_in_one_class ... ok
test tasks::tests::test_resolve_collection_planning_backfills_caches_after_db_lookup ... ok
test tasks::tests::test_process_one_task_export_failure_marks_single_failed_item ... ok
test tasks::tests::test_resolve_collection_planning_rejects_ambiguous_bare_name ... ok
test tasks::tests::test_resolve_object_planning_backfills_cache_after_db_lookup ... ok
test tasks::tests::test_update_collection_refreshes_runtime_ref_for_following_items ... ok
test tasks::tests::test_update_class_refreshes_runtime_ref_for_following_items ... ok
test tasks::tests::test_resolve_collection_planning_uses_path_to_disambiguate_name ... ok
test tasks::worker::cleanup_tests::cleanup_reservation_updates_schedule_only_after_commit::case_1_failure ... ok
test tasks::worker::cleanup_tests::cleanup_reservation_updates_schedule_only_after_commit::case_2_success ... ok
test tasks::worker::cleanup_tests::unavailable_cleanup_schedule_is_not_reserved_again::case_1_recent ... ok
test tasks::worker::cleanup_tests::unavailable_cleanup_schedule_is_not_reserved_again::case_2_in_progress ... ok
test tasks::tests::test_update_object_refreshes_runtime_ref_for_following_items ... ok
test tasks::worker::lease_heartbeat_tests::heartbeat_stays_running_until_failure_finalization_completes ... ok
test tasks::worker::lease_heartbeat_tests::lease_diagnostics_do_not_log_claim_tokens ... ok
test tasks::worker::lease_heartbeat_tests::heartbeat_progresses_while_task_runtime_thread_is_blocked ... ok
test tasks::worker::lease_heartbeat_tests::renewal_errors_signal_loss_at_the_confirmed_expiry ... ok
test tasks::worker::lease_heartbeat_tests::lease_loss_is_detected_while_task_runtime_thread_is_blocked ... ok
test tests::application_boundary::app_context_exposes_only_an_opaque_backend_handle ... ok
test tests::application_boundary::application_consumers_do_not_import_database_implementation_details ... ok
test tests::application_boundary::backend_neutral_layers_do_not_import_database_implementation_details ... ok
test tests::application_boundary::class_domain_types_are_free_of_persistence_implementation_details ... ok
test tests::application_boundary::collection_domain_types_are_free_of_persistence_implementation_details ... ok
test tests::application_boundary::event_administration_consumers_use_the_backend_neutral_application_service ... ok
test tests::application_boundary::export_consumers_use_only_backend_neutral_query_and_authorization_contracts ... ok
test tests::application_boundary::export_template_consumers_use_only_the_backend_neutral_lifecycle_contract ... ok
test tests::application_boundary::group_domain_types_are_free_of_persistence_implementation_details ... ok
test tests::application_boundary::object_domain_types_are_free_of_persistence_implementation_details ... ok
test tests::application_boundary::permission_domain_types_are_free_of_persistence_implementation_details ... ok
test tests::application_boundary::persistence_facades_do_not_reexport_internal_layers_wholesale ... ok
test tests::application_boundary::process_entry_points_compose_only_through_backend_neutral_storage ... ok
test tests::application_boundary::relation_domain_types_are_free_of_persistence_implementation_details ... ok
test tests::application_boundary::remaining_administration_consumers_do_not_use_postgres_facades ... ok
test tests::application_boundary::remote_target_consumers_use_the_backend_neutral_application_service ... ok
test tests::application_boundary::restore_consumers_use_only_the_mandatory_storage_contract ... ok
test tests::application_boundary::selectable_storage_backends_are_complete_and_test_models_are_not_selectable ... ok
test tests::application_boundary::storage_error_translation_has_one_way_dependency_direction ... ok
test tests::application_boundary::task_execution_consumers_do_not_import_postgres_task_state_helpers ... ok
test tests::client_allowlist::tests::allowlist_unit_tests::test_allows_multiple_cidrs ... ok
test tests::client_allowlist::tests::allowlist_unit_tests::test_allows_single_ip ... ok
test tests::client_allowlist::tests::allowlist_unit_tests::test_errors_on_empty ... ok
test tests::client_allowlist::tests::allowlist_unit_tests::test_errors_on_invalid_ip ... ok
test tests::client_allowlist::tests::allowlist_unit_tests::test_parses_any ... ok
test tests::client_allowlist::tests::allowlist_unit_tests::test_parses_default_hosts ... ok
test tests::client_allowlist::tests::allowlist_unit_tests::test_rejects_outside_network ... ok
test tests::client_allowlist::tests::test_allows_all_when_wildcard ... ok
test tests::client_allowlist::tests::test_allows_ipv6_in_range ... ok
test tests::client_allowlist::tests::test_allows_whitelisted_ipv4 ... ok
test tests::client_allowlist::tests::test_ignores_headers_when_trust_disabled ... ok
test tests::client_allowlist::tests::test_probe_paths_bypass_client_allowlist ... ok
test tests::client_allowlist::tests::test_rejects_non_whitelisted_ipv4 ... ok
test tests::client_allowlist::tests::test_spoofed_forwarded_for_cannot_bypass_allowlist ... ok
test tests::docs_examples::tests::exports_missing_required_blocks_clearly ... ok
test tests::docs_examples::tests::extracts_explicitly_labeled_fenced_blocks ... ok
test tests::id_newtypes::all_id_newtypes_reject_invalid_ids ... ok
test tests::id_newtypes::new_collection_assignee_rejects_a_non_positive_group_id ... ok
test tests::id_newtypes::new_service_account_owner_rejects_a_non_positive_group_id ... ok
test tasks::tests::test_process_one_task_marks_claimed_task_failed_when_execution_setup_errors ... ok
test tasks::tests::unchanged_temporal_import_overwrite_does_not_append_history::case_1_export_omitted ... ok
test tasks::tests::unchanged_temporal_import_overwrite_does_not_append_history::case_2_export_identical ... ok
test tasks::tests::unchanged_temporal_import_overwrite_does_not_append_history::case_3_remote_omitted ... ok
test tasks::tests::unchanged_temporal_import_overwrite_does_not_append_history::case_4_remote_identical ... ok
test tasks::tests::unchanged_core_import_overwrite_returns_current_row_without_history::case_1_collection ... ok
test tests::permissions::auth_target::class_relation_same_collection_populates_collection_id ... ok
test tests::permissions::auth_target::class_relation_cross_collection_populates_from_to_collections ... ok
test tasks::tests::unchanged_core_import_overwrite_returns_current_row_without_history::case_2_class ... ok
test tests::permissions::mock_treetop::mock_authorize_many_preserves_request_order ... ok
test tests::permissions::mock_treetop::mock_authorize_via_dyn_trait_works ... ok
test tests::permissions::mock_treetop::mock_authorizes_relation_via_from_to_collection_attrs ... ok
test tests::permissions::mock_treetop::mock_group_permission_on_synthesizes_row_from_rules ... ok
test tests::permissions::mock_treetop::mock_groups_with_permissions_on_filters_and_paginates ... ok
test tests::permissions::mock_treetop::mock_is_admin_uses_backend_rule_not_sql_group ... ok
test tests::permissions::mock_treetop::mock_mutation_methods_return_not_implemented ... ok
test tests::permissions::mock_treetop::mock_task_policy_can_allow_a_non_owner ... ok
test tests::permissions::mock_treetop::mock_task_policy_can_deny_the_task_owner ... ok
test tests::permissions::visibility::authorized_object_ids_are_sorted_and_deduplicated ... ok
test tests::permissions::visibility::authorized_object_ids_intersection_preserves_sorted_unique_ids ... ok
test tests::permissions::visibility::authorized_object_ids_reject_non_positive_values ... ok
test tests::permissions::visibility::authorized_page_preserves_order_across_batch_boundaries ... ok
test tests::permissions::visibility::candidate_authorization_bounds_each_expanded_permission_batch ... ok
test tasks::tests::unchanged_core_import_overwrite_returns_current_row_without_history::case_3_object ... ok
test tests::permissions::visibility::resource_permissions_are_normalized_to_policy_resource_kinds ... ok
test tasks::tests::unchanged_core_import_overwrite_returns_current_row_without_history::case_4_class_relation ... ok
test tests::permissions::auth_target::collection_to_resource_ref_populates_attrs ... ok
test tests::permissions::auth_target::class_to_resource_ref_populates_collection_id ... ok
test tasks::tests::unchanged_core_import_overwrite_returns_current_row_without_history::case_5_object_relation ... ok
test tests::permissions::auth_target::object_to_resource_ref_populates_collection_and_class_ids ... ok
test tests::permissions::auth_target::object_relation_cross_collection_populates_all_fields ... ok
test tests::permissions::backend_trait::local_backend_grants_then_authorizes_collection_read ... ok
test tests::permissions::backend_trait::local_backend_authorize_many_returns_per_request_decisions ... ok
test tests::permissions::auth_target::local_backend_relation_and_check_denies_partial_permission ... ok
test tests::permissions::visibility::paginate_authorized_filters_pages_correctly_under_slow_path ... ok
test tests::search::classes::test::test_class_search_json_schema::case_1_search_contains ... ok
test tests::search::classes::test::test_class_search_json_schema::case_2_search_lt ... ok
test tests::search::classes::test::test_class_search_json_schema::case_4_search_equals ... ok
test tests::search::classes::test::test_class_search_json_schema::case_3_search_gte ... ok
test tests::search::classes::test::test_class_search_json_schema::case_5_search_icontains ... ok
test tests::search::classes::test::test_class_search ... ok
test tests::search::classrelations::test::test_filter_by_class_field::case_1_search_by_id ... ok
test tests::search::classes::test::test_class_search_json_schema::case_7_search_regex ... ok
test tests::search::classes::test::test_class_search_json_schema::case_6_search_like ... ok
test tests::search::classes::test::test_equals ... ok
test tests::search::classes::test::test_search_int_ranges ... ok
test tests::search::classrelations::test::test_filter_by_class_field::case_2_search_by_class_from_name_contains ... ok
test tests::search::classrelations::test::test_filter_by_class_field::case_4_search_by_class_to_name_contains ... ok
test tests::storage_contract::every_available_storage_backend_composes_through_the_complete_contract ... ok
test tests::search::classrelations::test::test_filter_by_class_field::case_5_search_by_class_to_name_endswith ... ok
test tests::search::classrelations::test::test_filter_by_class_field::case_3_search_by_class_from_name_endswith ... ok
test tests::storage_contract::every_available_storage_backend_processes_event_retention ... ok
test tests::storage_contract::every_available_storage_backend_processes_event_fanout ... ok
test tests::storage_contract::every_available_storage_backend_supplies_authentication_projections ... ok
test tests::storage_contract::every_available_storage_backend_supplies_collection_record_compatibility ... ok
test tests::storage_contract::every_available_storage_backend_supplies_catalog_queries ... ok
test tests::storage_contract::every_available_storage_backend_supplies_backup_snapshots ... ok
test tests::storage_contract::every_available_storage_backend_supplies_complete_group_behavior ... ok
test tests::storage_contract::every_available_storage_backend_supplies_complete_event_administration ... ok
test tests::search::related_objects::malformed_related_filter_returns_bad_request ... ok
test tests::storage_contract::every_available_storage_backend_supplies_execution_context ... ok
test tests::search::related_objects::external_policy_requires_a_visible_path_and_preserves_allowed_alternatives ... ok
test tests::search::related_objects::related_groups_are_independent_existentials_combined_with_and ... ok
test tests::search::related_objects::related_depth_is_bounded_per_group ... ok
test tests::search::related_objects::related_target_object_filters_support_json_and_revision_fields ... ok
test tests::storage_contract::every_available_storage_backend_supplies_complete_temporal_history ... ok
test tests::storage_contract::every_available_storage_backend_supplies_consistent_inventory_counts ... ok
test tests::storage_contract::every_available_storage_backend_supplies_complete_identity_operations ... ok
test tests::storage_contract::every_available_storage_backend_supplies_computed_object_queries ... ok
test tests::storage_contract::every_available_storage_backend_supplies_event_health ... ok
test tests::storage_contract::every_available_storage_backend_supplies_metrics_snapshots ... ok
test tests::storage_contract::every_available_storage_backend_supplies_computed_field_lifecycle ... ok
test tests::storage_contract::every_available_storage_backend_supplies_export_template_lifecycle ... ok
test tests::storage_contract::every_available_storage_backend_supplies_the_export_query_scope ... ok
test tests::storage_contract::every_available_storage_backend_supplies_operational_state ... ok
test tests::storage_contract::every_available_storage_backend_supplies_object_aggregates ... ok
test tests::storage_contract::every_available_storage_backend_supplies_ranked_unified_search ... ok
test tests::storage_performance::changed_collection_update_writes_once_and_emits_one_event ... ok
test tests::storage_performance::class_relation_storage_query_budget_create_with_event_is_fixed ... ok
test tests::storage_contract::every_available_storage_backend_supplies_remote_target_lifecycle ... ok
test tests::storage_contract::every_available_storage_backend_supplies_local_authorization_data ... ok
test tests::storage_contract::every_available_storage_backend_supplies_restore_lifecycle_and_coordination ... ok
test tests::storage_performance::class_relation_storage_query_budget_point_resolution_is_fixed ... ok
test tests::storage_performance::class_storage_query_budget_create_with_event_is_fixed ... ok
test tests::storage_performance::class_relation_storage_query_budget_delete_with_event_is_fixed ... ok
test tests::storage_contract::every_available_storage_backend_supplies_relation_queries ... ok
test tests::storage_performance::class_storage_query_budget_point_read_uses_one_query ... ok
test tests::storage_performance::class_storage_query_budget_no_op_avoids_writes_and_events ... ok
test tests::storage_contract::every_available_storage_backend_supplies_token_retention ... ok
test tests::storage_contract::every_available_storage_backend_supplies_the_complete_task_queue ... ok
test tests::storage_performance::collection_create_with_event_has_a_fixed_query_budget ... ok
test tests::storage_contract::every_available_storage_backend_supplies_the_complete_import_contract ... ok
test tests::acl::test_endpoint_access ... ok
test tests::storage_performance::collection_no_op_update_does_not_write_or_emit_an_event ... ok
test tests::storage_performance::collection_point_read_uses_one_query ... ok
test tests::storage_performance::object_relation_create_has_a_fixed_query_and_checkout_budget ... ok
test tests::storage_performance::object_relation_storage_query_budget_create_with_event_is_fixed ... ok
test tests::storage_performance::object_relation_storage_query_budget_preparation_is_fixed ... ok
test tests::storage_performance::object_relation_storage_query_budget_point_resolution_is_fixed ... ok
test tests::storage_performance::object_relation_storage_query_budget_delete_with_event_is_fixed ... ok
test tests::storage_performance::collection_history_query_count_is_constant_with_page_size ... ok
test tests::storage_performance::object_storage_query_budget_create_with_event_is_fixed ... ok
test tests::storage_performance::object_storage_query_budget_no_op_avoids_object_writes_and_events ... ok
test tests::temporal::cascade_delete_records_history ... ok
test tests::storage_performance::object_storage_query_budget_point_read_uses_one_query ... ok
test tests::temporal::actor_scope_sets_actor_and_default_is_null ... ok
test tests::temporal::trigger_inserts_history_by_column_name ... ok
test tests::storage_contract::every_available_storage_backend_supplies_the_complete_task_state_machine ... ok
test tests::storage_performance::collection_point_read_plan_has_bounded_logical_work_at_representative_scale ... ok
test tests::temporal::trigger_records_ops_and_actor ... ok
test tests::temporal::trigger_timestamp_is_execution_time_not_transaction_start ... ok
test tests::temporal::anonymize_scrubs_pii_but_keeps_history_actor ... ok
test tests::temporal::worker_mutation_scope_records_root_task_provenance ... ok
test tests::test::test_updated_and_created_at ... ok
test tests::temporal::unchanged_domain_update_is_noop ... ok
test tests::storage_performance::object_page_query_count_is_constant_with_page_size ... ok
test tests::validation::test_validate_object::case_1_ok_40_74 ... ok
test tests::validation::test_validate_object::case_2_failed_91_74 ... ok
test tests::storage_performance::effective_permission_query_count_is_constant_with_collection_depth ... ok
test tests::validation::test_validate_object::case_3_failed_neg91_74 ... ok
test tests::validation::test_validate_object::case_4_failed_40_181 ... ok
test tests::validation::test_validate_object::case_5_failed_40_neg181 ... ok
test tests::validation::test_validate_object::case_8_failed_long_missing ... ok
test tests::workspace_boundaries::only_the_postgres_adapter_may_depend_on_diesel ... ok
test tests::workspace_boundaries::workspace_boundary_check_includes_target_dependencies ... ok
test tests::workspace_boundaries::workspace_boundary_check_resolves_renamed_dependencies ... ok
test tests::workspace_boundaries::workspace_crate_manifests_stay_app_neutral ... ok
test tls::tests::backend_selection_rejects_tls_requests_when_no_backend_is_enabled ... ok
test tls::tests::installs_a_process_wide_crypto_provider ... ok
test token_retention::tests::retention_worker_retries_immediately_after_deleting_rows ... ok
test token_retention::tests::retention_worker_sleeps_after_an_empty_batch ... ok
test token_retention::tests::retention_worker_sleeps_after_an_error ... ok
test traits::pagination::tests::jsonb_object_comparison_matches_stored_key_iteration::case_1 ... ok
test traits::pagination::tests::jsonb_object_comparison_matches_stored_key_iteration::case_2 ... ok
test utilities::aliases::tests::collapses_separators_and_trims ... ok
test tests::workspace_boundaries::domain_and_storage_contract_sources_stay_backend_and_transport_neutral ... ok
test utilities::aliases::tests::lowercases_and_inserts_camel_case_boundaries ... ok
test utilities::aliases::tests::rejects_empty ... ok
test utilities::aliases::tests::rejects_invalid_characters ... ok
test utilities::aliases::tests::rejects_leading_digit ... ok
test tests::validation::test_validate_object::case_7_failed_lat_missing ... ok
test utilities::bounded_file::tests::reads_a_regular_file_at_the_limit ... ok
test utilities::bounded_file::tests::rejects_a_regular_file_over_the_limit ... ok
test utilities::bounded_file::tests::rejects_non_regular_files_before_opening_them ... ok
test utilities::db::tests::parses_supported_database_urls::case_1 ... ok
test utilities::db::tests::parses_supported_database_urls::case_2 ... ok
test utilities::db::tests::parses_supported_database_urls::case_3 ... ok
test utilities::db::tests::rejects_a_database_url_without_a_host ... ok
test utilities::db::tests::rejects_an_unsupported_database_type ... ok
test utilities::exporting::tests::autoescapes_html_but_not_plain_text ... ok
test utilities::exporting::tests::invalidates_cached_environment_when_template_body_changes_without_timestamp_change ... ok
test utilities::exporting::tests::invalidates_cached_environment_when_templates_change ... ok
test utilities::exporting::tests::missing_value_warning_identifies_composed_template_name ... ok
test utilities::exporting::tests::omits_missing_values_when_requested ... ok
test utilities::exporting::tests::rejects_cross_collection_template_loading ... ok
test utilities::exporting::tests::renders_jinja_loops_and_nested_values ... ok
test utilities::exporting::tests::renders_null_for_missing_values_and_exports_warning ... ok
test utilities::exporting::tests::supports_curated_template_helpers ... ok
test utilities::exporting::tests::supports_same_collection_imports ... ok
test utilities::exporting::tests::supports_same_collection_includes ... ok
test utilities::exporting::tests::template_guide_csv_example_matches_renderer ... ok
test utilities::exporting::tests::template_guide_html_example_matches_renderer ... ok
test utilities::exporting::tests::template_guide_missing_data_policy_examples_match_renderer ... ok
test utilities::exporting::tests::template_guide_nested_array_example_matches_renderer ... ok
test utilities::exporting::tests::template_guide_plain_text_example_matches_renderer ... ok
test utilities::exporting::tests::validates_composed_template_sources::case_1_same_import ... ok
test utilities::exporting::tests::validates_composed_template_sources::case_2_missing ... ok
test utilities::extensions::tests::placeholder_rewriting_ignores_question_marks_in_sql_strings ... ok
test tests::validation::test_validate_object::case_6_failed_100_200 ... ok
test utilities::json_schema::tests::compiled_schemas_validate_instances::case_1 ... ok
test utilities::json_schema::tests::compiled_schemas_validate_instances::case_2 ... ok
test utilities::json_schema::tests::external_references_cannot_be_compiled_for_validation::case_1 ... ok
test utilities::json_schema::tests::external_references_cannot_be_compiled_for_validation::case_2 ... ok
test utilities::json_schema::tests::schema_documents_are_validated_without_external_resolution::case_1 ... ok
test utilities::json_schema::tests::schema_documents_are_validated_without_external_resolution::case_2 ... ok
test utilities::json_schema::tests::schema_documents_are_validated_without_external_resolution::case_3 ... ok
test utilities::json_schema::tests::schema_documents_are_validated_without_external_resolution::case_4 ... ok
test utilities::json_schema::tests::schema_documents_are_validated_without_external_resolution::case_5 ... ok
test tests::validation::test_validate_object::case_9_ok_extra_fields ... ok
test tests::validation::test_validate_update_object::case_1_ok_40_74 ... ok
test tests::validation::test_validate_update_object::case_2_failed_91_74 ... ok
test tests::validation::test_validate_update_object::case_3_failed_neg91_74 ... ok
test tests::validation::test_validate_update_object::case_4_failed_lat_missing ... ok
test utilities::init::tests::initialized_database_skips_default_password_hashing ... ok
test utilities::auth::tests::async_password_workers_hash_and_verify::case_1 ... ok
test utilities::auth::tests::async_password_workers_hash_and_verify::case_2 ... ok
test tests::validation::test_validate_update_object::case_5_failed_long_missing ... ok
test tests::storage_performance::collection_ancestor_plan_has_bounded_logical_work_at_representative_scale ... ok
test tests::storage_performance::collection_ancestor_query_count_is_constant_with_depth ... ok

test result: ok. 1236 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 40.86s


running 34 tests
test container_build::development_compose_limits_container_privileges ... ok
test container_build::development_compose_requires_a_local_password ... ok
test container_build::container_ci_exercises_live_single_host_http_continuity ... ok
test container_build::compose_deployments_forward_page_limit_configuration ... ok
test container_build::container_dependency_images_are_pinned ... ok
test container_build::lines_between_handles_platform_line_endings::case_1 ... ok
test container_build::lines_between_handles_platform_line_endings::case_2 ... ok
test container_build::postgres_benchmark_workflow_confirms_regressions_on_stable_base_runs ... ok
test container_build::production_container_base_images_are_pinned ... ok
test container_build::dockerfile_copies_every_workspace_manifest ... ok
test container_build::production_container_runs_as_non_root ... ok
test container_build::production_container_has_a_healthcheck ... ok
test container_build::single_host_api_health_checks_use_five_second_interval ... ok
test container_build::single_host_direct_routing_uses_one_health_checked_public_api_proxy ... ok
test container_build::single_host_installer_emits_canonical_caddyfile_indentation ... ok
test container_build::single_host_installer_generates_redundant_http_upstreams ... ok
test container_build::self_contained_benchmark_autodiscovery_excludes_feature_gated_targets ... ok
test container_build::single_host_installer_preserves_the_bind_mounted_caddyfile_inode ... ok
test container_build::single_host_installer_limits_api_container_privileges ... ok
test container_build::single_host_metrics_routes_target_each_backend_process ... ok
test container_build::tagged_release_attestors_can_persist_artifact_metadata ... ok
test container_build::single_host_updater_never_tears_down_the_stack ... ok
test container_build::tagged_release_validation_requires_each_direct_prerequisite ... ok
test container_build::tagged_release_jobs_explicitly_require_successful_dependencies ... ok
test container_build::healthcheck_uses_cli_runtime_role_over_environment::case_1 ... ok
test container_build::criterion_stability_rejects_excessive_base_to_base_drift::case_1 ... ok
test container_build::criterion_stability_rejects_excessive_base_to_base_drift::case_2 ... ok
test container_build::criterion_regression_requires_confident_relative_and_absolute_changes::case_2 ... ok
test container_build::criterion_regression_requires_confident_relative_and_absolute_changes::case_3 ... ok
test container_build::criterion_regression_requires_confident_relative_and_absolute_changes::case_1 ... ok
test container_build::criterion_reverse_comparison_reports_the_same_head_regression ... ok
test container_build::healthcheck_uses_cli_runtime_role_over_environment::case_2 ... ok
test container_build::entrypoint_cli_runtime_role_overrides_environment_for_migrations::case_1 ... ok
test container_build::entrypoint_cli_runtime_role_overrides_environment_for_migrations::case_2 ... ok

test result: ok. 34 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.97s


running 8 tests
test admin_help_exposes_reset_password ... ok
test invalid_log_level_is_reported_before_logging_is_initialized ... ok
test restore_requires_destructive_confirmation_before_database_access ... ok
test reset_password_does_not_parse_server_config_arguments ... ok
test export_template_health_reports_persisted_output_statistics ... ok
test audit_templates_rejects_an_invalid_stored_template ... ok
test reset_password_replaces_the_stored_credential ... ok
test backup_files_are_owner_only_and_atomically_replaced ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.92s


running 461 tests
test api_core_data_suite::by_name_routes::tests::numeric_looking_class_name_resolves_as_a_name ... ok
test api_core_data_suite::by_name_routes::tests::class_name_alias_uses_the_same_permissions_as_the_id_route ... ok
test api_core_data_suite::by_name_routes::tests::class_delete_by_name_deletes_the_named_class ... ok
test api_core_data_suite::by_name_routes::tests::numeric_looking_object_name_resolves_as_a_name ... ok
test api_core_data_suite::by_name_routes::tests::object_create_by_class_name_does_not_require_redundant_ids ... ok
test api_core_data_suite::by_name_routes::tests::class_update_by_name_updates_the_named_class ... ok
test api_core_data_suite::by_name_routes::tests::class_name_object_listing_is_scoped_to_the_named_class ... ok
test api_core_data_suite::by_name_routes::tests::class_related_name_alias_is_mounted::case_1_permissions ... ok
test api_core_data_suite::by_name_routes::tests::class_related_name_alias_is_mounted::case_3_related_relations ... ok
test api_core_data_suite::by_name_routes::tests::class_related_name_alias_is_mounted::case_2_related_classes ... ok
test api_core_data_suite::by_name_routes::tests::class_graph_name_alias_uses_the_named_class ... ok
test api_core_data_suite::by_name_routes::tests::object_delete_by_name_deletes_the_named_object ... ok
test api_core_data_suite::by_name_routes::tests::resolved_class_name_target_rejects_object_creation_after_a_rename ... ok
test api_core_data_suite::by_name_routes::tests::resolved_class_target_rejects_a_concurrent_rename::case_1_by_id ... ok
test api_core_data_suite::by_name_routes::tests::resolved_object_target_rejects_a_concurrent_rename::case_1_by_id ... ok
test api_core_data_suite::by_name_routes::tests::resolved_object_target_rejects_a_concurrent_rename::case_2_by_name ... ok
test api_core_data_suite::by_name_routes::tests::resolved_class_target_rejects_a_concurrent_collection_move::case_1_by_id ... ok
test api_core_data_suite::by_name_routes::tests::resolved_class_target_rejects_a_concurrent_collection_move::case_2_by_name ... ok
test api_core_data_suite::by_name_routes::tests::object_update_by_name_updates_the_named_object ... ok
test api_core_data_suite::by_name_routes::tests::object_related_name_alias_is_mounted::case_2_related_relations ... ok
test api_core_data_suite::by_name_routes::tests::object_related_name_alias_is_mounted::case_1_related_objects ... ok
test api_core_data_suite::by_name_routes::tests::object_graph_name_alias_uses_the_named_object ... ok
test api_core_data_suite::classes::tests::class_history_as_of_checks_the_selected_historical_collection::case_1_hidden ... ok
test api_core_data_suite::classes::tests::class_history_as_of_checks_the_selected_historical_collection::case_2_visible ... ok
test api_core_data_suite::classes::tests::missing_class_object_list_preserves_the_empty_page_contract ... ok
test api_core_data_suite::classes::tests::class_update_validates_the_schema_locked_for_the_write ... ok
test api_core_data_suite::classes::tests::test_api_class_history_404_for_missing ... ok
test api_core_data_suite::classes::tests::test_admin_can_list_classes_without_direct_owner_group_membership ... ok
test api_core_data_suite::classes::tests::test_admin_can_read_deleted_class_history ... ok
test api_core_data_suite::classes::tests::test_api_classes_create ... ok
test api_core_data_suite::classes::tests::class_history_lists_only_visible_historical_collections ... ok
test api_core_data_suite::classes::tests::test_api_class_history_list_and_as_of ... ok
test api_core_data_suite::classes::tests::test_api_class_history_cursor_pagination ... ok
test api_core_data_suite::classes::tests::docs_api_classes_cursor_pagination ... ok
test api_core_data_suite::classes::tests::test_api_classes_get_filtered_collections_equals ... ok
test api_core_data_suite::classes::tests::test_api_classes_get ... ok
test api_core_data_suite::classes::tests::test_api_classes_get_filtered_description_and_not_name_contains ... ok
test api_core_data_suite::classes::tests::test_api_classes_get_filtered_description_contains ... ok
test api_core_data_suite::classes::tests::test_api_classes_get_filtered_name_contains ... ok
test api_core_data_suite::classes::tests::test_api_classes_get_filtered_name_equals ... ok
test api_core_data_suite::classes::tests::test_api_classes_json_schema_filter_composes_with_pagination_and_count ... ok
test api_core_data_suite::classes::tests::test_api_classes_limit::case_1_limit_2 ... ok
test api_core_data_suite::classes::tests::test_api_classes_get_by_id ... ok
test api_core_data_suite::classes::tests::test_api_classes_limit::case_2_limit_5 ... ok
test api_core_data_suite::classes::tests::test_api_classes_get_failure ... ok
test api_core_data_suite::classes::tests::test_api_classes_limit::case_3_limit_7 ... ok
test api_core_data_suite::classes::tests::test_api_classes_patch ... ok
test api_core_data_suite::classes::tests::test_api_classes_rejects_unsafe_json_schemas::case_1 ... ok
test api_core_data_suite::classes::tests::test_api_classes_rejects_unsafe_json_schemas::case_2 ... ok
test api_core_data_suite::collections::tests::collection_creation_rejects_a_non_positive_assignee_group_id ... ok
test api_core_data_suite::classes::tests::test_api_classes_rejects_unsafe_json_schemas::case_3 ... ok
test api_core_data_suite::classes::tests::test_api_classes_sorted::case_1_sorted_id_default ... ok
test api_core_data_suite::collections::tests::conditional_collection_delete_reports_a_vanished_target_as_stale ... ok
test api_core_data_suite::classes::tests::test_api_classes_sorted::case_2_sorted_id_explicit_asc ... ok
test api_core_data_suite::classes::tests::test_api_create_records_actor ... ok
test api_core_data_suite::classes::tests::test_api_classes_delete ... ok
test api_core_data_suite::classes::tests::test_api_classes_sorted::case_3_sorted_id_descending ... ok
test api_core_data_suite::classes::tests::test_api_classes_get_filtered_json_schema ... ok
test api_core_data_suite::classes::tests::test_api_classes_patch_requires_target_collection_permission ... ok
test api_core_data_suite::collections::tests::stale_collection_delete_precedes_child_validation ... ok
test api_core_data_suite::collections::tests::permission_scoped_group_list_filters_by_revision ... ok
test api_core_data_suite::collections::tests::test_api_collection_history_404_for_missing ... ok
test api_core_data_suite::collections::tests::test_admin_can_list_collections_without_direct_owner_group_membership ... ok
test api_core_data_suite::collections::tests::permission_set_etag_excludes_mutable_group_fields ... ok
test api_core_data_suite::collections::tests::stale_collection_precondition_rejects_a_semantic_no_op ... ok
test api_core_data_suite::collections::tests::test_api_collection_permissions_put_empty_is_bad_request ... ok
test api_core_data_suite::collections::tests::test_api_collections_clamps_limit_above_configured_maximum ... ok
test api_core_data_suite::collections::tests::test_api_collection_permissions_sorted_and_limited ... ok
test api_core_data_suite::collections::tests::test_api_collection_history_list_and_as_of ... ok
test api_core_data_suite::collections::tests::test_api_collections_can_skip_exact_total_count ... ok
test api_core_data_suite::collections::tests::test_api_collection_permissions ... ok
test api_core_data_suite::collections::tests::test_api_collection_permissions_grant_and_delete_all ... ok
test api_core_data_suite::collections::tests::test_api_collections_sorted::case_1_sorted_id_default ... ok
test api_core_data_suite::collections::tests::test_api_collections_limit::case_2_limit_5 ... ok
test api_core_data_suite::collections::tests::test_api_collections_limit::case_1_limit_2 ... ok
test api_core_data_suite::collections::tests::test_api_collections_sorted::case_2_sorted_id_explicit_asc ... ok
test api_core_data_suite::collections::tests::test_api_collections_cursor_pagination ... ok
test api_core_data_suite::collections::tests::test_api_collections_sorted::case_3_sorted_id_descending ... ok
test api_core_data_suite::collections::tests::test_api_collections_limit::case_3_limit_7 ... ok
test api_core_data_suite::collections::tests::test_api_collections_sorted::case_4_sorted_name_asc ... ok
test api_core_data_suite::collections::tests::test_invalid_collection_id_in_path_is_rejected::case_1_zero ... ok
test api_core_data_suite::collections::tests::test_api_collections_sorted::case_5_sorted_name_desc ... ok
test api_core_data_suite::collections::tests::test_invalid_collection_id_in_path_is_rejected::case_2_negative_one ... ok
test api_core_data_suite::collections::tests::test_invalid_collection_id_in_path_is_rejected::case_3_i32_min ... ok
test api_core_data_suite::collections::tests::test_invalid_collection_id_in_path_is_rejected::case_4_non_numeric ... ok
test api_core_data_suite::collections::tests::test_invalid_collection_id_in_path_is_rejected::case_5_non_integer ... ok
test api_core_data_suite::collections::tests::test_api_collection_grants_work ... ok
test api_core_data_suite::collections::tests::test_api_collections_sorted::case_6_sorted_created_at_asc ... ok
test api_core_data_suite::collections::tests::test_invalid_parent_collection_id_in_body_is_rejected ... ok
test api_core_data_suite::collections::tests::test_api_collections_sorted::case_7_sorted_created_at_desc ... ok
test api_core_data_suite::computed_fields::tests::authorization::computed_filter_rejects_more_than_two_predicates_before_definition_resolution ... ok
test api_core_data_suite::collections::tests::test_looking_up_collections ... ok
test api_core_data_suite::computed_fields::tests::authorization::denied_computed_query_pages_omit_totals_when_disabled::case_1_scope ... ok
test api_core_data_suite::computed_fields::tests::authorization::computed_query_rejects_more_than_two_explicit_sort_fields ... ok
test api_core_data_suite::computed_fields::tests::authorization::denied_computed_query_pages_omit_totals_when_disabled::case_2_list_visibility ... ok
test api_core_data_suite::computed_fields::tests::authorization::computed_query_keys_are_hidden_when_only_the_synthetic_object_is_visible::case_1_existing ... ok
test api_core_data_suite::collections::tests::test_collection_permission_listings_total_count_match_paginated_results ... ok
test api_core_data_suite::computed_fields::tests::authorization::computed_query_keys_are_hidden_when_only_the_synthetic_object_is_visible::case_2_missing ... ok
test api_core_data_suite::computed_fields::tests::authorization::computed_query_honors_object_specific_treetop_visibility ... ok
test api_core_data_suite::computed_fields::tests::authorization::computed_query_keys_are_hidden_without_full_object_list_visibility::case_1_existing ... ok
test api_core_data_suite::collections::tests::test_create_patch_delete_collection ... ok
test api_core_data_suite::computed_fields::tests::authorization::computed_query_keys_are_hidden_without_full_object_list_visibility::case_2_missing ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_01_first_non_null ... ok
test api_core_data_suite::computed_fields::tests::consistency::computed_query_cursor_uses_the_resolved_definition_snapshot ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_02_sum ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_03_sum_rounds_a_power_boundary ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_04_sum_preserves_precision ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_05_average ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_06_repeating_average ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_07_minimum ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_08_maximum ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_09_all_present ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_10_any_present ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_11_count_present ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_12_all_present_and_equal ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_13_object_result ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_14_array_result ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_matches_the_domain_operation_catalog::case_15_non_numeric_operand ... ok
test api_core_data_suite::computed_fields::tests::consistency::computed_query_rejects_a_cursor_too_large_for_the_next_request ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_measures_compact_json_input ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_preserves_scope_output_limits ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_preserves_the_empty_pointer_token ... ok
test api_core_data_suite::computed_fields::tests::database_source_hash_matches_the_domain_canonical_json ... ok
test api_core_data_suite::computed_fields::tests::consistency::shared_computed_query_rejects_a_cache_row_for_old_source_data ... ok
test api_core_data_suite::computed_fields::tests::database_scope_evaluator_preserves_scope_work_limits ... ok
test api_core_data_suite::computed_fields::tests::consistency::personal_computed_query_is_owner_scoped_and_numeric ... ok
test api_core_data_suite::computed_fields::tests::consistency::raw_computed_sort_only_enriches_a_nonterminal_cursor_boundary ... ok
test api_core_data_suite::computed_fields::tests::definitions::computed_input_is_rejected_even_when_null ... ok
test api_core_data_suite::computed_fields::tests::consistency::shared_computed_query_falls_back_for_an_invalid_fresh_materialization::case_2_wrong_type ... ok
test api_core_data_suite::computed_fields::tests::consistency::shared_computed_query_falls_back_for_an_invalid_fresh_materialization::case_1_missing_key ... ok
test api_core_data_suite::computed_fields::tests::consistency::shared_computed_query_falls_back_for_an_invalid_fresh_materialization::case_3_extra_key ... ok
test api_core_data_suite::computed_fields::tests::consistency::shared_computed_query_falls_back_for_an_invalid_fresh_materialization::case_4_malformed_error ... ok
test api_core_data_suite::computed_fields::tests::consistency::numeric_computed_query_cursor_matches_domain_precision ... ok
test api_core_data_suite::computed_fields::tests::consistency::numeric_computed_query_cursor_preserves_a_power_boundary_aggregate ... ok
test api_core_data_suite::computed_fields::tests::definitions::shared_mutation_rejects_a_stale_authorized_collection ... ok
test api_core_data_suite::computed_fields::tests::definitions::personal_definitions_are_separate_from_shared_values ... ok
test api_core_data_suite::computed_fields::tests::definitions::object_writes_materialize_the_current_shared_revision ... ok
test api_core_data_suite::computed_fields::tests::definitions::update_class_permission_cannot_manage_shared_definitions ... ok
test api_core_data_suite::computed_fields::tests::definitions::personal_patch_rejects_a_stale_semantic_no_op ... ok
test api_core_data_suite::computed_fields::tests::definitions::personal_values_are_not_visible_to_another_human ... ok
test api_core_data_suite::computed_fields::tests::definitions::update_collection_permission_can_manage_shared_definitions ... ok
test api_core_data_suite::computed_fields::tests::definitions::service_accounts_cannot_manage_or_receive_personal_fields ... ok
test api_core_data_suite::computed_fields::tests::definitions::shared_definition_live_fallback_repairs_stale_materialization ... ok
test api_core_data_suite::computed_fields::tests::lifecycle::concurrent_personal_creates_preserve_scope_capacity ... ok
test api_core_data_suite::computed_fields::tests::lifecycle::lease_recovery_marks_the_class_rebuild_failed ... ok
test api_core_data_suite::computed_fields::tests::lifecycle::concurrent_backfill_and_object_update_cannot_restore_old_source_data ... ok
test api_core_data_suite::computed_fields::tests::definitions::shared_patch_requires_the_current_definition_revision ... ok
test api_core_data_suite::computed_fields::tests::lifecycle::deleting_a_class_cascades_definitions_and_materialization ... ok
test api_core_data_suite::computed_fields::tests::lifecycle::object_and_materialization_rollback_together_on_unexpected_failure ... ok
test api_core_data_suite::computed_fields::tests::lifecycle::user_anonymization_removes_personal_definitions ... ok
test api_core_data_suite::computed_fields::tests::lifecycle::concurrent_definition_and_object_updates_return_current_values ... ok
test api_core_data_suite::computed_fields::tests::lifecycle::manual_rebuild_queues_the_current_revision ... ok
test api_core_data_suite::computed_fields::tests::querying::class_object_list_filters_by_computed_result_type::case_1_string ... ok
test api_core_data_suite::computed_fields::tests::querying::class_object_list_filters_by_computed_result_type::case_2_string_in_whitespace ... ok
test api_core_data_suite::computed_fields::tests::querying::class_object_list_filters_by_computed_result_type::case_3_number ... ok
test api_core_data_suite::computed_fields::tests::querying::class_object_list_filters_by_computed_result_type::case_4_boolean ... ok
test api_core_data_suite::computed_fields::tests::querying::class_object_list_filters_by_computed_result_type::case_5_object ... ok
test api_core_data_suite::computed_fields::tests::querying::class_object_list_filters_by_computed_result_type::case_6_array ... ok
test api_core_data_suite::computed_fields::tests::querying::computed_filter_preserves_double_underscores_in_definition_keys ... ok
test api_core_data_suite::computed_fields::tests::querying::computed_filter_without_computed_response_skips_page_enrichment ... ok
test api_core_data_suite::computed_fields::tests::querying::computed_query_accepts_keys_named_after_directions::case_1_ascending_key ... ok
test api_core_data_suite::computed_fields::tests::querying::computed_query_accepts_keys_named_after_directions::case_2_descending_key ... ok
test api_core_data_suite::computed_fields::tests::querying::computed_query_replaces_conflicting_class_filters_with_path_class ... ok
test api_core_data_suite::object_aggregates::basic::collection_filter_aliases_apply_before_grouping::case_1 ... ok
test api_core_data_suite::object_aggregates::basic::collection_filter_aliases_apply_before_grouping::case_2 ... ok
test api_core_data_suite::object_aggregates::basic::filters_apply_before_multidimensional_grouping ... ok
test api_core_data_suite::object_aggregates::basic::global_numeric_measures_report_values_and_coverage::case_1 ... ok
test api_core_data_suite::object_aggregates::basic::global_numeric_measures_report_values_and_coverage::case_2 ... ok
test api_core_data_suite::object_aggregates::basic::global_numeric_measures_report_values_and_coverage::case_3 ... ok
test api_core_data_suite::computed_fields::tests::querying::enriched_pagination_preserves_totals_and_cursors ... ok
test api_core_data_suite::object_aggregates::basic::global_numeric_measures_report_values_and_coverage::case_4 ... ok
test api_core_data_suite::object_aggregates::basic::grouped_measures_keep_empty_buckets_explicit ... ok
test api_core_data_suite::object_aggregates::basic::groups_each_allow_listed_scalar_field::case_1 ... ok
test api_core_data_suite::object_aggregates::basic::groups_each_allow_listed_scalar_field::case_2 ... ok
test api_core_data_suite::object_aggregates::basic::groups_each_allow_listed_scalar_field::case_3 ... ok
test api_core_data_suite::object_aggregates::basic::groups_each_allow_listed_scalar_field::case_4 ... ok
test api_core_data_suite::object_aggregates::basic::groups_each_allow_listed_scalar_field::case_5 ... ok
test api_core_data_suite::object_aggregates::basic::json_null_and_missing_path_are_distinct_buckets ... ok
test api_core_data_suite::object_aggregates::basic::nested_json_groups_preserve_json_types ... ok
test api_core_data_suite::object_aggregates::computed::computed_grouping_paginates_byte_bounded_candidate_batches ... ok
test api_core_data_suite::computed_fields::tests::querying::shared_computed_query_is_stable_across_cursor_pages ... ok
test api_core_data_suite::object_aggregates::computed::invalid_computed_selectors_are_bad_requests::case_1 ... ok
test api_core_data_suite::object_aggregates::computed::invalid_computed_selectors_are_bad_requests::case_2 ... ok
test api_core_data_suite::object_aggregates::computed::personal_computed_filters_use_the_requesting_owners_definition ... ok
test api_core_data_suite::object_aggregates::computed::personal_computed_grouping_rejects_another_owners_definition ... ok
test api_core_data_suite::object_aggregates::computed::personal_computed_grouping_rejects_service_accounts ... ok
test api_core_data_suite::object_aggregates::computed::personal_computed_grouping_uses_the_requesting_owners_definition ... ok
test api_core_data_suite::object_aggregates::computed::shared_computed_filters_apply_before_scalar_aggregation ... ok
test api_core_data_suite::object_aggregates::computed::local_computed_filters_are_not_disclosed_outside_resource_scope::case_1 ... ok
test api_core_data_suite::object_aggregates::contracts::class_name_route_matches_the_id_route ... ok
test api_core_data_suite::object_aggregates::computed::local_computed_filters_are_not_disclosed_outside_resource_scope::case_2 ... ok
test api_core_data_suite::object_aggregates::computed::shared_computed_groups_evaluate_snapshots_and_use_unavailable_bucket ... ok
test api_core_data_suite::object_aggregates::computed::shared_computed_numeric_measure_uses_the_definition_snapshot ... ok
test api_core_data_suite::object_aggregates::computed::local_computed_filters_are_not_disclosed_outside_resource_scope::case_3 ... ok
test api_core_data_suite::object_aggregates::contracts::standard_object_list_contract_is_unchanged ... ok
test api_core_data_suite::object_aggregates::cursor::empty_aggregate_page_rejects_a_malformed_cursor ... ok
test api_core_data_suite::object_aggregates::contracts::route_class_constraint_prevents_a_conflicting_filter_from_escaping_the_route ... ok
test api_core_data_suite::object_aggregates::cursor::cursor_values_are_bound_as_data_even_when_the_group_key_looks_like_sql ... ok
test api_core_data_suite::object_aggregates::cursor::empty_class_returns_empty_aggregate_page ... ok
test api_core_data_suite::object_aggregates::cursor::empty_aggregate_page_rejects_a_cursor_for_different_dimensions ... ok
test api_core_data_suite::object_aggregates::cursor::empty_aggregate_page_rejects_structurally_invalid_cursor ... ok
test api_core_data_suite::object_aggregates::cursor::count_sort_cursor_is_deterministic_across_duplicate_counts ... ok
test api_core_data_suite::object_aggregates::cursor::oversized_group_key_is_rejected_before_a_cursor_is_emitted ... ok
test api_core_data_suite::object_aggregates::cursor::include_total_false_omits_group_cardinality_header ... ok
test api_core_data_suite::object_aggregates::external_authorization::denied_parent_permission_stops_before_object_authorization ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_aggregation_preserves_large_internal_sums ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_authorization_excludes_hidden_measure_inputs ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_authorization_filters_objects_before_aggregation ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_authorization_honors_permission_filters ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_authorization_requires_collection_read_access ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_collection_read_respects_token_scopes ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_authorization_does_not_hold_the_computed_definition_lock ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_computed_filters_apply_before_authorized_aggregation ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_computed_filters_are_not_disclosed_without_visible_objects::case_1 ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_computed_filters_are_not_disclosed_without_visible_objects::case_2 ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_computed_selectors_are_not_disclosed_without_visible_objects::case_1 ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_computed_filters_are_not_disclosed_without_visible_objects::case_3 ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_create_permission_filters_use_prospective_resources::case_1 ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_computed_selectors_are_not_disclosed_without_visible_objects::case_2 ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_create_permission_filters_use_prospective_resources::case_2 ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_computed_selectors_are_not_disclosed_without_visible_objects::case_3 ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_grouping_uses_the_authorized_object_snapshot ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_parent_permission_filters_use_complete_resources::case_1 ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_high_cardinality_groups_paginate_from_bounded_accumulator ... ok
test api_core_data_suite::object_data_patch::atomicity::concurrent_patches_compose_from_the_latest_row_locked_data ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_scalar_grouping_does_not_load_object_json ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_parent_permission_filters_use_complete_resources::case_2 ... ok
test api_core_data_suite::object_aggregates::external_authorization::non_pushdown_permission_filters_respect_token_scopes ... ok
test api_core_data_suite::object_data_patch::atomicity::object_data_patch_locks_computed_state_before_the_class_row ... ok
test api_core_data_suite::object_data_patch::atomicity::no_op_patch_keeps_timestamp_history_and_events_unchanged ... ok
test api_core_data_suite::object_data_patch::atomicity::object_data_patch_holds_the_class_schema_lock_until_commit ... ok
test api_core_data_suite::object_data_patch::atomicity::schema_failure_preserves_data_computed_history_and_events ... ok
test api_core_data_suite::object_data_patch::semantics::add_facts_creates_or_completely_replaces_the_member::case_1_missing_member ... ok
test api_core_data_suite::object_data_patch::semantics::add_facts_creates_or_completely_replaces_the_member::case_2_existing_member ... ok
test api_core_data_suite::object_data_patch::atomicity::computed_materialization_failure_rolls_back_data_history_and_events ... ok
test api_core_data_suite::object_data_patch::atomicity::successful_patch_updates_computed_history_event_and_timestamp_together ... ok
test api_core_data_suite::object_data_patch::semantics::failed_test_operation_leaves_the_object_unchanged ... ok
test api_core_data_suite::object_data_patch::semantics::empty_path_replaces_the_complete_data_document ... ok
test api_core_data_suite::object_data_patch::semantics::existing_object_patch_keeps_whole_data_replacement_semantics ... ok
test api_core_data_suite::object_data_patch::semantics::by_name_path_is_scoped_to_the_class ... ok
test api_core_data_suite::object_data_patch::semantics::by_name_path_percent_decodes_and_updates_the_named_object ... ok
test api_core_data_suite::object_data_patch::semantics::by_name_path_never_interprets_numeric_names_as_ids ... ok
test api_core_data_suite::object_data_patch::semantics::later_operation_failure_persists_none_of_the_patch ... ok
test api_core_data_suite::object_data_patch::validation::incorrect_content_type_returns_unsupported_media_type ... ok
test api_core_data_suite::object_data_patch::semantics::test_operation_compares_numbers_by_rfc_value ... ok
test api_core_data_suite::object_data_patch::validation::class_mismatch_returns_not_found ... ok
test api_core_data_suite::object_data_patch::validation::insufficient_permission_returns_forbidden ... ok
test api_core_data_suite::object_data_patch::validation::invalid_patch_structure_returns_bad_request ... ok
test api_core_data_suite::object_data_patch::validation::malformed_json_returns_bad_request ... ok
test api_core_data_suite::object_data_patch::validation::missing_authentication_returns_unauthorized ... ok
test api_core_data_suite::object_data_patch::validation::oversized_patch_returns_payload_too_large ... ok
test api_core_data_suite::object_data_patch::validation::missing_object_returns_not_found ... ok
test api_core_data_suite::object_data_patch::validation::postgres_jsonb_incompatible_patch_result_returns_bad_request::case_1_nul_string ... ok
test api_core_data_suite::object_data_patch::validation::postgres_jsonb_incompatible_patch_result_returns_bad_request::case_2_nul_key ... ok
test api_core_data_suite::object_data_patch::validation::postgres_jsonb_incompatible_patch_result_returns_bad_request::case_3_numeric_out_of_range ... ok
test api_core_data_suite::object_data_patch::validation::patch_result_larger_than_object_data_limit_returns_payload_too_large ... ok
test api_core_data_suite::objects::tests::admin_can_list_objects_without_direct_owner_group_membership ... ok
test api_core_data_suite::objects::tests::create_object_in_class::case_1_class_0_0_conflict ... ok
test api_core_data_suite::objects::tests::create_object_in_class::case_2_class_0_1_ok ... ok
test api_core_data_suite::objects::tests::create_object_in_class_rejects_body_class_mismatch ... ok
test api_core_data_suite::objects::tests::create_objects_in_class_failing_validation::case_1_ok_40_74 ... ok
test api_core_data_suite::objects::tests::create_object_in_class::case_3_class_0_2_ok ... ok
test api_core_data_suite::objects::tests::create_objects_in_class_failing_validation::case_4_failed_40_181 ... ok
test api_core_data_suite::objects::tests::create_objects_in_class_failing_validation::case_3_failed_neg91_74 ... ok
test api_core_data_suite::objects::tests::create_objects_in_class_failing_validation::case_2_failed_91_74 ... ok
test api_core_data_suite::objects::tests::create_object_in_class::case_4_class_1_1_conflict ... ok
test api_core_data_suite::objects::tests::create_object_in_class::case_5_class_2_2_conflict ... ok
test api_core_data_suite::objects::tests::create_objects_in_class_failing_validation::case_5_failed_40_neg181 ... ok
test api_core_data_suite::objects::tests::create_objects_in_class_failing_validation::case_6_failed_100_200 ... ok
test api_core_data_suite::objects::tests::create_objects_in_class_failing_validation::case_7_failed_lat_missing ... ok
test api_core_data_suite::objects::tests::create_objects_in_class_failing_validation::case_8_failed_long_missing ... ok
test api_core_data_suite::objects::tests::create_objects_in_class_failing_validation::case_9_ok_extra_fields ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_examples::case_2_filter_hostname_contains ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_examples::case_1_filter_status_equals ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_examples::case_3_filter_missing_path ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_ip_examples::case_1_docs_within_network ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_ip_examples::case_2_docs_contains_network ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_typed_examples::case_1_json_numeric_equals ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_ip_examples::case_3_docs_contains_ip ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_ip_examples::case_4_docs_overlaps_network ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_ip_examples::case_5_docs_inet_equals ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_typed_examples::case_2_json_numeric_between ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_typed_examples::case_3_json_boolean_equals ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_typed_examples::case_4_json_date_gt ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_typed_examples::case_5_json_date_between ... ok
test api_core_data_suite::objects::tests::docs_api_objects_filter_json_data_typed_examples::case_6_json_date_not_between ... ok
test api_core_data_suite::objects::tests::object_creation_locks_computed_state_before_the_class_row ... ok
test api_core_data_suite::objects::tests::test_api_object_history_404_for_missing ... ok
test api_core_data_suite::objects::tests::get_objects_in_class ... ok
test api_core_data_suite::objects::tests::patch_object_in_class_rejects_class_or_collection_move ... ok
test api_core_data_suite::objects::tests::patch_object_in_class_validates_schema ... ok
test api_core_data_suite::objects::tests::object_in_class_routes_require_matching_path_class ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_ip_operators::case_1_within_network ... ok
test api_core_data_suite::objects::tests::test_api_object_history_list_and_as_of ... ok
test api_core_data_suite::objects::tests::test_api_objects_cursor_pagination ... ok
test api_core_data_suite::objects::tests::get_patch_and_delete_objects_in_class ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_ip_operators::case_2_contains_network ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_ip_operators::case_3_contains_ip ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_ip_operators_reject_invalid_rhs::case_1 ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_ip_operators::case_4_overlaps_network ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_ip_operators::case_5_inet_equals ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_ip_operators::case_6_not_within_network ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_ip_operators_reject_invalid_rhs::case_2 ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_01_in_scalar ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_02_in_array ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_03_not_in_scalar ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_04_not_in_array ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_05_all_tags ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_06_not_all_tags ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_07_array_length_2 ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_08_array_length_3 ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_09_in_numeric_array ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_10_all_numeric_array ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_11_not_array_length ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_12_has_key ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_13_not_has_key ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_14_is_null ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_structure_operators::case_15_not_is_null ... ok
test api_core_data_suite::objects::tests::test_api_objects_sorted::case_1_sorted_id_default ... ok
test api_core_data_suite::querying::tests::test_any_is_alias_for_in ... ok
test api_core_data_suite::objects::tests::test_api_objects_limit::case_1_limit_2 ... ok
test api_core_data_suite::objects::tests::test_api_objects_limit::case_3_limit_7 ... ok
test api_core_data_suite::objects::tests::test_api_objects_limit::case_2_limit_5 ... ok
test api_core_data_suite::objects::tests::test_api_objects_sorted::case_2_sorted_id_explicit_asc ... ok
test api_core_data_suite::objects::tests::test_api_objects_sorted::case_3_sorted_id_descending ... ok
test api_core_data_suite::objects::tests::test_api_objects_sorted::case_4_sorted_name_asc ... ok
test api_core_data_suite::objects::tests::test_api_objects_sorted::case_5_sorted_name_desc ... ok
test api_core_data_suite::objects::tests::test_api_objects_sorted::case_7_sorted_created_at_desc ... ok
test api_core_data_suite::objects::tests::test_api_objects_sorted::case_6_sorted_created_at_asc ... ok
test api_core_data_suite::objects::tests::test_api_objects_sorted::case_8_sorted_collection_and_id_asc ... ok
test api_core_data_suite::querying::tests::test_documented_boolean_operators_on_classes::case_1_equals ... ok
test api_core_data_suite::querying::tests::test_documented_ip_network_json_operators_parse ... ok
test api_core_data_suite::querying::tests::test_documented_json_structure_operators_parse ... ok
test api_core_data_suite::querying::tests::test_documented_array_operators_on_related_objects::case_1_equals ... ok
test api_core_data_suite::querying::tests::test_documented_date_operators_on_objects::case_1_equals ... ok
test api_core_data_suite::querying::tests::test_documented_date_operators_on_objects::case_2_gt ... ok
test api_core_data_suite::querying::tests::test_documented_array_operators_on_related_objects::case_2_contains ... ok
test api_core_data_suite::querying::tests::test_documented_date_operators_on_objects::case_3_gte ... ok
test api_core_data_suite::querying::tests::test_documented_date_operators_on_objects::case_4_lt ... ok
test api_core_data_suite::querying::tests::test_documented_date_operators_on_objects::case_5_lte ... ok
test api_core_data_suite::querying::tests::test_documented_date_operators_on_objects::case_6_between ... ok
test api_core_data_suite::querying::tests::test_documented_operators_parse_for_documented_data_types::case_1_string ... ok
test api_core_data_suite::querying::tests::test_documented_operators_parse_for_documented_data_types::case_2_numeric_date ... ok
test api_core_data_suite::querying::tests::test_documented_operators_parse_for_documented_data_types::case_3_array ... ok
test api_core_data_suite::querying::tests::test_documented_operators_parse_for_documented_data_types::case_4_boolean ... ok
test api_core_data_suite::querying::tests::test_documented_date_operators_on_objects::case_7_in_op ... ok
test api_core_data_suite::querying::tests::test_documented_date_operators_on_objects::case_8_not_in_op ... ok
test api_core_data_suite::querying::tests::test_documented_numeric_operators_on_objects::case_1_equals ... ok
test api_core_data_suite::querying::tests::test_documented_numeric_operators_on_objects::case_2_gt ... ok
test api_core_data_suite::querying::tests::test_documented_numeric_operators_on_objects::case_3_gte ... ok
test api_core_data_suite::querying::tests::test_documented_numeric_operators_on_objects::case_4_lt ... ok
test api_core_data_suite::querying::tests::test_documented_numeric_operators_on_objects::case_5_lte ... ok
test api_core_data_suite::querying::tests::test_documented_numeric_operators_on_objects::case_6_between ... ok
test api_core_data_suite::querying::tests::test_documented_numeric_operators_on_objects::case_7_in_op ... ok
test api_core_data_suite::querying::tests::test_documented_numeric_operators_on_objects::case_8_not_in_op ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_01_equals ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_02_iequals ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_03_contains ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_04_icontains ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_05_startswith ... ok
test api_core_data_suite::querying::tests::test_querying_docs_operator_lists::case_1_string ... ok
test api_core_data_suite::querying::tests::test_querying_docs_operator_lists::case_2_numeric_date ... ok
test api_core_data_suite::querying::tests::test_querying_docs_operator_lists::case_3_array ... ok
test api_core_data_suite::querying::tests::test_querying_docs_operator_lists::case_4_boolean ... ok
test api_core_data_suite::querying::tests::test_querying_docs_operator_lists::case_5_ip_network_json ... ok
test api_core_data_suite::querying::tests::test_querying_docs_operator_lists::case_6_json_structure ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_06_istartswith ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_07_endswith ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_08_iendswith ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_09_like ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_10_regex ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_11_in_op ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_12_not_in_op ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_13_is_null_false ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_14_is_null_true ... ok
test api_core_data_suite::querying::tests::test_documented_string_operators_on_objects::case_15_not_is_null_true ... ok
test api_core_data_suite::querying::tests::test_sort_by_description_descending ... ok
test api_core_data_suite::relations::tests::test_admin_can_list_class_relations_without_direct_owner_group_membership ... ok
test api_core_data_suite::relations::tests::docs_api_related_objects_filter_json_data_examples::case_1_docs_from_json_data_matches_ancestor ... ok
test api_core_data_suite::relations::tests::docs_api_related_objects_filter_json_data_examples::case_2_docs_from_json_data_does_not_match_descendant_fields ... ok
test api_core_data_suite::relations::tests::docs_api_related_objects_filter_json_data_examples::case_3_docs_to_json_data_matches_descendants ... ok
test api_core_data_suite::relations::tests::test_class_relation_limit_must_be_positive ... ok
test api_core_data_suite::relations::tests::docs_api_related_objects_filter_json_data_examples::case_4_docs_to_json_data_does_not_match_ancestor_fields ... ok
test api_core_data_suite::querying::tests::test_sort_by_description_for_classes_collections_and_objects ... ok
test api_core_data_suite::relations::tests::test_admin_can_list_object_relations_without_direct_owner_group_membership ... ok
test api_core_data_suite::relations::tests::test_class_relation_limits_follow_classes_when_relation_order_is_normalized ... ok
test api_core_data_suite::relations::tests::test_api_related_objects_filter_json_data_ip_examples::case_1_from_json_data_contains_ip ... ok
test api_core_data_suite::relations::tests::test_api_related_objects_filter_json_data_ip_examples::case_2_to_json_data_within_network ... ok
test api_core_data_suite::relations::tests::test_deleting_class_relation_from_class_with_wrong_relation ... ok
test api_core_data_suite::relations::tests::test_class_relations_total_count_matches_paginated_results ... ok
test api_core_data_suite::relations::tests::test_creating_class_relation_from_class ... ok
test api_core_data_suite::relations::tests::test_deleting_class_relation_from_class ... ok
test api_core_data_suite::relations::tests::test_deleting_class_relation_from_global ... ok
test api_core_data_suite::relations::tests::test_creating_class_relation_from_class_reverse_duplicate_conflicts ... ok
test api_core_data_suite::relations::tests::test_delete_object_relation_from_class_endpoint::case_1_forward_order ... ok
test api_core_data_suite::relations::tests::test_delete_object_relation_from_class_endpoint::case_2_reverse_order ... ok
test api_core_data_suite::relations::tests::test_create_object_relation_from_class_endpoint_reverse_duplicate_conflicts ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_01_rel_0_0_empty ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_02_rel_0_0_from_name ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_03_rel_0_0_to_name ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_04_rel_0_0_to_desc ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_05_rel_0_0_depth_eq ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_06_rel_0_0_depth_gt ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_08_rel_0_0_path_equals_0_1 ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_07_rel_0_0_depth_lt ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_09_rel_0_0_path_equals_0_2 ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_10_rel_0_0_path_contains ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_11_rel_1_1_empty ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_12_rel_4_4_empty ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_13_rel_0_0_invalid_key ... ok
test api_core_data_suite::relations::tests::test_get_class_relation ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_14_rel_0_0_invalid_op ... ok
test api_core_data_suite::relations::tests::test_get_class_relations_list ... ok
test api_core_data_suite::relations::tests::test_filter_related_objects::case_15_rel_0_1_wrong_class ... ok
test api_core_data_suite::relations::tests::test_get_class_relations_cursor_pagination ... ok
test api_core_data_suite::relations::tests::test_get_class_relations_sorted_and_limited ... ok
test api_core_data_suite::relations::tests::test_get_object_relation_param::case_2_relation_12_rel_false_c1 ... ok
test api_core_data_suite::relations::tests::test_get_object_relation_param::case_1_relation_12_rel_true ... ok
test api_core_data_suite::relations::tests::test_get_class_relation_with_permissions ... ok
test api_core_data_suite::relations::tests::test_get_object_relation_param::case_3_relation_21_rel_true ... ok
test api_core_data_suite::relations::tests::test_get_object_relation_param::case_4_relation_32_true ... ok
test api_core_data_suite::relations::tests::test_get_object_relation_param::case_5_relation_15_true ... ok
test api_core_data_suite::relations::tests::test_get_object_relation_param::case_6_relation_34_false ... ok
test api_core_data_suite::relations::tests::test_get_object_relation_param::case_7_relation_45_false_r0 ... ok
test api_core_data_suite::relations::tests::test_get_object_relation_param::case_8_relation_45_false_r1 ... ok
test api_core_data_suite::relations::tests::test_get_object_relation_param::case_9_relation_45_false_r2 ... ok
test api_core_data_suite::relations::tests::test_object_relation_limit_does_not_serialize_unrelated_creates::case_1_unlimited ... ok
test api_core_data_suite::relations::tests::test_object_relation_limit_does_not_serialize_unrelated_creates::case_2_bounded_objects ... ok
test api_core_data_suite::relations::tests::test_get_related_object_relations ... ok
test api_core_data_suite::relations::tests::test_object_relation_limit_serializes_concurrent_creates ... ok
test api_core_data_suite::relations::tests::test_get_object_relations_sorted_and_limited ... ok
test api_core_data_suite::relations::tests::test_object_relation_limit_rejects_an_extra_relation_for_the_same_object ... ok
test api_core_data_suite::relations::tests::test_related_class_relations_total_count_matches_paginated_results ... ok
test api_core_data_suite::relations::tests::test_related_class_graph_enforces_limit ... ok
test api_core_data_suite::relations::tests::test_object_relations_total_count_matches_paginated_results ... ok
test api_core_data_suite::relations::tests::test_related_classes_cursor_pagination_with_path_sort ... ok
test api_core_data_suite::relations::tests::test_related_classes_bidirectional ... ok
test api_core_data_suite::relations::tests::test_related_classes_total_count_stays_constant_across_pages ... ok
test api_core_data_suite::relations::tests::test_related_object_graph ... ok
test api_core_data_suite::relations::tests::test_related_endpoints_forbid_hidden_root_object ... ok
test api_core_data_suite::relations::tests::test_related_objects_ignore_classes_filters_results_but_keeps_deeper_paths ... ok
test api_core_data_suite::relations::tests::test_related_objects_ignore_self_class_rejects_duplicate_values ... ok
test api_core_data_suite::relations::tests::test_related_objects_ignore_self_class_rejects_invalid_boolean ... ok
test api_core_data_suite::relations::tests::test_related_object_relations_total_count_matches_paginated_results ... ok
test api_core_data_suite::relations::tests::test_related_endpoints_require_relation_permission_for_neighbors ... ok
test api_core_data_suite::relations::tests::test_related_objects_ignore_self_class_defaults_true_and_can_be_disabled ... ok
test api_core_data_suite::relations::tests::test_related_objects_cursor_pagination_with_path_sort ... ok
test api_core_data_suite::relations::tests::test_unmounted_directional_class_routes_return_not_found::case_1_transitive ... ok
test api_core_data_suite::relations::tests::test_related_endpoints_hide_cross_collection_relations_without_permission ... ok
test api_core_data_suite::relations::tests::test_unmounted_directional_class_routes_return_not_found::case_2_transitive_to_class ... ok
test api_core_data_suite::search::tests::test_api_search_class_schema_toggle ... ok
test api_core_data_suite::relations::tests::test_unmounted_related_objects_route_returns_not_found ... ok
test api_core_data_suite::search::tests::test_api_search_invalid_requests ... ok
test api_core_data_suite::relations::tests::test_related_objects_total_count_matches_paginated_results ... ok
test api_core_data_suite::search::tests::test_api_search_stream_events ... ok
test api_core_data_suite::search::tests::test_api_search_object_data_toggle ... ok
test api_core_data_suite::search::tests::test_api_search_per_kind_cursor_pagination ... ok
test api_core_data_suite::search::tests::test_api_search_grouped_results_and_kind_filter ... ok
test api_core_data_suite::search::tests::test_api_search_permission_scoping ... ok
test api_core_data_suite::search::tests::test_api_search_resource_scoped_admin_without_group_grants ... ok
test api_core_data_suite::objects::tests::test_api_objects_filter_json_data_ip_operators_large_dataset_and_expression_index ... ok

test result: ok. 461 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 90.17s


running 274 tests
test api_identity_suite::auth::tests::test_auth_providers_are_publicly_discoverable ... ok
test api_identity_suite::auth::tests::test_invalid_login_credentials ... ok
test api_identity_suite::groups::tests::batch_group_responses_resolve_multiple_identity_scopes ... ok
test api_identity_suite::groups::tests::batch_principal_responses_resolve_multiple_identity_scopes ... ok
test api_identity_suite::groups::tests::legacy_identity_scope_upsert_returns_an_unchanged_row ... ok
test api_identity_suite::groups::tests::conditional_membership_add_does_not_recreate_a_deleted_membership ... ok
test api_identity_suite::groups::tests::membership_add_returns_the_revision_after_adding_the_manual_source ... ok
test api_identity_suite::groups::tests::membership_delete_returns_the_surviving_membership_revision ... ok
test api_identity_suite::groups::tests::stale_membership_delete_rejects_an_absent_manual_source ... ok
test api_identity_suite::groups::tests::tagged_group_points_exclude_revision_exempt_sync_bookkeeping ... ok
test api_identity_suite::groups::tests::test_create_and_delete_group ... ok
test api_identity_suite::auth::tests::test_password_spray_across_usernames_is_throttled_per_ip ... ok
test api_identity_suite::groups::tests::test_directory_managed_group_is_read_only ... ok
test api_identity_suite::auth::tests::test_login_is_rate_limited_after_repeated_failures ... ok
test api_identity_suite::groups::tests::test_group_members_cursor_pagination ... ok
test api_identity_suite::groups::tests::test_group_add_and_delete_member ... ok
test api_identity_suite::auth::tests::test_valid_login ... ok
test api_identity_suite::groups::tests::test_group_delete_member_only_targets_requested_group ... ok
test api_identity_suite::groups::tests::test_group_members_filtering ... ok
test api_identity_suite::groups::tests::test_list_groups_filtered::case_1_filter_by_name ... ok
test api_identity_suite::groups::tests::test_list_groups_cursor_pagination ... ok
test api_identity_suite::groups::tests::test_list_groups_filtered::case_2_filter_by_id ... ok
test api_identity_suite::groups::tests::test_list_groups_filtered::case_3_filter_by_desc ... ok
test api_identity_suite::auth::tests::test_rotating_spoofed_forwarded_for_cannot_bypass_rate_limit ... ok
test api_identity_suite::groups::tests::test_list_groups_limit::case_1_limit_1 ... ok
test api_identity_suite::groups::tests::test_list_groups_limit::case_2_limit_2 ... ok
test api_identity_suite::groups::tests::test_list_groups_limit::case_3_limit_5 ... ok
test api_identity_suite::groups::tests::test_list_groups_sorted::case_1_id_asc ... ok
test api_identity_suite::auth::tests::test_logout_single_token ... ok
test api_identity_suite::groups::tests::test_list_groups_sorted::case_2_id_desc ... ok
test api_identity_suite::auth::tests::oversized_login_name_is_rejected ... ok
test api_identity_suite::groups::tests::test_list_groups_sorted::case_3_name_asc ... ok
test api_identity_suite::groups::tests::test_list_groups_sorted::case_4_name_desc ... ok
test api_identity_suite::principal_settings::tests::cross_principal_access_requires_an_unscoped_human_admin::case_1_human_admin ... ok
test api_identity_suite::principal_settings::tests::cross_principal_access_requires_an_unscoped_human_admin::case_2_human_non_admin ... ok
test api_identity_suite::principal_settings::tests::database_rejects_non_object_settings ... ok
test api_identity_suite::groups::tests::test_patch_group ... ok
test api_identity_suite::principal_settings::tests::cross_principal_access_requires_an_unscoped_human_admin::case_3_scoped_human_admin ... ok
test api_identity_suite::auth::tests::test_logout_all_tokens_from_user ... ok
test api_identity_suite::principal_settings::tests::concurrent_patches_preserve_unrelated_changes ... ok
test api_identity_suite::principal_settings::tests::cross_principal_access_requires_an_unscoped_human_admin::case_4_service_account_admin_group ... ok
test api_identity_suite::principal_settings::tests::every_valid_principal_token_can_manage_its_own_settings::case_1_human ... ok
test api_identity_suite::groups::tests::test_show_group ... ok
test api_identity_suite::principal_settings::tests::every_valid_principal_token_can_manage_its_own_settings::case_2_scoped_human ... ok
test api_identity_suite::principal_settings::tests::delete_resets_settings::case_1_me ... ok
test api_identity_suite::principal_settings::tests::every_valid_principal_token_can_manage_its_own_settings::case_4_provider_managed ... ok
test api_identity_suite::principal_settings::tests::every_valid_principal_token_can_manage_its_own_settings::case_3_service_account ... ok
test api_identity_suite::principal_settings::tests::delete_resets_settings::case_2_principal ... ok
test api_identity_suite::principal_settings::tests::mutations_emit_complete_settings_snapshots_for_the_target_kind::case_1_human_put ... ok
test api_identity_suite::auth::tests::test_login_rate_limit_uses_trusted_forwarded_ip_when_enabled ... ok
test api_identity_suite::principal_settings::tests::new_principal_settings_are_empty::case_1_me ... ok
test api_identity_suite::principal_settings::tests::mutations_emit_complete_settings_snapshots_for_the_target_kind::case_2_human_patch ... ok
test api_identity_suite::principal_settings::tests::new_principal_settings_are_empty::case_2_principal ... ok
test api_identity_suite::principal_settings::tests::mutations_emit_complete_settings_snapshots_for_the_target_kind::case_4_service_account_put ... ok
test api_identity_suite::principal_settings::tests::mutations_emit_complete_settings_snapshots_for_the_target_kind::case_3_human_delete ... ok
test api_identity_suite::principal_settings::tests::mutations_emit_complete_settings_snapshots_for_the_target_kind::case_5_service_account_patch ... ok
test api_identity_suite::principal_settings::tests::patch_null_removes_keys_at_each_depth::case_1_me ... ok
test api_identity_suite::principal_settings::tests::mutations_emit_complete_settings_snapshots_for_the_target_kind::case_6_service_account_delete ... ok
test api_identity_suite::principal_settings::tests::service_account_settings_default_to_empty ... ok
test api_identity_suite::principal_settings::tests::patch_null_removes_keys_at_each_depth::case_2_principal ... ok
test api_identity_suite::principal_settings::tests::put_replaces_the_complete_settings_document::case_1_me ... ok
test api_identity_suite::principal_settings::tests::patch_recursively_merges_objects_and_replaces_other_values::case_1_me ... ok
test api_identity_suite::principal_settings::tests::put_replaces_the_complete_settings_document::case_2_principal ... ok
test api_identity_suite::auth::tests::test_logout_specific_token ... ok
test api_identity_suite::principal_settings::tests::patch_recursively_merges_objects_and_replaces_other_values::case_2_principal ... ok
test api_identity_suite::auth::tests::test_invalid_login_parameters ... ok
test api_identity_suite::principal_settings::tests::write_rejects_non_object_roots::case_01_put_array ... ok
test api_identity_suite::principal_settings::tests::write_rejects_non_object_roots::case_02_put_string ... ok
test api_identity_suite::principal_settings::tests::write_rejects_non_object_roots::case_03_put_number ... ok
test api_identity_suite::principal_settings::tests::unchanged_settings_mutations_do_not_update_the_principal_or_emit_events::case_3_delete ... ok
test api_identity_suite::principal_settings::tests::write_rejects_non_object_roots::case_04_put_boolean ... ok
test api_identity_suite::principal_settings::tests::unchanged_settings_mutations_do_not_update_the_principal_or_emit_events::case_1_put ... ok
test api_identity_suite::principal_settings::tests::write_rejects_non_object_roots::case_06_patch_array ... ok
test api_identity_suite::principal_settings::tests::write_rejects_non_object_roots::case_05_put_null ... ok
test api_identity_suite::principal_settings::tests::write_rejects_non_object_roots::case_07_patch_string ... ok
test api_identity_suite::principal_settings::tests::unchanged_settings_mutations_do_not_update_the_principal_or_emit_events::case_2_patch ... ok
test api_identity_suite::principal_settings::tests::write_rejects_non_object_roots::case_08_patch_number ... ok
test api_identity_suite::principal_settings::tests::write_rejects_non_object_roots::case_09_patch_boolean ... ok
test api_identity_suite::principal_settings::tests::write_rejects_non_object_roots::case_10_patch_null ... ok
test api_identity_suite::principal_settings_json_patch::tests::cross_principal_json_patch_preserves_existing_authorization_rules ... ok
test api_identity_suite::principal_settings_json_patch::tests::json_patch_rejects_an_excessively_deep_pointer ... ok
test api_identity_suite::principal_settings_json_patch::tests::json_patch_can_store_a_literal_null ... ok
test api_identity_suite::principal_settings_json_patch::tests::a_json_patch_no_op_does_not_advance_revision_or_emit_an_event ... ok
test api_identity_suite::principal_settings_json_patch::tests::both_settings_route_families_accept_json_patch::case_1_me ... ok
test api_identity_suite::principal_settings_json_patch::tests::both_settings_route_families_accept_json_patch::case_2_principal ... ok
test api_identity_suite::principal_settings_json_patch::tests::a_failed_test_rolls_back_prior_operations_and_audit_side_effects ... ok
test api_identity_suite::principal_settings_json_patch::tests::json_patch_can_insert_an_individual_array_element ... ok
test api_identity_suite::principal_settings_json_patch::tests::json_patch_rejects_an_excessively_nested_intermediate_result ... ok
test api_identity_suite::principal_settings_json_patch::tests::json_patch_rejects_a_non_object_final_root_without_persisting_it ... ok
test api_identity_suite::principal_settings_json_patch::tests::json_patch_rejects_an_oversized_request ... ok
test api_identity_suite::principal_settings_json_patch::tests::json_patch_rejects_too_many_operations ... ok
test api_identity_suite::principal_settings_json_patch::tests::malformed_json_patch_documents_are_rejected ... ok
test api_identity_suite::principal_settings_json_patch::tests::concurrent_json_patches_apply_to_the_latest_row_locked_settings ... ok
test api_identity_suite::principal_settings_json_patch::tests::json_patch_test_compares_numbers_by_rfc_value ... ok
test api_identity_suite::principal_settings_json_patch::tests::json_patch_rejects_results_postgresql_jsonb_cannot_represent ... ok
test api_identity_suite::principal_settings_json_patch::tests::json_patch_bounds_cumulative_application_work ... ok
test api_identity_suite::principal_settings_json_patch::tests::object_content_types_retain_json_merge_patch_semantics::case_1_json ... ok
test api_identity_suite::principal_settings_json_patch::tests::object_content_types_retain_json_merge_patch_semantics::case_2_merge_patch ... ok
test api_identity_suite::principal_settings_json_patch::tests::json_patch_rejects_an_oversized_result ... ok
test api_identity_suite::principal_settings_json_patch::tests::principal_settings_support_each_rfc_6902_operation::case_1_add ... ok
test api_identity_suite::principal_settings_json_patch::tests::principal_settings_support_each_rfc_6902_operation::case_2_remove ... ok
test api_identity_suite::principal_settings_json_patch::tests::unsupported_principal_settings_patch_media_types_are_rejected ... ok
test api_identity_suite::principal_settings_json_patch::tests::principal_settings_support_each_rfc_6902_operation::case_3_replace ... ok
test api_identity_suite::principal_settings_json_patch::tests::principal_settings_support_each_rfc_6902_operation::case_4_move_value ... ok
test api_identity_suite::principal_settings_json_patch::tests::principal_settings_support_each_rfc_6902_operation::case_5_copy ... ok
test api_identity_suite::principal_settings_json_patch::tests::principal_settings_support_each_rfc_6902_operation::case_6_test_success ... ok
test api_identity_suite::principal_settings_json_patch::tests::service_accounts_can_json_patch_their_own_settings ... ok
test api_identity_suite::service_accounts::tests::service_account_creation_rejects_a_non_positive_owner_group_id ... ok
test api_identity_suite::service_accounts::tests::test_cancel_pending_does_not_cancel_internal_reindex_tasks ... ok
test api_identity_suite::service_accounts::tests::test_admin_extractor_rejects_scoped_and_service_accounts::case_1_human_admin_unscoped ... ok
test api_identity_suite::service_accounts::tests::retained_token_operations_are_path_scoped::case_1_get ... ok
test api_identity_suite::service_accounts::tests::retained_token_operations_are_path_scoped::case_2_renew ... ok
test api_identity_suite::service_accounts::tests::test_admin_extractor_rejects_scoped_and_service_accounts::case_2_human_admin_scoped ... ok
test api_identity_suite::principal_settings_json_patch::tests::successful_json_patch_emits_complete_service_account_snapshots ... ok
test api_identity_suite::service_accounts::tests::test_cancel_pending_does_not_cancel_running_tasks ... ok
test api_identity_suite::service_accounts::tests::test_admin_extractor_rejects_scoped_and_service_accounts::case_3_sa_in_admin_group ... ok
test api_identity_suite::service_accounts::tests::test_collection_principal_permissions_route_for_service_account ... ok
test api_identity_suite::service_accounts::tests::test_class_resource_scope_covers_only_class_and_objects::case_1_class ... ok
test api_identity_suite::service_accounts::tests::test_class_resource_scope_covers_only_class_and_objects::case_2_descendant_object ... ok
test api_identity_suite::service_accounts::tests::test_class_resource_scope_covers_only_class_and_objects::case_4_sibling_class ... ok
test api_identity_suite::service_accounts::tests::test_class_resource_scope_covers_only_class_and_objects::case_3_parent_collection ... ok
test api_identity_suite::service_accounts::tests::test_collection_search_requires_read_collection::case_1_read_collection_visible ... ok
test api_identity_suite::service_accounts::tests::test_class_resource_scope_covers_only_class_and_objects::case_5_sibling_object ... ok
test api_identity_suite::service_accounts::tests::test_collection_search_requires_read_collection::case_2_create_class_only_hidden ... ok
test api_identity_suite::service_accounts::tests::test_collection_resource_scope_covers_only_its_hierarchy::case_2_descendant_class ... ok
test api_identity_suite::service_accounts::tests::test_disabled_sa_pending_task_is_cancelled ... ignored, flaky: queued task can be claimed by the global worker before cancellation
test api_identity_suite::service_accounts::tests::test_collection_resource_scope_covers_only_its_hierarchy::case_1_collection ... ok
test api_identity_suite::service_accounts::tests::test_collection_resource_scope_covers_only_its_hierarchy::case_4_other_collection ... ok
test api_identity_suite::service_accounts::tests::test_collection_resource_scope_covers_only_its_hierarchy::case_3_descendant_object ... ok
test api_identity_suite::service_accounts::tests::test_delete_user_cascades::case_1_principal ... ok
test api_identity_suite::service_accounts::tests::test_cross_kind_name_collision_rejected::case_1_user_then_sa ... ok
test api_identity_suite::service_accounts::tests::test_cross_kind_name_collision_rejected::case_2_sa_then_user ... ok
test api_identity_suite::service_accounts::tests::test_delete_user_cascades::case_2_users_row ... ok
test api_identity_suite::service_accounts::tests::test_delete_user_cascades::case_3_tokens ... ok
test api_identity_suite::service_accounts::tests::test_delete_user_cascades::case_4_memberships ... ok
test api_identity_suite::service_accounts::tests::test_last_used_at_advances_on_use ... FAILED
test api_identity_suite::service_accounts::tests::test_group_delete_rechecks_owners_after_waiting_for_concurrent_creation ... FAILED
test api_identity_suite::service_accounts::tests::test_group_member_listing_includes_both_kinds ... FAILED
test api_identity_suite::service_accounts::tests::test_disabled_sa_token_rejected_at_validation ... FAILED
test api_identity_suite::service_accounts::tests::test_computed_query_gate_checks_object_scope_against_target_class::case_2_other_class ... FAILED
test api_identity_suite::service_accounts::tests::test_disabled_sa_token_mint_returns_409 ... FAILED
test api_identity_suite::service_accounts::tests::test_last_used_at_matches_persisted_value ... ok
test api_identity_suite::service_accounts::tests::test_computed_query_gate_checks_object_scope_against_target_class::case_1_scoped_object_class ... ok
test api_identity_suite::service_accounts::tests::test_group_delete_conflicts_when_owning_service_accounts::case_1_owns_service_account ... ok
test api_identity_suite::service_accounts::tests::test_group_delete_conflicts_when_owning_service_accounts::case_2_no_service_accounts ... ok
test api_identity_suite::service_accounts::tests::test_group_member_mutation_is_admin_only::case_2_non_admin ... ok
test api_identity_suite::service_accounts::tests::test_group_member_mutation_is_admin_only::case_1_admin ... ok
test api_identity_suite::service_accounts::tests::test_group_delete_conflict_caps_service_account_preview ... ok
test api_identity_suite::service_accounts::tests::test_local_relation_operations_authorize_scoped_endpoints::case_2_read_class ... ok
test api_identity_suite::service_accounts::tests::test_management_endpoint_rejects_sa_and_scoped_callers::case_2_scoped_human ... ok
test api_identity_suite::service_accounts::tests::test_management_endpoint_rejects_sa_and_scoped_callers::case_1_service_account ... ok
test api_identity_suite::service_accounts::tests::test_local_relation_operations_authorize_scoped_endpoints::case_1_create_class ... ok
test api_identity_suite::service_accounts::tests::test_me_groups_route_works_for_service_account ... ok
test api_identity_suite::service_accounts::tests::test_me_route_reports_null_scope_for_unscoped_token ... ok
test api_identity_suite::service_accounts::tests::test_me_permissions_route_works_for_service_account ... ok
test api_identity_suite::service_accounts::tests::test_me_route_works_for_service_account ... ok
test api_identity_suite::service_accounts::tests::test_local_relation_operations_authorize_scoped_endpoints::case_3_delete_class ... ok
test api_identity_suite::service_accounts::tests::test_local_relation_operations_authorize_scoped_endpoints::case_4_create_object ... ok
test api_identity_suite::service_accounts::tests::test_local_relation_operations_authorize_scoped_endpoints::case_5_read_object ... ok
test api_identity_suite::service_accounts::tests::test_me_tokens_route_is_human_unscoped_only_and_self_scoped ... ok
test api_identity_suite::service_accounts::tests::test_local_relation_operations_authorize_scoped_endpoints::case_6_delete_object ... ok
test api_identity_suite::service_accounts::tests::test_object_resource_scope_covers_only_named_object::case_2_sibling_object ... ok
test api_identity_suite::service_accounts::tests::test_object_resource_scope_covers_only_named_object::case_1_object ... ok
test api_identity_suite::service_accounts::tests::test_owner_group_reassignment_authz::case_1_admin ... ok
test api_identity_suite::service_accounts::tests::test_object_resource_scope_covers_only_named_object::case_3_class ... ok
test api_identity_suite::service_accounts::tests::test_object_resource_scope_covers_only_named_object::case_4_collection ... ok
test api_identity_suite::service_accounts::tests::test_object_resource_scope_filters_list_and_total_count ... ok
test api_identity_suite::service_accounts::tests::test_owner_group_reassignment_authz::case_2_member_of_both ... ok
test api_identity_suite::service_accounts::tests::test_owner_group_reassignment_authz::case_3_member_of_current_only ... ok
test api_identity_suite::service_accounts::tests::test_principal_groups_route_works_for_service_account ... ok
test api_identity_suite::service_accounts::tests::test_principal_permissions_export_groups_by_granting_group ... ok
test api_identity_suite::service_accounts::tests::test_permission_and_resource_scope_dimensions_intersect::case_2_permission_mismatch ... ok
test api_identity_suite::service_accounts::tests::test_permission_and_resource_scope_dimensions_intersect::case_1_match_both ... ok
test api_identity_suite::service_accounts::tests::test_resource_scope_cannot_grant_missing_group_access ... ok
test api_identity_suite::service_accounts::tests::test_permission_and_resource_scope_dimensions_intersect::case_3_resource_mismatch ... ok
test api_identity_suite::service_accounts::tests::test_resource_only_token_round_trips_through_mint_and_me ... ok
test api_identity_suite::service_accounts::tests::test_revoked_token_is_rejected ... ok
test api_identity_suite::service_accounts::tests::test_resource_scoped_admin_lists_in_scope_resources_without_group_grants::case_1_collections ... ok
test api_identity_suite::service_accounts::tests::test_resource_scoped_admin_lists_in_scope_resources_without_group_grants::case_2_classes ... ok
test api_identity_suite::service_accounts::tests::test_revoked_token_row_is_retained ... ok
test api_identity_suite::service_accounts::tests::test_resource_scoped_admin_lists_in_scope_resources_without_group_grants::case_3_objects_by_class_id ... ok
test api_identity_suite::service_accounts::tests::test_resource_scoped_admin_lists_in_scope_resources_without_group_grants::case_4_objects_by_class_name ... ok
test api_identity_suite::service_accounts::tests::test_resource_scoped_admin_lists_in_scope_resources_without_group_grants::case_5_class_relations ... ok
test api_identity_suite::service_accounts::tests::test_resource_scoped_relations_require_both_endpoints::case_1_one_class ... ok
test api_identity_suite::service_accounts::tests::test_sa_task_load_authorization::case_1_admin ... ok
test api_identity_suite::service_accounts::tests::test_sa_task_load_authorization::case_2_sa_itself ... ok
test api_identity_suite::service_accounts::tests::test_scope_allows::case_1_unscoped_allows ... ok
test api_identity_suite::service_accounts::tests::test_scope_allows::case_2_empty_denies_all ... ok
test api_identity_suite::service_accounts::tests::test_scope_allows::case_3_match_allows ... ok
test api_identity_suite::service_accounts::tests::test_scope_allows::case_4_mismatch_denies ... ok
test api_identity_suite::service_accounts::tests::test_resource_scoped_admin_lists_in_scope_resources_without_group_grants::case_6_object_relations ... ok
test api_identity_suite::service_accounts::tests::test_resource_scoped_relations_require_both_endpoints::case_2_both_classes ... ok
test api_identity_suite::service_accounts::tests::test_resource_scoped_relations_require_both_endpoints::case_4_both_objects ... ok
test api_identity_suite::service_accounts::tests::test_resource_scoped_relations_require_both_endpoints::case_3_one_object ... ok
test api_identity_suite::service_accounts::tests::test_sa_listing_honours_page_limit ... ok
test api_identity_suite::service_accounts::tests::test_sa_listing_filters_by_owner_group_for_non_admin ... ok
test api_identity_suite::service_accounts::tests::test_sa_task_load_authorization::case_4_unrelated ... ok
test api_identity_suite::service_accounts::tests::test_sa_task_load_authorization::case_3_owner_group_member ... ok
test api_identity_suite::service_accounts::tests::test_scoped_task_persists_scope_snapshot ... ok
test api_identity_suite::service_accounts::tests::test_sa_token_mint_authz::case_1_admin ... ok
test api_identity_suite::service_accounts::tests::test_snapshot_permission_parse_is_fail_closed::case_1_known ... ok
test api_identity_suite::service_accounts::tests::test_snapshot_permission_parse_is_fail_closed::case_2_unknown ... ok
test api_identity_suite::service_accounts::tests::test_service_account_can_own_a_task ... ok
test api_identity_suite::service_accounts::tests::test_sa_token_mint_authz::case_3_outsider ... ok
test api_identity_suite::service_accounts::tests::test_sa_token_mint_authz::case_2_owner_group_member ... ok
test api_identity_suite::service_accounts::tests::test_service_account_cannot_password_login ... ok
test api_identity_suite::service_accounts::tests::test_subtype_fk_rejects_service_account_row_for_human_id ... ok
test api_identity_suite::service_accounts::tests::test_subtype_fk_rejects_user_row_for_service_account_id ... ok
test api_identity_suite::service_accounts::tests::test_scoped_token_denies_out_of_scope_permission ... ok
test api_identity_suite::service_accounts::tests::test_scoped_token_allows_in_scope_permission ... ok
test api_identity_suite::service_accounts::tests::test_service_account_can_read_its_own_task::case_1_submitting_sa ... ok
test api_identity_suite::service_accounts::tests::test_service_account_can_read_its_own_task::case_2_unrelated_sa ... ok
test api_identity_suite::service_accounts::tests::test_service_account_collection_access_requires_membership::case_2_nonmember_denied ... ok
test api_identity_suite::service_accounts::tests::test_service_account_collection_access_requires_membership::case_1_member_allowed ... ok
test api_identity_suite::service_accounts::tests::test_task_idempotency_is_per_principal::case_1_same_principal ... ok
test api_identity_suite::service_accounts::tests::test_token_expiry_validation::case_1_expired ... ok
test api_identity_suite::service_accounts::tests::test_token_expiry_validation::case_2_future ... ok
test api_identity_suite::service_accounts::tests::test_task_idempotency_is_per_principal::case_2_different_principal ... ok
test api_identity_suite::service_accounts::tests::test_token_expiry_validation::case_3_null_uses_window ... ok
test api_identity_suite::service_accounts::tests::test_token_metadata_loader_preserves_scopes_for_duplicate_tokens ... ok
test api_identity_suite::service_accounts::tests::test_token_mint_duplicate_permissions_rejected ... ok
test api_identity_suite::service_accounts::tests::test_token_mint_empty_permissions_rejected ... ok
test api_identity_suite::service_accounts::tests::test_token_mint_legacy_flat_scope_fields_rejected::case_1_permission_scopes ... ok
test api_identity_suite::service_accounts::tests::test_token_mint_legacy_flat_scope_fields_rejected::case_2_resource_scopes ... ok
test api_identity_suite::service_accounts::tests::test_token_mint_duplicate_resources_rejected ... ok
test api_identity_suite::service_accounts::tests::test_token_mint_empty_resources_rejected ... ok
test api_identity_suite::service_accounts::tests::test_token_mint_empty_scope_object_rejected ... ok
test api_identity_suite::service_accounts::tests::test_token_lists_include_scope_dimensions::case_1_me ... ok
test api_identity_suite::service_accounts::tests::test_token_mint_resource_limit_rejected ... ok
test api_identity_suite::service_accounts::tests::test_token_lists_include_scope_dimensions::case_2_principal ... ok
test api_identity_suite::service_accounts::tests::test_token_mint_omitted_scope_is_unscoped ... ok
test api_identity_suite::service_accounts::tests::test_token_mint_unknown_resource_rejected ... ok
test api_identity_suite::service_accounts::tests::test_service_account_mutations_emit_audit_events ... ok
test api_identity_suite::service_accounts::tests::test_user_can_on_any_respects_scopes::case_1_unscoped ... ok
test api_identity_suite::service_accounts::tests::test_user_can_on_any_respects_scopes::case_2_in_scope ... ok
test api_identity_suite::service_accounts::tests::test_user_can_on_any_respects_scopes::case_3_out_of_scope ... ok
test api_identity_suite::service_accounts::tests::test_token_revoke_is_path_scoped::case_2_wrong_principal ... ok
test api_identity_suite::service_accounts::tests::test_token_revoke_is_path_scoped::case_1_owning_principal ... ok
test api_identity_suite::service_accounts::tests::test_user_can_on_any_respects_collection_resource_scope ... ok
test api_identity_suite::service_accounts::tests::token_mint_materializes_and_returns_the_configured_default_expiry ... ok
test api_identity_suite::service_accounts::tests::token_mint_rejects_expiry_beyond_configured_maximum ... ok
test api_identity_suite::service_accounts::tests::token_mint_rejects_past_expiry ... ok
test api_identity_suite::service_accounts::tests::token_mint_returns_the_requested_expiry ... ok
test api_identity_suite::users::tests::test_api_anonymize_missing_user_returns_404 ... ok
test api_identity_suite::users::tests::tagged_token_points_exclude_revision_exempt_activity ... ok
test api_identity_suite::users::tests::test_api_anonymize_user ... ok
test api_identity_suite::users::tests::renewing_revoked_token_is_rejected ... ok
test api_identity_suite::users::tests::retained_revoked_tokens_are_discoverable_by_state ... ok
test api_identity_suite::users::tests::retained_expired_tokens_are_discoverable_only_when_requested::case_2_me ... ok
test api_identity_suite::users::tests::renewing_expired_token_copies_exact_scope_and_metadata ... ok
test api_identity_suite::users::tests::retained_expired_tokens_are_discoverable_only_when_requested::case_1_principal ... ok
test api_identity_suite::users::tests::test_list_users_filter_by_proper_name ... ok
test api_identity_suite::users::tests::test_list_users_requires_admin ... ok
test api_identity_suite::users::tests::test_list_users_cursor_pagination ... ok
test api_identity_suite::users::tests::test_directory_managed_user_is_read_only ... ok
test api_identity_suite::users::tests::test_list_users_limit::case_1_limit_1 ... ok
test api_identity_suite::users::tests::test_create_and_delete_user ... ok
test api_identity_suite::users::tests::test_list_users_limit::case_2_limit_2 ... ok
test api_identity_suite::users::tests::test_list_users_limit::case_3_limit_5 ... ok
test api_identity_suite::users::tests::test_list_users_sorted::case_1_id_asc ... ok
test api_identity_suite::users::tests::test_list_users_sorted::case_2_id_desc ... ok
test api_identity_suite::users::tests::test_list_users_sorted::case_3_name_asc ... ok
test api_identity_suite::users::tests::test_user_groups_filtering ... ok
test api_identity_suite::users::tests::test_list_users_sorted::case_4_name_desc ... ok
test api_identity_suite::users::tests::test_list_users_sorted::case_5_proper_name_asc ... ok
test api_identity_suite::users::tests::test_list_users_sorted::case_6_proper_name_desc ... ok
test api_identity_suite::users::tests::test_patch_user ... ok
test api_identity_suite::users::tests::test_user_tokens_cursor_pagination ... ok
test api_identity_suite::users::tests::token_lists_reject_invalid_state_queries::case_1 ... ok
test api_identity_suite::users::tests::token_lists_reject_invalid_state_queries::case_2 ... ok
test api_identity_suite::users::tests::test_user_groups_total_count_matches_paginated_results ... ok
test api_identity_suite::users::tests::test_user_tokens_filtering ... ok
test api_identity_suite::users::tests::test_user_tokens_total_count_matches_paginated_results ... ok
test api_identity_suite::users::tests::test_show_user ... ok

failures:

---- api_identity_suite::service_accounts::tests::test_last_used_at_advances_on_use stdout ----

thread 'api_identity_suite::service_accounts::tests::test_last_used_at_advances_on_use' (24063318) panicked at src/tests/mod.rs:546:5:
Failed to create user: DbConnectionError("Timed out in bb8")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- api_identity_suite::service_accounts::tests::test_group_delete_rechecks_owners_after_waiting_for_concurrent_creation stdout ----

thread 'api_identity_suite::service_accounts::tests::test_group_delete_rechecks_owners_after_waiting_for_concurrent_creation' (24063310) panicked at src/tests/mod.rs:546:5:
Failed to create user: DbConnectionError("Timed out in bb8")

---- api_identity_suite::service_accounts::tests::test_group_member_listing_includes_both_kinds stdout ----

thread 'api_identity_suite::service_accounts::tests::test_group_member_listing_includes_both_kinds' (24063312) panicked at src/tests/mod.rs:283:64:
called `Result::unwrap()` on an `Err` value: DbConnectionError("Timed out in bb8")

---- api_identity_suite::service_accounts::tests::test_disabled_sa_token_rejected_at_validation stdout ----

thread 'api_identity_suite::service_accounts::tests::test_disabled_sa_token_rejected_at_validation' (24063299) panicked at tests/api_identity_suite/service_accounts.rs:706:14:
called `Result::unwrap()` on an `Err` value: DbConnectionError("Timed out in bb8")

---- api_identity_suite::service_accounts::tests::test_computed_query_gate_checks_object_scope_against_target_class::case_2_other_class stdout ----

thread 'api_identity_suite::service_accounts::tests::test_computed_query_gate_checks_object_scope_against_target_class::case_2_other_class' (24063282) panicked at tests/api_identity_suite/service_accounts.rs:1514:9:
assertion `left == right` failed
  left: 500
 right: 200

---- api_identity_suite::service_accounts::tests::test_disabled_sa_token_mint_returns_409 stdout ----

thread 'api_identity_suite::service_accounts::tests::test_disabled_sa_token_mint_returns_409' (24063297) panicked at tests/api_identity_suite/service_accounts.rs:733:9:
assertion `left == right` failed
  left: 500
 right: 409


failures:
    api_identity_suite::service_accounts::tests::test_computed_query_gate_checks_object_scope_against_target_class::case_2_other_class
    api_identity_suite::service_accounts::tests::test_disabled_sa_token_mint_returns_409
    api_identity_suite::service_accounts::tests::test_disabled_sa_token_rejected_at_validation
    api_identity_suite::service_accounts::tests::test_group_delete_rechecks_owners_after_waiting_for_concurrent_creation
    api_identity_suite::service_accounts::tests::test_group_member_listing_includes_both_kinds
    api_identity_suite::service_accounts::tests::test_last_used_at_advances_on_use

test result: FAILED. 267 passed; 6 failed; 1 ignored; 0 measured; 0 filtered out; finished in 44.85s\n- \n- \n- \n- markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Finding: **/*.md !target
Linting: 41 files
Summary: 0 issues in 0 files\n- CI change classifier tests passed.\n- 
running 1 test
test container_build::dockerfile_copies_every_workspace_manifest ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 33 filtered out; finished in 0.00s\n\nThe production Docker image build did not start locally because Docker Desktop continued refusing its Unix socket after host-level retries. This layer changes no container-affecting input; pull-request container CI remains enabled.\n\nPart of #27.\n\nStacked on #333 as part of stack #286.