### PR TITLE
Benchmark maximum-depth structured search

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -101,10 +101,10 @@ jobs:
     name: Benchmarks
     needs: changes
     if: needs.changes.outputs.run_benchmarks == 'true'
-    uses: terjekv/rust-pr-bench/.github/workflows/rust-pr-bench.yml@57fc9bca852782f3ee421684762f23fd77afba5c # v1.1.0
+    uses: terjekv/rust-pr-bench/.github/workflows/rust-pr-bench.yml@cdeb6a01e7164eef7ebbd117f6b9edd6524db3d3 # v1.1.1
     secrets: inherit
     with:
-      action_ref: 57fc9bca852782f3ee421684762f23fd77afba5c
+      action_ref: cdeb6a01e7164eef7ebbd117f6b9edd6524db3d3
       backend: all
       auto_discover: true
       auto_detect_moved_benchmarks: true

--- a/benches/storage_postgres_criterion.rs
+++ b/benches/storage_postgres_criterion.rs
@@ -5,22 +5,29 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use diesel::{Connection, PgConnection};
+use diesel::sql_types::{Integer, Text};
+use diesel::{Connection, PgConnection, QueryableByName};
 use hubuum::events::EventContext;
+use hubuum::models::search::MAX_RELATED_FILTER_DEPTH;
 use hubuum::models::{
-    Collection, CollectionID, Group, GroupID, NewCollectionWithAssignee, NewGroup,
+    Collection, CollectionID, Group, GroupID, HubuumClassID, NewCollectionWithAssignee, NewGroup,
+    StructuredSearchOperator,
 };
 use hubuum::services::Services;
 use hubuum::storage::{BenchmarkStorageContext, TransactionStorage};
 use hubuum::traits::{CanDelete, CanSave};
 use hubuum_storage_core::StorageCollectionCreate;
-use hubuum_storage_postgres::{PostgresPool, PostgresPoolSettings, build_postgres_pool};
+use hubuum_storage_postgres::diesel_async_prelude::RunQueryDsl;
+use hubuum_storage_postgres::{
+    PostgresPool, PostgresPoolSettings, build_postgres_pool, with_connection,
+};
 use tokio::runtime::{Builder, Runtime};
 
 static NEXT_NAME_ID: AtomicU64 = AtomicU64::new(1);
 
 const POSTGRES_DATABASE: &str = "hubuum_bench";
 const POSTGRES_IMAGE: &str = "docker.io/library/postgres:18.4-alpine3.24@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15";
