### PR TITLE
Define the experimental storage adapter SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- The experimental public storage adapter SDK now has a closed six-crate
+  crates.io graph, one lockstep `0.1.0` version, exact in-graph dependencies,
+  Rust 1.88 MSRV and feature guarantees, explicit closed/non-exhaustive enum
+  policy, deprecation rules, coordinated release order, and adapter upgrade
+  process. `hubuum-storage-conformance` is the supported certification entry
+  point; the root application and PostgreSQL adapter remain internal.
+
 ### Changed
 
 - The workspace storage contract now exhaustively specifies every pageable,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "hubuum-events-core"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "hubuum-domain",
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "hubuum-query"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "base64 0.23.1",
  "bigdecimal",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "hubuum-task-core"
-version = "0.0.1"
+version = "0.1.0"
 
 [[package]]
 name = "hubuum-templates"

--- a/crates/hubuum-domain/Cargo.toml
+++ b/crates/hubuum-domain/Cargo.toml
@@ -6,10 +6,13 @@ rust-version = "1.88"
 description = "Backend-neutral domain types and validation for Hubuum."
 license = "MIT"
 repository = "https://github.com/hubuum/hubuum"
-publish = false
+readme = "../../docs/rust_api/hubuum-domain.md"
+publish = true
 
 [package.metadata.hubuum]
-rust-api = "workspace-internal"
+rust-api = "experimental-public"
+policy-document = "docs/rust_api/hubuum-domain.md"
+release-train = "storage-sdk"
 
 [dependencies]
 bigdecimal = "0.4"

--- a/crates/hubuum-events-core/Cargo.toml
+++ b/crates/hubuum-events-core/Cargo.toml
@@ -1,19 +1,22 @@
 [package]
 name = "hubuum-events-core"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Backend-agnostic event catalog and provenance types for Hubuum's unified event & audit stream."
 license = "MIT"
 repository = "https://github.com/hubuum/hubuum"
-publish = false
+readme = "../../docs/rust_api/hubuum-events-core.md"
+publish = true
 
 [package.metadata.hubuum]
-rust-api = "workspace-internal"
+rust-api = "experimental-public"
+policy-document = "docs/rust_api/hubuum-events-core.md"
+release-train = "storage-sdk"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-hubuum-domain = { version = "0.1.0", path = "../hubuum-domain" }
+hubuum-domain = { version = "=0.1.0", path = "../hubuum-domain" }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/hubuum-query/Cargo.toml
+++ b/crates/hubuum-query/Cargo.toml
@@ -1,15 +1,18 @@
 [package]
 name = "hubuum-query"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2024"
 rust-version = "1.88"
 description = "App-neutral query parsing and search parameter types for Hubuum."
 license = "MIT"
 repository = "https://github.com/hubuum/hubuum"
-publish = false
+readme = "../../docs/rust_api/hubuum-query.md"
+publish = true
 
 [package.metadata.hubuum]
-rust-api = "workspace-internal"
+rust-api = "experimental-public"
+policy-document = "docs/rust_api/hubuum-query.md"
+release-train = "storage-sdk"
 
 [dependencies]
 base64 = "0.23"

--- a/crates/hubuum-storage-conformance/Cargo.toml
+++ b/crates/hubuum-storage-conformance/Cargo.toml
@@ -6,15 +6,18 @@ rust-version = "1.88"
 description = "Reusable behavioral conformance contract for Hubuum storage adapters."
 license = "MIT"
 repository = "https://github.com/hubuum/hubuum"
-publish = false
+readme = "../../docs/rust_api/hubuum-storage-conformance.md"
+publish = true
 
 [package.metadata.hubuum]
-rust-api = "workspace-internal"
+rust-api = "experimental-public"
+policy-document = "docs/rust_api/hubuum-storage-conformance.md"
+release-train = "storage-sdk"
 
 [dependencies]
 async-trait = "0.1"
-hubuum-domain = { version = "0.1.0", path = "../hubuum-domain" }
-hubuum-storage-core = { version = "0.1.0", path = "../hubuum-storage-core" }
+hubuum-domain = { version = "=0.1.0", path = "../hubuum-domain" }
+hubuum-storage-core = { version = "=0.1.0", path = "../hubuum-storage-core" }
 
 [dev-dependencies]
-hubuum-events-core = { version = "0.0.1", path = "../hubuum-events-core" }
+hubuum-events-core = { version = "=0.1.0", path = "../hubuum-events-core" }

--- a/crates/hubuum-storage-core/Cargo.toml
+++ b/crates/hubuum-storage-core/Cargo.toml
@@ -6,19 +6,22 @@ rust-version = "1.88"
 description = "Backend-neutral storage contracts and diagnostics for Hubuum."
 license = "MIT"
 repository = "https://github.com/hubuum/hubuum"
-publish = false
+readme = "../../docs/rust_api/hubuum-storage-core.md"
+publish = true
 
 [package.metadata.hubuum]
-rust-api = "workspace-internal"
+rust-api = "experimental-public"
+policy-document = "docs/rust_api/hubuum-storage-core.md"
+release-train = "storage-sdk"
 
 [dependencies]
 async-trait = "0.1"
 base64 = "0.22"
 chrono = "0.4"
