### PR TITLE
Enforce principal persistence boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Breaking (administrator API):** the storage contract version is now `27`.
+  Principal point reads and the complete audited settings lifecycle now cross a
+  mandatory, uniformly observed backend contract. Principal and
+  principal-membership query rows, Diesel mappings, and SQL cursor mappings are
+  owned by the PostgreSQL adapter; the principal domain model contains no
+  Diesel or PostgreSQL implementation details. Required capability labels and
+  public HTTP request and response shapes are unchanged. Administration and
+  monitoring clients matching contract version `26` must accept version `27`.
 - **Breaking (administrator API):** the storage contract version is now `26`.
   Group lifecycle, identity-scope resolution, membership mutation, listing,
   paging, and counting now cross one mandatory, uniformly observed backend

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -182,7 +182,7 @@ use std::fmt;
 ///
 /// Increment this when a selectable backend must implement a new capability
 /// family or when an existing family's externally observable semantics change.
-pub const STORAGE_CONTRACT_VERSION: u16 = 26;
+pub const STORAGE_CONTRACT_VERSION: u16 = 27;
 
 /// Stable identity of a selectable storage backend.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -101,7 +101,10 @@ keep transitional point-load, validation, bulk lookup, and event-suppressed
 fixture operations behind the same mandatory backend boundary. None of these
 contracts exposes rows or connections. `GroupStorage` owns group point reads,
 identity-scope resolution, lifecycle writes, membership mutation, listing,
-paging, and counting through backend-neutral domain values.
+paging, and counting through backend-neutral domain values. `PrincipalStorage`
+owns principal point reads and the complete settings lifecycle, including
+atomic concurrency and audit behavior, without exposing adapter rows or
+connections.
 `TaskQueueStorage` replaces task submission and reads, while
 `TaskExecutionStorage` owns the complete worker claim and state machine.
 `BackupSnapshotStorage` owns consistent full-system reads, and computed rebuild
@@ -130,7 +133,10 @@ class, and object lifecycle and history rows, class- and object-relation rows, r
 graph query rows, remote-target history, and remote-call result persistence
 rows. Domain permission, group, collection, class, object, and relation values
 contain no Diesel derives, schema bindings, or SQL cursor mappings. Those mappings and
-explicit conversions live in the PostgreSQL adapter. Remaining mixed
+explicit conversions live in the PostgreSQL adapter. Principal and
+principal-membership query rows are also adapter-owned, and the principal
+domain model contains no Diesel derives, schema bindings, or SQL cursor
+mappings. Remaining mixed
 persistence rows move there as their backend-neutral DTOs are extracted. Their
 current locations are implementation details, not partial backend support.
 `StorageHandle` selects one certified PostgreSQL adapter, and only the storage
@@ -142,7 +148,10 @@ composition without implementing every operation behind those contracts.
 The storage contract version changes when a required family is added or when
 observable semantics change. The selected backend and contract version are
 reported in startup logs, process metrics, and the redacted admin configuration.
