### PR TITLE
Standardize portable audit document construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Breaking (workspace storage API):** audit event bodies now use the
+  validated backend-neutral `AuditDocument` construction path. It owns summary,
+  snapshot, metadata, and schema-version semantics; `NewEvent::from_document`
+  replaces the removed payload mutation setters. Collection snapshots are
+  constructed from `StorageCollection`, and selectable-backend conformance now
+  compares the exact persisted document. Adapter authors must construct and
+  validate an `AuditDocument` before appending an event and keep native event
+  rows as private serialization details.
 - The workspace storage contract now exhaustively specifies every pageable,
   searchable, batched, and complete-collection method, including supported
   query keys, cursor/count/visibility behavior, ordering, multiplicity,

--- a/crates/hubuum-events-core/src/lib.rs
+++ b/crates/hubuum-events-core/src/lib.rs
@@ -934,6 +934,18 @@ impl EventEnvelope {
         self.schema_version
     }
 
+    /// Return the backend-independent document carried by this envelope.
+    #[must_use]
+    pub fn audit_document(&self) -> AuditDocument {
+        AuditDocument {
+            summary: self.summary.clone(),
+            before: self.before.clone(),
+            after: self.after.clone(),
+            metadata: self.metadata.clone(),
+            schema_version: self.schema_version,
+        }
+    }
+
     #[must_use]
     pub fn without_payloads(mut self) -> Self {
         self.before = None;
@@ -1246,6 +1258,208 @@ impl From<EventId> for Uuid {
     }
 }
 
