### PR TITLE
Specify and enforce method-aware storage contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- The workspace storage contract now exhaustively specifies every pageable,
+  searchable, batched, and complete-collection method, including supported
+  query keys, cursor/count/visibility behavior, ordering, multiplicity,
+  completeness, bounds, snapshot consistency, and portable errors. Adapter
+  changes that omit a method contract now fail the architecture suite.
+- Storage semantic evidence is now method-aware: every contract method has one
+  machine-checked effect classification and direct named evidence, and the
+  context-free writer inventory is enforced exhaustively so new workflow
+  writers cannot be omitted silently.
 - **Breaking (workspace storage API):** authorization candidate reads now
   accept cursor-page query types and return `StorageCandidatePage<T>`, while
   unified-search reads return bounded pages of

--- a/crates/hubuum-storage-postgres/src/operations/authorization/queries.rs
+++ b/crates/hubuum-storage-postgres/src/operations/authorization/queries.rs
@@ -336,7 +336,9 @@ pub async fn load_authorization_group_candidates(
     let page_limit = query.page_limit();
     runtime
         .with_connection(async |connection| {
-            use crate::schema::groups::dsl::{created_at, groupname, groups, id, updated_at};
+            use crate::schema::groups::dsl::{
+                created_at, description, groupname, groups, id, revision, updated_at,
+            };
 
             let mut candidates = groups.into_boxed();
             for parameter in options.filters() {
@@ -345,11 +347,17 @@ pub async fn load_authorization_group_candidates(
                     FilterField::Name | FilterField::Groupname => {
                         crate::postgres_string_filter!(candidates, parameter, groupname)
                     }
+                    FilterField::Description => {
+                        crate::postgres_string_filter!(candidates, parameter, description)
+                    }
                     FilterField::CreatedAt => {
                         crate::postgres_datetime_filter!(candidates, parameter, created_at)
                     }
                     FilterField::UpdatedAt => {
                         crate::postgres_datetime_filter!(candidates, parameter, updated_at)
+                    }
+                    FilterField::Revision => {
+                        crate::postgres_revision_filter!(candidates, parameter, revision)
                     }
                     FilterField::Permissions => {}
                     _ => {

--- a/crates/hubuum-storage-postgres/src/operations/task_queue.rs
+++ b/crates/hubuum-storage-postgres/src/operations/task_queue.rs
@@ -400,6 +400,7 @@ pub async fn list_tasks(
 ) -> Result<StoragePage<StorageTask>, PostgresStorageError> {
     let (submitted_by, kind, status, options) = query.into_parts();
     let submitted_by = submitted_by.map(PrincipalId::id);
+    reject_query_filters(&options, "tasks")?;
     let options = crate::cursor::normalize_query_options(options, FilterField::Id, false)?;
     if options.include_total() {
         runtime
@@ -1005,6 +1006,7 @@ fn normalize_task_child_page_options(
     options: QueryOptions,
     resource: &str,
 ) -> Result<QueryOptions, PostgresStorageError> {
+    reject_query_filters(&options, resource)?;
     let options = crate::cursor::normalize_query_options(options, FilterField::Id, false)?;
     if options
         .sort()
@@ -1016,6 +1018,18 @@ fn normalize_task_child_page_options(
         )));
     }
     Ok(options)
+}
+
+fn reject_query_filters(
+    options: &QueryOptions,
+    resource: &str,
+) -> Result<(), PostgresStorageError> {
+    if options.filters().is_empty() {
+        return Ok(());
+    }
+    Err(PostgresStorageError::invalid_input(format!(
+        "QueryOptions filters are not supported for {resource}; use the typed query scope"
+    )))
 }
 
 fn decode_i64_page_cursor(
@@ -1093,7 +1107,7 @@ fn validate_positive_task_id(task_id: i32) -> Result<(), PostgresStorageError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hubuum_query::SortParam;
+    use hubuum_query::{ParsedQueryParam, SearchOperator, SortParam};
     use hubuum_storage_core::StorageErrorKind;
 
     #[test]
@@ -1122,6 +1136,46 @@ mod tests {
         .unwrap();
 
         assert_eq!(task_cursor_fields(&options).unwrap().len(), 7);
+    }
+
+    #[test]
+    fn task_pages_reject_untyped_query_filters() {
+        let options = QueryOptions::new(
+            vec![ParsedQueryParam::from_parts(
+                FilterField::Status,
+                SearchOperator::Equals { is_negated: false },
+                "queued",
+            )],
+            Vec::new(),
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+        let error = reject_query_filters(&options, "tasks").unwrap_err();
+
+        assert_eq!(error.kind(), StorageErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn task_child_pages_reject_query_filters() {
+        let options = QueryOptions::new(
+            vec![ParsedQueryParam::from_parts(
+                FilterField::Id,
+                SearchOperator::Equals { is_negated: false },
+                "1",
+            )],
+            Vec::new(),
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+        let error = normalize_task_child_page_options(options, "task events").unwrap_err();
+
+        assert_eq!(error.kind(), StorageErrorKind::InvalidInput);
     }
 
     #[test]

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -12,7 +12,7 @@ PostgreSQL is currently the only selectable backend. The in-memory resource mode
 - Use the [semantic capability group map](storage_boundary/capability-families.md)
   to find the trait that owns an operation and the groups it collaborates with.
 - Use [storage query semantics](storage_boundary/query-semantics.md) for the
-  common paging contract and the current method-specific support matrix.
+  common paging contract and the exhaustive method-specific rules.
 - Use the [backend author guide](storage_boundary/backend-author-guide.md) to implement or evaluate a backend.
 - Use the [maintainer guide](storage_boundary/maintainer-guide.md) to trace a call, locate its implementation, and change the boundary safely.
 - Use [transactions and side effects](storage_boundary/transactions-and-events.md) when a use case spans several resource operations or must define audit behavior.
@@ -20,6 +20,8 @@ PostgreSQL is currently the only selectable backend. The in-memory resource mode
 - Track deliberately deferred work in the
   [storage-boundary follow-up issues](https://github.com/hubuum/hubuum/issues?q=is%3Aissue%20is%3Aopen%20%22Deferred%20from%20%23336%22).
 - Inspect the machine-checked [semantic coverage inventory](storage_boundary/semantic-coverage.toml) for the exact methods, tracked input variants, and test evidence.
+- Inspect the machine-checked [method contract registry](storage_boundary/method-contracts.toml)
+  for exact page, candidate, batch, and complete-collection behavior.
 
 ## The Boundary in One Page
 
@@ -235,7 +237,8 @@ Moving a file does not by itself improve the boundary. Dependencies must continu
 
 The PostgreSQL path is exercised against a real migrated database by shared backend contracts, PostgreSQL-specific tests, service tests, HTTP integration tests, destructive restore tests, query-budget tests, platform and feature builds, production-container tests, and benchmarks. CI also migrates representative data from the adjacent stable release, starts the new application, and restarts the previous application against the migrated schema.
 
-The contract's methods and selected input variants are inventoried mechanically.
+The contract's methods, effects, selected input variants, and collection-shaped
+method semantics are inventoried mechanically.
 Every registered backend runs the reusable six-part audit verifier plus
 compact service, readiness, and authenticated HTTP point/list scenarios.
 Adapter-private deterministic failpoints prove rollback at representative

--- a/docs/storage_boundary/backend-author-guide.md
+++ b/docs/storage_boundary/backend-author-guide.md
@@ -53,9 +53,10 @@ convenience paths; adapters must not expect shorter aliases in capability
 modules.
 
 Read [storage query semantics](query-semantics.md) before implementing any
-pageable method. It defines the common page contract, the current
-method-specific matrix, and the remaining work required before the interface is
-promoted to a supported external adapter SDK.
+collection-shaped method. It defines the common page contract, while the
+[method contract registry](method-contracts.toml) defines every operation's
+exact carrier, supported query keys, cursor/count/visibility behavior, and
+batch or complete-read semantics.
 
 The following order minimizes rework:
 
@@ -428,9 +429,11 @@ point and list HTTP requests without registering a native client in Actix.
 
 Update `semantic-coverage.toml` when the contract or a tracked input enum
 changes. Its architecture test requires exact trait-method and variant lists
-plus an existing shared or native scenario. Native evidence is appropriate for
-transaction, notification, and driver mechanics; it must not hide a portable
-behavior that every backend should share.
+plus effect classification and method-specific shared or native evidence. Also
+update `method-contracts.toml` whenever a page, candidate, batch, or complete
+read is added or reclassified. Native evidence is appropriate for transaction,
+notification, and driver mechanics; it must not hide a portable behavior that
+every backend should share.
 
 ### Native behavior
 
@@ -488,6 +491,7 @@ A backend is selectable only when all of the following are true:
       registry includes the adapter only afterward.
 - [ ] The service and HTTP smoke contract passes through the backend fixture registry.
 - [ ] `semantic-coverage.toml` exactly inventories methods, variants, and evidence.
+- [ ] `method-contracts.toml` exactly specifies every collection-shaped method.
 - [ ] Native failure, consistency, concurrency, and recovery tests pass.
 - [ ] Service, API, CLI, worker, feature, and packaging tests pass.
 - [ ] Representative database round trips show no unexplained regression.

--- a/docs/storage_boundary/capability-families.md
+++ b/docs/storage_boundary/capability-families.md
@@ -452,5 +452,7 @@ When a semantic capability group changes, update all of the following together:
 5. Backend-native tests where consistency or failure mechanics change.
 6. `semantic-coverage.toml`, including exact methods, tracked variants, and
    shared or native scenario evidence.
-7. This document and any sanitized administrator settings affected by the
+7. `method-contracts.toml` when a page, candidate, batch, or complete read is
+   added or changed.
+8. This document and any sanitized administrator settings affected by the
    change.

--- a/docs/storage_boundary/contract.md
+++ b/docs/storage_boundary/contract.md
@@ -8,8 +8,10 @@ The exact Rust surface is `StorageBackend` in
 `crates/hubuum-storage-core/src/backend.rs`. The
 [semantic capability group map](capability-families.md) maps every required
 trait, and
-`semantic-coverage.toml` inventories every method and tracked input variant.
-Those machine-checked sources and this semantic contract must change together.
+`semantic-coverage.toml` inventories every method, effect, tracked input
+variant, and evidence scenario. `method-contracts.toml` exhaustively specifies
+every page, candidate, batch, and complete-collection method. Those
+machine-checked sources and this semantic contract must change together.
 
 ## Scope
 
@@ -302,11 +304,12 @@ reviewed as future publication boundaries and must remain usable by an
 out-of-tree adapter without root or adapter-private access.
 
 That usability is structural: an external crate can consume the types and
-implement the traits. Independent semantic certification remains future work
-until method-specific query matrices, neutral event construction, and the
-broader reusable compatibility fixtures are extracted from the application.
-See [storage query semantics](query-semantics.md) for the current query contract
-and its publication status.
+implement the traits. Method-specific query and collection behavior is now
+normative and exhaustive, but independent semantic certification still depends
+on the workspace compatibility suite. Neutral event construction, reusable
+certification packaging, and publication policy remain separate work. See
+[storage query semantics](query-semantics.md) and the
+[method contract registry](method-contracts.toml).
 
 `hubuum-storage-postgres`, `hubuum-storage-conformance`, and the root `hubuum`
 crate are workspace-internal. The conformance crate is a development dependency
@@ -334,7 +337,8 @@ Any storage-boundary change must update, as applicable:
 1. the owning trait and DTOs;
 2. the `StorageBackend` aggregate and exhaustive application dispatch;
 3. every selectable adapter;
-4. `semantic-coverage.toml` and shared conformance or compatibility scenarios;
+4. `semantic-coverage.toml`, `method-contracts.toml`, and shared conformance or
+   compatibility scenarios;
 5. backend-native consistency and failure tests;
 6. this contract and the affected capability or maintainer guide; and
 7. changelog, OpenAPI, migrations, CI classification, and container inputs

--- a/docs/storage_boundary/maintainer-guide.md
+++ b/docs/storage_boundary/maintainer-guide.md
@@ -67,7 +67,8 @@ back as `PostgresStorageError`, `StorageError`, and finally `ApiError`.
 | Reusable six-part behavioral verifier | `crates/hubuum-storage-conformance/src/lib.rs` |
 | Sealed selectable-backend certification | `src/storage/contract.rs` |
 | Method, variant, and scenario inventory | `docs/storage_boundary/semantic-coverage.toml` |
-| Common query contract and support matrices | `docs/storage_boundary/query-semantics.md` |
+| Common query contract | `docs/storage_boundary/query-semantics.md` |
+| Exact page, candidate, batch, and complete-read profiles | `docs/storage_boundary/method-contracts.toml` |
 | Boundary architecture guards | `src/tests/application_boundary.rs`, `src/tests/workspace_boundaries.rs` |
 | PostgreSQL query budgets | `src/tests/storage_performance.rs` |
 | HTTP integration suites | `tests/api_*_suite/*` |

--- a/docs/storage_boundary/method-contracts.toml
+++ b/docs/storage_boundary/method-contracts.toml
@@ -1,0 +1,935 @@
+# Normative observable contracts for collection-shaped storage methods.
+#
+# Every method classified as page_read, candidate_read, batch_read, or
+# complete_read in semantic-coverage.toml must occur exactly once below. A
+# method entry names its public carrier and one complete semantic profile.
+# Unsupported fields or combinations and malformed values both use the
+# backend-neutral errors named by the profile; adapters must not silently
+# ignore either case.
+
+[query_profiles.group]
+shape = "page"
+filters = ["id", "name/groupname", "identity_scope", "description", "created_at", "updated_at", "revision"]
+sorts = ["id", "name/groupname", "description", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "all groups visible to the caller of this storage capability"
+count = "optional exact count from the page predicate"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.principal_group]
+shape = "page"
+filters = ["id", "name/groupname", "identity_scope", "description", "created_at", "updated_at"]
+sorts = ["id", "name/groupname", "description", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "membership rows for exactly the carrier principal"
+count = "optional exact count from the page predicate"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.group_member]
+shape = "page"
+filters = ["id", "name/username", "created_at", "updated_at", "revision"]
+sorts = ["id", "name/username", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "membership rows for exactly the carrier group"
+count = "optional exact count from the page predicate"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.service_account]
+shape = "page"
+filters = ["id", "name", "identity_scope", "created_at", "updated_at", "revision", "structured"]
+sorts = ["id", "name", "identity_scope", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "administrators see all; other principals see accounts owned by their groups"
+count = "optional exact count after visibility and filters"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.user]
+shape = "page"
+filters = ["id", "name/username", "identity_scope", "proper_name", "email", "created_at", "updated_at", "revision", "structured"]
+sorts = ["id", "name/username", "identity_scope", "proper_name", "email", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "all local human users visible to this administrator capability"
+count = "optional exact count from the page predicate"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.token]
+shape = "page"
+filters = ["name", "issued_at", "expires_at", "last_used_at", "revision", "state"]
+sorts = ["id", "name", "issued_at", "expires_at", "last_used_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "tokens for exactly the carrier principal; secrets are never returned"
+count = "optional exact count using the same lifecycle observation instant"
+snapshot = "count, page, scopes, and lifecycle state share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.grant]
+shape = "page"
+filters = ["id", "name/groupname", "created_at", "updated_at", "permissions"]
+sorts = ["id", "name/groupname", "created_at", "updated_at"]
+cursor = "opaque keyset over requested sorts plus id; permissions is not sortable"
+visibility = "direct grants in the carrier collection or for the carrier principal"
+count = "optional exact count after permission containment filtering"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.permission_group]
+shape = "page"
+filters = ["id", "name/groupname", "description", "created_at", "updated_at", "revision"]
+sorts = ["id", "name/groupname", "description", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "groups with the required direct or inherited collection permission"
+count = "optional exact count from the effective-permission predicate"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.collection]
+shape = "page"
+filters = ["id", "name", "description", "created_at", "updated_at", "revision", "permissions", "structured"]
+sorts = ["id", "name", "description", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id; permissions and structured are not sortable"
+visibility = "StorageVisibility collection scope and required permissions are applied first"
+count = "optional exact count after visibility and filters"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.class]
+shape = "page"
+filters = ["id", "name", "description", "collections/collection_id", "validate_schema", "json_schema", "created_at", "updated_at", "revision", "permissions", "structured"]
+sorts = ["id", "name", "description", "collections/collection_id", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "StorageVisibility collection/resource scope and required permissions are applied first"
+count = "optional exact count after visibility and filters"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.object]
+shape = "page"
+filters = ["id", "name", "description", "collections/collection_id", "classes/class_id", "json_data", "related", "computed", "created_at", "updated_at", "revision", "permissions", "structured"]
+sorts = ["id", "name", "description", "collections/collection_id", "classes/class_id", "created_at", "updated_at", "revision", "computed"]
+cursor = "opaque keyset over normalized requested sorts plus id"
+visibility = "StorageVisibility collection/resource scope and required permissions are applied first"
+count = "optional exact count after visibility and filters"
+snapshot = "count, page, and computed projections share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds; computed execution fetches one look-ahead row"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.computed_field]
+shape = "page"
+filters = ["id", "name", "description", "class_id", "created_at", "updated_at", "revision"]
+sorts = ["id", "name", "class_id", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "definitions owned by the carrier principal in the carrier class"
+count = "optional exact count from the page predicate"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.object_aggregate]
+shape = "page"
+filters = ["target collection/class", "id", "name", "description", "collections/collection_id", "classes/class_id", "json_data", "related", "computed", "created_at", "updated_at", "revision", "structured", "group_by name/description/collection_id/created_at/updated_at/json_data/computed", "aggregate count/sum/min/max/avg"]
+sorts = ["dimensions_asc", "dimensions_desc", "object_count_asc", "object_count_desc"]
+cursor = "opaque aggregate keyset bounded by cursor_max_encoded_bytes"
+visibility = "StorageVisibility and required permissions are applied before aggregation"
+count = "optional exact number of aggregate groups"
+snapshot = "count and aggregate page share one read snapshot"
+bounds = "explicit page limit; at most 3 dimensions and 4 measures"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.class_relation]
+shape = "page"
+filters = ["id", "class_from", "class_to", "class_from_name", "class_to_name", "created_at", "updated_at", "revision", "permissions"]
+sorts = ["id", "class_from", "class_to", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "both endpoint classes must pass StorageVisibility"
+count = "optional exact count after visibility and filters"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.object_relation]
+shape = "page"
+filters = ["id", "class_relation", "object_from", "object_to", "created_at", "updated_at", "revision", "permissions"]
+sorts = ["id", "class_relation", "object_from", "object_to", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "both endpoint objects must pass StorageVisibility"
+count = "optional exact count after visibility and filters"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.relation_graph]
+shape = "page"
+filters = ["id", "object_from", "object_to", "class_from", "class_to", "classes/class_id", "collections/collection_id", "collections_from", "collections_to", "name", "name_from", "name_to", "description", "description_from", "description_to", "created_at", "created_at_from", "created_at_to", "updated_at", "updated_at_from", "updated_at_to", "depth", "path", "json_data_from", "json_data_to", "permissions"]
+sorts = ["id", "object_from", "object_to", "class_from", "class_to", "classes/class_id", "collections/collection_id", "collections_from", "collections_to", "name", "name_from", "name_to", "description", "description_from", "description_to", "created_at", "created_at_from", "created_at_to", "updated_at", "updated_at_from", "updated_at_to", "depth", "path"]
+cursor = "opaque keyset over the recursive projection plus a stable endpoint tie-breaker"
+visibility = "root and returned endpoints must pass StorageVisibility"
+count = "optional exact count of visible recursive rows"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit/cursor bounds and validated depth/path constraints"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.audit_event]
+shape = "page"
+filters = ["entity_type", "action", "entity_id", "actor_principal_id", "initiator_principal_id", "collection_id", "occurred_after", "occurred_before", "before_revision", "after_revision"]
+sorts = ["id", "occurred_at"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "accessible collection ids plus explicit collection-less visibility; indirect rows are redacted"
+count = "optional exact count after visibility, redaction eligibility, and filters"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.event_sink]
+shape = "page"
+filters = ["id", "name", "kind", "created_at", "revision"]
+sorts = ["id", "name", "kind", "created_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "administrator event configuration scope"
+count = "optional exact count from the page predicate"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.event_subscription]
+shape = "page"
+filters = ["id", "name", "created_at", "revision"]
+sorts = ["id", "name", "created_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "only subscriptions in the carrier collection"
+count = "optional exact count from the page predicate"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.event_delivery]
+shape = "page"
+filters = ["id", "status", "created_at", "updated_at", "next_attempt_at", "subscription_id"]
+sorts = ["id", "status", "created_at", "updated_at", "next_attempt_at"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "administrator delivery queue scope, optionally one subscription"
+count = "optional exact count from the page predicate"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.history]
+shape = "page"
+filters = ["revision"]
+sorts = ["history_id", "revision"]
+cursor = "opaque keyset over requested sorts plus history_id"
+visibility = "carrier collection scope is applied before resource and revision selection"
+count = "optional exact count from the page predicate"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.unified_search]
+shape = "candidate"
+filters = ["search_term", "search_extended_document"]
+sorts = ["native text rank desc", "stable resource id asc"]
+cursor = "adapter-owned rank cursor carried by each candidate"
+visibility = "StorageVisibility is applied before ranking and candidate paging"
+count = "none; application authorization decides whether an exact public total is required"
+snapshot = "each candidate page is one read; a cursor continues the same ranking projection"
+bounds = "StorageCandidatePageLimit, maximum 512"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.authorization_collection_candidate]
+shape = "candidate"
+filters = []
+sorts = ["resource id asc"]
+cursor = "opaque id cursor"
+visibility = "all collection candidates; delegated authorization runs after this read"
+count = "none; application authorization owns public totals"
+snapshot = "one bounded candidate read"
+bounds = "StorageCandidatePageLimit, maximum 512"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.authorization_group_candidate]
+shape = "candidate"
+filters = ["id", "name/groupname", "description", "created_at", "updated_at", "revision", "permissions (accepted but application-owned after candidate authorization)"]
+sorts = ["id", "name/groupname", "description", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "ordinary filters run in storage; the permissions predicate runs after delegated authorization"
+count = "none; application authorization owns public totals"
+snapshot = "one bounded candidate read"
+bounds = "StorageCandidatePageLimit, maximum 512"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.remote_target]
+shape = "page"
+filters = ["id", "name", "description", "collections/collection_id", "class_id", "kind", "created_at", "updated_at", "revision"]
+sorts = ["id", "name", "description", "collections/collection_id", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "administrator remote-target scope"
+count = "optional exact count from the page predicate"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.task]
+shape = "page"
+filters = ["typed carrier submitted_by", "typed carrier kind", "typed carrier status"]
+sorts = ["id", "kind", "status", "submitted_by", "created_at", "started_at", "finished_at"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "carrier submitter/kind/status scope prepared by task authorization"
+count = "optional exact count from the same scope"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.task_child]
+shape = "page"
+filters = []
+sorts = ["id"]
+cursor = "opaque id cursor in requested direction"
+visibility = "children of exactly the carrier task"
+count = "optional exact count for that task"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[query_profiles.export_template]
+shape = "page"
+filters = ["id", "name", "description", "collections/collection_id", "kind", "class_id", "created_at", "updated_at", "revision"]
+sorts = ["id", "name", "description", "collections/collection_id", "created_at", "updated_at", "revision"]
+cursor = "opaque keyset over requested sorts plus id"
+visibility = "carrier accessible collection ids"
+count = "optional exact count after collection visibility and filters"
+snapshot = "count and page share one read snapshot"
+bounds = "validated QueryOptions limit and cursor-byte bounds"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.tree_children]
+shape = "complete"
+ordering = "collection id ascending"
+duplicate_inputs = "not applicable: one collection id"
+missing_inputs = "unknown parent yields an empty collection"
+multiplicity = "one row per direct child"
+completeness = "all direct children"
+bounds = "bounded by stored direct-child cardinality"
+visibility = "internal lifecycle read; no additional authorization filtering"
+snapshot = "one native read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.tree_ancestors]
+shape = "complete"
+ordering = "nearest parent first, root last"
+duplicate_inputs = "not applicable: one collection id"
+missing_inputs = "unknown collection yields an empty collection"
+multiplicity = "one row per strict ancestor"
+completeness = "the complete strict ancestor chain"
+bounds = "bounded by validated collection-tree depth"
+visibility = "internal lifecycle read; no additional authorization filtering"
+snapshot = "one native recursive read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.strict_class_names]
+shape = "batch"
+ordering = "class id ascending"
+duplicate_inputs = "coalesced"
+missing_inputs = "any missing id returns NotFound and no partial result"
+multiplicity = "at most one pair per unique input id"
+completeness = "all unique ids or an error"
+bounds = "bounded by the validated input vector"
+visibility = "internal identity projection; no additional authorization filtering"
+snapshot = "one native read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.sparse_id_names]
+shape = "batch"
+ordering = "id ascending"
+duplicate_inputs = "coalesced"
+missing_inputs = "missing ids are omitted"
+multiplicity = "at most one pair per unique input id"
+completeness = "all existing unique ids"
+bounds = "bounded by the validated input vector"
+visibility = "internal identity projection; no additional authorization filtering"
+snapshot = "one native read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.scoped_complete]
+shape = "complete"
+ordering = "unspecified; callers must not depend on row order"
+duplicate_inputs = "not applicable: one scope carrier"
+missing_inputs = "an unknown or empty scope yields an empty collection unless the carrier validates it"
+multiplicity = "one row per matching persisted identity"
+completeness = "all rows in the carrier scope"
+bounds = "bounded by the persisted scope cardinality"
+visibility = "the carrier defines the complete authorized scope"
+snapshot = "one native read unless the carrier documents stronger aggregation"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.ordered_input_strict]
+shape = "batch"
+ordering = "input order, including repeated ids"
+duplicate_inputs = "preserved and repeated in output"
+missing_inputs = "any missing id returns NotFound and no partial result"
+multiplicity = "exactly one row per input element"
+completeness = "all inputs or an error"
+bounds = "bounded by the validated input vector"
+visibility = "carrier-owned scope and observation policy"
+snapshot = "one read snapshot including enrichment"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.normalized_sparse_ids]
+shape = "batch"
+ordering = "unspecified; callers must key results by returned id"
+duplicate_inputs = "sorted and coalesced by the carrier"
+missing_inputs = "missing ids are omitted"
+multiplicity = "at most one row per unique input id"
+completeness = "all existing visible unique ids"
+bounds = "bounded by the normalized carrier ids"
+visibility = "carrier StorageVisibility or authorization scope is applied before return"
+snapshot = "one native read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.normalized_boolean_all]
+shape = "batch"
+ordering = "not applicable: boolean result"
+duplicate_inputs = "sorted and coalesced by the carrier"
+missing_inputs = "missing or unauthorized ids make the result false; an empty set is true"
+multiplicity = "one boolean for the whole normalized input set"
+completeness = "true only when every unique input satisfies every required permission"
+bounds = "bounded by the normalized carrier ids"
+visibility = "principal membership and inherited collection grants"
+snapshot = "one native read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.policy_snapshot]
+shape = "complete"
+ordering = "collection id ascending, then group id ascending"
+duplicate_inputs = "not applicable: no input collection"
+missing_inputs = "an empty policy returns an empty collection"
+multiplicity = "one row per direct group-collection grant"
+completeness = "the complete local authorization policy"
+bounds = "bounded by persisted direct grant cardinality"
+visibility = "administrator/internal policy scope"
+snapshot = "one native read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.enrichment]
+shape = "batch"
+ordering = "input object order"
+duplicate_inputs = "preserved"
+missing_inputs = "not applicable: complete object values, not ids, are supplied"
+multiplicity = "exactly one enriched row per input object"
+completeness = "all supplied objects, with per-field evaluation errors represented in the row"
+bounds = "bounded by the supplied object vector and configured computed-field limits"
+visibility = "only definitions in shared scope and the optional personal-owner scope"
+snapshot = "definitions and values are read consistently for the batch"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.relation_ids]
+shape = "batch"
+ordering = "relation id ascending"
+duplicate_inputs = "sorted and coalesced by the carrier"
+missing_inputs = "ids with no visible touching/between relation contribute no rows"
+multiplicity = "one row per distinct visible relation"
+completeness = "all visible relations selected by the normalized ids"
+bounds = "bounded by input ids; object-touching queries additionally enforce max_results"
+visibility = "both endpoints must pass StorageVisibility"
+snapshot = "one native read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.related_roots]
+shape = "batch"
+ordering = "root id ascending, then requested Path/Name/CreatedAt order with stable object-id and path ties"
+duplicate_inputs = "coalesced when alternative paths are not preserved; otherwise each duplicate root preserves another copy of each path"
+missing_inputs = "missing or invisible roots contribute no rows"
+multiplicity = "one row per root/object/path according to preserve_alternative_paths"
+completeness = "all visible matches within the explicit per-root depth and limit"
+bounds = "explicit positive max_depth and per-root limit; oversized requests return InputTooLarge"
+visibility = "root and related objects must pass StorageVisibility"
+snapshot = "one native recursive read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.bidirectional_roots]
+shape = "batch"
+ordering = "root id ascending, then descendant object id, depth, and path ascending"
+duplicate_inputs = "coalesced when alternative paths are not preserved; otherwise each duplicate root preserves another copy of each path"
+missing_inputs = "missing or invisible roots contribute no rows"
+multiplicity = "one row per root/object/path according to preserve_alternative_paths"
+completeness = "all visible matches within the explicit per-root depth and cap"
+bounds = "explicit positive max_depth and per-root cap; oversized requests return InputTooLarge"
+visibility = "root and related objects must pass StorageVisibility"
+snapshot = "one native recursive read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.task_output_summaries]
+shape = "batch"
+ordering = "task id ascending"
+duplicate_inputs = "coalesced"
+missing_inputs = "tasks without the requested output kind are omitted"
+multiplicity = "at most one summary per unique task id"
+completeness = "all stored summaries for the requested ids"
+bounds = "bounded by the input task ids"
+visibility = "task authorization is performed before this storage projection"
+snapshot = "one native read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.import_names]
+shape = "batch"
+ordering = "unspecified; callers must key results by returned name and id"
+duplicate_inputs = "name inputs are coalesced"
+missing_inputs = "missing names are omitted"
+multiplicity = "one row per matching persisted resource; collection names may match more than once"
+completeness = "all matches in the carrier parent/collection/class scope"
+bounds = "bounded by the input names or stored equal-name cardinality"
+visibility = "import workflow internal scope"
+snapshot = "one native read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.import_equal_name]
+shape = "complete"
+ordering = "unspecified; callers must key results by returned collection id"
+duplicate_inputs = "not applicable: one name"
+missing_inputs = "a name with no matches yields an empty collection"
+multiplicity = "one row per persisted collection with the exact name"
+completeness = "all exact-name matches across the import-visible collection tree"
+bounds = "bounded by stored equal-name cardinality"
+visibility = "import workflow internal scope"
+snapshot = "one native read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[collection_profiles.fixed_id_complete]
+shape = "complete"
+ordering = "id ascending"
+duplicate_inputs = "optional exclusion id removes that row; otherwise not applicable"
+missing_inputs = "an empty or unknown parent scope yields an empty collection"
+multiplicity = "one row per persisted matching resource"
+completeness = "all rows in the carrier scope"
+bounds = "bounded by persisted scope cardinality"
+visibility = "carrier scope is prepared by application authorization"
+snapshot = "one native read"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
+[methods."CollectionStorage::list_collection_children"]
+effect = "complete_read"
+carrier = "CollectionId"
+profile = "tree_children"
+
+[methods."CollectionStorage::list_collection_ancestors"]
+effect = "complete_read"
+carrier = "CollectionId"
+profile = "tree_ancestors"
+
+[methods."ClassStorage::resolve_class_names"]
+effect = "batch_read"
+carrier = "Vec<ClassId>"
+profile = "strict_class_names"
+
+[methods."IdentityScopeStorage::resolve_identity_scope_names"]
+effect = "batch_read"
+carrier = "Vec<IdentityScopeId>"
+profile = "sparse_id_names"
+
+[methods."GroupMembershipStorage::list_principal_groups"]
+effect = "page_read"
+carrier = "StoragePrincipalGroupListQuery"
+profile = "principal_group"
+
+[methods."GroupMembershipStorage::load_group_member_principals"]
+effect = "complete_read"
+carrier = "GroupId"
+profile = "scoped_complete"
+
+[methods."GroupMembershipStorage::list_group_members"]
+effect = "page_read"
+carrier = "GroupId + QueryOptions"
+profile = "group_member"
+
+[methods."ServiceAccountStorage::list_manageable_service_accounts"]
+effect = "page_read"
+carrier = "StorageServiceAccountListQuery"
+profile = "service_account"
+
+[methods."UserStorage::list_users"]
+effect = "page_read"
+carrier = "StorageUserListQuery"
+profile = "user"
+
+[methods."TokenStorage::list_retained_tokens"]
+effect = "page_read"
+carrier = "StorageTokenListQuery"
+profile = "token"
+
+[methods."TokenStorage::load_token_metadata_by_ids"]
+effect = "batch_read"
+carrier = "Vec<TokenId> + StorageTokenObservation"
+profile = "ordered_input_strict"
+
+[methods."AuthorizationDataStorage::list_authorization_classes"]
+effect = "batch_read"
+carrier = "StorageAuthorizationResourceIds"
+profile = "normalized_sparse_ids"
+
+[methods."AuthorizationDataStorage::list_authorization_objects"]
+effect = "batch_read"
+carrier = "StorageAuthorizationResourceIds"
+profile = "normalized_sparse_ids"
+
+[methods."AuthorizationDataStorage::authorize_local_collections"]
+effect = "batch_read"
+carrier = "StorageAuthorizationCollectionsAccessQuery"
+profile = "normalized_boolean_all"
+
+[methods."AuthorizationDataStorage::list_local_authorized_collections"]
+effect = "complete_read"
+carrier = "StorageAuthorizationCollectionsQuery"
+profile = "scoped_complete"
+
+[methods."AuthorizationDataStorage::load_authorization_collection_candidates"]
+effect = "candidate_read"
+carrier = "StorageAuthorizationCollectionCandidateQuery"
+profile = "authorization_collection_candidate"
+
+[methods."AuthorizationDataStorage::load_authorization_group_candidates"]
+effect = "candidate_read"
+carrier = "StorageAuthorizationGroupCandidateQuery"
+profile = "authorization_group_candidate"
+
+[methods."AuthorizationDataStorage::get_authorization_policy_snapshot"]
+effect = "complete_read"
+carrier = "no arguments"
+profile = "policy_snapshot"
+
+[methods."AuthorizationDataStorage::list_local_collection_grants"]
+effect = "page_read"
+carrier = "StorageAuthorizationCollectionGrantListQuery"
+profile = "grant"
+
+[methods."CatalogStorage::list_collections"]
+effect = "page_read"
+carrier = "StorageCatalogListQuery"
+profile = "collection"
+
+[methods."CatalogStorage::list_classes"]
+effect = "page_read"
+carrier = "StorageCatalogListQuery"
+profile = "class"
+
+[methods."CatalogStorage::list_objects"]
+effect = "page_read"
+carrier = "StorageCatalogListQuery"
+profile = "object"
+
+[methods."ComputedFieldStorage::list_shared_computed_fields"]
+effect = "complete_read"
+carrier = "ClassId"
+profile = "scoped_complete"
+
+[methods."ComputedFieldStorage::list_personal_computed_fields"]
+effect = "page_read"
+carrier = "StoragePersonalComputedFieldListQuery"
+profile = "computed_field"
+
+[methods."ComputedObjectStorage::list_computed_objects"]
+effect = "page_read"
+carrier = "StorageComputedObjectListQuery"
+profile = "object"
+
+[methods."ComputedObjectStorage::enrich_objects_with_computed"]
+effect = "batch_read"
+carrier = "StorageComputedObjectEnrichmentQuery"
+profile = "enrichment"
+
+[methods."ObjectAggregateStorage::aggregate_objects"]
+effect = "page_read"
+carrier = "StorageObjectAggregateQuery + StorageObjectAggregateAuthorization"
+profile = "object_aggregate"
+
+[methods."RelationQueryStorage::list_class_relations"]
+effect = "page_read"
+carrier = "StorageRelationListQuery"
+profile = "class_relation"
+
+[methods."RelationQueryStorage::list_object_relations"]
+effect = "page_read"
+carrier = "StorageRelationListQuery"
+profile = "object_relation"
+
+[methods."RelationQueryStorage::list_class_relations_touching"]
+effect = "page_read"
+carrier = "StorageRelationTouchingQuery"
+profile = "class_relation"
+
+[methods."RelationQueryStorage::list_object_relations_touching"]
+effect = "page_read"
+carrier = "StorageRelationTouchingQuery"
+profile = "object_relation"
+
+[methods."RelationQueryStorage::list_class_relations_touching_ids"]
+effect = "batch_read"
+carrier = "StorageRelationIdsQuery"
+profile = "relation_ids"
+
+[methods."RelationQueryStorage::list_class_relations_between_ids"]
+effect = "batch_read"
+carrier = "StorageRelationIdsQuery"
+profile = "relation_ids"
+
+[methods."RelationQueryStorage::list_object_relations_touching_ids"]
+effect = "batch_read"
+carrier = "StorageObjectRelationsTouchingIdsQuery"
+profile = "relation_ids"
+
+[methods."RelationQueryStorage::list_object_relations_between_ids"]
+effect = "batch_read"
+carrier = "StorageRelationIdsQuery"
+profile = "relation_ids"
+
+[methods."RelationQueryStorage::list_related_classes"]
+effect = "page_read"
+carrier = "StorageRelationGraphQuery"
+profile = "relation_graph"
+
+[methods."RelationQueryStorage::list_related_objects"]
+effect = "page_read"
+carrier = "StorageRelationGraphQuery"
+profile = "relation_graph"
+
+[methods."RelationQueryStorage::list_related_objects_for_roots"]
+effect = "batch_read"
+carrier = "StorageRelatedObjectsForRootsQuery"
+profile = "related_roots"
+
+[methods."RelationQueryStorage::list_bidirectionally_related_objects_for_roots"]
+effect = "batch_read"
+carrier = "StorageBidirectionalRelatedObjectsQuery"
+profile = "bidirectional_roots"
+
+[methods."AuditEventStorage::list_audit_events"]
+effect = "page_read"
+carrier = "StorageAuditEventListQuery"
+profile = "audit_event"
+
+[methods."EventConfigurationStorage::list_event_sinks"]
+effect = "page_read"
+carrier = "StorageEventSinkListQuery"
+profile = "event_sink"
+
+[methods."EventConfigurationStorage::list_event_subscriptions"]
+effect = "page_read"
+carrier = "StorageEventSubscriptionListQuery"
+profile = "event_subscription"
+
+[methods."EventDeliveryAdministrationStorage::list_event_deliveries"]
+effect = "page_read"
+carrier = "StorageEventDeliveryListQuery"
+profile = "event_delivery"
+
+[methods."HistoryStorage::resolve_history_principal_names"]
+effect = "batch_read"
+carrier = "Vec<PrincipalId>"
+profile = "sparse_id_names"
+
+[methods."HistoryStorage::list_collection_history"]
+effect = "page_read"
+carrier = "StorageHistoryListQuery"
+profile = "history"
+
+[methods."HistoryStorage::list_class_history"]
+effect = "page_read"
+carrier = "StorageHistoryListQuery"
+profile = "history"
+
+[methods."HistoryStorage::list_object_history"]
+effect = "page_read"
+carrier = "StorageObjectHistoryListQuery"
+profile = "history"
+
+[methods."HistoryStorage::list_export_template_history"]
+effect = "page_read"
+carrier = "StorageHistoryListQuery"
+profile = "history"
+
+[methods."HistoryStorage::list_remote_target_history"]
+effect = "page_read"
+carrier = "StorageHistoryListQuery"
+profile = "history"
+
+[methods."OperationalStateStorage::load_export_template_health"]
+effect = "complete_read"
+carrier = "no arguments"
+profile = "fixed_id_complete"
+
+[methods."OperationalStateStorage::load_export_templates_for_audit"]
+effect = "complete_read"
+carrier = "no arguments"
+profile = "fixed_id_complete"
+
+[methods."UnifiedSearchStorage::search_collections"]
+effect = "candidate_read"
+carrier = "StorageUnifiedSearchQuery"
+profile = "unified_search"
+
+[methods."UnifiedSearchStorage::search_classes"]
+effect = "candidate_read"
+carrier = "StorageUnifiedSearchQuery"
+profile = "unified_search"
+
+[methods."UnifiedSearchStorage::search_objects"]
+effect = "candidate_read"
+carrier = "StorageUnifiedSearchQuery"
+profile = "unified_search"
+
+[methods."GroupStorage::list_groups"]
+effect = "page_read"
+carrier = "StorageGroupListQuery"
+profile = "group"
+
+[methods."CollectionAuthorizationQueryStorage::load_principal_collection_permissions"]
+effect = "complete_read"
+carrier = "StorageAuthorizationPrincipalCollectionQuery"
+profile = "scoped_complete"
+
+[methods."CollectionAuthorizationQueryStorage::list_all_principal_collection_permissions"]
+effect = "complete_read"
+carrier = "PrincipalId"
+profile = "scoped_complete"
+
+[methods."CollectionAuthorizationQueryStorage::list_principal_collection_permissions"]
+effect = "page_read"
+carrier = "StorageAuthorizationPrincipalCollectionPageQuery"
+profile = "grant"
+
+[methods."CollectionAuthorizationQueryStorage::list_effective_principal_collection_permissions"]
+effect = "complete_read"
+carrier = "StorageAuthorizationPrincipalCollectionQuery"
+profile = "scoped_complete"
+
+[methods."CollectionAuthorizationQueryStorage::list_visible_collections"]
+effect = "complete_read"
+carrier = "StorageAuthorizationCollectionVisibilityQuery"
+profile = "fixed_id_complete"
+
+[methods."CollectionAuthorizationQueryStorage::list_effective_group_collection_permissions"]
+effect = "complete_read"
+carrier = "CollectionId + GroupId"
+profile = "scoped_complete"
+
+[methods."CollectionAuthorizationQueryStorage::load_groups_with_collection_permission"]
+effect = "complete_read"
+carrier = "StorageAuthorizationCollectionGroupsQuery"
+profile = "fixed_id_complete"
+
+[methods."CollectionAuthorizationQueryStorage::list_groups_with_collection_permission"]
+effect = "page_read"
+carrier = "StorageAuthorizationCollectionGroupsPageQuery"
+profile = "permission_group"
+
+[methods."RemoteTargetStorage::list_remote_targets"]
+effect = "page_read"
+carrier = "StorageRemoteTargetListQuery"
+profile = "remote_target"
+
+[methods."TaskQueueStorage::list_tasks"]
+effect = "page_read"
+carrier = "StorageTaskListQuery"
+profile = "task"
+
+[methods."TaskQueueStorage::list_task_events"]
+effect = "page_read"
+carrier = "StorageTaskChildListQuery"
+profile = "task_child"
+
+[methods."TaskQueueStorage::list_import_task_results"]
+effect = "page_read"
+carrier = "StorageTaskChildListQuery"
+profile = "task_child"
+
+[methods."TaskQueueStorage::list_export_output_summaries"]
+effect = "batch_read"
+carrier = "Vec<TaskId>"
+profile = "task_output_summaries"
+
+[methods."TaskQueueStorage::list_backup_output_summaries"]
+effect = "batch_read"
+carrier = "Vec<TaskId>"
+profile = "task_output_summaries"
+
+[methods."ImportStorage::list_import_collections_by_name"]
+effect = "complete_read"
+carrier = "name"
+profile = "import_equal_name"
+
+[methods."ImportStorage::list_import_classes_by_names"]
+effect = "batch_read"
+carrier = "CollectionId + names"
+profile = "import_names"
+
+[methods."ImportStorage::list_import_objects_by_names"]
+effect = "batch_read"
+carrier = "ClassId + names"
+profile = "import_names"
+
+[methods."ExportTemplateStorage::list_export_templates"]
+effect = "page_read"
+carrier = "StorageExportTemplateListQuery"
+profile = "export_template"
+
+[methods."ExportTemplateStorage::list_export_templates_in_collection"]
+effect = "complete_read"
+carrier = "CollectionId + optional excluded ExportTemplateId"
+profile = "fixed_id_complete"

--- a/docs/storage_boundary/query-semantics.md
+++ b/docs/storage_boundary/query-semantics.md
@@ -5,6 +5,15 @@ backend must preserve. Method-specific query types may narrow the accepted
 filters, sorts, limits, and visibility inputs, but they must not reinterpret
 these rules.
 
+The machine-readable [method contract registry](method-contracts.toml) is the
+normative, exhaustive method-level companion to these common rules. Every
+pageable, searchable, batched, and complete-collection method names its exact
+input carrier and one profile. Query profiles define supported filter and sort
+keys, cursor, visibility, count, snapshot, bound, and error behavior.
+Collection profiles define ordering, duplicate and missing input behavior,
+multiplicity, completeness, bounds, visibility, snapshot consistency, and
+portable errors.
+
 ## Naming and Result Shapes
 
 `get_*` names one point lookup or named snapshot. A required point lookup
@@ -50,6 +59,10 @@ For every pageable operation:
    Contract-specific oversized input uses `InputTooLarge` where documented.
 8. An empty match returns an empty page and an exact total of zero when a total
    was requested. It is not `NotFound`.
+9. A field or combination absent from the method's registry profile is
+   unsupported and returns `InvalidInput`. A recognized field with a malformed
+   value or invalid operator also returns `InvalidInput`; neither case may be
+   silently ignored.
 
 `QueryOptions` is a validated carrier, not a promise that every `FilterField`
 is valid for every operation. Each capability owns its accepted subset.
@@ -86,8 +99,9 @@ it must never be higher than an explicit requested limit.
 
 ## Identity and Collection-Authorization Matrix
 
-This matrix is normative for the membership and collection-authorization page
-operations. Aliases separated by `/` address the same logical field.
+This convenience matrix is extracted from the normative registry for the
+membership and collection-authorization page operations. Aliases separated by
+`/` address the same logical field.
 
 | Operation | Filter fields | Sort fields |
 | --- | --- | --- |
@@ -101,18 +115,16 @@ operations. Aliases separated by `/` address the same logical field.
 The `permissions` filter selects grants containing the requested permission. It
 is a filter only and is not a cursor sort field.
 
-## Publication Status
+## Registry and Publication Status
 
-The common rules above are part of the workspace contract. The table is the
-first method-specific support inventory. Exact filter, sort, cursor, and
-consistency matrices for the remaining pageable capabilities, together with
-ordering, duplicate-input, missing-input, multiplicity, completeness, bounds,
-visibility, and snapshot semantics for batched or complete collection methods,
-still live across trait documentation and compatibility tests and are not yet a
-supported external-crate promise.
+The common rules and exhaustive registry are part of the workspace contract.
+The application-boundary guard derives the required registry keys from the
+method effect inventory, verifies every entry's result shape and portable error
+mapping, rejects unused profiles, and requires method-specific semantic
+evidence. Adding or reclassifying a collection-shaped method therefore requires
+updating its observable contract in the same change.
 
-Before `hubuum-storage-core` is published as an independently certifiable
-adapter SDK, maintainers must complete those method-specific query and
-collection contracts and make their drift machine-checkable. Until then, an
-out-of-tree adapter can compile against the boundary, but certification still
-requires the Hubuum workspace compatibility suite.
+This completes the method-level query and collection specification; it does
+not by itself publish `hubuum-storage-core` as a supported standalone adapter
+SDK. Crate publication, compatibility promises, versioning, and the supported
+certification entry point are a separate policy decision.

--- a/docs/storage_boundary/semantic-coverage.toml
+++ b/docs/storage_boundary/semantic-coverage.toml
@@ -1,14 +1,17 @@
 # Machine-checked inventory of the complete storage contract.
 #
-# `methods` must exactly match the named trait. `shared_scenarios` point to
+# `methods` must exactly match the named trait. `effects` classifies every
+# method exactly once as an observation, read shape, validation, mutation,
+# execution scope, or transaction. `shared_scenarios` point to
 # registry-driven compatibility tests, resource-service contracts, or focused
 # contract scenarios. `native_scenarios` identify adapter-only evidence for
 # mechanics that should not leak into the logical contract.
 
-# Review-maintained inventory of known complete-backend methods that can
-# durably write without accepting an EventContext. The guard verifies that
-# every listed name is a real method, but does not yet infer every writer from
-# method bodies. Every entry is a non-ordinary mutation; ordinary domain
+# Review-maintained classification of complete-backend methods that can
+# durably write without accepting an EventContext. The guard requires this set
+# to match the methods classified as observation or workflow_mutation exactly,
+# so a new context-free writer cannot be omitted silently. Every entry is a
+# non-ordinary mutation; ordinary domain
 # mutations are required to carry context and return a StorageMutationOutcome. Keep
 # this inventory and transactions-and-events.md aligned.
 [context_free_mutations]
@@ -64,227 +67,271 @@ maintenance = [
 [traits.CollectionStorage]
 source = "crates/hubuum-storage-core/src/resource_lifecycle.rs"
 methods = ["get_collection", "create_collection", "update_collection", "delete_collection", "list_collection_children", "list_collection_ancestors", "move_collection"]
-shared_scenarios = ["src/services/collections.rs::collection_contract_create_is_visible_to_point_reads", "src/services/collections.rs::collection_contract_move_reparents_the_subtree"]
+effects = { point_read = ["get_collection"], complete_read = ["list_collection_children", "list_collection_ancestors"], audited_mutation = ["create_collection", "update_collection", "delete_collection", "move_collection"] }
+shared_scenarios = ["src/services/collections.rs::collection_contract_create_is_visible_to_point_reads", "src/services/collections.rs::collection_contract_move_reparents_the_subtree", "src/tests/storage_contract.rs::every_available_storage_backend_supplies_collection_lifecycle"]
 native_scenarios = ["src/tests/storage_contract.rs::postgres_rolls_back_a_compound_collection_create_at_an_injected_failure"]
 
 [traits.ClassStorage]
 source = "crates/hubuum-storage-core/src/resource_lifecycle.rs"
 methods = ["resolve_class", "create_class", "update_class", "delete_class", "resolve_class_names"]
-shared_scenarios = ["src/services/classes.rs::class_contract_resolves_explicit_addresses", "src/services/classes.rs::class_contract_delete_removes_the_resolved_class"]
+effects = { point_read = ["resolve_class"], batch_read = ["resolve_class_names"], audited_mutation = ["create_class", "update_class", "delete_class"] }
+shared_scenarios = ["src/services/classes.rs::class_contract_resolves_explicit_addresses", "src/services/classes.rs::class_contract_delete_removes_the_resolved_class", "src/tests/storage_contract.rs::every_available_storage_backend_supplies_class_lifecycle"]
 
 [traits.ObjectStorage]
 source = "crates/hubuum-storage-core/src/resource_lifecycle.rs"
 methods = ["get_object", "resolve_object", "create_object", "update_object", "patch_object_data", "delete_object", "validate_object", "validate_object_create", "validate_object_update"]
-shared_scenarios = ["src/services/objects.rs::object_contract_resolves_explicit_addresses", "src/services/objects.rs::object_contract_delete_removes_the_resolved_object"]
+effects = { point_read = ["get_object", "resolve_object"], validation = ["validate_object", "validate_object_create", "validate_object_update"], audited_mutation = ["create_object", "update_object", "patch_object_data", "delete_object"] }
+shared_scenarios = ["src/services/objects.rs::object_contract_resolves_explicit_addresses", "src/services/objects.rs::object_contract_delete_removes_the_resolved_object", "src/tests/storage_contract.rs::every_available_storage_backend_supplies_object_lifecycle"]
 
 [traits.ClassRelationStorage]
 source = "crates/hubuum-storage-core/src/relation_lifecycle.rs"
 methods = ["prepare_class_relation", "resolve_class_relation", "create_class_relation", "delete_class_relation"]
-shared_scenarios = ["src/services/class_relations.rs::class_relation_contract_creates_and_resolves_the_endpoint_aggregate", "src/services/class_relations.rs::class_relation_contract_deletes_the_resolved_relation"]
+effects = { point_read = ["resolve_class_relation"], validation = ["prepare_class_relation"], audited_mutation = ["create_class_relation", "delete_class_relation"] }
+shared_scenarios = ["src/services/class_relations.rs::class_relation_contract_creates_and_resolves_the_endpoint_aggregate", "src/services/class_relations.rs::class_relation_contract_deletes_the_resolved_relation", "src/tests/storage_contract.rs::every_available_storage_backend_supplies_relation_lifecycle"]
 
 [traits.ObjectRelationStorage]
 source = "crates/hubuum-storage-core/src/relation_lifecycle.rs"
 methods = ["prepare_object_relation", "resolve_object_relation", "create_object_relation", "delete_object_relation"]
-shared_scenarios = ["src/services/object_relations.rs::object_relation_contract_prepares_a_normalized_endpoint_aggregate", "src/services/object_relations.rs::object_relation_contract_deletes_the_resolved_relation"]
+effects = { point_read = ["resolve_object_relation"], validation = ["prepare_object_relation"], audited_mutation = ["create_object_relation", "delete_object_relation"] }
+shared_scenarios = ["src/services/object_relations.rs::object_relation_contract_prepares_a_normalized_endpoint_aggregate", "src/services/object_relations.rs::object_relation_contract_deletes_the_resolved_relation", "src/tests/storage_contract.rs::every_available_storage_backend_supplies_relation_lifecycle"]
 
 [traits.AuthenticationStorage]
 source = "crates/hubuum-storage-core/src/identity.rs"
 methods = ["authenticate_bearer_token", "get_authentication_identity", "get_authentication_token_scope"]
+effects = { observation = ["authenticate_bearer_token"], point_read = ["get_authentication_identity", "get_authentication_token_scope"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_authentication_projections"]
 
 [traits.LocalIdentityCredentialStorage]
 source = "crates/hubuum-storage-core/src/identity_operations.rs"
 methods = ["is_default_admin_bootstrap_required", "bootstrap_default_admin", "reset_local_password"]
+effects = { point_read = ["is_default_admin_bootstrap_required"], audited_mutation = ["reset_local_password"], workflow_mutation = ["bootstrap_default_admin"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_identity_operations"]
 
 [traits.IdentityScopeStorage]
 source = "crates/hubuum-storage-core/src/identity_operations.rs"
 methods = ["ensure_identity_scope", "resolve_identity_scope_name", "resolve_identity_scope_names"]
+effects = { point_read = ["resolve_identity_scope_name"], batch_read = ["resolve_identity_scope_names"], workflow_mutation = ["ensure_identity_scope"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_identity_operations"]
 
 [traits.GroupMembershipStorage]
 source = "crates/hubuum-storage-core/src/identity_operations.rs"
 methods = ["get_principal_group", "list_principal_groups", "is_human_owner_group_member", "load_group_member_principals", "list_group_members", "add_group_member", "remove_group_member"]
+effects = { point_read = ["get_principal_group", "is_human_owner_group_member"], page_read = ["list_principal_groups", "list_group_members"], complete_read = ["load_group_member_principals"], audited_mutation = ["add_group_member", "remove_group_member"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_identity_operations", "src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_group_behavior"]
 native_scenarios = ["crates/hubuum-storage-postgres/tests/connection_loss.rs::connection_loss_before_commit_rolls_back_and_pool_recovers"]
 
 [traits.ServiceAccountStorage]
 source = "crates/hubuum-storage-core/src/identity_operations.rs"
 methods = ["is_service_account_disabled", "get_service_account", "get_service_account_details", "list_manageable_service_accounts", "create_service_account", "update_service_account", "disable_service_account", "delete_service_account"]
+effects = { point_read = ["is_service_account_disabled", "get_service_account", "get_service_account_details"], page_read = ["list_manageable_service_accounts"], audited_mutation = ["create_service_account", "update_service_account", "disable_service_account", "delete_service_account"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_identity_operations"]
 
 [traits.ExternalIdentityStorage]
 source = "crates/hubuum-storage-core/src/identity_operations.rs"
 methods = ["get_external_principal_state", "mark_external_sync_attempted", "sync_external_user"]
+effects = { point_read = ["get_external_principal_state"], workflow_mutation = ["mark_external_sync_attempted", "sync_external_user"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_identity_operations"]
 
 [traits.UserStorage]
 source = "crates/hubuum-storage-core/src/identity_users.rs"
 methods = ["get_user", "get_user_by_name", "get_user_details", "list_users", "create_user", "update_user", "set_user_password", "delete_user", "anonymize_user"]
+effects = { point_read = ["get_user", "get_user_by_name", "get_user_details"], page_read = ["list_users"], audited_mutation = ["create_user", "update_user", "set_user_password", "delete_user", "anonymize_user"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_identity_operations"]
 
 [traits.TokenStorage]
 source = "crates/hubuum-storage-core/src/identity_tokens.rs"
 methods = ["list_retained_tokens", "create_token", "renew_token", "get_token_metadata", "load_token_metadata_by_ids", "revoke_token", "revoke_token_by_hash", "revoke_all_principal_tokens"]
+effects = { point_read = ["get_token_metadata"], page_read = ["list_retained_tokens"], batch_read = ["load_token_metadata_by_ids"], audited_mutation = ["create_token", "renew_token", "revoke_token", "revoke_token_by_hash", "revoke_all_principal_tokens"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_identity_operations"]
 
 [traits.AuthorizationDataStorage]
 source = "crates/hubuum-storage-core/src/authorization.rs"
 methods = ["get_authorization_principal", "is_authorization_principal_group_member", "list_authorization_classes", "list_authorization_objects", "authorize_local_collection", "authorize_local_collections", "list_local_authorized_collections", "load_authorization_collection_candidates", "load_authorization_group_candidates", "get_authorization_policy_snapshot", "list_local_collection_grants", "get_local_collection_grant", "get_local_collection_permission_set", "apply_local_collection_grant", "revoke_local_collection_grant", "revoke_all_local_collection_grants"]
+effects = { point_read = ["get_authorization_principal", "is_authorization_principal_group_member", "authorize_local_collection", "get_local_collection_grant", "get_local_collection_permission_set"], page_read = ["list_local_collection_grants"], candidate_read = ["load_authorization_collection_candidates", "load_authorization_group_candidates"], batch_read = ["list_authorization_classes", "list_authorization_objects", "authorize_local_collections"], complete_read = ["list_local_authorized_collections", "get_authorization_policy_snapshot"], audited_mutation = ["apply_local_collection_grant", "revoke_local_collection_grant", "revoke_all_local_collection_grants"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_local_authorization_data"]
 
 [traits.CatalogStorage]
 source = "crates/hubuum-storage-core/src/catalog.rs"
 methods = ["list_collections", "list_classes", "list_objects"]
+effects = { page_read = ["list_collections", "list_classes", "list_objects"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_catalog_queries"]
 
 [traits.ComputedFieldStorage]
 source = "crates/hubuum-storage-core/src/computed_fields.rs"
 methods = ["get_computed_field_state", "list_shared_computed_fields", "list_personal_computed_fields", "get_computed_field", "create_shared_computed_field", "update_shared_computed_field", "delete_shared_computed_field", "create_personal_computed_field", "update_personal_computed_field", "delete_personal_computed_field", "request_computed_field_rebuild", "execute_computed_field_rebuild"]
+effects = { point_read = ["get_computed_field_state", "get_computed_field"], page_read = ["list_personal_computed_fields"], complete_read = ["list_shared_computed_fields"], audited_mutation = ["create_shared_computed_field", "update_shared_computed_field", "delete_shared_computed_field", "create_personal_computed_field", "update_personal_computed_field", "delete_personal_computed_field"], workflow_mutation = ["request_computed_field_rebuild", "execute_computed_field_rebuild"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_computed_fields"]
 
 [traits.ComputedObjectStorage]
 source = "crates/hubuum-storage-core/src/computed_objects.rs"
 methods = ["list_computed_objects", "enrich_objects_with_computed"]
+effects = { page_read = ["list_computed_objects"], batch_read = ["enrich_objects_with_computed"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_computed_object_queries"]
 
 [traits.ObjectAggregateStorage]
 source = "crates/hubuum-storage-core/src/object_aggregate.rs"
 methods = ["aggregate_objects"]
+effects = { page_read = ["aggregate_objects"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_object_aggregates"]
 
 [traits.RelationQueryStorage]
 source = "crates/hubuum-storage-core/src/relation_query.rs"
 methods = ["list_class_relations", "list_object_relations", "list_class_relations_touching", "list_object_relations_touching", "list_class_relations_touching_ids", "list_class_relations_between_ids", "list_object_relations_touching_ids", "list_object_relations_between_ids", "list_related_classes", "list_related_objects", "list_related_objects_for_roots", "list_bidirectionally_related_objects_for_roots"]
+effects = { page_read = ["list_class_relations", "list_object_relations", "list_class_relations_touching", "list_object_relations_touching", "list_related_classes", "list_related_objects"], batch_read = ["list_class_relations_touching_ids", "list_class_relations_between_ids", "list_object_relations_touching_ids", "list_object_relations_between_ids", "list_related_objects_for_roots", "list_bidirectionally_related_objects_for_roots"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_relation_queries"]
 
 [traits.AuditEventStorage]
 source = "crates/hubuum-storage-core/src/event_administration.rs"
 methods = ["list_audit_events"]
+effects = { page_read = ["list_audit_events"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_event_administration"]
 
 [traits.EventConfigurationStorage]
 source = "crates/hubuum-storage-core/src/event_administration.rs"
 methods = ["count_enabled_event_sinks", "list_event_sinks", "get_event_sink", "create_event_sink", "update_event_sink", "delete_event_sink", "list_event_subscriptions", "get_event_subscription", "create_event_subscription", "update_event_subscription", "delete_event_subscription"]
+effects = { point_read = ["count_enabled_event_sinks", "get_event_sink", "get_event_subscription"], page_read = ["list_event_sinks", "list_event_subscriptions"], audited_mutation = ["create_event_sink", "update_event_sink", "delete_event_sink", "create_event_subscription", "update_event_subscription", "delete_event_subscription"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_event_administration"]
 
 [traits.EventDeliveryAdministrationStorage]
 source = "crates/hubuum-storage-core/src/event_administration.rs"
 methods = ["list_event_deliveries", "get_event_delivery", "release_event_delivery_for_retry", "mark_event_delivery_dead"]
+effects = { point_read = ["get_event_delivery"], page_read = ["list_event_deliveries"], workflow_mutation = ["release_event_delivery_for_retry", "mark_event_delivery_dead"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_event_administration"]
 
 [traits.EventDeliveryWorkerStorage]
 source = "crates/hubuum-storage-core/src/events.rs"
 methods = ["claim_event_delivery_batch", "mark_event_delivery_succeeded", "mark_event_delivery_failed"]
-shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_composes_through_services_and_http"]
+effects = { workflow_mutation = ["claim_event_delivery_batch", "mark_event_delivery_succeeded", "mark_event_delivery_failed"] }
+shared_scenarios = ["src/events/delivery.rs::process_event_delivery_batch_with_schedule", "src/events/delivery.rs::process_event_delivery_work_item", "src/tests/storage_contract.rs::every_available_storage_backend_composes_through_services_and_http"]
 native_scenarios = ["src/tests/storage_contract.rs::postgres_delivery_faults_preserve_claim_acknowledgement_and_retry_recovery"]
 
 [traits.EventFanoutStorage]
 source = "crates/hubuum-storage-core/src/events.rs"
 methods = ["process_event_fanout_batch"]
+effects = { workflow_mutation = ["process_event_fanout_batch"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_processes_event_fanout"]
 
 [traits.EventHealthStorage]
 source = "crates/hubuum-storage-core/src/operational.rs"
 methods = ["get_event_delivery_health"]
+effects = { point_read = ["get_event_delivery_health"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_event_health"]
 
 [traits.EventRetentionStorage]
 source = "crates/hubuum-storage-core/src/events.rs"
 methods = ["claim_event_retention_batch", "complete_event_retention_batch"]
-shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_processes_event_retention"]
+effects = { workflow_mutation = ["claim_event_retention_batch", "complete_event_retention_batch"] }
+shared_scenarios = ["crates/hubuum-storage-core/src/events.rs::execute_event_retention_batch", "src/tests/storage_contract.rs::every_available_storage_backend_processes_event_retention"]
 
 [traits.HistoryStorage]
 source = "crates/hubuum-storage-core/src/history.rs"
 methods = ["resolve_history_principal_names", "list_collection_history", "get_collection_history_as_of", "list_class_history", "get_class_history_as_of", "list_object_history", "get_object_history_as_of", "list_export_template_history", "get_export_template_history_as_of", "list_remote_target_history", "get_remote_target_history_as_of"]
+effects = { point_read = ["get_collection_history_as_of", "get_class_history_as_of", "get_object_history_as_of", "get_export_template_history_as_of", "get_remote_target_history_as_of"], page_read = ["list_collection_history", "list_class_history", "list_object_history", "list_export_template_history", "list_remote_target_history"], batch_read = ["resolve_history_principal_names"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_temporal_history"]
 
 [traits.InventoryStorage]
 source = "crates/hubuum-storage-core/src/inventory.rs"
 methods = ["get_inventory_counts"]
+effects = { point_read = ["get_inventory_counts"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_consistent_inventory_counts"]
 
 [traits.MetricsStorage]
 source = "crates/hubuum-storage-core/src/metrics.rs"
 methods = ["get_inventory_metrics_snapshot", "get_task_metrics_snapshot", "get_event_metrics_snapshot"]
+effects = { point_read = ["get_inventory_metrics_snapshot", "get_task_metrics_snapshot", "get_event_metrics_snapshot"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_metrics_snapshots"]
 
 [traits.OperationalStateStorage]
 source = "crates/hubuum-storage-core/src/operational.rs"
 methods = ["get_readiness_snapshot", "get_maintenance_state", "get_task_queue_snapshot", "load_export_template_health", "load_export_templates_for_audit"]
+effects = { point_read = ["get_readiness_snapshot", "get_maintenance_state", "get_task_queue_snapshot"], complete_read = ["load_export_template_health", "load_export_templates_for_audit"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_operational_state"]
 
 [traits.TokenRetentionStorage]
 source = "crates/hubuum-storage-core/src/operational.rs"
 methods = ["purge_expired_tokens"]
+effects = { workflow_mutation = ["purge_expired_tokens"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_token_retention"]
 
 [traits.UnifiedSearchStorage]
 source = "crates/hubuum-storage-core/src/unified_search.rs"
 methods = ["search_collections", "search_classes", "search_objects"]
+effects = { candidate_read = ["search_collections", "search_classes", "search_objects"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_ranked_unified_search"]
 
 [traits.GroupStorage]
 source = "crates/hubuum-storage-core/src/identity_resources.rs"
 methods = ["list_groups", "get_group", "resolve_group_identity_scope_name", "create_group", "update_group", "delete_group"]
+effects = { point_read = ["get_group", "resolve_group_identity_scope_name"], page_read = ["list_groups"], audited_mutation = ["create_group", "update_group", "delete_group"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_group_behavior"]
 
 [traits.PrincipalStorage]
 source = "crates/hubuum-storage-core/src/identity_resources.rs"
 methods = ["get_principal", "get_principal_settings", "update_principal_settings"]
+effects = { point_read = ["get_principal", "get_principal_settings"], audited_mutation = ["update_principal_settings"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_principal_behavior"]
 
 [traits.CollectionAuthorizationQueryStorage]
 source = "crates/hubuum-storage-core/src/collection_authorization.rs"
 methods = ["load_principal_collection_permissions", "list_all_principal_collection_permissions", "list_principal_collection_permissions", "list_effective_principal_collection_permissions", "list_visible_collections", "has_group_collection_permission", "list_effective_group_collection_permissions", "load_groups_with_collection_permission", "list_groups_with_collection_permission"]
+effects = { point_read = ["has_group_collection_permission"], page_read = ["list_principal_collection_permissions", "list_groups_with_collection_permission"], complete_read = ["load_principal_collection_permissions", "list_all_principal_collection_permissions", "list_effective_principal_collection_permissions", "list_visible_collections", "list_effective_group_collection_permissions", "load_groups_with_collection_permission"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_local_authorization_data"]
 
 [traits.RemoteTargetStorage]
 source = "crates/hubuum-storage-core/src/remote_target.rs"
 methods = ["get_remote_target", "list_remote_targets", "create_remote_target", "update_remote_target", "delete_remote_target", "record_remote_target_invocation"]
+effects = { point_read = ["get_remote_target"], page_read = ["list_remote_targets"], audited_mutation = ["create_remote_target", "update_remote_target", "delete_remote_target", "record_remote_target_invocation"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_remote_target_lifecycle"]
 
 [traits.TaskQueueStorage]
 source = "crates/hubuum-storage-core/src/task_queue.rs"
 methods = ["create_task", "get_task_access", "list_tasks", "list_task_events", "list_import_task_results", "list_export_output_summaries", "list_backup_output_summaries", "get_export_output_summary", "get_backup_output_summary", "get_export_output", "get_backup_output"]
+effects = { point_read = ["get_task_access", "get_export_output_summary", "get_backup_output_summary", "get_export_output", "get_backup_output"], page_read = ["list_tasks", "list_task_events", "list_import_task_results"], batch_read = ["list_export_output_summaries", "list_backup_output_summaries"], workflow_mutation = ["create_task"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_the_complete_task_queue"]
 
 [traits.TaskExecutionStorage]
 source = "crates/hubuum-storage-core/src/task_execution.rs"
 methods = ["claim_next_task", "renew_task_lease", "recover_expired_task_leases", "append_task_event", "update_task_state", "complete_task", "fail_task", "purge_expired_export_outputs", "purge_expired_backup_outputs"]
+effects = { workflow_mutation = ["claim_next_task", "renew_task_lease", "recover_expired_task_leases", "append_task_event", "update_task_state", "complete_task", "fail_task", "purge_expired_export_outputs", "purge_expired_backup_outputs"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_the_complete_task_state_machine"]
 native_scenarios = ["src/tests/storage_contract.rs::postgres_rolls_back_task_finalization_at_an_injected_failure", "src/tests/storage_contract.rs::postgres_task_page_count_and_rows_share_one_snapshot", "src/tests/storage_contract.rs::postgres_lease_renewal_loss_expires_and_finalizes_without_replay"]
 
 [traits.BackupSnapshotStorage]
 source = "crates/hubuum-storage-core/src/backup_snapshot.rs"
 methods = ["capture_backup_snapshot"]
+effects = { point_read = ["capture_backup_snapshot"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_backup_snapshots"]
 
 [traits.RestoreStorage]
 source = "crates/hubuum-storage-core/src/restore.rs"
 methods = ["stage_restore", "get_restore_job", "get_restore_status", "expire_restore_stage", "start_restore_draining", "apply_restore", "fail_restore_and_resume", "get_restore_coordinator_snapshot", "resume_maintenance_without_restore", "resume_terminal_restore", "tick_restore_coordinator", "get_restore_drain_state", "remove_restore_instance"]
-shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_restore_lifecycle_and_coordination"]
+effects = { point_read = ["get_restore_job", "get_restore_status", "get_restore_coordinator_snapshot", "get_restore_drain_state"], workflow_mutation = ["stage_restore", "expire_restore_stage", "start_restore_draining", "apply_restore", "fail_restore_and_resume", "resume_maintenance_without_restore", "resume_terminal_restore", "tick_restore_coordinator", "remove_restore_instance"] }
+shared_scenarios = ["src/restores/mod.rs::confirm_restore", "src/restores/mod.rs::apply_restore", "src/tests/storage_contract.rs::every_available_storage_backend_supplies_restore_lifecycle_and_coordination"]
 native_scenarios = ["tests/restore_roundtrip.rs::interrupted_restore_is_reconciled_after_the_drain_transition", "src/tests/storage_contract.rs::postgres_restore_faults_roll_back_coordination_transitions"]
 
 [traits.ImportStorage]
 source = "crates/hubuum-storage-core/src/import_workflow.rs"
 methods = ["get_import_root_collection", "get_import_collection_by_id", "get_import_collection_by_key", "list_import_collections_by_name", "get_import_collection_child_by_name", "get_import_class_by_name", "list_import_classes_by_names", "get_import_object_by_name", "list_import_objects_by_names", "has_import_class_relation", "has_import_object_relation", "has_import_group", "preflight_import", "apply_import_strict", "apply_import_best_effort", "record_import_results"]
-shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_the_complete_import_contract"]
+effects = { point_read = ["get_import_root_collection", "get_import_collection_by_id", "get_import_collection_by_key", "get_import_collection_child_by_name", "get_import_class_by_name", "get_import_object_by_name", "has_import_class_relation", "has_import_object_relation", "has_import_group"], batch_read = ["list_import_classes_by_names", "list_import_objects_by_names"], complete_read = ["list_import_collections_by_name"], validation = ["preflight_import"], workflow_mutation = ["apply_import_strict", "apply_import_best_effort", "record_import_results"] }
+shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_the_complete_import_contract", "src/tests/storage_contract.rs::every_available_storage_backend_supplies_the_complete_task_queue"]
 
 [traits.ExportTemplateStorage]
 source = "crates/hubuum-storage-core/src/export_template_lifecycle.rs"
 methods = ["get_export_template", "list_export_templates", "list_export_templates_in_collection", "create_export_template", "replace_export_template", "delete_export_template"]
+effects = { point_read = ["get_export_template"], page_read = ["list_export_templates"], complete_read = ["list_export_templates_in_collection"], audited_mutation = ["create_export_template", "replace_export_template", "delete_export_template"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_export_template_lifecycle"]
 
 [traits.ExecutionStorage]
 source = "crates/hubuum-storage-core/src/execution.rs"
 methods = ["run_in_scope", "run_in_scope_send"]
+effects = { execution_scope = ["run_in_scope", "run_in_scope_send"] }
 shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_execution_context", "src/tests/storage_contract.rs::every_available_storage_backend_supplies_the_export_query_scope"]
 
 [traits.TransactionStorage]
 source = "crates/hubuum-storage-core/src/transaction.rs"
 methods = ["with_transaction"]
-shared_scenarios = ["src/tests/storage_transactions.rs::memory_transaction_composes_resources_and_rolls_back_events", "src/tests/storage_transactions.rs::postgres_transaction_composes_resources_and_rolls_back_events"]
+effects = { transaction = ["with_transaction"] }
+shared_scenarios = ["src/tests/storage_transactions.rs::exercise_resource_transaction", "src/tests/storage_transactions.rs::memory_transaction_composes_resources_and_rolls_back_events", "src/tests/storage_transactions.rs::postgres_transaction_composes_resources_and_rolls_back_events"]
 
 # Boundary enums accepted by backend methods or dispatch. The inventory is
 # exact: adding a variant requires consciously extending its semantic evidence.

--- a/docs/storage_boundary/testing.md
+++ b/docs/storage_boundary/testing.md
@@ -101,10 +101,16 @@ module-system proof against every possible indirect dependency.
 The same architecture suite reads
 `docs/storage_boundary/semantic-coverage.toml`. The inventory must match the
 aggregate trait set, each trait's methods, and each tracked boundary enum's
-variants exactly. Every entry must point to a test function that exists. A new
-method or variant therefore fails locally until its intended semantic evidence
-is recorded. The guard does not inspect test bodies or construct a call graph,
-so invocation and assertion depth remain review responsibilities. The
+variants exactly. Every method must have exactly one effect classification,
+and the context-free mutation set must exactly match the observation and
+workflow-mutation classifications. Named evidence must exist, collectively
+invoke every method directly, and contain an effect assertion. A new method or
+variant therefore fails locally until its intended semantic evidence is
+recorded. The guard does not construct a transitive call graph, so whether a
+helper's assertion proves the relevant effect remains a review responsibility.
+The suite also reads `docs/storage_boundary/method-contracts.toml` and requires
+exact coverage for every page, candidate, batch, and complete read, including
+complete profiles and portable error mappings. The
 observation guard derives its expected method count from this same inventory,
 including resource-operation methods observed by `ObservedStorage`, rather than
 maintaining a second hand-written operation list.

--- a/docs/storage_boundary/transactions-and-events.md
+++ b/docs/storage_boundary/transactions-and-events.md
@@ -117,12 +117,14 @@ ordinary user mutations.
 The following review-maintained list is intended to cover every
 `StorageBackend` method that may durably write without accepting an
 `EventContext`. They are deliberately outside the ordinary audited-mutation
-category. The current guard proves that each listed name is a real trait method;
-it does not yet infer write effects from method bodies or mechanically prove
-the reverse direction. That inference is deferred. Until it exists, reviewers
-must add every new context-free writer to `semantic-coverage.toml`, place it in
-one of these semantic categories, and review it here. An ordinary resource or
-configuration mutation is not eligible for an exception.
+category. Every contract method now has exactly one effect classification, and
+the guard requires this inventory to equal the union of `observation` and
+`workflow_mutation` methods. Reviewers must classify and test a new
+context-free writer, add it to the appropriate category here and in
+`semantic-coverage.toml`, or the architecture suite fails. Source inspection
+does not infer write effects, so choosing the correct effect remains a review
+responsibility. An ordinary resource or configuration mutation is not eligible
+for an exception.
 
 - Best-effort observation: `AuthenticationStorage::authenticate_bearer_token`
   may throttle-write token use time. This does not change authorization or

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -136,7 +136,20 @@ fn storage_semantic_manifest(root: &Path) -> toml::Value {
 }
 
 #[cfg(test)]
+fn storage_method_contract_manifest(root: &Path) -> toml::Value {
+    let path = root.join("docs/storage_boundary/method-contracts.toml");
+    let source = read_source(&path)
+        .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+    toml::from_str(&source).expect("storage method contracts should be valid TOML")
+}
+
+#[cfg(test)]
 fn assert_scenario_exists(root: &Path, scenario: &str) {
+    let _ = scenario_body(root, scenario);
+}
+
+#[cfg(test)]
+fn scenario_body(root: &Path, scenario: &str) -> String {
     let (path, symbol) = scenario.split_once("::").unwrap_or_else(|| {
         panic!("semantic coverage scenario must use path::symbol syntax: {scenario}")
     });
@@ -147,6 +160,35 @@ fn assert_scenario_exists(root: &Path, scenario: &str) {
         source.contains(&format!("fn {symbol}")),
         "semantic coverage scenario {scenario} does not name a function in its source"
     );
+    item_body(&source, "fn", symbol).to_string()
+}
+
+#[cfg(test)]
+const STORAGE_METHOD_EFFECTS: &[&str] = &[
+    "observation",
+    "point_read",
+    "page_read",
+    "candidate_read",
+    "batch_read",
+    "complete_read",
+    "validation",
+    "audited_mutation",
+    "workflow_mutation",
+    "execution_scope",
+    "transaction",
+];
+
+#[cfg(test)]
+fn scenario_asserts_an_effect(body: &str) -> bool {
+    [
+        "assert!(",
+        "assert_eq!(",
+        "assert_ne!(",
+        "matches!(",
+        ".expect_err(",
+    ]
+    .iter()
+    .any(|assertion| body.contains(assertion))
 }
 
 #[cfg(test)]
@@ -317,6 +359,7 @@ fn storage_semantic_coverage_inventory_matches_traits_variants_and_evidence() {
         "storage family bounds and semantic inventory must change together"
     );
 
+    let mut missing_method_evidence = Vec::new();
     for (trait_name, value) in traits {
         let entry = value
             .as_table()
@@ -327,10 +370,45 @@ fn storage_semantic_coverage_inventory_matches_traits_variants_and_evidence() {
             .unwrap_or_else(|| panic!("trait {trait_name} is missing its source"));
         let source = read_source(&root.join(source_path))
             .unwrap_or_else(|error| panic!("could not read {source_path}: {error}"));
+        let methods = toml_string_set(entry, "methods");
         assert_eq!(
-            toml_string_set(entry, "methods"),
+            methods,
             trait_methods(&source, trait_name),
             "trait method inventory drifted for {trait_name}"
+        );
+
+        let effects = entry
+            .get("effects")
+            .and_then(toml::Value::as_table)
+            .unwrap_or_else(|| {
+                panic!("trait {trait_name} is missing method effect classifications")
+            });
+        let mut classified_methods = BTreeSet::new();
+        for (effect, values) in effects {
+            assert!(
+                STORAGE_METHOD_EFFECTS.contains(&effect.as_str()),
+                "trait {trait_name} uses unknown method effect {effect}"
+            );
+            let values = values
+                .as_array()
+                .unwrap_or_else(|| panic!("trait {trait_name} effect {effect} must be an array"));
+            for value in values {
+                let method = value.as_str().unwrap_or_else(|| {
+                    panic!("trait {trait_name} effect {effect} entries must be method names")
+                });
+                assert!(
+                    methods.contains(method),
+                    "trait {trait_name} effect {effect} names unknown method {method}"
+                );
+                assert!(
+                    classified_methods.insert(method.to_string()),
+                    "trait {trait_name} method {method} has more than one effect"
+                );
+            }
+        }
+        assert_eq!(
+            classified_methods, methods,
+            "trait {trait_name} must classify every method effect exactly once"
         );
 
         let scenarios = ["shared_scenarios", "native_scenarios"]
@@ -342,10 +420,31 @@ fn storage_semantic_coverage_inventory_matches_traits_variants_and_evidence() {
             !scenarios.is_empty(),
             "trait {trait_name} must name shared or adapter-native semantic evidence"
         );
-        for scenario in scenarios {
-            assert_scenario_exists(&root, &scenario);
+        let scenario_bodies = scenarios
+            .iter()
+            .map(|scenario| (scenario, scenario_body(&root, scenario)))
+            .collect::<Vec<_>>();
+        assert!(
+            scenario_bodies
+                .iter()
+                .any(|(_, body)| scenario_asserts_an_effect(body)),
+            "trait {trait_name} must name an effect-asserting semantic scenario"
+        );
+        for scenario in &scenarios {
+            assert_scenario_exists(&root, scenario);
         }
+        missing_method_evidence.extend(methods.iter().filter_map(|method| {
+            let invocation = format!(".{method}(");
+            (!scenario_bodies
+                .iter()
+                .any(|(_, body)| body.contains(&invocation)))
+            .then(|| format!("{trait_name}::{method}"))
+        }));
     }
+    assert!(
+        missing_method_evidence.is_empty(),
+        "storage methods lack a named scenario that directly invokes the method and asserts effects: {missing_method_evidence:#?}"
+    );
 
     let context_free_mutations = manifest
         .get("context_free_mutations")
@@ -387,6 +486,38 @@ fn storage_semantic_coverage_inventory_matches_traits_variants_and_evidence() {
         }
     }
 
+    let expected_context_free = traits
+        .iter()
+        .flat_map(|(trait_name, value)| {
+            let effects = value
+                .as_table()
+                .and_then(|entry| entry.get("effects"))
+                .and_then(toml::Value::as_table)
+                .expect("every trait has checked effect classifications");
+            ["observation", "workflow_mutation"]
+                .into_iter()
+                .filter_map(|effect| effects.get(effect))
+                .flat_map(|values| {
+                    values
+                        .as_array()
+                        .expect("checked effect classifications are arrays")
+                })
+                .map(|method| {
+                    format!(
+                        "{trait_name}::{}",
+                        method
+                            .as_str()
+                            .expect("checked effect classifications contain strings")
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        classified, expected_context_free,
+        "context-free writer inventory must exactly match observation and workflow-mutation effects"
+    );
+
     let enums = manifest
         .get("enums")
         .and_then(toml::Value::as_table)
@@ -419,6 +550,164 @@ fn storage_semantic_coverage_inventory_matches_traits_variants_and_evidence() {
             assert_scenario_exists(&root, &scenario);
         }
     }
+}
+
+#[test]
+fn storage_collection_method_contracts_match_effect_inventory() {
+    const COLLECTION_EFFECTS: [&str; 4] =
+        ["page_read", "candidate_read", "batch_read", "complete_read"];
+    const QUERY_PROFILE_FIELDS: [&str; 10] = [
+        "shape",
+        "filters",
+        "sorts",
+        "cursor",
+        "visibility",
+        "count",
+        "snapshot",
+        "bounds",
+        "invalid_error",
+        "unsupported_error",
+    ];
+    const COLLECTION_PROFILE_FIELDS: [&str; 11] = [
+        "shape",
+        "ordering",
+        "duplicate_inputs",
+        "missing_inputs",
+        "multiplicity",
+        "completeness",
+        "bounds",
+        "visibility",
+        "snapshot",
+        "invalid_error",
+        "unsupported_error",
+    ];
+
+    let root = repository_root();
+    let semantic = storage_semantic_manifest(&root);
+    let semantic_traits = semantic
+        .get("traits")
+        .and_then(toml::Value::as_table)
+        .expect("semantic coverage should have a traits table");
+    let mut expected = std::collections::BTreeMap::new();
+    for (trait_name, value) in semantic_traits {
+        let effects = value
+            .get("effects")
+            .and_then(toml::Value::as_table)
+            .unwrap_or_else(|| panic!("trait {trait_name} should classify effects"));
+        for effect in COLLECTION_EFFECTS {
+            if let Some(methods) = effects.get(effect).and_then(toml::Value::as_array) {
+                for method in methods {
+                    let method = method.as_str().unwrap_or_else(|| {
+                        panic!("trait {trait_name} effect {effect} should contain method names")
+                    });
+                    expected.insert(format!("{trait_name}::{method}"), effect.to_string());
+                }
+            }
+        }
+    }
+
+    let contracts = storage_method_contract_manifest(&root);
+    let methods = contracts
+        .get("methods")
+        .and_then(toml::Value::as_table)
+        .expect("method contracts should have a methods table");
+    assert_eq!(
+        methods.keys().cloned().collect::<BTreeSet<_>>(),
+        expected.keys().cloned().collect::<BTreeSet<_>>(),
+        "method contracts must cover every collection-shaped storage method exactly"
+    );
+    let query_profiles = contracts
+        .get("query_profiles")
+        .and_then(toml::Value::as_table)
+        .expect("method contracts should have query profiles");
+    let collection_profiles = contracts
+        .get("collection_profiles")
+        .and_then(toml::Value::as_table)
+        .expect("method contracts should have collection profiles");
+    let mut used_query_profiles = BTreeSet::new();
+    let mut used_collection_profiles = BTreeSet::new();
+
+    for (qualified_method, value) in methods {
+        let entry = value
+            .as_table()
+            .unwrap_or_else(|| panic!("method contract {qualified_method} should be a table"));
+        let effect = entry
+            .get("effect")
+            .and_then(toml::Value::as_str)
+            .unwrap_or_else(|| panic!("method contract {qualified_method} needs an effect"));
+        assert_eq!(
+            Some(effect),
+            expected.get(qualified_method).map(String::as_str),
+            "method contract effect drifted for {qualified_method}"
+        );
+        assert!(
+            entry
+                .get("carrier")
+                .and_then(toml::Value::as_str)
+                .is_some_and(|carrier| !carrier.trim().is_empty()),
+            "method contract {qualified_method} needs its exact input carrier"
+        );
+        let profile_name = entry
+            .get("profile")
+            .and_then(toml::Value::as_str)
+            .unwrap_or_else(|| panic!("method contract {qualified_method} needs a profile"));
+        let (profiles, required_fields, used_profiles) = match effect {
+            "page_read" | "candidate_read" => (
+                query_profiles,
+                QUERY_PROFILE_FIELDS.as_slice(),
+                &mut used_query_profiles,
+            ),
+            "batch_read" | "complete_read" => (
+                collection_profiles,
+                COLLECTION_PROFILE_FIELDS.as_slice(),
+                &mut used_collection_profiles,
+            ),
+            other => panic!("method contract {qualified_method} has unsupported effect {other}"),
+        };
+        let profile = profiles
+            .get(profile_name)
+            .and_then(toml::Value::as_table)
+            .unwrap_or_else(|| {
+                panic!("method contract {qualified_method} names missing profile {profile_name}")
+            });
+        used_profiles.insert(profile_name.to_string());
+        for field in required_fields {
+            assert!(
+                profile.contains_key(*field),
+                "profile {profile_name} used by {qualified_method} is missing {field}"
+            );
+        }
+        for field in ["invalid_error", "unsupported_error"] {
+            assert_eq!(
+                profile.get(field).and_then(toml::Value::as_str),
+                Some("InvalidInput"),
+                "profile {profile_name} must map {field} to the portable InvalidInput error"
+            );
+        }
+        let expected_shape = match effect {
+            "page_read" => "page",
+            "candidate_read" => "candidate",
+            "batch_read" => "batch",
+            "complete_read" => "complete",
+            _ => unreachable!(),
+        };
+        assert_eq!(
+            profile.get("shape").and_then(toml::Value::as_str),
+            Some(expected_shape),
+            "profile {profile_name} has the wrong result shape for {qualified_method}"
+        );
+    }
+
+    assert_eq!(
+        used_query_profiles,
+        query_profiles.keys().cloned().collect(),
+        "query profiles must all be used"
+    );
+    assert_eq!(
+        used_collection_profiles,
+        collection_profiles.keys().cloned().collect(),
+        "collection profiles must all be used"
+    );
 }
 
 #[test]

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -86,47 +86,49 @@ use crate::storage::{
     StorageAuthorizationPrincipalCollectionPageQuery, StorageAuthorizationPrincipalCollectionQuery,
     StorageAuthorizationResourceIds, StorageBackendKind, StorageBackupTaskArtifact,
     StorageBidirectionalRelatedObjectsQuery, StorageCallSite, StorageCandidatePageLimit,
-    StorageCatalogListQuery, StorageClassCreate, StorageClassSelector, StorageClassUpdate,
-    StorageCollectionCreate, StorageCollectionUpdate, StorageComputedFieldDefinitionInput,
-    StorageComputedFieldDefinitionPatch, StorageComputedFieldRebuildRequest,
-    StorageComputedFieldVisibility, StorageComputedObjectEnrichmentQuery,
-    StorageComputedObjectListQuery, StorageComputedObjectProjection,
-    StorageComputedObjectQueryOptions, StorageComputedObjectVisibility,
-    StorageDefaultAdminBootstrap, StorageError, StorageErrorKind, StorageEventDeliveryListQuery,
-    StorageEventRetentionBatch, StorageEventSinkCreate, StorageEventSinkDelete,
-    StorageEventSinkListQuery, StorageEventSinkUpdate, StorageEventSubscriptionCreate,
-    StorageEventSubscriptionDelete, StorageEventSubscriptionListQuery,
-    StorageEventSubscriptionUpdate, StorageExecutionScope, StorageExportTaskArtifact,
-    StorageExportTemplateCreate, StorageExportTemplateDefinition, StorageExportTemplateDelete,
-    StorageExportTemplateListQuery, StorageExportTemplateReplace, StorageGroupCreate,
-    StorageGroupListQuery, StorageGroupUpdate, StorageHistoryAsOfQuery,
+    StorageCatalogListQuery, StorageClassCreate, StorageClassRelationCreate, StorageClassSelector,
+    StorageClassUpdate, StorageCollectionCreate, StorageCollectionUpdate,
+    StorageComputedFieldDefinitionInput, StorageComputedFieldDefinitionPatch,
+    StorageComputedFieldRebuildRequest, StorageComputedFieldVisibility,
+    StorageComputedObjectEnrichmentQuery, StorageComputedObjectListQuery,
+    StorageComputedObjectProjection, StorageComputedObjectQueryOptions,
+    StorageComputedObjectVisibility, StorageDefaultAdminBootstrap, StorageError, StorageErrorKind,
+    StorageEventDeliveryListQuery, StorageEventRetentionBatch, StorageEventSinkCreate,
+    StorageEventSinkDelete, StorageEventSinkListQuery, StorageEventSinkUpdate,
+    StorageEventSubscriptionCreate, StorageEventSubscriptionDelete,
+    StorageEventSubscriptionListQuery, StorageEventSubscriptionUpdate, StorageExecutionScope,
+    StorageExportTaskArtifact, StorageExportTemplateCreate, StorageExportTemplateDefinition,
+    StorageExportTemplateDelete, StorageExportTemplateListQuery, StorageExportTemplateReplace,
+    StorageGroupCreate, StorageGroupListQuery, StorageGroupUpdate, StorageHistoryAsOfQuery,
     StorageHistoryCollectionScope, StorageHistoryListQuery, StorageImportPlan,
     StorageImportPlanItem, StorageImportResult, StorageLocalPasswordReset, StorageObject,
     StorageObjectAggregateAuthorization, StorageObjectAggregateAuthorizationCandidate,
     StorageObjectAggregateAuthorizationTarget, StorageObjectAggregateQuery,
     StorageObjectAggregateSort, StorageObjectAggregateSpec, StorageObjectAggregateTarget,
-    StorageObjectHistoryAsOfQuery, StorageObjectHistoryListQuery,
-    StorageObjectRelationsTouchingIdsQuery, StoragePersonalComputedFieldCreate,
-    StoragePersonalComputedFieldDelete, StoragePersonalComputedFieldListQuery,
-    StoragePersonalComputedFieldUpdate, StoragePrincipalGroupListQuery,
-    StoragePrincipalSettingsMutation, StoragePrincipalTokensRevoke, StorageQueryBudget,
-    StorageRecordMetadata, StorageRelatedDirection, StorageRelatedObjectsForRootsQuery,
-    StorageRelatedSort, StorageRelationGraphQuery, StorageRelationIdsQuery,
-    StorageRelationListQuery, StorageRelationTouchingQuery, StorageRemoteCallArtifactOutcome,
-    StorageRemoteCallArtifactResponse, StorageRemoteCallArtifactTarget,
-    StorageRemoteCallTaskArtifact, StorageRemoteTargetCreate, StorageRemoteTargetDefinition,
-    StorageRemoteTargetDelete, StorageRemoteTargetInvocation, StorageRemoteTargetListQuery,
-    StorageRemoteTargetPatch, StorageRemoteTargetPolicy, StorageRemoteTargetTransport,
-    StorageRemoteTargetUpdate, StorageRestoreArtifactSummary, StorageRestoreFailure,
-    StorageRestoreInitiator, StorageRestoreJobStatus, StorageRestoreStageCreate,
-    StorageRevisionPrecondition, StorageRevisionTarget, StorageServiceAccountCreate,
-    StorageServiceAccountListQuery, StorageServiceAccountMutation, StorageServiceAccountUpdate,
-    StorageSharedComputedFieldCreate, StorageSharedComputedFieldDelete,
-    StorageSharedComputedFieldUpdate, StorageTaskActiveUpdate, StorageTaskChildListQuery,
-    StorageTaskCompletion, StorageTaskCompletionArtifact, StorageTaskCreateRequest,
-    StorageTaskEventAppend, StorageTaskEventInput, StorageTaskFailure, StorageTaskKind,
-    StorageTaskLease, StorageTaskLeaseDuration, StorageTaskListQuery, StorageTaskOutputLookup,
-    StorageTaskResultCounts, StorageTaskScopeSnapshot, StorageTaskStatus,
+    StorageObjectCreate, StorageObjectDataPatch, StorageObjectHistoryAsOfQuery,
+    StorageObjectHistoryListQuery, StorageObjectRelationCreate,
+    StorageObjectRelationCreateSelector, StorageObjectRelationSelector,
+    StorageObjectRelationsTouchingIdsQuery, StorageObjectSelector, StorageObjectUpdate,
+    StoragePersonalComputedFieldCreate, StoragePersonalComputedFieldDelete,
+    StoragePersonalComputedFieldListQuery, StoragePersonalComputedFieldUpdate,
+    StoragePrincipalGroupListQuery, StoragePrincipalSettingsMutation, StoragePrincipalTokensRevoke,
+    StorageQueryBudget, StorageRecordMetadata, StorageRelatedDirection,
+    StorageRelatedObjectsForRootsQuery, StorageRelatedSort, StorageRelationGraphQuery,
+    StorageRelationIdsQuery, StorageRelationListQuery, StorageRelationTouchingQuery,
+    StorageRemoteCallArtifactOutcome, StorageRemoteCallArtifactResponse,
+    StorageRemoteCallArtifactTarget, StorageRemoteCallTaskArtifact, StorageRemoteTargetCreate,
+    StorageRemoteTargetDefinition, StorageRemoteTargetDelete, StorageRemoteTargetInvocation,
+    StorageRemoteTargetListQuery, StorageRemoteTargetPatch, StorageRemoteTargetPolicy,
+    StorageRemoteTargetTransport, StorageRemoteTargetUpdate, StorageRestoreArtifactSummary,
+    StorageRestoreFailure, StorageRestoreInitiator, StorageRestoreJobStatus,
+    StorageRestoreStageCreate, StorageRevisionPrecondition, StorageRevisionTarget,
+    StorageServiceAccountCreate, StorageServiceAccountListQuery, StorageServiceAccountMutation,
+    StorageServiceAccountUpdate, StorageSharedComputedFieldCreate,
+    StorageSharedComputedFieldDelete, StorageSharedComputedFieldUpdate, StorageTaskActiveUpdate,
+    StorageTaskChildListQuery, StorageTaskCompletion, StorageTaskCompletionArtifact,
+    StorageTaskCreateRequest, StorageTaskEventAppend, StorageTaskEventInput, StorageTaskFailure,
+    StorageTaskKind, StorageTaskLease, StorageTaskLeaseDuration, StorageTaskListQuery,
+    StorageTaskOutputLookup, StorageTaskResultCounts, StorageTaskScopeSnapshot, StorageTaskStatus,
     StorageTaskTerminalUpdate, StorageTokenCreate, StorageTokenHashRevoke,
     StorageTokenIssuancePolicy, StorageTokenListQuery, StorageTokenListState,
     StorageTokenObservation, StorageTokenRenew, StorageTokenRevoke, StorageUnifiedSearchQuery,
@@ -1102,18 +1104,24 @@ async fn every_available_storage_backend_supplies_metrics_snapshots() {
     let _permit = postgres_permit().await;
 
     for backend in available_backends() {
-        backend
+        let inventory = backend
             .get_inventory_metrics_snapshot()
             .await
             .expect("certified backend should supply inventory metrics");
-        backend
+        assert!(inventory.counts().collections() >= 1);
+
+        let tasks = backend
             .get_task_metrics_snapshot()
             .await
             .expect("certified backend should supply task metrics");
-        backend
+        assert_eq!(tasks.ages().len(), StorageTaskKind::ALL.len());
+
+        let events = backend
             .get_event_metrics_snapshot()
             .await
             .expect("certified backend should supply event metrics");
+        assert!(events.fanout().pending_events() >= 0);
+        assert!(events.delivery().counts().total() >= 0);
     }
 }
 
@@ -3507,6 +3515,24 @@ async fn every_available_storage_backend_supplies_collection_lifecycle() {
             .expect("certified backend should move collections")
             .into_value();
         assert_eq!(moved.parent_collection_id(), Some(collection_id(1)));
+        let loaded = collections
+            .get_collection(created.id())
+            .await
+            .expect("certified backend should load collections by id");
+        assert_eq!(loaded, moved);
+        let children = collections
+            .list_collection_children(collection_id(1))
+            .await
+            .expect("certified backend should list direct collection children");
+        assert!(children.iter().any(|child| child.id() == created.id()));
+        let ancestors = collections
+            .list_collection_ancestors(created.id())
+            .await
+            .expect("certified backend should list collection ancestors");
+        assert_eq!(
+            ancestors.first().map(|ancestor| ancestor.id()),
+            Some(collection_id(1))
+        );
         collections
             .delete_collection(created.id(), &EventContext::system())
             .await
@@ -3628,6 +3654,357 @@ async fn every_available_storage_backend_supplies_class_lifecycle() {
         .delete_without_events(pool.get_ref())
         .await
         .expect("class lifecycle group should be removed");
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_supplies_object_lifecycle() {
+    let _permit = postgres_permit().await;
+    let pool = pool();
+    let group = crate::tests::create_test_group(pool.get_ref()).await;
+
+    for backend in available_backends() {
+        let collections = backend.collection_store();
+        let collection = collections
+            .create_collection(
+                StorageCollectionCreate::new(
+                    prefix("object_lifecycle_collection"),
+                    "object lifecycle collection",
+                    group_id(group.id),
+                    None,
+                ),
+                &EventContext::system(),
+            )
+            .await
+            .expect("certified backend should create the object collection")
+            .into_value();
+        let classes = backend.class_store();
+        let class = classes
+            .create_class(
+                StorageClassCreate::builder(
+                    prefix("object_lifecycle_class"),
+                    collection.id(),
+                    "object lifecycle class",
+                )
+                .json_schema(Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {"value": {"type": "integer"}}
+                })))
+                .validate_schema(true)
+                .build(),
+                &EventContext::system(),
+            )
+            .await
+            .expect("certified backend should create the object class")
+            .into_value();
+        let resolved_class = classes
+            .resolve_class(StorageClassSelector::Id(class.id()))
+            .await
+            .expect("certified backend should resolve the object class");
+        let objects = backend.object_store();
+        let object_name = prefix("object_lifecycle");
+        let create = StorageObjectCreate::new(
+            &object_name,
+            collection.id(),
+            class.id(),
+            serde_json::json!({"value": 1}),
+            "object lifecycle",
+        );
+        objects
+            .validate_object_create(create.clone())
+            .await
+            .expect("certified backend should validate object creation");
+        let created = objects
+            .create_object(&resolved_class, create, &EventContext::system())
+            .await
+            .expect("certified backend should create objects")
+            .into_value();
+        objects
+            .validate_object(created.clone())
+            .await
+            .expect("certified backend should validate stored objects");
+
+        let loaded = objects
+            .get_object(created.id())
+            .await
+            .expect("certified backend should load objects by id");
+        assert_eq!(loaded.object(), &created);
+        let resolved = objects
+            .resolve_object(StorageObjectSelector::Names {
+                class_name: class.name().to_string(),
+                object_name: object_name.clone(),
+            })
+            .await
+            .expect("certified backend should resolve objects by name");
+        assert_eq!(resolved.object().id(), created.id());
+
+        let update = StorageObjectUpdate::builder()
+            .description(Some("updated object lifecycle".to_string()))
+            .build();
+        objects
+            .validate_object_update(created.id(), update.clone())
+            .await
+            .expect("certified backend should validate object updates");
+        let updated = objects
+            .update_object(&resolved, update, &EventContext::system())
+            .await
+            .expect("certified backend should update objects")
+            .into_value();
+        assert_eq!(updated.description(), "updated object lifecycle");
+
+        let patch_document = serde_json::from_value(serde_json::json!([
+            {"op": "replace", "path": "/value", "value": 2}
+        ]))
+        .expect("object lifecycle patch should be valid");
+        let patch: StorageObjectDataPatch =
+            crate::services::storage_boundary::object_patch_to_storage(patch_document)
+                .expect("object lifecycle patch should cross the storage boundary");
+        let updated_target = objects
+            .get_object(created.id())
+            .await
+            .expect("updated object should remain resolvable");
+        let patched = objects
+            .patch_object_data(&updated_target, patch, &EventContext::system())
+            .await
+            .expect("certified backend should patch object data")
+            .into_value();
+        assert_eq!(patched.data(), &serde_json::json!({"value": 2}));
+
+        let delete_target = objects
+            .get_object(created.id())
+            .await
+            .expect("patched object should remain resolvable");
+        objects
+            .delete_object(&delete_target, &EventContext::system())
+            .await
+            .expect("certified backend should delete objects")
+            .into_value();
+        assert_eq!(
+            objects
+                .get_object(created.id())
+                .await
+                .err()
+                .expect("deleted objects must not resolve")
+                .kind(),
+            StorageErrorKind::NotFound
+        );
+        classes
+            .delete_class(&resolved_class, &EventContext::system())
+            .await
+            .expect("object lifecycle class should be removable")
+            .into_value();
+        collections
+            .delete_collection(collection.id(), &EventContext::system())
+            .await
+            .expect("object lifecycle collection should be removable")
+            .into_value();
+    }
+
+    group
+        .delete_without_events(pool.get_ref())
+        .await
+        .expect("object lifecycle group should be removed");
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_supplies_relation_lifecycle() {
+    let _permit = postgres_permit().await;
+    let pool = pool();
+    let group = crate::tests::create_test_group(pool.get_ref()).await;
+
+    for backend in available_backends() {
+        let collections = backend.collection_store();
+        let collection = collections
+            .create_collection(
+                StorageCollectionCreate::new(
+                    prefix("relation_lifecycle_collection"),
+                    "relation lifecycle collection",
+                    group_id(group.id),
+                    None,
+                ),
+                &EventContext::system(),
+            )
+            .await
+            .expect("certified backend should create the relation collection")
+            .into_value();
+        let classes = backend.class_store();
+        let from_class = classes
+            .create_class(
+                StorageClassCreate::builder(
+                    prefix("relation_lifecycle_from_class"),
+                    collection.id(),
+                    "relation lifecycle source class",
+                )
+                .build(),
+                &EventContext::system(),
+            )
+            .await
+            .expect("certified backend should create the source class")
+            .into_value();
+        let to_class = classes
+            .create_class(
+                StorageClassCreate::builder(
+                    prefix("relation_lifecycle_to_class"),
+                    collection.id(),
+                    "relation lifecycle target class",
+                )
+                .build(),
+                &EventContext::system(),
+            )
+            .await
+            .expect("certified backend should create the target class")
+            .into_value();
+
+        let class_relations = backend.class_relation_store();
+        let prepared_class_relation = class_relations
+            .prepare_class_relation(
+                StorageClassRelationCreate::builder(from_class.id(), to_class.id()).build(),
+            )
+            .await
+            .expect("certified backend should prepare class relations");
+        assert_eq!(prepared_class_relation.from_class().id(), from_class.id());
+        assert_eq!(prepared_class_relation.to_class().id(), to_class.id());
+        let class_relation = class_relations
+            .create_class_relation(&prepared_class_relation, &EventContext::system())
+            .await
+            .expect("certified backend should create class relations")
+            .into_value();
+        let class_relation_id = ClassRelationId::from(class_relation.relation().metadata().id());
+        let resolved_class_relation = class_relations
+            .resolve_class_relation(class_relation_id)
+            .await
+            .expect("certified backend should resolve class relations");
+        assert_eq!(
+            resolved_class_relation.relation(),
+            class_relation.relation()
+        );
+
+        let objects = backend.object_store();
+        let from_object = objects
+            .create_object(
+                &classes
+                    .resolve_class(StorageClassSelector::Id(from_class.id()))
+                    .await
+                    .expect("source class should resolve"),
+                StorageObjectCreate::new(
+                    prefix("relation_lifecycle_from_object"),
+                    collection.id(),
+                    from_class.id(),
+                    serde_json::json!({}),
+                    "relation lifecycle source object",
+                ),
+                &EventContext::system(),
+            )
+            .await
+            .expect("certified backend should create the source object")
+            .into_value();
+        let to_object = objects
+            .create_object(
+                &classes
+                    .resolve_class(StorageClassSelector::Id(to_class.id()))
+                    .await
+                    .expect("target class should resolve"),
+                StorageObjectCreate::new(
+                    prefix("relation_lifecycle_to_object"),
+                    collection.id(),
+                    to_class.id(),
+                    serde_json::json!({}),
+                    "relation lifecycle target object",
+                ),
+                &EventContext::system(),
+            )
+            .await
+            .expect("certified backend should create the target object")
+            .into_value();
+
+        let object_relations = backend.object_relation_store();
+        let prepared_object_relation = object_relations
+            .prepare_object_relation(StorageObjectRelationCreateSelector::Explicit(
+                StorageObjectRelationCreate::new(
+                    from_object.id(),
+                    to_object.id(),
+                    class_relation_id,
+                ),
+            ))
+            .await
+            .expect("certified backend should prepare object relations");
+        assert_eq!(prepared_object_relation.from_object(), &from_object);
+        assert_eq!(prepared_object_relation.to_object(), &to_object);
+        let object_relation = object_relations
+            .create_object_relation(&prepared_object_relation, &EventContext::system())
+            .await
+            .expect("certified backend should create object relations")
+            .into_value();
+        let object_relation_id = ObjectRelationId::from(object_relation.relation().metadata().id());
+        let resolved_object_relation = object_relations
+            .resolve_object_relation(StorageObjectRelationSelector::Id(object_relation_id))
+            .await
+            .expect("certified backend should resolve object relations");
+        assert_eq!(
+            resolved_object_relation.relation(),
+            object_relation.relation()
+        );
+
+        object_relations
+            .delete_object_relation(&resolved_object_relation, &EventContext::system())
+            .await
+            .expect("certified backend should delete object relations")
+            .into_value();
+        assert_eq!(
+            object_relations
+                .resolve_object_relation(StorageObjectRelationSelector::Id(object_relation_id))
+                .await
+                .err()
+                .expect("deleted object relations must not resolve")
+                .kind(),
+            StorageErrorKind::NotFound
+        );
+        for object in [from_object, to_object] {
+            let target = objects
+                .get_object(object.id())
+                .await
+                .expect("relation lifecycle object should resolve for cleanup");
+            objects
+                .delete_object(&target, &EventContext::system())
+                .await
+                .expect("relation lifecycle object should be removable")
+                .into_value();
+        }
+        class_relations
+            .delete_class_relation(&resolved_class_relation, &EventContext::system())
+            .await
+            .expect("certified backend should delete class relations")
+            .into_value();
+        assert_eq!(
+            class_relations
+                .resolve_class_relation(class_relation_id)
+                .await
+                .err()
+                .expect("deleted class relations must not resolve")
+                .kind(),
+            StorageErrorKind::NotFound
+        );
+        for class in [from_class, to_class] {
+            let target = classes
+                .resolve_class(StorageClassSelector::Id(class.id()))
+                .await
+                .expect("relation lifecycle class should resolve for cleanup");
+            classes
+                .delete_class(&target, &EventContext::system())
+                .await
+                .expect("relation lifecycle class should be removable")
+                .into_value();
+        }
+        collections
+            .delete_collection(collection.id(), &EventContext::system())
+            .await
+            .expect("relation lifecycle collection should be removable")
+            .into_value();
+    }
+
+    group
+        .delete_without_events(pool.get_ref())
+        .await
+        .expect("relation lifecycle group should be removed");
 }
 
 #[actix_web::test]
@@ -3949,7 +4326,18 @@ async fn every_available_storage_backend_supplies_local_authorization_data() {
 
         let group_candidates = backend
             .load_authorization_group_candidates(StorageAuthorizationGroupCandidateQuery::new(
-                QueryOptions::empty(),
+                QueryOptions::new(
+                    vec![ParsedQueryParam {
+                        field: FilterField::Description,
+                        operator: SearchOperator::Equals { is_negated: false },
+                        value: group.description.clone(),
+                    }],
+                    Vec::new(),
+                    None,
+                    None,
+                    false,
+                )
+                .expect("authorization candidate query should be valid"),
                 StorageCandidatePageLimit::try_new(512)
                     .expect("contract candidate page limit should be valid"),
             ))
@@ -5198,10 +5586,12 @@ async fn every_available_storage_backend_supplies_event_health() {
     let _permit = postgres_permit().await;
 
     for backend in available_backends() {
-        backend
+        let health = backend
             .get_event_delivery_health()
             .await
             .expect("certified backend should expose event delivery health");
+        assert!(health.fanout().pending_events() >= 0);
+        assert!(health.delivery().counts().total() >= 0);
     }
 }
 
@@ -5406,10 +5796,11 @@ async fn every_available_storage_backend_processes_event_fanout() {
         .expect("compatibility fan-out settings should be valid");
 
     for backend in available_backends() {
-        backend
+        let processed = backend
             .process_event_fanout_batch(settings)
             .await
             .expect("certified backend should process event fan-out");
+        assert!(processed <= settings.batch_size());
     }
 }
 


### PR DESCRIPTION
## Summary

- classify every storage method by observable effect and require named evidence that collectively invokes every method and asserts effects
- add an exhaustive method contract registry for pageable, candidate, batch, and complete reads, covering carriers, filters, sorting, cursor/count behavior, ordering, multiplicity, completeness, visibility, bounds, snapshots, and portable errors
- expand shared conformance coverage for collection, class, object, and relation lifecycles
- keep context-free writer exceptions exhaustive against the workflow-mutation and observation classifications

## Behavior notes

- authorization group candidate reads now accept description and revision filters, matching the public group query contract
- task and task-child storage reads reject unsupported QueryOptions filters as InvalidInput instead of silently ignoring them; typed task scope fields remain supported
- multi-root relation contracts document the adapter actual root-ID ordering and path-dependent duplicate behavior
- no supported public HTTP schema or route changes are introduced; hubuum-storage-core remains an internal workspace contract

## Changelog

The Unreleased section records the exhaustive method contract registry and method-aware semantic evidence enforcement.

## Verification

- source /work/terjekv/projects/private/hubuum-rust/.env && ./run_tests.sh
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- npx markdownlint-cli2 --config .markdownlint.json **/*.md !target
- cargo test storage_semantic_coverage_inventory_matches_traits_variants_and_evidence
- cargo test storage_collection_method_contracts_match_effect_inventory

Closes #338
Closes #345