-Version 26 additionally requires group point and lifecycle writes,
+Version 27 additionally requires principal point reads and the complete audited
+settings lifecycle to cross one mandatory, observed storage contract. Principal
+and principal-membership query rows, Diesel mappings, and SQL cursor mappings
+are adapter-owned. Version 26 additionally requires group point and lifecycle writes,
 identity-scope resolution, and complete membership mutation and query behavior
 to cross one mandatory, observed storage contract. Group, membership, update,
 and SQL cursor rows are adapter-owned. Version 25 required collection point and compatibility writes,

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -454,7 +454,7 @@ mod tests {
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
         assert!(json.contains("\"backend\":\"postgresql\""));
-        assert!(json.contains("\"contract_version\":26"));
+        assert!(json.contains("\"contract_version\":27"));
         assert!(json.contains("\"catalog_queries\""));
         assert!(json.contains("\"computed_object_queries\""));
         assert!(json.contains("\"computed_field_lifecycle\""));

--- a/src/models/principal.rs
+++ b/src/models/principal.rs
@@ -1,4 +1,3 @@
-use crate::storage::postgres::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::openapi::{RefOr, schema::Schema};
 use utoipa::{PartialSchema, ToSchema};
@@ -11,13 +10,9 @@ use crate::models::json_patch::{
     MAX_JSON_PATCH_POINTER_DEPTH, MAX_JSON_PATCH_RESULT_NESTING_DEPTH, MAX_JSON_PATCH_WORK_BYTES,
 };
 use crate::models::search::{FilterField, SortParam};
-use crate::schema::principals;
-use crate::storage::StorageContext;
-use crate::storage::postgres::operations::principal::PrincipalSettingsMutation;
+use crate::storage::{PrincipalStorage, StorageContext, storage_handle};
 use crate::traits::accessors::{IdAccessor, InstanceAdapter};
-use crate::traits::{
-    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
-};
+use crate::traits::{CursorPaginated, CursorValue};
 
 /// The kind of a principal: a human user or a non-human service account.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, ToSchema)]
@@ -57,10 +52,7 @@ impl PrincipalKind {
 /// The identity parent shared by both users and service accounts. A principal id
 /// IS the user/service-account id (class-table inheritance), and `(identity_scope_id,
 /// name)` is the race-safe authority for cross-kind identity-name uniqueness.
-#[derive(
-    Serialize, Deserialize, Queryable, Selectable, Insertable, PartialEq, Debug, Clone, ToSchema,
-)]
-#[diesel(table_name = principals)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, ToSchema)]
 pub struct Principal {
     pub id: i32,
     pub kind: String,
@@ -71,7 +63,7 @@ pub struct Principal {
     pub provider_managed: bool,
     #[serde(skip, default = "empty_principal_settings_value")]
     #[schema(ignore)]
-    settings: serde_json::Value,
+    pub(crate) settings: serde_json::Value,
     pub external_subject: Option<String>,
     pub last_sync_attempted_at: Option<chrono::NaiveDateTime>,
     pub last_sync_success_at: Option<chrono::NaiveDateTime>,
@@ -443,44 +435,6 @@ impl CursorPaginated for PrincipalMemberResponse {
     }
 }
 
-impl CursorSqlMapping for PrincipalMemberResponse {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id => CursorSqlField {
-                column: "principals.id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Name | FilterField::Username => CursorSqlField {
-                column: "principals.name",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::CreatedAt => CursorSqlField {
-                column: "group_memberships.created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAt => CursorSqlField {
-                column: "group_memberships.updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::Revision => CursorSqlField {
-                column: "group_memberships.revision",
-                sql_type: CursorSqlType::BigInt,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for memberships",
-                    field
-                )));
-            }
-        })
-    }
-}
-
 impl IdAccessor for Principal {
     fn accessor_id(&self) -> i32 {
         self.id
@@ -498,8 +452,6 @@ impl InstanceAdapter<Principal> for Principal {
 
 /// Insertable row for creating the parent principal. The id is assigned by the
 /// serial sequence; subtype tables (users/service_accounts) reference it.
-#[derive(Insertable)]
-#[diesel(table_name = principals)]
 pub struct NewPrincipal<'a> {
     pub identity_scope_id: i32,
     pub kind: &'a str,
@@ -539,8 +491,10 @@ impl PrincipalID {
     where
         C: StorageContext,
     {
-        crate::storage::postgres::operations::principal::load_principal_settings(backend, self.id())
+        storage_handle(backend)
+            .load_principal_settings(self.id())
             .await
+            .map_err(ApiError::from)
     }
 
     pub async fn replace_settings<C>(
@@ -552,14 +506,10 @@ impl PrincipalID {
     where
         C: StorageContext,
     {
-        crate::storage::postgres::operations::principal::mutate_principal_settings(
-            backend,
-            self.id(),
-            PrincipalSettingsMutation::Replace,
-            settings,
-            event_context,
-        )
-        .await
+        storage_handle(backend)
+            .replace_principal_settings(self.id(), settings, event_context)
+            .await
+            .map_err(ApiError::from)
     }
 
     pub async fn patch_settings<C>(
@@ -571,14 +521,10 @@ impl PrincipalID {
     where
         C: StorageContext,
     {
-        crate::storage::postgres::operations::principal::mutate_principal_settings(
-            backend,
-            self.id(),
-            PrincipalSettingsMutation::Patch,
-            patch,
-            event_context,
-        )
-        .await
+        storage_handle(backend)
+            .merge_principal_settings(self.id(), patch, event_context)
+            .await
+            .map_err(ApiError::from)
     }
 
     pub(crate) async fn apply_settings_patch<C>(
@@ -590,13 +536,10 @@ impl PrincipalID {
     where
         C: StorageContext,
     {
-        crate::storage::postgres::operations::principal::apply_principal_settings_patch(
-            backend,
-            self.id(),
-            patch,
-            event_context,
-        )
-        .await
+        storage_handle(backend)
+            .apply_principal_settings_patch(self.id(), patch, event_context)
+            .await
+            .map_err(ApiError::from)
     }
 
     pub async fn reset_settings<C>(
@@ -607,14 +550,10 @@ impl PrincipalID {
     where
         C: StorageContext,
     {
-        crate::storage::postgres::operations::principal::mutate_principal_settings(
-            backend,
-            self.id(),
-            PrincipalSettingsMutation::Reset,
-            PrincipalSettings::default(),
-            event_context,
-        )
-        .await
+        storage_handle(backend)
+            .reset_principal_settings(self.id(), event_context)
+            .await
+            .map_err(ApiError::from)
     }
 }
 
@@ -623,7 +562,10 @@ pub async fn load_principal_by_id(
     pool: &impl crate::storage::StorageContext,
     principal_id: i32,
 ) -> Result<Principal, ApiError> {
-    crate::storage::postgres::operations::principal::load_principal_by_id(pool, principal_id).await
+    storage_handle(pool)
+        .load_principal(principal_id)
+        .await
+        .map_err(ApiError::from)
 }
 
 impl CursorPaginated for Principal {
@@ -664,43 +606,5 @@ impl CursorPaginated for Principal {
 
     fn tie_breaker_sort() -> Vec<SortParam> {
         Self::default_sort()
-    }
-}
-
-impl CursorSqlMapping for Principal {
-    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
-        Ok(match field {
-            FilterField::Id => CursorSqlField {
-                column: "principals.id",
-                sql_type: CursorSqlType::Integer,
-                nullable: false,
-            },
-            FilterField::Name | FilterField::Username => CursorSqlField {
-                column: "principals.name",
-                sql_type: CursorSqlType::String,
-                nullable: false,
-            },
-            FilterField::CreatedAt => CursorSqlField {
-                column: "principals.created_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::UpdatedAt => CursorSqlField {
-                column: "principals.updated_at",
-                sql_type: CursorSqlType::DateTime,
-                nullable: false,
-            },
-            FilterField::Revision => CursorSqlField {
-                column: "principals.revision",
-                sql_type: CursorSqlType::BigInt,
-                nullable: false,
-            },
-            _ => {
-                return Err(ApiError::BadRequest(format!(
-                    "Field '{}' is not orderable for principals",
-                    field
-                )));
-            }
-        })
     }
 }

--- a/src/storage/context.rs
+++ b/src/storage/context.rs
@@ -13,8 +13,8 @@ use crate::models::search::QueryOptions;
 use crate::models::{
     ClassIdSet, Collection, CollectionKey, HubuumClass, HubuumObject, ImportMode, MaintenanceState,
     NewCollectionWithAssignee, NewGroup, NewHubuumClass, NewHubuumObject, Principal,
-    PrincipalGroup, TokenRetentionSettings, UpdateCollection, UpdateGroup, UpdateHubuumClass,
-    UpdateHubuumObject,
+    PrincipalGroup, PrincipalSettings, PrincipalSettingsPatch, PrincipalSettingsResponse,
+    TokenRetentionSettings, UpdateCollection, UpdateGroup, UpdateHubuumClass, UpdateHubuumObject,
 };
 use crate::models::{Group, Permission};
 use crate::permissions::{AppContext, PermissionBackend};
@@ -46,15 +46,15 @@ use crate::storage::{
     ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectHistoryRecord, ObjectRecordStorage,
     ObjectRelationsTouchingIdsQuery, OperationalExportTemplateAuditEntry,
     OperationalExportTemplateHealth, OperationalStateStorage, OperationalStorageSnapshot,
-    OperationalTaskQueueSnapshot, PostgresStorage, ReadinessSnapshot, RelatedObjectsForRootsQuery,
-    RelationGraphQuery, RelationIdsQuery, RelationListQuery, RelationPage, RelationQueryStorage,
-    RelationTouchingQuery, RemoteTargetHistoryRecord, RemoteTargetStorage, RestoreStorage,
-    StorageAuditEvent, StorageAuditEventListQuery, StorageBackend, StorageBackendDescriptor,
-    StorageBackupOutput, StorageBackupOutputSummary, StorageBackupSnapshot, StorageCallSite,
-    StorageClass, StorageClassComputationState, StorageClassGraphRow, StorageClassRelation,
-    StorageCollection, StorageComputedFieldDefinition, StorageComputedFieldMutation,
-    StorageComputedFieldPage, StorageComputedFieldRebuildRequest, StorageComputedObject,
-    StorageDefaultAdminBootstrap, StorageError, StorageEventDelivery,
+    OperationalTaskQueueSnapshot, PostgresStorage, PrincipalStorage, ReadinessSnapshot,
+    RelatedObjectsForRootsQuery, RelationGraphQuery, RelationIdsQuery, RelationListQuery,
+    RelationPage, RelationQueryStorage, RelationTouchingQuery, RemoteTargetHistoryRecord,
+    RemoteTargetStorage, RestoreStorage, StorageAuditEvent, StorageAuditEventListQuery,
+    StorageBackend, StorageBackendDescriptor, StorageBackupOutput, StorageBackupOutputSummary,
+    StorageBackupSnapshot, StorageCallSite, StorageClass, StorageClassComputationState,
+    StorageClassGraphRow, StorageClassRelation, StorageCollection, StorageComputedFieldDefinition,
+    StorageComputedFieldMutation, StorageComputedFieldPage, StorageComputedFieldRebuildRequest,
+    StorageComputedObject, StorageDefaultAdminBootstrap, StorageError, StorageEventDelivery,
     StorageEventDeliveryListQuery, StorageEventPage, StorageEventSink, StorageEventSinkCreate,
     StorageEventSinkDelete, StorageEventSinkListQuery, StorageEventSinkUpdate,
     StorageEventSubscription, StorageEventSubscriptionCreate, StorageEventSubscriptionDelete,
@@ -2846,6 +2846,115 @@ impl GroupStorage for StorageHandle {
                 BackendImplementation::Postgresql(backend) => {
                     backend
                         .remove_group_member(principal_id, group_id, context)
+                        .await
+                }
+            }
+        })
+        .await
+    }
+}
+
+#[async_trait]
+impl PrincipalStorage for StorageHandle {
+    async fn load_principal(&self, principal_id: i32) -> Result<Principal, StorageError> {
+        observe_storage_call(self.backend_name(), "principals", "load", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.load_principal(principal_id).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn load_principal_settings(
+        &self,
+        principal_id: i32,
+    ) -> Result<PrincipalSettingsResponse, StorageError> {
+        observe_storage_call(self.backend_name(), "principals", "settings_load", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend.load_principal_settings(principal_id).await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn replace_principal_settings(
+        &self,
+        principal_id: i32,
+        settings: PrincipalSettings,
+        context: &EventContext,
+    ) -> Result<PrincipalSettingsResponse, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "principals",
+            "settings_replace",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend
+                            .replace_principal_settings(principal_id, settings, context)
+                            .await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn merge_principal_settings(
+        &self,
+        principal_id: i32,
+        patch: PrincipalSettings,
+        context: &EventContext,
+    ) -> Result<PrincipalSettingsResponse, StorageError> {
+        observe_storage_call(self.backend_name(), "principals", "settings_merge", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend
+                        .merge_principal_settings(principal_id, patch, context)
+                        .await
+                }
+            }
+        })
+        .await
+    }
+
+    async fn apply_principal_settings_patch(
+        &self,
+        principal_id: i32,
+        patch: PrincipalSettingsPatch,
+        context: &EventContext,
+    ) -> Result<PrincipalSettingsResponse, StorageError> {
+        observe_storage_call(
+            self.backend_name(),
+            "principals",
+            "settings_json_patch",
+            async {
+                match &self.implementation {
+                    BackendImplementation::Postgresql(backend) => {
+                        backend
+                            .apply_principal_settings_patch(principal_id, patch, context)
+                            .await
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn reset_principal_settings(
+        &self,
+        principal_id: i32,
+        context: &EventContext,
+    ) -> Result<PrincipalSettingsResponse, StorageError> {
+        observe_storage_call(self.backend_name(), "principals", "settings_reset", async {
+            match &self.implementation {
+                BackendImplementation::Postgresql(backend) => {
+                    backend
+                        .reset_principal_settings(principal_id, context)
                         .await
                 }
             }

--- a/src/storage/contract.rs
+++ b/src/storage/contract.rs
@@ -9,8 +9,8 @@ use super::{
     EventSubscriptionStorage, ExportQueryStorage, ExportTemplateStorage, GroupStorage,
     HistoryStorage, IdentityStorage, ImportStorage, InventoryStorage, MetricsStorage,
     ObjectAggregateStorage, ObjectRecordStorage, ObjectRelationStore, ObjectStore,
-    OperationalStateStorage, PostgresStorage, RelationQueryStorage, RemoteTargetStorage,
-    RestoreStorage, StorageExecution, TaskExecutionStorage, TaskQueueStorage,
+    OperationalStateStorage, PostgresStorage, PrincipalStorage, RelationQueryStorage,
+    RemoteTargetStorage, RestoreStorage, StorageExecution, TaskExecutionStorage, TaskQueueStorage,
     TokenRetentionStorage, UnifiedSearchStorage, observed::ObservedLifecycleStorage,
 };
 
@@ -79,6 +79,7 @@ pub(crate) trait StorageBackend:
     + TokenRetentionStorage
     + UnifiedSearchStorage
     + GroupStorage
+    + PrincipalStorage
     + CollectionPermissionStorage
     + CollectionRecordStorage
     + ClassRecordStorage

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -18,6 +18,7 @@ mod observed;
 mod operational;
 #[doc(hidden)]
 pub mod postgres;
+mod principals;
 
 pub(crate) use class_relations::ClassRelationStore;
 pub(crate) use classes::{ClassRecordStorage, ClassStore};
@@ -154,3 +155,4 @@ pub(crate) use operational::{
     TokenRetentionStorage,
 };
 pub(crate) use postgres::PostgresStorage;
+pub(crate) use principals::PrincipalStorage;

--- a/src/storage/postgres/mod.rs
+++ b/src/storage/postgres/mod.rs
@@ -33,7 +33,8 @@ use crate::models::{
     NewGroup, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation,
     ObjectDataPatchDocument, ObjectRelationCreateSelector, ObjectRelationSelector, ObjectSelector,
     Permission, PreparedClassRelation, PreparedObjectRelation, Principal, PrincipalGroup,
-    PrincipalID, ResolvedClassRelationTarget, ResolvedClassTarget, ResolvedObjectRelationTarget,
+    PrincipalID, PrincipalSettings, PrincipalSettingsPatch, PrincipalSettingsResponse,
+    ResolvedClassRelationTarget, ResolvedClassTarget, ResolvedObjectRelationTarget,
     ResolvedObjectTarget, TokenRetentionSettings, UpdateCollection, UpdateGroup, UpdateHubuumClass,
     UpdateHubuumObject,
 };
@@ -96,7 +97,7 @@ use super::{
     ObjectHistoryAsOfQuery, ObjectHistoryListQuery, ObjectHistoryRecord, ObjectRecordStorage,
     ObjectRelationStore, ObjectRelationsTouchingIdsQuery, ObjectStore,
     OperationalExportTemplateAuditEntry, OperationalExportTemplateHealth, OperationalStateStorage,
-    OperationalStorageSnapshot, OperationalTaskQueueSnapshot, ReadinessSnapshot,
+    OperationalStorageSnapshot, OperationalTaskQueueSnapshot, PrincipalStorage, ReadinessSnapshot,
     RelatedObjectsForRootsQuery, RelationGraphQuery, RelationIdsQuery, RelationListQuery,
     RelationPage, RelationQueryStorage, RelationTouchingQuery, RemoteTargetHistoryRecord,
     StorageAuditEvent, StorageAuditEventListQuery, StorageCallSite, StorageClass,
@@ -1412,6 +1413,96 @@ impl GroupStorage for PostgresStorage {
             .remove_group_member_from_backend(principal_id, &self.pool, context)
             .await
             .map_err(map_postgres_error)
+    }
+}
+
+#[async_trait]
+impl PrincipalStorage for PostgresStorage {
+    async fn load_principal(&self, principal_id: i32) -> Result<Principal, StorageError> {
+        PrincipalID::new(principal_id).map_err(map_postgres_error)?;
+        operations::principal::load_principal_by_id(&self.pool, principal_id)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn load_principal_settings(
+        &self,
+        principal_id: i32,
+    ) -> Result<PrincipalSettingsResponse, StorageError> {
+        PrincipalID::new(principal_id).map_err(map_postgres_error)?;
+        operations::principal::load_principal_settings(&self.pool, principal_id)
+            .await
+            .map_err(map_postgres_error)
+    }
+
+    async fn replace_principal_settings(
+        &self,
+        principal_id: i32,
+        settings: PrincipalSettings,
+        context: &EventContext,
+    ) -> Result<PrincipalSettingsResponse, StorageError> {
+        PrincipalID::new(principal_id).map_err(map_postgres_error)?;
+        operations::principal::mutate_principal_settings(
+            &self.pool,
+            principal_id,
+            operations::principal::PrincipalSettingsMutation::Replace,
+            settings,
+            context,
+        )
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn merge_principal_settings(
+        &self,
+        principal_id: i32,
+        patch: PrincipalSettings,
+        context: &EventContext,
+    ) -> Result<PrincipalSettingsResponse, StorageError> {
+        PrincipalID::new(principal_id).map_err(map_postgres_error)?;
+        operations::principal::mutate_principal_settings(
+            &self.pool,
+            principal_id,
+            operations::principal::PrincipalSettingsMutation::Patch,
+            patch,
+            context,
+        )
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn apply_principal_settings_patch(
+        &self,
+        principal_id: i32,
+        patch: PrincipalSettingsPatch,
+        context: &EventContext,
+    ) -> Result<PrincipalSettingsResponse, StorageError> {
+        PrincipalID::new(principal_id).map_err(map_postgres_error)?;
+        operations::principal::apply_principal_settings_patch(
+            &self.pool,
+            principal_id,
+            patch,
+            context,
+        )
+        .await
+        .map_err(map_postgres_error)
+    }
+
+    async fn reset_principal_settings(
+        &self,
+        principal_id: i32,
+        context: &EventContext,
+    ) -> Result<PrincipalSettingsResponse, StorageError> {
+        PrincipalID::new(principal_id).map_err(map_postgres_error)?;
+        operations::principal::mutate_principal_settings(
+            &self.pool,
+            principal_id,
+            operations::principal::PrincipalSettingsMutation::Reset,
+            PrincipalSettings::default(),
+            context,
+        )
+        .await
+        .map_err(map_postgres_error)
     }
 }
 

--- a/src/storage/postgres/operations/external_identity.rs
+++ b/src/storage/postgres/operations/external_identity.rs
@@ -10,6 +10,7 @@ use crate::models::{
 use crate::storage::postgres::operations::event_record::emit_event;
 use crate::storage::postgres::operations::group::GroupRow;
 use crate::storage::postgres::operations::identity::ensure_identity_scope;
+use crate::storage::postgres::operations::principal::PrincipalRow;
 use crate::storage::postgres::prelude::*;
 use crate::storage::postgres::{with_connection, with_transaction};
 
@@ -122,7 +123,7 @@ pub async fn sync_external_user(
             .filter(principals::identity_scope_id.eq(scope.id))
             .filter(principals::external_subject.eq(&profile.subject))
             .select(principals::all_columns)
-            .first::<Principal>(conn)
+            .first::<PrincipalRow>(conn)
             .await
             .optional()?;
 
@@ -137,7 +138,7 @@ pub async fn sync_external_user(
                         principals::last_sync_attempted_at.eq(sync_time),
                         principals::last_sync_success_at.eq(sync_time),
                     ))
-                    .get_result::<Principal>(conn)
+                    .get_result::<PrincipalRow>(conn)
                     .await?
             }
         } else {
@@ -152,7 +153,7 @@ pub async fn sync_external_user(
                     principals::last_sync_success_at.eq(sync_time),
                 ))
                 .on_conflict_do_nothing()
-                .get_result::<Principal>(conn)
+                .get_result::<PrincipalRow>(conn)
                 .await
                 .optional()?;
 
@@ -162,7 +163,7 @@ pub async fn sync_external_user(
                     let principal = principals::table
                         .filter(principals::identity_scope_id.eq(scope.id))
                         .filter(principals::name.eq(&profile.name))
-                        .first::<Principal>(conn)
+                        .first::<PrincipalRow>(conn)
                         .await?;
                     if principal.provider_managed && principal.kind == PrincipalKind::Human.as_str()
                     {
@@ -176,6 +177,7 @@ pub async fn sync_external_user(
                 }
             }
         };
+        let principal: Principal = principal.into();
 
         if principal.kind != PrincipalKind::Human.as_str() {
             return Err(ApiError::Conflict(

--- a/src/storage/postgres/operations/group.rs
+++ b/src/storage/postgres/operations/group.rs
@@ -12,6 +12,7 @@ use crate::storage::postgres::operations::event_record::emit_event;
 use crate::storage::postgres::operations::identity::{
     identity_scope_by_name, identity_scope_id_by_name_conn,
 };
+use crate::storage::postgres::operations::principal::{PrincipalMemberQueryRow, PrincipalRow};
 use crate::storage::postgres::{PostgresConnection, with_connection, with_transaction};
 use crate::traits::{
     CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
@@ -805,10 +806,11 @@ impl GroupMembersBackend for Group {
                 .filter(group_id.eq(self.id))
                 .inner_join(principals)
                 .select(crate::schema::principals::all_columns)
-                .load::<Principal>(conn)
+                .load::<PrincipalRow>(conn)
                 .await
         })
         .await
+        .map(|rows| rows.into_iter().map(Into::into).collect())
     }
 
     async fn load_group_members_paginated(
@@ -856,21 +858,17 @@ impl GroupMembersBackend for Group {
             }
         }
 
-        crate::apply_query_options!(
-            base_query,
-            query_options,
-            crate::models::PrincipalMemberResponse
-        );
+        crate::apply_query_options!(base_query, query_options, PrincipalMemberQueryRow);
 
         with_connection(pool, async |conn| {
             base_query
-                .load::<(PrincipalGroupRow, Principal)>(conn)
+                .load::<(PrincipalGroupRow, PrincipalRow)>(conn)
                 .await
         })
         .await
         .map(|rows| {
             rows.into_iter()
-                .map(|(membership, principal)| (membership.into(), principal))
+                .map(|(membership, principal)| (membership.into(), principal.into()))
                 .collect()
         })
     }
@@ -1048,8 +1046,9 @@ pub(crate) async fn group_member_principal(
     with_connection(pool, async |conn| {
         principals
             .filter(id.eq(principal_id))
-            .first::<Principal>(conn)
+            .first::<PrincipalRow>(conn)
             .await
+            .map(Into::into)
     })
     .await
 }

--- a/src/storage/postgres/operations/principal.rs
+++ b/src/storage/postgres/operations/principal.rs
@@ -4,16 +4,182 @@ use serde_json::{Value, json};
 use crate::api::etag::RevisionOwner;
 use crate::errors::ApiError;
 use crate::events::{Action, EntityType, NewEvent};
+use crate::models::search::{FilterField, SortParam};
 use crate::models::{
-    NewPrincipal, Principal, PrincipalKind, PrincipalSettings, PrincipalSettingsPatch,
-    PrincipalSettingsResponse, ResourceRevision, ServiceAccount, ServiceAccountPointResponse, User,
-    UserPointResponse, UserResponse, UserWithName,
+    NewPrincipal, Principal, PrincipalKind, PrincipalMemberResponse, PrincipalSettings,
+    PrincipalSettingsPatch, PrincipalSettingsResponse, ResourceRevision, ServiceAccount,
+    ServiceAccountPointResponse, User, UserPointResponse, UserResponse, UserWithName,
 };
 use crate::storage::postgres::operations::event_record::emit_event;
 use crate::storage::postgres::prelude::*;
 use crate::storage::postgres::{
     PostgresConnection, assert_locked_revision_precondition, with_connection, with_transaction,
 };
+use crate::traits::{
+    CursorPaginated, CursorSqlField, CursorSqlMapping, CursorSqlType, CursorValue,
+};
+
+#[derive(Debug, Queryable, Selectable, Clone)]
+#[diesel(table_name = crate::schema::principals)]
+pub(crate) struct PrincipalRow {
+    pub(crate) id: i32,
+    pub(crate) kind: String,
+    pub(crate) name: String,
+    pub(crate) created_at: chrono::NaiveDateTime,
+    pub(crate) updated_at: chrono::NaiveDateTime,
+    pub(crate) identity_scope_id: i32,
+    pub(crate) provider_managed: bool,
+    pub(crate) settings: serde_json::Value,
+    pub(crate) external_subject: Option<String>,
+    pub(crate) last_sync_attempted_at: Option<chrono::NaiveDateTime>,
+    pub(crate) last_sync_success_at: Option<chrono::NaiveDateTime>,
+    pub(crate) revision: ResourceRevision,
+}
+
+impl From<PrincipalRow> for Principal {
+    fn from(row: PrincipalRow) -> Self {
+        Self {
+            id: row.id,
+            kind: row.kind,
+            name: row.name,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            identity_scope_id: row.identity_scope_id,
+            provider_managed: row.provider_managed,
+            settings: row.settings,
+            external_subject: row.external_subject,
+            last_sync_attempted_at: row.last_sync_attempted_at,
+            last_sync_success_at: row.last_sync_success_at,
+            revision: row.revision,
+        }
+    }
+}
+
+impl CursorPaginated for PrincipalRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        Principal::supports_sort(field)
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorValue::Integer(self.id as i64),
+            FilterField::Name | FilterField::Username => CursorValue::String(self.name.clone()),
+            FilterField::CreatedAt => CursorValue::DateTime(self.created_at),
+            FilterField::UpdatedAt => CursorValue::DateTime(self.updated_at),
+            FilterField::Revision => CursorValue::Integer(self.revision.get()),
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for principals",
+                    field
+                )));
+            }
+        })
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        Principal::default_sort()
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        Principal::tie_breaker_sort()
+    }
+}
+
+impl CursorSqlMapping for PrincipalRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorSqlField {
+                column: "principals.id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Name | FilterField::Username => CursorSqlField {
+                column: "principals.name",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::CreatedAt => CursorSqlField {
+                column: "principals.created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAt => CursorSqlField {
+                column: "principals.updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::Revision => CursorSqlField {
+                column: "principals.revision",
+                sql_type: CursorSqlType::BigInt,
+                nullable: false,
+            },
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for principals",
+                    field
+                )));
+            }
+        })
+    }
+}
+
+pub(crate) struct PrincipalMemberQueryRow(PrincipalMemberResponse);
+
+impl CursorPaginated for PrincipalMemberQueryRow {
+    fn supports_sort(field: &FilterField) -> bool {
+        PrincipalMemberResponse::supports_sort(field)
+    }
+
+    fn cursor_value(&self, field: &FilterField) -> Result<CursorValue, ApiError> {
+        self.0.cursor_value(field)
+    }
+
+    fn default_sort() -> Vec<SortParam> {
+        PrincipalMemberResponse::default_sort()
+    }
+
+    fn tie_breaker_sort() -> Vec<SortParam> {
+        PrincipalMemberResponse::tie_breaker_sort()
+    }
+}
+
+impl CursorSqlMapping for PrincipalMemberQueryRow {
+    fn sql_field(field: &FilterField) -> Result<CursorSqlField, ApiError> {
+        Ok(match field {
+            FilterField::Id => CursorSqlField {
+                column: "principals.id",
+                sql_type: CursorSqlType::Integer,
+                nullable: false,
+            },
+            FilterField::Name | FilterField::Username => CursorSqlField {
+                column: "principals.name",
+                sql_type: CursorSqlType::String,
+                nullable: false,
+            },
+            FilterField::CreatedAt => CursorSqlField {
+                column: "group_memberships.created_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::UpdatedAt => CursorSqlField {
+                column: "group_memberships.updated_at",
+                sql_type: CursorSqlType::DateTime,
+                nullable: false,
+            },
+            FilterField::Revision => CursorSqlField {
+                column: "group_memberships.revision",
+                sql_type: CursorSqlType::BigInt,
+                nullable: false,
+            },
+            _ => {
+                return Err(ApiError::BadRequest(format!(
+                    "Field '{}' is not orderable for memberships",
+                    field
+                )));
+            }
+        })
+    }
+}
 
 pub trait InsertPrincipalRecord {
     /// Insert the principal row and return it (principal-first id allocation).
@@ -30,8 +196,9 @@ impl InsertPrincipalRecord for NewPrincipal<'_> {
                 principals::kind.eq(self.kind),
                 principals::name.eq(self.name),
             ))
-            .get_result::<Principal>(conn)
+            .get_result::<PrincipalRow>(conn)
             .await
+            .map(Into::into)
             .map_err(ApiError::from)
     }
 }
@@ -44,8 +211,9 @@ pub async fn load_principal_by_id(
     with_connection(pool, async |conn| {
         principals_table
             .filter(id.eq(principal_id_value))
-            .first::<Principal>(conn)
+            .first::<PrincipalRow>(conn)
             .await
+            .map(Into::into)
     })
     .await
 }

--- a/src/storage/postgres/operations/task_import.rs
+++ b/src/storage/postgres/operations/task_import.rs
@@ -28,6 +28,7 @@ use crate::storage::postgres::operations::object::{
 use crate::storage::postgres::operations::permissions::{
     NewPermission, PermissionRow, UpdatePermission,
 };
+use crate::storage::postgres::operations::principal::PrincipalRow;
 use crate::storage::postgres::operations::relation_rows::{
     HubuumClassRelationRow, HubuumObjectRelationRow, NewHubuumClassRelationRow,
     NewHubuumObjectRelationRow,
@@ -1009,7 +1010,7 @@ pub async fn upsert_principal_db(
         .filter(p::identity_scope_id.eq(identity_scope_id_value))
         .filter(p::name.eq(&input.name))
         .for_update()
-        .first::<Principal>(conn)
+        .first::<PrincipalRow>(conn)
         .await
         .optional()?;
     if let Some(existing) = &existing {
@@ -1046,13 +1047,13 @@ pub async fn upsert_principal_db(
                             p::created_at.eq(created),
                             p::updated_at.eq(updated),
                         ))
-                        .get_result::<Principal>(conn)
+                        .get_result::<PrincipalRow>(conn)
                         .await
                         .optional(),
                     async || {
                         p::principals
                             .filter(p::id.eq(existing.id))
-                            .first(conn)
+                            .first::<PrincipalRow>(conn)
                             .await
                     },
                 )
@@ -1077,10 +1078,11 @@ pub async fn upsert_principal_db(
                     p::created_at.eq(created),
                     p::updated_at.eq(updated),
                 ))
-                .get_result::<Principal>(conn)
+                .get_result::<PrincipalRow>(conn)
                 .await?
         }
     };
+    let principal: Principal = principal.into();
 
     match &input.subtype {
         ImportPrincipalSubtype::Human {

--- a/src/storage/principals.rs
+++ b/src/storage/principals.rs
@@ -1,0 +1,49 @@
+use async_trait::async_trait;
+
+use crate::events::EventContext;
+use crate::models::{
+    Principal, PrincipalSettings, PrincipalSettingsPatch, PrincipalSettingsResponse,
+};
+
+use super::StorageError;
+
+/// Complete principal point and settings behavior required from every backend.
+///
+/// The application owns principal and settings DTOs. Backends own persistence,
+/// concurrency control, audit-event atomicity, and implementation errors.
+#[async_trait]
+pub(crate) trait PrincipalStorage: Send + Sync {
+    async fn load_principal(&self, principal_id: i32) -> Result<Principal, StorageError>;
+
+    async fn load_principal_settings(
+        &self,
+        principal_id: i32,
+    ) -> Result<PrincipalSettingsResponse, StorageError>;
+
+    async fn replace_principal_settings(
+        &self,
+        principal_id: i32,
+        settings: PrincipalSettings,
+        context: &EventContext,
+    ) -> Result<PrincipalSettingsResponse, StorageError>;
+
+    async fn merge_principal_settings(
+        &self,
+        principal_id: i32,
+        patch: PrincipalSettings,
+        context: &EventContext,
+    ) -> Result<PrincipalSettingsResponse, StorageError>;
+
+    async fn apply_principal_settings_patch(
+        &self,
+        principal_id: i32,
+        patch: PrincipalSettingsPatch,
+        context: &EventContext,
+    ) -> Result<PrincipalSettingsResponse, StorageError>;
+
+    async fn reset_principal_settings(
+        &self,
+        principal_id: i32,
+        context: &EventContext,
+    ) -> Result<PrincipalSettingsResponse, StorageError>;
+}

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -263,6 +263,49 @@ fn group_domain_types_are_free_of_persistence_implementation_details() {
 }
 
 #[test]
+fn principal_domain_types_are_free_of_persistence_implementation_details() {
+    let root = repository_root();
+    let path = root.join("src/models/principal.rs");
+    let source = fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+    let production_source = source.split("#[cfg(test)]").next().unwrap_or(&source);
+    let violations = [
+        "diesel::",
+        "diesel(",
+        "crate::schema",
+        "storage::postgres",
+        "CursorSqlMapping",
+        "CursorSqlField",
+        "CursorSqlType",
+    ]
+    .into_iter()
+    .filter(|forbidden| production_source.contains(forbidden))
+    .collect::<Vec<_>>();
+
+    let adapter_path = root.join("src/storage/postgres/operations/principal.rs");
+    let adapter_source = fs::read_to_string(&adapter_path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", adapter_path.display()));
+    for required in [
+        "struct PrincipalRow",
+        "struct PrincipalMemberQueryRow",
+        "impl From<PrincipalRow> for Principal",
+        "impl CursorSqlMapping for PrincipalRow",
+        "impl CursorSqlMapping for PrincipalMemberQueryRow",
+    ] {
+        assert!(
+            adapter_source.contains(required),
+            "PostgreSQL principal adapter is missing {required}"
+        );
+    }
+
+    assert!(
+        violations.is_empty(),
+        "principal domain types crossed into persistence details: {}",
+        violations.join(", ")
+    );
+}
+
+#[test]
 fn permission_domain_types_are_free_of_persistence_implementation_details() {
     let root = repository_root();
     let mut violations = Vec::new();
@@ -594,6 +637,7 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         "CollectionRecordStorage",
         "ClassRecordStorage",
         "GroupStorage",
+        "PrincipalStorage",
         "ObjectRecordStorage",
         "RemoteTargetStorage",
         "TaskQueueStorage",
@@ -652,6 +696,19 @@ fn selectable_storage_backends_are_complete_and_test_models_are_not_selectable()
         assert!(
             compact_context.contains(&format!("\"groups\",\"{operation}\"")),
             "group operation {operation} must use the common storage observer"
+        );
+    }
+    for operation in [
+        "load",
+        "settings_load",
+        "settings_replace",
+        "settings_merge",
+        "settings_json_patch",
+        "settings_reset",
+    ] {
+        assert!(
+            compact_context.contains(&format!("\"principals\",\"{operation}\"")),
+            "principal operation {operation} must use the common storage observer"
         );
     }
     for operation in ["list", "enrich"] {

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -24,7 +24,8 @@ use crate::models::{
     HubuumClassHistory, HubuumObjectHistory, ImportAtomicity, ImportClassInput,
     ImportCollectionInput, ImportMode, NewCollectionWithAssignee, NewComputedFieldDefinition,
     NewGroup, NewHubuumClass, NewHubuumClassRelation, NewHubuumObject, NewHubuumObjectRelation,
-    Permissions, RemoteTargetHistory, UpdateCollection, UpdateGroup,
+    Permissions, PrincipalSettings, PrincipalSettingsPatch, PrincipalSettingsPatchDocument,
+    RemoteTargetHistory, UpdateCollection, UpdateGroup,
 };
 use crate::pagination::prepare_db_pagination;
 use crate::services::Services;
@@ -50,10 +51,10 @@ use crate::storage::{
     MetricsStorage, ObjectAggregateAuthorizationMode, ObjectAggregateAuthorizer,
     ObjectAggregateStorage, ObjectAggregateStorageQuery, ObjectHistoryAsOfQuery,
     ObjectHistoryListQuery, ObjectRelationsTouchingIdsQuery, OperationalStateStorage,
-    RelatedObjectsForRootsQuery, RelationGraphQuery, RelationIdsQuery, RelationListQuery,
-    RelationQueryStorage, RelationTouchingQuery, RemoteTargetStorage, RestoreStorage,
-    RetainedEvent, STORAGE_CONTRACT_VERSION, StorageAuditEventFilters, StorageAuditEventListQuery,
-    StorageBackendKind, StorageBackupTaskArtifact, StorageCallSite,
+    PrincipalStorage, RelatedObjectsForRootsQuery, RelationGraphQuery, RelationIdsQuery,
+    RelationListQuery, RelationQueryStorage, RelationTouchingQuery, RemoteTargetStorage,
+    RestoreStorage, RetainedEvent, STORAGE_CONTRACT_VERSION, StorageAuditEventFilters,
+    StorageAuditEventListQuery, StorageBackendKind, StorageBackupTaskArtifact, StorageCallSite,
     StorageComputedFieldDefinitionInput, StorageComputedFieldDefinitionPatch,
     StorageComputedFieldRebuildRequest, StorageComputedFieldVisibility,
     StorageDefaultAdminBootstrap, StorageError, StorageEventDeliveryListQuery,
@@ -286,6 +287,87 @@ async fn every_available_storage_backend_supplies_complete_group_behavior() {
                         .expect("certified backend should delete groups"),
                     1
                 );
+            }
+        }
+    }
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_supplies_complete_principal_behavior() {
+    let _permit = postgres_permit().await;
+    let pool = pool();
+    let user = crate::tests::create_user_with_params(
+        pool.get_ref(),
+        &prefix("principal_contract_user"),
+        "testpassword",
+    )
+    .await;
+    let event_context = EventContext::user(user.id, None, None);
+
+    for kind in StorageBackendKind::ALL {
+        match kind {
+            StorageBackendKind::Postgresql => {
+                let backend = StorageHandle::postgres(pool.get_ref().clone());
+                let loaded = backend
+                    .load_principal(user.id)
+                    .await
+                    .expect("certified backend should load principals");
+                assert_eq!(loaded.id, user.id);
+
+                let initial = backend
+                    .load_principal_settings(user.id)
+                    .await
+                    .expect("certified backend should load principal settings");
+                assert_eq!(initial.as_value(), &serde_json::json!({}));
+
+                let replaced = backend
+                    .replace_principal_settings(
+                        user.id,
+                        PrincipalSettings::new(serde_json::json!({
+                            "theme": "light",
+                            "notifications": {"email": true}
+                        }))
+                        .expect("valid principal settings"),
+                        &event_context,
+                    )
+                    .await
+                    .expect("certified backend should replace principal settings");
+                assert_eq!(replaced.as_value()["theme"], "light");
+
+                let merged = backend
+                    .merge_principal_settings(
+                        user.id,
+                        PrincipalSettings::new(serde_json::json!({
+                            "notifications": {"push": true}
+                        }))
+                        .expect("valid principal settings patch"),
+                        &event_context,
+                    )
+                    .await
+                    .expect("certified backend should merge principal settings");
+                assert_eq!(merged.as_value()["notifications"]["email"], true);
+                assert_eq!(merged.as_value()["notifications"]["push"], true);
+
+                let patch_document =
+                    serde_json::from_value::<PrincipalSettingsPatchDocument>(serde_json::json!([
+                        {"op": "replace", "path": "/theme", "value": "dark"}
+                    ]))
+                    .expect("valid bounded principal settings JSON Patch");
+                let patched = backend
+                    .apply_principal_settings_patch(
+                        user.id,
+                        PrincipalSettingsPatch::JsonPatch(patch_document),
+                        &event_context,
+                    )
+                    .await
+                    .expect("certified backend should apply principal settings JSON Patch");
+                assert_eq!(patched.as_value()["theme"], "dark");
+
+                let reset = backend
+                    .reset_principal_settings(user.id, &event_context)
+                    .await
+                    .expect("certified backend should reset principal settings");
+                assert_eq!(reset.as_value(), &serde_json::json!({}));
             }
         }
     }

--- a/tests/api_identity_suite/groups.rs
+++ b/tests/api_identity_suite/groups.rs
@@ -10,7 +10,7 @@ mod tests {
     use crate::models::user::{NewUser, User};
     use crate::models::{
         IdentityScope, LDAP_PROVIDER_KIND, MembershipPrincipalResponse, NewIdentityScope,
-        Principal, PrincipalID, PrincipalKind, PrincipalMemberResponse,
+        PrincipalID, PrincipalKind, PrincipalMemberResponse,
     };
     use crate::pagination::NEXT_CURSOR_HEADER;
     use crate::storage::postgres::operations::identity::ensure_identity_scope;
@@ -296,7 +296,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let external = with_connection(&context.pool, async |conn| {
+        let external_id = with_connection(&context.pool, async |conn| {
             use crate::schema::principals;
 
             diesel::insert_into(principals::table)
@@ -307,11 +307,17 @@ mod tests {
                     principals::provider_managed.eq(true),
                     principals::external_subject.eq(context.scoped_name("batch_subject")),
                 ))
-                .get_result::<Principal>(conn)
+                .returning(principals::id)
+                .get_result::<i32>(conn)
                 .await
         })
         .await
         .unwrap();
+        let external = PrincipalID::new(external_id)
+            .unwrap()
+            .principal(&context.pool)
+            .await
+            .unwrap();
 
         let responses =
             futures::future::try_join_all(vec![local, external].into_iter().map(|principal| {

--- a/tests/api_platform_suite/metrics.rs
+++ b/tests/api_platform_suite/metrics.rs
@@ -133,7 +133,7 @@ async fn storage_metrics_export_backend_identity_and_bounded_operation_labels() 
 
     assert!(
         body.contains(
-            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"26\"} 1"
+            "hubuum_storage_backend_info{backend=\"postgresql\",contract_version=\"27\"} 1"
         )
     );
     assert!(body.contains(

--- a/tests/api_platform_suite/runtime_config.rs
+++ b/tests/api_platform_suite/runtime_config.rs
@@ -37,7 +37,7 @@ mod tests {
         let serialized = serde_json::to_string(&body).unwrap();
 
         assert_eq!(body["database"]["backend"], "postgresql");
-        assert_eq!(body["database"]["contract_version"], 26);
+        assert_eq!(body["database"]["contract_version"], 27);
         assert_eq!(
             body["database"]["capabilities"],
             serde_json::json!([


### PR DESCRIPTION
## Summary

- require every selectable storage backend to implement principal point reads and the complete principal-settings lifecycle
- route principal settings replacement, merge patch, bounded JSON Patch, and reset through the observed storage boundary
- move principal and principal-membership Diesel rows and SQL cursor mappings into the PostgreSQL adapter
- keep the principal domain model free of Diesel, PostgreSQL, schema, and SQL cursor implementation details
- advance the administrator-visible storage contract to version 27

## Rationale

Principal settings are concurrency-sensitive, audited persistence behavior. Leaving those operations as direct PostgreSQL calls allowed application consumers to bypass backend completeness, common error translation, tracing, and metrics. The mandatory `PrincipalStorage` contract makes point reads and every settings mutation part of backend certification while preserving the existing HTTP behavior.

## Behavior

- all principal storage entry points use bounded `principals/*` observability labels
- PostgreSQL retains row locking, no-op behavior, revision handling, and atomic audit events inside its adapter
- shared compatibility tests invoke every principal operation for every selectable backend
- administrator configuration and metrics report storage contract version 27
- public HTTP request and response shapes are unchanged

## Breaking change

The administrator-visible storage contract version changes from 26 to 27. Administration and monitoring clients matching version 26 must accept version 27.

## Verification

- `cargo fmt --all`
- `cargo check --all-targets --features integration-test-support`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --features integration-test-support -- -D warnings`
- `source .env && ./run_tests.sh`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `scripts/test-classify-ci-changes.sh`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`

The cumulative production Docker build could not start because the configured Docker Desktop daemon socket was unavailable on the host. This layer does not change a workspace manifest, `Cargo.lock`, Dockerfile, entrypoint, or Docker build feature.
