### PR TITLE
Add common secret-source abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Added a common typed secret-source layer with non-printing binary values,
+  validated aliases and versions, async environment and confined mounted-file
+  providers, entry- and byte-bounded single-flight caching, atomic provider
+  groups, explicit stale policy, health diagnostics, and low-cardinality
+  metrics. PostgreSQL,
+  token hashing, LDAP bind passwords, event sinks, and remote targets now use
+  the shared boundary; existing environment names remain compatible, and LDAP
+  supports `bind_password_ref` with ambiguous inline/reference configuration
+  rejected.
+
+### Changed
+
+- **Breaking (experimental `hubuum-events-core` API):** removed
+  `resolve_event_sink_secret`, `resolve_event_sink_secret_uri`, and
+  `EventSinkSecretError`, which read process environment directly from the
+  domain event crate. Sink adapters must now receive a resolved
+  `hubuum_secrets::SecretValue` through `SinkDelivery` and use
+  `hubuum_event_sinks_common::resolve_secret_uri` for URI substitution.
+- Operators can set `HUBUUM_SECRET_SOURCE=file` with
+  `HUBUUM_SECRET_FILE_ROOT` to use bounded regular files, including confined
+  Kubernetes projected-secret symlinks. LDAP, event, and remote integrations
+  observe rotation after cache refresh; PostgreSQL pools and token hashing
+  explicitly require restart rather than claiming unsafe live rotation.
+
 ## [0.0.11] - 2026-08-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "hubuum-events-core",
  "hubuum-outbound-http",
  "hubuum-query",
+ "hubuum-secrets",
  "hubuum-storage-conformance",
  "hubuum-storage-core",
  "hubuum-storage-memory",
