### PR TITLE
Migrate benchmarks to Rust PR Bench v1

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -108,9 +108,10 @@ jobs:
     name: Self-contained benchmarks
     needs: changes
     if: needs.changes.outputs.run_self_contained == 'true'
-    uses: terjekv/github-action-iai-callgrind/.github/workflows/rust-pr-bench.yml@a0993c0f7cbfcb4e34c9e13dbea62176608c833c # v3
+    uses: terjekv/rust-pr-bench/.github/workflows/rust-pr-bench.yml@0343a98c94e04d326c5fbfea753fad9934eee7be # v1.0.0
     secrets: inherit
     with:
+      action_ref: 0343a98c94e04d326c5fbfea753fad9934eee7be
       backend: all
       auto_discover: true
       auto_detect_moved_benchmarks: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -153,7 +153,8 @@ must pass before `main-latest` artifacts or container images are published.
 
 ## Benchmarks
 
-Benchmarking runs in a separate GitHub workflow, `.github/workflows/benchmarks.yml`, via `terjekv/github-action-iai-callgrind`.
+Benchmarking runs in a separate GitHub workflow, `.github/workflows/benchmarks.yml`, via
+`terjekv/rust-pr-bench`.
 
 ### Local execution
 


### PR DESCRIPTION
## Summary

- Switch the self-contained benchmark job from the legacy `github-action-iai-callgrind` repository to `rust-pr-bench`.
- Pin the reusable workflow to the immutable commit behind `v1.0.0`.
- Update the development documentation to use the new canonical action name.
- Preserve Gungraun, Criterion, autodiscovery, moved-benchmark detection, feature sets, and regression thresholds.

## Rationale

Hubuum already completed its benchmark dependency and input migration to Gungraun. This PR moves the remaining workflow and documentation references to the successor repository.

Existing `*_callgrind` benchmark target names remain unchanged to preserve benchmark identity and history.

## Impact

This changes benchmark CI tooling and its documentation only. Production behavior and public APIs are unchanged.

## Changelog

No changelog entry is warranted because this is an internal CI workflow migration with no user-facing Hubuum impact.

## Verification

- `actionlint .github/workflows/benchmarks.yml`
- `npx markdownlint-cli2 --config .markdownlint.json docs/development.md`
- `git diff --check`
- Signed commit verified with `git verify-commit HEAD`