### PR TITLE
Allow main publication after skipped CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1447,7 +1447,12 @@ jobs:
 
   build-main-linux-artifacts:
     name: Build static main artifacts (${{ matrix.platform.os_name }}, ${{ matrix.feature.ext }})
-    if: github.ref == 'refs/heads/main' && needs.changes.outputs.artifacts == 'true'
+    if: >-
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      needs.changes.result == 'success' &&
+      needs.ci-gate.result == 'success' &&
+      needs.changes.outputs.artifacts == 'true'
     needs:
       - changes
       - ci-gate
@@ -1515,7 +1520,12 @@ jobs:
 
   build-main-native-artifacts:
     name: Build native main artifacts (${{ matrix.platform.os_name }}, ${{ matrix.feature.ext }})
-    if: github.ref == 'refs/heads/main' && needs.changes.outputs.artifacts == 'true'
+    if: >-
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      needs.changes.result == 'success' &&
+      needs.ci-gate.result == 'success' &&
+      needs.changes.outputs.artifacts == 'true'
     needs:
       - changes
       - ci-gate
@@ -1614,7 +1624,12 @@ jobs:
 
   publish-main-container-images:
     name: Build main container (${{ matrix.platform.arch }})
-    if: github.ref == 'refs/heads/main' && needs.changes.outputs.artifacts == 'true'
+    if: >-
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      needs.changes.result == 'success' &&
+      needs.ci-gate.result == 'success' &&
+      needs.changes.outputs.artifacts == 'true'
     needs:
       - changes
       - ci-gate
@@ -1684,7 +1699,10 @@ jobs:
 
   publish-main-container-manifests:
     name: Create main multi-arch manifest
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      needs.publish-main-container-images.result == 'success'
     needs: publish-main-container-images
     runs-on: ubuntu-24.04
     permissions:

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -666,6 +666,43 @@ fn main_builds_remain_run_artifacts_without_a_rolling_github_release() {
 }
 
 #[test]
+fn main_publication_runs_after_inapplicable_ci_jobs_are_skipped() {
+    let workflow = read_repository_text(".github/workflows/ci.yml");
+
+    for (job, next_job) in [
+        ("build-main-linux-artifacts", "build-main-native-artifacts"),
+        (
+            "build-main-native-artifacts",
+            "publish-main-container-images",
+        ),
+        (
+            "publish-main-container-images",
+            "publish-main-container-manifests",
+        ),
+    ] {
+        let job_definition =
+            lines_between(&workflow, &format!("  {job}:"), &format!("  {next_job}:"))
+                .unwrap_or_else(|| panic!("CI should define {job} before {next_job}"))
+                .join("\n");
+
+        assert!(job_definition.contains("    if: >-\n      always() &&"));
+        assert!(job_definition.contains("needs.changes.result == 'success'"));
+        assert!(job_definition.contains("needs.ci-gate.result == 'success'"));
+        assert!(job_definition.contains("needs.changes.outputs.artifacts == 'true'"));
+    }
+
+    let manifest_job = lines_between(
+        &workflow,
+        "  publish-main-container-manifests:",
+        "  publish-tag-container-images:",
+    )
+    .expect("CI should define main manifest publication before tagged publication")
+    .join("\n");
+    assert!(manifest_job.contains("    if: >-\n      always() &&"));
+    assert!(manifest_job.contains("needs.publish-main-container-images.result == 'success'"));
+}
+
+#[test]
 fn main_container_manifest_is_sha_addressed_before_channel_promotion() {
     let workflow = read_repository_text(".github/workflows/ci.yml");
     let job_start = workflow


### PR DESCRIPTION
## Summary

- Evaluate main artifact and container publication with `always()` so an inapplicable transitive CI job cannot suppress publication after the aggregate gate succeeds.
- Require `changes` and `ci-gate` to succeed explicitly, while preserving the `artifacts=true` path decision.
- Require both platform image jobs to succeed explicitly before promoting the multi-arch `main` manifest.
- Add a regression test for all four publication conditions.

## Cause

Exact-main run 33290710963 classified the merge as `artifacts=true` and passed the CI gate, but all main publication jobs were skipped. The Treetop conformance job was correctly skipped as inapplicable; GitHub Actions implicit `success()` propagated that transitive skip to jobs depending on the aggregate gate. The preceding run executed Treetop and reached publication, which exposed the condition-dependent behavior.

## Behavior

Main publication still runs only on `refs/heads/main`, only for artifact-affecting changes, and only after both classification and the complete CI gate succeed. A skipped inapplicable CI job accepted by the gate no longer suppresses publication. The channel manifest is promoted only after all platform image builds succeed.

## Changelog

No changelog entry: this corrects internal release automation and has no user-facing product behavior.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/test-classify-ci-changes.sh`
- `git diff --check`