+/// Schema version for audit documents without revision-bearing snapshots.
+pub const BASE_AUDIT_DOCUMENT_SCHEMA_VERSION: i32 = 1;
+
+/// Schema version for audit documents with a revision-bearing snapshot.
+pub const REVISION_AWARE_AUDIT_DOCUMENT_SCHEMA_VERSION: i32 = 2;
+
+/// The backend-independent, permission-scoped body of a durable audit event.
+///
+/// This value owns every field whose representation must be identical across
+/// storage adapters. Native event rows add persistence coordinates such as a
+/// sequence and occurrence timestamp, while [`NewEvent`] adds the logical
+/// entity and mutation provenance.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AuditDocument {
+    summary: String,
+    before: Option<serde_json::Value>,
+    after: Option<serde_json::Value>,
+    metadata: serde_json::Value,
+    schema_version: i32,
+}
+
+impl AuditDocument {
+    /// Start a canonical audit document with an empty metadata object.
+    #[must_use]
+    pub fn builder(summary: impl Into<String>) -> AuditDocumentBuilder {
+        AuditDocumentBuilder {
+            summary: summary.into(),
+            before: None,
+            after: None,
+            metadata: serde_json::Value::Object(serde_json::Map::new()),
+        }
+    }
+
+    /// Construct a summary-only canonical audit document.
+    #[must_use]
+    pub fn summary(summary: impl Into<String>) -> Self {
+        Self {
+            summary: summary.into(),
+            before: None,
+            after: None,
+            metadata: serde_json::Value::Object(serde_json::Map::new()),
+            schema_version: BASE_AUDIT_DOCUMENT_SCHEMA_VERSION,
+        }
+    }
+
+    /// Construct and validate a canonical audit document in one call.
+    pub fn try_new(
+        summary: impl Into<String>,
+        before: Option<serde_json::Value>,
+        after: Option<serde_json::Value>,
+        metadata: serde_json::Value,
+    ) -> Result<Self, AuditDocumentError> {
+        Self::builder(summary)
+            .before_opt(before)
+            .after_opt(after)
+            .metadata(metadata)
+            .try_build()
+    }
+
+    #[must_use]
+    pub fn summary_text(&self) -> &str {
+        &self.summary
+    }
+
+    #[must_use]
+    pub const fn before(&self) -> Option<&serde_json::Value> {
+        self.before.as_ref()
+    }
+
+    #[must_use]
+    pub const fn after(&self) -> Option<&serde_json::Value> {
+        self.after.as_ref()
+    }
+
+    #[must_use]
+    pub const fn metadata(&self) -> &serde_json::Value {
+        &self.metadata
+    }
+
+    #[must_use]
+    pub const fn schema_version(&self) -> i32 {
+        self.schema_version
+    }
+}
+
+impl fmt::Debug for AuditDocument {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuditDocument")
+            .field("summary", &self.summary)
+            .field("before", &self.before.as_ref().map(|_| "<redacted>"))
+            .field("after", &self.after.as_ref().map(|_| "<redacted>"))
+            .field("metadata", &"<redacted>")
+            .field("schema_version", &self.schema_version)
+            .finish()
+    }
+}
+
+/// Validating builder for a canonical [`AuditDocument`].
+pub struct AuditDocumentBuilder {
+    summary: String,
+    before: Option<serde_json::Value>,
+    after: Option<serde_json::Value>,
+    metadata: serde_json::Value,
+}
+
+impl AuditDocumentBuilder {
+    #[must_use]
+    pub fn before(mut self, before: serde_json::Value) -> Self {
+        self.before = Some(before);
+        self
+    }
+
+    #[must_use]
+    pub fn before_opt(mut self, before: Option<serde_json::Value>) -> Self {
+        self.before = before;
+        self
+    }
+
+    #[must_use]
+    pub fn after(mut self, after: serde_json::Value) -> Self {
+        self.after = Some(after);
+        self
+    }
+
+    #[must_use]
+    pub fn after_opt(mut self, after: Option<serde_json::Value>) -> Self {
+        self.after = after;
+        self
+    }
+
+    #[must_use]
+    pub fn metadata(mut self, metadata: serde_json::Value) -> Self {
+        self.metadata = metadata;
+        self
+    }
+
+    pub fn try_build(self) -> Result<AuditDocument, AuditDocumentError> {
+        for (field, snapshot) in [("before", &self.before), ("after", &self.after)] {
+            if snapshot.as_ref().is_some_and(|value| !value.is_object()) {
+                return Err(AuditDocumentError::new(format!(
+                    "audit document {field} snapshot must be a JSON object"
+                )));
+            }
+        }
+        if !self.metadata.is_object() {
+            return Err(AuditDocumentError::new(
+                "audit document metadata must be a JSON object",
+            ));
+        }
+        let mut revision_aware = false;
+        for (field, snapshot) in [("before", &self.before), ("after", &self.after)] {
+            let Some(revision) = snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.get("revision"))
+                .filter(|revision| revision.is_number())
+            else {
+                continue;
+            };
+            if revision.as_i64().is_none_or(|revision| revision <= 0) {
+                return Err(AuditDocumentError::new(format!(
+                    "audit document {field} revision must be a positive integer"
+                )));
+            }
+            revision_aware = true;
+        }
+        let schema_version = if revision_aware {
+            REVISION_AWARE_AUDIT_DOCUMENT_SCHEMA_VERSION
+        } else {
+            BASE_AUDIT_DOCUMENT_SCHEMA_VERSION
+        };
+        Ok(AuditDocument {
+            summary: self.summary,
+            before: self.before,
+            after: self.after,
+            metadata: self.metadata,
+            schema_version,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuditDocumentError {
+    message: String,
+}
+
+impl AuditDocumentError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for AuditDocumentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for AuditDocumentError {}
+
 /// A validated event mutation ready to be appended by a storage adapter.
 ///
 /// Storage-owned columns such as the database id, occurrence timestamp, and
@@ -1264,11 +1478,7 @@ pub struct NewEvent {
     task_id: Option<TaskId>,
     request_id: Option<Uuid>,
     correlation_id: Option<String>,
-    summary: String,
-    before: Option<serde_json::Value>,
-    after: Option<serde_json::Value>,
-    metadata: serde_json::Value,
-    schema_version: i32,
+    document: AuditDocument,
 }
 
 impl fmt::Debug for NewEvent {
@@ -1287,11 +1497,7 @@ impl fmt::Debug for NewEvent {
             .field("task_id", &self.task_id)
             .field("request_id", &self.request_id)
             .field("correlation_id", &self.correlation_id)
-            .field("summary", &self.summary)
-            .field("before", &self.before.as_ref().map(|_| "<redacted>"))
-            .field("after", &self.after.as_ref().map(|_| "<redacted>"))
-            .field("metadata", &"<redacted>")
-            .field("schema_version", &self.schema_version)
+            .field("document", &self.document)
             .finish()
     }
 }
@@ -1303,6 +1509,21 @@ impl NewEvent {
         action: Action,
         actor_kind: ActorKind,
         summary: impl Into<String>,
+    ) -> Result<Self, EventCatalogError> {
+        Self::from_document(
+            entity_type,
+            action,
+            actor_kind,
+            AuditDocument::summary(summary),
+        )
+    }
+
+    /// Construct an event from a validated backend-independent document.
+    pub fn from_document(
+        entity_type: EntityType,
+        action: Action,
+        actor_kind: ActorKind,
+        document: AuditDocument,
     ) -> Result<Self, EventCatalogError> {
         if !is_valid_pair(entity_type, action) {
             return Err(EventCatalogError::InvalidActionForType {
@@ -1323,11 +1544,7 @@ impl NewEvent {
             task_id: None,
             request_id: None,
             correlation_id: None,
-            summary: summary.into(),
-            before: None,
-            after: None,
-            metadata: serde_json::Value::Object(serde_json::Map::new()),
-            schema_version: 1,
+            document,
         })
     }
 
@@ -1384,36 +1601,6 @@ impl NewEvent {
     #[must_use]
     pub fn with_correlation_id(mut self, correlation_id: impl Into<String>) -> Self {
         self.correlation_id = Some(correlation_id.into());
-        self
-    }
-
-    #[must_use]
-    pub fn with_before(mut self, before: serde_json::Value) -> Self {
-        self.before = Some(before);
-        self
-    }
-
-    #[must_use]
-    pub fn with_before_opt(mut self, before: Option<serde_json::Value>) -> Self {
-        self.before = before;
-        self
-    }
-
-    #[must_use]
-    pub fn with_after(mut self, after: serde_json::Value) -> Self {
-        self.after = Some(after);
-        self
-    }
-
-    #[must_use]
-    pub fn with_after_opt(mut self, after: Option<serde_json::Value>) -> Self {
-        self.after = after;
-        self
-    }
-
-    #[must_use]
-    pub fn with_metadata(mut self, metadata: serde_json::Value) -> Self {
-        self.metadata = metadata;
         self
     }
 
@@ -1479,27 +1666,32 @@ impl NewEvent {
 
     #[must_use]
     pub fn summary(&self) -> &str {
-        &self.summary
+        self.document.summary_text()
     }
 
     #[must_use]
     pub const fn before(&self) -> Option<&serde_json::Value> {
-        self.before.as_ref()
+        self.document.before()
     }
 
     #[must_use]
     pub const fn after(&self) -> Option<&serde_json::Value> {
-        self.after.as_ref()
+        self.document.after()
     }
 
     #[must_use]
     pub const fn metadata(&self) -> &serde_json::Value {
-        &self.metadata
+        self.document.metadata()
     }
 
     #[must_use]
     pub const fn schema_version(&self) -> i32 {
-        self.schema_version
+        self.document.schema_version()
+    }
+
+    #[must_use]
+    pub const fn document(&self) -> &AuditDocument {
+        &self.document
     }
 }
 
@@ -1990,16 +2182,20 @@ mod tests {
             ),
             Err(EventCatalogError::InvalidActionForType { .. })
         ));
-        let event = NewEvent::new(
+        let document = AuditDocument::try_new(
+            "created",
+            Some(serde_json::json!({"token": "before-secret"})),
+            Some(serde_json::json!({"token": "after-secret"})),
+            serde_json::json!({"token": "metadata-secret"}),
+        )
+        .unwrap();
+        let event = NewEvent::from_document(
             EntityType::Collection,
             Action::Created,
             ActorKind::User,
-            "created",
+            document,
         )
-        .unwrap()
-        .with_before(serde_json::json!({"token": "before-secret"}))
-        .with_after(serde_json::json!({"token": "after-secret"}))
-        .with_metadata(serde_json::json!({"token": "metadata-secret"}));
+        .unwrap();
 
         let debug = format!("{event:?}");
 
@@ -2007,6 +2203,56 @@ mod tests {
         assert!(!debug.contains("before-secret"));
         assert!(!debug.contains("after-secret"));
         assert!(!debug.contains("metadata-secret"));
+    }
+
+    #[test]
+    fn audit_document_validates_payload_shapes_and_owns_schema_version() {
+        assert!(
+            AuditDocument::builder("invalid snapshot")
+                .before(serde_json::json!([]))
+                .try_build()
+                .is_err()
+        );
+        assert!(
+            AuditDocument::builder("invalid metadata")
+                .metadata(serde_json::json!(null))
+                .try_build()
+                .is_err()
+        );
+        assert!(
+            AuditDocument::builder("invalid revision")
+                .after(serde_json::json!({"revision": 0}))
+                .try_build()
+                .is_err()
+        );
+
+        let document = AuditDocument::try_new(
+            "valid",
+            Some(serde_json::json!({"revision": 1})),
+            None,
+            serde_json::json!({"source": "test"}),
+        )
+        .unwrap();
+        assert_eq!(
+            document.schema_version(),
+            REVISION_AWARE_AUDIT_DOCUMENT_SCHEMA_VERSION
+        );
+        assert_eq!(
+            AuditDocument::summary("legacy-shaped").schema_version(),
+            BASE_AUDIT_DOCUMENT_SCHEMA_VERSION
+        );
+    }
+
+    #[test]
+    fn event_envelope_exposes_its_canonical_audit_document() {
+        let envelope = envelope();
+        let document = envelope.audit_document();
+
+        assert_eq!(document.summary_text(), envelope.summary());
+        assert_eq!(document.before(), envelope.before());
+        assert_eq!(document.after(), envelope.after());
+        assert_eq!(document.metadata(), envelope.metadata());
+        assert_eq!(document.schema_version(), envelope.schema_version());
     }
 
     #[test]

--- a/crates/hubuum-storage-conformance/src/lib.rs
+++ b/crates/hubuum-storage-conformance/src/lib.rs
@@ -13,8 +13,9 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 use hubuum_domain::ResourceRevision;
 use hubuum_storage_core::{
-    StorageError, StorageErrorKind, StorageEventRetentionBatchId, StorageEventRetentionSummary,
-    StorageMutationOutcome, StorageObservation, StorageObserver, StorageRecordedEvent,
+    AuditDocument, StorageError, StorageErrorKind, StorageEventRetentionBatchId,
+    StorageEventRetentionSummary, StorageMutationOutcome, StorageObservation, StorageObserver,
+    StorageRecordedEvent,
 };
 
 /// Thread-safe application observer used by backend contract fixtures.
@@ -186,14 +187,20 @@ pub trait ApplicationCompatibilityFixture {
 pub struct CommittedMutationProbe {
     outcome: StorageMutationOutcome<()>,
     persisted_events: Vec<StorageRecordedEvent>,
+    expected_documents: Vec<AuditDocument>,
 }
 
 impl CommittedMutationProbe {
     #[must_use]
-    pub fn new(outcome: StorageMutationOutcome<()>, persisted_event: StorageRecordedEvent) -> Self {
+    pub fn new(
+        outcome: StorageMutationOutcome<()>,
+        persisted_event: StorageRecordedEvent,
+        expected_document: AuditDocument,
+    ) -> Self {
         Self {
             outcome,
             persisted_events: vec![persisted_event],
+            expected_documents: vec![expected_document],
         }
     }
 
@@ -203,10 +210,12 @@ impl CommittedMutationProbe {
     pub const fn with_events(
         outcome: StorageMutationOutcome<()>,
         persisted_events: Vec<StorageRecordedEvent>,
+        expected_documents: Vec<AuditDocument>,
     ) -> Self {
         Self {
             outcome,
             persisted_events,
+            expected_documents,
         }
     }
 }
@@ -510,6 +519,7 @@ pub enum ContractViolation {
     MissingAuditReceipt,
     AuditReceiptCountMismatch,
     ReceiptDoesNotMatchPersistedEvent,
+    AuditDocumentMismatch,
     NoopReturnedAuditReceipt,
     NoopAppendedAuditEvent,
     RollbackPersistedState,
@@ -558,6 +568,9 @@ impl fmt::Display for ContractViolation {
             }
             Self::ReceiptDoesNotMatchPersistedEvent => {
                 "audit receipt does not identify the persisted event"
+            }
+            Self::AuditDocumentMismatch => {
+                "persisted audit document does not match the canonical document"
             }
             Self::NoopReturnedAuditReceipt => "unchanged mutation returned an audit receipt",
             Self::NoopAppendedAuditEvent => "unchanged mutation appended an audit event",
@@ -796,13 +809,16 @@ fn verify_committed_mutation(probe: CommittedMutationProbe) -> Result<(), Contra
         .outcome
         .audits()
         .ok_or(ContractViolation::MissingAuditReceipt)?;
-    if receipts.len() != probe.persisted_events.len() {
+    if receipts.len() != probe.persisted_events.len()
+        || receipts.len() != probe.expected_documents.len()
+    {
         return Err(ContractViolation::AuditReceiptCountMismatch);
     }
     let mut persisted_events = probe
         .persisted_events
         .into_iter()
-        .map(StorageRecordedEvent::into_parts)
+        .zip(probe.expected_documents)
+        .map(|(event, document)| (event.into_parts(), document))
         .collect::<Vec<_>>();
     let mut receipt_sequences = HashSet::with_capacity(receipts.len());
     let mut receipt_event_ids = HashSet::with_capacity(receipts.len());
@@ -814,11 +830,12 @@ fn verify_committed_mutation(probe: CommittedMutationProbe) -> Result<(), Contra
         }
         let Some(event_index) = persisted_events
             .iter()
-            .position(|(event, _, _)| event.id() == receipt.sequence())
+            .position(|((event, _, _), _)| event.id() == receipt.sequence())
         else {
             return Err(ContractViolation::ReceiptDoesNotMatchPersistedEvent);
         };
-        let (event, before_revision, after_revision) = persisted_events.swap_remove(event_index);
+        let ((event, before_revision, after_revision), expected_document) =
+            persisted_events.swap_remove(event_index);
         if event.event_id() != receipt.event_id().as_uuid()
             || event.entity_type() != receipt.entity_type()
             || event.action() != receipt.action()
@@ -826,6 +843,9 @@ fn verify_committed_mutation(probe: CommittedMutationProbe) -> Result<(), Contra
             || after_revision != receipt.after_revision()
         {
             return Err(ContractViolation::ReceiptDoesNotMatchPersistedEvent);
+        }
+        if event.audit_document() != expected_document {
+            return Err(ContractViolation::AuditDocumentMismatch);
         }
     }
     Ok(())
@@ -937,17 +957,42 @@ mod tests {
     #[test]
     fn committed_probe_rejects_duplicate_receipts_that_hide_a_persisted_event() {
         let first_event = recorded_event(1);
+        let second_event = recorded_event(2);
         let duplicated_receipt = first_event.clone().into_audit_receipt();
         let outcome = StorageMutationOutcome::committed_with_audits(
             (),
             StorageAuditReceipts::new(duplicated_receipt.clone(), vec![duplicated_receipt]),
         );
-        let probe =
-            CommittedMutationProbe::with_events(outcome, vec![first_event, recorded_event(2)]);
+        let expected_documents = vec![
+            first_event.clone().into_parts().0.audit_document(),
+            second_event.clone().into_parts().0.audit_document(),
+        ];
+        let probe = CommittedMutationProbe::with_events(
+            outcome,
+            vec![first_event, second_event],
+            expected_documents,
+        );
 
         assert!(matches!(
             verify_committed_mutation(probe),
             Err(ContractViolation::ReceiptDoesNotMatchPersistedEvent)
+        ));
+    }
+
+    #[test]
+    fn committed_probe_rejects_a_noncanonical_document() {
+        let event = recorded_event(1);
+        let receipt = event.clone().into_audit_receipt();
+        let outcome = StorageMutationOutcome::committed((), receipt);
+        let probe = CommittedMutationProbe::new(
+            outcome,
+            event,
+            AuditDocument::summary("different summary"),
+        );
+
+        assert!(matches!(
+            verify_committed_mutation(probe),
+            Err(ContractViolation::AuditDocumentMismatch)
         ));
     }
 

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -128,6 +128,7 @@ pub use history::{
     StorageObjectHistoryListQuery, StorageObjectHistoryRecord, StorageRemoteTargetHistoryRecord,
 };
 pub use hubuum_domain::PrincipalKind;
+pub use hubuum_events_core::AuditDocument;
 pub use identity::{
     AuthenticationStorage, StorageAuthenticatedToken, StorageAuthenticatedTokenBuilder,
     StorageAuthenticationAttempt, StorageAuthenticationCredential, StorageAuthenticationHuman,

--- a/crates/hubuum-storage-core/src/unified_search.rs
+++ b/crates/hubuum-storage-core/src/unified_search.rs
@@ -403,6 +403,24 @@ impl StorageCollection {
     pub const fn parent_collection_id(&self) -> Option<CollectionId> {
         self.parent_collection_id
     }
+
+    /// Return the canonical collection snapshot stored in audit documents.
+    ///
+    /// Adapters should construct collection events from this projection rather
+    /// than serializing native persistence rows. Timestamps intentionally use
+    /// the existing UTC-naive wire representation of durable audit snapshots.
+    #[must_use]
+    pub fn audit_snapshot(&self) -> Value {
+        serde_json::json!({
+            "id": self.id.id(),
+            "name": self.name,
+            "description": self.description,
+            "created_at": self.created_at.naive_utc(),
+            "updated_at": self.updated_at.naive_utc(),
+            "parent_collection_id": self.parent_collection_id.map(CollectionId::id),
+            "revision": self.revision.get(),
+        })
+    }
 }
 
 /// Expanded class projection used by catalog and unified-search reads.
@@ -725,6 +743,39 @@ mod tests {
         assert_eq!(
             scope.object_ids(),
             &[ObjectId::new(2).unwrap(), ObjectId::new(7).unwrap()]
+        );
+    }
+
+    #[test]
+    fn collection_audit_snapshot_has_backend_independent_shape() {
+        let created_at = "2026-08-30T12:00:00Z".parse().unwrap();
+        let updated_at = "2026-08-30T12:01:00Z".parse().unwrap();
+        let metadata = StorageRecordMetadata::try_new(
+            ResourceId::new(7).unwrap(),
+            created_at,
+            updated_at,
+            ResourceRevision::new(3).unwrap(),
+        )
+        .unwrap();
+        let collection = StorageCollection::try_new(
+            metadata,
+            "portable",
+            "canonical",
+            Some(CollectionId::new(2).unwrap()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            collection.audit_snapshot(),
+            serde_json::json!({
+                "id": 7,
+                "name": "portable",
+                "description": "canonical",
+                "created_at": "2026-08-30T12:00:00",
+                "updated_at": "2026-08-30T12:01:00",
+                "parent_collection_id": 2,
+                "revision": 3,
+            })
         );
     }
 

--- a/crates/hubuum-storage-postgres/src/error.rs
+++ b/crates/hubuum-storage-postgres/src/error.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use diesel_async::pooled_connection::bb8::RunError as PoolError;
 use hubuum_domain::{JsonSchemaError, JsonSchemaErrorKind, PositiveIdError, ResourceRevision};
-use hubuum_events_core::EventIdentifierError;
+use hubuum_events_core::{AuditDocumentError, EventIdentifierError};
 use hubuum_storage_core::{
     StorageCandidatePage, StorageCandidatePageLimit, StorageError, StorageErrorKind, StoragePage,
 };
@@ -192,6 +192,12 @@ impl From<PositiveIdError> for PostgresStorageError {
 impl From<EventIdentifierError> for PostgresStorageError {
     fn from(error: EventIdentifierError) -> Self {
         Self::database(format!("Invalid persisted event identifier: {error}"))
+    }
+}
+
+impl From<AuditDocumentError> for PostgresStorageError {
+    fn from(error: AuditDocumentError) -> Self {
+        Self::database(format!("Invalid audit document: {error}"))
     }
 }
 

--- a/crates/hubuum-storage-postgres/src/operations/authorization/mutations.rs
+++ b/crates/hubuum-storage-postgres/src/operations/authorization/mutations.rs
@@ -1,7 +1,7 @@
 use diesel::prelude::{ExpressionMethods, OptionalExtension, QueryDsl};
 use diesel::{AsChangeset, Insertable};
 use diesel_async::RunQueryDsl;
-use hubuum_events_core::{Action, EntityType, EventContext, NewEvent};
+use hubuum_events_core::{Action, AuditDocument, EntityType, EventContext, NewEvent};
 use hubuum_storage_core::{
     StorageAuditReceipt, StorageAuthorizationGrant, StorageAuthorizationGrantDelete,
     StorageAuthorizationGrantMutation, StorageAuthorizationPermission, StorageMutationOutcome,
@@ -475,28 +475,15 @@ async fn append_permission_event(
     if let Some(replace_existing) = details.replace_existing {
         metadata["replace_existing"] = json!(replace_existing);
     }
-    let event = NewEvent::new(
-        EntityType::Permission,
-        details.action,
-        details.context.actor_kind(),
-        summary,
-    )
-    .map_err(|error| PostgresStorageError::database(error.to_string()))?
-    .with_context(details.context)
-    .with_entity_id(hubuum_events_core::EventEntityId::new(details.after.id)?)
-    .with_collection_id(hubuum_domain::CollectionId::new(
-        details.after.collection_id,
-    )?)
-    .with_metadata(metadata)
-    .with_before(match details.before {
+    let before = match details.before {
         Some(before) => permission_snapshot(before, details.before_revision),
         None => empty_permission_snapshot(
             details.after.collection_id,
             details.after.group_id,
             details.before_revision,
         ),
-    })
-    .with_after(if details.removes_grant {
+    };
+    let after = if details.removes_grant {
         empty_permission_snapshot(
             details.after.collection_id,
             details.after.group_id,
@@ -504,7 +491,20 @@ async fn append_permission_event(
         )
     } else {
         permission_snapshot(details.after, details.after_revision)
-    });
+    };
+    let document = AuditDocument::try_new(summary, Some(before), Some(after), metadata)?;
+    let event = NewEvent::from_document(
+        EntityType::Permission,
+        details.action,
+        details.context.actor_kind(),
+        document,
+    )
+    .map_err(|error| PostgresStorageError::database(error.to_string()))?
+    .with_context(details.context)
+    .with_entity_id(hubuum_events_core::EventEntityId::new(details.after.id)?)
+    .with_collection_id(hubuum_domain::CollectionId::new(
+        details.after.collection_id,
+    )?);
     Ok(append_event(connection, &event).await?.into_audit_receipt())
 }
 

--- a/crates/hubuum-storage-postgres/src/operations/class.rs
+++ b/crates/hubuum-storage-postgres/src/operations/class.rs
@@ -5,7 +5,7 @@ use diesel::prelude::{ExpressionMethods, OptionalExtension, QueryDsl};
 use diesel::{AsChangeset, Queryable, Selectable};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{CollectionId, validate_json_schema, validate_json_schema_for_instances};
-use hubuum_events_core::{Action, EntityType, EventContext, NewEvent};
+use hubuum_events_core::{Action, AuditDocument, EntityType, EventContext, NewEvent};
 use hubuum_storage_core::{
     StorageClass, StorageClassCreate, StorageClassSelector, StorageClassUpdate,
     StorageMutationOutcome, StorageResolvedClass,
@@ -143,13 +143,13 @@ pub(crate) async fn create_class_on(
 ) -> Result<StorageMutationOutcome<StorageClass>, PostgresStorageError> {
     validate_class_create(&command)?;
     let class = insert_class(connection, &command).await?;
-    let event = class_event(
-        &class,
-        Action::Created,
-        context,
+    let document = AuditDocument::try_new(
         format!("Class '{}' created", class.name),
-    )?
-    .with_after(class.snapshot());
+        None,
+        Some(class.snapshot()),
+        json!({}),
+    )?;
+    let event = class_event(&class, Action::Created, context, document)?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok(StorageMutationOutcome::committed(
         class.into_storage()?,
@@ -190,14 +190,13 @@ pub(crate) async fn update_class_on(
     .set(update)
     .get_result::<ClassRow>(connection)
     .await?;
-    let event = class_event(
-        &updated,
-        Action::Updated,
-        context,
+    let document = AuditDocument::try_new(
         format!("Class '{}' updated", updated.name),
-    )?
-    .with_before(before.snapshot())
-    .with_after(updated.snapshot());
+        Some(before.snapshot()),
+        Some(updated.snapshot()),
+        json!({}),
+    )?;
+    let event = class_event(&updated, Action::Updated, context, document)?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok(StorageMutationOutcome::committed(
         updated.into_storage()?,
@@ -231,13 +230,13 @@ pub(crate) async fn delete_class_on(
     )
     .execute(connection)
     .await?;
-    let event = class_event(
-        &before,
-        Action::Deleted,
-        context,
+    let document = AuditDocument::try_new(
         format!("Class '{}' deleted", before.name),
-    )?
-    .with_before(before.snapshot());
+        Some(before.snapshot()),
+        None,
+        json!({}),
+    )?;
+    let event = class_event(&before, Action::Deleted, context, document)?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok(StorageMutationOutcome::committed((), audit))
 }
@@ -396,9 +395,9 @@ fn class_event(
     class: &ClassRow,
     action: Action,
     context: &EventContext,
-    summary: String,
+    document: AuditDocument,
 ) -> Result<NewEvent, PostgresStorageError> {
-    NewEvent::new(EntityType::Class, action, context.actor_kind(), summary)
+    NewEvent::from_document(EntityType::Class, action, context.actor_kind(), document)
         .map_err(|error| PostgresStorageError::database(error.to_string()))
         .and_then(|event| {
             Ok(event

--- a/crates/hubuum-storage-postgres/src/operations/collection.rs
+++ b/crates/hubuum-storage-postgres/src/operations/collection.rs
@@ -5,7 +5,7 @@ use diesel::prelude::{ExpressionMethods, OptionalExtension, QueryDsl};
 use diesel::{AsChangeset, JoinOnDsl, Queryable, Selectable, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::CollectionId;
-use hubuum_events_core::{Action, EntityType, EventContext, NewEvent};
+use hubuum_events_core::{Action, AuditDocument, EntityType, EventContext, NewEvent};
 use hubuum_storage_core::{
     StorageCollection, StorageCollectionCreate, StorageCollectionUpdate, StorageMutationOutcome,
 };
@@ -47,16 +47,10 @@ impl CollectionRow {
         )
     }
 
-    fn snapshot(&self) -> serde_json::Value {
-        json!({
-            "id": self.id,
-            "name": self.name,
-            "description": self.description,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
-            "parent_collection_id": self.parent_collection_id,
-            "revision": self.revision,
-        })
+    fn audit_snapshot(&self) -> Result<serde_json::Value, PostgresStorageError> {
+        self.clone()
+            .into_storage()
+            .map(|collection| collection.audit_snapshot())
     }
 }
 
@@ -145,14 +139,13 @@ pub(crate) async fn create_collection_on(
         Some(connection),
     )
     .await?;
-    let event = collection_event(
-        &created,
-        Action::Created,
-        context,
+    let document = AuditDocument::try_new(
         format!("Collection '{}' created", created.name),
-    )?
-    .with_after(created.snapshot())
-    .with_metadata(json!({ "assignee_group_id": command.owner_group_id() }));
+        None,
+        Some(created.audit_snapshot()?),
+        json!({ "assignee_group_id": command.owner_group_id() }),
+    )?;
+    let event = collection_event(&created, Action::Created, context, document)?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok(StorageMutationOutcome::committed(
         created.into_storage()?,
@@ -207,14 +200,13 @@ pub(crate) async fn update_collection_on(
     .set(update)
     .get_result::<CollectionRow>(connection)
     .await?;
-    let event = collection_event(
-        &updated,
-        Action::Updated,
-        context,
+    let document = AuditDocument::try_new(
         format!("Collection '{}' updated", updated.name),
-    )?
-    .with_before(before.snapshot())
-    .with_after(updated.snapshot());
+        Some(before.audit_snapshot()?),
+        Some(updated.audit_snapshot()?),
+        json!({}),
+    )?;
+    let event = collection_event(&updated, Action::Updated, context, document)?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok(StorageMutationOutcome::committed(
         updated.into_storage()?,
@@ -249,13 +241,13 @@ pub(crate) async fn delete_collection_on(
     )
     .execute(connection)
     .await?;
-    let event = collection_event(
-        &collection,
-        Action::Deleted,
-        context,
+    let document = AuditDocument::try_new(
         format!("Collection '{}' deleted", collection.name),
-    )?
-    .with_before(collection.snapshot());
+        Some(collection.audit_snapshot()?),
+        None,
+        json!({}),
+    )?;
+    let event = collection_event(&collection, Action::Deleted, context, document)?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok(StorageMutationOutcome::committed((), audit))
 }
@@ -382,14 +374,13 @@ pub(crate) async fn move_collection_on(
         .await?;
     move_collection_closure_rows(connection, collection_id, new_parent_id).await?;
     let updated = load_collection(connection, collection_id).await?;
-    let event = collection_event(
-        &updated,
-        Action::Updated,
-        context,
+    let document = AuditDocument::try_new(
         format!("Collection '{}' moved", updated.name),
-    )?
-    .with_before(before.snapshot())
-    .with_after(updated.snapshot());
+        Some(before.audit_snapshot()?),
+        Some(updated.audit_snapshot()?),
+        json!({}),
+    )?;
+    let event = collection_event(&updated, Action::Updated, context, document)?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok(StorageMutationOutcome::committed(
         updated.into_storage()?,
@@ -553,13 +544,13 @@ fn collection_event(
     collection: &CollectionRow,
     action: Action,
     context: &EventContext,
-    summary: String,
+    document: AuditDocument,
 ) -> Result<NewEvent, PostgresStorageError> {
-    NewEvent::new(
+    NewEvent::from_document(
         EntityType::Collection,
         action,
         context.actor_kind(),
-        summary,
+        document,
     )
     .map_err(|error| PostgresStorageError::database(error.to_string()))
     .and_then(|event| {

--- a/crates/hubuum-storage-postgres/src/operations/computed_fields.rs
+++ b/crates/hubuum-storage-postgres/src/operations/computed_fields.rs
@@ -12,7 +12,9 @@ use hubuum_computed_fields::{
     SEMANTICS_VERSION,
 };
 use hubuum_domain::{ClassId, PrincipalId, TaskId};
-use hubuum_events_core::{Action, EntityType, EventContext, MutationProvenance, NewEvent};
+use hubuum_events_core::{
+    Action, AuditDocument, EntityType, EventContext, MutationProvenance, NewEvent,
+};
 use hubuum_query::{FilterField, QueryOptions, SortParam};
 use hubuum_storage_core::{
     StorageClassComputationState, StorageComputationRebuildStatus, StorageComputationRevision,
@@ -448,8 +450,9 @@ pub async fn create_shared_computed_field(
                 Action::Created,
                 &context,
                 format!("Shared computed field '{}' created", definition.key()),
-            )?
-            .with_after(definition.snapshot());
+                None,
+                Some(definition.snapshot()),
+            )?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>((definition, state, audit))
         })
@@ -508,9 +511,9 @@ pub async fn update_shared_computed_field(
                 Action::Updated,
                 &context,
                 format!("Shared computed field '{}' updated", definition.key()),
-            )?
-            .with_before(current.snapshot())
-            .with_after(definition.snapshot());
+                Some(current.snapshot()),
+                Some(definition.snapshot()),
+            )?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>((definition, state, Some(audit)))
         })
@@ -563,8 +566,9 @@ pub async fn delete_shared_computed_field(
                 Action::Deleted,
                 &context,
                 format!("Shared computed field '{}' deleted", current.key()),
-            )?
-            .with_before(current.snapshot());
+                Some(current.snapshot()),
+                None,
+            )?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>((state, audit))
         })
@@ -611,8 +615,10 @@ pub async fn create_personal_computed_field(
                 Action::Created,
                 &context,
                 format!("Personal computed field '{}' created", definition.key()),
+                None,
+                Some(definition.snapshot()),
             )?
-            .with_after(definition.snapshot());
+            ;
             let audit = append_event(connection, &event)
                 .await?
                 .into_audit_receipt();
@@ -659,9 +665,9 @@ pub async fn update_personal_computed_field(
                 Action::Updated,
                 &context,
                 format!("Personal computed field '{}' updated", definition.key()),
-            )?
-            .with_before(current.snapshot())
-            .with_after(definition.snapshot());
+                Some(current.snapshot()),
+                Some(definition.snapshot()),
+            )?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>((definition, Some(audit)))
         })
@@ -707,8 +713,9 @@ pub async fn delete_personal_computed_field(
                 Action::Deleted,
                 &context,
                 format!("Personal computed field '{}' deleted", current.key()),
-            )?
-            .with_before(current.snapshot());
+                Some(current.snapshot()),
+                None,
+            )?;
             Ok::<_, PostgresStorageError>(
                 append_event(connection, &event).await?.into_audit_receipt(),
             )
@@ -1301,12 +1308,15 @@ fn computed_field_event(
     action: Action,
     context: &EventContext,
     summary: String,
+    before: Option<Value>,
+    after: Option<Value>,
 ) -> Result<NewEvent, PostgresStorageError> {
-    NewEvent::new(
+    let document = AuditDocument::try_new(summary, before, after, json!({ "class_id": class.id }))?;
+    NewEvent::from_document(
         EntityType::ComputedFieldDefinition,
         action,
         context.actor_kind(),
-        summary,
+        document,
     )
     .map_err(|error| PostgresStorageError::internal(error.to_string()))
     .and_then(|event| {
@@ -1314,8 +1324,7 @@ fn computed_field_event(
             .with_context(context)
             .with_entity_id(hubuum_events_core::EventEntityId::new(definition.id())?)
             .with_entity_name(definition.key())
-            .with_collection_id(hubuum_domain::CollectionId::new(class.collection_id)?)
-            .with_metadata(json!({ "class_id": class.id })))
+            .with_collection_id(hubuum_domain::CollectionId::new(class.collection_id)?))
     })
 }
 
@@ -1543,15 +1552,20 @@ fn task_event(
     summary: &str,
     provenance: &MutationProvenance,
 ) -> Result<NewEvent, PostgresStorageError> {
-    NewEvent::new(EntityType::Task, action, provenance.actor_kind(), summary)
+    let document = AuditDocument::try_new(
+        summary,
+        None,
+        None,
+        json!({
+            "task_id": task.id,
+            "task_kind": task.kind,
+        }),
+    )?;
+    NewEvent::from_document(EntityType::Task, action, provenance.actor_kind(), document)
         .map_err(|error| PostgresStorageError::internal(error.to_string()))
         .and_then(|event| {
             Ok(event
                 .with_entity_id(hubuum_events_core::EventEntityId::new(task.id)?)
-                .with_metadata(json!({
-                    "task_id": task.id,
-                    "task_kind": task.kind,
-                }))
                 .with_mutation_provenance(provenance))
         })
 }

--- a/crates/hubuum-storage-postgres/src/operations/event_subscription.rs
+++ b/crates/hubuum-storage-postgres/src/operations/event_subscription.rs
@@ -5,7 +5,9 @@ use diesel::prelude::{ExpressionMethods, QueryDsl};
 use diesel::{AsChangeset, Insertable, Queryable, Selectable};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{CollectionId, EventSinkId, EventSubscriptionId};
-use hubuum_events_core::{Action, EntityType, EventContext, NewEvent, redact_event_sink_config};
+use hubuum_events_core::{
+    Action, AuditDocument, EntityType, EventContext, NewEvent, redact_event_sink_config,
+};
 use hubuum_query::{FilterField, QueryOptions};
 use hubuum_storage_core::{
     StorageAuditReceipt, StorageEventSink, StorageEventSinkCreate, StorageEventSinkDelete,
@@ -738,23 +740,26 @@ async fn append_sink_audit(
     before: Option<&EventSinkRow>,
     after: &EventSinkRow,
 ) -> Result<StorageAuditReceipt, PostgresStorageError> {
-    let event = NewEvent::new(
+    let document = AuditDocument::try_new(
+        format!("Event sink '{}' {}", after.name, action.as_str()),
+        before.map(event_sink_snapshot),
+        (action != Action::Deleted).then(|| event_sink_snapshot(after)),
+        json!({
+            "sink_id": after.id,
+            "kind": after.kind,
+            "enabled": after.enabled,
+        }),
+    )?;
+    let event = NewEvent::from_document(
         EntityType::EventSink,
         action,
         context.actor_kind(),
-        format!("Event sink '{}' {}", after.name, action.as_str()),
+        document,
     )
     .map_err(|error| PostgresStorageError::database(error.to_string()))?
     .with_context(context)
     .with_entity_id(hubuum_events_core::EventEntityId::new(after.id)?)
-    .with_entity_name(&after.name)
-    .with_before_opt(before.map(event_sink_snapshot))
-    .with_after_opt((action != Action::Deleted).then(|| event_sink_snapshot(after)))
-    .with_metadata(json!({
-        "sink_id": after.id,
-        "kind": after.kind,
-        "enabled": after.enabled,
-    }));
+    .with_entity_name(&after.name);
     Ok(append_event(connection, &event).await?.into_audit_receipt())
 }
 
@@ -765,25 +770,28 @@ async fn append_subscription_audit(
     before: Option<&EventSubscriptionRow>,
     after: &EventSubscriptionRow,
 ) -> Result<StorageAuditReceipt, PostgresStorageError> {
-    let event = NewEvent::new(
+    let document = AuditDocument::try_new(
+        format!("Event subscription '{}' {}", after.name, action.as_str()),
+        before.map(event_subscription_snapshot),
+        (action != Action::Deleted).then(|| event_subscription_snapshot(after)),
+        json!({
+            "subscription_id": after.id,
+            "sink_id": after.sink_id,
+            "collection_id": after.collection_id,
+            "enabled": after.enabled,
+        }),
+    )?;
+    let event = NewEvent::from_document(
         EntityType::EventSubscription,
         action,
         context.actor_kind(),
-        format!("Event subscription '{}' {}", after.name, action.as_str()),
+        document,
     )
     .map_err(|error| PostgresStorageError::database(error.to_string()))?
     .with_context(context)
     .with_entity_id(hubuum_events_core::EventEntityId::new(after.id)?)
     .with_entity_name(&after.name)
-    .with_collection_id(hubuum_domain::CollectionId::new(after.collection_id)?)
-    .with_before_opt(before.map(event_subscription_snapshot))
-    .with_after_opt((action != Action::Deleted).then(|| event_subscription_snapshot(after)))
-    .with_metadata(json!({
-        "subscription_id": after.id,
-        "sink_id": after.sink_id,
-        "collection_id": after.collection_id,
-        "enabled": after.enabled,
-    }));
+    .with_collection_id(hubuum_domain::CollectionId::new(after.collection_id)?);
     Ok(append_event(connection, &event).await?.into_audit_receipt())
 }
 

--- a/crates/hubuum-storage-postgres/src/operations/export_template.rs
+++ b/crates/hubuum-storage-postgres/src/operations/export_template.rs
@@ -3,7 +3,7 @@ use diesel::prelude::{ExpressionMethods, QueryDsl};
 use diesel::{AsChangeset, Insertable, Queryable, Selectable};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{ClassId, CollectionId};
-use hubuum_events_core::{Action, EntityType, EventContext, NewEvent};
+use hubuum_events_core::{Action, AuditDocument, EntityType, EventContext, NewEvent};
 use hubuum_query::{FilterField, QueryOptions, SortParam};
 use hubuum_storage_core::{
     StorageAuditReceipt, StorageExportTemplate, StorageExportTemplateCreate,
@@ -611,19 +611,23 @@ async fn append_export_template_audit(
     before: Option<&ExportTemplateRow>,
     after: &ExportTemplateRow,
 ) -> Result<StorageAuditReceipt, PostgresStorageError> {
-    let event = NewEvent::new(
+    let document = AuditDocument::try_new(
+        format!("Export template '{}' {}", after.name, action.as_str()),
+        before.map(ExportTemplateRow::audit_snapshot),
+        (action != Action::Deleted).then(|| after.audit_snapshot()),
+        json!({}),
+    )?;
+    let event = NewEvent::from_document(
         EntityType::ExportTemplate,
         action,
         context.actor_kind(),
-        format!("Export template '{}' {}", after.name, action.as_str()),
+        document,
     )
     .map_err(|error| PostgresStorageError::database(error.to_string()))?
     .with_context(context)
     .with_entity_id(hubuum_events_core::EventEntityId::new(after.id)?)
     .with_entity_name(&after.name)
-    .with_collection_id(hubuum_domain::CollectionId::new(after.collection_id)?)
-    .with_before_opt(before.map(ExportTemplateRow::audit_snapshot))
-    .with_after_opt((action != Action::Deleted).then(|| after.audit_snapshot()));
+    .with_collection_id(hubuum_domain::CollectionId::new(after.collection_id)?);
     Ok(append_event(connection, &event).await?.into_audit_receipt())
 }
 

--- a/crates/hubuum-storage-postgres/src/operations/external_identity.rs
+++ b/crates/hubuum-storage-postgres/src/operations/external_identity.rs
@@ -9,7 +9,7 @@ use diesel::upsert::excluded;
 use diesel::{Insertable, JoinOnDsl, Queryable, QueryableByName, Selectable, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{EXTERNAL_MEMBERSHIP_SOURCE, LOCAL_PROVIDER_KIND, UserId};
-use hubuum_events_core::{Action, EntityType, EventContext, NewEvent};
+use hubuum_events_core::{Action, AuditDocument, EntityType, EventContext, NewEvent};
 use hubuum_storage_core::{
     StorageExternalPrincipalState, StorageExternalUserSync, StorageMutationOutcome,
     StorageSyncedHuman,
@@ -254,23 +254,28 @@ pub async fn sync_external_user(
             remove_stale_memberships(connection, scope_id, principal.id, &synced_group_ids).await?;
 
             let context = EventContext::system();
-            let event = NewEvent::new(
+            let document = AuditDocument::try_new(
+                format!("External identity '{name}' synced in scope '{scope_name}'"),
+                None,
+                None,
+                json!({
+                    "principal_id": principal.id,
+                    "identity_scope": scope_name,
+                    "provider_kind": provider_kind,
+                    "external_subject": subject,
+                    "synced_group_count": synced_group_count,
+                }),
+            )?;
+            let event = NewEvent::from_document(
                 EntityType::ExternalIdentitySync,
                 Action::Succeeded,
                 context.actor_kind(),
-                format!("External identity '{name}' synced in scope '{scope_name}'"),
+                document,
             )
             .map_err(|error| PostgresStorageError::database(error.to_string()))?
             .with_context(&context)
             .with_entity_id(hubuum_events_core::EventEntityId::new(principal.id)?)
-            .with_entity_name(name)
-            .with_metadata(json!({
-                "principal_id": principal.id,
-                "identity_scope": scope_name,
-                "provider_kind": provider_kind,
-                "external_subject": subject,
-                "synced_group_count": synced_group_count,
-            }));
+            .with_entity_name(name);
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed(
                 user.into_storage()?,

--- a/crates/hubuum-storage-postgres/src/operations/group.rs
+++ b/crates/hubuum-storage-postgres/src/operations/group.rs
@@ -5,7 +5,7 @@ use diesel::prelude::{ExpressionMethods, OptionalExtension, QueryDsl};
 use diesel::{AsChangeset, JoinOnDsl, Queryable, Selectable, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{GroupId, IdentityScopeId, PrincipalId};
-use hubuum_events_core::{Action, EntityType, EventContext, NewEvent};
+use hubuum_events_core::{Action, AuditDocument, EntityType, EventContext, NewEvent};
 use hubuum_query::{FilterField, QueryOptions};
 use hubuum_storage_core::{
     StorageGroupCreate, StorageGroupListQuery, StorageGroupMember, StorageGroupUpdate,
@@ -378,13 +378,13 @@ pub async fn create_group(
     runtime
         .with_transaction(async move |connection| {
             let group = insert_local_group(connection, &name, &description).await?;
-            let event = group_event(
-                &group,
-                Action::Created,
-                &context,
+            let document = AuditDocument::try_new(
                 format!("Group '{}' created", group.groupname),
-            )?
-            .with_after(group.snapshot());
+                None,
+                Some(group.snapshot()),
+                json!({}),
+            )?;
+            let event = group_event(&group, Action::Created, &context, document)?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed(
                 group.into_storage()?,
@@ -416,14 +416,13 @@ pub async fn update_group(
             .set(UpdateGroupRow::from(&update))
             .get_result::<GroupRow>(connection)
             .await?;
-            let event = group_event(
-                &after,
-                Action::Updated,
-                &context,
+            let document = AuditDocument::try_new(
                 format!("Group '{}' updated", after.groupname),
-            )?
-            .with_before(before.snapshot())
-            .with_after(after.snapshot());
+                Some(before.snapshot()),
+                Some(after.snapshot()),
+                json!({}),
+            )?;
+            let event = group_event(&after, Action::Updated, &context, document)?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed(
                 after.into_storage()?,
@@ -450,13 +449,13 @@ pub async fn delete_group(
             )
             .execute(connection)
             .await?;
-            let event = group_event(
-                &group,
-                Action::Deleted,
-                &context,
+            let document = AuditDocument::try_new(
                 format!("Group '{}' deleted", group.groupname),
-            )?
-            .with_before(group.snapshot());
+                Some(group.snapshot()),
+                None,
+                json!({}),
+            )?;
+            let event = group_event(&group, Action::Deleted, &context, document)?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed(deleted, audit))
         })
@@ -552,16 +551,16 @@ pub async fn add_group_member(
             let (membership, effective_membership_created) =
                 insert_manual_membership(connection, principal_id, group_id).await?;
             if effective_membership_created {
-                let event = membership_event(
-                    &membership,
-                    Action::Added,
-                    &context,
+                let document = AuditDocument::try_new(
                     format!(
                         "Principal {} added to group {}",
                         membership.principal_id, membership.group_id
                     ),
-                )?
-                .with_after(membership.snapshot());
+                    None,
+                    Some(membership.snapshot()),
+                    membership_metadata(&membership),
+                )?;
+                let event = membership_event(Action::Added, &context, document)?;
                 let audit = append_event(connection, &event).await?.into_audit_receipt();
                 return Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed(
                     membership.into_storage()?,
@@ -589,16 +588,16 @@ pub async fn remove_group_member(
             let removed =
                 remove_manual_membership_source(connection, principal_id, group_id).await?;
             if let Some(membership) = removed.as_ref() {
-                let event = membership_event(
-                    membership,
-                    Action::Removed,
-                    &context,
+                let document = AuditDocument::try_new(
                     format!(
                         "Principal {} removed from group {}",
                         membership.principal_id, membership.group_id
                     ),
-                )?
-                .with_before(membership.snapshot());
+                    Some(membership.snapshot()),
+                    None,
+                    membership_metadata(membership),
+                )?;
+                let event = membership_event(Action::Removed, &context, document)?;
                 let audit = append_event(connection, &event).await?.into_audit_receipt();
                 return Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed((), audit));
             }
@@ -931,9 +930,9 @@ fn group_event(
     group: &GroupRow,
     action: Action,
     context: &EventContext,
-    summary: String,
+    document: AuditDocument,
 ) -> Result<NewEvent, PostgresStorageError> {
-    NewEvent::new(EntityType::Group, action, context.actor_kind(), summary)
+    NewEvent::from_document(EntityType::Group, action, context.actor_kind(), document)
         .map_err(|error| PostgresStorageError::database(error.to_string()))
         .and_then(|event| {
             Ok(event
@@ -944,19 +943,25 @@ fn group_event(
 }
 
 fn membership_event(
-    membership: &PrincipalGroupRow,
     action: Action,
     context: &EventContext,
-    summary: String,
+    document: AuditDocument,
 ) -> Result<NewEvent, PostgresStorageError> {
-    NewEvent::new(EntityType::UserGroup, action, context.actor_kind(), summary)
-        .map_err(|error| PostgresStorageError::database(error.to_string()))
-        .map(|event| {
-            event.with_context(context).with_metadata(json!({
-                "principal_id": membership.principal_id,
-                "group_id": membership.group_id,
-            }))
-        })
+    NewEvent::from_document(
+        EntityType::UserGroup,
+        action,
+        context.actor_kind(),
+        document,
+    )
+    .map_err(|error| PostgresStorageError::database(error.to_string()))
+    .map(|event| event.with_context(context))
+}
+
+fn membership_metadata(membership: &PrincipalGroupRow) -> Value {
+    json!({
+        "principal_id": membership.principal_id,
+        "group_id": membership.group_id,
+    })
 }
 
 fn validate_positive_id(id: i32, field: &str) -> Result<(), PostgresStorageError> {

--- a/crates/hubuum-storage-postgres/src/operations/object.rs
+++ b/crates/hubuum-storage-postgres/src/operations/object.rs
@@ -5,7 +5,7 @@ use diesel::prelude::{ExpressionMethods, OptionalExtension, QueryDsl};
 use diesel::{AsChangeset, JoinOnDsl, Queryable, Selectable, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{ClassId, CollectionId, ObjectId, validate_json_value};
-use hubuum_events_core::{Action, EntityType, EventContext, NewEvent};
+use hubuum_events_core::{Action, AuditDocument, EntityType, EventContext, NewEvent};
 use hubuum_storage_core::{
     StorageError, StorageMutationOutcome, StorageObject, StorageObjectCreate,
     StorageObjectDataPatch, StorageObjectSelector, StorageObjectUpdate, StorageResolvedClass,
@@ -185,13 +185,13 @@ pub(crate) async fn create_object_on(
         ObjectMaterializationInput::new(object.id, object.hubuum_class_id, &object.data),
     )
     .await?;
-    let event = object_event(
+    let document = object_audit_document(
         &object,
-        Action::Created,
-        context,
         format!("Object '{}' created", object.name),
-    )?
-    .with_after(object.snapshot());
+        None,
+        Some(object.snapshot()),
+    )?;
+    let event = object_event(&object, Action::Created, context, document)?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     record_computed_evaluation(runtime, evaluation.as_ref());
     Ok(StorageMutationOutcome::committed(
@@ -287,14 +287,13 @@ pub(crate) async fn patch_object_data_on(
         ObjectMaterializationInput::new(updated.id, updated.hubuum_class_id, &updated.data),
     )
     .await?;
-    let event = object_event(
+    let document = object_audit_document(
         &updated,
-        Action::Updated,
-        context,
         format!("Object '{}' updated", updated.name),
-    )?
-    .with_before(before.snapshot())
-    .with_after(updated.snapshot());
+        Some(before.snapshot()),
+        Some(updated.snapshot()),
+    )?;
+    let event = object_event(&updated, Action::Updated, context, document)?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     record_computed_evaluation(runtime, evaluation.as_ref());
     Ok(StorageMutationOutcome::committed(
@@ -330,13 +329,13 @@ pub(crate) async fn delete_object_on(
     )
     .execute(connection)
     .await?;
-    let event = object_event(
+    let document = object_audit_document(
         &before,
-        Action::Deleted,
-        context,
         format!("Object '{}' deleted", before.name),
-    )?
-    .with_before(before.snapshot());
+        Some(before.snapshot()),
+        None,
+    )?;
+    let event = object_event(&before, Action::Deleted, context, document)?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok(StorageMutationOutcome::committed((), audit))
 }
@@ -601,14 +600,13 @@ async fn persist_object_update(
         ObjectMaterializationInput::new(updated.id, updated.hubuum_class_id, &updated.data),
     )
     .await?;
-    let event = object_event(
+    let document = object_audit_document(
         &updated,
-        Action::Updated,
-        context,
         format!("Object '{}' updated", updated.name),
-    )?
-    .with_before(before.snapshot())
-    .with_after(updated.snapshot());
+        Some(before.snapshot()),
+        Some(updated.snapshot()),
+    )?;
+    let event = object_event(&updated, Action::Updated, context, document)?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok((
         StorageMutationOutcome::committed(updated, audit),
@@ -677,18 +675,32 @@ fn object_event(
     object: &ObjectRow,
     action: Action,
     context: &EventContext,
-    summary: String,
+    document: AuditDocument,
 ) -> Result<NewEvent, PostgresStorageError> {
-    NewEvent::new(EntityType::Object, action, context.actor_kind(), summary)
+    NewEvent::from_document(EntityType::Object, action, context.actor_kind(), document)
         .map_err(|error| PostgresStorageError::database(error.to_string()))
         .and_then(|event| {
             Ok(event
                 .with_context(context)
                 .with_entity_id(hubuum_events_core::EventEntityId::new(object.id)?)
                 .with_entity_name(&object.name)
-                .with_collection_id(hubuum_domain::CollectionId::new(object.collection_id)?)
-                .with_metadata(json!({ "class_id": object.hubuum_class_id })))
+                .with_collection_id(hubuum_domain::CollectionId::new(object.collection_id)?))
         })
+}
+
+fn object_audit_document(
+    object: &ObjectRow,
+    summary: String,
+    before: Option<serde_json::Value>,
+    after: Option<serde_json::Value>,
+) -> Result<AuditDocument, PostgresStorageError> {
+    AuditDocument::try_new(
+        summary,
+        before,
+        after,
+        json!({ "class_id": object.hubuum_class_id }),
+    )
+    .map_err(PostgresStorageError::from)
 }
 
 fn record_computed_evaluation(

--- a/crates/hubuum-storage-postgres/src/operations/principal.rs
+++ b/crates/hubuum-storage-postgres/src/operations/principal.rs
@@ -1,7 +1,7 @@
 use diesel::{ExpressionMethods, QueryDsl, Queryable, Selectable, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{BoundedJsonPatch, IdentityScopeId, JsonPatchErrorKind, PrincipalKind};
-use hubuum_events_core::{Action, EntityType, EventContext, NewEvent};
+use hubuum_events_core::{Action, AuditDocument, EntityType, EventContext, NewEvent};
 use hubuum_storage_core::{
     StorageMutationOutcome, StoragePrincipal, StoragePrincipalSettings,
     StoragePrincipalSettingsMutation,
@@ -166,18 +166,22 @@ pub async fn update_principal_settings(
                 .await?;
 
                 let entity_type = principal_entity_type(kind);
-                let event = NewEvent::new(
+                let document = AuditDocument::try_new(
+                    format!("Principal settings for '{name}' updated"),
+                    Some(json!({ "revision": before_revision, "settings": before })),
+                    Some(json!({ "revision": after_revision, "settings": after })),
+                    json!({}),
+                )?;
+                let event = NewEvent::from_document(
                     entity_type,
                     Action::Updated,
                     event_context.actor_kind(),
-                    format!("Principal settings for '{name}' updated"),
+                    document,
                 )
                 .map_err(|error| PostgresStorageError::database(error.to_string()))?
                 .with_context(event_context)
                 .with_entity_id(hubuum_events_core::EventEntityId::new(principal_id)?)
-                .with_entity_name(name)
-                .with_before(json!({ "revision": before_revision, "settings": before }))
-                .with_after(json!({ "revision": after_revision, "settings": after }));
+                .with_entity_name(name);
                 let audit = append_event(connection, &event).await?.into_audit_receipt();
 
                 let settings = crate::validate_persisted(

--- a/crates/hubuum-storage-postgres/src/operations/relation.rs
+++ b/crates/hubuum-storage-postgres/src/operations/relation.rs
@@ -5,7 +5,7 @@ use diesel::prelude::{ExpressionMethods, QueryDsl};
 use diesel::{Insertable, Queryable, Selectable};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{ClassId, ClassRelationId, ObjectId, normalize_template_alias};
-use hubuum_events_core::{Action, EntityType, EventContext, NewEvent};
+use hubuum_events_core::{Action, AuditDocument, EntityType, EventContext, NewEvent};
 use hubuum_storage_core::{
     StorageClassRelation, StorageClassRelationCreate, StorageMutationOutcome, StorageObject,
     StorageObjectRelation, StorageObjectRelationCreate, StorageObjectRelationCreateSelector,
@@ -240,8 +240,15 @@ pub(crate) async fn create_class_relation_on(
         ));
     }
     let relation = insert_class_relation(connection, &command).await?;
-    let event = class_relation_event(&relation, Action::Created, context, &from_class, &to_class)?
-        .with_after(relation.snapshot());
+    let event = class_relation_event(
+        &relation,
+        Action::Created,
+        context,
+        &from_class,
+        &to_class,
+        None,
+        Some(relation.snapshot()),
+    )?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok(StorageMutationOutcome::committed(
         crate::validate_persisted(
@@ -290,8 +297,15 @@ pub(crate) async fn delete_class_relation_on(
         ));
     }
     delete_class_relation_row(connection, relation.id).await?;
-    let event = class_relation_event(&relation, Action::Deleted, context, &from_class, &to_class)?
-        .with_before(relation.snapshot());
+    let event = class_relation_event(
+        &relation,
+        Action::Deleted,
+        context,
+        &from_class,
+        &to_class,
+        Some(relation.snapshot()),
+        None,
+    )?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok(StorageMutationOutcome::committed((), audit))
 }
@@ -476,9 +490,15 @@ pub(crate) async fn create_object_relation_on(
         prepared.class_relation(),
     )?;
     let relation = insert_object_relation(connection, command).await?;
-    let event =
-        object_relation_event(relation, Action::Created, context, &from_object, &to_object)?
-            .with_after(relation.snapshot());
+    let event = object_relation_event(
+        relation,
+        Action::Created,
+        context,
+        &from_object,
+        &to_object,
+        None,
+        Some(relation.snapshot()),
+    )?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok(StorageMutationOutcome::committed(
         crate::validate_persisted(
@@ -532,9 +552,15 @@ pub(crate) async fn delete_object_relation_on(
         ));
     }
     delete_object_relation_row(connection, relation.id).await?;
-    let event =
-        object_relation_event(relation, Action::Deleted, context, &from_object, &to_object)?
-            .with_before(relation.snapshot());
+    let event = object_relation_event(
+        relation,
+        Action::Deleted,
+        context,
+        &from_object,
+        &to_object,
+        Some(relation.snapshot()),
+        None,
+    )?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok(StorageMutationOutcome::committed((), audit))
 }
@@ -976,28 +1002,35 @@ fn class_relation_event(
     context: &EventContext,
     from_class: &ClassRow,
     to_class: &ClassRow,
+    before: Option<serde_json::Value>,
+    after: Option<serde_json::Value>,
 ) -> Result<NewEvent, PostgresStorageError> {
-    NewEvent::new(
-        EntityType::ClassRelation,
-        action,
-        context.actor_kind(),
+    let document = AuditDocument::try_new(
         format!(
             "Class relation {} -> {} {}",
             relation.from_hubuum_class_id,
             relation.to_hubuum_class_id,
             action_verb(action)
         ),
+        before,
+        after,
+        json!({
+            "from_class_id": from_class.id,
+            "to_class_id": to_class.id,
+            "related_collection_ids": [from_class.collection_id, to_class.collection_id],
+        }),
+    )?;
+    NewEvent::from_document(
+        EntityType::ClassRelation,
+        action,
+        context.actor_kind(),
+        document,
     )
     .map_err(|error| PostgresStorageError::database(error.to_string()))
     .and_then(|event| {
         Ok(event
             .with_context(context)
-            .with_entity_id(hubuum_events_core::EventEntityId::new(relation.id)?)
-            .with_metadata(json!({
-                "from_class_id": from_class.id,
-                "to_class_id": to_class.id,
-                "related_collection_ids": [from_class.collection_id, to_class.collection_id],
-            })))
+            .with_entity_id(hubuum_events_core::EventEntityId::new(relation.id)?))
     })
 }
 
@@ -1007,31 +1040,38 @@ fn object_relation_event(
     context: &EventContext,
     from_object: &ObjectRow,
     to_object: &ObjectRow,
+    before: Option<serde_json::Value>,
+    after: Option<serde_json::Value>,
 ) -> Result<NewEvent, PostgresStorageError> {
-    NewEvent::new(
-        EntityType::ObjectRelation,
-        action,
-        context.actor_kind(),
+    let document = AuditDocument::try_new(
         format!(
             "Object relation {} -> {} {}",
             relation.from_hubuum_object_id,
             relation.to_hubuum_object_id,
             action_verb(action)
         ),
+        before,
+        after,
+        json!({
+            "class_relation_id": relation.class_relation_id,
+            "from_object_id": from_object.id,
+            "to_object_id": to_object.id,
+            "from_class_id": from_object.hubuum_class_id,
+            "to_class_id": to_object.hubuum_class_id,
+            "related_collection_ids": [from_object.collection_id, to_object.collection_id],
+        }),
+    )?;
+    NewEvent::from_document(
+        EntityType::ObjectRelation,
+        action,
+        context.actor_kind(),
+        document,
     )
     .map_err(|error| PostgresStorageError::database(error.to_string()))
     .and_then(|event| {
         Ok(event
             .with_context(context)
-            .with_entity_id(hubuum_events_core::EventEntityId::new(relation.id)?)
-            .with_metadata(json!({
-                "class_relation_id": relation.class_relation_id,
-                "from_object_id": from_object.id,
-                "to_object_id": to_object.id,
-                "from_class_id": from_object.hubuum_class_id,
-                "to_class_id": to_object.hubuum_class_id,
-                "related_collection_ids": [from_object.collection_id, to_object.collection_id],
-            })))
+            .with_entity_id(hubuum_events_core::EventEntityId::new(relation.id)?))
     })
 }
 

--- a/crates/hubuum-storage-postgres/src/operations/remote_target.rs
+++ b/crates/hubuum-storage-postgres/src/operations/remote_target.rs
@@ -5,7 +5,7 @@ use diesel::prelude::{ExpressionMethods, QueryDsl};
 use diesel::{AsChangeset, Insertable, Queryable, Selectable};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{ClassId, CollectionId};
-use hubuum_events_core::{Action, EntityType, EventContext, NewEvent};
+use hubuum_events_core::{Action, AuditDocument, EntityType, EventContext, NewEvent};
 use hubuum_query::{FilterField, QueryOptions};
 use hubuum_storage_core::{
     StorageAuditReceipt, StorageMutationOutcome, StoragePage, StorageRemoteTarget,
@@ -490,22 +490,27 @@ pub async fn record_remote_target_invocation(
         .with_transaction(
             async |connection| -> Result<StorageMutationOutcome<()>, PostgresStorageError> {
                 let target = load_remote_target_row(connection, target_id).await?;
-                let event = NewEvent::new(
+                let document = AuditDocument::try_new(
+                    format!("Remote target '{}' invoked", target.name),
+                    None,
+                    None,
+                    json!({
+                        "task_id": task_id,
+                        "subject_type": subject_type.as_str(),
+                        "subject_id": subject_id,
+                    }),
+                )?;
+                let event = NewEvent::from_document(
                     EntityType::RemoteTarget,
                     Action::Invoked,
                     event_context.actor_kind(),
-                    format!("Remote target '{}' invoked", target.name),
+                    document,
                 )
                 .map_err(|error| PostgresStorageError::database(error.to_string()))?
                 .with_context(&event_context)
                 .with_entity_id(hubuum_events_core::EventEntityId::new(target.id)?)
                 .with_entity_name(&target.name)
-                .with_collection_id(hubuum_domain::CollectionId::new(target.collection_id)?)
-                .with_metadata(json!({
-                    "task_id": task_id,
-                    "subject_type": subject_type.as_str(),
-                    "subject_id": subject_id,
-                }));
+                .with_collection_id(hubuum_domain::CollectionId::new(target.collection_id)?);
                 let audit = append_event(connection, &event).await?.into_audit_receipt();
                 Ok(StorageMutationOutcome::committed((), audit))
             },
@@ -562,19 +567,23 @@ async fn append_remote_target_audit(
     before: Option<&RemoteTargetRow>,
     after: &RemoteTargetRow,
 ) -> Result<StorageAuditReceipt, PostgresStorageError> {
-    let event = NewEvent::new(
+    let document = AuditDocument::try_new(
+        format!("Remote target '{}' {}", after.name, action.as_str()),
+        before.map(RemoteTargetRow::audit_snapshot),
+        (action != Action::Deleted).then(|| after.audit_snapshot()),
+        json!({}),
+    )?;
+    let event = NewEvent::from_document(
         EntityType::RemoteTarget,
         action,
         context.actor_kind(),
-        format!("Remote target '{}' {}", after.name, action.as_str()),
+        document,
     )
     .map_err(|error| PostgresStorageError::database(error.to_string()))?
     .with_context(context)
     .with_entity_id(hubuum_events_core::EventEntityId::new(after.id)?)
     .with_entity_name(&after.name)
-    .with_collection_id(hubuum_domain::CollectionId::new(after.collection_id)?)
-    .with_before_opt(before.map(RemoteTargetRow::audit_snapshot))
-    .with_after_opt((action != Action::Deleted).then(|| after.audit_snapshot()));
+    .with_collection_id(hubuum_domain::CollectionId::new(after.collection_id)?);
     Ok(append_event(connection, &event).await?.into_audit_receipt())
 }
 

--- a/crates/hubuum-storage-postgres/src/operations/restore_lifecycle.rs
+++ b/crates/hubuum-storage-postgres/src/operations/restore_lifecycle.rs
@@ -8,7 +8,7 @@ use diesel::sql_types::{Jsonb, Timestamp};
 use diesel::{Insertable, Queryable, Selectable, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{MaintenanceState, PrincipalId, RestoreJobId};
-use hubuum_events_core::{Action, ActorKind, EntityType, NewEvent};
+use hubuum_events_core::{Action, ActorKind, AuditDocument, EntityType, NewEvent};
 use hubuum_storage_core::{
     StorageBackupHistorySection, StorageBackupHistorySections, StorageBackupRow,
     StorageBackupStateSection, StorageBackupStateSections, StorageCallSite, StorageRestoreApply,
@@ -518,27 +518,32 @@ pub async fn apply_restore(
                 diesel::sql_query("SELECT set_config('hubuum.restore_events', 'off', true)")
                     .execute(connection)
                     .await?;
-                let provenance = NewEvent::new(
+                let document = AuditDocument::try_new(
+                    "System restore completed",
+                    None,
+                    None,
+                    serde_json::json!({
+                        "restore_job_id": job.id,
+                        "backup_sha256": job.sha256,
+                        "backup_version": backup_version,
+                        "backup_source_version": backup_source_version,
+                        "backup_created_at": backup_created_at,
+                        "includes_history": includes_history,
+                        "initiated_by": {
+                            "principal_id": job.requested_by,
+                            "identity_scope": job.requested_by_identity_scope,
+                            "name": job.requested_by_name,
+                        },
+                    }),
+                )?;
+                let provenance = NewEvent::from_document(
                     EntityType::Restore,
                     Action::Succeeded,
                     ActorKind::System,
-                    "System restore completed",
+                    document,
                 )
                 .map_err(|error| PostgresStorageError::internal(error.to_string()))?
-                .with_entity_name(job.sha256.clone())
-                .with_metadata(serde_json::json!({
-                    "restore_job_id": job.id,
-                    "backup_sha256": job.sha256,
-                    "backup_version": backup_version,
-                    "backup_source_version": backup_source_version,
-                    "backup_created_at": backup_created_at,
-                    "includes_history": includes_history,
-                    "initiated_by": {
-                        "principal_id": job.requested_by,
-                        "identity_scope": job.requested_by_identity_scope,
-                        "name": job.requested_by_name,
-                    },
-                }));
+                .with_entity_name(job.sha256.clone());
                 append_event(connection, &provenance).await?;
 
                 let finished_at = Utc::now().naive_utc();

--- a/crates/hubuum-storage-postgres/src/operations/service_account.rs
+++ b/crates/hubuum-storage-postgres/src/operations/service_account.rs
@@ -5,7 +5,9 @@ use diesel::prelude::{ExpressionMethods, QueryDsl};
 use diesel::{AsChangeset, JoinOnDsl, Queryable, QueryableByName, Selectable, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{GroupId, IdentityScopeId, PrincipalId, ServiceAccountId, TaskId};
-use hubuum_events_core::{Action, EntityType, EventContext, MutationProvenance, NewEvent};
+use hubuum_events_core::{
+    Action, AuditDocument, EntityType, EventContext, MutationProvenance, NewEvent,
+};
 use hubuum_query::FilterField;
 use hubuum_storage_core::{
     StorageMutationOutcome, StoragePage, StorageServiceAccount, StorageServiceAccountCreate,
@@ -323,18 +325,17 @@ async fn create_service_account_parts(
                 .get_result::<ServiceAccountRow>(connection)
                 .await?;
             let revision = principal_revision(connection, principal_id).await?;
-            let event = service_account_event(
-                &account,
-                &name,
-                Action::Created,
-                &context,
+            let document = AuditDocument::try_new(
                 format!("Service account '{name}' created"),
-            )?
-            .with_after(account.snapshot(&name, revision))
-            .with_metadata(json!({
-                "owner_group_id": account.owner_group_id,
-                "created_by": created_by,
-            }));
+                None,
+                Some(account.snapshot(&name, revision)),
+                json!({
+                    "owner_group_id": account.owner_group_id,
+                    "created_by": created_by,
+                }),
+            )?;
+            let event =
+                service_account_event(&account, &name, Action::Created, &context, document)?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed(
                 account.into_storage()?,
@@ -378,16 +379,13 @@ pub async fn update_service_account(
             .await?;
             let name = principal_name(connection, service_account_id).await?;
             let after_revision = principal_revision(connection, service_account_id).await?;
-            let event = service_account_event(
-                &after,
-                &name,
-                Action::Updated,
-                &context,
+            let document = AuditDocument::try_new(
                 format!("Service account '{name}' updated"),
-            )?
-            .with_before(before.snapshot(&name, before_revision))
-            .with_after(after.snapshot(&name, after_revision))
-            .with_metadata(json!({ "owner_group_id": after.owner_group_id }));
+                Some(before.snapshot(&name, before_revision)),
+                Some(after.snapshot(&name, after_revision)),
+                json!({ "owner_group_id": after.owner_group_id }),
+            )?;
+            let event = service_account_event(&after, &name, Action::Updated, &context, document)?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed(
                 after.into_storage()?,
@@ -429,16 +427,14 @@ async fn disable_service_account_parts(
             .await?;
             let name = principal_name(connection, service_account_id).await?;
             let after_revision = principal_revision(connection, service_account_id).await?;
-            let event = service_account_event(
-                &disabled,
-                &name,
-                Action::Disabled,
-                &context,
+            let document = AuditDocument::try_new(
                 format!("Service account '{name}' disabled"),
-            )?
-            .with_before(before.snapshot(&name, before_revision))
-            .with_after(disabled.snapshot(&name, after_revision))
-            .with_metadata(json!({ "owner_group_id": disabled.owner_group_id }));
+                Some(before.snapshot(&name, before_revision)),
+                Some(disabled.snapshot(&name, after_revision)),
+                json!({ "owner_group_id": disabled.owner_group_id }),
+            )?;
+            let event =
+                service_account_event(&disabled, &name, Action::Disabled, &context, document)?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
 
             crate::operations::token::revoke_all_principal_tokens_on_connection(
@@ -482,15 +478,14 @@ pub async fn delete_service_account(
             let before_revision = lock_principal_revision(connection, service_account_id).await?;
             let account = load_service_account_row(connection, service_account_id).await?;
             let name = principal_name(connection, service_account_id).await?;
-            let event = service_account_event(
-                &account,
-                &name,
-                Action::Deleted,
-                &context,
+            let document = AuditDocument::try_new(
                 format!("Service account '{name}' deleted"),
-            )?
-            .with_before(account.snapshot(&name, before_revision))
-            .with_metadata(json!({ "owner_group_id": account.owner_group_id }));
+                Some(account.snapshot(&name, before_revision)),
+                None,
+                json!({ "owner_group_id": account.owner_group_id }),
+            )?;
+            let event =
+                service_account_event(&account, &name, Action::Deleted, &context, document)?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             diesel::delete(
                 crate::schema::principals::table
@@ -552,15 +547,20 @@ async fn cancel_pending_tasks(
             }
             None => MutationProvenance::system_for_task(initiator_user_id, task_id),
         };
-        let event = NewEvent::new(
+        let document = AuditDocument::try_new(
+            DISABLED_TASK_SUMMARY,
+            None,
+            None,
+            json!({ "task_id": task_id, "task_kind": task_kind }),
+        )?;
+        let event = NewEvent::from_document(
             EntityType::Task,
             Action::Cancelled,
             provenance.actor_kind(),
-            DISABLED_TASK_SUMMARY,
+            document,
         )
         .map_err(|error| PostgresStorageError::database(error.to_string()))?
         .with_entity_id(hubuum_events_core::EventEntityId::new(task_id.id())?)
-        .with_metadata(json!({ "task_id": task_id, "task_kind": task_kind }))
         .with_mutation_provenance(&provenance);
         append_event(connection, &event).await?;
     }
@@ -692,13 +692,13 @@ fn service_account_event(
     name: &str,
     action: Action,
     context: &EventContext,
-    summary: String,
+    document: AuditDocument,
 ) -> Result<NewEvent, PostgresStorageError> {
-    NewEvent::new(
+    NewEvent::from_document(
         EntityType::ServiceAccount,
         action,
         context.actor_kind(),
-        summary,
+        document,
     )
     .map_err(|error| PostgresStorageError::database(error.to_string()))
     .and_then(|event| {

--- a/crates/hubuum-storage-postgres/src/operations/task_execution.rs
+++ b/crates/hubuum-storage-postgres/src/operations/task_execution.rs
@@ -10,7 +10,7 @@ use diesel::sql_types::{Array, BigInt, Integer, Nullable, Text, Timestamp};
 use diesel::{Insertable, QueryableByName, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{PrincipalId, TaskId};
-use hubuum_events_core::{Action, EntityType, MutationProvenance, NewEvent};
+use hubuum_events_core::{Action, AuditDocument, EntityType, MutationProvenance, NewEvent};
 use hubuum_storage_core::{
     StorageBackupTaskArtifact, StorageExportTaskArtifact, StorageRemoteCallTaskArtifact,
     StorageTask, StorageTaskActiveUpdate, StorageTaskClaim, StorageTaskClaimToken,
@@ -637,11 +637,12 @@ async fn append_task_lifecycle_event(
     if let Some(data) = data {
         metadata["data"] = data;
     }
-    let event = NewEvent::new(EntityType::Task, action, provenance.actor_kind(), message)
-        .map_err(|error| PostgresStorageError::internal(error.to_string()))?
-        .with_entity_id(hubuum_events_core::EventEntityId::new(task.id)?)
-        .with_metadata(metadata)
-        .with_mutation_provenance(provenance);
+    let document = AuditDocument::try_new(message, None, None, metadata)?;
+    let event =
+        NewEvent::from_document(EntityType::Task, action, provenance.actor_kind(), document)
+            .map_err(|error| PostgresStorageError::internal(error.to_string()))?
+            .with_entity_id(hubuum_events_core::EventEntityId::new(task.id)?)
+            .with_mutation_provenance(provenance);
     append_event(connection, &event).await
 }
 

--- a/crates/hubuum-storage-postgres/src/operations/task_queue.rs
+++ b/crates/hubuum-storage-postgres/src/operations/task_queue.rs
@@ -13,7 +13,7 @@ use diesel::{Insertable, Queryable, QueryableByName, Selectable, SelectableHelpe
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{GroupId, ImportTaskResultId, PrincipalId, TaskId};
 use hubuum_events_core::{
-    Action, ActorKind, EntityType, EventSequence, MutationProvenance, NewEvent,
+    Action, ActorKind, AuditDocument, EntityType, EventSequence, MutationProvenance, NewEvent,
 };
 use hubuum_query::{CursorValue, FilterField, QueryOptions};
 use hubuum_storage_core::{
@@ -800,19 +800,20 @@ async fn insert_queued_task(
         task.initiator_user_id.map(PrincipalId::new).transpose()?,
         TaskId::new(task.id)?,
     );
-    let event = NewEvent::new(
-        EntityType::Task,
-        Action::Queued,
-        ActorKind::User,
+    let document = AuditDocument::try_new(
         "Task queued",
-    )
-    .map_err(|error| PostgresStorageError::internal(error.to_string()))?
-    .with_entity_id(hubuum_events_core::EventEntityId::new(task.id)?)
-    .with_metadata(json!({
-        "task_id": task.id,
-        "task_kind": task.kind,
-    }))
-    .with_mutation_provenance(&provenance);
+        None,
+        None,
+        json!({
+            "task_id": task.id,
+            "task_kind": task.kind,
+        }),
+    )?;
+    let event =
+        NewEvent::from_document(EntityType::Task, Action::Queued, ActorKind::User, document)
+            .map_err(|error| PostgresStorageError::internal(error.to_string()))?
+            .with_entity_id(hubuum_events_core::EventEntityId::new(task.id)?)
+            .with_mutation_provenance(&provenance);
     append_event(connection, &event).await?;
     notify_task_queue(connection, task.id).await?;
     Ok(task)

--- a/crates/hubuum-storage-postgres/src/operations/token.rs
+++ b/crates/hubuum-storage-postgres/src/operations/token.rs
@@ -9,7 +9,7 @@ use diesel::sql_types::Timestamp;
 use diesel::{BoolExpressionMethods, Insertable, Queryable, Selectable, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{ClassId, CollectionId, ObjectId, TokenId, TokenIssuancePolicy};
-use hubuum_events_core::{Action, EntityType, EventContext, NewEvent};
+use hubuum_events_core::{Action, AuditDocument, EntityType, EventContext, NewEvent};
 use hubuum_query::{FilterField, QueryOptions};
 use hubuum_storage_core::{
     StorageAuditReceipt, StorageAuditReceipts, StorageAuthenticationResourceScope,
@@ -461,9 +461,9 @@ pub async fn revoke_token(
                         after.id, after.principal_id
                     ),
                     None,
-                )?
-                .with_before(before.snapshot(scope.as_ref()))
-                .with_after(after.snapshot(scope.as_ref()));
+                    Some(before.snapshot(scope.as_ref())),
+                    Some(after.snapshot(scope.as_ref())),
+                )?;
                 let audit = append_event(connection, &event).await?.into_audit_receipt();
                 Ok(StorageMutationOutcome::committed(1, audit))
             },
@@ -521,9 +521,9 @@ pub async fn revoke_token_by_hash(
                     after.id, after.principal_id
                 ),
                 None,
-            )?
-            .with_before(before.snapshot(scope.as_ref()))
-            .with_after(after.snapshot(scope.as_ref()));
+                Some(before.snapshot(scope.as_ref())),
+                Some(after.snapshot(scope.as_ref())),
+            )?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed(1, audit))
         })
@@ -590,9 +590,9 @@ pub async fn revoke_all_principal_tokens(
                         token.id, token.principal_id
                     ),
                     None,
-                )?
-                .with_before(before.snapshot(scope))
-                .with_after(token.snapshot(scope));
+                    Some(before.snapshot(scope)),
+                    Some(token.snapshot(scope)),
+                )?;
                 audits.push(append_event(connection, &event).await?.into_audit_receipt());
             }
             Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed_with_audits(
@@ -780,8 +780,9 @@ async fn create_token_row(
             token.id, token.principal_id
         ),
         renewed_from_token_id,
-    )?
-    .with_after(token.snapshot(scope.as_ref()));
+        None,
+        Some(token.snapshot(scope.as_ref())),
+    )?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok((token, audit))
 }
@@ -1152,6 +1153,8 @@ fn token_event(
     context: &EventContext,
     summary: String,
     renewed_from_token_id: Option<i32>,
+    before: Option<Value>,
+    after: Option<Value>,
 ) -> Result<NewEvent, PostgresStorageError> {
     let mut metadata = json!({
         "principal_id": token.principal_id,
@@ -1162,14 +1165,14 @@ fn token_event(
     if let Some(source_id) = renewed_from_token_id {
         metadata["renewed_from_token_id"] = json!(source_id);
     }
-    NewEvent::new(EntityType::Token, action, context.actor_kind(), summary)
+    let document = AuditDocument::try_new(summary, before, after, metadata)?;
+    NewEvent::from_document(EntityType::Token, action, context.actor_kind(), document)
         .map_err(|error| PostgresStorageError::database(error.to_string()))
         .and_then(|event| {
             Ok(event
                 .with_context(context)
                 .with_entity_id(hubuum_events_core::EventEntityId::new(token.id)?)
-                .with_entity_name(token.name.clone().unwrap_or_else(|| token.id.to_string()))
-                .with_metadata(metadata))
+                .with_entity_name(token.name.clone().unwrap_or_else(|| token.id.to_string())))
         })
 }
 

--- a/crates/hubuum-storage-postgres/src/operations/token_retention.rs
+++ b/crates/hubuum-storage-postgres/src/operations/token_retention.rs
@@ -5,7 +5,7 @@ use diesel::sql_types::{BigInt, Bool, Integer, Timestamp};
 use diesel::{ExpressionMethods, QueryDsl, Queryable, QueryableByName};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::MAX_TOKEN_RESOURCE_SCOPES;
-use hubuum_events_core::{Action, ActorKind, EntityType, NewEvent};
+use hubuum_events_core::{Action, ActorKind, AuditDocument, EntityType, NewEvent};
 use hubuum_storage_core::{StorageAuthorizationPermission, StorageError};
 
 use crate::operations::event_record::append_events;
@@ -497,25 +497,29 @@ fn token_purge_event(
         "scope": scope,
         "revision": token.revision,
     });
-    NewEvent::new(
-        EntityType::Token,
-        Action::Purged,
-        ActorKind::System,
+    let document = AuditDocument::try_new(
         format!(
             "Token {} purged after retention for principal {}",
             token.id, token.principal_id
         ),
+        Some(snapshot),
+        None,
+        serde_json::json!({
+            "principal_id": token.principal_id,
+            "retention_basis": basis.as_str(),
+        }),
+    )?;
+    NewEvent::from_document(
+        EntityType::Token,
+        Action::Purged,
+        ActorKind::System,
+        document,
     )
     .map_err(|error| PostgresStorageError::database(error.to_string()))
     .and_then(|event| {
         Ok(event
             .with_entity_id(hubuum_events_core::EventEntityId::new(token.id)?)
-            .with_entity_name(token.name.clone().unwrap_or_else(|| token.id.to_string()))
-            .with_before(snapshot)
-            .with_metadata(serde_json::json!({
-                "principal_id": token.principal_id,
-                "retention_basis": basis.as_str(),
-            })))
+            .with_entity_name(token.name.clone().unwrap_or_else(|| token.id.to_string())))
     })
 }
 

--- a/crates/hubuum-storage-postgres/src/operations/user.rs
+++ b/crates/hubuum-storage-postgres/src/operations/user.rs
@@ -5,7 +5,7 @@ use diesel::prelude::{ExpressionMethods, QueryDsl};
 use diesel::{AsChangeset, JoinOnDsl, Queryable, Selectable, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{IdentityScopeId, UserId};
-use hubuum_events_core::{Action, EntityType, EventContext, NewEvent};
+use hubuum_events_core::{Action, AuditDocument, EntityType, EventContext, NewEvent};
 use hubuum_query::FilterField;
 use hubuum_storage_core::{
     StorageMutationOutcome, StoragePage, StorageUser, StorageUserAnonymize, StorageUserCreate,
@@ -348,14 +348,13 @@ pub async fn create_user(
                 .get_result::<UserRow>(connection)
                 .await?;
             let revision = principal_revision(connection, principal_id).await?;
-            let event = user_event(
-                &user,
-                &name,
-                Action::Created,
-                &context,
+            let document = AuditDocument::try_new(
                 format!("User '{name}' created"),
-            )?
-            .with_after(user.snapshot(&name, revision));
+                None,
+                Some(user.snapshot(&name, revision)),
+                json!({}),
+            )?;
+            let event = user_event(&user, &name, Action::Created, &context, document)?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed(
                 user.into_storage()?,
@@ -406,16 +405,13 @@ pub async fn update_user(
                 revoke_all_tokens(connection, user_id).await?;
             }
             let after_revision = principal_revision(connection, user_id).await?;
-            let event = user_event(
-                &after,
-                &name,
-                Action::Updated,
-                &context,
+            let document = AuditDocument::try_new(
                 format!("User '{name}' updated"),
-            )?
-            .with_before(before.snapshot(&name, before_revision))
-            .with_after(after.snapshot(&name, after_revision))
-            .with_metadata(json!({ "password_changed": password_changed }));
+                Some(before.snapshot(&name, before_revision)),
+                Some(after.snapshot(&name, after_revision)),
+                json!({ "password_changed": password_changed }),
+            )?;
+            let event = user_event(&after, &name, Action::Updated, &context, document)?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed(
                 after.into_storage()?,
@@ -457,20 +453,17 @@ pub(crate) async fn set_user_password_on_connection(
     let revoked = revoke_all_tokens(connection, user_id).await?;
     let after = load_user_row(connection, user_id).await?;
     let after_revision = principal_revision(connection, user_id).await?;
-    let event = user_event(
-        &after,
-        &name,
-        Action::Updated,
-        context,
+    let document = AuditDocument::try_new(
         format!("User '{name}' password changed"),
-    )?
-    .with_before(before.snapshot(&name, before_revision))
-    .with_after(after.snapshot(&name, after_revision))
-    .with_metadata(json!({
-        "password_changed": true,
-        "revoked_token_count": revoked,
-        "credential_reset": credential_reset,
-    }));
+        Some(before.snapshot(&name, before_revision)),
+        Some(after.snapshot(&name, after_revision)),
+        json!({
+            "password_changed": true,
+            "revoked_token_count": revoked,
+            "credential_reset": credential_reset,
+        }),
+    )?;
+    let event = user_event(&after, &name, Action::Updated, context, document)?;
     let audit = append_event(connection, &event).await?.into_audit_receipt();
     Ok(StorageMutationOutcome::committed(revoked, audit))
 }
@@ -492,14 +485,13 @@ pub async fn delete_user(
             )
             .execute(connection)
             .await?;
-            let event = user_event(
-                &user,
-                &name,
-                Action::Deleted,
-                &context,
+            let document = AuditDocument::try_new(
                 format!("User '{name}' deleted"),
-            )?
-            .with_before(user.snapshot(&name, before_revision));
+                Some(user.snapshot(&name, before_revision)),
+                None,
+                json!({}),
+            )?;
+            let event = user_event(&user, &name, Action::Deleted, &context, document)?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed(deleted, audit))
         })
@@ -556,16 +548,13 @@ pub async fn anonymize_user(
             let after = load_user_row(connection, user_id).await?;
             let anonymized_name = principal_name(connection, user_id).await?;
             let after_revision = principal_revision(connection, user_id).await?;
-            let event = user_event(
-                &after,
-                &name,
-                Action::Updated,
-                &context,
+            let document = AuditDocument::try_new(
                 format!("User '{name}' anonymized"),
-            )?
-            .with_before(before.snapshot(&name, before_revision))
-            .with_after(after.snapshot(&anonymized_name, after_revision))
-            .with_metadata(json!({ "anonymized": true }));
+                Some(before.snapshot(&name, before_revision)),
+                Some(after.snapshot(&anonymized_name, after_revision)),
+                json!({ "anonymized": true }),
+            )?;
+            let event = user_event(&after, &name, Action::Updated, &context, document)?;
             let audit = append_event(connection, &event).await?.into_audit_receipt();
             Ok::<_, PostgresStorageError>(StorageMutationOutcome::committed((), audit))
         })
@@ -721,9 +710,9 @@ fn user_event(
     name: &str,
     action: Action,
     context: &EventContext,
-    summary: String,
+    document: AuditDocument,
 ) -> Result<NewEvent, PostgresStorageError> {
-    NewEvent::new(EntityType::User, action, context.actor_kind(), summary)
+    NewEvent::from_document(EntityType::User, action, context.actor_kind(), document)
         .map_err(|error| PostgresStorageError::database(error.to_string()))
         .and_then(|event| {
             Ok(event

--- a/docs/events.md
+++ b/docs/events.md
@@ -8,6 +8,12 @@ The event stream is append-only during normal application operation. Domain
 changes emit events in the same database transaction as the state change, so an
 event exists only if the change commits.
 
+New event bodies are constructed as backend-neutral `AuditDocument` values.
+The type validates object-shaped snapshots and metadata and owns schema-version
+selection: version 1 has no numeric resource revision, while version 2 carries
+a positive `revision` in at least one snapshot. Storage adapters add entity and
+actor coordinates but do not define a separate document shape.
+
 At the storage boundary, ordinary audited mutations require an explicit actor
 context and return a committed receipt identifying that durable event. A
 receipt is non-sensitive proof of persistence, not an audit projection; event

--- a/docs/storage_boundary/backend-author-guide.md
+++ b/docs/storage_boundary/backend-author-guide.md
@@ -134,6 +134,28 @@ contract. Convert them to native keys only inside the adapter. Treat
 query intent; do not reinterpret their private representation or add SQL
 concepts to the shared query crate.
 
+### Audit documents
+
+Construct every new event body through `AuditDocument::try_new` or
+`AuditDocument::builder(...).try_build()`, then attach its entity and
+provenance with `NewEvent::from_document`. The builder owns document-shape
+validation and chooses schema version 1 or revision-aware version 2. Do not
+write an adapter-local schema-version constant or populate summary, snapshots,
+and metadata directly on a native event row.
+
+Use canonical snapshot methods on boundary projections where they are
+available. For a collection, convert the native row to `StorageCollection`
+and call `audit_snapshot()`. This preserves the established timestamp,
+identifier, parent, and revision representation without making a new adapter
+copy PostgreSQL row serialization. Keep the native event insert type private;
+it should only translate `NewEvent` accessors into storage columns.
+
+The selectable-backend conformance fixture supplies an expected
+`AuditDocument` independently of the persisted event and compares every field
+exactly. Add equivalent expectations when expanding its representative
+mutations. Receipt equality alone is insufficient because it does not cover
+summary, snapshots, metadata, or schema version.
+
 ### Projection validation
 
 Fallible value constructors and projection builders use `try_new` and

--- a/docs/storage_boundary/contract.md
+++ b/docs/storage_boundary/contract.md
@@ -121,6 +121,29 @@ callers retrieve those through `AuditEventStorage`.
 Returning a receipt is not permission to synthesize evidence after commit. It
 must be derived from the event persisted by the same atomic operation.
 
+### Portable audit documents
+
+Every adapter constructs the permission-scoped body of a new event with
+`AuditDocument` from `hubuum-events-core`, reexported by
+`hubuum-storage-core`. The document owns the summary, optional `before` and
+`after` object snapshots, metadata object, and schema version. Adapters add
+entity coordinates and provenance through `NewEvent`, but must not assemble
+those document fields in a native event row.
+
+`AuditDocument::try_new` and `AuditDocumentBuilder::try_build` reject non-object
+snapshots or metadata. Schema selection is also backend-neutral: documents
+without a numeric resource revision use version 1, while a snapshot containing
+a positive integer `revision` uses revision-aware version 2. An adapter cannot
+select or advance that version independently. A new document schema requires a
+new construction rule and matching conformance expectations before any native
+serialization changes.
+
+Entity snapshots are made from boundary projections when a canonical helper
+exists. Collection lifecycle events, for example, use
+`StorageCollection::audit_snapshot`; a native collection row is first
+validated into `StorageCollection` and never defines its own public audit
+shape. Persistence rows and backend serialization remain adapter-private.
+
 ### 3. State and Durable Side Effects Are Atomic
 
 The state mutation and canonical audit append share one backend-native commit
@@ -193,7 +216,8 @@ or retry against an authoritative revision.
 `verify_backend_audit_contract` runner. For each `StorageBackendKind::ALL`
 entry, it verifies:
 
-1. a committed receipt matches the durable event;
+1. a committed receipt matches the durable event and its exact canonical
+   `AuditDocument`;
 2. a no-op returns no receipt and appends no event;
 3. an injected failure persists neither state nor event;
 4. the committed event creates durable fan-out and reaches a recording sink;

--- a/docs/storage_boundary/testing.md
+++ b/docs/storage_boundary/testing.md
@@ -18,7 +18,7 @@ The obligations being tested are defined by the normative
 | Resource lifecycle semantics | Strong | Focused resource-operation contracts run against PostgreSQL and a deterministic memory model, including whole-graph transaction commit and state-plus-event rollback. |
 | Boundary direction and type isolation | Strong | Compile-time aggregate bounds plus architecture and workspace source guards reject known PostgreSQL, Diesel, pool, and `ApiError` leaks. |
 | Mandatory family-bound availability | Strong | `StorageBackend` requires every trait, opt-in is explicit, dispatch is exhaustive, and a sealed certification gate covers every selectable kind. |
-| Audit/event contract | Strong | The reusable conformance harness verifies a durable receipt, no-op behavior, rollback, outbox-to-sink delivery, and logical/backend/failure telemetry for every registered backend. |
+| Audit/event contract | Strong | The reusable conformance harness verifies exact portable audit documents, durable receipts, no-op behavior, rollback, outbox-to-sink delivery, and logical/backend/failure telemetry for every registered backend. |
 | Every method's observable semantics | Strong inventory, curated scenarios | A machine-checked inventory must exactly match every complete-backend trait method and selected input-enum variant, and each entry names shared or native evidence. The guard verifies names and test existence, not that a test invokes each listed method or asserts all of its effects. |
 | Application and HTTP behavior | Strong | Every registered backend runs a service point read, readiness, and representative authenticated point/list HTTP requests. Larger integration suites exercise the remaining real application path. |
 | Concurrency and failure recovery | Good | Portable runners own delivery, restore-coordination, and lease-loss expectations; adapters provide deterministic fault injection. Native connection-loss, notification, transaction, retention, and atomicity tests cover implementation mechanics. |
@@ -58,6 +58,11 @@ not prove PostgreSQL transaction isolation.
 `hubuum-storage-core` unit tests validate constructors, builders, invariants,
 redaction, cursor values, error taxonomy, and other backend-neutral behavior.
 They are deterministic and require no database.
+
+`hubuum-events-core` tests additionally validate `AuditDocument` object shapes,
+revision-aware schema selection, and redacted diagnostics. Storage-core tests
+pin canonical collection snapshot fields and timestamp representation without
+using a native row.
 
 Three `hubuum-storage-core` integration tests compile as external crates.
 `external_adapter_api.rs` verifies transaction-scoped resource ports and
@@ -153,6 +158,13 @@ backend. Every registered backend is then exercised through `Services`, the
 readiness handler, and authenticated collection point and list routes. The
 Actix application receives only `AppContext`; adapter-native clients remain
 inside the exhaustive fixture-construction match.
+
+The common committed-mutation probe receives both the persisted event and an
+independently constructed expected `AuditDocument`. It matches the receipt to
+the event and then compares summary, snapshots, metadata, and schema version
+exactly. PostgreSQL's collection fixture builds its expectation from
+`StorageCollection::audit_snapshot`, so the portable assertion does not use a
+PostgreSQL row or its private serializer.
 
 The suite covers these semantic-group behaviors:
 

--- a/docs/storage_boundary/transactions-and-events.md
+++ b/docs/storage_boundary/transactions-and-events.md
@@ -86,10 +86,12 @@ not pass an optional event context to individual transactional mutations.
 For every successful transactional mutation:
 
 1. The adapter performs the state mutation.
-2. The adapter appends the mutation's durable audit event using the inherited
+2. The adapter constructs the summary, snapshots, metadata, and schema version
+   through the backend-neutral `AuditDocument` API.
+3. The adapter appends the mutation's durable audit event using the inherited
    context.
-3. Both changes are part of the same native transaction.
-4. The backend publishes follow-on transactional notifications, if any, only
+4. Both changes are part of the same native transaction.
+5. The backend publishes follow-on transactional notifications, if any, only
    as part of that commit.
 
 If the callback returns `Err`, state, audit events, and transactional

--- a/src/events/model.rs
+++ b/src/events/model.rs
@@ -321,16 +321,20 @@ mod tests {
 
     #[test]
     fn new_event_debug_redacts_payload_snapshots() {
-        let event = hubuum_events_core::NewEvent::new(
+        let document = hubuum_events_core::AuditDocument::try_new(
+            "created",
+            Some(serde_json::json!({"token": "before-secret"})),
+            Some(serde_json::json!({"token": "after-secret"})),
+            serde_json::json!({"token": "metadata-secret"}),
+        )
+        .unwrap();
+        let event = hubuum_events_core::NewEvent::from_document(
             EntityType::Collection,
             Action::Created,
             ActorKind::User,
-            "created",
+            document,
         )
-        .unwrap()
-        .with_before(serde_json::json!({"token": "before-secret"}))
-        .with_after(serde_json::json!({"token": "after-secret"}))
-        .with_metadata(serde_json::json!({"token": "metadata-secret"}));
+        .unwrap();
 
         let debug = format!("{event:?}");
 

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -490,6 +490,11 @@ impl PostgresAuditContractFixture {
 #[async_trait]
 impl BackendAuditFixture for PostgresAuditContractFixture {
     async fn committed_mutation(&self) -> Result<CommittedMutationProbe, FixtureError> {
+        let before = self
+            .backend
+            .collection_store()
+            .get_collection(collection_id(self.collection_id))
+            .await?;
         let outcome = self
             .backend
             .collection_store()
@@ -502,6 +507,12 @@ impl BackendAuditFixture for PostgresAuditContractFixture {
                 &EventContext::system(),
             )
             .await?;
+        let expected_document = hubuum_events_core::AuditDocument::try_new(
+            format!("Collection '{}' updated", outcome.value().name()),
+            Some(before.audit_snapshot()),
+            Some(outcome.value().audit_snapshot()),
+            serde_json::json!({}),
+        )?;
         let receipt = outcome
             .audits()
             .map(hubuum_storage_core::StorageAuditReceipts::first)
@@ -512,7 +523,11 @@ impl BackendAuditFixture for PostgresAuditContractFixture {
             .into_iter()
             .find(|event| event.clone().into_parts().0.id() == receipt.sequence())
             .ok_or_else(|| std::io::Error::other("receipt event was not queryable"))?;
-        Ok(CommittedMutationProbe::new(outcome.map(drop), event))
+        Ok(CommittedMutationProbe::new(
+            outcome.map(drop),
+            event,
+            expected_document,
+        ))
     }
 
     async fn unchanged_mutation(&self) -> Result<UnchangedMutationProbe, FixtureError> {

--- a/tests/api_platform_suite/events.rs
+++ b/tests/api_platform_suite/events.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use actix_web::{http::StatusCode, test};
+    use hubuum_events_core::AuditDocument;
     use rstest::rstest;
     use serde_json::json;
 
@@ -267,22 +268,26 @@ mod tests {
         } else {
             json!(related_collection.id)
         };
+        let document = AuditDocument::try_new(
+            "related collection audit test",
+            Some(json!({"secret": "source-before"})),
+            Some(json!({"secret": "source-after"})),
+            json!({
+                "related_collection_ids": [related_collection_id],
+            }),
+        )
+        .unwrap();
         let event = emit_test_event(
             context.pool.get_ref(),
-            &NewEvent::new(
+            &NewEvent::from_document(
                 EntityType::ClassRelation,
                 Action::Created,
                 ActorKind::System,
-                "related collection audit test",
+                document,
             )
             .unwrap()
             .with_collection_id(collection_id(source_collection.id))
-            .with_entity_id(event_entity_id(source_collection.id))
-            .with_before(json!({"secret": "source-before"}))
-            .with_after(json!({"secret": "source-after"}))
-            .with_metadata(json!({
-                "related_collection_ids": [related_collection_id],
-            })),
+            .with_entity_id(event_entity_id(source_collection.id)),
         )
         .await;
 


### PR DESCRIPTION
## Summary

- introduce a validated, backend-neutral `AuditDocument` that owns summaries, before/after snapshots, metadata, and schema-version selection
- migrate every PostgreSQL audit-event producer to construct that canonical document before persistence
- derive collection audit snapshots from the neutral storage projection instead of PostgreSQL row serialization
- extend the reusable storage conformance probe to compare exact persisted audit documents
- document the portable audit contract and adapter-author requirements

## Behavior

`AuditDocumentBuilder` accepts only object-shaped snapshots and metadata. It selects schema version 2 when either snapshot carries a positive integer `revision`; otherwise it selects the base schema version 1. `EventEnvelope::audit_document` reconstructs the same portable document from persisted events, allowing backend conformance tests to compare exact summaries, snapshots, metadata, and schema versions.

PostgreSQL remains responsible for transactionality and durable append, but no longer owns the audit payload shape. All existing audited mutation families now use the same neutral construction boundary.

## Breaking changes

This changes the experimental workspace storage SDK introduced in #355: the `NewEvent::with_before`, `with_after`, and `with_metadata` setters are removed. Adapter authors must construct an `AuditDocument` and pass it through `NewEvent::from_document`. Summary-only events can continue to use `NewEvent::new`.

There is no HTTP API or OpenAPI schema change and no database migration.

## Verification

- `source .env && CARGO_INCREMENTAL=0 ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- focused unit tests for `hubuum-events-core`, `hubuum-storage-core`, and `hubuum-storage-conformance`

Closes #340