-hubuum-domain = { version = "0.1.0", path = "../hubuum-domain" }
-hubuum-events-core = { version = "0.0.1", path = "../hubuum-events-core" }
-hubuum-query = { version = "0.0.1", path = "../hubuum-query" }
-hubuum-task-core = { version = "0.0.1", path = "../hubuum-task-core" }
+hubuum-domain = { version = "=0.1.0", path = "../hubuum-domain" }
+hubuum-events-core = { version = "=0.1.0", path = "../hubuum-events-core" }
+hubuum-query = { version = "=0.1.0", path = "../hubuum-query" }
+hubuum-task-core = { version = "=0.1.0", path = "../hubuum-task-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"

--- a/crates/hubuum-storage-postgres/Cargo.toml
+++ b/crates/hubuum-storage-postgres/Cargo.toml
@@ -27,8 +27,8 @@ diesel_migrations = { version = "2.3.2", optional = true }
 futures-util = "0.3"
 hubuum-computed-fields = { path = "../hubuum-computed-fields" }
 hubuum-domain = { version = "0.1.0", path = "../hubuum-domain" }
-hubuum-events-core = { version = "0.0.1", path = "../hubuum-events-core" }
-hubuum-query = { version = "0.0.1", path = "../hubuum-query" }
+hubuum-events-core = { version = "0.1.0", path = "../hubuum-events-core" }
+hubuum-query = { version = "0.1.0", path = "../hubuum-query" }
 hubuum-storage-core = { version = "0.1.0", path = "../hubuum-storage-core" }
 hubuum-templates = { version = "0.0.1", path = "../hubuum-templates" }
 ipnet = "2.12"

--- a/crates/hubuum-task-core/Cargo.toml
+++ b/crates/hubuum-task-core/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
 name = "hubuum-task-core"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Backend-neutral task identity and idempotency types for Hubuum."
 license = "MIT"
 repository = "https://github.com/hubuum/hubuum"
-publish = false
+readme = "../../docs/rust_api/hubuum-task-core.md"
+publish = true
 
 [package.metadata.hubuum]
-rust-api = "workspace-internal"
+rust-api = "experimental-public"
+policy-document = "docs/rust_api/hubuum-task-core.md"
+release-train = "storage-sdk"

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,7 +72,7 @@ for package classifications, publishing policy, and promotion requirements.
   and backend-specific initialization errors only at the application
   composition edge.
 - `crates/hubuum-storage-conformance`:
-  The workspace-internal six-part behavioral verifier for audited mutation
+  The experimental public six-part behavioral verifier for audited mutation
   receipts, no-ops, rollback, event delivery, telemetry, and exact revision
   conflicts. Retention retry safety has its own protocol verifier. It is a
   development dependency and is not linked into production binaries.

--- a/docs/rust_api/hubuum-domain.md
+++ b/docs/rust_api/hubuum-domain.md
@@ -1,19 +1,20 @@
-# `hubuum-domain` Future Rust API Design
+# `hubuum-domain` Rust API Policy
 
-Status: workspace-internal; candidate for a later publication review.
+Status: experimental public API in the storage SDK `0.1` release train.
 
 ## Purpose and Callers
 
 `hubuum-domain` provides validated, persistence-neutral policy values shared by
-Hubuum applications and storage adapters. A future external backend crate could
-depend on these types after promotion. It is not an HTTP client or a server
+Hubuum applications and storage adapters. External backend crates may depend on
+these types without linking the server. It is not an HTTP client or a server
 embedding API.
 
 ## Compatibility
 
-There is no current third-party SemVer promise or crates.io release. A separate
-promotion change must define the initial supported surface and compatibility
-policy. The workspace MSRV is Rust 1.88.
+The crate follows the lockstep versioning, exact dependency, MSRV, feature,
+deprecation, and release rules in the
+[Storage Adapter SDK Compatibility policy](../storage_adapter_sdk.md). The
+release-train MSRV is Rust 1.88.
 
 Its values are in-memory contracts; it makes no wire-format guarantee unless a
 type's documentation explicitly says otherwise. The optional `openapi` feature
@@ -39,6 +40,7 @@ without exposing PostgreSQL JSONB rules or an adapter error to callers.
 
 ## Ownership and Verification
 
-Hubuum maintainers own the workspace crate. Ordinary workspace tests and the
-storage consumers verify it today. A later promotion must enable rustdoc,
-package, and crates.io compatibility gates before the first public release.
+Hubuum maintainers own the crate. Ordinary workspace tests and storage
+consumers verify its behavior. CI packages it, builds rustdoc with warnings
+denied, and compares it with the latest crates.io release when a baseline
+exists.

--- a/docs/rust_api/hubuum-events-core.md
+++ b/docs/rust_api/hubuum-events-core.md
@@ -1,6 +1,6 @@
-# `hubuum-events-core` Future Rust API Design
+# `hubuum-events-core` Rust API Policy
 
-Status: workspace-internal; candidate for a later publication review.
+Status: experimental public API in the storage SDK `0.1` release train.
 
 ## Purpose and Callers
 
@@ -10,9 +10,10 @@ may use these types without depending on the server crate.
 
 ## Compatibility
 
-There is no current third-party SemVer promise or crates.io release. A separate
-promotion change must define the initial supported surface and compatibility
-policy. The workspace MSRV is Rust 1.88.
+The crate follows the lockstep versioning, exact dependency, MSRV, feature,
+deprecation, and release rules in the
+[Storage Adapter SDK Compatibility policy](../storage_adapter_sdk.md). The
+release-train MSRV is Rust 1.88.
 
 The default feature set is empty. The `schema` feature adds Utoipa schema
 implementations and is supported. Serialized event values are compatible only
@@ -37,6 +38,6 @@ Cancellation is not applicable.
 
 ## Ownership and Verification
 
-Hubuum maintainers own the workspace crate. Storage and event-sink consumers
-verify it today. A later promotion must enable rustdoc, package, and crates.io
-compatibility gates before the first public release.
+Hubuum maintainers own the crate. Storage and event-sink consumers verify its
+behavior. CI packages it, builds rustdoc with warnings denied, and compares it
+with the latest crates.io release when a baseline exists.

--- a/docs/rust_api/hubuum-query.md
+++ b/docs/rust_api/hubuum-query.md
@@ -1,6 +1,6 @@
-# `hubuum-query` Future Rust API Design
+# `hubuum-query` Rust API Policy
 
-Status: workspace-internal; candidate for a later publication review.
+Status: experimental public API in the storage SDK `0.1` release train.
 
 ## Purpose and Callers
 
@@ -10,9 +10,10 @@ It does not construct SQL or authorize a query.
 
 ## Compatibility
 
-There is no current third-party SemVer promise or crates.io release. A separate
-promotion change must define the initial supported surface and compatibility
-policy. The workspace MSRV is Rust 1.88. There are no feature flags.
+The crate follows the lockstep versioning, exact dependency, MSRV, deprecation,
+and release rules in the
+[Storage Adapter SDK Compatibility policy](../storage_adapter_sdk.md). The
+release-train MSRV is Rust 1.88. There are no feature flags.
 
 Parser behavior, accepted operators, and public validation errors are part of
 the supported API. Rust values are not a separate serialized wire contract.
@@ -35,6 +36,7 @@ of this crate's API.
 
 ## Ownership and Verification
 
-Hubuum maintainers own the workspace crate. `hubuum-storage-core`, the root
-application, and parser benchmarks verify it today. A later promotion must
-enable rustdoc, package, and crates.io compatibility gates.
+Hubuum maintainers own the crate. `hubuum-storage-core`, the root application,
+and parser benchmarks verify its behavior. CI packages it, builds rustdoc with
+warnings denied, and compares it with the latest crates.io release when a
+baseline exists.

--- a/docs/rust_api/hubuum-storage-conformance.md
+++ b/docs/rust_api/hubuum-storage-conformance.md
@@ -1,0 +1,52 @@
+# `hubuum-storage-conformance` Rust API Policy
+
+Status: experimental public API in the storage SDK `0.1` release train.
+
+## Purpose and Callers
+
+`hubuum-storage-conformance` is the reusable behavioral certification harness
+for complete Hubuum storage adapters. Adapter authors implement its fixture
+traits using public `hubuum-storage-core` values and run the exported verifiers
+without depending on the root server crate or PostgreSQL implementation.
+
+The supported entrypoints are the public fixture traits, probe types, recording
+observer and sink helpers, and `verify_*` functions exported by the crate.
+Application-owned HTTP fixture implementations remain outside this crate.
+
+## Compatibility
+
+The crate follows the lockstep versioning, exact dependency, MSRV, deprecation,
+and release rules in the
+[Storage Adapter SDK Compatibility policy](../storage_adapter_sdk.md).
+There are no feature flags or independent serialization guarantees.
+
+Adding a required fixture method or strengthening an existing expectation is a
+behavioral compatibility change for adapter authors. It must accompany the
+corresponding storage contract change and use the coordinated incompatible SDK
+release when an already conforming adapter needs source or behavior changes.
+
+## Errors, Runtime, and Cancellation
+
+Fixture setup and verification return crate-owned `ConformanceError` values;
+invalid adapter results are reported rather than panicking. Panics are reserved
+for defects in the conformance harness itself.
+
+The asynchronous fixture traits require Send-capable futures but do not select
+an executor. Dropping a verifier future requests cancellation. Fixtures own
+cleanup for durable test state and must document backend work that can continue
+after cancellation.
+
+## Security and Data
+
+The harness accepts only synthetic fixture credentials and bounded recording
+values. Debug output and errors must not reveal live credentials, bearer
+tokens, connection strings, claim capabilities, or unbounded application
+payloads. Probe structs are in-memory test results, not persisted or wire
+formats.
+
+## Ownership and Verification
+
+Hubuum maintainers own the crate. CI packages it, builds rustdoc with warnings
+denied, compares it with the latest crates.io release, and runs its verifiers
+through every selectable in-repository backend. Adapter authors additionally
+own their backend-native failure and consistency tests.

--- a/docs/rust_api/hubuum-storage-core.md
+++ b/docs/rust_api/hubuum-storage-core.md
@@ -1,14 +1,14 @@
-# `hubuum-storage-core` Future Rust API Design
+# `hubuum-storage-core` Rust API Policy
 
-Status: workspace-internal; candidate for a later publication review.
+Status: experimental public API in the storage SDK `0.1` release train.
 
 ## Purpose and Callers
 
 `hubuum-storage-core` is the complete backend-neutral storage extension
 contract. It exposes capability traits, private-field DTOs, the bounded
 `StorageError` taxonomy, and the aggregate `StorageBackend` compile-time check.
-The interface is designed so a backend crate may later live outside this
-workspace, but this change does not publish or support that packaging yet.
+Backend crates may live outside this workspace and depend on the supported SDK
+graph without linking the server.
 Hubuum uses static Cargo composition; this is not a dynamic plugin ABI and has
 no runtime contract version handshake.
 
@@ -36,9 +36,10 @@ HTTP clients should use Hubuum's versioned API instead of this storage API.
 
 ## Compatibility
 
-There is no current third-party SemVer promise or crates.io release. A separate
-promotion change must define the initial supported surface, versioning, and
-adapter migration policy. The workspace MSRV is Rust 1.88.
+The crate follows the lockstep versioning, exact dependency, MSRV, deprecation,
+aggregate evolution, and adapter upgrade rules in the
+[Storage Adapter SDK Compatibility policy](../storage_adapter_sdk.md). The
+release-train MSRV is Rust 1.88.
 
 There are no feature flags. DTOs are in-memory Rust contracts, not durable or
 wire formats unless their documentation explicitly says otherwise. Backend
@@ -87,16 +88,16 @@ labels.
 
 ## Ownership and Verification
 
-Hubuum maintainers own the workspace crate. The PostgreSQL adapter is the
+Hubuum maintainers own the crate. The PostgreSQL adapter is the
 reference implementation, and shared compatibility tests exercise every
 statically registered backend. The
-workspace-internal `hubuum-storage-conformance` harness certifies durable
+experimental public `hubuum-storage-conformance` harness certifies durable
 receipts, no-op behavior, rollback, outbox-to-sink delivery, telemetry, exact
 revision conflicts, retention retry identity, delivery recovery, restore
 coordination rollback, and lease-loss finalization, while each backend owns
 native query, transaction, migration, connection-loss, and failure tests.
 External-crate integration tests implement all 44 complete-backend traits,
 compile every one of their 249 methods, exercise every transaction port, and
-name public construction paths for all current adapter-returned values. This
-prevents accidental reliance on crate-private adapter hooks before a later
-promotion review.
+name public construction paths for all current adapter-returned values. CI also
+packages the crate, builds rustdoc with warnings denied, and compares it with
+the latest crates.io release when a baseline exists.

--- a/docs/rust_api/hubuum-task-core.md
+++ b/docs/rust_api/hubuum-task-core.md
@@ -1,19 +1,20 @@
-# `hubuum-task-core` Future Rust API Design
+# `hubuum-task-core` Rust API Policy
 
-Status: workspace-internal; candidate for a later publication review.
+Status: experimental public API in the storage SDK `0.1` release train.
 
 ## Purpose and Callers
 
 `hubuum-task-core` provides validated task identifiers and idempotency values
-used across application and storage boundaries. A future external backend crate
-could use them without depending on Hubuum's server implementation.
+used across application and storage boundaries. External backend crates may use
+them without depending on Hubuum's server implementation.
 
 ## Compatibility
 
-There is no current third-party SemVer promise or crates.io release. A separate
-promotion change must define the initial supported surface and compatibility
-policy. The workspace MSRV is Rust 1.88. There are no feature flags or
-independent serialization guarantees.
+The crate follows the lockstep versioning, exact dependency, MSRV, deprecation,
+and release rules in the
+[Storage Adapter SDK Compatibility policy](../storage_adapter_sdk.md). The
+release-train MSRV is Rust 1.88. There are no feature flags or independent
+serialization guarantees.
 
 ## Errors, Runtime, and Security
 
@@ -24,6 +25,7 @@ their type promises redaction.
 
 ## Ownership and Verification
 
-Hubuum maintainers own the workspace crate. `hubuum-storage-core` and the root
-task services verify it today. A later promotion must enable rustdoc, package,
-and crates.io compatibility gates.
+Hubuum maintainers own the crate. `hubuum-storage-core` and the root task
+services verify its behavior. CI packages it, builds rustdoc with warnings
+denied, and compares it with the latest crates.io release when a baseline
+exists.

--- a/docs/rust_api_boundary.md
+++ b/docs/rust_api_boundary.md
@@ -14,10 +14,12 @@ and its committed OpenAPI document. Rust API consumers should use
 `hubuum-client-rust`, which wraps that HTTP contract. The Python client follows
 the same boundary.
 
-Every workspace package currently sets `publish = false`. The backend-neutral
-boundary crates are being shaped as candidates for a later publication change,
-but this decision does not create a third-party SemVer promise. Public Rust
-visibility remains an implementation detail until a separate promotion review.
+The six-crate storage adapter SDK is classified `experimental-public` and has a
+documented crates.io publication graph. Its exact compatibility rules are in
+the [Storage Adapter SDK Compatibility policy](storage_adapter_sdk.md). All
+other workspace packages remain unpublished. Public Rust visibility in those
+internal packages remains an implementation detail until a separate promotion
+review.
 
 ## Current consumers
 
@@ -77,19 +79,19 @@ manifest.
 | `hubuum-auth-core` | Workspace-internal |
 | `hubuum-auth-ldap` | Workspace-internal |
 | `hubuum-computed-fields` | Workspace-internal |
-| `hubuum-domain` | Workspace-internal |
+| `hubuum-domain` | Experimental public |
 | `hubuum-event-sink-amqp` | Workspace-internal |
 | `hubuum-event-sink-email` | Workspace-internal |
 | `hubuum-event-sink-valkey` | Workspace-internal |
 | `hubuum-event-sink-webhook` | Workspace-internal |
 | `hubuum-event-sinks-common` | Workspace-internal |
-| `hubuum-events-core` | Workspace-internal |
+| `hubuum-events-core` | Experimental public |
 | `hubuum-outbound-http` | Workspace-internal |
-| `hubuum-query` | Workspace-internal |
-| `hubuum-storage-core` | Workspace-internal |
-| `hubuum-storage-conformance` | Workspace-internal |
+| `hubuum-query` | Experimental public |
+| `hubuum-storage-core` | Experimental public |
+| `hubuum-storage-conformance` | Experimental public |
 | `hubuum-storage-postgres` | Workspace-internal |
-| `hubuum-task-core` | Workspace-internal |
+| `hubuum-task-core` | Experimental public |
 | `hubuum-templates` | Workspace-internal |
 
 The machine values are:
@@ -99,15 +101,21 @@ The machine values are:
 - `experimental-public`; and
 - `stable-public`.
 
+`experimental-public` is a supported pre-1.0 source API with the versioning and
+migration rules in its package policy. It does not mean “unversioned” or
+“best-effort.” `stable-public` additionally promises ordinary post-1.0 SemVer.
+
 `scripts/check-rust-api-policy.py` rejects an unclassified package. Internal
 classifications require Cargo publishing to be disabled; public classifications
 require `publish = true` or a registry allowlist containing `crates-io`, plus a
-package-specific policy document that resolves to a readable file inside this
-repository. The checker uses Cargo's resolved workspace membership, including
-automatically admitted in-tree path dependencies. CI and tagged release
-validation run the policy and its regression fixtures. The CI change classifier
-also discovers declared policy document paths so their deletion or movement
-cannot bypass validation as a documentation-only change.
+package-specific policy document that is also packaged as the crate readme.
+Public crates cannot depend on internal workspace packages. Packages in a named
+release train must share one version and use exact requirements for every
+in-train path dependency. The checker uses Cargo's resolved workspace
+membership, including automatically admitted in-tree path dependencies. CI and
+tagged release validation run the policy and its regression fixtures. The CI
+change classifier also discovers declared policy document paths so their
+deletion or movement cannot bypass validation as a documentation-only change.
 
 ## Internal package rules
 
@@ -173,6 +181,12 @@ An intentional supported-API break requires the correct version change, a
 changelog entry labeled as a supported Rust crate break, and migration guidance.
 Narrow baseline-specific exceptions are preferred over disabling compatibility
 validation.
+
+The storage SDK promotion applies this process to a closed, exact-version
+release train. Its package graph, feature matrix, MSRV, enum policy,
+deprecation timeline, aggregate evolution rules, release order, and adapter
+upgrade steps are defined in
+[Storage Adapter SDK Compatibility](storage_adapter_sdk.md).
 
 ## Changelog terminology
 

--- a/docs/storage_adapter_sdk.md
+++ b/docs/storage_adapter_sdk.md
@@ -1,0 +1,199 @@
+# Storage Adapter SDK Compatibility
+
+Status: accepted for the experimental `0.1` release train.
+
+## Supported Crate Graph
+
+The statically linked storage adapter SDK consists of exactly these crates:
+
+| Crate | Supported purpose | Supported features |
+| --- | --- | --- |
+| `hubuum-domain` | Validated identifiers, revisions, JSON Patch, and domain values | Default; `openapi` |
+| `hubuum-events-core` | Event catalog, envelopes, filters, and mutation provenance | Default; `schema` |
+| `hubuum-query` | Bounded, backend-neutral query parsing and values | Default only |
+| `hubuum-task-core` | Task identity and idempotency values | Default only |
+| `hubuum-storage-core` | Complete capability traits, DTOs, errors, transactions, and aggregate | Default only |
+| `hubuum-storage-conformance` | Reusable behavioral certification for complete adapters | Default only |
+
+Their publication graph is closed:
+
+```text
+hubuum-storage-conformance
+        |          |
+        |          +-- hubuum-domain
+        v
+hubuum-storage-core
+    |       |       |       |
+    |       |       |       +-- hubuum-task-core
+    |       |       +---------- hubuum-query
+    |       +------------------ hubuum-events-core
+    +-------------------------- hubuum-domain
+                                    ^
+                                    |
+                            hubuum-events-core
+```
+
+Every in-graph dependency uses an exact version requirement. The six packages
+share one version and are released together. The root application and
+`hubuum-storage-postgres` are not part of the supported SDK. PostgreSQL remains
+the in-repository reference implementation, while an external adapter depends
+only on the graph above.
+
+The SDK is a Rust source compatibility contract for static Cargo composition.
+It is not a dynamic plugin ABI, wire protocol, runtime capability handshake, or
+server embedding API.
+
+## Versioning and Aggregate Evolution
+
+The SDK begins as `experimental-public` at `0.1.0`. During the `0.x` series:
+
+- a patch release is source compatible with its minor line;
+- a minor release may make a documented breaking change;
+- all six crates still advance together, even when only one crate changes; and
+- adapter manifests use an exact requirement for `hubuum-storage-core` and the
+  matching `hubuum-storage-conformance` release.
+
+At `1.0.0`, ordinary Semantic Versioning applies: compatible additions use a
+minor release, fixes use a patch release, and incompatible changes use a major
+release.
+
+`StorageBackend` is the mandatory aggregate. Adding a required supertrait or
+trait method, removing or changing a method, changing a carrier or result, or
+changing a closed semantic vocabulary is incompatible for adapter authors. It
+therefore requires a coordinated minor release before `1.0.0` and a major
+release afterward. The project will not hide a required capability behind an
+unsupported default. A versioned parallel aggregate is introduced only if a
+future migration genuinely requires two application contract generations to
+coexist; it is not the routine evolution mechanism.
+
+`cargo-semver-checks` runs against the latest crates.io release for every SDK
+crate. Its result supplements the policy above: a change that is behaviorally
+breaking still requires the coordinated incompatible release even if a source
+API checker cannot detect it.
+
+## MSRV and Features
+
+The minimum supported Rust version is Rust 1.88 for the entire release train.
+Every documented feature combination must build and be usable on that version.
+Raising the MSRV requires an incompatible coordinated release and migration
+notice during `0.x`; after `1.0.0`, it follows the project's documented major
+release policy unless a future policy explicitly establishes an MSRV window.
+
+The two optional features are additive:
+
+- `hubuum-domain/openapi` adds Utoipa schema implementations; and
+- `hubuum-events-core/schema` adds Utoipa schema implementations and enables
+  `hubuum-domain/openapi`.
+
+Default behavior must not change when either feature is disabled. Removing or
+renaming a feature, making it mandatory, or changing a feature so it removes
+an API is incompatible. New additive features are compatible when existing
+feature combinations keep their behavior.
+
+## Enum Evolution
+
+Public SDK enums have an explicit closed or extensible policy.
+
+`hubuum-storage-core::StorageCapability` is extensible and carries
+`#[non_exhaustive]`. Downstream diagnostics must include a wildcard match arm;
+new capability labels are compatible additions.
+
+Every other public SDK enum is a closed semantic vocabulary. Adding, removing,
+renaming, or reinterpreting a variant is an incompatible change. The audited
+closed set is:
+
+- `hubuum-domain`: `EventDeliveryStatus`, `JsonPatchErrorKind`,
+  `JsonSchemaErrorKind`, `MaintenanceState`, `PrincipalKind`,
+  `ResourceRevisionError`, and `StorageJsonValidationError`;
+- `hubuum-events-core`: `Action`, `ActorKind`, `EntityType`,
+  `EventCatalogError`, `EventFilterError`, and `EventSinkSecretError`;
+- `hubuum-query`: `ComputedFieldScope`, `ComputedQueryValueType`,
+  `CursorCodecError`, `CursorValue`, `DataType`, `Operator`,
+  `QueryError`, `QueryScalarType`, `RelatedClassField`,
+  `RelatedFilterTarget`, `RelatedObjectField`, `SearchOperator`,
+  `StructuredQueryExpression`, and `StructuredQueryField`;
+- `hubuum-task-core`: `IdempotencyKeyError`; and
+- `hubuum-storage-core`: all public enums except `StorageCapability`, including
+  authorization permissions, errors, lifecycle selectors, query dimensions,
+  task and restore states, import policies, mutation outcomes, notifications,
+  and execution call sites.
+
+Error enums are deliberately closed because their classifications are part of
+the portable contract. A new failure category requires adapter and caller
+review rather than being silently absorbed by a wildcard. Private adapter
+enums and application HTTP enums are outside this SDK policy.
+
+## Deprecation and Removal
+
+A supported item is normally deprecated for at least one coordinated minor
+release before removal. Removal occurs only in an incompatible release and the
+changelog gives the replacement and migration action. A required aggregate
+method is not deprecated until its replacement can express the complete
+semantics and the conformance suite covers the migration.
+
+An urgent security or soundness problem may require immediate removal or
+restriction. That release must contain an explicit security note, affected
+versions, and the safest available migration.
+
+## Release Process
+
+SDK releases are distinct from server `vX.Y.Z` releases. Maintainers:
+
+1. choose one version for all six packages and update every exact in-graph
+   dependency plus `Cargo.lock`;
+2. record supported additions, changes, deprecations, and every breaking
+   migration in `CHANGELOG.md`;
+3. update the crate policy documents, storage contract, method registry,
+   semantic evidence, and conformance behavior together;
+4. run the Rust API policy, package, rustdoc, SemVer, formatting, lint, and full
+   repository suites;
+5. publish in dependency order, waiting for crates.io index visibility between
+   layers: `hubuum-domain`, `hubuum-query`, and `hubuum-task-core` first,
+   `hubuum-events-core` second, `hubuum-storage-core` third, and
+   `hubuum-storage-conformance` last; and
+6. create an annotated `storage-sdk-vX.Y.Z` tag and release notes only after all
+   six immutable crate versions are visible.
+
+The local publication checks are:
+
+```bash
+python3 scripts/check-rust-api-policy.py
+python3 scripts/test-rust-api-policy.py
+cargo package --locked \
+  --package hubuum-domain \
+  --package hubuum-events-core \
+  --package hubuum-query \
+  --package hubuum-task-core \
+  --package hubuum-storage-core \
+  --package hubuum-storage-conformance
+```
+
+CI builds rustdoc with warnings denied and all features enabled. It runs
+`cargo-semver-checks` once a registry baseline exists. Publication itself is a
+maintainer-controlled operation because crates.io versions cannot be replaced.
+
+## Adapter Upgrade Process
+
+Adapter authors should upgrade `hubuum-storage-core` and
+`hubuum-storage-conformance` to the same exact SDK version, update every direct
+SDK dependency to that version, and then:
+
+1. compile the complete `StorageBackend` aggregate;
+2. run the unchanged portable conformance suite;
+3. run backend-native transaction, consistency, migration, failure, and
+   connection-loss tests; and
+4. review the SDK changelog for behavior changes that compile-time checks do
+   not express.
+
+An adapter version supports exactly the SDK version it declares. Applications
+select adapters statically and do not negotiate compatibility at runtime.
+
+## Data, Errors, Runtime, and Security
+
+Crate-specific policy documents under `docs/rust_api/` define supported
+entrypoints, error and panic behavior, runtime and cancellation expectations,
+serialization guarantees, and secret-redaction requirements. The
+[storage contract](storage_boundary/contract.md),
+[query semantics](storage_boundary/query-semantics.md), and
+[testing contract](storage_boundary/testing.md) are normative for adapter
+behavior.

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -17,6 +17,9 @@ PostgreSQL is currently the only selectable backend. The in-memory resource mode
 - Use the [maintainer guide](storage_boundary/maintainer-guide.md) to trace a call, locate its implementation, and change the boundary safely.
 - Use [transactions and side effects](storage_boundary/transactions-and-events.md) when a use case spans several resource operations or must define audit behavior.
 - Use [testing and compatibility](storage_boundary/testing.md) to understand what the test layers prove and where confidence remains limited.
+- Use the [storage adapter SDK policy](storage_adapter_sdk.md) for the published
+  crate graph, versioning, MSRV, features, enum evolution, releases, and
+  upgrades.
 - Track deliberately deferred work in the
   [storage-boundary follow-up issues](https://github.com/hubuum/hubuum/issues?q=is%3Aissue%20is%3Aopen%20%22Deferred%20from%20%23336%22).
 - Inspect the machine-checked [semantic coverage inventory](storage_boundary/semantic-coverage.toml) for the exact methods, tracked input variants, and test evidence.
@@ -210,14 +213,15 @@ hubuum application
   delivery, restore-coordination, and lease-loss protocol expectations, and
   the common application, service, readiness, and authenticated HTTP
   expectations.
-  It is workspace-internal and used only as a development dependency.
+  It is an experimental public development dependency for adapter authors.
 - `hubuum-storage-postgres` owns the native pool, TLS, endpoint diagnostics, generated schema, migrations, JSONB validation, query instrumentation, and all production PostgreSQL operations.
 - The root crate owns application services and static composition. It constructs the PostgreSQL adapter with telemetry and dedicated operational pools, then places it behind the opaque handle.
 - The root crate has no PostgreSQL module tree. Adapter-specific integration
   fixtures are typed, feature-gated APIs owned by `hubuum-storage-postgres`.
 
-The backend-neutral contracts needed by an out-of-tree adapter remain
-workspace-internal in this pull request; they are not being published yet.
+The backend-neutral contracts needed by an out-of-tree adapter form the
+experimental public six-crate
+[storage adapter SDK](storage_adapter_sdk.md).
 External-crate integration tests nevertheless implement all 44
 complete-backend traits and their 249 methods, compile every transaction port,
 exercise representative typed query APIs, and name public construction paths
@@ -225,11 +229,11 @@ for all current adapter-returned values without crate-private access. Backend
 registration remains explicit, exhaustive, and application-owned. Hubuum does
 not load storage plugins dynamically.
 
-This establishes structural out-of-tree usability, not a supported standalone
-adapter SDK. The
-[storage-boundary follow-up issues](https://github.com/hubuum/hubuum/issues?q=is%3Aissue%20is%3Aopen%20%22Deferred%20from%20%23336%22)
-track the remaining portability validation, semantic evidence, value audits,
-neutral event construction, and publication policy work.
+The SDK is a supported pre-1.0 Rust source contract for statically linked
+adapters. It is not a promise that the PostgreSQL adapter, server composition,
+or a dynamic plugin ABI is public. Remaining follow-up work validates the
+boundary with an independent adapter and standardizes neutral audit-document
+construction before a stable 1.0 designation.
 
 Moving a file does not by itself improve the boundary. Dependencies must continue to point from the application to contracts and from adapters to contracts, never from a contract or adapter back into the application.
 

--- a/docs/storage_boundary/backend-author-guide.md
+++ b/docs/storage_boundary/backend-author-guide.md
@@ -83,10 +83,9 @@ helpers that share native transactions and queries.
 ## Boundary Values
 
 Use the request and result DTOs owned by `hubuum-storage-core` and the validated
-values owned by its backend-neutral workspace dependencies. They are designed
-for later publication but remain unpublished in this change. Root application
-models may be converted into those DTOs, but they are not part of the adapter
-contract.
+values owned by the experimental public
+[storage adapter SDK](../storage_adapter_sdk.md). Root application models may
+be converted into those DTOs, but they are not part of the adapter contract.
 
 Boundary values describe application intent and observable results, not the
 adapter's schema.

--- a/docs/storage_boundary/contract.md
+++ b/docs/storage_boundary/contract.md
@@ -297,25 +297,23 @@ container inputs, and native migration tests as required.
 
 ## Packaging and Public API
 
-`hubuum-storage-core` is the experimental extension surface. It and its
-backend-neutral dependencies remain workspace-internal in this change; this
-pull request does not publish them as external crates. Their APIs are still
-reviewed as future publication boundaries and must remain usable by an
-out-of-tree adapter without root or adapter-private access.
+`hubuum-storage-core` is the experimental public extension surface. It, its
+backend-neutral dependencies, and `hubuum-storage-conformance` form the
+exact-version [storage adapter SDK](../storage_adapter_sdk.md). They must remain
+usable by an out-of-tree adapter without root or adapter-private access.
 
-That usability is structural: an external crate can consume the types and
-implement the traits. Method-specific query and collection behavior is now
-normative and exhaustive, but independent semantic certification still depends
-on the workspace compatibility suite. Neutral event construction, reusable
-certification packaging, and publication policy remain separate work. See
+An external crate can consume the types, implement the traits, and use the
+published conformance harness. Method-specific query and collection behavior
+is normative and exhaustive. Neutral audit-document construction and
+validation by a second complete adapter remain follow-up work. See
 [storage query semantics](query-semantics.md) and the
 [method contract registry](method-contracts.toml).
 
-`hubuum-storage-postgres`, `hubuum-storage-conformance`, and the root `hubuum`
-crate are workspace-internal. The conformance crate is a development dependency
-of the application and must not enter production binaries. PostgreSQL schema,
-migrations, native clients, and telemetry types remain in the PostgreSQL
-adapter rather than leaking into `hubuum-storage-core`.
+`hubuum-storage-postgres` and the root `hubuum` crate are workspace-internal.
+The conformance crate is a public development dependency and must not enter
+production binaries. PostgreSQL schema, migrations, native clients, and
+telemetry types remain in the PostgreSQL adapter rather than leaking into
+`hubuum-storage-core`.
 
 ## Performance Contract
 

--- a/docs/storage_boundary/maintainer-guide.md
+++ b/docs/storage_boundary/maintainer-guide.md
@@ -302,8 +302,8 @@ authentication configuration, or raw driver option string.
   endpoint shape during composition.
 - `hubuum-storage-conformance` owns reusable audit, retention, delivery-fault,
   restore-coordination, lease-loss, and application/service/HTTP compatibility
-  expectations. It is a
-  workspace-internal development dependency, not production code.
+  expectations. It is an experimental public development dependency, not
+  production code.
 - `hubuum-storage-postgres` owns pool construction, schema, migrations, native helpers, and production operation implementations.
 - The root crate owns application services, authorization-policy selection,
   adapter registration, observer wiring, settings and legacy-diagnostics

--- a/docs/storage_boundary/query-semantics.md
+++ b/docs/storage_boundary/query-semantics.md
@@ -124,7 +124,7 @@ mapping, rejects unused profiles, and requires method-specific semantic
 evidence. Adding or reclassifying a collection-shaped method therefore requires
 updating its observable contract in the same change.
 
-This completes the method-level query and collection specification; it does
-not by itself publish `hubuum-storage-core` as a supported standalone adapter
-SDK. Crate publication, compatibility promises, versioning, and the supported
-certification entry point are a separate policy decision.
+This completes the method-level query and collection specification used by the
+experimental public [storage adapter SDK](../storage_adapter_sdk.md). The SDK
+policy defines crate publication, compatibility, versioning, and the supported
+conformance entry point.

--- a/docs/storage_boundary/testing.md
+++ b/docs/storage_boundary/testing.md
@@ -181,15 +181,14 @@ The suite covers these semantic-group behaviors:
 
 The aggregate trait guarantees that every method exists. The semantic coverage
 inventory guarantees that the method and tracked input-variant lists cannot
-drift unnoticed. The compatibility suite supplies representative semantics by
-semantic capability group and directly invokes most methods. A listed scenario is not mechanical
-method-level evidence: broad scenarios may cover several methods, and the guard
-does not verify which ones they call. Some native worker operations—most
-notably delivery claims—still receive their deepest coverage in
-PostgreSQL-specific tests. Optional notification providers are tested beside
+drift unnoticed. Named scenarios collectively invoke every method directly and
+assert observable effects. Broad scenarios may still cover several methods,
+and the guard does not construct a transitive call graph. Some native worker
+operations—most notably delivery claims—receive their deepest failure coverage
+in PostgreSQL-specific tests. Optional notification providers are tested beside
 their adapter rather than inventoried as complete-backend traits.
 
-`hubuum-storage-conformance` owns the reusable, workspace-internal,
+`hubuum-storage-conformance` owns the reusable, experimental public,
 backend-independent six-part audit verifier. Each adapter supplies an isolated
 fixture through `BackendAuditFixture`; the root registry invokes it for every
 `BackendTestEnvironment` entry. A selectable backend must demonstrate:

--- a/scripts/check-rust-api-policy.py
+++ b/scripts/check-rust-api-policy.py
@@ -26,10 +26,12 @@ VALID_STATUSES = INTERNAL_STATUSES | PUBLIC_STATUSES
 @dataclass(frozen=True)
 class PackagePolicy:
     name: str
+    version: str
     manifest: str
     rust_api: str
     publish: bool
     policy_document: str | None
+    release_train: str | None
 
 
 @dataclass(frozen=True)
@@ -218,6 +220,9 @@ def declared_policy_documents(root: Path) -> list[str]:
 
 def package_policy(root: Path, manifest: Path) -> PackagePolicy:
     name, package, hubuum = package_manifest(root, manifest)
+    version = package.get("version")
+    if not isinstance(version, str) or not version:
+        fail(f"package {name} must declare a version")
     rust_api = hubuum.get("rust-api") if hubuum is not None else None
     if rust_api not in VALID_STATUSES:
         fail(
@@ -227,11 +232,18 @@ def package_policy(root: Path, manifest: Path) -> PackagePolicy:
 
     publish = cargo_publish_policy(name, package.get("publish", True))
     policy_document = hubuum.get("policy-document") if hubuum is not None else None
+    release_train = hubuum.get("release-train") if hubuum is not None else None
+    if release_train is not None and (
+        not isinstance(release_train, str) or not release_train.strip()
+    ):
+        fail(f"package {name} has an invalid release-train")
     if rust_api in INTERNAL_STATUSES:
         if publish.enabled:
             fail(f"internal package {name} must disable publishing")
         if policy_document is not None:
             fail(f"internal package {name} must not declare policy-document")
+        if release_train is not None:
+            fail(f"internal package {name} must not declare release-train")
     else:
         if not publish.enabled:
             fail(
@@ -248,14 +260,111 @@ def package_policy(root: Path, manifest: Path) -> PackagePolicy:
             name,
             policy_document,
         )
+        readme = package.get("readme")
+        if not isinstance(readme, str) or not readme:
+            fail(f"public package {name} must package its policy document as readme")
+        readme_path = (manifest.parent / readme).resolve()
+        policy_path = (root / policy_document).resolve()
+        if readme_path != policy_path:
+            fail(
+                f"public package {name} readme must be its declared policy document "
+                f"{policy_document}"
+            )
 
     return PackagePolicy(
         name=name,
+        version=version,
         manifest=str(manifest.relative_to(root)),
         rust_api=rust_api,
         publish=publish.enabled,
         policy_document=policy_document,
+        release_train=release_train,
     )
+
+
+def dependency_tables(data: dict[str, object]) -> list[dict[str, object]]:
+    tables: list[dict[str, object]] = []
+    for key in ("dependencies", "dev-dependencies", "build-dependencies"):
+        table = data.get(key)
+        if isinstance(table, dict):
+            tables.append(table)
+    targets = data.get("target")
+    if isinstance(targets, dict):
+        for target in targets.values():
+            if not isinstance(target, dict):
+                continue
+            for key in ("dependencies", "dev-dependencies", "build-dependencies"):
+                table = target.get(key)
+                if isinstance(table, dict):
+                    tables.append(table)
+    return tables
+
+
+def validate_public_dependency_graph(root: Path, result: list[PackagePolicy]) -> None:
+    by_manifest = {
+        (root / policy.manifest).resolve(): policy
+        for policy in result
+    }
+    for policy in result:
+        if policy.rust_api not in PUBLIC_STATUSES:
+            continue
+        manifest = (root / policy.manifest).resolve()
+        data = read_manifest(manifest)
+        for table in dependency_tables(data):
+            for dependency_name, dependency in table.items():
+                if not isinstance(dependency, dict) or "path" not in dependency:
+                    continue
+                path = dependency.get("path")
+                if not isinstance(path, str) or not path:
+                    fail(
+                        f"public package {policy.name} has an invalid path dependency "
+                        f"for {dependency_name}"
+                    )
+                dependency_manifest = (manifest.parent / path / "Cargo.toml").resolve()
+                dependency_policy = by_manifest.get(dependency_manifest)
+                if dependency_policy is None:
+                    fail(
+                        f"public package {policy.name} path dependency {dependency_name} "
+                        "must resolve to a workspace package"
+                    )
+                if dependency_policy.rust_api not in PUBLIC_STATUSES:
+                    fail(
+                        f"public package {policy.name} must not depend on internal "
+                        f"workspace package {dependency_policy.name}"
+                    )
+                requirement = dependency.get("version")
+                if not isinstance(requirement, str) or not requirement:
+                    fail(
+                        f"public package {policy.name} path dependency "
+                        f"{dependency_policy.name} must declare a registry version"
+                    )
+                if policy.release_train is not None:
+                    if dependency_policy.release_train != policy.release_train:
+                        fail(
+                            f"release train {policy.release_train} package {policy.name} "
+                            f"must not depend on workspace package {dependency_policy.name} "
+                            "from another release train"
+                        )
+                    expected = f"={dependency_policy.version}"
+                    if requirement != expected:
+                        fail(
+                            f"release train {policy.release_train} dependency "
+                            f"{policy.name} -> {dependency_policy.name} must use exact "
+                            f"requirement {expected}"
+                        )
+
+    trains: dict[str, list[PackagePolicy]] = {}
+    for policy in result:
+        if policy.release_train is not None:
+            trains.setdefault(policy.release_train, []).append(policy)
+    for train, packages in trains.items():
+        versions = {package.version for package in packages}
+        if len(versions) != 1:
+            rendered = ", ".join(
+                f"{package.name}={package.version}"
+                for package in sorted(packages, key=lambda item: item.name)
+            )
+            fail(f"release train {train} packages must share one version: {rendered}")
 
 
 def policies(root: Path) -> list[PackagePolicy]:
@@ -265,7 +374,9 @@ def policies(root: Path) -> list[PackagePolicy]:
     names = [policy.name for policy in result]
     if len(names) != len(set(names)):
         fail("workspace package names must be unique")
-    return sorted(result, key=lambda policy: policy.name)
+    result = sorted(result, key=lambda policy: policy.name)
+    validate_public_dependency_graph(root, result)
+    return result
 
 
 def main() -> int:

--- a/scripts/test-rust-api-policy.py
+++ b/scripts/test-rust-api-policy.py
@@ -37,6 +37,8 @@ class RustApiPolicyTests(unittest.TestCase):
         member_status: str = "workspace-internal",
         member_publish: str = "false",
         member_policy: str = "",
+        member_version: str = "0.0.1",
+        member_release_train: str = "",
     ) -> None:
         (self.root / "Cargo.toml").write_text(
             textwrap.dedent(
@@ -61,13 +63,15 @@ class RustApiPolicyTests(unittest.TestCase):
                 f"""
                 [package]
                 name = "member"
-                version = "0.0.1"
+                version = "{member_version}"
                 edition = "2024"
+                readme = "../../docs/member.md"
                 publish = {member_publish}
 
                 [package.metadata.hubuum]
                 rust-api = "{member_status}"
                 {member_policy}
+                {member_release_train}
                 """
             ),
             encoding="utf-8",
@@ -93,14 +97,66 @@ class RustApiPolicyTests(unittest.TestCase):
         publish: str = "true",
         policy_path: str = "docs/member.md",
         create_policy: bool = True,
+        version: str = "0.0.1",
+        release_train: str | None = None,
     ) -> None:
         self.write_workspace(
             member_status=status,
             member_publish=publish,
             member_policy=f'policy-document = "{policy_path}"',
+            member_version=version,
+            member_release_train=(
+                f'release-train = "{release_train}"' if release_train else ""
+            ),
         )
         if create_policy:
             self.write_policy_document(policy_path)
+
+    def write_dependency_package(
+        self,
+        *,
+        status: str,
+        publish: str,
+        version: str = "0.1.0",
+        release_train: str | None = None,
+    ) -> None:
+        dependency = self.root / "crates" / "dependency"
+        (dependency / "src").mkdir(parents=True)
+        (dependency / "src" / "lib.rs").write_text("", encoding="utf-8")
+        policy = ""
+        train = ""
+        if status in {"experimental-public", "stable-public"}:
+            policy = 'policy-document = "docs/dependency.md"'
+            self.write_policy_document("docs/dependency.md")
+        if release_train is not None:
+            train = f'release-train = "{release_train}"'
+        (dependency / "Cargo.toml").write_text(
+            textwrap.dedent(
+                f"""
+                [package]
+                name = "dependency"
+                version = "{version}"
+                edition = "2024"
+                readme = "../../docs/dependency.md"
+                publish = {publish}
+
+                [package.metadata.hubuum]
+                rust-api = "{status}"
+                {policy}
+                {train}
+                """
+            ),
+            encoding="utf-8",
+        )
+
+    def add_member_dependency(self, version: str) -> None:
+        with (self.root / "crates" / "member" / "Cargo.toml").open(
+            "a", encoding="utf-8"
+        ) as manifest:
+            manifest.write(
+                "\n[dependencies]\n"
+                f'dependency = {{ path = "../dependency", version = "{version}" }}\n'
+            )
 
     def test_internal_workspace_is_accepted(self) -> None:
         self.write_workspace()
@@ -191,6 +247,58 @@ class RustApiPolicyTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("must allow crates.io publishing", result.stderr)
 
+    def test_public_package_cannot_depend_on_an_internal_workspace_package(self) -> None:
+        self.write_public_member()
+        self.write_dependency_package(status="workspace-internal", publish="false")
+        self.add_member_dependency("=0.1.0")
+
+        result = self.run_checker()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must not depend on internal workspace package", result.stderr)
+
+    def test_release_train_requires_exact_in_graph_versions(self) -> None:
+        self.write_public_member(version="0.1.0", release_train="storage-sdk")
+        self.write_dependency_package(
+            status="experimental-public",
+            publish="true",
+            release_train="storage-sdk",
+        )
+        self.add_member_dependency("0.1.0")
+
+        result = self.run_checker()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must use exact requirement =0.1.0", result.stderr)
+
+    def test_release_train_packages_share_one_version(self) -> None:
+        self.write_public_member(version="0.1.0", release_train="storage-sdk")
+        self.write_dependency_package(
+            status="experimental-public",
+            publish="true",
+            version="0.2.0",
+            release_train="storage-sdk",
+        )
+        self.add_member_dependency("=0.2.0")
+
+        result = self.run_checker()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("packages must share one version", result.stderr)
+
+    def test_release_train_accepts_one_version_and_exact_requirements(self) -> None:
+        self.write_public_member(version="0.1.0", release_train="storage-sdk")
+        self.write_dependency_package(
+            status="experimental-public",
+            publish="true",
+            release_train="storage-sdk",
+        )
+        self.add_member_dependency("=0.1.0")
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_public_package_policy_document_must_exist(self) -> None:
         self.write_public_member(policy_path="docs/missing.md", create_policy=False)
 
@@ -198,6 +306,25 @@ class RustApiPolicyTests(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("policy-document does not exist as a file", result.stderr)
+
+    def test_public_package_readme_must_be_its_policy_document(self) -> None:
+        self.write_public_member()
+        manifest = self.root / "crates" / "member" / "Cargo.toml"
+        manifest.write_text(
+            manifest.read_text(encoding="utf-8").replace(
+                'readme = "../../docs/member.md"',
+                'readme = "README.md"',
+            ),
+            encoding="utf-8",
+        )
+        (self.root / "crates" / "member" / "README.md").write_text(
+            "# Other readme\n", encoding="utf-8"
+        )
+
+        result = self.run_checker()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("readme must be its declared policy document", result.stderr)
 
     def test_declared_policy_documents_include_a_missing_file(self) -> None:
         self.write_public_member(policy_path="docs/missing.md", create_policy=False)

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -1596,10 +1596,17 @@ fn every_registered_backend_runs_the_reusable_six_part_audit_contract() {
     let root = repository_root();
     let manifest = read_source(&root.join("crates/hubuum-storage-conformance/Cargo.toml"))
         .expect("storage conformance manifest should be readable");
-    assert!(
-        manifest.contains("publish = false"),
-        "the conformance harness must remain workspace-internal"
-    );
+    for required in [
+        "publish = true",
+        "rust-api = \"experimental-public\"",
+        "policy-document = \"docs/rust_api/hubuum-storage-conformance.md\"",
+        "release-train = \"storage-sdk\"",
+    ] {
+        assert!(
+            manifest.contains(required),
+            "the public conformance harness is missing {required}"
+        );
+    }
 
     let fixture = read_source(&root.join("src/tests/storage_contract.rs"))
         .expect("registered backend contract fixture should be readable");


### PR DESCRIPTION
## Summary

- promote exactly six backend-neutral crates to an experimental public `0.1.0` storage SDK release train
- close the publishable dependency graph with exact in-train requirements and packaged per-crate policy documents
- define SemVer, MSRV, feature, enum, deprecation, aggregate-evolution, release-order, and adapter-upgrade guarantees
- extend the Rust API policy checker to reject public-to-internal path dependencies, release-train version drift, non-exact train dependencies, and mismatched packaged readmes

## Supported boundary

The public train contains `hubuum-domain`, `hubuum-events-core`, `hubuum-query`, `hubuum-task-core`, `hubuum-storage-core`, and `hubuum-storage-conformance`. The root application and `hubuum-storage-postgres` remain workspace-internal. `StorageBackend` remains the mandatory complete aggregate; incompatible aggregate changes require a coordinated minor release during `0.x` and a major release after `1.0`.

This change makes the crate graph registry-ready and establishes its compatibility contract. It does not upload immutable artifacts to crates.io; publication remains an explicit maintainer release operation. There is no supported HTTP API or server runtime behavior change. This is the initial supported experimental Rust API, not a break from a prior supported Rust API.

## Verification

- `source /work/terjekv/projects/private/hubuum-rust/.env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- Rust API policy, registry-baseline, and CI classifier regression suites
- clean locked packaging and warning-denied all-feature rustdoc for all six SDK crates
- Dockerfile/workspace manifest parity regression
- production container build with rustls and OpenSSL features

Closes #342