### PR TITLE
Use target-specific benchmark features

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -101,10 +101,10 @@ jobs:
     name: Benchmarks
     needs: changes
     if: needs.changes.outputs.run_benchmarks == 'true'
-    uses: terjekv/rust-pr-bench/.github/workflows/rust-pr-bench.yml@0343a98c94e04d326c5fbfea753fad9934eee7be # v1.0.0
+    uses: terjekv/rust-pr-bench/.github/workflows/rust-pr-bench.yml@57fc9bca852782f3ee421684762f23fd77afba5c # v1.1.0
     secrets: inherit
     with:
-      action_ref: 0343a98c94e04d326c5fbfea753fad9934eee7be
+      action_ref: 57fc9bca852782f3ee421684762f23fd77afba5c
       backend: all
       auto_discover: true
       auto_detect_moved_benchmarks: true
@@ -113,10 +113,6 @@ jobs:
       regression_threshold_pct_gungraun: 3
       regression_threshold_pct_criterion: 50
       fail_on_regression: true
-      feature_sets_json: >-
-        [
-          {"name":"default","features":"postgres-bench"}
-        ]
 
   runtime-behavior:
     name: Runtime behavior validation

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -279,10 +279,10 @@ fn benchmark_action_autodiscovers_every_cargo_benchmark() {
             .any(|line| line.contains("benchmarks_json:"))
     );
     assert!(
-        benchmark_job
+        !benchmark_job
             .iter()
             .any(|line| line.contains("\"features\":\"postgres-bench\"")),
-        "benchmark action should enable the feature-gated PostgreSQL benchmark"
+        "root-only benchmark features must not be applied to workspace members"
     );
 
     let manifest = read_repository_text("Cargo.toml");
@@ -293,6 +293,24 @@ fn benchmark_action_autodiscovers_every_cargo_benchmark() {
         .and_then(toml::Value::as_array)
         .expect("root Cargo manifest should declare benchmarks");
     assert!(!benchmarks.is_empty());
+
+    let postgres_benchmark = benchmarks
+        .iter()
+        .find(|benchmark| {
+            benchmark.get("name").and_then(toml::Value::as_str)
+                == Some("storage_postgres_criterion")
+        })
+        .expect("root Cargo manifest should declare the PostgreSQL benchmark");
+    let required_features = postgres_benchmark
+        .get("required-features")
+        .and_then(toml::Value::as_array)
+        .expect("PostgreSQL benchmark should declare required features");
+    assert!(
+        required_features
+            .iter()
+            .any(|feature| feature.as_str() == Some("postgres-bench")),
+        "PostgreSQL benchmark should own its feature requirement"
+    );
 
     for benchmark in benchmarks {
         let name = benchmark


### PR DESCRIPTION
## Summary

- upgrade the pinned rust-pr-bench action and reusable workflow to v1.1.0
- remove the global postgres-bench feature set so workspace members do not receive a root-only feature
- update the repository guard to require target-owned Cargo required-features

## Rationale

The global feature set caused every member-crate benchmark command to receive postgres-bench. Member crates do not define that feature, so rust-pr-bench v1.0.0 classified five valid benchmarks as missing in both base and head. v1.1.0 reads each Cargo benchmark target required-features and applies them only to that target.

## Changelog

No changelog entry: this corrects internal pull-request benchmark execution and does not change user-facing Hubuum behavior.

## Verification

- source .env && ./run_tests.sh
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- bash scripts/test-classify-ci-changes.sh
- bash scripts/classify-ci-changes.sh .github/workflows/benchmarks.yml
- generated the released action matrix and confirmed only storage_postgres_criterion receives postgres-bench