+const STRUCTURED_SEARCH_CHAINS: i32 = 128;
 
 fn benchmark_pool(database_url: &str) -> PostgresPool {
     let settings = PostgresPoolSettings::builder(database_url)
@@ -193,6 +200,152 @@ struct StorageFixture {
     services: Services,
     owner_group: Group,
     collections: Vec<Collection>,
+    structured_search: StructuredSearchFixture,
+}
+
+struct StructuredSearchFixture {
+    source_class_id: HubuumClassID,
+    target_class_id: HubuumClassID,
+    selective_target_name: String,
+    target_name_fragment: String,
+}
+
+#[derive(QueryableByName)]
+struct ClassIdRow {
+    #[diesel(sql_type = Integer)]
+    id: i32,
+}
+
+impl StructuredSearchFixture {
+    fn new(runtime: &Runtime, pool: &PostgresPool, collection_id: i32) -> Self {
+        let prefix = unique_name("structured-depth-ten");
+        let source_class_name = format!("{prefix}-class-00");
+        let target_class_name = format!("{prefix}-class-{MAX_RELATED_FILTER_DEPTH:02}");
+        let target_name_fragment = format!("{prefix}-target");
+        let selective_target_name = format!("{target_name_fragment}-000");
+
+        let (source_class_id, target_class_id) = runtime
+            .block_on(with_connection(pool, async |connection| {
+                diesel::sql_query(
+                    "INSERT INTO hubuumclass \
+                        (name, collection_id, description, validate_schema) \
+                     SELECT $1 || '-class-' || lpad(level::text, 2, '0'), \
+                            $2, \
+                            'structured search depth benchmark class', \
+                            false \
+                     FROM generate_series(0, $3) AS level \
+                     ORDER BY level",
+                )
+                .bind::<Text, _>(&prefix)
+                .bind::<Integer, _>(collection_id)
+                .bind::<Integer, _>(i32::from(MAX_RELATED_FILTER_DEPTH))
+                .execute(connection)
+                .await?;
+
+                diesel::sql_query(
+                    "INSERT INTO hubuumclass_relation \
+                        (from_hubuum_class_id, to_hubuum_class_id) \
+                     SELECT lower_class.id, upper_class.id \
+                     FROM generate_series(0, $2 - 1) AS level \
+                     JOIN hubuumclass lower_class \
+                       ON lower_class.name = $1 || '-class-' || lpad(level::text, 2, '0') \
+                     JOIN hubuumclass upper_class \
+                       ON upper_class.name = $1 || '-class-' || lpad((level + 1)::text, 2, '0') \
+                     ORDER BY level",
+                )
+                .bind::<Text, _>(&prefix)
+                .bind::<Integer, _>(i32::from(MAX_RELATED_FILTER_DEPTH))
+                .execute(connection)
+                .await?;
+
+                diesel::sql_query(
+                    "INSERT INTO hubuumobject \
+                        (name, collection_id, hubuum_class_id, data, description) \
+                     SELECT CASE \
+                                WHEN level = $3 THEN \
+                                    $1 || '-target-' || lpad(chain::text, 3, '0') \
+                                ELSE \
+                                    $1 || '-node-' || lpad(level::text, 2, '0') || '-' || \
+                                    lpad(chain::text, 3, '0') \
+                            END, \
+                            $2, \
+                            class.id, \
+                            jsonb_build_object('chain', chain, 'level', level), \
+                            'structured search depth benchmark object' \
+                     FROM generate_series(0, $3) AS level \
+                     CROSS JOIN generate_series(0, $4 - 1) AS chain \
+                     JOIN hubuumclass class \
+                       ON class.name = $1 || '-class-' || lpad(level::text, 2, '0') \
+                     ORDER BY level, chain",
+                )
+                .bind::<Text, _>(&prefix)
+                .bind::<Integer, _>(collection_id)
+                .bind::<Integer, _>(i32::from(MAX_RELATED_FILTER_DEPTH))
+                .bind::<Integer, _>(STRUCTURED_SEARCH_CHAINS)
+                .execute(connection)
+                .await?;
+
+                diesel::sql_query(
+                    "INSERT INTO hubuumobject_relation \
+                        (from_hubuum_object_id, to_hubuum_object_id, class_relation_id) \
+                     SELECT LEAST(lower_object.id, upper_object.id), \
+                            GREATEST(lower_object.id, upper_object.id), \
+                            class_relation.id \
+                     FROM generate_series(0, $2 - 1) AS level \
+                     CROSS JOIN generate_series(0, $3 - 1) AS chain \
+                     JOIN hubuumclass lower_class \
+                       ON lower_class.name = $1 || '-class-' || lpad(level::text, 2, '0') \
+                     JOIN hubuumclass upper_class \
+                       ON upper_class.name = $1 || '-class-' || lpad((level + 1)::text, 2, '0') \
+                     JOIN hubuumclass_relation class_relation \
+                       ON class_relation.from_hubuum_class_id = lower_class.id \
+                      AND class_relation.to_hubuum_class_id = upper_class.id \
+                     JOIN hubuumobject lower_object \
+                       ON lower_object.hubuum_class_id = lower_class.id \
+                      AND (lower_object.data ->> 'chain')::integer = chain \
+                     JOIN hubuumobject upper_object \
+                       ON upper_object.hubuum_class_id = upper_class.id \
+                      AND (upper_object.data ->> 'chain')::integer = chain \
+                     ORDER BY level, chain",
+                )
+                .bind::<Text, _>(&prefix)
+                .bind::<Integer, _>(i32::from(MAX_RELATED_FILTER_DEPTH))
+                .bind::<Integer, _>(STRUCTURED_SEARCH_CHAINS)
+                .execute(connection)
+                .await?;
+
+                for table in [
+                    "hubuumclass",
+                    "hubuumclass_relation",
+                    "hubuumobject",
+                    "hubuumobject_relation",
+                ] {
+                    diesel::sql_query(format!("ANALYZE {table}"))
+                        .execute(connection)
+                        .await?;
+                }
+
+                let source = diesel::sql_query("SELECT id FROM hubuumclass WHERE name = $1")
+                    .bind::<Text, _>(&source_class_name)
+                    .get_result::<ClassIdRow>(connection)
+                    .await?;
+                let target = diesel::sql_query("SELECT id FROM hubuumclass WHERE name = $1")
+                    .bind::<Text, _>(&target_class_name)
+                    .get_result::<ClassIdRow>(connection)
+                    .await?;
+                Ok::<_, hubuum_storage_postgres::PostgresStorageError>((source.id, target.id))
+            }))
+            .expect("structured search benchmark graph should save");
+
+        Self {
+            source_class_id: HubuumClassID::new(source_class_id)
+                .expect("source class id should be positive"),
+            target_class_id: HubuumClassID::new(target_class_id)
+                .expect("target class id should be positive"),
+            selective_target_name,
+            target_name_fragment,
+        }
+    }
 }
 
 impl StorageFixture {
@@ -252,11 +405,19 @@ impl StorageFixture {
             collections.push(collection);
         }
 
+        let fixture_pool = {
+            let _runtime_guard = runtime.enter();
+            benchmark_pool(database_url)
+        };
+        let structured_search =
+            StructuredSearchFixture::new(runtime, &fixture_pool, collections[0].id);
+
         Self {
             storage,
             services,
             owner_group,
             collections,
+            structured_search,
         }
     }
 
@@ -301,6 +462,28 @@ fn benchmark_postgres_storage(c: &mut Criterion) {
     runtime
         .block_on(collections.ancestors(leaf_id))
         .expect("ancestor warmup should succeed");
+    let selective_rows = runtime
+        .block_on(hubuum::benchmark_support::structured_related_object_search(
+            &fixture.storage,
+            fixture.structured_search.source_class_id,
+            fixture.structured_search.target_class_id,
+            StructuredSearchOperator::Equals,
+            &fixture.structured_search.selective_target_name,
+            MAX_RELATED_FILTER_DEPTH,
+        ))
+        .expect("selective structured-search warmup should succeed");
+    assert_eq!(selective_rows.len(), 1);
+    let non_selective_rows = runtime
+        .block_on(hubuum::benchmark_support::structured_related_object_search(
+            &fixture.storage,
+            fixture.structured_search.source_class_id,
+            fixture.structured_search.target_class_id,
+            StructuredSearchOperator::Icontains,
+            &fixture.structured_search.target_name_fragment,
+            MAX_RELATED_FILTER_DEPTH,
+        ))
+        .expect("non-selective structured-search warmup should succeed");
+    assert_eq!(non_selective_rows.len(), STRUCTURED_SEARCH_CHAINS as usize);
 
     let mut group = c.benchmark_group("storage_postgres");
     group.bench_function("collection_point_read", |b| {
@@ -317,6 +500,36 @@ fn benchmark_postgres_storage(c: &mut Criterion) {
                 .block_on(collections.ancestors(black_box(leaf_id)))
                 .expect("ancestor read should succeed");
             black_box(ancestors);
+        });
+    });
+    group.bench_function("structured_related_depth_10_selective", |b| {
+        b.iter(|| {
+            let rows = runtime
+                .block_on(hubuum::benchmark_support::structured_related_object_search(
+                    &fixture.storage,
+                    black_box(fixture.structured_search.source_class_id),
+                    black_box(fixture.structured_search.target_class_id),
+                    StructuredSearchOperator::Equals,
+                    black_box(&fixture.structured_search.selective_target_name),
+                    MAX_RELATED_FILTER_DEPTH,
+                ))
+                .expect("selective structured search should succeed");
+            black_box(rows);
+        });
+    });
+    group.bench_function("structured_related_depth_10_non_selective", |b| {
+        b.iter(|| {
+            let rows = runtime
+                .block_on(hubuum::benchmark_support::structured_related_object_search(
+                    &fixture.storage,
+                    black_box(fixture.structured_search.source_class_id),
+                    black_box(fixture.structured_search.target_class_id),
+                    StructuredSearchOperator::Icontains,
+                    black_box(&fixture.structured_search.target_name_fragment),
+                    MAX_RELATED_FILTER_DEPTH,
+                ))
+                .expect("non-selective structured search should succeed");
+            black_box(rows);
         });
     });
     group.bench_function("collection_create_with_event", |b| {

--- a/docs/development.md
+++ b/docs/development.md
@@ -274,12 +274,20 @@ cargo install --locked --version 0.19.4 gungraun-runner
 The PostgreSQL storage benchmark is opt-in and requires Docker. It provisions,
 migrates, and removes a disposable PostgreSQL container itself. Container
 startup, fixture creation, cleanup, and warmup happen outside the timed
-regions. The create scenario intentionally leaves its append-only audit events
-behind:
+regions. It includes selective and non-selective structured related-object
+searches over 128 independent chains at the maximum supported depth of 10. The
+create scenario intentionally leaves its append-only audit events behind:
 
 ```bash
 cargo bench --features postgres-bench \
   --bench storage_postgres_criterion -- --noplot
+```
+
+To run only the structured-search cases:
+
+```bash
+cargo bench --features postgres-bench \
+  --bench storage_postgres_criterion -- structured_related_depth_10 --noplot
 ```
 
 The runtime behavior validator is opt-in and requires a migrated, disposable

--- a/docs/search_api.md
+++ b/docs/search_api.md
@@ -492,6 +492,34 @@ caller to narrow the query. PostgreSQL work is bounded by
 `HUBUUM_DB_STATEMENT_TIMEOUT_MS`; pool acquisition remains bounded by
 `HUBUUM_DB_POOL_ACQUIRE_TIMEOUT_MS`.
 
+#### Measured depth-10 baseline
+
+The self-contained `storage_postgres_criterion` benchmark exercises the
+production recursive query at the maximum related depth. Its fixture contains
+128 independent chains of 11 objects: 1,408 objects and 1,280 relations in
+total. The selective case matches one target by exact name; the non-selective
+case matches all 128 targets by a case-insensitive substring. Both request 250
+rows with `include_total=false`. Fixture creation, migration, `ANALYZE`, and
+warmup are outside the timed region.
+
+The reference run on 2026-08-30 used PostgreSQL 18.4 in the pinned benchmark
+container, Rust 1.98.0, and an Intel Xeon Silver 4216 host. Criterion collected
+100 samples after its normal three-second warmup:
+
+| Target predicate | Matched roots | Median | Median 95% interval |
+| --- | ---: | ---: | ---: |
+| Exact target name | 1 | 15.636 ms | 15.631–15.645 ms |
+| Case-insensitive substring | 128 | 24.039 ms | 24.033–24.044 ms |
+
+These host-specific numbers are a reference baseline, not a latency SLO. Pull
+requests compare the same benchmark between base and head. The deterministic
+storage test separately pins both cases to one pool checkout, four domain
+queries, three transaction-control statements, one recursive result query,
+and no count query. This measured workload does not justify another graph
+index: the recursive CTE can traverse the existing
+`idx_hubuumobject_relation_on_from_to` and
+`idx_hubuumobject_relation_on_to` indexes in their respective directions.
+
 ### Errors and compatibility
 
 The endpoint uses the normal `ApiError` response shape. Common statuses are:
@@ -548,3 +576,21 @@ database connection before result events are paced by the client, preventing a
 slow or disconnected consumer from occupying the connection pool. A disconnect
 before completion drops the pending search future; database statements remain
 bounded by the configured statement timeout.
+
+The initial streaming decision uses these measured or enforced bounds:
+
+| Property | Page-progressive behavior |
+| --- | --- |
+| Time to `started` | Emitted before polling search execution; zero search queries must complete first |
+| Time to first `result` | At least the complete authorized page-query latency; 15.636–24.039 ms in the depth-10 reference cases above |
+| Connection occupancy under a slow client | Zero after the page future resolves; result pacing owns the completed page, not a database connection |
+| Buffered result memory | Linear in the effective page limit; at most 250 rows with the default maximum-page configuration |
+| Disconnect before completion | Drops the pending execution future; PostgreSQL work remains bounded by the statement timeout |
+| Disconnect during result delivery | Drops only the completed in-memory page and stream state |
+
+Database-row streaming would improve first-result latency only by retaining a
+pool connection across client backpressure and by weakening the point at which
+authorization and global ordering are final. The measured depth-10 page latency
+does not justify that tradeoff for version 1. Revisit this decision if
+base/head benchmarks or production pool telemetry show that page completion,
+memory, or cancellation behavior is the limiting resource.

--- a/src/benchmark_support.rs
+++ b/src/benchmark_support.rs
@@ -14,7 +14,19 @@ use crate::services::Services;
 #[cfg(feature = "postgres-bench")]
 use crate::storage::{BenchmarkStorageContext, StorageHandle};
 #[cfg(feature = "postgres-bench")]
+use crate::{
+    errors::ApiError,
+    models::{
+        HubuumClassID, HubuumObject, STRUCTURED_SEARCH_VERSION, StructuredClassSelector,
+        StructuredRelatedPredicate, StructuredSearchExpression, StructuredSearchField,
+        StructuredSearchFieldPredicate, StructuredSearchOperator, StructuredSearchRequest,
+        StructuredSearchTarget,
+    },
+};
+#[cfg(feature = "postgres-bench")]
 use hubuum_storage_postgres::PostgresPool;
+#[cfg(feature = "postgres-bench")]
+use serde_json::Value;
 
 /// Build the collection service around the production observability wrapper.
 ///
@@ -46,4 +58,58 @@ pub fn storage_for_postgres(pool: PostgresPool) -> BenchmarkStorageContext {
 #[must_use]
 pub fn services_for_storage(storage: &BenchmarkStorageContext) -> Services {
     Services::from_storage(storage.clone())
+}
+
+/// Run the production PostgreSQL structured-related-object query used by the
+/// self-contained storage benchmark.
+///
+/// Fixture construction resolves both class IDs before the timed region. The
+/// synthetic administrator ID is safe because SQL-backed administrator
+/// visibility does not consult group membership, while the catalog adapter
+/// still applies its normal collection, class, object, and relation scopes.
+#[cfg(feature = "postgres-bench")]
+#[doc(hidden)]
+pub async fn structured_related_object_search(
+    storage: &BenchmarkStorageContext,
+    source_class_id: HubuumClassID,
+    target_class_id: HubuumClassID,
+    target_operator: StructuredSearchOperator,
+    target_value: &str,
+    depth: u8,
+) -> Result<Vec<HubuumObject>, ApiError> {
+    let request = StructuredSearchRequest {
+        version: STRUCTURED_SEARCH_VERSION,
+        target: StructuredSearchTarget::Object {
+            class: Some(StructuredClassSelector::Id {
+                id: source_class_id,
+            }),
+        },
+        filter: Some(StructuredSearchExpression::Related {
+            predicate: StructuredRelatedPredicate {
+                class: StructuredClassSelector::Id {
+                    id: target_class_id,
+                },
+                filters: vec![StructuredSearchFieldPredicate {
+                    field: StructuredSearchField::Name,
+                    operator: target_operator,
+                    path: None,
+                    value: Some(Value::String(target_value.to_string())),
+                }],
+                depth,
+            },
+        }),
+        sort: Vec::new(),
+        limit: Some(250),
+        cursor: None,
+        include_total: false,
+    };
+    // This request is constructed from typed benchmark inputs above. Do not
+    // call the public HTTP validator here: page-limit validation reads the
+    // application CLI configuration, which must remain uninitialized while
+    // Criterion owns the benchmark process arguments.
+    let options = request.query_options(Some(source_class_id), None)?;
+    let (rows, total) =
+        crate::services::catalog::list_objects(storage, 1, true, None, options).await?;
+    debug_assert!(total.is_none(), "benchmark search must skip exact counts");
+    Ok(rows)
 }

--- a/src/tests/storage_performance.rs
+++ b/src/tests/storage_performance.rs
@@ -16,7 +16,10 @@ use crate::models::{
     HubuumObjectRelationID, NewCollectionWithAssignee, NewHubuumClass, NewHubuumClassRelation,
     NewHubuumObject, NewHubuumObjectRelation, ObjectAggregateCursorBudget, ObjectAggregateRequest,
     ObjectAggregateTarget, ObjectRelationCreateSelector, ObjectRelationSelector, ObjectSelector,
-    Permissions, StorageObjectAggregateAuthorization, UpdateCollection, UpdateHubuumClass,
+    Permissions, STRUCTURED_SEARCH_VERSION, StorageObjectAggregateAuthorization,
+    StructuredClassSelector, StructuredRelatedPredicate, StructuredSearchExpression,
+    StructuredSearchField, StructuredSearchFieldPredicate, StructuredSearchOperator,
+    StructuredSearchRequest, StructuredSearchTarget, UpdateCollection, UpdateHubuumClass,
     UpdateHubuumObject, UserID, parse_object_aggregate_query,
 };
 use crate::services::Services;
@@ -95,6 +98,136 @@ async fn object_relation_budget_fixture(
         class_relation_id: class_relation.id,
     });
     (fixture, services, selector)
+}
+
+struct StructuredSearchPerformanceFixture {
+    collection: CollectionFixture,
+    source_class_id: HubuumClassID,
+    target_class_id: HubuumClassID,
+    selective_target_name: String,
+    target_name_fragment: String,
+}
+
+impl StructuredSearchPerformanceFixture {
+    async fn new(scope: &TestScope, label: &str) -> Self {
+        let collection = scope.collection_fixture(label).await;
+        let mut classes = Vec::new();
+        for depth in 0..=crate::models::search::MAX_RELATED_FILTER_DEPTH {
+            classes.push(
+                NewHubuumClass {
+                    collection_id: collection.collection.id,
+                    name: scope.scoped_name(&format!("{label}_class_{depth:02}")),
+                    description: "structured search performance class".to_string(),
+                    json_schema: None,
+                    validate_schema: None,
+                }
+                .save_without_events(&scope.pool)
+                .await
+                .expect("structured search performance class should save"),
+            );
+        }
+
+        let mut class_relations = Vec::new();
+        for endpoints in classes.windows(2) {
+            class_relations.push(
+                NewHubuumClassRelation {
+                    from_hubuum_class_id: endpoints[0].id,
+                    to_hubuum_class_id: endpoints[1].id,
+                    forward_template_alias: None,
+                    reverse_template_alias: None,
+                    from_max_relations: None,
+                    to_max_relations: None,
+                }
+                .save_without_events(&scope.pool)
+                .await
+                .expect("structured search performance class relation should save"),
+            );
+        }
+
+        let target_name_fragment = scope.scoped_name(&format!("{label}_target"));
+        let selective_target_name = format!("{target_name_fragment}_0");
+        for chain in 0..2 {
+            let mut objects = Vec::new();
+            for (depth, class) in classes.iter().enumerate() {
+                let name = if depth == usize::from(crate::models::search::MAX_RELATED_FILTER_DEPTH)
+                {
+                    format!("{target_name_fragment}_{chain}")
+                } else {
+                    scope.scoped_name(&format!("{label}_node_{depth:02}_{chain}"))
+                };
+                objects.push(
+                    NewHubuumObject {
+                        collection_id: collection.collection.id,
+                        hubuum_class_id: class.id,
+                        name,
+                        description: "structured search performance object".to_string(),
+                        data: serde_json::json!({"chain": chain, "depth": depth}),
+                    }
+                    .save_without_events(&scope.pool)
+                    .await
+                    .expect("structured search performance object should save"),
+                );
+            }
+            for (depth, endpoints) in objects.windows(2).enumerate() {
+                NewHubuumObjectRelation {
+                    from_hubuum_object_id: endpoints[0].id,
+                    to_hubuum_object_id: endpoints[1].id,
+                    class_relation_id: class_relations[depth].id,
+                }
+                .save_without_events(&scope.pool)
+                .await
+                .expect("structured search performance object relation should save");
+            }
+        }
+
+        Self {
+            collection,
+            source_class_id: HubuumClassID::new(classes[0].id).expect("valid source class id"),
+            target_class_id: HubuumClassID::new(classes.last().expect("target class").id)
+                .expect("valid target class id"),
+            selective_target_name,
+            target_name_fragment,
+        }
+    }
+
+    fn query(
+        &self,
+        operator: StructuredSearchOperator,
+        value: &str,
+    ) -> crate::models::search::QueryOptions {
+        let request = StructuredSearchRequest {
+            version: STRUCTURED_SEARCH_VERSION,
+            target: StructuredSearchTarget::Object {
+                class: Some(StructuredClassSelector::Id {
+                    id: self.source_class_id,
+                }),
+            },
+            filter: Some(StructuredSearchExpression::Related {
+                predicate: StructuredRelatedPredicate {
+                    class: StructuredClassSelector::Id {
+                        id: self.target_class_id,
+                    },
+                    filters: vec![StructuredSearchFieldPredicate {
+                        field: StructuredSearchField::Name,
+                        operator,
+                        path: None,
+                        value: Some(Value::String(value.to_string())),
+                    }],
+                    depth: crate::models::search::MAX_RELATED_FILTER_DEPTH,
+                },
+            }),
+            sort: Vec::new(),
+            limit: Some(20),
+            cursor: None,
+            include_total: false,
+        };
+        request
+            .validate()
+            .expect("performance request should validate");
+        request
+            .query_options(Some(self.source_class_id), None)
+            .expect("performance query options should build")
+    }
 }
 
 #[derive(QueryableByName)]
@@ -1082,6 +1215,81 @@ async fn object_page_query_count_is_constant_with_page_size() {
     assert_eq!(large_queries.connection_checkouts(), 1);
 
     fixture.cleanup().await.expect("object fixture cleanup");
+}
+
+#[actix_web::test]
+async fn structured_related_depth_limit_has_fixed_query_shape_and_skips_count_work() {
+    let scope = TestScope::new();
+    let fixture =
+        StructuredSearchPerformanceFixture::new(&scope, "structured_search_depth_limit").await;
+    let subject = UserID::new(1).expect("valid synthetic runtime-admin subject id");
+
+    let run = |operator, value: &str| {
+        let query = fixture.query(operator, value);
+        async {
+            crate::services::catalog::list_objects(&scope.pool, subject.id(), true, None, query)
+                .await
+        }
+    };
+
+    let (selective, selective_queries) = capture_queries(run(
+        StructuredSearchOperator::Equals,
+        &fixture.selective_target_name,
+    ))
+    .await;
+    let (selective_rows, selective_total) = selective.expect("selective search should succeed");
+    assert_eq!(selective_rows.len(), 1);
+    assert_eq!(selective_total, None);
+
+    let (non_selective, non_selective_queries) = capture_queries(run(
+        StructuredSearchOperator::Icontains,
+        &fixture.target_name_fragment,
+    ))
+    .await;
+    let (non_selective_rows, non_selective_total) =
+        non_selective.expect("non-selective search should succeed");
+    assert_eq!(non_selective_rows.len(), 2);
+    assert_eq!(non_selective_total, None);
+
+    assert_eq!(
+        selective_queries.total_queries(),
+        non_selective_queries.total_queries()
+    );
+    assert_eq!(
+        selective_queries.domain_queries(),
+        non_selective_queries.domain_queries()
+    );
+    assert_eq!(
+        selective_queries.control_queries(),
+        non_selective_queries.control_queries()
+    );
+    assert_eq!(
+        selective_queries.connection_checkouts(),
+        non_selective_queries.connection_checkouts()
+    );
+    assert_eq!(
+        non_selective_queries.total_queries(),
+        7,
+        "{:#?}",
+        non_selective_queries.query_counts()
+    );
+    assert_eq!(non_selective_queries.domain_queries(), 4);
+    assert_eq!(non_selective_queries.control_queries(), 3);
+    assert_eq!(non_selective_queries.connection_checkouts(), 1);
+    assert_eq!(selective_queries.queries_matching("WITH RECURSIVE"), 1);
+    assert_eq!(non_selective_queries.queries_matching("WITH RECURSIVE"), 1);
+    assert_eq!(
+        non_selective_queries.queries_matching("SELECT count("),
+        0,
+        "include_total=false must not execute a count query: {:#?}",
+        non_selective_queries.query_counts()
+    );
+
+    fixture
+        .collection
+        .cleanup()
+        .await
+        .expect("structured search performance fixture cleanup");
 }
 
 #[actix_web::test]


### PR DESCRIPTION
## Summary

- add selective and non-selective PostgreSQL Criterion cases for structured related-object search at the maximum supported graph depth of 10
- add a deterministic storage test that fixes the query and checkout budget for both predicate shapes and proves `include_total=false` skips count work
- record the measured depth-10 baseline and the page-progressive SSE resource/latency decision in the search documentation
- pin `rust-pr-bench` v1.1.1 so newly added Criterion functions remain unknown instead of producing a false target-level regression

## Rationale

Issue #282's structured POST search behavior shipped in #292 and its SSE form shipped in #294. The remaining acceptance criteria were performance coverage at the maximum related depth and a streaming decision grounded in measurements.

The benchmark fixture bulk-loads 128 independent 11-object chains (1,408 objects and 1,280 relations), analyzes the graph tables outside the timed region, and executes the production recursive query through the opaque application storage context. The exact predicate returns one root; the case-insensitive substring predicate returns all 128 roots.

## Measurements and behavior

The reference run used the repository-pinned PostgreSQL 18.4 image, Rust 1.98.0, and an Intel Xeon Silver 4216 host:

| Predicate | Results | Median | Median 95% interval |
| --- | ---: | ---: | ---: |
| Exact target name | 1 | 15.636 ms | 15.631–15.645 ms |
| Case-insensitive substring | 128 | 24.039 ms | 24.033–24.044 ms |

Both cases use one connection checkout, four domain queries, three transaction-control statements, one recursive result query, and no count query. At this scale the existing bidirectional relation indexes are sufficient, so this change adds no migration.

The recorded v1 streaming decision keeps page-progressive delivery: `started` is emitted before query execution, the completed page is released from the database connection before client-paced result delivery, and buffering remains bounded by the effective page limit. A database-row stream would improve first-result latency at the cost of holding a pool connection under client backpressure and weakening the point at which authorization and global ordering are final; these measurements do not justify that tradeoff.

The first CI comparison exposed a reporting bug rather than a code regression: the two new head-only Criterion functions were added to the target total against a zero base, yielding a false +355% delta. `rust-pr-bench` v1.1.1 compares target totals only across shared metric identities and reports added functions as unknown.

## Changelog

No new changelog entry is needed. The existing Unreleased entries already describe structured search, structured SSE, bounded related predicates, count opt-out, and connection-release behavior; this PR supplies the remaining validation and decision record for that same feature.

Closes #282.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --features postgres-bench -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `cargo bench --features postgres-bench --bench storage_postgres_criterion -- structured_related_depth_10 --noplot`
- `scripts/test-classify-ci-changes.sh`
