### PR TITLE
Upgrade Alpine runtime packages for v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Security
 
+- Production container builds now upgrade packages from the pinned Alpine 3.24
+  repositories before installing runtime dependencies. This incorporates
+  OpenSSL 3.5.8-r0, which fixes CVE-2026-14456 in the 3.24.1 base image.
 - Mitigated RUSTSEC-2026-0258 by disabling Actix's optional HTTP/2 feature, so
   vulnerable `h2` 0.3 code is not compiled. HTTP/1.1, TLS, compression,
   cookies, and WebSockets remain enabled. Deployments requiring HTTP/2 must

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,8 @@ FROM docker.io/library/alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0b
 ARG HUBUUM_UID="10001"
 ARG HUBUUM_GID="10001"
 
-RUN apk add --no-cache ca-certificates && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates && \
     addgroup -S -g "${HUBUUM_GID}" hubuum && \
     adduser -S -D -H -u "${HUBUUM_UID}" -G hubuum hubuum
 

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -247,6 +247,21 @@ fn production_container_base_images_are_pinned() {
 }
 
 #[test]
+fn production_container_refreshes_runtime_packages() {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let dockerfile = fs::read_to_string(repository.join("Dockerfile"))
+        .expect("repository Dockerfile should be readable");
+    let (_, runtime_stage) = dockerfile
+        .rsplit_once("\nFROM ")
+        .expect("production Dockerfile should contain a runtime stage");
+
+    assert!(
+        runtime_stage.contains("\nRUN apk upgrade --no-cache && \\\n"),
+        "production runtime stage must upgrade packages from the pinned Alpine repositories"
+    );
+}
+
+#[test]
 fn container_dependency_images_are_pinned() {
     let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let workflow = fs::read_to_string(repository.join(".github/workflows/ci.yml"))

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -248,9 +248,7 @@ fn production_container_base_images_are_pinned() {
 
 #[test]
 fn production_container_refreshes_runtime_packages() {
-    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let dockerfile = fs::read_to_string(repository.join("Dockerfile"))
-        .expect("repository Dockerfile should be readable");
+    let dockerfile = read_repository_text("Dockerfile");
     let (_, runtime_stage) = dockerfile
         .rsplit_once("\nFROM ")
         .expect("production Dockerfile should contain a runtime stage");


### PR DESCRIPTION
## Summary

- Upgrade runtime packages from the pinned Alpine 3.24 repositories before installing production dependencies.
- Incorporate OpenSSL 3.5.8-r0, which fixes CVE-2026-14456.
- Add a regression test requiring the final runtime stage to refresh packages.
- Record the security fix in the v0.0.10 release notes.

## Cause

The exact-main publication workflow for the v0.0.10 release commit failed its fixed-vulnerability policy. The pinned Alpine 3.24.1 image contains libcrypto3 and libssl3 3.5.7-r0, while the Alpine 3.24 repositories now provide fixed revision 3.5.8-r0. No Alpine 3.24.2 image tag is currently available, so refreshing packages from the still-pinned release repositories is the narrowest reproducible fix. This PR does not add a vulnerability exception.

## Behavior

The runtime stage remains based on the digest-pinned Alpine 3.24.1 image, then upgrades installed packages using the pinned 3.24 repositories. The final image was inspected locally and contains libcrypto3-3.5.8-r0 and libssl3-3.5.8-r0.

## Verification

- source .env && ./run_tests.sh
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- npx markdownlint-cli2 --config .markdownlint.json **/*.md !target
- scripts/test-classify-ci-changes.sh
- cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked
- docker build --build-arg CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release --tag hubuum-server:verify .
- Inspected the final image for libcrypto3-3.5.8-r0 and libssl3-3.5.8-r0