@@ -2149,10 +2150,13 @@ dependencies = [
 name = "hubuum-auth-ldap"
 version = "0.0.1"
 dependencies = [
+ "async-trait",
  "hubuum-auth-core",
+ "hubuum-secrets",
  "ldap3",
  "regex",
  "serde",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -2241,6 +2245,7 @@ dependencies = [
  "hubuum-event-sinks-common",
  "hubuum-events-core",
  "hubuum-outbound-http",
+ "hubuum-secrets",
  "serde",
  "serde_json",
  "tokio",
@@ -2254,6 +2259,8 @@ name = "hubuum-event-sinks-common"
 version = "0.0.1"
 dependencies = [
  "hubuum-events-core",
+ "hubuum-secrets",
+ "percent-encoding",
  "serde",
  "serde_json",
  "tokio",
@@ -2265,7 +2272,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "hubuum-domain",
- "percent-encoding",
  "serde",
  "serde_json",
  "utoipa",
@@ -2294,6 +2300,16 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "hubuum-secrets"
+version = "0.0.1"
+dependencies = [
+ "async-trait",
+ "libc",
+ "tokio",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "crates/hubuum-events-core",
     "crates/hubuum-outbound-http",
     "crates/hubuum-query",
+    "crates/hubuum-secrets",
     "crates/hubuum-storage-core",
     "crates/hubuum-storage-conformance",
     "crates/hubuum-storage-memory",
@@ -91,6 +92,7 @@ hubuum-templates = { path = "crates/hubuum-templates" }
 hubuum-events-core = { path = "crates/hubuum-events-core", features = ["schema"] }
 hubuum-outbound-http = { path = "crates/hubuum-outbound-http" }
 hubuum-query = { path = "crates/hubuum-query" }
+hubuum-secrets = { path = "crates/hubuum-secrets" }
 hubuum-storage-core = { path = "crates/hubuum-storage-core" }
 hubuum-storage-memory = { path = "crates/hubuum-storage-memory" }
 hubuum-storage-postgres = { path = "crates/hubuum-storage-postgres" }
@@ -114,7 +116,6 @@ utoipa-swagger-ui = { version = "9", features = [
 ], optional = true }
 urlparse = "0.7"
 uuid = { version = "1", features = ["v4", "serde"] }
-percent-encoding = "2"
 rustls = { version = "0.23", features = ["aws-lc-rs", "ring"] }
 prometheus = "0.14"
 sysinfo = { version = "0.39.6", default-features = false, features = ["system"] }
@@ -132,6 +133,7 @@ criterion = "0.8.2"
 gungraun = "0.19.4"
 hubuum-storage-conformance = { path = "crates/hubuum-storage-conformance" }
 hubuum-storage-postgres = { path = "crates/hubuum-storage-postgres", features = ["integration-test-support", "query-capture"] }
+percent-encoding = "2"
 regex = "1"
 rstest = "0.26"
 tokio-rustls = "0.26"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY crates/hubuum-event-sinks-common/Cargo.toml ./crates/hubuum-event-sinks-com
 COPY crates/hubuum-events-core/Cargo.toml ./crates/hubuum-events-core/Cargo.toml
 COPY crates/hubuum-outbound-http/Cargo.toml ./crates/hubuum-outbound-http/Cargo.toml
 COPY crates/hubuum-query/Cargo.toml ./crates/hubuum-query/Cargo.toml
+COPY crates/hubuum-secrets/Cargo.toml ./crates/hubuum-secrets/Cargo.toml
 COPY crates/hubuum-storage-core/Cargo.toml ./crates/hubuum-storage-core/Cargo.toml
 COPY crates/hubuum-storage-conformance/Cargo.toml ./crates/hubuum-storage-conformance/Cargo.toml
 COPY crates/hubuum-storage-memory/Cargo.toml ./crates/hubuum-storage-memory/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ inspecting and releasing throttled scopes), see [docs/login_rate_limiting.md](do
 
 ### Token Hash Key
 
-- `HUBUUM_TOKEN_HASH_KEY` sets the server-side key used for deterministic token hashing at rest.
+- `HUBUUM_TOKEN_HASH_KEY` sets the server-side key used for deterministic token hashing at rest with the default environment secret source. Mounted-file configuration and rotation behavior are described in [Secret Sources](docs/secret_sources.md).
 - If unset, Hubuum generates an ephemeral in-memory key at startup and logs a warning.
 - With an ephemeral key, all existing bearer tokens become invalid after each restart.
 

--- a/benches/token_storage_hash_callgrind.rs
+++ b/benches/token_storage_hash_callgrind.rs
@@ -8,9 +8,17 @@ use std::hint::black_box;
 // benchmark is self-contained and deterministic in instruction count.
 const RAW_TOKEN: &str = "hubuum_pat_0123456789abcdef0123456789abcdef0123456789abcdef";
 
-#[library_benchmark]
-fn bench_token_storage_hash() -> usize {
-    let digest = Token::storage_hash_from_raw(black_box(RAW_TOKEN));
+fn setup() -> &'static str {
+    // Application startup resolves the process-wide key before bearer-token
+    // authentication begins. Keep that one-time provider/cache initialization
+    // outside the measured per-request hashing path.
+    let _ = Token::storage_hash_from_raw("");
+    RAW_TOKEN
+}
+
+#[library_benchmark(setup = setup)]
+fn bench_token_storage_hash(raw_token: &str) -> usize {
+    let digest = Token::storage_hash_from_raw(black_box(raw_token));
 
     black_box(digest.len())
 }

--- a/crates/hubuum-auth-ldap/Cargo.toml
+++ b/crates/hubuum-auth-ldap/Cargo.toml
@@ -9,9 +9,14 @@ publish = false
 rust-api = "workspace-internal"
 
 [dependencies]
+async-trait = "0.1"
 hubuum-auth-core = { path = "../hubuum-auth-core" }
+hubuum-secrets = { path = "../hubuum-secrets" }
 ldap3 = { version = "0.12", default-features = false, features = ["tls-rustls-ring"] }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 url = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/hubuum-auth-ldap/src/lib.rs
+++ b/crates/hubuum-auth-ldap/src/lib.rs
@@ -4,6 +4,7 @@ use hubuum_auth_core::{
     AuthProviderError, AuthenticatedExternalUser, ExternalGroup, ExternalIdentityProvider,
     ExternalUserProfile, ExternalUserRefreshRequest, IdentityScopeName,
 };
+use hubuum_secrets::{ResolvedSecret, SecretError, SecretName};
 use ldap3::{LdapConnAsync, LdapConnSettings, Scope, SearchEntry};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -18,6 +19,7 @@ pub struct LdapScopeConfig {
     pub url: String,
     pub bind_dn: Option<String>,
     pub bind_password: Option<String>,
+    pub bind_password_ref: Option<String>,
     #[serde(default = "default_connect_timeout_seconds")]
     pub connect_timeout_seconds: u64,
     #[serde(default = "default_operation_timeout_seconds")]
@@ -66,6 +68,10 @@ impl fmt::Debug for LdapScopeConfig {
             .field(
                 "bind_password",
                 &self.bind_password.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "bind_password_ref",
+                &self.bind_password_ref.as_ref().map(|_| "<redacted>"),
             )
             .field("connect_timeout_seconds", &self.connect_timeout_seconds)
             .field("operation_timeout_seconds", &self.operation_timeout_seconds)
@@ -123,10 +129,30 @@ pub struct LdapIdentityProvider {
     group_filters: Vec<Regex>,
     rules: Vec<GroupMappingRule>,
     starttls: bool,
+    secret_source: Option<std::sync::Arc<dyn LdapSecretSource>>,
+}
+
+#[async_trait::async_trait]
+pub trait LdapSecretSource: Send + Sync {
+    async fn resolve(&self, alias: &str) -> Result<ResolvedSecret, SecretError>;
 }
 
 impl LdapIdentityProvider {
     pub fn new(config: LdapScopeConfig) -> Result<Self, AuthProviderError> {
+        Self::new_with_optional_secret_source(config, None)
+    }
+
+    pub fn with_secret_source(
+        config: LdapScopeConfig,
+        secret_source: std::sync::Arc<dyn LdapSecretSource>,
+    ) -> Result<Self, AuthProviderError> {
+        Self::new_with_optional_secret_source(config, Some(secret_source))
+    }
+
+    fn new_with_optional_secret_source(
+        config: LdapScopeConfig,
+        secret_source: Option<std::sync::Arc<dyn LdapSecretSource>>,
+    ) -> Result<Self, AuthProviderError> {
         let scope_name = IdentityScopeName::new(config.scope.clone())?;
         let parsed_url = Url::parse(&config.url)
             .map_err(|e| AuthProviderError::Config(format!("invalid ldap url: {e}")))?;
@@ -170,9 +196,27 @@ impl LdapIdentityProvider {
                 "ldap operation_timeout_seconds must be positive".to_string(),
             ));
         }
-        if config.bind_dn.is_some() != config.bind_password.is_some() {
+        if config.bind_password.is_some() && config.bind_password_ref.is_some() {
             return Err(AuthProviderError::Config(
-                "ldap bind_dn and bind_password must be configured together".to_string(),
+                "ldap bind_password and bind_password_ref are mutually exclusive".to_string(),
+            ));
+        }
+        if let Some(alias) = &config.bind_password_ref {
+            SecretName::new(alias.clone()).map_err(|_| {
+                AuthProviderError::Config("ldap bind_password_ref is invalid".to_string())
+            })?;
+            if secret_source.is_none() {
+                return Err(AuthProviderError::Config(
+                    "ldap bind_password_ref requires a configured secret source".to_string(),
+                ));
+            }
+        }
+        let has_bind_password =
+            config.bind_password.is_some() || config.bind_password_ref.is_some();
+        if config.bind_dn.is_some() != has_bind_password {
+            return Err(AuthProviderError::Config(
+                "ldap bind_dn and one of bind_password or bind_password_ref must be configured together"
+                    .to_string(),
             ));
         }
         let group_filters = config
@@ -203,6 +247,7 @@ impl LdapIdentityProvider {
             group_filters,
             rules,
             starttls,
+            secret_source,
         })
     }
 
@@ -252,20 +297,59 @@ impl LdapIdentityProvider {
     }
 
     async fn bind_service(&self, ldap: &mut ldap3::Ldap) -> Result<(), AuthProviderError> {
-        match (&self.config.bind_dn, &self.config.bind_password) {
-            (Some(dn), Some(password)) => ldap
-                .with_timeout(self.operation_timeout())
-                .simple_bind(dn, password)
-                .await
-                .map_err(|e| AuthProviderError::Unavailable(e.to_string()))?
-                .success()
-                .map_err(|e| AuthProviderError::Config(format!("ldap service bind failed: {e}")))
-                .map(|_| ()),
-            (None, None) => Ok(()),
+        match (
+            &self.config.bind_dn,
+            &self.config.bind_password,
+            &self.config.bind_password_ref,
+        ) {
+            (Some(dn), Some(password), None) => {
+                self.bind_service_password(ldap, dn, password).await
+            }
+            (Some(dn), None, Some(alias)) => {
+                let resolved = self.resolve_bind_password(alias).await?;
+                let password = resolved.value().expose_utf8().map_err(|_| {
+                    AuthProviderError::Config(
+                        "ldap bind password secret must contain valid UTF-8".to_string(),
+                    )
+                })?;
+                self.bind_service_password(ldap, dn, password).await
+            }
+            (None, None, None) => Ok(()),
             _ => Err(AuthProviderError::Config(
-                "ldap bind_dn and bind_password must be configured together".to_string(),
+                "ldap bind credentials are inconsistent".to_string(),
             )),
         }
+    }
+
+    async fn resolve_bind_password(
+        &self,
+        alias: &str,
+    ) -> Result<ResolvedSecret, AuthProviderError> {
+        let source = self.secret_source.as_ref().ok_or_else(|| {
+            AuthProviderError::Config(
+                "ldap bind password secret source is not configured".to_string(),
+            )
+        })?;
+        source.resolve(alias).await.map_err(|_| {
+            AuthProviderError::Unavailable("ldap bind password secret is unavailable".to_string())
+        })
+    }
+
+    async fn bind_service_password(
+        &self,
+        ldap: &mut ldap3::Ldap,
+        dn: &str,
+        password: &str,
+    ) -> Result<(), AuthProviderError> {
+        ldap.with_timeout(self.operation_timeout())
+            .simple_bind(dn, password)
+            .await
+            .map_err(|error| AuthProviderError::Unavailable(error.to_string()))?
+            .success()
+            .map_err(|error| {
+                AuthProviderError::Config(format!("ldap service bind failed: {error}"))
+            })
+            .map(|_| ())
     }
 
     async fn load_user_by_filter(
@@ -491,8 +575,48 @@ fn default_operation_timeout_seconds() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use hubuum_secrets::{FileProvider, SecretName, SecretProviderKind, SecretRef, SecretResolver};
+
     use super::*;
     use std::collections::HashMap;
+
+    static NEXT_SECRET_TEST_ID: AtomicU64 = AtomicU64::new(1);
+
+    struct TestSecretDirectory(PathBuf);
+
+    impl TestSecretDirectory {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "hubuum-ldap-secrets-{}-{}",
+                std::process::id(),
+                NEXT_SECRET_TEST_ID.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TestSecretDirectory {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    struct TestLdapSecretSource {
+        resolver: SecretResolver,
+        reference: SecretRef,
+    }
+
+    #[async_trait::async_trait]
+    impl LdapSecretSource for TestLdapSecretSource {
+        async fn resolve(&self, _alias: &str) -> Result<ResolvedSecret, SecretError> {
+            self.resolver.resolve(&self.reference).await
+        }
+    }
 
     fn ldap_config(url: &str) -> LdapScopeConfig {
         LdapScopeConfig {
@@ -500,6 +624,7 @@ mod tests {
             url: url.into(),
             bind_dn: None,
             bind_password: None,
+            bind_password_ref: None,
             connect_timeout_seconds: default_connect_timeout_seconds(),
             operation_timeout_seconds: default_operation_timeout_seconds(),
             user_base_dn: "dc=example,dc=org".into(),
@@ -607,7 +732,7 @@ mod tests {
         assert!(matches!(&error, AuthProviderError::Config(_)));
         assert_eq!(
             error.to_string(),
-            "provider configuration error: ldap bind_dn and bind_password must be configured together"
+            "provider configuration error: ldap bind_dn and one of bind_password or bind_password_ref must be configured together"
         );
     }
 
@@ -623,7 +748,87 @@ mod tests {
         assert!(matches!(&error, AuthProviderError::Config(_)));
         assert_eq!(
             error.to_string(),
-            "provider configuration error: ldap bind_dn and bind_password must be configured together"
+            "provider configuration error: ldap bind_dn and one of bind_password or bind_password_ref must be configured together"
+        );
+    }
+
+    #[test]
+    fn inline_and_referenced_bind_passwords_are_rejected_as_ambiguous() {
+        let error = LdapIdentityProvider::new(LdapScopeConfig {
+            bind_dn: Some("cn=service,dc=example,dc=org".into()),
+            bind_password: Some("inline-secret".into()),
+            bind_password_ref: Some("directory_bind".into()),
+            ..ldap_config("ldaps://localhost")
+        })
+        .err()
+        .unwrap();
+
+        assert_eq!(
+            error.to_string(),
+            "provider configuration error: ldap bind_password and bind_password_ref are mutually exclusive"
+        );
+    }
+
+    #[test]
+    fn referenced_bind_password_requires_an_injected_secret_source() {
+        let error = LdapIdentityProvider::new(LdapScopeConfig {
+            bind_dn: Some("cn=service,dc=example,dc=org".into()),
+            bind_password_ref: Some("directory_bind".into()),
+            ..ldap_config("ldaps://localhost")
+        })
+        .err()
+        .unwrap();
+
+        assert_eq!(
+            error.to_string(),
+            "provider configuration error: ldap bind_password_ref requires a configured secret source"
+        );
+    }
+
+    #[tokio::test]
+    async fn referenced_bind_password_observes_an_invalidated_file_rotation() {
+        let directory = TestSecretDirectory::new();
+        std::fs::write(directory.0.join("directory_bind"), b"first-password").unwrap();
+        let reference = SecretRef::new(
+            SecretProviderKind::file(),
+            SecretName::new("directory_bind").unwrap(),
+        );
+        let source = Arc::new(TestLdapSecretSource {
+            resolver: SecretResolver::builder()
+                .provider(FileProvider::builder(&directory.0).build().unwrap())
+                .unwrap()
+                .build(),
+            reference: reference.clone(),
+        });
+        let provider = LdapIdentityProvider::with_secret_source(
+            LdapScopeConfig {
+                bind_dn: Some("cn=service,dc=example,dc=org".into()),
+                bind_password_ref: Some("directory_bind".into()),
+                ..ldap_config("ldaps://localhost")
+            },
+            source.clone(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            provider
+                .resolve_bind_password("directory_bind")
+                .await
+                .unwrap()
+                .value()
+                .expose(),
+            b"first-password"
+        );
+        std::fs::write(directory.0.join("directory_bind"), b"second-password").unwrap();
+        source.resolver.invalidate(&reference).await;
+        assert_eq!(
+            provider
+                .resolve_bind_password("directory_bind")
+                .await
+                .unwrap()
+                .value()
+                .expose(),
+            b"second-password"
         );
     }
 

--- a/crates/hubuum-event-sink-amqp/src/lib.rs
+++ b/crates/hubuum-event-sink-amqp/src/lib.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use hubuum_event_sinks_common::{
     DEFAULT_MAX_ENVELOPE_BYTES, EventEnvelope, SinkDelivery, SinkError, UriConnectionPool,
     parse_sink_config, reject_literal_uri_credentials, require_non_empty, require_tls_uri_scheme,
-    resolve_event_sink_secret_uri, serialize_envelope_to_vec,
+    resolve_secret_uri, serialize_envelope_to_vec,
 };
 use lapin::options::{BasicPublishOptions, ConfirmSelectOptions, ExchangeDeclareOptions};
 use lapin::types::FieldTable;
@@ -54,7 +54,7 @@ impl AmqpSink {
         delivery: SinkDelivery<'_>,
     ) -> Result<(), SinkError> {
         let config = parse_config(&delivery)?;
-        let uri = resolve_event_sink_secret_uri(&config.uri, delivery.secret_ref(), "AMQP")?;
+        let uri = resolve_secret_uri(&config.uri, delivery.secret(), "AMQP")?;
         require_tls_uri_scheme(&uri, "AMQP", &["amqps"])?;
         let channel = self.channel(&uri).await?;
 
@@ -190,6 +190,8 @@ fn default_true() -> bool {
 
 #[cfg(test)]
 mod tests {
+    use hubuum_event_sinks_common::SecretValue;
+
     use chrono::Utc;
     use uuid::Uuid;
 
@@ -251,9 +253,9 @@ mod tests {
     fn delivery<'a>(
         config: &'a serde_json::Value,
         routing: &'a serde_json::Value,
-        secret_ref: Option<&'a str>,
+        secret: Option<&'a SecretValue>,
     ) -> SinkDelivery<'a> {
-        SinkDelivery::new(config, routing, secret_ref)
+        SinkDelivery::new(config, routing, secret)
     }
 
     #[test]
@@ -296,12 +298,9 @@ mod tests {
 
     #[test]
     fn secret_ref_requires_uri_placeholder() {
-        let error = resolve_event_sink_secret_uri(
-            "amqps://publisher@example/%2f",
-            Some("rabbitmq"),
-            "AMQP",
-        )
-        .unwrap_err();
+        let secret = SecretValue::new(b"unused".to_vec()).unwrap();
+        let error =
+            resolve_secret_uri("amqps://publisher@example/%2f", Some(&secret), "AMQP").unwrap_err();
         assert_eq!(
             error.to_string(),
             "Invalid AMQP config: uri must include {secret} when secret_ref is set"
@@ -311,8 +310,7 @@ mod tests {
     #[test]
     fn secret_placeholder_requires_secret_ref() {
         let error =
-            resolve_event_sink_secret_uri("amqps://publisher:{secret}@example/%2f", None, "AMQP")
-                .unwrap_err();
+            resolve_secret_uri("amqps://publisher:{secret}@example/%2f", None, "AMQP").unwrap_err();
         assert_eq!(
             error.to_string(),
             "Invalid AMQP config: uri includes {secret} without secret_ref"
@@ -335,14 +333,11 @@ mod tests {
 
     #[test]
     fn secret_ref_replaces_placeholder_with_encoded_secret() {
-        let secret_ref = "amqp_sink_unit_test";
-        unsafe {
-            std::env::set_var("HUBUUM_EVENT_SINK_SECRET_AMQP_SINK_UNIT_TEST", "p@ss/w:rd");
-        }
+        let secret = SecretValue::new(b"p@ss/w:rd".to_vec()).unwrap();
 
-        let uri = resolve_event_sink_secret_uri(
+        let uri = resolve_secret_uri(
             "amqps://publisher:{secret}@rabbitmq.example/%2f",
-            Some(secret_ref),
+            Some(&secret),
             "AMQP",
         )
         .unwrap();
@@ -351,10 +346,6 @@ mod tests {
             uri,
             "amqps://publisher:p%40ss%2Fw%3Ard@rabbitmq.example/%2f"
         );
-
-        unsafe {
-            std::env::remove_var("HUBUUM_EVENT_SINK_SECRET_AMQP_SINK_UNIT_TEST");
-        }
     }
 
     #[test]

--- a/crates/hubuum-event-sink-email/src/lib.rs
+++ b/crates/hubuum-event-sink-email/src/lib.rs
@@ -3,8 +3,7 @@ use std::fmt;
 use hubuum_event_sinks_common::{
     DEFAULT_MAX_ENVELOPE_BYTES, EventEnvelope, SinkDelivery, SinkError, UriConnectionPool,
     ensure_payload_within_limit, parse_sink_config, parse_sink_routing,
-    reject_literal_uri_credentials, require_non_empty, require_tls_uri_scheme,
-    resolve_event_sink_secret_uri,
+    reject_literal_uri_credentials, require_non_empty, require_tls_uri_scheme, resolve_secret_uri,
 };
 use hubuum_templates::{TemplateLimits, prepare_template};
 use lettre::message::Mailbox;
@@ -85,7 +84,7 @@ impl EmailSink {
     ) -> Result<(), SinkError> {
         let config = parse_config(&delivery)?;
         let routing = parse_routing(&delivery)?;
-        let uri = resolve_event_sink_secret_uri(&config.uri, delivery.secret_ref(), "email")?;
+        let uri = resolve_secret_uri(&config.uri, delivery.secret(), "email")?;
         require_tls_uri_scheme(&uri, "email", &["smtps"])?;
         let rendered = render_email(envelope, &config)?;
         let message = build_message(&config, &routing, rendered)?;
@@ -283,6 +282,8 @@ fn default_body_template() -> String {
 
 #[cfg(test)]
 mod tests {
+    use hubuum_event_sinks_common::SecretValue;
+
     use chrono::Utc;
     use uuid::Uuid;
 
@@ -357,9 +358,9 @@ mod tests {
     fn delivery<'a>(
         config: &'a Value,
         routing: &'a Value,
-        secret_ref: Option<&'a str>,
+        secret: Option<&'a SecretValue>,
     ) -> SinkDelivery<'a> {
-        SinkDelivery::new(config, routing, secret_ref)
+        SinkDelivery::new(config, routing, secret)
     }
 
     fn config() -> EmailConfig {
@@ -467,23 +468,16 @@ mod tests {
 
     #[test]
     fn secret_ref_replaces_smtp_uri_placeholder_with_encoded_secret() {
-        let secret_ref = "email_sink_unit_test";
-        unsafe {
-            std::env::set_var("HUBUUM_EVENT_SINK_SECRET_EMAIL_SINK_UNIT_TEST", "p@ss/w:rd");
-        }
+        let secret = SecretValue::new(b"p@ss/w:rd".to_vec()).unwrap();
 
-        let uri = resolve_event_sink_secret_uri(
+        let uri = resolve_secret_uri(
             "smtps://publisher:{secret}@smtp.example",
-            Some(secret_ref),
+            Some(&secret),
             "email",
         )
         .unwrap();
 
         assert_eq!(uri, "smtps://publisher:p%40ss%2Fw%3Ard@smtp.example");
-
-        unsafe {
-            std::env::remove_var("HUBUUM_EVENT_SINK_SECRET_EMAIL_SINK_UNIT_TEST");
-        }
     }
 
     #[test]

--- a/crates/hubuum-event-sink-valkey/src/lib.rs
+++ b/crates/hubuum-event-sink-valkey/src/lib.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use hubuum_event_sinks_common::{
     DEFAULT_MAX_ENVELOPE_BYTES, EventEnvelope, SinkDelivery, SinkError, UriConnectionPool,
     parse_sink_config, parse_sink_routing, reject_literal_uri_credentials, require_non_empty,
-    require_tls_uri_scheme, resolve_event_sink_secret_uri, serialize_envelope_to_string,
+    require_tls_uri_scheme, resolve_secret_uri, serialize_envelope_to_string,
 };
 use redis::Client;
 use serde::Deserialize;
@@ -81,7 +81,7 @@ impl ValkeySink {
     ) -> Result<(), SinkError> {
         let config = parse_config(&delivery)?;
         let routing = parse_routing(&delivery)?;
-        let uri = resolve_event_sink_secret_uri(&config.uri, delivery.secret_ref(), "Valkey")?;
+        let uri = resolve_secret_uri(&config.uri, delivery.secret(), "Valkey")?;
         require_tls_uri_scheme(&uri, "Valkey", &["rediss"])?;
         let client = self.client(&uri).await?;
         let entry = stream_entry(envelope, routing, config)?;
@@ -216,6 +216,8 @@ fn default_true() -> bool {
 
 #[cfg(test)]
 mod tests {
+    use hubuum_event_sinks_common::SecretValue;
+
     use chrono::Utc;
     use uuid::Uuid;
 
@@ -290,9 +292,9 @@ mod tests {
     fn delivery<'a>(
         config: &'a serde_json::Value,
         routing: &'a serde_json::Value,
-        secret_ref: Option<&'a str>,
+        secret: Option<&'a SecretValue>,
     ) -> SinkDelivery<'a> {
-        SinkDelivery::new(config, routing, secret_ref)
+        SinkDelivery::new(config, routing, secret)
     }
 
     #[test]
@@ -390,25 +392,15 @@ mod tests {
 
     #[test]
     fn secret_ref_replaces_uri_placeholder_with_encoded_secret() {
-        let secret_ref = "valkey_sink_unit_test";
-        unsafe {
-            std::env::set_var(
-                "HUBUUM_EVENT_SINK_SECRET_VALKEY_SINK_UNIT_TEST",
-                "p@ss/w:rd",
-            );
-        }
+        let secret = SecretValue::new(b"p@ss/w:rd".to_vec()).unwrap();
 
-        let uri = resolve_event_sink_secret_uri(
+        let uri = resolve_secret_uri(
             "redis://default:{secret}@valkey.example/0",
-            Some(secret_ref),
+            Some(&secret),
             "Valkey",
         )
         .unwrap();
 
         assert_eq!(uri, "redis://default:p%40ss%2Fw%3Ard@valkey.example/0");
-
-        unsafe {
-            std::env::remove_var("HUBUUM_EVENT_SINK_SECRET_VALKEY_SINK_UNIT_TEST");
-        }
     }
 }

--- a/crates/hubuum-event-sink-webhook/Cargo.toml
+++ b/crates/hubuum-event-sink-webhook/Cargo.toml
@@ -15,6 +15,7 @@ futures = "0.3"
 hubuum-event-sinks-common = { path = "../hubuum-event-sinks-common" }
 hubuum-events-core = { path = "../hubuum-events-core" }
 hubuum-outbound-http = { path = "../hubuum-outbound-http" }
+hubuum-secrets = { path = "../hubuum-secrets" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/hubuum-event-sink-webhook/src/lib.rs
+++ b/crates/hubuum-event-sink-webhook/src/lib.rs
@@ -3,7 +3,6 @@ use std::{fmt, time::Duration};
 use hubuum_event_sinks_common::{
     EventEnvelope, SinkDelivery, SinkError, ensure_payload_within_limit, parse_sink_config,
     parse_sink_routing, reject_literal_uri_credentials, require_non_empty,
-    resolve_event_sink_secret,
 };
 use hubuum_outbound_http::{OutboundHeaders, OutboundMethod, OutboundRequest};
 use serde::Deserialize;
@@ -131,7 +130,7 @@ async fn deliver_webhook(
 
     let config: WebhookConfig = parse_sink_config(&delivery, "webhook")?;
 
-    let mut headers = webhook_headers(&config, delivery.secret_ref())?;
+    let mut headers = webhook_headers(&config, delivery.secret())?;
     headers
         .insert("content-type", "application/json")
         .map_err(sink_error)?;
@@ -177,7 +176,7 @@ async fn deliver_webhook(
 
 fn webhook_headers(
     config: &WebhookConfig,
-    secret_ref: Option<&str>,
+    secret: Option<&hubuum_secrets::SecretValue>,
 ) -> Result<OutboundHeaders, SinkError> {
     let mut headers = OutboundHeaders::new();
     if let Some(config_headers) = &config.headers {
@@ -191,8 +190,8 @@ fn webhook_headers(
         }
     }
 
-    if let Some(secret_ref) = secret_ref {
-        let secret = resolve_event_sink_secret(secret_ref)?;
+    if let Some(secret) = secret {
+        let secret = secret.expose_utf8()?;
         headers
             .insert("authorization", &format!("Bearer {secret}"))
             .map_err(|_| SinkError::new("Resolved webhook secret is not a valid header"))?;
@@ -422,19 +421,14 @@ mod tests {
 
     #[tokio::test]
     async fn webhook_sink_posts_event_payload_with_idempotency_header_and_secret() {
-        unsafe {
-            std::env::set_var(
-                "HUBUUM_EVENT_SINK_SECRET_WEBHOOK_TEST_TOKEN",
-                "expected-token",
-            );
-        }
+        let secret = hubuum_secrets::SecretValue::new(b"expected-token".to_vec()).unwrap();
         let (port, request_rx) = spawn_https_server("202 Accepted").await;
         let envelope = envelope();
         let (config, routing) = delivery(format!("https://localhost:{port}/events"));
         WebhookSink::new(settings())
             .deliver(
                 &envelope,
-                SinkDelivery::new(&config, &routing, Some("webhook_test_token")),
+                SinkDelivery::new(&config, &routing, Some(&secret)),
             )
             .await
             .unwrap();
@@ -454,18 +448,13 @@ mod tests {
 
     #[tokio::test]
     async fn webhook_sink_treats_non_success_status_as_delivery_error() {
-        unsafe {
-            std::env::set_var(
-                "HUBUUM_EVENT_SINK_SECRET_WEBHOOK_TEST_TOKEN",
-                "expected-token",
-            );
-        }
+        let secret = hubuum_secrets::SecretValue::new(b"expected-token".to_vec()).unwrap();
         let (port, request_rx) = spawn_https_server("500 Internal Server Error").await;
         let (config, routing) = delivery(format!("https://localhost:{port}/events"));
         let error = WebhookSink::new(settings())
             .deliver(
                 &envelope(),
-                SinkDelivery::new(&config, &routing, Some("webhook_test_token")),
+                SinkDelivery::new(&config, &routing, Some(&secret)),
             )
             .await
             .unwrap_err();

--- a/crates/hubuum-event-sinks-common/Cargo.toml
+++ b/crates/hubuum-event-sinks-common/Cargo.toml
@@ -12,6 +12,8 @@ rust-api = "workspace-internal"
 
 [dependencies]
 hubuum-events-core = { path = "../hubuum-events-core" }
+hubuum-secrets = { path = "../hubuum-secrets" }
+percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["sync"] }

--- a/crates/hubuum-event-sinks-common/src/lib.rs
+++ b/crates/hubuum-event-sinks-common/src/lib.rs
@@ -5,13 +5,14 @@ use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Weak};
 
+use hubuum_secrets::SecretError;
+pub use hubuum_secrets::SecretValue;
+use percent_encoding::{NON_ALPHANUMERIC, percent_encode};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use tokio::sync::{Mutex, OnceCell};
 
-pub use hubuum_events_core::{
-    EventEnvelope, EventSinkSecretError, resolve_event_sink_secret, resolve_event_sink_secret_uri,
-};
+pub use hubuum_events_core::EventEnvelope;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SinkError {
@@ -34,8 +35,8 @@ impl fmt::Display for SinkError {
 
 impl std::error::Error for SinkError {}
 
-impl From<EventSinkSecretError> for SinkError {
-    fn from(error: EventSinkSecretError) -> Self {
+impl From<SecretError> for SinkError {
+    fn from(error: SecretError) -> Self {
         Self::new(error.to_string())
     }
 }
@@ -84,7 +85,7 @@ pub fn ensure_payload_within_limit(
 pub struct SinkDelivery<'a> {
     config: &'a Value,
     routing: &'a Value,
-    secret_ref: Option<&'a str>,
+    secret: Option<&'a SecretValue>,
 }
 
 impl fmt::Debug for SinkDelivery<'_> {
@@ -94,11 +95,11 @@ impl fmt::Debug for SinkDelivery<'_> {
 }
 
 impl<'a> SinkDelivery<'a> {
-    pub fn new(config: &'a Value, routing: &'a Value, secret_ref: Option<&'a str>) -> Self {
+    pub fn new(config: &'a Value, routing: &'a Value, secret: Option<&'a SecretValue>) -> Self {
         Self {
             config,
             routing,
-            secret_ref,
+            secret,
         }
     }
 
@@ -110,8 +111,29 @@ impl<'a> SinkDelivery<'a> {
         self.routing
     }
 
-    pub fn secret_ref(&self) -> Option<&'a str> {
-        self.secret_ref
+    pub fn secret(&self) -> Option<&'a SecretValue> {
+        self.secret
+    }
+}
+
+pub fn resolve_secret_uri(
+    uri: &str,
+    secret: Option<&SecretValue>,
+    sink_label: &str,
+) -> Result<String, SinkError> {
+    let contains_secret_placeholder = uri.contains("{secret}");
+    match secret {
+        Some(_) if !contains_secret_placeholder => Err(SinkError::new(format!(
+            "Invalid {sink_label} config: uri must include {{secret}} when secret_ref is set"
+        ))),
+        Some(secret) => {
+            let encoded = percent_encode(secret.expose(), NON_ALPHANUMERIC).to_string();
+            Ok(uri.replace("{secret}", &encoded))
+        }
+        None if contains_secret_placeholder => Err(SinkError::new(format!(
+            "Invalid {sink_label} config: uri includes {{secret}} without secret_ref"
+        ))),
+        None => Ok(uri.to_string()),
     }
 }
 

--- a/crates/hubuum-events-core/Cargo.toml
+++ b/crates/hubuum-events-core/Cargo.toml
@@ -17,7 +17,6 @@ release-train = "storage-sdk"
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 hubuum-domain = { version = "=0.1.0", path = "../hubuum-domain" }
-percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 utoipa = { version = "5", features = ["chrono", "uuid"], optional = true }

--- a/crates/hubuum-events-core/src/lib.rs
+++ b/crates/hubuum-events-core/src/lib.rs
@@ -16,7 +16,6 @@ use std::fmt;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 pub use hubuum_domain::{CollectionId, PrincipalId, TaskId};
-use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "schema")]
 use utoipa::ToSchema;
@@ -1154,70 +1153,6 @@ fn ensure_unique_uuid(field: &'static str, values: &[Uuid]) -> Result<(), EventF
     }
     Ok(())
 }
-
-pub fn resolve_event_sink_secret(secret_ref: &str) -> Result<String, EventSinkSecretError> {
-    let key = format!(
-        "HUBUUM_EVENT_SINK_SECRET_{}",
-        secret_ref.to_ascii_uppercase()
-    );
-    std::env::var(&key).map_err(|_| EventSinkSecretError::MissingSecret {
-        secret_ref: secret_ref.to_string(),
-    })
-}
-
-pub fn resolve_event_sink_secret_uri(
-    uri: &str,
-    secret_ref: Option<&str>,
-    sink_label: &str,
-) -> Result<String, EventSinkSecretError> {
-    let contains_secret_placeholder = uri.contains("{secret}");
-    match secret_ref {
-        Some(secret_ref) => {
-            if !contains_secret_placeholder {
-                return Err(EventSinkSecretError::MissingSecretPlaceholder {
-                    sink_label: sink_label.to_string(),
-                });
-            }
-            let secret = resolve_event_sink_secret(secret_ref)?;
-            let encoded = utf8_percent_encode(&secret, NON_ALPHANUMERIC).to_string();
-            Ok(uri.replace("{secret}", &encoded))
-        }
-        None if contains_secret_placeholder => {
-            Err(EventSinkSecretError::UnexpectedSecretPlaceholder {
-                sink_label: sink_label.to_string(),
-            })
-        }
-        None => Ok(uri.to_string()),
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum EventSinkSecretError {
-    MissingSecret { secret_ref: String },
-    MissingSecretPlaceholder { sink_label: String },
-    UnexpectedSecretPlaceholder { sink_label: String },
-}
-
-impl fmt::Display for EventSinkSecretError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::MissingSecret { secret_ref } => write!(
-                f,
-                "Event sink secret reference '{secret_ref}' is not configured"
-            ),
-            Self::MissingSecretPlaceholder { sink_label } => write!(
-                f,
-                "Invalid {sink_label} config: uri must include {{secret}} when secret_ref is set"
-            ),
-            Self::UnexpectedSecretPlaceholder { sink_label } => write!(
-                f,
-                "Invalid {sink_label} config: uri includes {{secret}} without secret_ref"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for EventSinkSecretError {}
 
 /// Validates that `action` is legal for `entity_type`.
 pub fn is_valid_pair(entity_type: EntityType, action: Action) -> bool {

--- a/crates/hubuum-secrets/Cargo.toml
+++ b/crates/hubuum-secrets/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "hubuum-secrets"
+version = "0.0.1"
+edition = "2024"
+description = "Typed secret references and bounded secret providers for Hubuum."
+license = "MIT"
+repository = "https://github.com/hubuum/hubuum"
+publish = false
+
+[package.metadata.hubuum]
+rust-api = "workspace-internal"
+
+[dependencies]
+async-trait = "0.1"
+tokio = { version = "1", features = ["sync", "time"] }
+zeroize = "1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/hubuum-secrets/src/error.rs
+++ b/crates/hubuum-secrets/src/error.rs
@@ -1,0 +1,55 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecretErrorKind {
+    InvalidReference,
+    InvalidProviderConfiguration,
+    ProviderNotConfigured,
+    NotFound,
+    PermissionDenied,
+    InvalidValue,
+    TooLarge,
+    UnsafePath,
+    UnsupportedVersion,
+    ChangedDuringRead,
+    Timeout,
+    Unavailable,
+    Internal,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct SecretError {
+    kind: SecretErrorKind,
+    message: String,
+}
+
+impl SecretError {
+    pub fn new(kind: SecretErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    pub fn kind(&self) -> SecretErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Debug for SecretError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SecretError")
+            .field("kind", &self.kind)
+            .field("message", &self.message)
+            .finish()
+    }
+}
+
+impl fmt::Display for SecretError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for SecretError {}

--- a/crates/hubuum-secrets/src/file.rs
+++ b/crates/hubuum-secrets/src/file.rs
@@ -1,0 +1,613 @@
+use std::collections::BTreeMap;
+use std::collections::hash_map::RandomState;
+use std::fmt;
+use std::fs::{self, File, Metadata};
+use std::io::{Read, Take};
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::provider::{ProviderSecret, ensure_provider, ensure_version, opaque_version};
+use crate::{
+    DEFAULT_MAX_SECRET_BYTES, SecretError, SecretErrorKind, SecretName, SecretProvider,
+    SecretProviderKind, SecretRef, SecretValue,
+};
+
+const STABLE_READ_ATTEMPTS: usize = 3;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FileSymlinkPolicy {
+    #[default]
+    Reject,
+    AllowWithinRoot,
+}
+
+pub struct FileProviderBuilder {
+    kind: SecretProviderKind,
+    root: PathBuf,
+    paths: BTreeMap<SecretName, PathBuf>,
+    path_prefix: PathBuf,
+    max_bytes: usize,
+    symlink_policy: FileSymlinkPolicy,
+}
+
+impl FileProviderBuilder {
+    pub fn kind(mut self, kind: SecretProviderKind) -> Self {
+        self.kind = kind;
+        self
+    }
+
+    pub fn path(mut self, name: SecretName, path: impl Into<PathBuf>) -> Self {
+        self.paths.insert(name, path.into());
+        self
+    }
+
+    pub fn path_prefix(mut self, path_prefix: impl Into<PathBuf>) -> Self {
+        self.path_prefix = path_prefix.into();
+        self
+    }
+
+    pub fn max_bytes(mut self, max_bytes: usize) -> Self {
+        self.max_bytes = max_bytes;
+        self
+    }
+
+    pub fn symlink_policy(mut self, symlink_policy: FileSymlinkPolicy) -> Self {
+        self.symlink_policy = symlink_policy;
+        self
+    }
+
+    pub fn build(self) -> Result<FileProvider, SecretError> {
+        if self.max_bytes == 0 {
+            return Err(SecretError::new(
+                SecretErrorKind::InvalidProviderConfiguration,
+                "file secret size limit must be positive",
+            ));
+        }
+        let root = fs::canonicalize(&self.root)
+            .map_err(|error| map_io_error(error, "file secret root is unavailable"))?;
+        if !fs::metadata(&root)
+            .map_err(|error| map_io_error(error, "file secret root is unavailable"))?
+            .is_dir()
+        {
+            return Err(SecretError::new(
+                SecretErrorKind::UnsafePath,
+                "file secret root must be a directory",
+            ));
+        }
+        for path in self.paths.values() {
+            validate_relative_path(path)?;
+        }
+        if !self.path_prefix.as_os_str().is_empty() {
+            validate_relative_path(&self.path_prefix)?;
+        }
+        Ok(FileProvider {
+            kind: self.kind,
+            root,
+            paths: self.paths,
+            path_prefix: self.path_prefix,
+            max_bytes: self.max_bytes,
+            symlink_policy: self.symlink_policy,
+            version_hasher: RandomState::new(),
+        })
+    }
+}
+
+pub struct FileProvider {
+    kind: SecretProviderKind,
+    root: PathBuf,
+    paths: BTreeMap<SecretName, PathBuf>,
+    path_prefix: PathBuf,
+    max_bytes: usize,
+    symlink_policy: FileSymlinkPolicy,
+    version_hasher: RandomState,
+}
+
+impl FileProvider {
+    pub fn builder(root: impl Into<PathBuf>) -> FileProviderBuilder {
+        FileProviderBuilder {
+            kind: SecretProviderKind::file(),
+            root: root.into(),
+            paths: BTreeMap::new(),
+            path_prefix: PathBuf::new(),
+            max_bytes: DEFAULT_MAX_SECRET_BYTES,
+            symlink_policy: FileSymlinkPolicy::Reject,
+        }
+    }
+
+    fn relative_path(&self, name: &SecretName) -> PathBuf {
+        self.paths
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| self.path_prefix.join(name.as_str()))
+    }
+
+    fn read(&self, reference: &SecretRef) -> Result<ProviderSecret, SecretError> {
+        ensure_provider(reference, &self.kind)?;
+        let relative = self.relative_path(reference.name());
+        validate_relative_path(&relative)?;
+        let candidate = self.root.join(&relative);
+
+        for attempt in 0..STABLE_READ_ATTEMPTS {
+            match self.read_once(&candidate, reference) {
+                Err(error)
+                    if error.kind() == SecretErrorKind::ChangedDuringRead
+                        && attempt + 1 < STABLE_READ_ATTEMPTS => {}
+                result => return result,
+            }
+        }
+        unreachable!("the bounded stable-read loop always returns on its final attempt")
+    }
+
+    fn read_once(
+        &self,
+        candidate: &Path,
+        reference: &SecretRef,
+    ) -> Result<ProviderSecret, SecretError> {
+        if self.symlink_policy == FileSymlinkPolicy::Reject {
+            reject_symlink_components(&self.root, candidate)?;
+        }
+
+        let resolved = fs::canonicalize(candidate)
+            .map_err(|error| map_io_error(error, "file secret is unavailable"))?;
+        ensure_within_root(&self.root, &resolved)?;
+        let path_metadata = fs::metadata(&resolved)
+            .map_err(|error| map_io_error(error, "file secret is unavailable"))?;
+        validate_regular_file(&path_metadata, self.max_bytes)?;
+
+        let file = File::open(&resolved)
+            .map_err(|error| map_io_error(error, "file secret is unavailable"))?;
+        ensure_open_file_within_root(&self.root, &file)?;
+        let before = file
+            .metadata()
+            .map_err(|error| map_io_error(error, "file secret is unavailable"))?;
+        validate_regular_file(&before, self.max_bytes)?;
+
+        let bytes = read_bounded_descriptor(file, &before, self.max_bytes)?;
+        let current = fs::canonicalize(candidate).map_err(|_| changed_during_read())?;
+        if current != resolved {
+            return Err(changed_during_read());
+        }
+
+        let version = opaque_version(&self.version_hasher, &bytes)?;
+        ensure_version(reference.version(), &version)?;
+        Ok(ProviderSecret {
+            value: Arc::new(SecretValue::new(bytes)?),
+            version,
+        })
+    }
+}
+
+impl fmt::Debug for FileProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FileProvider")
+            .field("kind", &self.kind)
+            .field("root", &"<redacted>")
+            .field("mapped_secret_count", &self.paths.len())
+            .field("max_bytes", &self.max_bytes)
+            .field("symlink_policy", &self.symlink_policy)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl SecretProvider for FileProvider {
+    fn kind(&self) -> &SecretProviderKind {
+        &self.kind
+    }
+
+    async fn resolve(&self, reference: &SecretRef) -> Result<ProviderSecret, SecretError> {
+        self.read(reference)
+    }
+
+    async fn resolve_group(
+        &self,
+        references: &[SecretRef],
+    ) -> Result<Vec<ProviderSecret>, SecretError> {
+        for attempt in 0..STABLE_READ_ATTEMPTS {
+            let first = references
+                .iter()
+                .map(|reference| self.read(reference))
+                .collect::<Result<Vec<_>, _>>()?;
+            let versions = references
+                .iter()
+                .map(|reference| self.read(reference).map(|value| value.version))
+                .collect::<Result<Vec<_>, _>>()?;
+            if first.iter().map(|value| &value.version).eq(versions.iter()) {
+                return Ok(first);
+            }
+            if attempt + 1 == STABLE_READ_ATTEMPTS {
+                return Err(changed_during_read());
+            }
+        }
+        unreachable!("the bounded stable group-read loop always returns")
+    }
+}
+
+fn validate_relative_path(path: &Path) -> Result<(), SecretError> {
+    if path.as_os_str().is_empty()
+        || !path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+    {
+        return Err(SecretError::new(
+            SecretErrorKind::UnsafePath,
+            "file secret paths must be non-empty provider-relative paths without traversal",
+        ));
+    }
+    Ok(())
+}
+
+fn reject_symlink_components(root: &Path, candidate: &Path) -> Result<(), SecretError> {
+    let relative = candidate.strip_prefix(root).map_err(|_| {
+        SecretError::new(
+            SecretErrorKind::UnsafePath,
+            "file secret path escapes the configured root",
+        )
+    })?;
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        current.push(component);
+        let metadata = fs::symlink_metadata(&current)
+            .map_err(|error| map_io_error(error, "file secret is unavailable"))?;
+        if metadata.file_type().is_symlink() {
+            return Err(SecretError::new(
+                SecretErrorKind::UnsafePath,
+                "file secret symlinks are disabled",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn ensure_within_root(root: &Path, resolved: &Path) -> Result<(), SecretError> {
+    if !resolved.starts_with(root) || resolved == root {
+        return Err(SecretError::new(
+            SecretErrorKind::UnsafePath,
+            "file secret path escapes the configured root",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn ensure_open_file_within_root(root: &Path, file: &File) -> Result<(), SecretError> {
+    use std::os::fd::AsRawFd;
+
+    let descriptor_path = PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()));
+    let resolved = fs::canonicalize(descriptor_path).map_err(|_| changed_during_read())?;
+    ensure_within_root(root, &resolved)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn ensure_open_file_within_root(_root: &Path, _file: &File) -> Result<(), SecretError> {
+    Ok(())
+}
+
+fn validate_regular_file(metadata: &Metadata, max_bytes: usize) -> Result<(), SecretError> {
+    if !metadata.is_file() {
+        return Err(SecretError::new(
+            SecretErrorKind::UnsafePath,
+            "file secret must be an ordinary file",
+        ));
+    }
+    if metadata.len() > max_bytes as u64 {
+        return Err(SecretError::new(
+            SecretErrorKind::TooLarge,
+            "file secret exceeds the configured size limit",
+        ));
+    }
+    Ok(())
+}
+
+fn read_bounded_descriptor(
+    file: File,
+    before: &Metadata,
+    max_bytes: usize,
+) -> Result<Vec<u8>, SecretError> {
+    let mut bytes = Vec::with_capacity(before.len() as usize);
+    let mut bounded: Take<File> = file.take((max_bytes as u64).saturating_add(1));
+    bounded
+        .read_to_end(&mut bytes)
+        .map_err(|error| map_io_error(error, "file secret could not be read"))?;
+    if bytes.len() > max_bytes {
+        return Err(SecretError::new(
+            SecretErrorKind::TooLarge,
+            "file secret exceeds the configured size limit",
+        ));
+    }
+    let file = bounded.into_inner();
+    let after = file
+        .metadata()
+        .map_err(|error| map_io_error(error, "file secret is unavailable"))?;
+    if metadata_changed(before, &after) {
+        return Err(changed_during_read());
+    }
+    Ok(bytes)
+}
+
+fn metadata_changed(before: &Metadata, after: &Metadata) -> bool {
+    if before.len() != after.len() || before.modified().ok() != after.modified().ok() {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        before.dev() != after.dev() || before.ino() != after.ino()
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
+fn changed_during_read() -> SecretError {
+    SecretError::new(
+        SecretErrorKind::ChangedDuringRead,
+        "file secret changed while it was being read",
+    )
+}
+
+fn map_io_error(error: std::io::Error, message: &'static str) -> SecretError {
+    let kind = match error.kind() {
+        std::io::ErrorKind::NotFound => SecretErrorKind::NotFound,
+        std::io::ErrorKind::PermissionDenied => SecretErrorKind::PermissionDenied,
+        std::io::ErrorKind::TimedOut => SecretErrorKind::Timeout,
+        _ => SecretErrorKind::Unavailable,
+    };
+    SecretError::new(kind, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, OpenOptions};
+    use std::io::Write;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(1);
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "hubuum-secrets-{}-{}",
+                std::process::id(),
+                NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn reference(name: &str) -> SecretRef {
+        SecretRef::new(SecretProviderKind::file(), SecretName::new(name).unwrap())
+    }
+
+    #[tokio::test]
+    async fn reads_binary_secret_at_the_limit() {
+        let directory = TestDirectory::new();
+        fs::write(directory.path().join("binary"), [0, 1, 0xff, 2]).unwrap();
+        let provider = FileProvider::builder(directory.path())
+            .max_bytes(4)
+            .build()
+            .unwrap();
+
+        let value = provider.resolve(&reference("binary")).await.unwrap();
+
+        assert_eq!(value.value.expose(), [0, 1, 0xff, 2]);
+    }
+
+    #[test]
+    fn descriptor_read_detects_growth_after_initial_metadata() {
+        let directory = TestDirectory::new();
+        let path = directory.path().join("growing");
+        fs::write(&path, b"12").unwrap();
+        let file = File::open(&path).unwrap();
+        let before = file.metadata().unwrap();
+        OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"3")
+            .unwrap();
+
+        assert_eq!(
+            read_bounded_descriptor(file, &before, 4)
+                .unwrap_err()
+                .kind(),
+            SecretErrorKind::ChangedDuringRead
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_and_non_regular_files() {
+        let directory = TestDirectory::new();
+        fs::write(directory.path().join("large"), b"12345").unwrap();
+        fs::create_dir(directory.path().join("subdir")).unwrap();
+        let provider = FileProvider::builder(directory.path())
+            .max_bytes(4)
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            provider
+                .resolve(&reference("large"))
+                .await
+                .unwrap_err()
+                .kind(),
+            SecretErrorKind::TooLarge
+        );
+        assert_eq!(
+            provider
+                .resolve(&reference("subdir"))
+                .await
+                .unwrap_err()
+                .kind(),
+            SecretErrorKind::UnsafePath
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rejects_devices_fifos_and_sockets_without_opening_them() {
+        use std::os::unix::net::UnixListener;
+
+        let directory = TestDirectory::new();
+        let fifo = directory.path().join("fifo");
+        let fifo_path = std::ffi::CString::new(fifo.as_os_str().as_encoded_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) }, 0);
+        let socket_path = directory.path().join("socket");
+        let listener = UnixListener::bind(&socket_path).ok();
+        let provider = FileProvider::builder(directory.path()).build().unwrap();
+
+        assert_eq!(
+            provider
+                .resolve(&reference("fifo"))
+                .await
+                .unwrap_err()
+                .kind(),
+            SecretErrorKind::UnsafePath
+        );
+        if listener.is_some() {
+            assert_eq!(
+                provider
+                    .resolve(&reference("socket"))
+                    .await
+                    .unwrap_err()
+                    .kind(),
+                SecretErrorKind::UnsafePath
+            );
+        }
+
+        let device_provider = FileProvider::builder("/dev").build().unwrap();
+        assert_eq!(
+            device_provider
+                .resolve(&reference("null"))
+                .await
+                .unwrap_err()
+                .kind(),
+            SecretErrorKind::UnsafePath
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn projected_secret_symlinks_are_explicit_and_confined() {
+        use std::os::unix::fs::symlink;
+
+        let directory = TestDirectory::new();
+        let generation = directory.path().join("..2026_08_31");
+        fs::create_dir(&generation).unwrap();
+        fs::write(generation.join("password"), b"rotated-secret").unwrap();
+        symlink("..2026_08_31", directory.path().join("..data")).unwrap();
+        symlink("..data/password", directory.path().join("password")).unwrap();
+
+        let strict = FileProvider::builder(directory.path()).build().unwrap();
+        assert_eq!(
+            strict
+                .resolve(&reference("password"))
+                .await
+                .unwrap_err()
+                .kind(),
+            SecretErrorKind::UnsafePath
+        );
+
+        let projected = FileProvider::builder(directory.path())
+            .symlink_policy(FileSymlinkPolicy::AllowWithinRoot)
+            .build()
+            .unwrap();
+        assert_eq!(
+            projected
+                .resolve(&reference("password"))
+                .await
+                .unwrap()
+                .value
+                .expose(),
+            b"rotated-secret"
+        );
+
+        let next_generation = directory.path().join("..2026_09_01");
+        fs::create_dir(&next_generation).unwrap();
+        fs::write(next_generation.join("password"), b"next-secret").unwrap();
+        symlink("..2026_09_01", directory.path().join("..data-next")).unwrap();
+        fs::rename(
+            directory.path().join("..data-next"),
+            directory.path().join("..data"),
+        )
+        .unwrap();
+        assert_eq!(
+            projected
+                .resolve(&reference("password"))
+                .await
+                .unwrap()
+                .value
+                .expose(),
+            b"next-secret"
+        );
+
+        fs::remove_file(directory.path().join("password")).unwrap();
+        symlink("/etc/passwd", directory.path().join("password")).unwrap();
+        assert_eq!(
+            projected
+                .resolve(&reference("password"))
+                .await
+                .unwrap_err()
+                .kind(),
+            SecretErrorKind::UnsafePath
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn projected_secret_groups_use_one_complete_generation() {
+        use std::os::unix::fs::symlink;
+
+        let directory = TestDirectory::new();
+        let first_generation = directory.path().join("..2026_08_31");
+        fs::create_dir(&first_generation).unwrap();
+        fs::write(first_generation.join("username"), b"first-user").unwrap();
+        fs::write(first_generation.join("password"), b"first-password").unwrap();
+        symlink("..2026_08_31", directory.path().join("..data")).unwrap();
+        symlink("..data/username", directory.path().join("username")).unwrap();
+        symlink("..data/password", directory.path().join("password")).unwrap();
+        let provider = FileProvider::builder(directory.path())
+            .symlink_policy(FileSymlinkPolicy::AllowWithinRoot)
+            .build()
+            .unwrap();
+        let references = [reference("username"), reference("password")];
+
+        let first = provider.resolve_group(&references).await.unwrap();
+        assert_eq!(first[0].value().expose(), b"first-user");
+        assert_eq!(first[1].value().expose(), b"first-password");
+
+        let second_generation = directory.path().join("..2026_09_01");
+        fs::create_dir(&second_generation).unwrap();
+        fs::write(second_generation.join("username"), b"second-user").unwrap();
+        fs::write(second_generation.join("password"), b"second-password").unwrap();
+        symlink("..2026_09_01", directory.path().join("..data-next")).unwrap();
+        fs::rename(
+            directory.path().join("..data-next"),
+            directory.path().join("..data"),
+        )
+        .unwrap();
+
+        let second = provider.resolve_group(&references).await.unwrap();
+        assert_eq!(second[0].value().expose(), b"second-user");
+        assert_eq!(second[1].value().expose(), b"second-password");
+    }
+}

--- a/crates/hubuum-secrets/src/lib.rs
+++ b/crates/hubuum-secrets/src/lib.rs
@@ -1,0 +1,22 @@
+//! Typed, non-printing secret values and bounded environment/file providers.
+
+pub const DEFAULT_MAX_SECRET_BYTES: usize = 1024 * 1024;
+
+mod error;
+mod file;
+mod provider;
+mod reference;
+mod resolver;
+mod value;
+
+pub use error::{SecretError, SecretErrorKind};
+pub use file::{FileProvider, FileProviderBuilder, FileSymlinkPolicy};
+pub use provider::{
+    EnvironmentProvider, ProviderHealth, ProviderHealthState, ProviderSecret, SecretProvider,
+};
+pub use reference::{SecretName, SecretProviderKind, SecretRef, SecretVersionSelector};
+pub use resolver::{
+    CachePolicy, ResolvedSecret, ResolvedSecretGroup, SecretResolver, SecretResolverBuilder,
+    SecretResolverDiagnostics, StalePolicy,
+};
+pub use value::{SecretValue, SecretVersion};

--- a/crates/hubuum-secrets/src/provider.rs
+++ b/crates/hubuum-secrets/src/provider.rs
@@ -1,0 +1,406 @@
+use std::collections::{BTreeMap, hash_map::RandomState};
+use std::fmt;
+use std::hash::BuildHasher;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+
+use crate::{
+    DEFAULT_MAX_SECRET_BYTES, SecretError, SecretErrorKind, SecretName, SecretProviderKind,
+    SecretRef, SecretValue, SecretVersion, SecretVersionSelector,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderHealthState {
+    Unknown,
+    Healthy,
+    Degraded,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderHealth {
+    pub(crate) kind: SecretProviderKind,
+    pub(crate) state: ProviderHealthState,
+    pub(crate) last_success: Option<SystemTime>,
+    pub(crate) last_error_kind: Option<SecretErrorKind>,
+}
+
+impl ProviderHealth {
+    pub fn kind(&self) -> &SecretProviderKind {
+        &self.kind
+    }
+
+    pub fn state(&self) -> ProviderHealthState {
+        self.state
+    }
+
+    pub fn last_success(&self) -> Option<SystemTime> {
+        self.last_success
+    }
+
+    pub fn last_error_kind(&self) -> Option<SecretErrorKind> {
+        self.last_error_kind
+    }
+}
+
+pub struct ProviderSecret {
+    pub(crate) value: Arc<SecretValue>,
+    pub(crate) version: SecretVersion,
+}
+
+impl fmt::Debug for ProviderSecret {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderSecret")
+            .field("value", &"<redacted>")
+            .field("version", &self.version)
+            .finish()
+    }
+}
+
+impl ProviderSecret {
+    pub fn new(value: SecretValue, version: SecretVersion) -> Self {
+        Self {
+            value: Arc::new(value),
+            version,
+        }
+    }
+
+    pub fn value(&self) -> &Arc<SecretValue> {
+        &self.value
+    }
+
+    pub fn version(&self) -> &SecretVersion {
+        &self.version
+    }
+}
+
+#[async_trait]
+pub trait SecretProvider: Send + Sync + fmt::Debug {
+    fn kind(&self) -> &SecretProviderKind;
+
+    async fn resolve(&self, reference: &SecretRef) -> Result<ProviderSecret, SecretError>;
+
+    async fn resolve_group(
+        &self,
+        references: &[SecretRef],
+    ) -> Result<Vec<ProviderSecret>, SecretError>;
+}
+
+pub struct EnvironmentProvider {
+    kind: SecretProviderKind,
+    prefix: String,
+    mappings: BTreeMap<SecretName, String>,
+    max_bytes: usize,
+    version_hasher: RandomState,
+}
+
+impl EnvironmentProvider {
+    pub fn new(prefix: impl Into<String>) -> Result<Self, SecretError> {
+        Self::with_kind(SecretProviderKind::environment(), prefix)
+    }
+
+    pub fn with_kind(
+        kind: SecretProviderKind,
+        prefix: impl Into<String>,
+    ) -> Result<Self, SecretError> {
+        let prefix = prefix.into();
+        if prefix.len() > 128
+            || !prefix
+                .bytes()
+                .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
+        {
+            return Err(SecretError::new(
+                SecretErrorKind::InvalidProviderConfiguration,
+                "environment secret prefixes must contain at most 128 uppercase ASCII letters, numbers, or underscores",
+            ));
+        }
+        Ok(Self {
+            kind,
+            prefix,
+            mappings: BTreeMap::new(),
+            max_bytes: DEFAULT_MAX_SECRET_BYTES,
+            version_hasher: RandomState::new(),
+        })
+    }
+
+    pub fn max_bytes(mut self, max_bytes: usize) -> Result<Self, SecretError> {
+        if max_bytes == 0 {
+            return Err(SecretError::new(
+                SecretErrorKind::InvalidProviderConfiguration,
+                "environment secret size limit must be positive",
+            ));
+        }
+        self.max_bytes = max_bytes;
+        Ok(self)
+    }
+
+    pub fn mapping(
+        mut self,
+        name: SecretName,
+        environment_name: impl Into<String>,
+    ) -> Result<Self, SecretError> {
+        let environment_name = environment_name.into();
+        if environment_name.is_empty()
+            || environment_name.len() > 256
+            || !environment_name
+                .bytes()
+                .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
+        {
+            return Err(SecretError::new(
+                SecretErrorKind::InvalidProviderConfiguration,
+                "mapped environment names must contain 1-256 uppercase ASCII letters, numbers, or underscores",
+            ));
+        }
+        self.mappings.insert(name, environment_name);
+        Ok(self)
+    }
+
+    fn key(&self, name: &SecretName) -> String {
+        if let Some(mapped) = self.mappings.get(name) {
+            return mapped.clone();
+        }
+        format!("{}{}", self.prefix, name.as_str().to_ascii_uppercase()).replace('-', "_")
+    }
+
+    fn read(&self, reference: &SecretRef) -> Result<ProviderSecret, SecretError> {
+        ensure_provider(reference, &self.kind)?;
+        let key = self.key(reference.name());
+        let value = std::env::var_os(&key).ok_or_else(|| {
+            SecretError::new(
+                SecretErrorKind::NotFound,
+                "environment secret is not configured",
+            )
+        })?;
+        #[cfg(unix)]
+        let bytes = {
+            use std::os::unix::ffi::OsStringExt;
+            value.into_vec()
+        };
+        #[cfg(not(unix))]
+        let bytes = value.into_string().map(String::into_bytes).map_err(|_| {
+            SecretError::new(
+                SecretErrorKind::InvalidValue,
+                "environment secret is not valid Unicode on this platform",
+            )
+        })?;
+        if bytes.len() > self.max_bytes {
+            return Err(SecretError::new(
+                SecretErrorKind::TooLarge,
+                "environment secret exceeds the configured size limit",
+            ));
+        }
+        let version = opaque_version(&self.version_hasher, &bytes)?;
+        ensure_version(reference.version(), &version)?;
+        Ok(ProviderSecret {
+            value: Arc::new(SecretValue::new(bytes)?),
+            version,
+        })
+    }
+}
+
+impl fmt::Debug for EnvironmentProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EnvironmentProvider")
+            .field("kind", &self.kind)
+            .field("prefix", &"<redacted>")
+            .field("mapped_secret_count", &self.mappings.len())
+            .field("max_bytes", &self.max_bytes)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl SecretProvider for EnvironmentProvider {
+    fn kind(&self) -> &SecretProviderKind {
+        &self.kind
+    }
+
+    async fn resolve(&self, reference: &SecretRef) -> Result<ProviderSecret, SecretError> {
+        self.read(reference)
+    }
+
+    async fn resolve_group(
+        &self,
+        references: &[SecretRef],
+    ) -> Result<Vec<ProviderSecret>, SecretError> {
+        for attempt in 0..3 {
+            let first = references
+                .iter()
+                .map(|reference| self.read(reference))
+                .collect::<Result<Vec<_>, _>>()?;
+            let versions = references
+                .iter()
+                .map(|reference| self.read(reference).map(|value| value.version))
+                .collect::<Result<Vec<_>, _>>()?;
+            if first.iter().map(|value| &value.version).eq(versions.iter()) {
+                return Ok(first);
+            }
+            if attempt == 2 {
+                return Err(SecretError::new(
+                    SecretErrorKind::ChangedDuringRead,
+                    "environment secret group changed while it was being resolved",
+                ));
+            }
+        }
+        unreachable!("the bounded environment group-read loop always returns")
+    }
+}
+
+pub(crate) fn ensure_provider(
+    reference: &SecretRef,
+    expected: &SecretProviderKind,
+) -> Result<(), SecretError> {
+    if reference.provider() != expected {
+        return Err(SecretError::new(
+            SecretErrorKind::InvalidReference,
+            "secret reference was sent to the wrong provider",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn opaque_version(
+    state: &RandomState,
+    value: &[u8],
+) -> Result<SecretVersion, SecretError> {
+    SecretVersion::new(format!("v{:016x}", state.hash_one(value)))
+}
+
+pub(crate) fn ensure_version(
+    selector: &SecretVersionSelector,
+    actual: &SecretVersion,
+) -> Result<(), SecretError> {
+    if let SecretVersionSelector::Exact(expected) = selector
+        && expected != actual
+    {
+        return Err(SecretError::new(
+            SecretErrorKind::UnsupportedVersion,
+            "the requested secret version is not available",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static NEXT_ENVIRONMENT_ID: AtomicU64 = AtomicU64::new(1);
+
+    struct TestEnvironment {
+        key: String,
+        name: SecretName,
+    }
+
+    impl TestEnvironment {
+        fn new() -> Self {
+            Self {
+                key: format!(
+                    "SECRET_PROVIDER_TEST_{}_{}",
+                    std::process::id(),
+                    NEXT_ENVIRONMENT_ID.fetch_add(1, Ordering::Relaxed)
+                ),
+                name: SecretName::new("value").unwrap(),
+            }
+        }
+
+        fn provider(&self) -> EnvironmentProvider {
+            EnvironmentProvider::new("")
+                .unwrap()
+                .mapping(self.name.clone(), &self.key)
+                .unwrap()
+        }
+
+        fn reference(&self) -> SecretRef {
+            SecretRef::new(SecretProviderKind::environment(), self.name.clone())
+        }
+
+        fn set(&self, value: &OsStr) {
+            unsafe { std::env::set_var(&self.key, value) };
+        }
+    }
+
+    impl Drop for TestEnvironment {
+        fn drop(&mut self) {
+            unsafe { std::env::remove_var(&self.key) };
+        }
+    }
+
+    #[tokio::test]
+    async fn environment_provider_distinguishes_missing_from_empty_values() {
+        let environment = TestEnvironment::new();
+        let provider = environment.provider();
+
+        assert_eq!(
+            provider
+                .resolve(&environment.reference())
+                .await
+                .unwrap_err()
+                .kind(),
+            SecretErrorKind::NotFound
+        );
+        environment.set(OsStr::new(""));
+        assert_eq!(
+            provider
+                .resolve(&environment.reference())
+                .await
+                .unwrap_err()
+                .kind(),
+            SecretErrorKind::InvalidValue
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn environment_provider_preserves_binary_values() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let environment = TestEnvironment::new();
+        let provider = environment.provider();
+        let value = std::ffi::OsString::from_vec(vec![0xff, 0x01]);
+        environment.set(&value);
+
+        assert_eq!(
+            provider
+                .resolve(&environment.reference())
+                .await
+                .unwrap()
+                .value()
+                .expose(),
+            [0xff, 0x01]
+        );
+    }
+
+    #[tokio::test]
+    async fn environment_provider_enforces_its_configured_size_limit() {
+        let environment = TestEnvironment::new();
+        let provider = environment.provider().max_bytes(4).unwrap();
+        environment.set(OsStr::new("1234"));
+        assert_eq!(
+            provider
+                .resolve(&environment.reference())
+                .await
+                .unwrap()
+                .value()
+                .len(),
+            4
+        );
+        environment.set(OsStr::new("12345"));
+
+        assert_eq!(
+            provider
+                .resolve(&environment.reference())
+                .await
+                .unwrap_err()
+                .kind(),
+            SecretErrorKind::TooLarge
+        );
+    }
+}

--- a/crates/hubuum-secrets/src/reference.rs
+++ b/crates/hubuum-secrets/src/reference.rs
@@ -1,0 +1,142 @@
+use std::fmt;
+
+use crate::{SecretError, SecretErrorKind, SecretVersion};
+
+const MAX_NAME_BYTES: usize = 128;
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SecretName(String);
+
+impl SecretName {
+    pub fn new(value: impl Into<String>) -> Result<Self, SecretError> {
+        let value = value.into();
+        if value.is_empty()
+            || value.len() > MAX_NAME_BYTES
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+        {
+            return Err(SecretError::new(
+                SecretErrorKind::InvalidReference,
+                "secret names must contain 1-128 ASCII letters, numbers, underscores, or hyphens",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SecretName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SecretName(<redacted>)")
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SecretProviderKind {
+    Environment,
+    File,
+}
+
+impl fmt::Debug for SecretProviderKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl SecretProviderKind {
+    pub const fn environment() -> Self {
+        Self::Environment
+    }
+
+    pub const fn file() -> Self {
+        Self::File
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Environment => "environment",
+            Self::File => "file",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum SecretVersionSelector {
+    Latest,
+    Exact(SecretVersion),
+}
+
+impl fmt::Debug for SecretVersionSelector {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Latest => formatter.write_str("Latest"),
+            Self::Exact(_) => formatter.write_str("Exact(<redacted>)"),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct SecretRef {
+    provider: SecretProviderKind,
+    name: SecretName,
+    version: SecretVersionSelector,
+}
+
+impl SecretRef {
+    pub fn new(provider: SecretProviderKind, name: SecretName) -> Self {
+        Self {
+            provider,
+            name,
+            version: SecretVersionSelector::Latest,
+        }
+    }
+
+    pub fn with_version(mut self, version: SecretVersionSelector) -> Self {
+        self.version = version;
+        self
+    }
+
+    pub fn provider(&self) -> &SecretProviderKind {
+        &self.provider
+    }
+
+    pub fn name(&self) -> &SecretName {
+        &self.name
+    }
+
+    pub fn version(&self) -> &SecretVersionSelector {
+        &self.version
+    }
+}
+
+impl fmt::Debug for SecretRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SecretRef")
+            .field("provider", &self.provider)
+            .field("name", &"<redacted>")
+            .field("version", &self.version)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn references_reject_paths_and_debug_without_names() {
+        assert!(SecretName::new("../database-password").is_err());
+        let reference = SecretRef::new(
+            SecretProviderKind::environment(),
+            SecretName::new("database-password").unwrap(),
+        );
+
+        let debug = format!("{reference:?}");
+        assert!(!debug.contains("database-password"));
+        assert!(debug.contains("environment"));
+    }
+}

--- a/crates/hubuum-secrets/src/resolver.rs
+++ b/crates/hubuum-secrets/src/resolver.rs
@@ -1,0 +1,1060 @@
+use std::collections::{HashMap, VecDeque};
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant, SystemTime};
+
+use tokio::sync::{Mutex, OnceCell};
+
+use crate::provider::ProviderSecret;
+use crate::{
+    ProviderHealth, ProviderHealthState, SecretError, SecretErrorKind, SecretProvider,
+    SecretProviderKind, SecretRef, SecretValue, SecretVersion,
+};
+
+const DEFAULT_CACHE_CAPACITY: usize = 128;
+const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(300);
+const DEFAULT_MAX_GROUP_SIZE: usize = 32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StalePolicy {
+    FailClosed,
+    AllowFor(Duration),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CachePolicy {
+    capacity: NonZeroUsize,
+    max_total_bytes: NonZeroUsize,
+    ttl: Duration,
+    stale: StalePolicy,
+    max_group_size: NonZeroUsize,
+}
+
+impl CachePolicy {
+    pub fn new(capacity: NonZeroUsize, ttl: Duration) -> Self {
+        let max_total_bytes = NonZeroUsize::new(
+            capacity
+                .get()
+                .saturating_mul(crate::DEFAULT_MAX_SECRET_BYTES),
+        )
+        .expect("a positive cache capacity produces a positive byte limit");
+        Self {
+            capacity,
+            max_total_bytes,
+            ttl,
+            stale: StalePolicy::FailClosed,
+            max_group_size: NonZeroUsize::new(DEFAULT_MAX_GROUP_SIZE)
+                .expect("the default maximum group size is non-zero"),
+        }
+    }
+
+    pub fn stale_policy(mut self, stale: StalePolicy) -> Self {
+        self.stale = stale;
+        self
+    }
+
+    pub fn max_total_bytes(mut self, max_total_bytes: NonZeroUsize) -> Self {
+        self.max_total_bytes = max_total_bytes;
+        self
+    }
+
+    pub fn max_group_size(mut self, max_group_size: NonZeroUsize) -> Self {
+        self.max_group_size = max_group_size;
+        self
+    }
+
+    pub fn capacity(self) -> NonZeroUsize {
+        self.capacity
+    }
+
+    pub fn ttl(self) -> Duration {
+        self.ttl
+    }
+
+    pub fn total_byte_limit(self) -> NonZeroUsize {
+        self.max_total_bytes
+    }
+
+    pub fn stale(self) -> StalePolicy {
+        self.stale
+    }
+
+    pub fn group_size_limit(self) -> NonZeroUsize {
+        self.max_group_size
+    }
+}
+
+impl Default for CachePolicy {
+    fn default() -> Self {
+        Self::new(
+            NonZeroUsize::new(DEFAULT_CACHE_CAPACITY)
+                .expect("the default cache capacity is non-zero"),
+            DEFAULT_CACHE_TTL,
+        )
+    }
+}
+
+#[derive(Clone)]
+pub struct ResolvedSecret {
+    value: Arc<SecretValue>,
+    version: SecretVersion,
+    generation: u64,
+    loaded_at: Instant,
+}
+
+impl ResolvedSecret {
+    pub fn value(&self) -> &SecretValue {
+        &self.value
+    }
+
+    pub fn version(&self) -> &SecretVersion {
+        &self.version
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn age(&self) -> Duration {
+        self.loaded_at.elapsed()
+    }
+}
+
+impl fmt::Debug for ResolvedSecret {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ResolvedSecret")
+            .field("value", &"<redacted>")
+            .field("version", &self.version)
+            .field("generation", &self.generation)
+            .finish()
+    }
+}
+
+pub struct ResolvedSecretGroup {
+    values: Vec<ResolvedSecret>,
+    generation: u64,
+}
+
+impl ResolvedSecretGroup {
+    pub fn values(&self) -> &[ResolvedSecret] {
+        &self.values
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+}
+
+impl fmt::Debug for ResolvedSecretGroup {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ResolvedSecretGroup")
+            .field("value_count", &self.values.len())
+            .field("generation", &self.generation)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SecretResolverDiagnostics {
+    providers: Vec<ProviderHealth>,
+    cache_entries: usize,
+    cache_capacity: usize,
+    cached_bytes: usize,
+    cache_byte_capacity: usize,
+}
+
+impl SecretResolverDiagnostics {
+    pub fn providers(&self) -> &[ProviderHealth] {
+        &self.providers
+    }
+
+    pub fn cache_entries(&self) -> usize {
+        self.cache_entries
+    }
+
+    pub fn cache_capacity(&self) -> usize {
+        self.cache_capacity
+    }
+
+    pub fn cached_bytes(&self) -> usize {
+        self.cached_bytes
+    }
+
+    pub fn cache_byte_capacity(&self) -> usize {
+        self.cache_byte_capacity
+    }
+}
+
+#[derive(Default)]
+pub struct SecretResolverBuilder {
+    providers: HashMap<SecretProviderKind, Arc<dyn SecretProvider>>,
+    cache_policy: CachePolicy,
+}
+
+impl SecretResolverBuilder {
+    pub fn provider(
+        mut self,
+        provider: impl SecretProvider + 'static,
+    ) -> Result<Self, SecretError> {
+        let kind = *provider.kind();
+        if self.providers.insert(kind, Arc::new(provider)).is_some() {
+            return Err(SecretError::new(
+                SecretErrorKind::InvalidProviderConfiguration,
+                "a secret provider kind may only be configured once",
+            ));
+        }
+        Ok(self)
+    }
+
+    pub fn shared_provider(
+        mut self,
+        provider: Arc<dyn SecretProvider>,
+    ) -> Result<Self, SecretError> {
+        let kind = *provider.kind();
+        if self.providers.insert(kind, provider).is_some() {
+            return Err(SecretError::new(
+                SecretErrorKind::InvalidProviderConfiguration,
+                "a secret provider kind may only be configured once",
+            ));
+        }
+        Ok(self)
+    }
+
+    pub fn cache_policy(mut self, cache_policy: CachePolicy) -> Self {
+        self.cache_policy = cache_policy;
+        self
+    }
+
+    pub fn build(self) -> SecretResolver {
+        let health = self
+            .providers
+            .keys()
+            .cloned()
+            .map(|kind| {
+                (
+                    kind,
+                    ProviderHealth {
+                        kind,
+                        state: ProviderHealthState::Unknown,
+                        last_success: None,
+                        last_error_kind: None,
+                    },
+                )
+            })
+            .collect();
+        SecretResolver {
+            providers: self.providers,
+            cache_policy: self.cache_policy,
+            state: Mutex::new(ResolverState {
+                cache: HashMap::new(),
+                recency: VecDeque::new(),
+                health,
+            }),
+            next_generation: AtomicU64::new(1),
+        }
+    }
+}
+
+pub struct SecretResolver {
+    providers: HashMap<SecretProviderKind, Arc<dyn SecretProvider>>,
+    cache_policy: CachePolicy,
+    state: Mutex<ResolverState>,
+    next_generation: AtomicU64,
+}
+
+struct ResolverState {
+    cache: HashMap<SecretRef, CacheEntry>,
+    recency: VecDeque<SecretRef>,
+    health: HashMap<SecretProviderKind, ProviderHealth>,
+}
+
+struct CacheEntry {
+    cell: Arc<OnceCell<ResolvedSecret>>,
+    stale: Option<ResolvedSecret>,
+    expires_at: Option<Instant>,
+}
+
+enum ResolutionPlan {
+    Ready(ResolvedSecret),
+    Load {
+        cell: Arc<OnceCell<ResolvedSecret>>,
+        stale: Option<ResolvedSecret>,
+    },
+}
+
+impl SecretResolver {
+    pub fn builder() -> SecretResolverBuilder {
+        SecretResolverBuilder::default()
+    }
+
+    pub async fn resolve(&self, reference: &SecretRef) -> Result<ResolvedSecret, SecretError> {
+        let provider = self.providers.get(reference.provider()).ok_or_else(|| {
+            SecretError::new(
+                SecretErrorKind::ProviderNotConfigured,
+                "secret provider is not configured",
+            )
+        })?;
+        let plan = self.resolution_plan(reference).await?;
+        let ResolutionPlan::Load { cell, stale } = plan else {
+            let ResolutionPlan::Ready(value) = plan else {
+                unreachable!()
+            };
+            return Ok(value);
+        };
+
+        let result = cell
+            .get_or_try_init(|| async {
+                provider
+                    .resolve(reference)
+                    .await
+                    .and_then(|secret| self.resolved_for_cache(secret, None))
+            })
+            .await
+            .cloned();
+
+        match result {
+            Ok(value) => {
+                self.finish_success(reference, &cell).await;
+                Ok(value)
+            }
+            Err(error) => {
+                self.finish_failure(reference, &cell, error.kind()).await;
+                if self.stale_allowed(stale.as_ref()) {
+                    return Ok(stale.expect("the stale policy checked this value"));
+                }
+                Err(error)
+            }
+        }
+    }
+
+    pub async fn resolve_group(
+        &self,
+        references: &[SecretRef],
+    ) -> Result<ResolvedSecretGroup, SecretError> {
+        if references.is_empty() {
+            return Err(SecretError::new(
+                SecretErrorKind::InvalidReference,
+                "secret groups must contain at least one reference",
+            ));
+        }
+        if references.len() > self.cache_policy.group_size_limit().get() {
+            return Err(SecretError::new(
+                SecretErrorKind::InvalidReference,
+                "secret group exceeds the configured size limit",
+            ));
+        }
+        let provider_kind = references[0].provider();
+        if references
+            .iter()
+            .any(|reference| reference.provider() != provider_kind)
+        {
+            return Err(SecretError::new(
+                SecretErrorKind::InvalidReference,
+                "an atomic secret group must use one provider",
+            ));
+        }
+        let provider = self.providers.get(provider_kind).ok_or_else(|| {
+            SecretError::new(
+                SecretErrorKind::ProviderNotConfigured,
+                "secret provider is not configured",
+            )
+        })?;
+        match provider.resolve_group(references).await {
+            Ok(values) if values.len() == references.len() => {
+                let total_bytes = values
+                    .iter()
+                    .try_fold(0usize, |total, value| {
+                        total.checked_add(value.value().len()).ok_or(())
+                    })
+                    .unwrap_or(usize::MAX);
+                if total_bytes > self.cache_policy.total_byte_limit().get() {
+                    let error = SecretError::new(
+                        SecretErrorKind::TooLarge,
+                        "resolved secret group exceeds the configured byte limit",
+                    );
+                    self.record_failure(provider_kind, error.kind()).await;
+                    return Err(error);
+                }
+                self.record_success(provider_kind).await;
+                let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+                let loaded_at = Instant::now();
+                Ok(ResolvedSecretGroup {
+                    values: values
+                        .into_iter()
+                        .map(|value| self.resolved(value, Some((generation, loaded_at))))
+                        .collect(),
+                    generation,
+                })
+            }
+            Ok(_) => {
+                let error = SecretError::new(
+                    SecretErrorKind::Internal,
+                    "secret provider returned an incomplete group",
+                );
+                self.record_failure(provider_kind, error.kind()).await;
+                Err(error)
+            }
+            Err(error) => {
+                self.record_failure(provider_kind, error.kind()).await;
+                Err(error)
+            }
+        }
+    }
+
+    pub async fn refresh(&self, reference: &SecretRef) -> Result<ResolvedSecret, SecretError> {
+        self.invalidate(reference).await;
+        self.resolve(reference).await
+    }
+
+    pub async fn invalidate(&self, reference: &SecretRef) {
+        let mut state = self.state.lock().await;
+        state.cache.remove(reference);
+        state.remove_recency(reference);
+    }
+
+    pub async fn invalidate_provider(&self, provider: &SecretProviderKind) {
+        let mut state = self.state.lock().await;
+        state
+            .cache
+            .retain(|reference, _| reference.provider() != provider);
+        state
+            .recency
+            .retain(|reference| reference.provider() != provider);
+    }
+
+    pub async fn diagnostics(&self) -> SecretResolverDiagnostics {
+        let state = self.state.lock().await;
+        let mut providers = state.health.values().cloned().collect::<Vec<_>>();
+        providers.sort_by(|left, right| left.kind().cmp(right.kind()));
+        SecretResolverDiagnostics {
+            providers,
+            cache_entries: state.cache.len(),
+            cache_capacity: self.cache_policy.capacity().get(),
+            cached_bytes: state.cached_bytes(),
+            cache_byte_capacity: self.cache_policy.total_byte_limit().get(),
+        }
+    }
+
+    async fn resolution_plan(&self, reference: &SecretRef) -> Result<ResolutionPlan, SecretError> {
+        let mut state = self.state.lock().await;
+        state.touch(reference);
+        if let Some(entry) = state.cache.get_mut(reference) {
+            if let Some(value) = entry.cell.get().cloned() {
+                if entry
+                    .expires_at
+                    .is_some_and(|expires_at| expires_at > Instant::now())
+                {
+                    return Ok(ResolutionPlan::Ready(value));
+                }
+                entry.stale = Some(value);
+                entry.cell = Arc::new(OnceCell::new());
+                entry.expires_at = None;
+            }
+            return Ok(ResolutionPlan::Load {
+                cell: Arc::clone(&entry.cell),
+                stale: entry.stale.clone(),
+            });
+        }
+
+        let capacity = self.cache_policy.capacity().get();
+        state.evict_to(
+            capacity.saturating_sub(1),
+            self.cache_policy.total_byte_limit().get(),
+        );
+        if state.cache.len() >= capacity {
+            state.remove_recency(reference);
+            return Err(SecretError::new(
+                SecretErrorKind::Unavailable,
+                "secret resolver capacity is temporarily exhausted",
+            ));
+        }
+        let cell = Arc::new(OnceCell::new());
+        state.cache.insert(
+            reference.clone(),
+            CacheEntry {
+                cell: Arc::clone(&cell),
+                stale: None,
+                expires_at: None,
+            },
+        );
+        Ok(ResolutionPlan::Load { cell, stale: None })
+    }
+
+    fn resolved(
+        &self,
+        secret: ProviderSecret,
+        generation_and_time: Option<(u64, Instant)>,
+    ) -> ResolvedSecret {
+        let (generation, loaded_at) = generation_and_time.unwrap_or_else(|| {
+            (
+                self.next_generation.fetch_add(1, Ordering::Relaxed),
+                Instant::now(),
+            )
+        });
+        ResolvedSecret {
+            value: secret.value,
+            version: secret.version,
+            generation,
+            loaded_at,
+        }
+    }
+
+    fn resolved_for_cache(
+        &self,
+        secret: ProviderSecret,
+        generation_and_time: Option<(u64, Instant)>,
+    ) -> Result<ResolvedSecret, SecretError> {
+        if secret.value().len() > self.cache_policy.total_byte_limit().get() {
+            return Err(SecretError::new(
+                SecretErrorKind::TooLarge,
+                "resolved secret exceeds the configured cache byte limit",
+            ));
+        }
+        Ok(self.resolved(secret, generation_and_time))
+    }
+
+    async fn finish_success(&self, reference: &SecretRef, cell: &Arc<OnceCell<ResolvedSecret>>) {
+        let mut state = self.state.lock().await;
+        if let Some(entry) = state.cache.get_mut(reference)
+            && Arc::ptr_eq(&entry.cell, cell)
+        {
+            entry.expires_at = Some(Instant::now() + self.cache_policy.ttl());
+            entry.stale = None;
+        }
+        state.record_success(reference.provider());
+        state.evict_to(
+            self.cache_policy.capacity().get(),
+            self.cache_policy.total_byte_limit().get(),
+        );
+    }
+
+    async fn finish_failure(
+        &self,
+        reference: &SecretRef,
+        cell: &Arc<OnceCell<ResolvedSecret>>,
+        error_kind: SecretErrorKind,
+    ) {
+        let mut state = self.state.lock().await;
+        let remove = state.cache.get(reference).is_some_and(|entry| {
+            Arc::ptr_eq(&entry.cell, cell) && entry.cell.get().is_none() && entry.stale.is_none()
+        });
+        if remove {
+            state.cache.remove(reference);
+            state.remove_recency(reference);
+        }
+        state.record_failure(reference.provider(), error_kind);
+    }
+
+    fn stale_allowed(&self, stale: Option<&ResolvedSecret>) -> bool {
+        match (self.cache_policy.stale(), stale) {
+            (StalePolicy::AllowFor(max_stale), Some(stale)) => {
+                stale.age() <= self.cache_policy.ttl().saturating_add(max_stale)
+            }
+            _ => false,
+        }
+    }
+
+    async fn record_success(&self, provider: &SecretProviderKind) {
+        self.state.lock().await.record_success(provider);
+    }
+
+    async fn record_failure(&self, provider: &SecretProviderKind, error_kind: SecretErrorKind) {
+        self.state.lock().await.record_failure(provider, error_kind);
+    }
+}
+
+impl fmt::Debug for SecretResolver {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SecretResolver")
+            .field("provider_count", &self.providers.len())
+            .field("cache_policy", &self.cache_policy)
+            .finish()
+    }
+}
+
+impl ResolverState {
+    fn touch(&mut self, reference: &SecretRef) {
+        self.remove_recency(reference);
+        self.recency.push_back(reference.clone());
+    }
+
+    fn remove_recency(&mut self, reference: &SecretRef) {
+        if let Some(index) = self
+            .recency
+            .iter()
+            .position(|candidate| candidate == reference)
+        {
+            self.recency.remove(index);
+        }
+    }
+
+    fn cached_bytes(&self) -> usize {
+        self.cache
+            .values()
+            .filter_map(|entry| entry.cell.get())
+            .fold(0usize, |total, value| {
+                total.saturating_add(value.value.len())
+            })
+    }
+
+    fn evict_to(&mut self, capacity: usize, byte_capacity: usize) {
+        let mut candidates = self.recency.len();
+        while (self.cache.len() > capacity || self.cached_bytes() > byte_capacity) && candidates > 0
+        {
+            candidates -= 1;
+            let Some(reference) = self.recency.pop_front() else {
+                return;
+            };
+            let idle = self
+                .cache
+                .get(&reference)
+                .is_some_and(|entry| Arc::strong_count(&entry.cell) == 1);
+            if idle {
+                self.cache.remove(&reference);
+            } else {
+                self.recency.push_back(reference);
+            }
+        }
+    }
+
+    fn record_success(&mut self, provider: &SecretProviderKind) {
+        if let Some(health) = self.health.get_mut(provider) {
+            health.state = ProviderHealthState::Healthy;
+            health.last_success = Some(SystemTime::now());
+            health.last_error_kind = None;
+        }
+    }
+
+    fn record_failure(&mut self, provider: &SecretProviderKind, error_kind: SecretErrorKind) {
+        if let Some(health) = self.health.get_mut(provider) {
+            health.state = if health.last_success.is_some() {
+                ProviderHealthState::Degraded
+            } else {
+                ProviderHealthState::Unavailable
+            };
+            health.last_error_kind = Some(error_kind);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+
+    use async_trait::async_trait;
+    use tokio::sync::Notify;
+
+    use super::*;
+    use crate::{ProviderSecret, SecretName, SecretVersion};
+
+    struct TestProvider {
+        kind: SecretProviderKind,
+        calls: AtomicU64,
+        fail: AtomicBool,
+        gate: Option<Arc<Notify>>,
+    }
+
+    impl fmt::Debug for TestProvider {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("TestProvider")
+        }
+    }
+
+    #[async_trait]
+    impl SecretProvider for TestProvider {
+        fn kind(&self) -> &SecretProviderKind {
+            &self.kind
+        }
+
+        async fn resolve(&self, reference: &SecretRef) -> Result<ProviderSecret, SecretError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(gate) = &self.gate {
+                gate.notified().await;
+            }
+            if self.fail.load(Ordering::SeqCst) {
+                return Err(SecretError::new(
+                    SecretErrorKind::Unavailable,
+                    "test provider unavailable",
+                ));
+            }
+            ProviderSecret::new(
+                SecretValue::new(reference.name().as_str().as_bytes().to_vec())?,
+                SecretVersion::new("version-1")?,
+            )
+            .pipe(Ok)
+        }
+
+        async fn resolve_group(
+            &self,
+            references: &[SecretRef],
+        ) -> Result<Vec<ProviderSecret>, SecretError> {
+            let mut values = Vec::with_capacity(references.len());
+            for reference in references {
+                values.push(self.resolve(reference).await?);
+            }
+            Ok(values)
+        }
+    }
+
+    trait Pipe: Sized {
+        fn pipe<T>(self, apply: impl FnOnce(Self) -> T) -> T {
+            apply(self)
+        }
+    }
+
+    impl<T> Pipe for T {}
+
+    fn reference(name: &str) -> SecretRef {
+        SecretRef::new(
+            SecretProviderKind::environment(),
+            SecretName::new(name).unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn concurrent_resolves_use_one_provider_call() {
+        let provider = Arc::new(TestProvider {
+            kind: SecretProviderKind::environment(),
+            calls: AtomicU64::new(0),
+            fail: AtomicBool::new(false),
+            gate: None,
+        });
+        let resolver = Arc::new(
+            SecretResolver::builder()
+                .shared_provider(provider.clone())
+                .unwrap()
+                .build(),
+        );
+        let reference = reference("shared");
+
+        let mut tasks = Vec::new();
+        for _ in 0..16 {
+            let resolver = Arc::clone(&resolver);
+            let reference = reference.clone();
+            tasks.push(tokio::spawn(
+                async move { resolver.resolve(&reference).await },
+            ));
+        }
+        let mut values = Vec::new();
+        for task in tasks {
+            values.push(task.await.unwrap());
+        }
+
+        assert!(values.into_iter().all(|value| value.is_ok()));
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cache_is_bounded_after_resolutions_complete() {
+        let provider = Arc::new(TestProvider {
+            kind: SecretProviderKind::environment(),
+            calls: AtomicU64::new(0),
+            fail: AtomicBool::new(false),
+            gate: None,
+        });
+        let resolver = SecretResolver::builder()
+            .shared_provider(provider)
+            .unwrap()
+            .cache_policy(CachePolicy::new(
+                NonZeroUsize::new(2).unwrap(),
+                Duration::from_secs(60),
+            ))
+            .build();
+
+        for name in ["one", "two", "three", "four"] {
+            resolver.resolve(&reference(name)).await.unwrap();
+        }
+
+        assert_eq!(resolver.diagnostics().await.cache_entries(), 2);
+    }
+
+    #[tokio::test]
+    async fn cache_evicts_entries_to_stay_within_its_total_byte_limit() {
+        let provider = Arc::new(TestProvider {
+            kind: SecretProviderKind::environment(),
+            calls: AtomicU64::new(0),
+            fail: AtomicBool::new(false),
+            gate: None,
+        });
+        let resolver = SecretResolver::builder()
+            .shared_provider(provider)
+            .unwrap()
+            .cache_policy(
+                CachePolicy::new(NonZeroUsize::new(10).unwrap(), Duration::from_secs(60))
+                    .max_total_bytes(NonZeroUsize::new(6).unwrap()),
+            )
+            .build();
+
+        for name in ["one", "two", "three"] {
+            resolver.resolve(&reference(name)).await.unwrap();
+        }
+
+        let diagnostics = resolver.diagnostics().await;
+        assert_eq!(diagnostics.cache_entries(), 1);
+        assert_eq!(diagnostics.cached_bytes(), 5);
+        assert_eq!(diagnostics.cache_byte_capacity(), 6);
+    }
+
+    #[tokio::test]
+    async fn cache_rejects_one_value_larger_than_its_total_byte_limit() {
+        let provider = Arc::new(TestProvider {
+            kind: SecretProviderKind::environment(),
+            calls: AtomicU64::new(0),
+            fail: AtomicBool::new(false),
+            gate: None,
+        });
+        let resolver = SecretResolver::builder()
+            .shared_provider(provider)
+            .unwrap()
+            .cache_policy(
+                CachePolicy::new(NonZeroUsize::new(2).unwrap(), Duration::from_secs(60))
+                    .max_total_bytes(NonZeroUsize::new(4).unwrap()),
+            )
+            .build();
+
+        assert_eq!(
+            resolver
+                .resolve(&reference("oversized"))
+                .await
+                .unwrap_err()
+                .kind(),
+            SecretErrorKind::TooLarge
+        );
+        assert_eq!(resolver.diagnostics().await.cache_entries(), 0);
+    }
+
+    #[tokio::test]
+    async fn in_flight_resolutions_cannot_exceed_cache_capacity() {
+        let gate = Arc::new(Notify::new());
+        let provider = Arc::new(TestProvider {
+            kind: SecretProviderKind::environment(),
+            calls: AtomicU64::new(0),
+            fail: AtomicBool::new(false),
+            gate: Some(Arc::clone(&gate)),
+        });
+        let resolver = Arc::new(
+            SecretResolver::builder()
+                .shared_provider(provider.clone())
+                .unwrap()
+                .cache_policy(CachePolicy::new(
+                    NonZeroUsize::new(2).unwrap(),
+                    Duration::from_secs(60),
+                ))
+                .build(),
+        );
+        let mut tasks = Vec::new();
+        for name in ["one", "two"] {
+            let resolver = Arc::clone(&resolver);
+            let reference = reference(name);
+            tasks.push(tokio::spawn(
+                async move { resolver.resolve(&reference).await },
+            ));
+        }
+        while provider.calls.load(Ordering::SeqCst) < 2 {
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            resolver
+                .resolve(&reference("three"))
+                .await
+                .unwrap_err()
+                .kind(),
+            SecretErrorKind::Unavailable
+        );
+        assert_eq!(resolver.diagnostics().await.cache_entries(), 2);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+
+        gate.notify_waiters();
+        for task in tasks {
+            task.await.unwrap().unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_initialization_can_be_retried() {
+        let gate = Arc::new(Notify::new());
+        let provider = Arc::new(TestProvider {
+            kind: SecretProviderKind::environment(),
+            calls: AtomicU64::new(0),
+            fail: AtomicBool::new(false),
+            gate: Some(Arc::clone(&gate)),
+        });
+        let resolver = Arc::new(
+            SecretResolver::builder()
+                .shared_provider(provider.clone())
+                .unwrap()
+                .build(),
+        );
+        let reference = reference("cancelled");
+        let task = tokio::spawn({
+            let resolver = Arc::clone(&resolver);
+            let reference = reference.clone();
+            async move { resolver.resolve(&reference).await }
+        });
+        while provider.calls.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+        task.abort();
+        let _ = task.await;
+
+        let retry = tokio::spawn({
+            let resolver = Arc::clone(&resolver);
+            async move { resolver.resolve(&reference).await }
+        });
+        while provider.calls.load(Ordering::SeqCst) < 2 {
+            tokio::task::yield_now().await;
+        }
+        gate.notify_waiters();
+
+        assert_eq!(retry.await.unwrap().unwrap().value().expose(), b"cancelled");
+    }
+
+    #[tokio::test]
+    async fn fail_closed_does_not_return_expired_values() {
+        let provider = Arc::new(TestProvider {
+            kind: SecretProviderKind::environment(),
+            calls: AtomicU64::new(0),
+            fail: AtomicBool::new(false),
+            gate: None,
+        });
+        let resolver = SecretResolver::builder()
+            .shared_provider(provider.clone())
+            .unwrap()
+            .cache_policy(CachePolicy::new(
+                NonZeroUsize::new(2).unwrap(),
+                Duration::ZERO,
+            ))
+            .build();
+        let reference = reference("outage");
+        resolver.resolve(&reference).await.unwrap();
+        provider.fail.store(true, Ordering::SeqCst);
+
+        assert_eq!(
+            resolver.resolve(&reference).await.unwrap_err().kind(),
+            SecretErrorKind::Unavailable
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_resolutions_are_not_cached_and_provider_recovery_is_observed() {
+        let provider = Arc::new(TestProvider {
+            kind: SecretProviderKind::environment(),
+            calls: AtomicU64::new(0),
+            fail: AtomicBool::new(true),
+            gate: None,
+        });
+        let resolver = SecretResolver::builder()
+            .shared_provider(provider.clone())
+            .unwrap()
+            .build();
+        let reference = reference("recovery");
+
+        assert_eq!(
+            resolver.resolve(&reference).await.unwrap_err().kind(),
+            SecretErrorKind::Unavailable
+        );
+        provider.fail.store(false, Ordering::SeqCst);
+        assert_eq!(
+            resolver.resolve(&reference).await.unwrap().value().expose(),
+            b"recovery"
+        );
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            resolver.diagnostics().await.providers()[0].state(),
+            ProviderHealthState::Healthy
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_stale_policy_survives_repeated_provider_failures() {
+        let provider = Arc::new(TestProvider {
+            kind: SecretProviderKind::environment(),
+            calls: AtomicU64::new(0),
+            fail: AtomicBool::new(false),
+            gate: None,
+        });
+        let resolver = SecretResolver::builder()
+            .shared_provider(provider.clone())
+            .unwrap()
+            .cache_policy(
+                CachePolicy::new(NonZeroUsize::new(2).unwrap(), Duration::ZERO)
+                    .stale_policy(StalePolicy::AllowFor(Duration::from_secs(60))),
+            )
+            .build();
+        let reference = reference("outage");
+        resolver.resolve(&reference).await.unwrap();
+        provider.fail.store(true, Ordering::SeqCst);
+
+        for _ in 0..2 {
+            assert_eq!(
+                resolver.resolve(&reference).await.unwrap().value().expose(),
+                b"outage"
+            );
+        }
+        assert_eq!(
+            resolver.diagnostics().await.providers()[0].state(),
+            ProviderHealthState::Degraded
+        );
+    }
+
+    #[tokio::test]
+    async fn groups_share_one_generation_and_reject_mixed_providers() {
+        let provider = TestProvider {
+            kind: SecretProviderKind::environment(),
+            calls: AtomicU64::new(0),
+            fail: AtomicBool::new(false),
+            gate: None,
+        };
+        let resolver = SecretResolver::builder()
+            .provider(provider)
+            .unwrap()
+            .build();
+        let references = [reference("first"), reference("second")];
+
+        let group = resolver.resolve_group(&references).await.unwrap();
+
+        assert_eq!(group.values().len(), 2);
+        assert!(
+            group
+                .values()
+                .iter()
+                .all(|value| value.generation() == group.generation())
+        );
+        let mixed = [
+            reference("first"),
+            SecretRef::new(
+                SecretProviderKind::file(),
+                SecretName::new("second").unwrap(),
+            ),
+        ];
+        assert_eq!(
+            resolver.resolve_group(&mixed).await.unwrap_err().kind(),
+            SecretErrorKind::InvalidReference
+        );
+    }
+
+    #[tokio::test]
+    async fn diagnostics_never_include_secret_names_or_values() {
+        let provider = TestProvider {
+            kind: SecretProviderKind::environment(),
+            calls: AtomicU64::new(0),
+            fail: AtomicBool::new(false),
+            gate: None,
+        };
+        let resolver = SecretResolver::builder()
+            .provider(provider)
+            .unwrap()
+            .build();
+        resolver.resolve(&reference("canary-secret")).await.unwrap();
+
+        let debug = format!("{:?}", resolver.diagnostics().await);
+        assert!(!debug.contains("canary-secret"));
+        assert!(!debug.contains("test provider unavailable"));
+    }
+}

--- a/crates/hubuum-secrets/src/value.rs
+++ b/crates/hubuum-secrets/src/value.rs
@@ -1,0 +1,97 @@
+use std::fmt;
+use std::sync::Arc;
+
+use zeroize::Zeroize;
+
+use crate::{SecretError, SecretErrorKind};
+
+pub struct SecretValue(Box<[u8]>);
+
+impl SecretValue {
+    pub fn new(value: impl Into<Vec<u8>>) -> Result<Self, SecretError> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(SecretError::new(
+                SecretErrorKind::InvalidValue,
+                "resolved secret value must not be empty",
+            ));
+        }
+        Ok(Self(value.into_boxed_slice()))
+    }
+
+    pub fn expose(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn expose_utf8(&self) -> Result<&str, SecretError> {
+        std::str::from_utf8(self.expose()).map_err(|_| {
+            SecretError::new(
+                SecretErrorKind::InvalidValue,
+                "resolved secret is not valid UTF-8",
+            )
+        })
+    }
+}
+
+impl Drop for SecretValue {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl fmt::Debug for SecretValue {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SecretValue(<redacted>)")
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct SecretVersion(Arc<str>);
+
+impl SecretVersion {
+    pub fn new(value: impl Into<String>) -> Result<Self, SecretError> {
+        let value = value.into();
+        if value.is_empty()
+            || value.len() > 128
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+        {
+            return Err(SecretError::new(
+                SecretErrorKind::InvalidValue,
+                "secret versions must contain 1-128 safe ASCII characters",
+            ));
+        }
+        Ok(Self(value.into()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SecretVersion {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SecretVersion(<redacted>)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn values_do_not_print_secret_bytes() {
+        let value = SecretValue::new(b"canary-secret".to_vec()).unwrap();
+        assert_eq!(format!("{value:?}"), "SecretValue(<redacted>)");
+        assert!(!format!("{value:?}").contains("canary-secret"));
+    }
+}

--- a/docs/events.md
+++ b/docs/events.md
@@ -263,9 +263,9 @@ delivery limits:
 }
 ```
 
-When `secret_ref` is set, Hubuum reads
-`HUBUUM_EVENT_SINK_SECRET_<SECRET_REF>` with the reference uppercased and sends
-it as a bearer token. For the example above, the environment variable is
+When `secret_ref` is set, Hubuum resolves the alias through the selected
+[secret source](secret_sources.md) and sends it as a bearer token. With the
+default environment source, the example maps to
 `HUBUUM_EVENT_SINK_SECRET_INVENTORY_WEBHOOK`.
 
 Webhook HTTP execution uses the shared hardened outbound HTTP layer: HTTPS-only
@@ -294,10 +294,11 @@ AMQP sink publishes the event envelope as JSON to the exchange in sink
 }
 ```
 
-When `secret_ref` is set, the AMQP URI must contain `{secret}`. Hubuum reads
-`HUBUUM_EVENT_SINK_SECRET_<SECRET_REF>`, percent-encodes the value for URI
-userinfo use, and substitutes it into the URI. For the example above, the
-environment variable is `HUBUUM_EVENT_SINK_SECRET_RABBITMQ_PASSWORD`.
+When `secret_ref` is set, the AMQP URI must contain `{secret}`. Hubuum resolves
+the alias through the selected [secret source](secret_sources.md),
+percent-encodes the value for URI userinfo use, and substitutes it into the
+URI. The default environment source maps this example to
+`HUBUUM_EVENT_SINK_SECRET_RABBITMQ_PASSWORD`.
 Literal credentials in sink URIs are rejected; use `{secret}` plus `secret_ref`
 instead.
 
@@ -340,10 +341,11 @@ settings:
 }
 ```
 
-When `secret_ref` is set, the URI must contain `{secret}`. Hubuum reads
-`HUBUUM_EVENT_SINK_SECRET_<SECRET_REF>`, percent-encodes the value for URI
-userinfo use, and substitutes it into the URI. For the example above, the
-environment variable is `HUBUUM_EVENT_SINK_SECRET_VALKEY_PASSWORD`.
+When `secret_ref` is set, the URI must contain `{secret}`. Hubuum resolves the
+alias through the selected [secret source](secret_sources.md), percent-encodes
+the value for URI userinfo use, and substitutes it into the URI. The default
+environment source maps this example to
+`HUBUUM_EVENT_SINK_SECRET_VALKEY_PASSWORD`.
 Literal credentials in sink URIs are rejected; use `{secret}` plus `secret_ref`
 instead. `io_timeout_ms` bounds the Redis protocol connection and socket I/O
 for the blocking driver call and defaults to 25,000 ms.
@@ -390,10 +392,10 @@ address, and MiniJinja export templates for the subject and text body:
 ```
 
 SMTP URLs must use the TLS `smtps://` scheme. When `secret_ref` is set, the URI
-must contain `{secret}`. Hubuum
-reads `HUBUUM_EVENT_SINK_SECRET_<SECRET_REF>`, percent-encodes the value for
-URI userinfo use, and substitutes it into the URI. For the example above, the
-environment variable is `HUBUUM_EVENT_SINK_SECRET_SMTP_PASSWORD`.
+must contain `{secret}`. Hubuum resolves the alias through the selected
+[secret source](secret_sources.md), percent-encodes the value for URI userinfo
+use, and substitutes it into the URI. The default environment source maps this
+example to `HUBUUM_EVENT_SINK_SECRET_SMTP_PASSWORD`.
 Literal credentials in sink URIs are rejected; use `{secret}` plus `secret_ref`
 instead.
 

--- a/docs/external_auth.md
+++ b/docs/external_auth.md
@@ -14,14 +14,14 @@ sets the container path automatically. See
 [Single-Host Container Deployment](deployment.md#external-authentication-configuration).
 The configuration source must be a regular UTF-8 file no larger than 1 MiB.
 Parse errors identify the line and column but deliberately omit the source line
-because it may contain credentials such as `bind_password`.
+because legacy files may contain credentials such as `bind_password`.
 
 ```toml
 [[ldap]]
 scope = "example-directory"
 url = "ldaps://ldap.example.org"
 bind_dn = "cn=readonly,dc=example,dc=org"
-bind_password = "readonly-password"
+bind_password_ref = "readonly_password"
 connect_timeout_seconds = 5
 operation_timeout_seconds = 10
 user_base_dn = "ou=people,dc=example,dc=org"
@@ -46,9 +46,13 @@ description = "Directory group $1"
 LDAP transport is always encrypted. Use `ldaps://` for implicit TLS. An
 `ldap://` URL is upgraded with StartTLS before any bind or search, and the
 connection fails if the server cannot establish verified TLS. Plaintext LDAP
-binds are not supported. Configure `bind_dn` and `bind_password` together, or
-omit both for an anonymous service search; an incomplete pair is rejected at
-startup.
+binds are not supported. Configure `bind_dn` with `bind_password_ref`, then
+provide the alias through the selected [secret source](secret_sources.md). The
+environment source maps this example to
+`HUBUUM_LDAP_SECRET_READONLY_PASSWORD`. Inline `bind_password` remains a
+compatibility option, but it cannot be combined with `bind_password_ref`.
+Omit the bind DN and both password fields for an anonymous service search;
+incomplete or ambiguous credentials are rejected at startup.
 
 All group extraction is configuration-driven. Use `group_attributes` and
 `group_rules` to map provider attributes to Hubuum groups; do not hard-code

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -28435,6 +28435,7 @@
           "backups",
           "restores",
           "remote_calls",
+          "secrets",
           "authentication",
           "permissions",
           "pagination",
@@ -28471,11 +28472,55 @@
           "restores": {
             "$ref": "#/components/schemas/RestoreConfig"
           },
+          "secrets": {
+            "$ref": "#/components/schemas/SecretSourceConfig"
+          },
           "server": {
             "$ref": "#/components/schemas/ServerConfig"
           },
           "tasks": {
             "$ref": "#/components/schemas/TaskConfig"
+          }
+        }
+      },
+      "SecretSourceConfig": {
+        "type": "object",
+        "required": [
+          "provider",
+          "file_root_configured",
+          "cache_capacity_per_consumer",
+          "cache_total_bytes_per_consumer",
+          "cache_ttl_seconds",
+          "stale_values_allowed",
+          "projected_symlinks_confined_to_root"
+        ],
+        "properties": {
+          "cache_capacity_per_consumer": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "cache_total_bytes_per_consumer": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "cache_ttl_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "file_root_configured": {
+            "type": "boolean",
+            "description": "Whether a mounted-secret root was configured. The path is never returned."
+          },
+          "projected_symlinks_confined_to_root": {
+            "type": "boolean"
+          },
+          "provider": {
+            "type": "string",
+            "description": "Selected process-wide provider. Values are `environment`, `file`, or\n`invalid` when startup configuration cannot be parsed."
+          },
+          "stale_values_allowed": {
+            "type": "boolean"
           }
         }
       },

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -221,8 +221,12 @@ Paginated responses include `X-Page-Limit` with the effective page size.
 | `HUBUUM_LOGIN_RATE_LIMIT_VALKEY_PREFIX` | `hubuum:login-rate-limit` | Shared limiter key namespace |
 | `HUBUUM_LOGIN_RATE_LIMIT_VALKEY_IO_TIMEOUT_MS` | `1000` | Shared backend I/O timeout |
 | `HUBUUM_TOKEN_HASH_KEY` | *(generated per startup if unset)* | Key used for deterministic token hashing at rest |
+| `HUBUUM_SECRET_SOURCE` | `environment` | Process-wide secret source: `environment` or `file` |
+| `HUBUUM_SECRET_FILE_ROOT` | *(empty)* | Mounted secret root required by the `file` source |
 
-See [External Authentication](external_auth.md) for LDAP scopes.
+See [Secret Sources](secret_sources.md) for the mounted-file layout and
+rotation contracts, and [External Authentication](external_auth.md) for LDAP
+scopes.
 
 **Token lifetime note**: Newly issued tokens always receive an explicit
 `expires_at`. If a mint request omits it, the server applies

--- a/docs/remote_targets.md
+++ b/docs/remote_targets.md
@@ -10,7 +10,7 @@ The first version is manual invocation only:
 - execution is queued through the generic task system as `remote_call`
 - outbound methods are `get`, `post`, `patch`, and `delete`
 - rendered outbound URLs must use `https://`
-- auth secrets are referenced by name and resolved from server environment variables at execution time
+- auth secrets are referenced by name and resolved through the selected server secret source at execution time
 
 Endpoints:
 
@@ -106,16 +106,17 @@ For `get` and `delete`, Hubuum omits the outbound request body unless `body_temp
 
 ## Auth configuration
 
-Secrets are never stored in target rows. Targets store a secret reference name, and the worker
-resolves the value from an environment variable:
+Secrets are never stored in target rows. Targets store a validated alias, and
+the worker resolves it through the selected [secret source](secret_sources.md).
+The default environment source maps aliases as follows:
 
 ```text
 HUBUUM_REMOTE_SECRET_<UPPERCASE_SECRET_NAME>
 ```
 
 The reference name is configuration metadata, not a secret value. Users with `ReadRemoteTarget` can
-see which reference name a target uses, but only the worker reads the corresponding environment
-variable value.
+see which reference name a target uses, but only the worker receives the
+resolved value.
 
 For example, this target auth config:
 
@@ -360,7 +361,7 @@ The worker:
 2. re-checks subject read permission and target execution permission for the submitting user
 3. renders URL, headers, and body
 4. validates the rendered URL and screens the destination address (see Outbound safety)
-5. resolves auth secrets from environment variables
+5. resolves auth secrets through the selected secret source
 6. performs the outbound HTTP request
 7. stores a sanitized result row
 8. finalizes the task

--- a/docs/rust_api_boundary.md
+++ b/docs/rust_api_boundary.md
@@ -88,6 +88,7 @@ manifest.
 | `hubuum-events-core` | Experimental public |
 | `hubuum-outbound-http` | Workspace-internal |
 | `hubuum-query` | Experimental public |
+| `hubuum-secrets` | Workspace-internal |
 | `hubuum-storage-core` | Experimental public |
 | `hubuum-storage-conformance` | Experimental public |
 | `hubuum-storage-postgres` | Workspace-internal |

--- a/docs/secret_sources.md
+++ b/docs/secret_sources.md
@@ -1,0 +1,99 @@
+# Secret Sources
+
+Hubuum resolves credential material through one process-wide secret source. API
+records and authentication configuration contain validated aliases only; they
+cannot select an environment variable, provider, or filesystem path.
+
+## Environment Source
+
+The default source is `environment`. Existing deployments remain compatible:
+
+| Consumer | Environment mapping |
+| --- | --- |
+| PostgreSQL | `HUBUUM_DATABASE_URL` |
+| Token hashing | `HUBUUM_TOKEN_HASH_KEY` |
+| Event sink alias `NAME` | `HUBUUM_EVENT_SINK_SECRET_NAME` |
+| Remote-target alias `NAME` | `HUBUUM_REMOTE_SECRET_NAME` |
+| LDAP alias `NAME` | `HUBUUM_LDAP_SECRET_NAME` |
+
+Alias letters are uppercased and hyphens become underscores for environment
+lookup. Missing `HUBUUM_SECRET_SOURCE` is equivalent to:
+
+```text
+HUBUUM_SECRET_SOURCE=environment
+```
+
+Environment values are limited to 1 MiB and preserve raw bytes on Unix.
+Missing and empty values are distinct; an empty value is rejected as invalid.
+
+## Mounted File Source
+
+Set both variables to use a mounted secret volume:
+
+```text
+HUBUUM_SECRET_SOURCE=file
+HUBUUM_SECRET_FILE_ROOT=/run/secrets/hubuum
+```
+
+The root has a fixed, application-owned layout:
+
+```text
+/run/secrets/hubuum/
+├── database/
+│   └── url
+├── event-sink/
+│   └── <alias>
+├── ldap/
+│   └── <alias>
+├── remote/
+│   └── <alias>
+└── token/
+    └── key
+```
+
+The file provider accepts binary values up to 1 MiB, opens ordinary files
+only, performs a descriptor-bounded read, detects changes during the read, and
+rejects traversal outside the configured root. Consumer protocols that require
+text reject values that are not UTF-8.
+
+Kubernetes projected-secret symlinks are supported explicitly. Every resolved
+target and opened descriptor must remain below `HUBUUM_SECRET_FILE_ROOT`;
+symlinks escaping that root are rejected. Other users of the internal file
+provider default to rejecting symlinks unless they opt into the same confined
+projected-volume behavior.
+
+## Reload And Rotation
+
+Secret resolution is single-flight and cached separately for each bounded
+consumer class. Each cache holds at most 128 aliases and 128 MiB for five
+minutes. Failed resolutions are not cached. The application fails closed on
+provider errors and does not return expired values; the internal resolver
+exposes an explicit opt-in stale policy for consumers that define a different
+availability contract.
+
+LDAP service binds, event deliveries, and remote-target calls observe a rotated
+value after the cache entry expires or is explicitly invalidated. AMQP, SMTP,
+and Valkey sink connection pools key clients by the resolved URI, so a rotated
+credential creates a new client and old idle clients leave through the existing
+bounded LRU policy.
+
+The PostgreSQL URL and token-hash key are startup secrets. Rotate them by
+updating every replica's source and restarting the replicas according to the
+database or token-key migration procedure. Hubuum does not claim live rotation
+for an established database pool or for token hashing. Token key-ring rotation
+is tracked separately from this source abstraction.
+
+The login rate-limit Valkey URL, Treetop URL, TLS private-key passphrase, and
+other certificate paths continue to use their existing configuration adapters
+and require restart after changes. They are intentionally listed here so those
+consumers are not mistaken for live-rotating integrations.
+
+## Diagnostics
+
+Administrator configuration reports the selected provider, whether a file root
+is configured, the effective cache bounds, fail-closed stale policy, and
+projected-symlink confinement without returning aliases, paths, versions, or
+values. Prometheus exports `hubuum_secret_source_info`,
+`hubuum_secret_resolutions_total`, and
+`hubuum_secret_resolution_duration_seconds` with bounded provider, consumer,
+and outcome labels. Secret values and alias names are never labels.

--- a/src/application.rs
+++ b/src/application.rs
@@ -61,7 +61,7 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
     }
 
     #[cfg(not(test))]
-    let config = match initialize_config() {
+    let mut config = match initialize_config() {
         Ok(cfg) => cfg.clone(),
         Err(e) => fatal_error(
             &format!("Failed to load configuration: {}", e),
@@ -69,7 +69,7 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
         ),
     };
     #[cfg(test)]
-    let config = match get_config() {
+    let mut config = match get_config() {
         Ok(cfg) => cfg.clone(),
         Err(e) => fatal_error(
             &format!("Failed to load configuration: {}", e),
@@ -86,10 +86,17 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
         fatal_error(&err, EXIT_CODE_CONFIG_ERROR);
     }
 
+    if let Err(error) = crate::secrets::validate_configuration() {
+        fatal_error(
+            &format!("Failed to configure secret sources: {error}"),
+            EXIT_CODE_CONFIG_ERROR,
+        );
+    }
+
     if token_hash_key_is_ephemeral() {
         warn!(
-            message = "HUBUUM_TOKEN_HASH_KEY is not set; using ephemeral in-memory key. Existing tokens will be invalid after restart.",
-            recommendation = "Set HUBUUM_TOKEN_HASH_KEY to a stable secret to preserve token validity across restarts"
+            message = "The token hash key is unavailable; using an ephemeral in-memory key. Existing tokens will be invalid after restart.",
+            recommendation = "Configure a stable token key through the selected Hubuum secret source to preserve token validity across restarts"
         );
     }
 
@@ -101,6 +108,16 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
             );
         }
         observability::metrics::runtime_identity(config.runtime_role);
+    }
+    if config.storage_backend == StorageBackendKind::Postgres {
+        config.database_url = crate::secrets::resolve_database_url(&config.database_url)
+            .await
+            .unwrap_or_else(|error| {
+                fatal_error(
+                    &format!("Failed to resolve the database connection secret: {error}"),
+                    EXIT_CODE_CONFIG_ERROR,
+                )
+            });
     }
     utilities::auth::initialize_dummy_password_hash();
     let storage_settings = match config.storage_backend {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2,7 +2,7 @@ use chrono::NaiveDateTime;
 #[cfg(feature = "integration-test-support")]
 use hubuum_auth_core::AuthenticatedExternalUser;
 use hubuum_auth_core::{AuthProviderError, ExternalIdentityProvider, ExternalUserRefreshRequest};
-use hubuum_auth_ldap::{LdapIdentityProvider, LdapScopeConfig};
+use hubuum_auth_ldap::{LdapIdentityProvider, LdapScopeConfig, LdapSecretSource};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs::File;
@@ -116,6 +116,18 @@ impl ConfiguredLdapScope {
 
 struct AuthProviderRegistry {
     providers: HashMap<String, RegisteredAuthProvider>,
+}
+
+struct ApplicationLdapSecretSource;
+
+#[async_trait::async_trait]
+impl LdapSecretSource for ApplicationLdapSecretSource {
+    async fn resolve(
+        &self,
+        alias: &str,
+    ) -> Result<hubuum_secrets::ResolvedSecret, hubuum_secrets::SecretError> {
+        crate::secrets::resolve_ldap_secret(alias).await
+    }
 }
 
 type AuthProviderFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, ApiError>> + Send + 'a>>;
@@ -326,7 +338,11 @@ impl LdapAuthProvider {
     ) -> Result<(), ApiError> {
         let refresh_policy = configured.refresh_policy()?;
         let scope = configured.ldap.scope.clone();
-        let provider = LdapIdentityProvider::new(configured.ldap).map_err(provider_config_error)?;
+        let provider = LdapIdentityProvider::with_secret_source(
+            configured.ldap,
+            Arc::new(ApplicationLdapSecretSource),
+        )
+        .map_err(provider_config_error)?;
         registry.register(RegisteredAuthProvider {
             name: scope.clone(),
             kind: LDAP_PROVIDER_KIND.to_string(),
@@ -783,6 +799,7 @@ mod tests {
                 url: "ldap://ldap.example.org".to_string(),
                 bind_dn: None,
                 bind_password: None,
+                bind_password_ref: None,
                 connect_timeout_seconds: 5,
                 operation_timeout_seconds: 10,
                 user_base_dn: "ou=people,dc=example,dc=org".to_string(),
@@ -913,6 +930,20 @@ mod tests {
         .unwrap();
 
         assert_eq!(registry.provider_names(), vec!["local", "alpha", "zeta"]);
+    }
+
+    #[test]
+    fn registry_accepts_referenced_ldap_bind_password_without_resolving_it_at_startup() {
+        let mut configured = ldap_scope("directory");
+        configured.ldap.bind_dn = Some("cn=service,dc=example,dc=org".to_string());
+        configured.ldap.bind_password_ref = Some("directory_bind".to_string());
+
+        let registry = AuthProviderRegistry::from_config(AuthProvidersConfig {
+            ldap: vec![configured],
+        })
+        .unwrap();
+
+        assert_eq!(registry.provider_names(), vec!["local", "directory"]);
     }
 
     #[test]

--- a/src/config/environment.rs
+++ b/src/config/environment.rs
@@ -177,6 +177,8 @@ pub const APP_CONFIG_ENVIRONMENT: &[EnvironmentVariable] = &[
 /// Exact Hubuum variables resolved outside clap's `AppConfig` adapter.
 pub const PROCESS_ENVIRONMENT: &[EnvironmentVariable] = &[
     option!("HUBUUM_TOKEN_HASH_KEY", Authentication, sensitive),
+    option!("HUBUUM_SECRET_SOURCE", Operations),
+    option!("HUBUUM_SECRET_FILE_ROOT", Operations, sensitive),
     option!("HUBUUM_BUILD_GIT_SHA", Operations),
     option!("HUBUUM_SKIP_MIGRATIONS", Operations),
     option!("HUBUUM_AUTH_CONFIG_HOST_PATH", Operations, sensitive),
@@ -193,19 +195,19 @@ pub const PROCESS_ENVIRONMENT: &[EnvironmentVariable] = &[
 pub const DYNAMIC_SECRET_PREFIXES: &[(&str, EnvironmentOwner)] = &[
     ("HUBUUM_REMOTE_SECRET_", EnvironmentOwner::RemoteCalls),
     ("HUBUUM_EVENT_SINK_SECRET_", EnvironmentOwner::Events),
+    ("HUBUUM_LDAP_SECRET_", EnvironmentOwner::Authentication),
 ];
 
 /// Files allowed to translate Hubuum-owned environment values. This list is
-/// intentionally small and reviewable. Dynamic secret resolvers remain here
-/// until they can receive an injected secret-provider trait.
+/// intentionally small and reviewable. The application secret adapter owns
+/// dynamic namespace mapping and injects resolved values into consumers.
 pub const ENVIRONMENT_ADAPTER_PATHS: &[&str] = &[
     "src/config.rs",
     "src/config/token_hash.rs",
     "src/administration.rs",
     "src/logger.rs",
-    "src/tasks/remote_call.rs",
+    "src/secrets.rs",
     "src/tests/permissions/live_treetop_parity.rs",
-    "crates/hubuum-events-core/src/lib.rs",
     "crates/hubuum-storage-postgres/src/test_support.rs",
 ];
 

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -18,6 +18,7 @@ pub struct RunningConfig {
     pub backups: BackupConfig,
     pub restores: RestoreConfig,
     pub remote_calls: RemoteCallConfig,
+    pub secrets: SecretSourceConfig,
     pub authentication: AuthenticationConfig,
     pub permissions: PermissionConfig,
     pub pagination: PaginationConfig,
@@ -59,6 +60,20 @@ pub struct ClientAuthenticationConfig {
 pub struct SecretStatus {
     /// Whether a value is configured. The value itself is never returned.
     pub configured: bool,
+}
+
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct SecretSourceConfig {
+    /// Selected process-wide provider. Values are `environment`, `file`, or
+    /// `invalid` when startup configuration cannot be parsed.
+    pub provider: String,
+    /// Whether a mounted-secret root was configured. The path is never returned.
+    pub file_root_configured: bool,
+    pub cache_capacity_per_consumer: usize,
+    pub cache_total_bytes_per_consumer: usize,
+    pub cache_ttl_seconds: u64,
+    pub stale_values_allowed: bool,
+    pub projected_symlinks_confined_to_root: bool,
 }
 
 #[derive(Clone, Debug, Serialize, ToSchema)]
@@ -260,6 +275,9 @@ impl RunningConfig {
                 network_count: networks.len(),
             },
         };
+        let (secret_provider, secret_file_root_configured) =
+            crate::secrets::running_source_configuration();
+        let secret_cache_policy = hubuum_secrets::CachePolicy::default();
 
         Self {
             server: ServerConfig {
@@ -350,6 +368,15 @@ impl RunningConfig {
                 timeout_ms: config.remote_call_timeout_ms,
                 max_response_bytes: config.remote_call_max_response_bytes,
                 allow_private_targets: config.remote_call_allow_private_targets,
+            },
+            secrets: SecretSourceConfig {
+                provider: secret_provider.to_string(),
+                file_root_configured: secret_file_root_configured,
+                cache_capacity_per_consumer: secret_cache_policy.capacity().get(),
+                cache_total_bytes_per_consumer: secret_cache_policy.total_byte_limit().get(),
+                cache_ttl_seconds: secret_cache_policy.ttl().as_secs(),
+                stale_values_allowed: false,
+                projected_symlinks_confined_to_root: true,
             },
             authentication: AuthenticationConfig {
                 token_lifetime_hours: config.token_lifetime_hours,
@@ -449,6 +476,8 @@ mod tests {
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
         assert!(json.contains("\"backend\":\"postgresql\""));
+        assert!(json.contains("\"secrets\":{\"provider\":\"environment\""));
+        assert!(json.contains("\"stale_values_allowed\":false"));
         assert!(!json.contains("contract_version"));
         assert!(!json.contains("capabilities"));
         assert!(!debug.contains("secret-password"));

--- a/src/config/token_hash.rs
+++ b/src/config/token_hash.rs
@@ -8,14 +8,11 @@ struct TokenHashKeyConfig {
 }
 
 static TOKEN_HASH_KEY_CONFIG: LazyLock<TokenHashKeyConfig> = LazyLock::new(|| {
-    if let Ok(env_key) = std::env::var("HUBUUM_TOKEN_HASH_KEY") {
-        let trimmed = env_key.trim();
-        if !trimmed.is_empty() {
-            return TokenHashKeyConfig {
-                key: trimmed.as_bytes().to_vec(),
-                is_ephemeral: false,
-            };
-        }
+    if let Ok(key) = crate::secrets::resolve_token_hash_key() {
+        return TokenHashKeyConfig {
+            key,
+            is_ephemeral: false,
+        };
     }
 
     let generated = format!("{}{}", Uuid::new_v4(), Uuid::new_v4());

--- a/src/events/sink.rs
+++ b/src/events/sink.rs
@@ -73,15 +73,24 @@ impl SinkResolver for DefaultSinkResolver {
     }
 }
 
+async fn sink_secret(
+    sink: &StorageEventDeliverySink,
+) -> Result<Option<hubuum_secrets::ResolvedSecret>, SinkError> {
+    match sink.secret_ref() {
+        Some(alias) => crate::secrets::resolve_event_sink_secret(alias)
+            .await
+            .map(Some)
+            .map_err(SinkError::from),
+        None => Ok(None),
+    }
+}
+
 fn sink_delivery<'a>(
     subscription: &'a StorageEventDeliverySubscription,
     sink: &'a StorageEventDeliverySink,
+    secret: Option<&'a hubuum_secrets::SecretValue>,
 ) -> SinkDelivery<'a> {
-    SinkDelivery::new(
-        sink.configuration(),
-        subscription.routing(),
-        sink.secret_ref(),
-    )
+    SinkDelivery::new(sink.configuration(), subscription.routing(), secret)
 }
 
 fn webhook_settings() -> WebhookSinkSettings {
@@ -113,8 +122,16 @@ impl Sink for hubuum_event_sink_webhook::WebhookSink {
         sink: &'a StorageEventDeliverySink,
     ) -> BoxFuture<'a, Result<(), SinkError>> {
         async move {
-            self.deliver(envelope, sink_delivery(subscription, sink))
-                .await
+            let secret = sink_secret(sink).await?;
+            self.deliver(
+                envelope,
+                sink_delivery(
+                    subscription,
+                    sink,
+                    secret.as_ref().map(|value| value.value()),
+                ),
+            )
+            .await
         }
         .boxed()
     }
@@ -129,8 +146,16 @@ impl Sink for hubuum_event_sink_amqp::AmqpSink {
         sink: &'a StorageEventDeliverySink,
     ) -> BoxFuture<'a, Result<(), SinkError>> {
         async move {
-            self.deliver(envelope, sink_delivery(subscription, sink))
-                .await
+            let secret = sink_secret(sink).await?;
+            self.deliver(
+                envelope,
+                sink_delivery(
+                    subscription,
+                    sink,
+                    secret.as_ref().map(|value| value.value()),
+                ),
+            )
+            .await
         }
         .boxed()
     }
@@ -145,8 +170,16 @@ impl Sink for hubuum_event_sink_email::EmailSink {
         sink: &'a StorageEventDeliverySink,
     ) -> BoxFuture<'a, Result<(), SinkError>> {
         async move {
-            self.deliver(envelope, sink_delivery(subscription, sink))
-                .await
+            let secret = sink_secret(sink).await?;
+            self.deliver(
+                envelope,
+                sink_delivery(
+                    subscription,
+                    sink,
+                    secret.as_ref().map(|value| value.value()),
+                ),
+            )
+            .await
         }
         .boxed()
     }
@@ -161,8 +194,16 @@ impl Sink for hubuum_event_sink_valkey::ValkeySink {
         sink: &'a StorageEventDeliverySink,
     ) -> BoxFuture<'a, Result<(), SinkError>> {
         async move {
-            self.deliver(envelope, sink_delivery(subscription, sink))
-                .await
+            let secret = sink_secret(sink).await?;
+            self.deliver(
+                envelope,
+                sink_delivery(
+                    subscription,
+                    sink,
+                    secret.as_ref().map(|value| value.value()),
+                ),
+            )
+            .await
         }
         .boxed()
     }
@@ -268,7 +309,8 @@ mod tests {
         let routing = serde_json::json!({
             "url": "https://user:routing-secret@example.invalid/events"
         });
-        let delivery = SinkDelivery::new(&config, &routing, Some("secret-reference"));
+        let secret = hubuum_secrets::SecretValue::new(b"secret-reference".to_vec()).unwrap();
+        let delivery = SinkDelivery::new(&config, &routing, Some(&secret));
 
         let debug = format!("{delivery:?}");
         assert_eq!(debug, "SinkDelivery { .. }");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod observability;
 pub mod pagination;
 pub mod permissions;
 pub mod restores;
+pub(crate) mod secrets;
 #[cfg(any(test, feature = "integration-test-support"))]
 #[doc(hidden)]
 pub use hubuum_storage_postgres::schema;

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -11,6 +11,7 @@ mod process;
 mod registry;
 mod remote_call;
 mod scrape;
+mod secret;
 mod security;
 mod storage;
 mod task;
@@ -54,6 +55,7 @@ pub use self::login::{login_attempt, login_lockout};
 pub use self::registry::{init, runtime_identity};
 pub use self::remote_call::remote_call_finished;
 pub use self::scrape::scrape;
+pub(crate) use self::secret::{secret_resolution_finished, secret_source_identity};
 pub use self::security::{client_allowlist_rejected, revision_condition};
 pub use self::storage::{storage_backend_identity, storage_operation_finished};
 pub use self::task::{
@@ -104,6 +106,9 @@ struct Metrics {
     storage_backend_info: Gauge<u64>,
     storage_operation_duration: Histogram<f64>,
     storage_operation_errors: Counter<u64>,
+    secret_source_info: Gauge<u64>,
+    secret_resolution_duration: Histogram<f64>,
+    secret_resolutions: Counter<u64>,
     task_worker_iterations: Counter<u64>,
     task_claims: Counter<u64>,
     task_lease_recoveries: Counter<u64>,

--- a/src/observability/metrics/registry.rs
+++ b/src/observability/metrics/registry.rs
@@ -29,6 +29,7 @@ const HTTP_REQUEST_DURATION: &str = "hubuum_http_request_duration";
 const DB_CONNECTION_ACQUIRE_DURATION: &str = "hubuum_db_connection_acquire_duration";
 const DB_OPERATION_DURATION: &str = "hubuum_db_operation_duration";
 const STORAGE_OPERATION_DURATION: &str = "hubuum_storage_operation_duration";
+const SECRET_RESOLUTION_DURATION: &str = "hubuum_secret_resolution_duration";
 const REMOTE_CALL_DURATION: &str = "hubuum_remote_call_duration";
 const TASK_QUEUE_WAIT_DURATION: &str = "hubuum_task_queue_wait_duration";
 const TASK_EXECUTION_DURATION: &str = "hubuum_task_execution_duration";
@@ -42,7 +43,8 @@ fn duration_histogram_view(instrument: &Instrument) -> Option<Stream> {
         HTTP_REQUEST_DURATION
         | DB_CONNECTION_ACQUIRE_DURATION
         | DB_OPERATION_DURATION
-        | STORAGE_OPERATION_DURATION => LATENCY_BUCKETS_SECONDS,
+        | STORAGE_OPERATION_DURATION
+        | SECRET_RESOLUTION_DURATION => LATENCY_BUCKETS_SECONDS,
         REMOTE_CALL_DURATION => OUTBOUND_BUCKETS_SECONDS,
         TASK_QUEUE_WAIT_DURATION
         | TASK_EXECUTION_DURATION
@@ -195,6 +197,19 @@ pub fn init() -> Result<(), ApiError> {
         storage_operation_errors: meter
             .u64_counter("hubuum_storage_operation_errors")
             .with_description("Backend-neutral logical storage operation failures")
+            .build(),
+        secret_source_info: meter
+            .u64_gauge("hubuum_secret_source_info")
+            .with_description("Selected secret provider")
+            .build(),
+        secret_resolution_duration: duration_histogram(
+            &meter,
+            SECRET_RESOLUTION_DURATION,
+            "Secret resolution duration by bounded provider and consumer",
+        ),
+        secret_resolutions: meter
+            .u64_counter("hubuum_secret_resolutions")
+            .with_description("Secret resolution outcomes by bounded provider and consumer")
             .build(),
         task_worker_iterations: meter
             .u64_counter("hubuum_task_worker_iterations")

--- a/src/observability/metrics/secret.rs
+++ b/src/observability/metrics/secret.rs
@@ -1,0 +1,32 @@
+use std::time::Duration;
+
+use opentelemetry::KeyValue;
+
+use super::current;
+
+pub(crate) fn secret_source_identity(provider: &'static str) {
+    if let Some(metrics) = current() {
+        metrics
+            .secret_source_info
+            .record(1, &[KeyValue::new("provider", provider)]);
+    }
+}
+
+pub(crate) fn secret_resolution_finished(
+    provider: &'static str,
+    consumer: &'static str,
+    outcome: &'static str,
+    duration: Duration,
+) {
+    if let Some(metrics) = current() {
+        let attributes = [
+            KeyValue::new("provider", provider),
+            KeyValue::new("consumer", consumer),
+            KeyValue::new("outcome", outcome),
+        ];
+        metrics
+            .secret_resolution_duration
+            .record(duration.as_secs_f64(), &attributes);
+        metrics.secret_resolutions.add(1, &attributes);
+    }
+}

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,0 +1,354 @@
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+use std::time::Instant;
+
+use hubuum_secrets::{
+    EnvironmentProvider, FileProvider, FileSymlinkPolicy, ResolvedSecret, SecretError,
+    SecretErrorKind, SecretName, SecretProviderKind, SecretRef, SecretResolver,
+};
+
+const SOURCE_ENVIRONMENT: &str = "HUBUUM_SECRET_SOURCE";
+const FILE_ROOT_ENVIRONMENT: &str = "HUBUUM_SECRET_FILE_ROOT";
+
+static APPLICATION_SECRETS: LazyLock<Result<ApplicationSecrets, SecretError>> =
+    LazyLock::new(ApplicationSecrets::from_environment);
+
+struct ConsumerSecrets {
+    provider_kind: SecretProviderKind,
+    provider_label: &'static str,
+    consumer_label: &'static str,
+    resolver: SecretResolver,
+}
+
+impl ConsumerSecrets {
+    async fn resolve(&self, alias: &str) -> Result<ResolvedSecret, SecretError> {
+        let started = Instant::now();
+        crate::observability::metrics::secret_source_identity(self.provider_label);
+        let result = match SecretName::new(alias) {
+            Ok(name) => {
+                let reference = SecretRef::new(self.provider_kind, name);
+                self.resolver.resolve(&reference).await
+            }
+            Err(error) => Err(error),
+        };
+        crate::observability::metrics::secret_resolution_finished(
+            self.provider_label,
+            self.consumer_label,
+            result
+                .as_ref()
+                .map(|_| "ok")
+                .unwrap_or_else(|error| error_outcome(error.kind())),
+            started.elapsed(),
+        );
+        result
+    }
+}
+
+struct ApplicationSecrets {
+    source: SecretSource,
+    database: ConsumerSecrets,
+    event_sink: ConsumerSecrets,
+    remote: ConsumerSecrets,
+    ldap: ConsumerSecrets,
+    token: ConsumerSecrets,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SecretSource {
+    Environment,
+    File,
+}
+
+impl SecretSource {
+    fn from_environment() -> Result<Self, SecretError> {
+        match std::env::var(SOURCE_ENVIRONMENT) {
+            Ok(value) if value.eq_ignore_ascii_case("environment") => Ok(Self::Environment),
+            Ok(value) if value.eq_ignore_ascii_case("file") => Ok(Self::File),
+            Ok(_) => Err(SecretError::new(
+                SecretErrorKind::InvalidReference,
+                "HUBUUM_SECRET_SOURCE must be 'environment' or 'file'",
+            )),
+            Err(std::env::VarError::NotPresent) => Ok(Self::Environment),
+            Err(std::env::VarError::NotUnicode(_)) => Err(SecretError::new(
+                SecretErrorKind::InvalidReference,
+                "HUBUUM_SECRET_SOURCE must contain valid Unicode",
+            )),
+        }
+    }
+
+    fn as_label(self) -> &'static str {
+        match self {
+            Self::Environment => "environment",
+            Self::File => "file",
+        }
+    }
+}
+
+impl ApplicationSecrets {
+    fn from_environment() -> Result<Self, SecretError> {
+        let source = SecretSource::from_environment()?;
+        let root = match source {
+            SecretSource::Environment => None,
+            SecretSource::File => Some(PathBuf::from(
+                std::env::var_os(FILE_ROOT_ENVIRONMENT).ok_or_else(|| {
+                    SecretError::new(
+                        SecretErrorKind::InvalidReference,
+                        "HUBUUM_SECRET_FILE_ROOT is required when HUBUUM_SECRET_SOURCE=file",
+                    )
+                })?,
+            )),
+        };
+        Self::new(source, root.as_deref())
+    }
+
+    fn new(source: SecretSource, root: Option<&Path>) -> Result<Self, SecretError> {
+        crate::observability::metrics::secret_source_identity(source.as_label());
+        Ok(Self {
+            source,
+            database: consumer_resolver(
+                source,
+                root,
+                "",
+                Some(("url", "HUBUUM_DATABASE_URL")),
+                "database",
+                "database",
+            )?,
+            event_sink: consumer_resolver(
+                source,
+                root,
+                "HUBUUM_EVENT_SINK_SECRET_",
+                None,
+                "event-sink",
+                "event_sink",
+            )?,
+            remote: consumer_resolver(
+                source,
+                root,
+                "HUBUUM_REMOTE_SECRET_",
+                None,
+                "remote",
+                "remote_target",
+            )?,
+            ldap: consumer_resolver(source, root, "HUBUUM_LDAP_SECRET_", None, "ldap", "ldap")?,
+            token: consumer_resolver(
+                source,
+                root,
+                "",
+                Some(("key", "HUBUUM_TOKEN_HASH_KEY")),
+                "token",
+                "token_hash",
+            )?,
+        })
+    }
+}
+
+fn consumer_resolver(
+    source: SecretSource,
+    root: Option<&Path>,
+    environment_prefix: &str,
+    exact_environment_key: Option<(&str, &str)>,
+    file_prefix: &str,
+    consumer_label: &'static str,
+) -> Result<ConsumerSecrets, SecretError> {
+    let provider_kind = match source {
+        SecretSource::Environment => SecretProviderKind::environment(),
+        SecretSource::File => SecretProviderKind::file(),
+    };
+    let builder = SecretResolver::builder();
+    let resolver = match source {
+        SecretSource::Environment => {
+            let mut provider = EnvironmentProvider::new(environment_prefix)?;
+            if let Some((alias, environment_name)) = exact_environment_key {
+                provider = provider.mapping(SecretName::new(alias)?, environment_name)?;
+            }
+            builder.provider(provider)?.build()
+        }
+        SecretSource::File => {
+            let root = root.ok_or_else(|| {
+                SecretError::new(
+                    SecretErrorKind::InvalidReference,
+                    "file secret source requires a configured root",
+                )
+            })?;
+            builder
+                .provider(
+                    FileProvider::builder(root)
+                        .path_prefix(file_prefix)
+                        .symlink_policy(FileSymlinkPolicy::AllowWithinRoot)
+                        .build()?,
+                )?
+                .build()
+        }
+    };
+    Ok(ConsumerSecrets {
+        provider_kind,
+        provider_label: source.as_label(),
+        consumer_label,
+        resolver,
+    })
+}
+
+fn error_outcome(kind: SecretErrorKind) -> &'static str {
+    match kind {
+        SecretErrorKind::NotFound => "not_found",
+        SecretErrorKind::PermissionDenied => "permission_denied",
+        SecretErrorKind::TooLarge => "too_large",
+        SecretErrorKind::UnsafePath => "unsafe_path",
+        SecretErrorKind::ChangedDuringRead => "changed_during_read",
+        SecretErrorKind::InvalidReference
+        | SecretErrorKind::InvalidProviderConfiguration
+        | SecretErrorKind::InvalidValue
+        | SecretErrorKind::UnsupportedVersion => "invalid",
+        SecretErrorKind::ProviderNotConfigured
+        | SecretErrorKind::Timeout
+        | SecretErrorKind::Unavailable
+        | SecretErrorKind::Internal => "unavailable",
+    }
+}
+
+fn configured() -> Result<&'static ApplicationSecrets, SecretError> {
+    APPLICATION_SECRETS.as_ref().map_err(Clone::clone)
+}
+
+pub(crate) fn validate_configuration() -> Result<(), SecretError> {
+    configured().map(|_| ())
+}
+
+pub(crate) async fn resolve_event_sink_secret(alias: &str) -> Result<ResolvedSecret, SecretError> {
+    configured()?.event_sink.resolve(alias).await
+}
+
+pub(crate) async fn resolve_database_url(fallback: &str) -> Result<String, SecretError> {
+    let secrets = configured()?;
+    match secrets.database.resolve("url").await {
+        Ok(resolved) => Ok(resolved.value().expose_utf8()?.to_string()),
+        Err(error)
+            if secrets.source == SecretSource::Environment
+                && error.kind() == SecretErrorKind::NotFound =>
+        {
+            Ok(fallback.to_string())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+pub(crate) async fn resolve_remote_secret(alias: &str) -> Result<ResolvedSecret, SecretError> {
+    configured()?.remote.resolve(alias).await
+}
+
+pub(crate) async fn resolve_ldap_secret(alias: &str) -> Result<ResolvedSecret, SecretError> {
+    configured()?.ldap.resolve(alias).await
+}
+
+pub(crate) fn resolve_token_hash_key() -> Result<Vec<u8>, SecretError> {
+    let secrets = configured()?;
+    let resolved = futures::executor::block_on(secrets.token.resolve("key"))?;
+    if secrets.source == SecretSource::Environment {
+        let trimmed = resolved.value().expose_utf8()?.trim();
+        if trimmed.is_empty() {
+            return Err(SecretError::new(
+                SecretErrorKind::InvalidValue,
+                "token hash key must not be empty or whitespace",
+            ));
+        }
+        return Ok(trimmed.as_bytes().to_vec());
+    }
+    Ok(resolved.value().expose().to_vec())
+}
+
+pub(crate) fn running_source_configuration() -> (&'static str, bool) {
+    let provider = SecretSource::from_environment()
+        .map(SecretSource::as_label)
+        .unwrap_or("invalid");
+    (provider, std::env::var_os(FILE_ROOT_ENVIRONMENT).is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(1);
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "hubuum-application-secrets-{}-{}",
+                std::process::id(),
+                NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[actix_rt::test]
+    async fn file_source_keeps_consumer_namespaces_separate() {
+        let directory = TestDirectory::new();
+        for namespace in ["event-sink", "remote", "ldap", "token"] {
+            fs::create_dir(directory.0.join(namespace)).unwrap();
+        }
+        fs::write(directory.0.join("event-sink/shared"), b"sink-value").unwrap();
+        fs::write(directory.0.join("remote/shared"), b"remote-value").unwrap();
+        fs::write(directory.0.join("ldap/shared"), b"ldap-value").unwrap();
+        fs::write(directory.0.join("token/key"), b"token-value").unwrap();
+        let secrets = ApplicationSecrets::new(SecretSource::File, Some(&directory.0)).unwrap();
+
+        assert_eq!(
+            secrets
+                .event_sink
+                .resolve("shared")
+                .await
+                .unwrap()
+                .value()
+                .expose(),
+            b"sink-value"
+        );
+        assert_eq!(
+            secrets
+                .remote
+                .resolve("shared")
+                .await
+                .unwrap()
+                .value()
+                .expose(),
+            b"remote-value"
+        );
+        assert_eq!(
+            secrets
+                .ldap
+                .resolve("shared")
+                .await
+                .unwrap()
+                .value()
+                .expose(),
+            b"ldap-value"
+        );
+    }
+
+    #[actix_rt::test]
+    async fn aliases_cannot_select_paths_or_providers() {
+        let directory = TestDirectory::new();
+        for namespace in ["event-sink", "remote", "ldap", "token"] {
+            fs::create_dir(directory.0.join(namespace)).unwrap();
+        }
+        let secrets = ApplicationSecrets::new(SecretSource::File, Some(&directory.0)).unwrap();
+
+        for alias in ["../token/key", "file:token", "/etc/passwd"] {
+            assert_eq!(
+                secrets.remote.resolve(alias).await.unwrap_err().kind(),
+                SecretErrorKind::InvalidReference
+            );
+        }
+    }
+}

--- a/src/tasks/remote_call.rs
+++ b/src/tasks/remote_call.rs
@@ -178,7 +178,7 @@ where
         .transpose()?;
 
     let mut headers = rendered_headers;
-    apply_auth(&mut headers, &target.auth_config)?;
+    apply_auth(&mut headers, &target.auth_config).await?;
 
     let timeout_ms = bounded_timeout_ms(target.timeout_ms);
     let preview_limit = get_config()
@@ -455,21 +455,30 @@ fn render_headers(
     Ok(headers)
 }
 
-fn apply_auth(
+async fn apply_auth(
     headers: &mut OutboundHeaders,
     auth_config: &RemoteAuthConfig,
 ) -> Result<(), ApiError> {
     match auth_config {
         RemoteAuthConfig::None => Ok(()),
         RemoteAuthConfig::BearerSecret { secret } => {
-            let value = format!("Bearer {}", resolve_secret(secret)?);
+            let secret = resolve_secret(secret).await?;
+            let value = format!(
+                "Bearer {}",
+                secret.value().expose_utf8().map_err(secret_error)?
+            );
             headers.insert("authorization", &value).map_err(|_| {
                 ApiError::BadRequest("Resolved bearer secret is not a valid header".to_string())
             })?;
             Ok(())
         }
         RemoteAuthConfig::BasicSecret { username, secret } => {
-            let raw = format!("{}:{}", username, resolve_secret(secret)?);
+            let secret = resolve_secret(secret).await?;
+            let raw = format!(
+                "{}:{}",
+                username,
+                secret.value().expose_utf8().map_err(secret_error)?
+            );
             let encoded = base64::engine::general_purpose::STANDARD.encode(raw);
             headers
                 .insert("authorization", &format!("Basic {encoded}"))
@@ -479,33 +488,33 @@ fn apply_auth(
             Ok(())
         }
         RemoteAuthConfig::ApiKeySecret { header, secret } => {
-            let value = resolve_secret(secret)?;
-            headers
-                .insert(header, &value)
-                .map_err(|error| match error {
-                    OutboundHttpError::InvalidHeaderName { .. } => {
-                        ApiError::BadRequest(format!("Invalid API key header name: {header}"))
-                    }
-                    error @ OutboundHttpError::TransportControlledHeader { .. } => {
-                        ApiError::BadRequest(outbound_error_to_api_message(error))
-                    }
-                    OutboundHttpError::InvalidHeaderValue { .. } => ApiError::BadRequest(
-                        "Resolved API key secret is not a valid header".to_string(),
-                    ),
-                    other => ApiError::BadRequest(outbound_error_to_api_message(other)),
-                })?;
+            let secret = resolve_secret(secret).await?;
+            let value = secret.value().expose_utf8().map_err(secret_error)?;
+            headers.insert(header, value).map_err(|error| match error {
+                OutboundHttpError::InvalidHeaderName { .. } => {
+                    ApiError::BadRequest(format!("Invalid API key header name: {header}"))
+                }
+                error @ OutboundHttpError::TransportControlledHeader { .. } => {
+                    ApiError::BadRequest(outbound_error_to_api_message(error))
+                }
+                OutboundHttpError::InvalidHeaderValue { .. } => ApiError::BadRequest(
+                    "Resolved API key secret is not a valid header".to_string(),
+                ),
+                other => ApiError::BadRequest(outbound_error_to_api_message(other)),
+            })?;
             Ok(())
         }
     }
 }
 
-fn resolve_secret(secret: &str) -> Result<String, ApiError> {
-    let key = format!("HUBUUM_REMOTE_SECRET_{}", secret.to_ascii_uppercase());
-    std::env::var(&key).map_err(|_| {
-        ApiError::BadRequest(format!(
-            "Remote secret reference '{secret}' is not configured"
-        ))
-    })
+async fn resolve_secret(secret: &str) -> Result<hubuum_secrets::ResolvedSecret, ApiError> {
+    crate::secrets::resolve_remote_secret(secret)
+        .await
+        .map_err(secret_error)
+}
+
+fn secret_error(_error: hubuum_secrets::SecretError) -> ApiError {
+    ApiError::BadRequest("Remote secret is not configured or is unavailable".to_string())
 }
 
 fn outbound_method(method: RemoteHttpMethod) -> OutboundMethod {

--- a/tests/api_identity_suite/users.rs
+++ b/tests/api_identity_suite/users.rs
@@ -72,6 +72,7 @@ mod tests {
                 url: "ldap://ldap.example.org".to_string(),
                 bind_dn: None,
                 bind_password: None,
+                bind_password_ref: None,
                 connect_timeout_seconds: 5,
                 operation_timeout_seconds: 10,
                 user_base_dn: "ou=people,dc=example,dc=org".to_string(),


### PR DESCRIPTION
## Summary

- add a workspace-internal typed secret-source crate with validated references, non-printing binary values, typed errors, bounded providers, atomic groups, health diagnostics, and bounded single-flight caching
- support compatible environment lookup and confined mounted-file lookup, including Kubernetes projected-secret symlinks that remain within the configured root
- migrate PostgreSQL startup, token hashing, LDAP bind passwords, event sinks, and remote targets to application-owned resolvers while preserving existing environment variable names
- expose redacted running configuration and low-cardinality resolution metrics, and document rotation or restart semantics for every inventoried consumer
- keep one-time token-key provider/cache initialization outside the per-request token-storage-hash benchmark; the corrected hot path measures 48,977 instructions locally versus the previous 52,072 baseline

## Security and behavior

- file reads are relative to a canonical root, reject unsafe paths and non-regular files, enforce descriptor-based size bounds, detect growth during reads, and support binary values
- cache bounds apply to both entries and total bytes; concurrent misses are single-flight, failures are not cached, cancellation is retried, and stale fallback is opt-in and disabled by application composition
- LDAP, event sinks, and remote targets observe refreshed values; PostgreSQL pools and token hashing explicitly require restart
- API-level aliases select only names inside fixed consumer namespaces and cannot select a provider, environment variable, or filesystem path

## Breaking changes

This removes the experimental hubuum-events-core functions resolve_event_sink_secret and resolve_event_sink_secret_uri, plus EventSinkSecretError. These helpers read the process environment from the domain event crate and bypassed the common boundary.

Migration: sink adapters must accept the resolved hubuum_secrets::SecretValue supplied through SinkDelivery and call hubuum_event_sinks_common::resolve_secret_uri when substituting a URI secret.

## Verification

- source .env && ./run_tests.sh
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"
- regenerated OpenAPI matches docs/openapi.json
- scripts/test-classify-ci-changes.sh
- scripts/check-rust-api-policy.py
- cargo bench --bench token_storage_hash_callgrind (48,977 instructions; no regression)
- production Docker build with tls-rustls, tls-openssl, locked dependencies, and release mode

Fixes #260
