### PR TITLE
Support online token hash key rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Added bounded online token hash key-ring rotation with versioned bearer
+  tokens, active and previous verification keys, race-safe migration of legacy
+  digests, strict stable-key startup enforcement, per-key retirement
+  diagnostics through `hubuum-admin --token-key-status`, redacted runtime ring
+  identity, and low-cardinality authentication and stored-token metrics.
 - Added a common typed secret-source layer with non-printing binary values,
   validated aliases and versions, async environment and confined mounted-file
   providers, entry- and byte-bounded single-flight caching, atomic provider
@@ -21,6 +26,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Breaking (experimental `hubuum-storage-core` API):** token creation and
+  renewal now receive typed `StorageTokenDigest` values, authentication and
+  hash-based revocation accept bounded credential candidates, successful
+  authentication reports migration outcome, and every complete adapter must
+  implement `TokenStorage::token_key_usage`. Third-party adapter authors must
+  persist token format, hash algorithm, and optional key ID metadata and add
+  the new aggregate diagnostic before upgrading.
+- Newly issued bearer values use the opaque `hbt1.<key-id>.<secret>` format.
+  Existing unversioned tokens and the single `HUBUUM_TOKEN_HASH_KEY`
+  configuration remain compatible; clients that already treat bearer values
+  as opaque require no change.
 - **Breaking (experimental `hubuum-events-core` API):** removed
   `resolve_event_sink_secret`, `resolve_event_sink_secret_uri`, and
   `EventSinkSecretError`, which read process environment directly from the

--- a/README.md
+++ b/README.md
@@ -198,9 +198,17 @@ inspecting and releasing throttled scopes), see [docs/login_rate_limiting.md](do
 
 ### Token Hash Key
 
-- `HUBUUM_TOKEN_HASH_KEY` sets the server-side key used for deterministic token hashing at rest with the default environment secret source. Mounted-file configuration and rotation behavior are described in [Secret Sources](docs/secret_sources.md).
+- `HUBUUM_TOKEN_HASH_KEY` remains the compatible single-key configuration.
+- Online rotation uses `HUBUUM_TOKEN_HASH_ACTIVE_KEY_ID`,
+  `HUBUUM_TOKEN_HASH_PREVIOUS_KEY_IDS`, and one secret named
+  `HUBUUM_TOKEN_HASH_KEY_<ID>` per configured ID.
+- Set `HUBUUM_REQUIRE_STABLE_TOKEN_HASH_KEY=true` to reject startup instead of
+  generating an ephemeral key when stable material is absent.
 - If unset, Hubuum generates an ephemeral in-memory key at startup and logs a warning.
 - With an ephemeral key, all existing bearer tokens become invalid after each restart.
+- Keys must contain at least 32 bytes. IDs, staged rollout, mounted-file paths,
+  rollback, and retirement checks are described in
+  [Secret Sources](docs/secret_sources.md).
 
 ### Container Image
 

--- a/crates/hubuum-storage-core/src/identity.rs
+++ b/crates/hubuum-storage-core/src/identity.rs
@@ -5,41 +5,10 @@ use hubuum_domain::{
     TokenId, UserId,
 };
 
-use crate::{StorageAuthorizationPermission, StorageError, StorageValidationError};
-
-/// Opaque, redacted lookup material for one presented bearer credential.
-///
-/// The application authentication service derives this value from the raw
-/// bearer token. Adapters may compare it with their persisted credential
-/// representation, but neither the raw token nor a backend row crosses the
-/// storage boundary.
-#[derive(Clone, PartialEq, Eq)]
-pub struct StorageAuthenticationCredential {
-    lookup_value: String,
-}
-
-impl std::fmt::Debug for StorageAuthenticationCredential {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter
-            .debug_struct("StorageAuthenticationCredential")
-            .field("lookup_value", &"<redacted>")
-            .finish()
-    }
-}
-
-impl StorageAuthenticationCredential {
-    #[must_use]
-    pub fn new(lookup_value: impl Into<String>) -> Self {
-        Self {
-            lookup_value: lookup_value.into(),
-        }
-    }
-
-    #[must_use]
-    pub fn lookup_value(&self) -> &str {
-        &self.lookup_value
-    }
-}
+use crate::{
+    MAX_TOKEN_HASH_KEYS, StorageAuthenticationCredential, StorageAuthorizationPermission,
+    StorageError, StorageTokenDigest, StorageTokenFormat, StorageValidationError,
+};
 
 /// Deterministic inputs for one bearer-credential validation.
 ///
@@ -48,7 +17,8 @@ impl StorageAuthenticationCredential {
 /// configuration and makes compatibility tests deterministic.
 #[derive(Clone, PartialEq, Eq)]
 pub struct StorageAuthenticationAttempt {
-    credential: StorageAuthenticationCredential,
+    credentials: Vec<StorageAuthenticationCredential>,
+    migration_target: Option<StorageTokenDigest>,
     observed_at: DateTime<Utc>,
     legacy_valid_after: DateTime<Utc>,
 }
@@ -57,7 +27,8 @@ impl std::fmt::Debug for StorageAuthenticationAttempt {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("StorageAuthenticationAttempt")
-            .field("credential", &self.credential)
+            .field("credential_count", &self.credentials.len())
+            .field("has_migration_target", &self.migration_target.is_some())
             .field("observed_at", &"<redacted>")
             .field("legacy_valid_after", &"<redacted>")
             .finish()
@@ -70,13 +41,53 @@ impl StorageAuthenticationAttempt {
         observed_at: DateTime<Utc>,
         legacy_valid_after: DateTime<Utc>,
     ) -> Result<Self, StorageValidationError> {
+        Self::try_candidates(vec![credential], None, observed_at, legacy_valid_after)
+    }
+
+    pub fn try_candidates(
+        credentials: Vec<StorageAuthenticationCredential>,
+        migration_target: Option<StorageTokenDigest>,
+        observed_at: DateTime<Utc>,
+        legacy_valid_after: DateTime<Utc>,
+    ) -> Result<Self, StorageValidationError> {
         if legacy_valid_after > observed_at {
             return Err(StorageValidationError::invalid(
                 "legacy token validity cutoff cannot be after the observation time",
             ));
         }
+        if credentials.is_empty() || credentials.len() > MAX_TOKEN_HASH_KEYS {
+            return Err(StorageValidationError::invalid(
+                "authentication requires a bounded, non-empty token candidate set",
+            ));
+        }
+        if credentials.iter().enumerate().any(|(index, candidate)| {
+            credentials[index + 1..]
+                .iter()
+                .any(|other| candidate.digest() == other.digest())
+        }) {
+            return Err(StorageValidationError::invalid(
+                "authentication token candidates must be unique",
+            ));
+        }
+        if migration_target.as_ref().is_some_and(|target| {
+            target.format() != StorageTokenFormat::Legacy || target.key_id().is_none()
+        }) {
+            return Err(StorageValidationError::invalid(
+                "legacy token migration requires an identified legacy target digest",
+            ));
+        }
+        if migration_target.as_ref().is_some_and(|target| {
+            !credentials
+                .iter()
+                .any(|credential| credential.digest() == target)
+        }) {
+            return Err(StorageValidationError::invalid(
+                "legacy token migration target must be one of the lookup candidates",
+            ));
+        }
         Ok(Self {
-            credential,
+            credentials,
+            migration_target,
             observed_at,
             legacy_valid_after,
         })
@@ -86,11 +97,17 @@ impl StorageAuthenticationAttempt {
     pub fn into_parts(
         self,
     ) -> (
-        StorageAuthenticationCredential,
+        Vec<StorageAuthenticationCredential>,
+        Option<StorageTokenDigest>,
         DateTime<Utc>,
         DateTime<Utc>,
     ) {
-        (self.credential, self.observed_at, self.legacy_valid_after)
+        (
+            self.credentials,
+            self.migration_target,
+            self.observed_at,
+            self.legacy_valid_after,
+        )
     }
 }
 
@@ -112,6 +129,14 @@ pub struct StorageAuthenticatedToken {
     permission_scoped: bool,
     resource_scoped: bool,
     revision: ResourceRevision,
+    migration_outcome: StorageTokenMigrationOutcome,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StorageTokenMigrationOutcome {
+    NotNeeded,
+    Migrated,
+    Conflict,
 }
 
 impl std::fmt::Debug for StorageAuthenticatedToken {
@@ -137,6 +162,7 @@ impl std::fmt::Debug for StorageAuthenticatedToken {
             .field("permission_scoped", &self.permission_scoped)
             .field("resource_scoped", &self.resource_scoped)
             .field("revision", &"<redacted>")
+            .field("migration_outcome", &self.migration_outcome)
             .finish()
     }
 }
@@ -160,6 +186,7 @@ impl StorageAuthenticatedToken {
             permission_scoped: false,
             resource_scoped: false,
             revision,
+            migration_outcome: StorageTokenMigrationOutcome::NotNeeded,
         }
     }
 
@@ -217,6 +244,11 @@ impl StorageAuthenticatedToken {
     pub const fn revision(&self) -> ResourceRevision {
         self.revision
     }
+
+    #[must_use]
+    pub const fn migration_outcome(&self) -> StorageTokenMigrationOutcome {
+        self.migration_outcome
+    }
 }
 
 /// Builder for the hash-free token projection returned after successful
@@ -232,6 +264,7 @@ pub struct StorageAuthenticatedTokenBuilder {
     permission_scoped: bool,
     resource_scoped: bool,
     revision: ResourceRevision,
+    migration_outcome: StorageTokenMigrationOutcome,
 }
 
 impl StorageAuthenticatedTokenBuilder {
@@ -271,6 +304,12 @@ impl StorageAuthenticatedTokenBuilder {
         self
     }
 
+    #[must_use]
+    pub const fn migration_outcome(mut self, outcome: StorageTokenMigrationOutcome) -> Self {
+        self.migration_outcome = outcome;
+        self
+    }
+
     pub fn try_build(self) -> Result<StorageAuthenticatedToken, StorageValidationError> {
         if self.expires_at.is_some_and(|value| value < self.issued) {
             return Err(StorageValidationError::invalid(
@@ -293,6 +332,7 @@ impl StorageAuthenticatedTokenBuilder {
             permission_scoped: self.permission_scoped,
             resource_scoped: self.resource_scoped,
             revision: self.revision,
+            migration_outcome: self.migration_outcome,
         })
     }
 }
@@ -709,6 +749,60 @@ mod tests {
                 StorageAuthenticationCredential::new("lookup"),
                 observed_at,
                 valid_after,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn authentication_attempt_rejects_unbounded_or_duplicate_candidates() {
+        let observed_at = DateTime::<Utc>::default();
+        let credential = StorageAuthenticationCredential::new("lookup");
+
+        assert!(
+            StorageAuthenticationAttempt::try_candidates(
+                vec![credential.clone(); MAX_TOKEN_HASH_KEYS + 1],
+                None,
+                observed_at,
+                observed_at,
+            )
+            .is_err()
+        );
+        assert!(
+            StorageAuthenticationAttempt::try_candidates(
+                vec![credential.clone(), credential],
+                None,
+                observed_at,
+                observed_at,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn authentication_attempt_requires_migration_target_lookup_candidate() {
+        let observed_at = DateTime::<Utc>::default();
+        let candidate = StorageTokenDigest::try_new(
+            "candidate",
+            StorageTokenFormat::Legacy,
+            crate::StorageTokenHashAlgorithm::HmacSha256V1,
+            Some(crate::StorageTokenHashKeyId::try_new("active").unwrap()),
+        )
+        .unwrap();
+        let target = StorageTokenDigest::try_new(
+            "other",
+            StorageTokenFormat::Legacy,
+            crate::StorageTokenHashAlgorithm::HmacSha256V1,
+            Some(crate::StorageTokenHashKeyId::try_new("active").unwrap()),
+        )
+        .unwrap();
+
+        assert!(
+            StorageAuthenticationAttempt::try_candidates(
+                vec![StorageAuthenticationCredential::from_digest(candidate)],
+                Some(target),
+                observed_at,
+                observed_at,
             )
             .is_err()
         );

--- a/crates/hubuum-storage-core/src/identity_tokens.rs
+++ b/crates/hubuum-storage-core/src/identity_tokens.rs
@@ -6,14 +6,97 @@ use hubuum_domain::{PrincipalId, TokenId};
 use hubuum_events_core::EventContext;
 
 use crate::{
-    StorageAuthenticationTokenScope, StorageError, StorageMutationOutcome, StoragePage,
-    StorageTokenListQuery, StorageTokenMetadata, StorageTokenObservation,
+    MAX_TOKEN_HASH_KEYS, StorageAuthenticationCredential, StorageAuthenticationTokenScope,
+    StorageError, StorageMutationOutcome, StoragePage, StorageTokenDigest, StorageTokenListQuery,
+    StorageTokenMetadata, StorageTokenObservation, StorageValidationError,
 };
+
+/// Aggregate retirement evidence for one persisted token-hash key identity.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StorageTokenKeyUsage {
+    key_id: Option<crate::StorageTokenHashKeyId>,
+    active: i64,
+    revoked: i64,
+    expired: i64,
+    latest_validation: Option<DateTime<Utc>>,
+    earliest_expiry: Option<DateTime<Utc>>,
+    latest_expiry: Option<DateTime<Utc>>,
+}
+
+impl StorageTokenKeyUsage {
+    pub fn try_new(
+        key_id: Option<crate::StorageTokenHashKeyId>,
+        active: i64,
+        revoked: i64,
+        expired: i64,
+        latest_validation: Option<DateTime<Utc>>,
+        earliest_expiry: Option<DateTime<Utc>>,
+        latest_expiry: Option<DateTime<Utc>>,
+    ) -> Result<Self, StorageValidationError> {
+        if active < 0 || revoked < 0 || expired < 0 {
+            return Err(StorageValidationError::invalid(
+                "token key usage counts cannot be negative",
+            ));
+        }
+        if earliest_expiry
+            .zip(latest_expiry)
+            .is_some_and(|(earliest, latest)| earliest > latest)
+        {
+            return Err(StorageValidationError::invalid(
+                "token key usage expiry bounds are inverted",
+            ));
+        }
+        Ok(Self {
+            key_id,
+            active,
+            revoked,
+            expired,
+            latest_validation,
+            earliest_expiry,
+            latest_expiry,
+        })
+    }
+
+    #[must_use]
+    pub const fn key_id(&self) -> Option<&crate::StorageTokenHashKeyId> {
+        self.key_id.as_ref()
+    }
+
+    #[must_use]
+    pub const fn active(&self) -> i64 {
+        self.active
+    }
+
+    #[must_use]
+    pub const fn revoked(&self) -> i64 {
+        self.revoked
+    }
+
+    #[must_use]
+    pub const fn expired(&self) -> i64 {
+        self.expired
+    }
+
+    #[must_use]
+    pub const fn latest_validation(&self) -> Option<DateTime<Utc>> {
+        self.latest_validation
+    }
+
+    #[must_use]
+    pub const fn earliest_expiry(&self) -> Option<DateTime<Utc>> {
+        self.earliest_expiry
+    }
+
+    #[must_use]
+    pub const fn latest_expiry(&self) -> Option<DateTime<Utc>> {
+        self.latest_expiry
+    }
+}
 
 /// Named token-creation fields exposed to an adapter.
 pub struct StorageTokenCreateParts {
     principal_id: PrincipalId,
-    token_hash: String,
+    digest: StorageTokenDigest,
     name: Option<String>,
     description: Option<String>,
     expires_at: Option<DateTime<Utc>>,
@@ -29,8 +112,8 @@ impl StorageTokenCreateParts {
     }
 
     #[must_use]
-    pub fn token_hash(&self) -> &str {
-        &self.token_hash
+    pub const fn digest(&self) -> &StorageTokenDigest {
+        &self.digest
     }
 
     #[must_use]
@@ -124,7 +207,7 @@ impl std::error::Error for StorageTokenIssuancePolicyError {}
 #[derive(Clone, PartialEq, Eq)]
 pub struct StorageTokenCreate {
     principal_id: PrincipalId,
-    token_hash: String,
+    digest: StorageTokenDigest,
     name: Option<String>,
     description: Option<String>,
     expires_at: Option<DateTime<Utc>>,
@@ -137,13 +220,13 @@ impl StorageTokenCreate {
     #[must_use]
     pub fn new(
         principal_id: PrincipalId,
-        token_hash: impl Into<String>,
+        digest: StorageTokenDigest,
         policy: StorageTokenIssuancePolicy,
         event_context: EventContext,
     ) -> Self {
         Self {
             principal_id,
-            token_hash: token_hash.into(),
+            digest,
             name: None,
             description: None,
             expires_at: None,
@@ -181,7 +264,7 @@ impl StorageTokenCreate {
     pub fn into_parts(self) -> StorageTokenCreateParts {
         StorageTokenCreateParts {
             principal_id: self.principal_id,
-            token_hash: self.token_hash,
+            digest: self.digest,
             name: self.name,
             description: self.description,
             expires_at: self.expires_at,
@@ -197,7 +280,7 @@ impl fmt::Debug for StorageTokenCreate {
         formatter
             .debug_struct("StorageTokenCreate")
             .field("principal_id", &"<redacted>")
-            .field("token_hash", &"<redacted>")
+            .field("digest", &self.digest)
             .field("has_name", &self.name.is_some())
             .field("has_description", &self.description.is_some())
             .field("has_expiry", &self.expires_at.is_some())
@@ -213,7 +296,7 @@ impl fmt::Debug for StorageTokenCreate {
 pub struct StorageTokenRenew {
     source_token_id: TokenId,
     principal_id: PrincipalId,
-    token_hash: String,
+    digest: StorageTokenDigest,
     expires_at: Option<DateTime<Utc>>,
     policy: StorageTokenIssuancePolicy,
     event_context: EventContext,
@@ -224,7 +307,7 @@ impl StorageTokenRenew {
     pub fn new(
         source_token_id: TokenId,
         principal_id: PrincipalId,
-        token_hash: impl Into<String>,
+        digest: StorageTokenDigest,
         expires_at: Option<DateTime<Utc>>,
         policy: StorageTokenIssuancePolicy,
         event_context: EventContext,
@@ -232,7 +315,7 @@ impl StorageTokenRenew {
         Self {
             source_token_id,
             principal_id,
-            token_hash: token_hash.into(),
+            digest,
             expires_at,
             policy,
             event_context,
@@ -245,7 +328,7 @@ impl StorageTokenRenew {
     ) -> (
         TokenId,
         PrincipalId,
-        String,
+        StorageTokenDigest,
         Option<DateTime<Utc>>,
         StorageTokenIssuancePolicy,
         EventContext,
@@ -253,7 +336,7 @@ impl StorageTokenRenew {
         (
             self.source_token_id,
             self.principal_id,
-            self.token_hash,
+            self.digest,
             self.expires_at,
             self.policy,
             self.event_context,
@@ -267,7 +350,7 @@ impl fmt::Debug for StorageTokenRenew {
             .debug_struct("StorageTokenRenew")
             .field("source_token_id", &"<redacted>")
             .field("principal_id", &"<redacted>")
-            .field("token_hash", &"<redacted>")
+            .field("digest", &self.digest)
             .field("has_expiry", &self.expires_at.is_some())
             .field("event_context", &"<redacted>")
             .finish()
@@ -317,7 +400,7 @@ impl fmt::Debug for StorageTokenRevoke {
 #[derive(Clone, PartialEq, Eq)]
 pub struct StorageTokenHashRevoke {
     principal_id: Option<PrincipalId>,
-    token_hash: String,
+    credentials: Vec<StorageAuthenticationCredential>,
     event_context: EventContext,
 }
 
@@ -325,19 +408,51 @@ impl StorageTokenHashRevoke {
     #[must_use]
     pub fn new(
         principal_id: Option<PrincipalId>,
-        token_hash: impl Into<String>,
+        lookup_value: impl Into<String>,
         event_context: EventContext,
     ) -> Self {
         Self {
             principal_id,
-            token_hash: token_hash.into(),
+            credentials: vec![StorageAuthenticationCredential::new(lookup_value)],
             event_context,
         }
     }
 
+    pub fn try_candidates(
+        principal_id: Option<PrincipalId>,
+        credentials: Vec<StorageAuthenticationCredential>,
+        event_context: EventContext,
+    ) -> Result<Self, StorageValidationError> {
+        if credentials.is_empty() || credentials.len() > MAX_TOKEN_HASH_KEYS {
+            return Err(StorageValidationError::invalid(
+                "token revocation requires a bounded, non-empty candidate set",
+            ));
+        }
+        if credentials.iter().enumerate().any(|(index, candidate)| {
+            credentials[index + 1..]
+                .iter()
+                .any(|other| candidate.digest() == other.digest())
+        }) {
+            return Err(StorageValidationError::invalid(
+                "token revocation candidates must be unique",
+            ));
+        }
+        Ok(Self {
+            principal_id,
+            credentials,
+            event_context,
+        })
+    }
+
     #[must_use]
-    pub fn into_parts(self) -> (Option<PrincipalId>, String, EventContext) {
-        (self.principal_id, self.token_hash, self.event_context)
+    pub fn into_parts(
+        self,
+    ) -> (
+        Option<PrincipalId>,
+        Vec<StorageAuthenticationCredential>,
+        EventContext,
+    ) {
+        (self.principal_id, self.credentials, self.event_context)
     }
 }
 
@@ -346,7 +461,7 @@ impl fmt::Debug for StorageTokenHashRevoke {
         formatter
             .debug_struct("StorageTokenHashRevoke")
             .field("has_principal", &self.principal_id.is_some())
-            .field("token_hash", &"<redacted>")
+            .field("credential_count", &self.credentials.len())
             .field("event_context", &"<redacted>")
             .finish()
     }
@@ -393,6 +508,12 @@ pub trait TokenStorage: Send + Sync {
         &self,
         query: StorageTokenListQuery,
     ) -> Result<StoragePage<StorageTokenMetadata>, StorageError>;
+
+    /// Aggregate persisted token usage by non-secret hash key identity.
+    async fn token_key_usage(
+        &self,
+        observation: StorageTokenObservation,
+    ) -> Result<Vec<StorageTokenKeyUsage>, StorageError>;
 
     async fn create_token(
         &self,
@@ -442,7 +563,7 @@ mod tests {
     fn token_request_debug_output_redacts_hashes_and_ids() {
         let request = StorageTokenCreate::new(
             PrincipalId::new(42).unwrap(),
-            "sensitive-token-hash",
+            StorageTokenDigest::legacy_unidentified("sensitive-token-hash"),
             StorageTokenIssuancePolicy::try_new(24, 48).unwrap(),
             EventContext::system(),
         )

--- a/crates/hubuum-storage-core/src/lib.rs
+++ b/crates/hubuum-storage-core/src/lib.rs
@@ -40,6 +40,7 @@ mod restore;
 mod task_execution;
 mod task_queue;
 mod telemetry;
+mod token_credentials;
 mod transaction;
 mod unified_search;
 mod validation;
@@ -131,10 +132,10 @@ pub use hubuum_domain::PrincipalKind;
 pub use hubuum_events_core::AuditDocument;
 pub use identity::{
     AuthenticationStorage, StorageAuthenticatedToken, StorageAuthenticatedTokenBuilder,
-    StorageAuthenticationAttempt, StorageAuthenticationCredential, StorageAuthenticationHuman,
-    StorageAuthenticationIdentity, StorageAuthenticationPrincipal,
-    StorageAuthenticationResourceScope, StorageAuthenticationTokenScope,
-    StorageAuthenticationTokenScopeQuery,
+    StorageAuthenticationAttempt, StorageAuthenticationHuman, StorageAuthenticationIdentity,
+    StorageAuthenticationPrincipal, StorageAuthenticationResourceScope,
+    StorageAuthenticationTokenScope, StorageAuthenticationTokenScopeQuery,
+    StorageTokenMigrationOutcome,
 };
 pub use identity_operations::{
     ExternalIdentityStorage, GroupMembershipStorage, IdentityScopeStorage,
@@ -157,7 +158,7 @@ pub use identity_resources::{
 pub use identity_tokens::{
     StoragePrincipalTokensRevoke, StorageTokenCreate, StorageTokenCreateParts,
     StorageTokenHashRevoke, StorageTokenIssuancePolicy, StorageTokenIssuancePolicyError,
-    StorageTokenRenew, StorageTokenRevoke, TokenStorage,
+    StorageTokenKeyUsage, StorageTokenRenew, StorageTokenRevoke, TokenStorage,
 };
 pub use identity_users::{
     StorageUser, StorageUserAnonymize, StorageUserCreate, StorageUserDelete, StorageUserDetails,
@@ -281,6 +282,10 @@ pub use task_queue::{
     StorageTaskStatus, TaskQueueStorage,
 };
 pub use telemetry::{StorageCapability, StorageObservation, StorageObserver};
+pub use token_credentials::{
+    MAX_TOKEN_HASH_KEYS, StorageAuthenticationCredential, StorageTokenDigest, StorageTokenFormat,
+    StorageTokenHashAlgorithm, StorageTokenHashKeyId,
+};
 pub use transaction::{
     StorageTransaction, StorageTransactionFuture, TransactionStorage, TransactionalClassRelations,
     TransactionalClasses, TransactionalCollections, TransactionalObjectRelations,

--- a/crates/hubuum-storage-core/src/token_credentials.rs
+++ b/crates/hubuum-storage-core/src/token_credentials.rs
@@ -1,0 +1,275 @@
+use std::fmt;
+
+use crate::StorageValidationError;
+
+/// Maximum number of token-hash keys accepted in one rotation ring.
+pub const MAX_TOKEN_HASH_KEYS: usize = 8;
+
+/// Stable, non-secret identifier for one token-hashing key.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StorageTokenHashKeyId(String);
+
+impl StorageTokenHashKeyId {
+    pub fn try_new(value: impl Into<String>) -> Result<Self, StorageValidationError> {
+        let value = value.into();
+        let bytes = value.as_bytes();
+        if bytes.is_empty() || bytes.len() > 32 {
+            return Err(StorageValidationError::invalid(
+                "token hash key IDs must contain 1-32 characters",
+            ));
+        }
+        let valid_edge = |byte: u8| byte.is_ascii_lowercase() || byte.is_ascii_digit();
+        if !valid_edge(bytes[0])
+            || !valid_edge(bytes[bytes.len() - 1])
+            || !bytes.iter().all(|byte| valid_edge(*byte) || *byte == b'-')
+        {
+            return Err(StorageValidationError::invalid(
+                "token hash key IDs must use lowercase ASCII letters, numbers, or interior hyphens",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for StorageTokenHashKeyId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("StorageTokenHashKeyId")
+            .field(&self.0)
+            .finish()
+    }
+}
+
+impl fmt::Display for StorageTokenHashKeyId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Bearer-token syntax family represented by a persisted digest.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StorageTokenFormat {
+    Legacy,
+    Version1,
+}
+
+impl StorageTokenFormat {
+    #[must_use]
+    pub const fn persistence_value(self) -> i16 {
+        match self {
+            Self::Legacy => 0,
+            Self::Version1 => 1,
+        }
+    }
+
+    pub fn from_persistence(value: i16) -> Result<Self, StorageValidationError> {
+        match value {
+            0 => Ok(Self::Legacy),
+            1 => Ok(Self::Version1),
+            _ => Err(StorageValidationError::invalid(
+                "unsupported persisted token format",
+            )),
+        }
+    }
+}
+
+/// One-way algorithm used for a persisted bearer-token digest.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StorageTokenHashAlgorithm {
+    HmacSha256V1,
+}
+
+impl StorageTokenHashAlgorithm {
+    #[must_use]
+    pub const fn persistence_value(self) -> i16 {
+        1
+    }
+
+    pub fn from_persistence(value: i16) -> Result<Self, StorageValidationError> {
+        match value {
+            1 => Ok(Self::HmacSha256V1),
+            _ => Err(StorageValidationError::invalid(
+                "unsupported persisted token hash algorithm",
+            )),
+        }
+    }
+}
+
+/// Redacted digest and the non-secret metadata needed to interpret it.
+#[derive(Clone, PartialEq, Eq)]
+pub struct StorageTokenDigest {
+    lookup_value: String,
+    format: StorageTokenFormat,
+    algorithm: StorageTokenHashAlgorithm,
+    key_id: Option<StorageTokenHashKeyId>,
+}
+
+impl StorageTokenDigest {
+    pub fn try_new(
+        lookup_value: impl Into<String>,
+        format: StorageTokenFormat,
+        algorithm: StorageTokenHashAlgorithm,
+        key_id: Option<StorageTokenHashKeyId>,
+    ) -> Result<Self, StorageValidationError> {
+        let lookup_value = lookup_value.into();
+        if lookup_value.is_empty() {
+            return Err(StorageValidationError::invalid(
+                "token digest must not be empty",
+            ));
+        }
+        if format == StorageTokenFormat::Version1 && key_id.is_none() {
+            return Err(StorageValidationError::invalid(
+                "versioned token digests require a hash key ID",
+            ));
+        }
+        Ok(Self {
+            lookup_value,
+            format,
+            algorithm,
+            key_id,
+        })
+    }
+
+    /// Compatibility representation for a row created before key metadata existed.
+    #[must_use]
+    pub fn legacy_unidentified(lookup_value: impl Into<String>) -> Self {
+        Self {
+            lookup_value: lookup_value.into(),
+            format: StorageTokenFormat::Legacy,
+            algorithm: StorageTokenHashAlgorithm::HmacSha256V1,
+            key_id: None,
+        }
+    }
+
+    #[must_use]
+    pub fn lookup_value(&self) -> &str {
+        &self.lookup_value
+    }
+
+    /// Compares a persisted lookup value without data-dependent byte exits.
+    #[must_use]
+    pub fn matches_lookup_value(&self, persisted: &str) -> bool {
+        let mut difference = self.lookup_value.len() ^ persisted.len();
+        for (expected, actual) in self.lookup_value.bytes().zip(persisted.bytes()) {
+            difference |= usize::from(expected ^ actual);
+        }
+        difference == 0
+    }
+
+    #[must_use]
+    pub const fn format(&self) -> StorageTokenFormat {
+        self.format
+    }
+
+    #[must_use]
+    pub const fn algorithm(&self) -> StorageTokenHashAlgorithm {
+        self.algorithm
+    }
+
+    #[must_use]
+    pub const fn key_id(&self) -> Option<&StorageTokenHashKeyId> {
+        self.key_id.as_ref()
+    }
+
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        String,
+        StorageTokenFormat,
+        StorageTokenHashAlgorithm,
+        Option<StorageTokenHashKeyId>,
+    ) {
+        (self.lookup_value, self.format, self.algorithm, self.key_id)
+    }
+}
+
+impl fmt::Debug for StorageTokenDigest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageTokenDigest")
+            .field("lookup_value", &"<redacted>")
+            .field("format", &self.format)
+            .field("algorithm", &self.algorithm)
+            .field("key_id", &self.key_id)
+            .finish()
+    }
+}
+
+/// One possible persisted representation of a presented bearer value.
+#[derive(Clone, PartialEq, Eq)]
+pub struct StorageAuthenticationCredential {
+    digest: StorageTokenDigest,
+}
+
+impl StorageAuthenticationCredential {
+    /// Compatibility constructor for one unidentified legacy digest.
+    #[must_use]
+    pub fn new(lookup_value: impl Into<String>) -> Self {
+        Self {
+            digest: StorageTokenDigest::legacy_unidentified(lookup_value),
+        }
+    }
+
+    #[must_use]
+    pub const fn from_digest(digest: StorageTokenDigest) -> Self {
+        Self { digest }
+    }
+
+    #[must_use]
+    pub fn lookup_value(&self) -> &str {
+        self.digest.lookup_value()
+    }
+
+    #[must_use]
+    pub const fn digest(&self) -> &StorageTokenDigest {
+        &self.digest
+    }
+}
+
+impl fmt::Debug for StorageAuthenticationCredential {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageAuthenticationCredential")
+            .field("digest", &self.digest)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_ids_reject_ambiguous_environment_aliases() {
+        for invalid in ["", "UPPER", "under_score", "-edge", "edge-", "a..b"] {
+            assert!(
+                StorageTokenHashKeyId::try_new(invalid).is_err(),
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn digest_debug_output_redacts_lookup_material() {
+        let digest = StorageTokenDigest::legacy_unidentified("sensitive-token-digest");
+        let debug = format!("{digest:?}");
+
+        assert!(!debug.contains("sensitive-token-digest"));
+    }
+
+    #[test]
+    fn digest_lookup_comparison_checks_content_and_length() {
+        let digest = StorageTokenDigest::legacy_unidentified("abcdef");
+
+        assert!(digest.matches_lookup_value("abcdef"));
+        assert!(!digest.matches_lookup_value("abcdeg"));
+        assert!(!digest.matches_lookup_value("abcdef0"));
+        assert!(!digest.matches_lookup_value("abcde"));
+    }
+}

--- a/crates/hubuum-storage-core/tests/complete_external_adapter.rs
+++ b/crates/hubuum-storage-core/tests/complete_external_adapter.rs
@@ -539,6 +539,13 @@ impl TokenStorage for CompleteExternalAdapter {
         fixture_result()
     }
 
+    async fn token_key_usage(
+        &self,
+        observation: StorageTokenObservation,
+    ) -> Result<Vec<StorageTokenKeyUsage>, StorageError> {
+        fixture_result()
+    }
+
     async fn create_token(
         &self,
         request: StorageTokenCreate,

--- a/crates/hubuum-storage-memory/src/identity.rs
+++ b/crates/hubuum-storage-memory/src/identity.rs
@@ -6,15 +6,28 @@ impl AuthenticationStorage for MemoryStorage {
         &self,
         attempt: StorageAuthenticationAttempt,
     ) -> Result<StorageAuthenticatedToken, StorageError> {
-        let (credential, observed_at, legacy_valid_after) = attempt.into_parts();
+        let (credentials, migration_target, observed_at, legacy_valid_after) = attempt.into_parts();
         let observation = StorageTokenObservation::try_new(observed_at, legacy_valid_after)
             .map_err(invalid_contract_value)?;
         let mut state = self.state.write().await;
-        let token_id = state
+        let matching = state
             .tokens
             .values()
-            .find(|record| record.token_hash == credential.lookup_value())
+            .filter(|record| {
+                credentials
+                    .iter()
+                    .any(|credential| record.matches_credential(credential))
+            })
             .map(|record| record.id)
+            .collect::<Vec<_>>();
+        if matching.len() > 1 {
+            return Err(StorageError::internal(
+                "multiple token rows matched one bearer credential",
+            ));
+        }
+        let token_id = matching
+            .first()
+            .copied()
             .ok_or_else(|| StorageError::authentication_required("Invalid bearer token"))?;
         let token = state
             .tokens
@@ -53,10 +66,28 @@ impl AuthenticationStorage for MemoryStorage {
             .clone()
             .map(StorageAuthenticationTokenScope::into_parts)
             .is_some_and(|parts| parts.1.is_some());
+        let migration_target = migration_target.filter(|_| {
+            token.token_format == StorageTokenFormat::Legacy && token.token_hash_key_id.is_none()
+        });
+        if migration_target.as_ref().is_some_and(|target| {
+            state.tokens.values().any(|candidate| {
+                candidate.id != token_id && target.matches_lookup_value(&candidate.token_hash)
+            })
+        }) {
+            return Err(StorageError::internal(
+                "legacy token migration target conflicts with another token row",
+            ));
+        }
         let record = state
             .tokens
             .get_mut(&token_id.id())
             .ok_or_else(|| StorageError::internal("authenticated token disappeared"))?;
+        let migration_outcome = if let Some(target) = migration_target {
+            record.migrate_legacy_digest(target);
+            StorageTokenMigrationOutcome::Migrated
+        } else {
+            StorageTokenMigrationOutcome::NotNeeded
+        };
         record.last_used_at = Some(observed_at);
         StorageAuthenticatedToken::builder(
             token.id,
@@ -70,6 +101,7 @@ impl AuthenticationStorage for MemoryStorage {
         .last_used_at(Some(observed_at))
         .permission_scoped(permission_scoped)
         .resource_scoped(resource_scoped)
+        .migration_outcome(migration_outcome)
         .try_build()
         .map_err(invalid_contract_value)
     }
@@ -1436,6 +1468,57 @@ impl TokenStorage for MemoryStorage {
         page(rows, &options)
     }
 
+    async fn token_key_usage(
+        &self,
+        observation: StorageTokenObservation,
+    ) -> Result<Vec<StorageTokenKeyUsage>, StorageError> {
+        #[derive(Default)]
+        struct Usage {
+            active: i64,
+            revoked: i64,
+            expired: i64,
+            latest_validation: Option<DateTime<Utc>>,
+            earliest_expiry: Option<DateTime<Utc>>,
+            latest_expiry: Option<DateTime<Utc>>,
+        }
+
+        let state = self.state.read().await;
+        let mut usage = BTreeMap::<Option<StorageTokenHashKeyId>, Usage>::new();
+        for token in state.tokens.values() {
+            let metadata = token.metadata(observation)?;
+            let item = usage.entry(token.token_hash_key_id.clone()).or_default();
+            if metadata.revoked_at().is_some() {
+                item.revoked += 1;
+            } else if metadata.is_expired() {
+                item.expired += 1;
+            } else {
+                item.active += 1;
+            }
+            item.latest_validation = item.latest_validation.max(token.last_used_at);
+            item.earliest_expiry = match (item.earliest_expiry, token.expires_at) {
+                (Some(current), Some(candidate)) => Some(current.min(candidate)),
+                (None, candidate) => candidate,
+                (current, None) => current,
+            };
+            item.latest_expiry = item.latest_expiry.max(token.expires_at);
+        }
+        usage
+            .into_iter()
+            .map(|(key_id, usage)| {
+                StorageTokenKeyUsage::try_new(
+                    key_id,
+                    usage.active,
+                    usage.revoked,
+                    usage.expired,
+                    usage.latest_validation,
+                    usage.earliest_expiry,
+                    usage.latest_expiry,
+                )
+                .map_err(invalid_contract_value)
+            })
+            .collect()
+    }
+
     async fn create_token(
         &self,
         request: StorageTokenCreate,
@@ -1451,7 +1534,7 @@ impl TokenStorage for MemoryStorage {
         if state
             .tokens
             .values()
-            .any(|token| token.token_hash == request.token_hash())
+            .any(|token| request.digest().matches_lookup_value(&token.token_hash))
         {
             return Err(StorageError::conflict("Token credential already exists"));
         }
@@ -1472,10 +1555,15 @@ impl TokenStorage for MemoryStorage {
                 "Token expiry is outside the issuance policy",
             ));
         }
+        let (token_hash, token_format, token_hash_algorithm, token_hash_key_id) =
+            request.digest().clone().into_parts();
         let record = MemoryTokenRecord {
             id,
             principal_id: request.principal_id(),
-            token_hash: request.token_hash().to_string(),
+            token_hash,
+            token_format,
+            token_hash_algorithm,
+            token_hash_key_id,
             name: request.name().map(ToOwned::to_owned),
             description: request.description().map(ToOwned::to_owned),
             issued,
@@ -1504,8 +1592,7 @@ impl TokenStorage for MemoryStorage {
         &self,
         request: StorageTokenRenew,
     ) -> Result<StorageMutationOutcome<StorageTokenMetadata>, StorageError> {
-        let (source_id, principal_id, token_hash, expires_at, policy, context) =
-            request.into_parts();
+        let (source_id, principal_id, digest, expires_at, policy, context) = request.into_parts();
         let source = self
             .state
             .read()
@@ -1524,7 +1611,7 @@ impl TokenStorage for MemoryStorage {
             )));
         }
         self.create_token(
-            StorageTokenCreate::new(principal_id, token_hash, policy, context)
+            StorageTokenCreate::new(principal_id, digest, policy, context)
                 .name(source.name)
                 .description(source.description)
                 .expires_at(expires_at)
@@ -1612,7 +1699,7 @@ impl TokenStorage for MemoryStorage {
         &self,
         request: StorageTokenHashRevoke,
     ) -> Result<StorageMutationOutcome<usize>, StorageError> {
-        let (principal_id, token_hash, context) = request.into_parts();
+        let (principal_id, credentials, context) = request.into_parts();
         let token_id = self
             .state
             .read()
@@ -1620,7 +1707,9 @@ impl TokenStorage for MemoryStorage {
             .tokens
             .values()
             .find(|token| {
-                token.token_hash == token_hash
+                credentials
+                    .iter()
+                    .any(|credential| token.matches_credential(credential))
                     && principal_id.is_none_or(|id| token.principal_id == id)
             })
             .map(|token| token.id);

--- a/crates/hubuum-storage-memory/src/imports.rs
+++ b/crates/hubuum-storage-memory/src/imports.rs
@@ -1,13 +1,37 @@
 use super::*;
 
-impl MemoryStorage {
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            state: Arc::new(RwLock::new(MemoryState::new())),
-        }
+fn assert_import_revision(
+    condition: Option<StorageImportWriteCondition>,
+    current_revision: ResourceRevision,
+) -> Result<(), StorageError> {
+    let Some(expected) = condition.and_then(StorageImportWriteCondition::expected_revision) else {
+        return Ok(());
+    };
+    if expected == current_revision.get() {
+        return Ok(());
     }
+    Err(StorageError::precondition_failed(
+        format!(
+            "stale_revision: expected revision {expected}, observed {}",
+            current_revision.get()
+        ),
+        Some(current_revision),
+    ))
+}
 
+fn assert_import_create_condition(
+    condition: Option<StorageImportWriteCondition>,
+) -> Result<(), StorageError> {
+    if condition.is_some_and(StorageImportWriteCondition::requires_existing) {
+        return Err(StorageError::precondition_failed(
+            "conditional_import_target_missing",
+            None,
+        ));
+    }
+    Ok(())
+}
+
+impl MemoryStorage {
     async fn import_identity_scope_id(
         &self,
         reference: Option<&str>,

--- a/crates/hubuum-storage-memory/src/lib.rs
+++ b/crates/hubuum-storage-memory/src/lib.rs
@@ -11,10 +11,14 @@ use chrono::{DateTime, Duration, Utc};
 use hubuum_domain::*;
 use hubuum_events_core::*;
 use hubuum_query::*;
-use hubuum_storage_core::StorageValidationError;
 use hubuum_storage_core::capabilities::{
     backend::*, common::*, events::*, identity::*, operational::*, queries::*, resources::*,
     workflows::*,
+};
+use hubuum_storage_core::{
+    StorageAuthenticationCredential, StorageTokenDigest, StorageTokenFormat,
+    StorageTokenHashAlgorithm, StorageTokenHashKeyId, StorageTokenMigrationOutcome,
+    StorageValidationError,
 };
 use tokio::sync::RwLock;
 use uuid::Uuid;
@@ -41,6 +45,9 @@ struct MemoryTokenRecord {
     id: TokenId,
     principal_id: PrincipalId,
     token_hash: String,
+    token_format: StorageTokenFormat,
+    token_hash_algorithm: StorageTokenHashAlgorithm,
+    token_hash_key_id: Option<StorageTokenHashKeyId>,
     name: Option<String>,
     description: Option<String>,
     issued: DateTime<Utc>,
@@ -264,6 +271,33 @@ impl MemoryTaskRecord {
 }
 
 impl MemoryTokenRecord {
+    fn matches_credential(&self, credential: &StorageAuthenticationCredential) -> bool {
+        let digest = credential.digest();
+        if !digest.matches_lookup_value(&self.token_hash)
+            || self.token_format != digest.format()
+            || self.token_hash_algorithm != digest.algorithm()
+        {
+            return false;
+        }
+        match self.token_format {
+            StorageTokenFormat::Version1 => self.token_hash_key_id.as_ref() == digest.key_id(),
+            StorageTokenFormat::Legacy => {
+                self.token_hash_key_id.is_none()
+                    || digest.key_id().is_none()
+                    || self.token_hash_key_id.as_ref() == digest.key_id()
+            }
+        }
+    }
+
+    fn migrate_legacy_digest(&mut self, target: StorageTokenDigest) {
+        let (token_hash, token_format, token_hash_algorithm, token_hash_key_id) =
+            target.into_parts();
+        self.token_hash = token_hash;
+        self.token_format = token_format;
+        self.token_hash_algorithm = token_hash_algorithm;
+        self.token_hash_key_id = token_hash_key_id;
+    }
+
     fn metadata(
         &self,
         observation: StorageTokenObservation,
@@ -272,7 +306,7 @@ impl MemoryTokenRecord {
         let expired = self
             .expires_at
             .is_some_and(|expires_at| expires_at <= observed_at)
-            || (self.expires_at.is_none() && self.issued < legacy_valid_after);
+            || (self.expires_at.is_none() && self.issued <= legacy_valid_after);
         StorageTokenMetadata::builder(self.id, self.principal_id, self.issued, self.revision)
             .name(self.name.clone())
             .description(self.description.clone())
@@ -351,155 +385,6 @@ struct MemoryState {
 }
 
 impl MemoryState {
-    fn new() -> Self {
-        let now = Utc::now();
-        let metadata = StorageRecordMetadata::try_new(
-            ResourceId::new(ROOT_COLLECTION_ID).expect("root resource id is valid"),
-            now,
-            now,
-            ResourceRevision::INITIAL,
-        )
-        .expect("root collection metadata is valid");
-        let root = StorageCollection::try_new(metadata, "root", "Root collection", None)
-            .expect("root collection is valid");
-        let local_scope_id = IdentityScopeId::new(1).expect("local identity scope id is valid");
-        let local_scope = StorageIdentityScope::try_new(
-            local_scope_id,
-            LOCAL_IDENTITY_SCOPE,
-            LOCAL_PROVIDER_KIND,
-            now,
-            now,
-            ResourceRevision::INITIAL,
-        )
-        .expect("local identity scope is valid");
-        let admin_principal_id = PrincipalId::new(1).expect("admin principal id is valid");
-        let admin_metadata = StorageRecordMetadata::try_new(
-            ResourceId::new(admin_principal_id.id()).expect("admin resource id is valid"),
-            now,
-            now,
-            ResourceRevision::INITIAL,
-        )
-        .expect("admin principal metadata is valid");
-        let admin_principal = StoragePrincipal::builder(
-            admin_metadata,
-            PrincipalKind::Human,
-            "admin",
-            local_scope_id,
-        )
-        .try_build()
-        .expect("admin principal is valid");
-        let admin_user = StorageUser::try_new(
-            UserId::new(admin_principal_id.id()).expect("admin user id is valid"),
-            Some("memory-adapter-placeholder-password-hash".to_string()),
-            Some("Administrator".to_string()),
-            None,
-            now,
-            now,
-            None,
-        )
-        .expect("admin user is valid");
-        let admin_group_id = GroupId::new(1).expect("admin group id is valid");
-        let admin_group_metadata = StorageRecordMetadata::try_new(
-            ResourceId::new(admin_group_id.id()).expect("admin group resource id is valid"),
-            now,
-            now,
-            ResourceRevision::INITIAL,
-        )
-        .expect("admin group metadata is valid");
-        let admin_group = StorageIdentityGroup::builder(
-            admin_group_metadata,
-            "admin",
-            "Administrators",
-            local_scope_id,
-            LOCAL_PROVIDER_KIND,
-        )
-        .try_build()
-        .expect("admin group is valid");
-        let admin_membership = StoragePrincipalGroup::try_new(
-            admin_principal_id,
-            admin_group_id,
-            now,
-            now,
-            ResourceRevision::INITIAL,
-        )
-        .expect("admin group membership is valid");
-        Self {
-            next_collection_id: ROOT_COLLECTION_ID + 1,
-            next_class_id: 1,
-            next_object_id: 1,
-            next_class_relation_id: 1,
-            next_object_relation_id: 1,
-            next_event_sequence: 1,
-            next_identity_scope_id: 2,
-            next_principal_id: 2,
-            next_group_id: 2,
-            next_token_id: 1,
-            next_task_id: 1,
-            next_task_event_sequence: 1,
-            next_import_result_id: 1,
-            next_computed_field_id: 1,
-            next_export_template_id: 1,
-            next_remote_target_id: 1,
-            next_authorization_grant_id: 1,
-            next_event_sink_id: 1,
-            next_event_subscription_id: 1,
-            next_event_delivery_id: 1,
-            next_history_id: 1,
-            next_restore_job_id: 1,
-            fanout_event_cursor: 0,
-            collections: BTreeMap::from([(ROOT_COLLECTION_ID, root)]),
-            classes: BTreeMap::new(),
-            objects: BTreeMap::new(),
-            class_relations: BTreeMap::new(),
-            object_relations: BTreeMap::new(),
-            identity_scopes: BTreeMap::from([(local_scope_id.id(), local_scope)]),
-            principals: BTreeMap::from([(admin_principal_id.id(), admin_principal)]),
-            users: BTreeMap::from([(
-                admin_principal_id.id(),
-                MemoryUserRecord {
-                    user: admin_user,
-                    identity_scope_id: local_scope_id,
-                    name: "admin".to_string(),
-                    provider_managed: false,
-                    external_subject: None,
-                    last_sync_attempted_at: None,
-                    last_sync_success_at: None,
-                },
-            )]),
-            groups: BTreeMap::from([(admin_group_id.id(), admin_group)]),
-            memberships: BTreeMap::from([(
-                (admin_principal_id.id(), admin_group_id.id()),
-                admin_membership,
-            )]),
-            external_memberships: BTreeSet::new(),
-            tokens: BTreeMap::new(),
-            service_accounts: BTreeMap::new(),
-            tasks: BTreeMap::new(),
-            task_events: BTreeMap::new(),
-            import_task_results: BTreeMap::new(),
-            export_outputs: BTreeMap::new(),
-            backup_outputs: BTreeMap::new(),
-            export_templates: BTreeMap::new(),
-            remote_targets: BTreeMap::new(),
-            computed_fields: BTreeMap::new(),
-            computation_states: BTreeMap::new(),
-            computed_rebuild_tasks: BTreeMap::new(),
-            authorization_grants: BTreeMap::new(),
-            event_sinks: BTreeMap::new(),
-            event_subscriptions: BTreeMap::new(),
-            event_deliveries: BTreeMap::new(),
-            event_delivery_claims: BTreeMap::new(),
-            event_retention_batches: BTreeMap::new(),
-            history: Vec::new(),
-            restore_jobs: BTreeMap::new(),
-            maintenance_state: MaintenanceState::Normal,
-            maintenance_restore_job_id: None,
-            maintenance_generation: 0,
-            restore_instances: BTreeMap::new(),
-            events: Vec::new(),
-        }
-    }
-
     fn append_event_record(
         &mut self,
         request: MemoryEventAppend<'_>,
@@ -734,43 +619,14 @@ pub struct MemoryStorage {
     state: Arc<RwLock<MemoryState>>,
 }
 
-fn ordered_ids<T: Ord>(first: T, second: T) -> (T, T) {
-    if first < second {
-        (first, second)
-    } else {
-        (second, first)
+impl MemoryStorage {
+    /// Creates an empty in-memory adapter with Hubuum's required bootstrap records.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(RwLock::new(MemoryState::new())),
+        }
     }
-}
-
-fn assert_import_revision(
-    condition: Option<StorageImportWriteCondition>,
-    current_revision: ResourceRevision,
-) -> Result<(), StorageError> {
-    let Some(expected) = condition.and_then(StorageImportWriteCondition::expected_revision) else {
-        return Ok(());
-    };
-    if expected == current_revision.get() {
-        return Ok(());
-    }
-    Err(StorageError::precondition_failed(
-        format!(
-            "stale_revision: expected revision {expected}, observed {}",
-            current_revision.get()
-        ),
-        Some(current_revision),
-    ))
-}
-
-fn assert_import_create_condition(
-    condition: Option<StorageImportWriteCondition>,
-) -> Result<(), StorageError> {
-    if condition.is_some_and(StorageImportWriteCondition::requires_existing) {
-        return Err(StorageError::precondition_failed(
-            "conditional_import_target_missing",
-            None,
-        ));
-    }
-    Ok(())
 }
 
 impl Default for MemoryStorage {
@@ -779,584 +635,15 @@ impl Default for MemoryStorage {
     }
 }
 
-fn invalid_contract_value(error: StorageValidationError) -> StorageError {
-    StorageError::internal(error.to_string())
-}
+mod support;
+use support::*;
 
-fn page<T>(mut rows: Vec<T>, options: &QueryOptions) -> Result<StoragePage<T>, StorageError> {
-    let total = options
-        .include_total()
-        .then(|| i64::try_from(rows.len()).unwrap_or(i64::MAX));
-    if let Some(limit) = options.limit() {
-        rows.truncate(limit);
-    }
-    StoragePage::try_new(rows, total).map_err(invalid_contract_value)
-}
-
-fn string_filter_matches(actual: &str, operator: &SearchOperator, expected: &str) -> bool {
-    let (operator, negated) = operator.op_and_neg();
-    let actual_lower = actual.to_lowercase();
-    let expected_lower = expected.to_lowercase();
-    let matched = match operator {
-        Operator::Equals => actual == expected,
-        Operator::IEquals => actual_lower == expected_lower,
-        Operator::Contains => actual.contains(expected),
-        Operator::IContains => actual_lower.contains(&expected_lower),
-        Operator::StartsWith => actual.starts_with(expected),
-        Operator::IStartsWith => actual_lower.starts_with(&expected_lower),
-        Operator::EndsWith => actual.ends_with(expected),
-        Operator::IEndsWith => actual_lower.ends_with(&expected_lower),
-        Operator::In => expected.split(',').any(|value| actual == value.trim()),
-        _ => true,
-    };
-    matched != negated
-}
-
-fn resource_filters_match(options: &QueryOptions, id: i32, name: &str, description: &str) -> bool {
-    options.filters().as_slice().iter().all(|filter| {
-        let actual = match filter.field {
-            FilterField::Id => id.to_string(),
-            FilterField::Name => name.to_string(),
-            FilterField::Description => description.to_string(),
-            _ => return true,
-        };
-        string_filter_matches(&actual, &filter.operator, &filter.value)
-    })
-}
-
-fn authorization_collection(
-    collection: &StorageCollection,
-) -> Result<StorageAuthorizationCollection, StorageError> {
-    StorageAuthorizationCollection::try_new(
-        collection.id(),
-        collection.name(),
-        collection.description(),
-        collection.created_at(),
-        collection.updated_at(),
-        collection.parent_collection_id(),
-        collection.revision(),
-    )
-    .map_err(invalid_contract_value)
-}
-
-fn authorization_group(
-    group: &StorageIdentityGroup,
-) -> Result<StorageAuthorizationGroup, StorageError> {
-    let identity = StorageAuthorizationGroupIdentity::new(
-        group.id(),
-        group.name(),
-        group.identity_scope_id(),
-        group.managed_by(),
-        group.external_key().map(ToOwned::to_owned),
-    );
-    let profile = StorageAuthorizationGroupProfile::try_new(
-        group.description(),
-        group.created_at(),
-        group.updated_at(),
-        group.revision(),
-    )
-    .map_err(invalid_contract_value)?;
-    let sync = StorageAuthorizationGroupSyncState::try_new(
-        group.last_sync_attempted_at(),
-        group.last_sync_success_at(),
-    )
-    .map_err(invalid_contract_value)?;
-    Ok(StorageAuthorizationGroup::new(identity, profile, sync))
-}
-
-fn principal_group_ids(state: &MemoryState, principal_id: PrincipalId) -> Vec<GroupId> {
-    state
-        .memberships
-        .keys()
-        .filter(|(candidate_principal_id, _)| *candidate_principal_id == principal_id.id())
-        .map(|(_, group_id)| GroupId::new(*group_id).expect("stored group ids are positive"))
-        .collect()
-}
-
-fn permissions_include(
-    available: &[StorageAuthorizationPermission],
-    required: &[StorageAuthorizationPermission],
-) -> bool {
-    required
-        .iter()
-        .all(|permission| available.contains(permission))
-}
-
-fn principal_has_collection_permissions(
-    state: &MemoryState,
-    principal_id: PrincipalId,
-    collection_id: CollectionId,
-    permissions: &[StorageAuthorizationPermission],
-) -> bool {
-    let group_ids = principal_group_ids(state, principal_id);
-    group_ids.iter().any(|group_id| {
-        state
-            .authorization_grants
-            .get(&(collection_id.id(), group_id.id()))
-            .is_some_and(|grant| permissions_include(grant.permissions(), permissions))
-    })
-}
-
-fn authorization_group_grant(
-    state: &MemoryState,
-    grant: &StorageAuthorizationGrant,
-) -> Result<StorageAuthorizationGroupGrant, StorageError> {
-    let group = state
-        .groups
-        .get(&grant.group_id().id())
-        .ok_or_else(|| StorageError::internal("authorization grant group is missing"))?;
-    StorageAuthorizationGroupGrant::try_new(authorization_group(group)?, grant.clone())
-        .map_err(invalid_contract_value)
-}
-
-fn authorization_policy_row(
-    state: &MemoryState,
-    grant: &StorageAuthorizationGrant,
-) -> Result<StorageAuthorizationPolicySnapshotRow, StorageError> {
-    let group = state
-        .groups
-        .get(&grant.group_id().id())
-        .ok_or_else(|| StorageError::internal("authorization grant group is missing"))?;
-    let collection = state
-        .collections
-        .get(&grant.collection_id().id())
-        .ok_or_else(|| StorageError::internal("authorization grant collection is missing"))?;
-    StorageAuthorizationPolicySnapshotRow::try_new(
-        grant.clone(),
-        authorization_group(group)?,
-        authorization_collection(collection)?,
-    )
-    .map_err(invalid_contract_value)
-}
-
-fn authorization_effective_group_grant(
-    state: &MemoryState,
-    grant: &StorageAuthorizationGrant,
-) -> Result<StorageAuthorizationEffectiveGroupGrant, StorageError> {
-    let collection = state
-        .collections
-        .get(&grant.collection_id().id())
-        .ok_or_else(|| StorageError::internal("authorization grant collection is missing"))?;
-    let group = state
-        .groups
-        .get(&grant.group_id().id())
-        .ok_or_else(|| StorageError::internal("authorization grant group is missing"))?;
-    let collection = authorization_collection(collection)?;
-    Ok(StorageAuthorizationEffectiveGroupGrant::new(
-        collection.clone(),
-        collection,
-        0,
-        false,
-        authorization_group(group)?,
-        grant.clone(),
-    ))
-}
-
-fn rebuild_event_delivery(
-    delivery: &StorageEventDelivery,
-    status: EventDeliveryStatus,
-    attempts: i32,
-    next_attempt_at: DateTime<Utc>,
-    last_error: Option<String>,
-    locked_until: Option<DateTime<Utc>>,
-) -> Result<StorageEventDelivery, StorageError> {
-    StorageEventDelivery::builder(
-        delivery.id(),
-        delivery.event_id(),
-        delivery.subscription_id(),
-        status,
-        next_attempt_at,
-        delivery.created_at(),
-        Utc::now(),
-    )
-    .attempts(attempts)
-    .last_error(last_error)
-    .locked_until(locked_until)
-    .try_build()
-    .map_err(invalid_contract_value)
-}
-
-fn event_status_counts(
-    deliveries: impl IntoIterator<Item = EventDeliveryStatus>,
-) -> Result<StorageEventDeliveryStatusSnapshot, StorageError> {
-    let mut total = 0_i64;
-    let mut pending = 0_i64;
-    let mut in_flight = 0_i64;
-    let mut succeeded = 0_i64;
-    let mut failed = 0_i64;
-    let mut dead = 0_i64;
-    for status in deliveries {
-        total += 1;
-        match status {
-            EventDeliveryStatus::Pending => pending += 1,
-            EventDeliveryStatus::InFlight => in_flight += 1,
-            EventDeliveryStatus::Succeeded => succeeded += 1,
-            EventDeliveryStatus::Failed => failed += 1,
-            EventDeliveryStatus::Dead => dead += 1,
-        }
-    }
-    StorageEventDeliveryStatusSnapshot::try_new(
-        total, pending, in_flight, succeeded, failed, dead, failed,
-    )
-    .map_err(invalid_contract_value)
-}
-
-fn history_scope_allows(
-    scope: &StorageHistoryCollectionScope,
-    collection_id: CollectionId,
-) -> bool {
-    match scope {
-        StorageHistoryCollectionScope::All => true,
-        StorageHistoryCollectionScope::Visible(ids) => ids.contains(&collection_id),
-    }
-}
-
-fn history_valid_to(state: &MemoryState, entry: &MemoryHistoryEntry) -> Option<DateTime<Utc>> {
-    let variant = std::mem::discriminant(&entry.value);
-    state
-        .history
-        .iter()
-        .filter(|candidate| {
-            candidate.id != entry.id
-                && candidate.value.entity_id() == entry.value.entity_id()
-                && std::mem::discriminant(&candidate.value) == variant
-                && (candidate.valid_from > entry.valid_from
-                    || (candidate.valid_from == entry.valid_from
-                        && candidate.id.id() > entry.id.id()))
-        })
-        .min_by_key(|candidate| (candidate.valid_from, candidate.id.id()))
-        .map(|candidate| candidate.valid_from)
-}
-
-fn transition_restore_record(
-    record: &MemoryRestoreRecord,
-    status: StorageRestoreJobStatus,
-    error: Option<String>,
-    confirmed_at: Option<DateTime<Utc>>,
-    finished_at: Option<DateTime<Utc>>,
-    erase_document: bool,
-) -> Result<MemoryRestoreRecord, StorageError> {
-    let (summary, mut document, capability_hash) = record.job.clone().into_parts();
-    let (id, _, initiator, artifact, _, timestamps) = summary.into_parts();
-    let timestamp_parts = timestamps.into_parts();
-    let timestamps = StorageRestoreTimestamps::try_new(
-        timestamp_parts.expires_at(),
-        confirmed_at,
-        finished_at,
-        timestamp_parts.created_at(),
-        Utc::now(),
-    )
-    .map_err(invalid_contract_value)?;
-    let summary =
-        StorageRestoreJobSummary::try_new(id, status, initiator, artifact, error, timestamps)
-            .map_err(invalid_contract_value)?;
-    if erase_document {
-        document.clear();
-    }
-    let job = StorageRestoreJob::try_new(summary, document, capability_hash)
-        .map_err(invalid_contract_value)?;
-    Ok(MemoryRestoreRecord {
-        job,
-        validation_summary: record.validation_summary.clone(),
-    })
-}
-
-fn class_with_collection(
-    state: &MemoryState,
-    class: &StorageClass,
-) -> Result<StorageClassWithCollection, StorageError> {
-    let collection = state
-        .collections
-        .get(&class.collection_id().id())
-        .cloned()
-        .ok_or_else(|| StorageError::internal("class collection is missing"))?;
-    let metadata = StorageRecordMetadata::try_new(
-        ResourceId::new(class.id().id()).expect("class id is positive"),
-        class.created_at(),
-        class.updated_at(),
-        class.revision(),
-    )
-    .map_err(invalid_contract_value)?;
-    Ok(
-        StorageClassWithCollection::builder(
-            metadata,
-            class.name(),
-            collection,
-            class.description(),
-        )
-        .json_schema(class.json_schema().cloned())
-        .validate_schema(class.validates_schema())
-        .build(),
-    )
-}
-
-fn search_rank(name: &str, description: &str, extended: Option<&str>, term: &str) -> Option<i32> {
-    let name = name.to_lowercase();
-    let description = description.to_lowercase();
-    let extended = extended.map(str::to_lowercase);
-    let term = term.to_lowercase();
-    if name == term {
-        Some(3)
-    } else if name.starts_with(&term) {
-        Some(2)
-    } else if name.contains(&term)
-        || description.contains(&term)
-        || extended.as_ref().is_some_and(|value| value.contains(&term))
-    {
-        Some(1)
-    } else {
-        None
-    }
-}
-
-fn graph_class(class: &StorageClass) -> Result<StorageGraphClass, StorageError> {
-    let metadata = StorageRecordMetadata::try_new(
-        ResourceId::new(class.id().id()).expect("class id is positive"),
-        class.created_at(),
-        class.updated_at(),
-        class.revision(),
-    )
-    .map_err(invalid_contract_value)?;
-    Ok(StorageGraphClass::new(
-        StorageGraphResource::new(
-            metadata,
-            class.name().to_string(),
-            class.collection_id(),
-            class.description().to_string(),
-        ),
-        class.json_schema().cloned(),
-        class.validates_schema(),
-    ))
-}
-
-fn graph_object(object: &StorageObject) -> Result<StorageGraphObject, StorageError> {
-    let metadata = StorageRecordMetadata::try_new(
-        ResourceId::new(object.id().id()).expect("object id is positive"),
-        object.created_at(),
-        object.updated_at(),
-        object.revision(),
-    )
-    .map_err(invalid_contract_value)?;
-    Ok(StorageGraphObject::new(
-        StorageGraphResource::new(
-            metadata,
-            object.name().to_string(),
-            object.collection_id(),
-            object.description().to_string(),
-        ),
-        object.class_id(),
-        object.data().clone(),
-    ))
-}
-
-fn ready_computation_state(
-    class_id: ClassId,
-    revision: i64,
-    created_at: DateTime<Utc>,
-) -> Result<StorageClassComputationState, StorageError> {
-    StorageClassComputationState::builder(
-        class_id,
-        StorageComputationRevision::try_new(revision).map_err(invalid_contract_value)?,
-        StorageComputationRebuildStatus::Ready,
-        created_at,
-        Utc::now(),
-    )
-    .try_build()
-    .map_err(invalid_contract_value)
-}
-
-fn updated_computed_field(
-    current: &StorageComputedFieldDefinition,
-    patch: &StorageComputedFieldDefinitionPatch,
-    actor_id: PrincipalId,
-) -> Result<StorageComputedFieldDefinition, StorageError> {
-    let metadata = current.metadata();
-    let metadata = StorageRecordMetadata::try_new(
-        metadata.id(),
-        metadata.created_at(),
-        Utc::now(),
-        metadata
-            .revision()
-            .checked_advance()
-            .map_err(|error| StorageError::internal(error.to_string()))?,
-    )
-    .map_err(invalid_contract_value)?;
-    let input = StorageComputedFieldDefinitionInput::new(
-        patch.key().unwrap_or(current.key()).to_string(),
-        patch.label().unwrap_or(current.label()).to_string(),
-        patch
-            .operation()
-            .cloned()
-            .unwrap_or_else(|| current.operation().clone()),
-        patch
-            .result_type()
-            .unwrap_or(current.result_type())
-            .to_string(),
-    )
-    .with_description(
-        patch
-            .description()
-            .unwrap_or(current.description())
-            .to_string(),
-    )
-    .with_enabled(patch.enabled().unwrap_or(current.enabled()));
-    Ok(StorageComputedFieldDefinition::new(
-        metadata,
-        current.class_id(),
-        current.visibility(),
-        StorageComputedFieldDefinitionContent::new(input, current.semantics_version()),
-        StorageComputedFieldProvenance::new(current.created_by(), Some(actor_id)),
-    ))
-}
-
-fn evaluate_computed_definition(
-    definition: &StorageComputedFieldDefinition,
-    object: &StorageObject,
-) -> serde_json::Value {
-    definition
-        .operation()
-        .get("paths")
-        .and_then(serde_json::Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(serde_json::Value::as_str)
-        .find_map(|path| object.data().pointer(path).cloned())
-        .unwrap_or(serde_json::Value::Null)
-}
-
-fn computed_scope(
-    state: &MemoryState,
-    object: &StorageObject,
-    visibility: StorageComputedFieldVisibility,
-) -> StorageComputedScope {
-    let values = state
-        .computed_fields
-        .values()
-        .filter(|definition| {
-            definition.class_id() == object.class_id()
-                && definition.visibility() == visibility
-                && definition.enabled()
-        })
-        .map(|definition| {
-            (
-                definition.key().to_string(),
-                evaluate_computed_definition(definition, object),
-            )
-        })
-        .collect();
-    StorageComputedScope::new(values, BTreeMap::new())
-}
-
-fn computed_object(
-    state: &MemoryState,
-    object: StorageObject,
-    personal_owner_id: Option<PrincipalId>,
-) -> Result<StorageComputedObject, StorageError> {
-    let revision = state
-        .computation_states
-        .get(&object.class_id().id())
-        .map_or(0, |value| value.evaluation_revision().get());
-    let shared = StorageSharedComputedScope::new(
-        StorageComputationRevision::try_new(revision).map_err(invalid_contract_value)?,
-        false,
-        computed_scope(state, &object, StorageComputedFieldVisibility::Shared),
-    );
-    let personal = personal_owner_id.map(|owner_id| {
-        computed_scope(
-            state,
-            &object,
-            StorageComputedFieldVisibility::Personal { owner_id },
-        )
-    });
-    Ok(StorageComputedObject::new(object, shared, personal))
-}
-
-fn export_output_summary(
-    output: &StorageExportOutput,
-) -> Result<StorageExportOutputSummary, StorageError> {
-    StorageExportOutputSummary::try_new(
-        output.task_id(),
-        output.template_name().map(ToOwned::to_owned),
-        output.content_type(),
-        output.warning_count(),
-        output.truncated(),
-        output.output_expires_at(),
-        output.durations(),
-    )
-    .map_err(invalid_contract_value)
-}
-
-fn backup_output_summary(
-    output: &StorageBackupOutput,
-) -> Result<StorageBackupOutputSummary, StorageError> {
-    StorageBackupOutputSummary::try_new(
-        output.task_id(),
-        output.byte_size(),
-        output.sha256(),
-        output.output_expires_at(),
-    )
-    .map_err(invalid_contract_value)
-}
-
-fn invalid_task_lease() -> StorageError {
-    StorageError::conflict("Task lease is no longer valid")
-}
-
-fn advanced_principal(
-    current: &StoragePrincipal,
-    name: impl Into<String>,
-    settings: serde_json::Value,
-    updated_at: DateTime<Utc>,
-) -> Result<StoragePrincipal, StorageError> {
-    let revision = current
-        .revision()
-        .checked_advance()
-        .map_err(|error| StorageError::internal(error.to_string()))?;
-    let metadata = StorageRecordMetadata::try_new(
-        ResourceId::new(current.id().id()).expect("principal id is positive"),
-        current.created_at(),
-        updated_at,
-        revision,
-    )
-    .map_err(invalid_contract_value)?;
-    StoragePrincipal::builder(metadata, current.kind(), name, current.identity_scope_id())
-        .provider_managed(current.provider_managed())
-        .settings(settings)
-        .external_subject(current.external_subject().map(ToOwned::to_owned))
-        .last_sync_attempted_at(current.last_sync_attempted_at())
-        .last_sync_success_at(current.last_sync_success_at())
-        .try_build()
-        .map_err(invalid_contract_value)
-}
-
-fn token_state_matches(metadata: &StorageTokenMetadata, state: StorageTokenListState) -> bool {
-    match state {
-        StorageTokenListState::Active => metadata.is_active(),
-        StorageTokenListState::Expired => metadata.is_expired(),
-        StorageTokenListState::Revoked => metadata.revoked_at().is_some(),
-        StorageTokenListState::All => true,
-    }
-}
-
-fn empty_event_fanout_snapshot() -> Result<StorageEventFanoutSnapshot, StorageError> {
-    StorageEventFanoutSnapshot::try_new(0, 0, 0, None).map_err(invalid_contract_value)
-}
-
-fn empty_event_queue_snapshot() -> Result<StorageEventQueueSnapshot, StorageError> {
-    StorageEventQueueSnapshot::try_new(
-        StorageEventDeliveryStatusSnapshot::try_new(0, 0, 0, 0, 0, 0, 0)
-            .map_err(invalid_contract_value)?,
-        0,
-        None,
-    )
-    .map_err(invalid_contract_value)
-}
-
-mod adapter;
 mod events;
 mod execution;
 mod identity;
+mod imports;
 mod operational;
 mod queries;
 mod resources;
+mod state;
 mod workflows;

--- a/crates/hubuum-storage-memory/src/state.rs
+++ b/crates/hubuum-storage-memory/src/state.rs
@@ -1,0 +1,152 @@
+use super::*;
+
+impl MemoryState {
+    pub(super) fn new() -> Self {
+        let now = Utc::now();
+        let metadata = StorageRecordMetadata::try_new(
+            ResourceId::new(ROOT_COLLECTION_ID).expect("root resource id is valid"),
+            now,
+            now,
+            ResourceRevision::INITIAL,
+        )
+        .expect("root collection metadata is valid");
+        let root = StorageCollection::try_new(metadata, "root", "Root collection", None)
+            .expect("root collection is valid");
+        let local_scope_id = IdentityScopeId::new(1).expect("local identity scope id is valid");
+        let local_scope = StorageIdentityScope::try_new(
+            local_scope_id,
+            LOCAL_IDENTITY_SCOPE,
+            LOCAL_PROVIDER_KIND,
+            now,
+            now,
+            ResourceRevision::INITIAL,
+        )
+        .expect("local identity scope is valid");
+        let admin_principal_id = PrincipalId::new(1).expect("admin principal id is valid");
+        let admin_metadata = StorageRecordMetadata::try_new(
+            ResourceId::new(admin_principal_id.id()).expect("admin resource id is valid"),
+            now,
+            now,
+            ResourceRevision::INITIAL,
+        )
+        .expect("admin principal metadata is valid");
+        let admin_principal = StoragePrincipal::builder(
+            admin_metadata,
+            PrincipalKind::Human,
+            "admin",
+            local_scope_id,
+        )
+        .try_build()
+        .expect("admin principal is valid");
+        let admin_user = StorageUser::try_new(
+            UserId::new(admin_principal_id.id()).expect("admin user id is valid"),
+            Some("memory-adapter-placeholder-password-hash".to_string()),
+            Some("Administrator".to_string()),
+            None,
+            now,
+            now,
+            None,
+        )
+        .expect("admin user is valid");
+        let admin_group_id = GroupId::new(1).expect("admin group id is valid");
+        let admin_group_metadata = StorageRecordMetadata::try_new(
+            ResourceId::new(admin_group_id.id()).expect("admin group resource id is valid"),
+            now,
+            now,
+            ResourceRevision::INITIAL,
+        )
+        .expect("admin group metadata is valid");
+        let admin_group = StorageIdentityGroup::builder(
+            admin_group_metadata,
+            "admin",
+            "Administrators",
+            local_scope_id,
+            LOCAL_PROVIDER_KIND,
+        )
+        .try_build()
+        .expect("admin group is valid");
+        let admin_membership = StoragePrincipalGroup::try_new(
+            admin_principal_id,
+            admin_group_id,
+            now,
+            now,
+            ResourceRevision::INITIAL,
+        )
+        .expect("admin group membership is valid");
+        Self {
+            next_collection_id: ROOT_COLLECTION_ID + 1,
+            next_class_id: 1,
+            next_object_id: 1,
+            next_class_relation_id: 1,
+            next_object_relation_id: 1,
+            next_event_sequence: 1,
+            next_identity_scope_id: 2,
+            next_principal_id: 2,
+            next_group_id: 2,
+            next_token_id: 1,
+            next_task_id: 1,
+            next_task_event_sequence: 1,
+            next_import_result_id: 1,
+            next_computed_field_id: 1,
+            next_export_template_id: 1,
+            next_remote_target_id: 1,
+            next_authorization_grant_id: 1,
+            next_event_sink_id: 1,
+            next_event_subscription_id: 1,
+            next_event_delivery_id: 1,
+            next_history_id: 1,
+            next_restore_job_id: 1,
+            fanout_event_cursor: 0,
+            collections: BTreeMap::from([(ROOT_COLLECTION_ID, root)]),
+            classes: BTreeMap::new(),
+            objects: BTreeMap::new(),
+            class_relations: BTreeMap::new(),
+            object_relations: BTreeMap::new(),
+            identity_scopes: BTreeMap::from([(local_scope_id.id(), local_scope)]),
+            principals: BTreeMap::from([(admin_principal_id.id(), admin_principal)]),
+            users: BTreeMap::from([(
+                admin_principal_id.id(),
+                MemoryUserRecord {
+                    user: admin_user,
+                    identity_scope_id: local_scope_id,
+                    name: "admin".to_string(),
+                    provider_managed: false,
+                    external_subject: None,
+                    last_sync_attempted_at: None,
+                    last_sync_success_at: None,
+                },
+            )]),
+            groups: BTreeMap::from([(admin_group_id.id(), admin_group)]),
+            memberships: BTreeMap::from([(
+                (admin_principal_id.id(), admin_group_id.id()),
+                admin_membership,
+            )]),
+            external_memberships: BTreeSet::new(),
+            tokens: BTreeMap::new(),
+            service_accounts: BTreeMap::new(),
+            tasks: BTreeMap::new(),
+            task_events: BTreeMap::new(),
+            import_task_results: BTreeMap::new(),
+            export_outputs: BTreeMap::new(),
+            backup_outputs: BTreeMap::new(),
+            export_templates: BTreeMap::new(),
+            remote_targets: BTreeMap::new(),
+            computed_fields: BTreeMap::new(),
+            computation_states: BTreeMap::new(),
+            computed_rebuild_tasks: BTreeMap::new(),
+            authorization_grants: BTreeMap::new(),
+            event_sinks: BTreeMap::new(),
+            event_subscriptions: BTreeMap::new(),
+            event_deliveries: BTreeMap::new(),
+            event_delivery_claims: BTreeMap::new(),
+            event_retention_batches: BTreeMap::new(),
+            history: Vec::new(),
+            restore_jobs: BTreeMap::new(),
+            maintenance_state: MaintenanceState::Normal,
+            maintenance_restore_job_id: None,
+            maintenance_generation: 0,
+            restore_instances: BTreeMap::new(),
+            events: Vec::new(),
+        }
+    }
+}

--- a/crates/hubuum-storage-memory/src/support.rs
+++ b/crates/hubuum-storage-memory/src/support.rs
@@ -1,0 +1,605 @@
+use super::*;
+
+pub(super) fn ordered_ids<T: Ord>(first: T, second: T) -> (T, T) {
+    if first < second {
+        (first, second)
+    } else {
+        (second, first)
+    }
+}
+
+pub(super) fn invalid_contract_value(error: StorageValidationError) -> StorageError {
+    StorageError::internal(error.to_string())
+}
+
+pub(super) fn page<T>(
+    mut rows: Vec<T>,
+    options: &QueryOptions,
+) -> Result<StoragePage<T>, StorageError> {
+    let total = options
+        .include_total()
+        .then(|| i64::try_from(rows.len()).unwrap_or(i64::MAX));
+    if let Some(limit) = options.limit() {
+        rows.truncate(limit);
+    }
+    StoragePage::try_new(rows, total).map_err(invalid_contract_value)
+}
+
+pub(super) fn string_filter_matches(
+    actual: &str,
+    operator: &SearchOperator,
+    expected: &str,
+) -> bool {
+    let (operator, negated) = operator.op_and_neg();
+    let actual_lower = actual.to_lowercase();
+    let expected_lower = expected.to_lowercase();
+    let matched = match operator {
+        Operator::Equals => actual == expected,
+        Operator::IEquals => actual_lower == expected_lower,
+        Operator::Contains => actual.contains(expected),
+        Operator::IContains => actual_lower.contains(&expected_lower),
+        Operator::StartsWith => actual.starts_with(expected),
+        Operator::IStartsWith => actual_lower.starts_with(&expected_lower),
+        Operator::EndsWith => actual.ends_with(expected),
+        Operator::IEndsWith => actual_lower.ends_with(&expected_lower),
+        Operator::In => expected.split(',').any(|value| actual == value.trim()),
+        _ => true,
+    };
+    matched != negated
+}
+
+pub(super) fn resource_filters_match(
+    options: &QueryOptions,
+    id: i32,
+    name: &str,
+    description: &str,
+) -> bool {
+    options.filters().as_slice().iter().all(|filter| {
+        let actual = match filter.field {
+            FilterField::Id => id.to_string(),
+            FilterField::Name => name.to_string(),
+            FilterField::Description => description.to_string(),
+            _ => return true,
+        };
+        string_filter_matches(&actual, &filter.operator, &filter.value)
+    })
+}
+
+pub(super) fn authorization_collection(
+    collection: &StorageCollection,
+) -> Result<StorageAuthorizationCollection, StorageError> {
+    StorageAuthorizationCollection::try_new(
+        collection.id(),
+        collection.name(),
+        collection.description(),
+        collection.created_at(),
+        collection.updated_at(),
+        collection.parent_collection_id(),
+        collection.revision(),
+    )
+    .map_err(invalid_contract_value)
+}
+
+pub(super) fn authorization_group(
+    group: &StorageIdentityGroup,
+) -> Result<StorageAuthorizationGroup, StorageError> {
+    let identity = StorageAuthorizationGroupIdentity::new(
+        group.id(),
+        group.name(),
+        group.identity_scope_id(),
+        group.managed_by(),
+        group.external_key().map(ToOwned::to_owned),
+    );
+    let profile = StorageAuthorizationGroupProfile::try_new(
+        group.description(),
+        group.created_at(),
+        group.updated_at(),
+        group.revision(),
+    )
+    .map_err(invalid_contract_value)?;
+    let sync = StorageAuthorizationGroupSyncState::try_new(
+        group.last_sync_attempted_at(),
+        group.last_sync_success_at(),
+    )
+    .map_err(invalid_contract_value)?;
+    Ok(StorageAuthorizationGroup::new(identity, profile, sync))
+}
+
+pub(super) fn principal_group_ids(state: &MemoryState, principal_id: PrincipalId) -> Vec<GroupId> {
+    state
+        .memberships
+        .keys()
+        .filter(|(candidate_principal_id, _)| *candidate_principal_id == principal_id.id())
+        .map(|(_, group_id)| GroupId::new(*group_id).expect("stored group ids are positive"))
+        .collect()
+}
+
+pub(super) fn permissions_include(
+    available: &[StorageAuthorizationPermission],
+    required: &[StorageAuthorizationPermission],
+) -> bool {
+    required
+        .iter()
+        .all(|permission| available.contains(permission))
+}
+
+pub(super) fn principal_has_collection_permissions(
+    state: &MemoryState,
+    principal_id: PrincipalId,
+    collection_id: CollectionId,
+    permissions: &[StorageAuthorizationPermission],
+) -> bool {
+    let group_ids = principal_group_ids(state, principal_id);
+    group_ids.iter().any(|group_id| {
+        state
+            .authorization_grants
+            .get(&(collection_id.id(), group_id.id()))
+            .is_some_and(|grant| permissions_include(grant.permissions(), permissions))
+    })
+}
+
+pub(super) fn authorization_group_grant(
+    state: &MemoryState,
+    grant: &StorageAuthorizationGrant,
+) -> Result<StorageAuthorizationGroupGrant, StorageError> {
+    let group = state
+        .groups
+        .get(&grant.group_id().id())
+        .ok_or_else(|| StorageError::internal("authorization grant group is missing"))?;
+    StorageAuthorizationGroupGrant::try_new(authorization_group(group)?, grant.clone())
+        .map_err(invalid_contract_value)
+}
+
+pub(super) fn authorization_policy_row(
+    state: &MemoryState,
+    grant: &StorageAuthorizationGrant,
+) -> Result<StorageAuthorizationPolicySnapshotRow, StorageError> {
+    let group = state
+        .groups
+        .get(&grant.group_id().id())
+        .ok_or_else(|| StorageError::internal("authorization grant group is missing"))?;
+    let collection = state
+        .collections
+        .get(&grant.collection_id().id())
+        .ok_or_else(|| StorageError::internal("authorization grant collection is missing"))?;
+    StorageAuthorizationPolicySnapshotRow::try_new(
+        grant.clone(),
+        authorization_group(group)?,
+        authorization_collection(collection)?,
+    )
+    .map_err(invalid_contract_value)
+}
+
+pub(super) fn authorization_effective_group_grant(
+    state: &MemoryState,
+    grant: &StorageAuthorizationGrant,
+) -> Result<StorageAuthorizationEffectiveGroupGrant, StorageError> {
+    let collection = state
+        .collections
+        .get(&grant.collection_id().id())
+        .ok_or_else(|| StorageError::internal("authorization grant collection is missing"))?;
+    let group = state
+        .groups
+        .get(&grant.group_id().id())
+        .ok_or_else(|| StorageError::internal("authorization grant group is missing"))?;
+    let collection = authorization_collection(collection)?;
+    Ok(StorageAuthorizationEffectiveGroupGrant::new(
+        collection.clone(),
+        collection,
+        0,
+        false,
+        authorization_group(group)?,
+        grant.clone(),
+    ))
+}
+
+pub(super) fn rebuild_event_delivery(
+    delivery: &StorageEventDelivery,
+    status: EventDeliveryStatus,
+    attempts: i32,
+    next_attempt_at: DateTime<Utc>,
+    last_error: Option<String>,
+    locked_until: Option<DateTime<Utc>>,
+) -> Result<StorageEventDelivery, StorageError> {
+    StorageEventDelivery::builder(
+        delivery.id(),
+        delivery.event_id(),
+        delivery.subscription_id(),
+        status,
+        next_attempt_at,
+        delivery.created_at(),
+        Utc::now(),
+    )
+    .attempts(attempts)
+    .last_error(last_error)
+    .locked_until(locked_until)
+    .try_build()
+    .map_err(invalid_contract_value)
+}
+
+pub(super) fn event_status_counts(
+    deliveries: impl IntoIterator<Item = EventDeliveryStatus>,
+) -> Result<StorageEventDeliveryStatusSnapshot, StorageError> {
+    let mut total = 0_i64;
+    let mut pending = 0_i64;
+    let mut in_flight = 0_i64;
+    let mut succeeded = 0_i64;
+    let mut failed = 0_i64;
+    let mut dead = 0_i64;
+    for status in deliveries {
+        total += 1;
+        match status {
+            EventDeliveryStatus::Pending => pending += 1,
+            EventDeliveryStatus::InFlight => in_flight += 1,
+            EventDeliveryStatus::Succeeded => succeeded += 1,
+            EventDeliveryStatus::Failed => failed += 1,
+            EventDeliveryStatus::Dead => dead += 1,
+        }
+    }
+    StorageEventDeliveryStatusSnapshot::try_new(
+        total, pending, in_flight, succeeded, failed, dead, failed,
+    )
+    .map_err(invalid_contract_value)
+}
+
+pub(super) fn history_scope_allows(
+    scope: &StorageHistoryCollectionScope,
+    collection_id: CollectionId,
+) -> bool {
+    match scope {
+        StorageHistoryCollectionScope::All => true,
+        StorageHistoryCollectionScope::Visible(ids) => ids.contains(&collection_id),
+    }
+}
+
+pub(super) fn history_valid_to(
+    state: &MemoryState,
+    entry: &MemoryHistoryEntry,
+) -> Option<DateTime<Utc>> {
+    let variant = std::mem::discriminant(&entry.value);
+    state
+        .history
+        .iter()
+        .filter(|candidate| {
+            candidate.id != entry.id
+                && candidate.value.entity_id() == entry.value.entity_id()
+                && std::mem::discriminant(&candidate.value) == variant
+                && (candidate.valid_from > entry.valid_from
+                    || (candidate.valid_from == entry.valid_from
+                        && candidate.id.id() > entry.id.id()))
+        })
+        .min_by_key(|candidate| (candidate.valid_from, candidate.id.id()))
+        .map(|candidate| candidate.valid_from)
+}
+
+pub(super) fn transition_restore_record(
+    record: &MemoryRestoreRecord,
+    status: StorageRestoreJobStatus,
+    error: Option<String>,
+    confirmed_at: Option<DateTime<Utc>>,
+    finished_at: Option<DateTime<Utc>>,
+    erase_document: bool,
+) -> Result<MemoryRestoreRecord, StorageError> {
+    let (summary, mut document, capability_hash) = record.job.clone().into_parts();
+    let (id, _, initiator, artifact, _, timestamps) = summary.into_parts();
+    let timestamp_parts = timestamps.into_parts();
+    let timestamps = StorageRestoreTimestamps::try_new(
+        timestamp_parts.expires_at(),
+        confirmed_at,
+        finished_at,
+        timestamp_parts.created_at(),
+        Utc::now(),
+    )
+    .map_err(invalid_contract_value)?;
+    let summary =
+        StorageRestoreJobSummary::try_new(id, status, initiator, artifact, error, timestamps)
+            .map_err(invalid_contract_value)?;
+    if erase_document {
+        document.clear();
+    }
+    let job = StorageRestoreJob::try_new(summary, document, capability_hash)
+        .map_err(invalid_contract_value)?;
+    Ok(MemoryRestoreRecord {
+        job,
+        validation_summary: record.validation_summary.clone(),
+    })
+}
+
+pub(super) fn class_with_collection(
+    state: &MemoryState,
+    class: &StorageClass,
+) -> Result<StorageClassWithCollection, StorageError> {
+    let collection = state
+        .collections
+        .get(&class.collection_id().id())
+        .cloned()
+        .ok_or_else(|| StorageError::internal("class collection is missing"))?;
+    let metadata = StorageRecordMetadata::try_new(
+        ResourceId::new(class.id().id()).expect("class id is positive"),
+        class.created_at(),
+        class.updated_at(),
+        class.revision(),
+    )
+    .map_err(invalid_contract_value)?;
+    Ok(
+        StorageClassWithCollection::builder(
+            metadata,
+            class.name(),
+            collection,
+            class.description(),
+        )
+        .json_schema(class.json_schema().cloned())
+        .validate_schema(class.validates_schema())
+        .build(),
+    )
+}
+
+pub(super) fn search_rank(
+    name: &str,
+    description: &str,
+    extended: Option<&str>,
+    term: &str,
+) -> Option<i32> {
+    let name = name.to_lowercase();
+    let description = description.to_lowercase();
+    let extended = extended.map(str::to_lowercase);
+    let term = term.to_lowercase();
+    if name == term {
+        Some(3)
+    } else if name.starts_with(&term) {
+        Some(2)
+    } else if name.contains(&term)
+        || description.contains(&term)
+        || extended.as_ref().is_some_and(|value| value.contains(&term))
+    {
+        Some(1)
+    } else {
+        None
+    }
+}
+
+pub(super) fn graph_class(class: &StorageClass) -> Result<StorageGraphClass, StorageError> {
+    let metadata = StorageRecordMetadata::try_new(
+        ResourceId::new(class.id().id()).expect("class id is positive"),
+        class.created_at(),
+        class.updated_at(),
+        class.revision(),
+    )
+    .map_err(invalid_contract_value)?;
+    Ok(StorageGraphClass::new(
+        StorageGraphResource::new(
+            metadata,
+            class.name().to_string(),
+            class.collection_id(),
+            class.description().to_string(),
+        ),
+        class.json_schema().cloned(),
+        class.validates_schema(),
+    ))
+}
+
+pub(super) fn graph_object(object: &StorageObject) -> Result<StorageGraphObject, StorageError> {
+    let metadata = StorageRecordMetadata::try_new(
+        ResourceId::new(object.id().id()).expect("object id is positive"),
+        object.created_at(),
+        object.updated_at(),
+        object.revision(),
+    )
+    .map_err(invalid_contract_value)?;
+    Ok(StorageGraphObject::new(
+        StorageGraphResource::new(
+            metadata,
+            object.name().to_string(),
+            object.collection_id(),
+            object.description().to_string(),
+        ),
+        object.class_id(),
+        object.data().clone(),
+    ))
+}
+
+pub(super) fn ready_computation_state(
+    class_id: ClassId,
+    revision: i64,
+    created_at: DateTime<Utc>,
+) -> Result<StorageClassComputationState, StorageError> {
+    StorageClassComputationState::builder(
+        class_id,
+        StorageComputationRevision::try_new(revision).map_err(invalid_contract_value)?,
+        StorageComputationRebuildStatus::Ready,
+        created_at,
+        Utc::now(),
+    )
+    .try_build()
+    .map_err(invalid_contract_value)
+}
+
+pub(super) fn updated_computed_field(
+    current: &StorageComputedFieldDefinition,
+    patch: &StorageComputedFieldDefinitionPatch,
+    actor_id: PrincipalId,
+) -> Result<StorageComputedFieldDefinition, StorageError> {
+    let metadata = current.metadata();
+    let metadata = StorageRecordMetadata::try_new(
+        metadata.id(),
+        metadata.created_at(),
+        Utc::now(),
+        metadata
+            .revision()
+            .checked_advance()
+            .map_err(|error| StorageError::internal(error.to_string()))?,
+    )
+    .map_err(invalid_contract_value)?;
+    let input = StorageComputedFieldDefinitionInput::new(
+        patch.key().unwrap_or(current.key()).to_string(),
+        patch.label().unwrap_or(current.label()).to_string(),
+        patch
+            .operation()
+            .cloned()
+            .unwrap_or_else(|| current.operation().clone()),
+        patch
+            .result_type()
+            .unwrap_or(current.result_type())
+            .to_string(),
+    )
+    .with_description(
+        patch
+            .description()
+            .unwrap_or(current.description())
+            .to_string(),
+    )
+    .with_enabled(patch.enabled().unwrap_or(current.enabled()));
+    Ok(StorageComputedFieldDefinition::new(
+        metadata,
+        current.class_id(),
+        current.visibility(),
+        StorageComputedFieldDefinitionContent::new(input, current.semantics_version()),
+        StorageComputedFieldProvenance::new(current.created_by(), Some(actor_id)),
+    ))
+}
+
+pub(super) fn evaluate_computed_definition(
+    definition: &StorageComputedFieldDefinition,
+    object: &StorageObject,
+) -> serde_json::Value {
+    definition
+        .operation()
+        .get("paths")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .find_map(|path| object.data().pointer(path).cloned())
+        .unwrap_or(serde_json::Value::Null)
+}
+
+pub(super) fn computed_scope(
+    state: &MemoryState,
+    object: &StorageObject,
+    visibility: StorageComputedFieldVisibility,
+) -> StorageComputedScope {
+    let values = state
+        .computed_fields
+        .values()
+        .filter(|definition| {
+            definition.class_id() == object.class_id()
+                && definition.visibility() == visibility
+                && definition.enabled()
+        })
+        .map(|definition| {
+            (
+                definition.key().to_string(),
+                evaluate_computed_definition(definition, object),
+            )
+        })
+        .collect();
+    StorageComputedScope::new(values, BTreeMap::new())
+}
+
+pub(super) fn computed_object(
+    state: &MemoryState,
+    object: StorageObject,
+    personal_owner_id: Option<PrincipalId>,
+) -> Result<StorageComputedObject, StorageError> {
+    let revision = state
+        .computation_states
+        .get(&object.class_id().id())
+        .map_or(0, |value| value.evaluation_revision().get());
+    let shared = StorageSharedComputedScope::new(
+        StorageComputationRevision::try_new(revision).map_err(invalid_contract_value)?,
+        false,
+        computed_scope(state, &object, StorageComputedFieldVisibility::Shared),
+    );
+    let personal = personal_owner_id.map(|owner_id| {
+        computed_scope(
+            state,
+            &object,
+            StorageComputedFieldVisibility::Personal { owner_id },
+        )
+    });
+    Ok(StorageComputedObject::new(object, shared, personal))
+}
+
+pub(super) fn export_output_summary(
+    output: &StorageExportOutput,
+) -> Result<StorageExportOutputSummary, StorageError> {
+    StorageExportOutputSummary::try_new(
+        output.task_id(),
+        output.template_name().map(ToOwned::to_owned),
+        output.content_type(),
+        output.warning_count(),
+        output.truncated(),
+        output.output_expires_at(),
+        output.durations(),
+    )
+    .map_err(invalid_contract_value)
+}
+
+pub(super) fn backup_output_summary(
+    output: &StorageBackupOutput,
+) -> Result<StorageBackupOutputSummary, StorageError> {
+    StorageBackupOutputSummary::try_new(
+        output.task_id(),
+        output.byte_size(),
+        output.sha256(),
+        output.output_expires_at(),
+    )
+    .map_err(invalid_contract_value)
+}
+
+pub(super) fn invalid_task_lease() -> StorageError {
+    StorageError::conflict("Task lease is no longer valid")
+}
+
+pub(super) fn advanced_principal(
+    current: &StoragePrincipal,
+    name: impl Into<String>,
+    settings: serde_json::Value,
+    updated_at: DateTime<Utc>,
+) -> Result<StoragePrincipal, StorageError> {
+    let revision = current
+        .revision()
+        .checked_advance()
+        .map_err(|error| StorageError::internal(error.to_string()))?;
+    let metadata = StorageRecordMetadata::try_new(
+        ResourceId::new(current.id().id()).expect("principal id is positive"),
+        current.created_at(),
+        updated_at,
+        revision,
+    )
+    .map_err(invalid_contract_value)?;
+    StoragePrincipal::builder(metadata, current.kind(), name, current.identity_scope_id())
+        .provider_managed(current.provider_managed())
+        .settings(settings)
+        .external_subject(current.external_subject().map(ToOwned::to_owned))
+        .last_sync_attempted_at(current.last_sync_attempted_at())
+        .last_sync_success_at(current.last_sync_success_at())
+        .try_build()
+        .map_err(invalid_contract_value)
+}
+
+pub(super) fn token_state_matches(
+    metadata: &StorageTokenMetadata,
+    state: StorageTokenListState,
+) -> bool {
+    match state {
+        StorageTokenListState::Active => metadata.is_active(),
+        StorageTokenListState::Expired => metadata.is_expired(),
+        StorageTokenListState::Revoked => metadata.revoked_at().is_some(),
+        StorageTokenListState::All => true,
+    }
+}
+
+pub(super) fn empty_event_fanout_snapshot() -> Result<StorageEventFanoutSnapshot, StorageError> {
+    StorageEventFanoutSnapshot::try_new(0, 0, 0, None).map_err(invalid_contract_value)
+}
+
+pub(super) fn empty_event_queue_snapshot() -> Result<StorageEventQueueSnapshot, StorageError> {
+    StorageEventQueueSnapshot::try_new(
+        StorageEventDeliveryStatusSnapshot::try_new(0, 0, 0, 0, 0, 0, 0)
+            .map_err(invalid_contract_value)?,
+        0,
+        None,
+    )
+    .map_err(invalid_contract_value)
+}

--- a/crates/hubuum-storage-postgres/migrations/2026-08-31-000001_token_hash_key_ring/down.sql
+++ b/crates/hubuum-storage-postgres/migrations/2026-08-31-000001_token_hash_key_ring/down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE tokens
+    DROP CONSTRAINT IF EXISTS tokens_hash_key_id_valid,
+    DROP CONSTRAINT IF EXISTS tokens_versioned_key_id_present,
+    DROP CONSTRAINT IF EXISTS tokens_token_hash_algorithm_supported,
+    DROP CONSTRAINT IF EXISTS tokens_token_format_supported,
+    DROP COLUMN IF EXISTS token_hash_key_id,
+    DROP COLUMN IF EXISTS token_hash_algorithm,
+    DROP COLUMN IF EXISTS token_format;

--- a/crates/hubuum-storage-postgres/migrations/2026-08-31-000001_token_hash_key_ring/up.sql
+++ b/crates/hubuum-storage-postgres/migrations/2026-08-31-000001_token_hash_key_ring/up.sql
@@ -1,0 +1,17 @@
+ALTER TABLE tokens
+    ADD COLUMN token_format SMALLINT NOT NULL DEFAULT 0,
+    ADD COLUMN token_hash_algorithm SMALLINT NOT NULL DEFAULT 1,
+    ADD COLUMN token_hash_key_id VARCHAR(32);
+
+ALTER TABLE tokens
+    ADD CONSTRAINT tokens_token_format_supported
+        CHECK (token_format IN (0, 1)) NOT VALID,
+    ADD CONSTRAINT tokens_token_hash_algorithm_supported
+        CHECK (token_hash_algorithm = 1) NOT VALID,
+    ADD CONSTRAINT tokens_versioned_key_id_present
+        CHECK (token_format = 0 OR token_hash_key_id IS NOT NULL) NOT VALID,
+    ADD CONSTRAINT tokens_hash_key_id_valid
+        CHECK (
+            token_hash_key_id IS NULL
+            OR token_hash_key_id ~ '^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$'
+        ) NOT VALID;

--- a/crates/hubuum-storage-postgres/migrations/2026-08-31-000002_validate_token_hash_key_ring/down.sql
+++ b/crates/hubuum-storage-postgres/migrations/2026-08-31-000002_validate_token_hash_key_ring/down.sql
@@ -1,0 +1,1 @@
+-- Validation changes no schema state and requires no rollback action.

--- a/crates/hubuum-storage-postgres/migrations/2026-08-31-000002_validate_token_hash_key_ring/up.sql
+++ b/crates/hubuum-storage-postgres/migrations/2026-08-31-000002_validate_token_hash_key_ring/up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE tokens VALIDATE CONSTRAINT tokens_token_format_supported;
+
+ALTER TABLE tokens VALIDATE CONSTRAINT tokens_token_hash_algorithm_supported;
+
+ALTER TABLE tokens VALIDATE CONSTRAINT tokens_versioned_key_id_present;
+
+ALTER TABLE tokens VALIDATE CONSTRAINT tokens_hash_key_id_valid;

--- a/crates/hubuum-storage-postgres/migrations/2026-08-31-000003_token_hash_key_retirement_index/down.sql
+++ b/crates/hubuum-storage-postgres/migrations/2026-08-31-000003_token_hash_key_retirement_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tokens_token_hash_key_retirement_idx;

--- a/crates/hubuum-storage-postgres/migrations/2026-08-31-000003_token_hash_key_retirement_index/metadata.toml
+++ b/crates/hubuum-storage-postgres/migrations/2026-08-31-000003_token_hash_key_retirement_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/hubuum-storage-postgres/migrations/2026-08-31-000003_token_hash_key_retirement_index/up.sql
+++ b/crates/hubuum-storage-postgres/migrations/2026-08-31-000003_token_hash_key_retirement_index/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY tokens_token_hash_key_retirement_idx
+    ON tokens (token_hash_key_id, revoked_at, expires_at);

--- a/crates/hubuum-storage-postgres/src/backend/capabilities/identity.rs
+++ b/crates/hubuum-storage-postgres/src/backend/capabilities/identity.rs
@@ -410,6 +410,15 @@ impl TokenStorage for PostgresStorage {
             .map_err(StorageError::from)
     }
 
+    async fn token_key_usage(
+        &self,
+        observation: StorageTokenObservation,
+    ) -> Result<Vec<StorageTokenKeyUsage>, StorageError> {
+        crate::operations::token::token_key_usage(self.runtime(), observation)
+            .await
+            .map_err(StorageError::from)
+    }
+
     async fn create_token(
         &self,
         request: StorageTokenCreate,

--- a/crates/hubuum-storage-postgres/src/operations/authentication.rs
+++ b/crates/hubuum-storage-postgres/src/operations/authentication.rs
@@ -5,9 +5,10 @@ use diesel::sql_types::{Bool, Nullable};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{IdentityScopeId, PrincipalId, PrincipalKind, UserId};
 use hubuum_storage_core::{
-    StorageAuthenticatedToken, StorageAuthenticationAttempt, StorageAuthenticationHuman,
-    StorageAuthenticationIdentity, StorageAuthenticationPrincipal, StorageAuthenticationTokenScope,
-    StorageAuthenticationTokenScopeQuery,
+    StorageAuthenticatedToken, StorageAuthenticationAttempt, StorageAuthenticationCredential,
+    StorageAuthenticationHuman, StorageAuthenticationIdentity, StorageAuthenticationPrincipal,
+    StorageAuthenticationTokenScope, StorageAuthenticationTokenScopeQuery, StorageTokenFormat,
+    StorageTokenHashAlgorithm, StorageTokenHashKeyId, StorageTokenMigrationOutcome,
 };
 
 use crate::schema;
@@ -17,6 +18,76 @@ use crate::{PostgresRevision, PostgresRuntime, PostgresStorageError};
 /// stay read-only on the hot path, and a telemetry write failure never rejects
 /// an otherwise valid credential.
 const LAST_USED_AT_THROTTLE_SECS: i64 = 60;
+
+#[derive(Clone, Queryable, Selectable)]
+#[diesel(table_name = crate::schema::tokens)]
+struct AuthenticationTokenRow {
+    id: i32,
+    token: String,
+    principal_id: i32,
+    name: Option<String>,
+    description: Option<String>,
+    issued: NaiveDateTime,
+    expires_at: Option<NaiveDateTime>,
+    last_used_at: Option<NaiveDateTime>,
+    permission_scoped: bool,
+    resource_scoped: bool,
+    revision: PostgresRevision,
+    token_format: i16,
+    token_hash_algorithm: i16,
+    token_hash_key_id: Option<String>,
+}
+
+impl AuthenticationTokenRow {
+    fn matches(
+        &self,
+        credential: &StorageAuthenticationCredential,
+    ) -> Result<bool, PostgresStorageError> {
+        persisted_credential_matches(
+            &self.token,
+            self.token_format,
+            self.token_hash_algorithm,
+            self.token_hash_key_id.as_deref(),
+            credential,
+        )
+    }
+}
+
+pub(crate) fn persisted_credential_matches(
+    token_hash: &str,
+    token_format: i16,
+    token_hash_algorithm: i16,
+    token_hash_key_id: Option<&str>,
+    credential: &StorageAuthenticationCredential,
+) -> Result<bool, PostgresStorageError> {
+    let persisted_format = StorageTokenFormat::from_persistence(token_format)
+        .map_err(|error| PostgresStorageError::invalid_persisted_value("token format", error))?;
+    let persisted_algorithm = StorageTokenHashAlgorithm::from_persistence(token_hash_algorithm)
+        .map_err(|error| {
+            PostgresStorageError::invalid_persisted_value("token hash algorithm", error)
+        })?;
+    let persisted_key_id = token_hash_key_id
+        .map(StorageTokenHashKeyId::try_new)
+        .transpose()
+        .map_err(|error| {
+            PostgresStorageError::invalid_persisted_value("token hash key ID", error)
+        })?;
+    let candidate = credential.digest();
+    if !candidate.matches_lookup_value(token_hash)
+        || persisted_format != candidate.format()
+        || persisted_algorithm != candidate.algorithm()
+    {
+        return Ok(false);
+    }
+    Ok(match persisted_format {
+        StorageTokenFormat::Version1 => persisted_key_id.as_ref() == candidate.key_id(),
+        StorageTokenFormat::Legacy => {
+            persisted_key_id.is_none()
+                || candidate.key_id().is_none()
+                || persisted_key_id.as_ref() == candidate.key_id()
+        }
+    })
+}
 
 /// Boxed PostgreSQL predicate for an active token.
 ///
@@ -42,77 +113,108 @@ pub async fn authenticate_bearer_token(
 ) -> Result<StorageAuthenticatedToken, PostgresStorageError> {
     use crate::schema::service_accounts;
     use crate::schema::tokens::dsl::{
-        description, expires_at, id as token_id, issued, last_used_at, name, permission_scoped,
-        principal_id, resource_scoped, revision, token, tokens,
+        id as token_id, last_used_at, token, token_format, token_hash_algorithm, token_hash_key_id,
+        tokens,
     };
 
-    let (credential, observed_at, legacy_valid_after) = attempt.into_parts();
+    let (credentials, migration_target, observed_at, legacy_valid_after) = attempt.into_parts();
     let observed_at = observed_at.naive_utc();
     let legacy_valid_after = legacy_valid_after.naive_utc();
-    let lookup_value = credential.lookup_value().to_string();
-    let row = runtime
+    let lookup_values = credentials
+        .iter()
+        .map(|credential| credential.lookup_value().to_string())
+        .collect::<Vec<_>>();
+    let rows = runtime
         .with_connection(async move |conn| {
             tokens
-                .filter(token.eq(lookup_value))
+                .filter(token.eq_any(lookup_values))
                 .filter(active_token_predicate(observed_at, legacy_valid_after))
                 .filter(diesel::dsl::not(diesel::dsl::exists(
                     service_accounts::table
-                        .filter(service_accounts::id.eq(principal_id))
+                        .filter(service_accounts::id.eq(crate::schema::tokens::principal_id))
                         .filter(service_accounts::disabled_at.is_not_null()),
                 )))
-                .select((
-                    token_id,
-                    principal_id,
-                    name,
-                    description,
-                    issued,
-                    expires_at,
-                    permission_scoped,
-                    resource_scoped,
-                    last_used_at,
-                    revision,
-                ))
-                .first::<(
-                    i32,
-                    i32,
-                    Option<String>,
-                    Option<String>,
-                    NaiveDateTime,
-                    Option<NaiveDateTime>,
-                    bool,
-                    bool,
-                    Option<NaiveDateTime>,
-                    PostgresRevision,
-                )>(conn)
+                .select(AuthenticationTokenRow::as_select())
+                .load::<AuthenticationTokenRow>(conn)
                 .await
-                .optional()
         })
         .await?;
-
-    let Some((
-        id,
-        principal_id_value,
-        token_name,
-        token_description,
-        token_issued,
-        token_expires_at,
-        is_permission_scoped,
-        is_resource_scoped,
-        last_used,
-        token_revision,
-    )) = row
-    else {
+    let mut matching = rows
+        .into_iter()
+        .map(|row| {
+            let matches = credentials
+                .iter()
+                .map(|credential| row.matches(credential))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
+                .any(|matches| matches);
+            Ok(matches.then_some(row))
+        })
+        .collect::<Result<Vec<_>, PostgresStorageError>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    if matching.len() > 1 {
+        return Err(PostgresStorageError::database(
+            "multiple token rows matched one bearer credential",
+        ));
+    }
+    let Some(row) = matching.pop() else {
         return Err(PostgresStorageError::authentication_required(
             "Invalid token",
         ));
     };
 
+    let mut migration_outcome = StorageTokenMigrationOutcome::NotNeeded;
+    if row.token_format == StorageTokenFormat::Legacy.persistence_value()
+        && row.token_hash_key_id.is_none()
+        && let Some(target) = migration_target
+    {
+        let (target_hash, target_format, target_algorithm, target_key_id) = target.into_parts();
+        let target_key_id = target_key_id.map(|id| id.to_string());
+        let matched_hash = row.token.clone();
+        let id = row.id;
+        let migration = runtime
+            .with_connection(async move |conn| {
+                diesel::update(
+                    tokens
+                        .filter(token_id.eq(id))
+                        .filter(token.eq(matched_hash))
+                        .filter(token_format.eq(StorageTokenFormat::Legacy.persistence_value()))
+                        .filter(token_hash_key_id.is_null())
+                        .filter(active_token_predicate(observed_at, legacy_valid_after)),
+                )
+                .set((
+                    token.eq(target_hash),
+                    token_format.eq(target_format.persistence_value()),
+                    token_hash_algorithm.eq(target_algorithm.persistence_value()),
+                    token_hash_key_id.eq(target_key_id),
+                ))
+                .execute(conn)
+                .await
+            })
+            .await;
+        match migration {
+            Ok(1) => migration_outcome = StorageTokenMigrationOutcome::Migrated,
+            Ok(_) => migration_outcome = StorageTokenMigrationOutcome::Conflict,
+            Err(_) => {
+                migration_outcome = StorageTokenMigrationOutcome::Conflict;
+                tracing::warn!(
+                    message = "Legacy token digest migration did not complete",
+                    outcome = "storage_conflict"
+                );
+            }
+        }
+    }
+
     let throttle = chrono::Duration::seconds(LAST_USED_AT_THROTTLE_SECS);
-    let mut observed_last_used = last_used;
-    let last_used_is_stale = last_used
+    let mut observed_last_used = row.last_used_at;
+    let last_used_is_stale = row
+        .last_used_at
         .map(|previous| observed_at - previous >= throttle)
         .unwrap_or(true);
     if last_used_is_stale {
+        let id = row.id;
         let updated = runtime
             .with_connection(async move |conn| {
                 diesel::update(tokens.filter(token_id.eq(id)))
@@ -129,17 +231,18 @@ pub async fn authenticate_bearer_token(
     crate::validate_persisted(
         "authenticated token",
         StorageAuthenticatedToken::builder(
-            hubuum_domain::TokenId::new(id)?,
-            hubuum_domain::PrincipalId::new(principal_id_value)?,
-            token_issued.and_utc(),
-            token_revision.into_domain(),
+            hubuum_domain::TokenId::new(row.id)?,
+            hubuum_domain::PrincipalId::new(row.principal_id)?,
+            row.issued.and_utc(),
+            row.revision.into_domain(),
         )
-        .name(token_name)
-        .description(token_description)
-        .expires_at(token_expires_at.map(|timestamp| timestamp.and_utc()))
+        .name(row.name)
+        .description(row.description)
+        .expires_at(row.expires_at.map(|timestamp| timestamp.and_utc()))
         .last_used_at(observed_last_used.map(|timestamp| timestamp.and_utc()))
-        .permission_scoped(is_permission_scoped)
-        .resource_scoped(is_resource_scoped)
+        .permission_scoped(row.permission_scoped)
+        .resource_scoped(row.resource_scoped)
+        .migration_outcome(migration_outcome)
         .try_build(),
     )
 }

--- a/crates/hubuum-storage-postgres/src/operations/token.rs
+++ b/crates/hubuum-storage-postgres/src/operations/token.rs
@@ -5,8 +5,10 @@ use std::collections::HashMap;
 use chrono::NaiveDateTime;
 use diesel::pg::Pg;
 use diesel::prelude::{ExpressionMethods, OptionalExtension, QueryDsl};
-use diesel::sql_types::Timestamp;
-use diesel::{BoolExpressionMethods, Insertable, Queryable, Selectable, SelectableHelper};
+use diesel::sql_types::{BigInt, Nullable, Text, Timestamp};
+use diesel::{
+    BoolExpressionMethods, Insertable, Queryable, QueryableByName, Selectable, SelectableHelper,
+};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{ClassId, CollectionId, ObjectId, TokenId, TokenIssuancePolicy};
 use hubuum_events_core::{Action, AuditDocument, EntityType, EventContext, NewEvent};
@@ -15,7 +17,8 @@ use hubuum_storage_core::{
     StorageAuditReceipt, StorageAuditReceipts, StorageAuthenticationResourceScope,
     StorageAuthenticationTokenScope, StorageAuthenticationTokenScopeQuery,
     StorageAuthorizationPermission, StorageMutationOutcome, StoragePage,
-    StoragePrincipalTokensRevoke, StorageTokenCreate, StorageTokenHashRevoke,
+    StoragePrincipalTokensRevoke, StorageTokenCreate, StorageTokenDigest, StorageTokenFormat,
+    StorageTokenHashAlgorithm, StorageTokenHashKeyId, StorageTokenHashRevoke, StorageTokenKeyUsage,
     StorageTokenListQuery, StorageTokenListState, StorageTokenMetadata, StorageTokenObservation,
     StorageTokenRenew, StorageTokenRevoke,
 };
@@ -29,6 +32,24 @@ use crate::runtime::assert_locked_revision_precondition;
 use crate::{PostgresConnection, PostgresRevision, PostgresRuntime, PostgresStorageError};
 
 const SERVICE_ACCOUNT_PRINCIPAL_KIND: &str = "service_account";
+
+#[derive(QueryableByName)]
+struct TokenKeyUsageRow {
+    #[diesel(sql_type = Nullable<Text>)]
+    token_hash_key_id: Option<String>,
+    #[diesel(sql_type = BigInt)]
+    active: i64,
+    #[diesel(sql_type = BigInt)]
+    revoked: i64,
+    #[diesel(sql_type = BigInt)]
+    expired: i64,
+    #[diesel(sql_type = Nullable<Timestamp>)]
+    latest_validation: Option<NaiveDateTime>,
+    #[diesel(sql_type = Nullable<Timestamp>)]
+    earliest_expiry: Option<NaiveDateTime>,
+    #[diesel(sql_type = Nullable<Timestamp>)]
+    latest_expiry: Option<NaiveDateTime>,
+}
 
 fn permission_from_persisted(
     value: String,
@@ -52,6 +73,9 @@ struct TokenRow {
     permission_scoped: bool,
     resource_scoped: bool,
     revision: PostgresRevision,
+    token_format: i16,
+    token_hash_algorithm: i16,
+    token_hash_key_id: Option<String>,
 }
 
 impl TokenRow {
@@ -64,6 +88,26 @@ impl TokenRow {
         scope: Option<StorageAuthenticationTokenScope>,
         observation: StorageTokenObservation,
     ) -> Result<StorageTokenMetadata, PostgresStorageError> {
+        let token_format =
+            StorageTokenFormat::from_persistence(self.token_format).map_err(|error| {
+                PostgresStorageError::invalid_persisted_value("token format", error)
+            })?;
+        StorageTokenHashAlgorithm::from_persistence(self.token_hash_algorithm).map_err(
+            |error| PostgresStorageError::invalid_persisted_value("token hash algorithm", error),
+        )?;
+        let key_id = self
+            .token_hash_key_id
+            .as_deref()
+            .map(StorageTokenHashKeyId::try_new)
+            .transpose()
+            .map_err(|error| {
+                PostgresStorageError::invalid_persisted_value("token hash key ID", error)
+            })?;
+        if token_format == StorageTokenFormat::Version1 && key_id.is_none() {
+            return Err(PostgresStorageError::database(
+                "versioned token row is missing its hash key ID",
+            ));
+        }
         if self.is_scoped() != scope.is_some() {
             return Err(PostgresStorageError::database(format!(
                 "Token {} has inconsistent scope flags and rows",
@@ -113,6 +157,9 @@ impl TokenRow {
             "resource_scoped": self.resource_scoped,
             "scope": scope.map(scope_snapshot),
             "revision": self.revision,
+            "token_format": self.token_format,
+            "token_hash_algorithm": self.token_hash_algorithm,
+            "token_hash_key_id": self.token_hash_key_id,
         })
     }
 }
@@ -234,7 +281,7 @@ pub async fn create_token(
 ) -> Result<StorageMutationOutcome<StorageTokenMetadata>, PostgresStorageError> {
     let parts = request.into_parts();
     let principal_id = parts.principal_id().id();
-    let token_hash = parts.token_hash().to_string();
+    let digest = parts.digest().clone();
     let name = parts.name().map(str::to_string);
     let description = parts.description().map(str::to_string);
     let expires_at = parts.expires_at().map(|timestamp| timestamp.naive_utc());
@@ -252,7 +299,7 @@ pub async fn create_token(
                     connection,
                     TokenCreateParts {
                         principal_id,
-                        token_hash,
+                        digest,
                         name,
                         description,
                         expires_at,
@@ -273,11 +320,63 @@ pub async fn create_token(
         .await
 }
 
+pub async fn token_key_usage(
+    runtime: &PostgresRuntime,
+    observation: StorageTokenObservation,
+) -> Result<Vec<StorageTokenKeyUsage>, PostgresStorageError> {
+    let (observed_at, legacy_valid_after) = observation.into_parts();
+    let observed_at = observed_at.naive_utc();
+    let legacy_valid_after = legacy_valid_after.naive_utc();
+    let rows = runtime
+        .with_connection(async move |connection| {
+            diesel::sql_query(
+                "SELECT token_hash_key_id, \
+                 COUNT(*) FILTER (WHERE revoked_at IS NULL AND \
+                     (expires_at > $1 OR (expires_at IS NULL AND issued > $2))) AS active, \
+                 COUNT(*) FILTER (WHERE revoked_at IS NOT NULL) AS revoked, \
+                 COUNT(*) FILTER (WHERE revoked_at IS NULL AND NOT \
+                     (expires_at > $1 OR (expires_at IS NULL AND issued > $2))) AS expired, \
+                 MAX(last_used_at) AS latest_validation, \
+                 MIN(expires_at) AS earliest_expiry, \
+                 MAX(expires_at) AS latest_expiry \
+                 FROM tokens GROUP BY token_hash_key_id ORDER BY token_hash_key_id NULLS FIRST",
+            )
+            .bind::<Timestamp, _>(observed_at)
+            .bind::<Timestamp, _>(legacy_valid_after)
+            .load::<TokenKeyUsageRow>(connection)
+            .await
+        })
+        .await?;
+    rows.into_iter()
+        .map(|row| {
+            let key_id = row
+                .token_hash_key_id
+                .map(StorageTokenHashKeyId::try_new)
+                .transpose()
+                .map_err(|error| {
+                    PostgresStorageError::invalid_persisted_value("token hash key ID", error)
+                })?;
+            crate::validate_persisted(
+                "token key usage",
+                StorageTokenKeyUsage::try_new(
+                    key_id,
+                    row.active,
+                    row.revoked,
+                    row.expired,
+                    row.latest_validation.map(|value| value.and_utc()),
+                    row.earliest_expiry.map(|value| value.and_utc()),
+                    row.latest_expiry.map(|value| value.and_utc()),
+                ),
+            )
+        })
+        .collect()
+}
+
 pub async fn renew_token(
     runtime: &PostgresRuntime,
     request: StorageTokenRenew,
 ) -> Result<StorageMutationOutcome<StorageTokenMetadata>, PostgresStorageError> {
-    let (source_token_id, principal_id, token_hash, expires_at, policy, event_context) =
+    let (source_token_id, principal_id, digest, expires_at, policy, event_context) =
         request.into_parts();
     let expires_at = expires_at.map(|timestamp| timestamp.naive_utc());
     let source_token_id = source_token_id.id();
@@ -318,7 +417,7 @@ pub async fn renew_token(
                     connection,
                     TokenCreateParts {
                         principal_id,
-                        token_hash,
+                        digest,
                         name: source.name,
                         description: source.description,
                         expires_at,
@@ -475,24 +574,65 @@ pub async fn revoke_token_by_hash(
     runtime: &PostgresRuntime,
     request: StorageTokenHashRevoke,
 ) -> Result<StorageMutationOutcome<usize>, PostgresStorageError> {
-    let (principal_id, token_hash, event_context) = request.into_parts();
+    let (principal_id, credentials, event_context) = request.into_parts();
     let principal_id = principal_id.map(|principal_id| principal_id.id());
     if let Some(principal_id) = principal_id {
         validate_positive_id(principal_id, "principal id")?;
     }
     runtime
         .with_transaction(async move |connection| {
-            let before = crate::schema::tokens::table
-                .filter(crate::schema::tokens::token.eq(token_hash))
+            let lookup_values = credentials
+                .iter()
+                .map(|credential| credential.lookup_value().to_string())
+                .collect::<Vec<_>>();
+            let mut candidates = crate::schema::tokens::table
+                .filter(crate::schema::tokens::token.eq_any(lookup_values))
                 .filter(crate::schema::tokens::revoked_at.is_null())
+                .select((
+                    crate::schema::tokens::id,
+                    crate::schema::tokens::token,
+                    crate::schema::tokens::token_format,
+                    crate::schema::tokens::token_hash_algorithm,
+                    crate::schema::tokens::token_hash_key_id,
+                ))
                 .for_update()
-                .select(TokenRow::as_select())
-                .first::<TokenRow>(connection)
-                .await
-                .optional()?;
-            let Some(before) = before else {
+                .load::<(i32, String, i16, i16, Option<String>)>(connection)
+                .await?
+                .into_iter()
+                .map(|candidate| {
+                    let matches = credentials
+                        .iter()
+                        .map(|credential| {
+                            crate::operations::authentication::persisted_credential_matches(
+                                &candidate.1,
+                                candidate.2,
+                                candidate.3,
+                                candidate.4.as_deref(),
+                                credential,
+                            )
+                        })
+                        .collect::<Result<Vec<_>, _>>()?
+                        .into_iter()
+                        .any(|matches| matches);
+                    Ok(matches.then_some(candidate.0))
+                })
+                .collect::<Result<Vec<_>, PostgresStorageError>>()?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+            if candidates.len() > 1 {
+                return Err(PostgresStorageError::database(
+                    "multiple token rows matched one bearer credential",
+                ));
+            }
+            let Some(token_id) = candidates.pop() else {
                 return Ok(StorageMutationOutcome::unchanged(0));
             };
+            let before = crate::schema::tokens::table
+                .filter(crate::schema::tokens::id.eq(token_id))
+                .select(TokenRow::as_select())
+                .first::<TokenRow>(connection)
+                .await?;
             if principal_id.is_some_and(|principal_id| principal_id != before.principal_id) {
                 return Ok(StorageMutationOutcome::unchanged(0));
             }
@@ -688,7 +828,7 @@ pub(crate) async fn load_token_scope(
 
 struct TokenCreateParts {
     principal_id: i32,
-    token_hash: String,
+    digest: StorageTokenDigest,
     name: Option<String>,
     description: Option<String>,
     expires_at: Option<NaiveDateTime>,
@@ -705,7 +845,7 @@ async fn create_token_row(
 ) -> Result<(TokenRow, StorageAuditReceipt), PostgresStorageError> {
     let TokenCreateParts {
         principal_id,
-        token_hash,
+        digest,
         name,
         description,
         expires_at,
@@ -715,6 +855,8 @@ async fn create_token_row(
         renewed_from_token_id,
         principal_already_checked,
     } = parts;
+    let (token_hash, token_format, token_hash_algorithm, token_hash_key_id) = digest.into_parts();
+    let token_hash_key_id = token_hash_key_id.map(|id| id.to_string());
     let (permissions, resources) = scope
         .clone()
         .map(StorageAuthenticationTokenScope::into_parts)
@@ -757,6 +899,10 @@ async fn create_token_row(
             crate::schema::tokens::expires_at.eq(Some(effective_expiry)),
             crate::schema::tokens::permission_scoped.eq(permission_scoped),
             crate::schema::tokens::resource_scoped.eq(resource_scoped),
+            crate::schema::tokens::token_format.eq(token_format.persistence_value()),
+            crate::schema::tokens::token_hash_algorithm
+                .eq(token_hash_algorithm.persistence_value()),
+            crate::schema::tokens::token_hash_key_id.eq(token_hash_key_id),
         ))
         .returning(TokenRow::as_returning())
         .get_result::<TokenRow>(connection)

--- a/crates/hubuum-storage-postgres/src/runtime.rs
+++ b/crates/hubuum-storage-postgres/src/runtime.rs
@@ -20,7 +20,7 @@ use crate::revision::revision_owner_key;
 use crate::{PostgresConnection, PostgresPool, PostgresPooledConnection, PostgresStorageError};
 
 /// Latest migration required by this adapter.
-pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260824000001";
+pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260831000003";
 pub const DEFAULT_COMPUTED_REINDEX_BATCH_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
 
 /// Adapter-level observation hook supplied by the application composition root.
@@ -716,5 +716,31 @@ fn log_completion<R>(
             elapsed_ms,
             error = %error,
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use super::REQUIRED_DATABASE_MIGRATION_VERSION;
+
+    #[test]
+    fn required_database_migration_version_matches_latest_migration() {
+        let migrations = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("migrations");
+        let latest = fs::read_dir(migrations)
+            .expect("migration directory must be readable")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .max()
+            .expect("at least one migration must exist");
+        let version = latest
+            .split_once('_')
+            .map_or(latest.as_str(), |(version, _)| version)
+            .replace('-', "");
+
+        assert_eq!(REQUIRED_DATABASE_MIGRATION_VERSION, version);
     }
 }

--- a/crates/hubuum-storage-postgres/src/schema.rs
+++ b/crates/hubuum-storage-postgres/src/schema.rs
@@ -751,6 +751,10 @@ diesel::table! {
         permission_scoped -> Bool,
         resource_scoped -> Bool,
         revision -> Int8,
+        token_format -> Int2,
+        token_hash_algorithm -> Int2,
+        #[max_length = 32]
+        token_hash_key_id -> Nullable<Varchar>,
     }
 }
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -476,6 +476,11 @@ Backend:
 - `HUBUUM_BIND_PORT`: internal backend API listen port. Default: `8080`.
 - `HUBUUM_LOG_LEVEL=info`
 - `HUBUUM_TOKEN_HASH_KEY`: generated stable token hash key.
+- `HUBUUM_REQUIRE_STABLE_TOKEN_HASH_KEY=true`: prevents accidental ephemeral
+  startup. The generated installation remains in compatible single-key mode;
+  convert it with the staged procedure in
+  [Secret Sources](secret_sources.md#token-key-ring-rotation) when rotation is
+  required.
 - `HUBUUM_CLIENT_ALLOWLIST`: defaults to the container bridge subnet.
 - `HUBUUM_TRUST_IP_HEADERS=false`
 - `HUBUUM_TOKEN_LIFETIME_HOURS=24`

--- a/docs/distributed_deployment.md
+++ b/docs/distributed_deployment.md
@@ -214,9 +214,10 @@ All replicas must use the same values for settings that define cluster-wide
 identity or behavior. In particular:
 
 - `HUBUUM_DATABASE_URL` must point to the same PostgreSQL database.
-- `HUBUUM_TOKEN_HASH_KEY` must be one stable shared secret. Tokens are stored in
-  PostgreSQL, but replicas cannot verify the same token hash with different
-  keys.
+- The token hash key ring (active ID, ordered previous IDs, and every key's
+  material) must be equivalent on all replicas except during the documented
+  staged rotation boundary. Compare the redacted ring identity in runtime
+  configuration before advancing a rollout.
 - Authentication-provider configuration and referenced credentials must be
   equivalent on every API and worker replica.
 - Task lease and event lock durations should be consistent across worker
@@ -231,6 +232,10 @@ running-configuration endpoint. Secret fields report only whether they are
 configured. Its database section also reports the selected complete storage
 backend and effective pool settings. Every replica in one deployment must
 report the same backend and compatible settings.
+
+Use the [token key-ring rotation procedure](secret_sources.md#token-key-ring-rotation)
+for multi-replica changes. Changing a single key in place is not a safe online
+rotation.
 
 ## Shared Login Throttling
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -19436,11 +19436,19 @@
           "token_retention_purge_interval_seconds",
           "token_retention_purge_batch_size",
           "stable_token_hash_key_configured",
+          "token_hash_key_mode",
+          "active_token_hash_key_id",
+          "previous_token_hash_key_ids",
+          "token_hash_key_ring_identity",
+          "require_stable_token_hash_key",
           "admin_groupname",
           "provider_config_path",
           "login_rate_limit"
         ],
         "properties": {
+          "active_token_hash_key_id": {
+            "type": "string"
+          },
           "admin_groupname": {
             "type": "string"
           },
@@ -19457,11 +19465,26 @@
             "type": "integer",
             "format": "int64"
           },
+          "previous_token_hash_key_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "provider_config_path": {
             "$ref": "#/components/schemas/SecretStatus"
           },
+          "require_stable_token_hash_key": {
+            "type": "boolean"
+          },
           "stable_token_hash_key_configured": {
             "type": "boolean"
+          },
+          "token_hash_key_mode": {
+            "type": "string"
+          },
+          "token_hash_key_ring_identity": {
+            "type": "string"
           },
           "token_lifetime_hours": {
             "type": "integer",

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -221,6 +221,9 @@ Paginated responses include `X-Page-Limit` with the effective page size.
 | `HUBUUM_LOGIN_RATE_LIMIT_VALKEY_PREFIX` | `hubuum:login-rate-limit` | Shared limiter key namespace |
 | `HUBUUM_LOGIN_RATE_LIMIT_VALKEY_IO_TIMEOUT_MS` | `1000` | Shared backend I/O timeout |
 | `HUBUUM_TOKEN_HASH_KEY` | *(generated per startup if unset)* | Key used for deterministic token hashing at rest |
+| `HUBUUM_TOKEN_HASH_ACTIVE_KEY_ID` | *(legacy single-key mode)* | Active key ID for newly issued tokens |
+| `HUBUUM_TOKEN_HASH_PREVIOUS_KEY_IDS` | *(empty)* | Comma-separated previous verification key IDs (maximum seven) |
+| `HUBUUM_REQUIRE_STABLE_TOKEN_HASH_KEY` | `false` | Fail startup when stable token key material is unavailable |
 | `HUBUUM_SECRET_SOURCE` | `environment` | Process-wide secret source: `environment` or `file` |
 | `HUBUUM_SECRET_FILE_ROOT` | *(empty)* | Mounted secret root required by the `file` source |
 
@@ -239,7 +242,12 @@ also exposes this limit as `authentication.max_token_lifetime_hours`.
 
 **Login rate-limit note**: These settings throttle failed logins across layered scopes with exponential backoff. For the full model, client-IP resolution behind proxies, and the admin endpoints for inspecting and releasing throttled scopes, see [login_rate_limiting.md](login_rate_limiting.md).
 
-**Token hash key note**: If `HUBUUM_TOKEN_HASH_KEY` is not set, Hubuum generates an ephemeral key on startup and logs a warning. Tokens issued before restart will be invalid after restart. All API replicas must use the same stable value.
+**Token hash key note**: If neither the compatible
+`HUBUUM_TOKEN_HASH_KEY` nor a key ring is configured, Hubuum generates an
+ephemeral key on startup and logs a warning. Tokens issued before restart will
+be invalid after restart. All API replicas must use the same ring. See
+[Secret Sources](secret_sources.md#token-key-ring-rotation) for the staged
+multi-replica procedure.
 
 For runtime roles, one-shot migrations, task recovery, database connection
 budgeting, and shared limiter behavior, see

--- a/docs/rust_api/hubuum-storage-core.md
+++ b/docs/rust_api/hubuum-storage-core.md
@@ -97,7 +97,7 @@ revision conflicts, retention retry identity, delivery recovery, restore
 coordination rollback, and lease-loss finalization, while each backend owns
 native query, transaction, migration, connection-loss, and failure tests.
 External-crate integration tests implement all 44 complete-backend traits,
-compile every one of their 249 methods, exercise every transaction port, and
+compile every one of their 250 methods, exercise every transaction port, and
 name public construction paths for all current adapter-returned values. CI also
 packages the crate, builds rustdoc with warnings denied, and compares it with
 the latest crates.io release when a baseline exists.

--- a/docs/secret_sources.md
+++ b/docs/secret_sources.md
@@ -11,7 +11,8 @@ The default source is `environment`. Existing deployments remain compatible:
 | Consumer | Environment mapping |
 | --- | --- |
 | PostgreSQL | `HUBUUM_DATABASE_URL` |
-| Token hashing | `HUBUUM_TOKEN_HASH_KEY` |
+| Token hashing (compatible single key) | `HUBUUM_TOKEN_HASH_KEY` |
+| Token key-ring ID `primary` | `HUBUUM_TOKEN_HASH_KEY_PRIMARY` |
 | Event sink alias `NAME` | `HUBUUM_EVENT_SINK_SECRET_NAME` |
 | Remote-target alias `NAME` | `HUBUUM_REMOTE_SECRET_NAME` |
 | LDAP alias `NAME` | `HUBUUM_LDAP_SECRET_NAME` |
@@ -48,7 +49,9 @@ The root has a fixed, application-owned layout:
 ├── remote/
 │   └── <alias>
 └── token/
-    └── key
+    ├── key
+    ├── primary
+    └── previous
 ```
 
 The file provider accepts binary values up to 1 MiB, opens ordinary files
@@ -77,11 +80,10 @@ and Valkey sink connection pools key clients by the resolved URI, so a rotated
 credential creates a new client and old idle clients leave through the existing
 bounded LRU policy.
 
-The PostgreSQL URL and token-hash key are startup secrets. Rotate them by
-updating every replica's source and restarting the replicas according to the
-database or token-key migration procedure. Hubuum does not claim live rotation
-for an established database pool or for token hashing. Token key-ring rotation
-is tracked separately from this source abstraction.
+The PostgreSQL URL and token-hash keys are startup secrets. Updating their
+source does not change an established process; restart replicas according to
+the database or token key-ring procedure. The ring makes rolling process
+restarts safe, but does not hot-reload key material inside a process.
 
 The login rate-limit Valkey URL, Treetop URL, TLS private-key passphrase, and
 other certificate paths continue to use their existing configuration adapters
@@ -97,3 +99,71 @@ values. Prometheus exports `hubuum_secret_source_info`,
 `hubuum_secret_resolutions_total`, and
 `hubuum_secret_resolution_duration_seconds` with bounded provider, consumer,
 and outcome labels. Secret values and alias names are never labels.
+
+## Token Key-Ring Rotation
+
+Hubuum accepts one active issuance key and at most seven previous verification
+keys. Key IDs contain 1-32 lowercase ASCII letters, numbers, or interior
+hyphens. Every key must contain at least 32 bytes. Startup rejects missing keys,
+duplicate IDs or material, malformed IDs, short or empty material, and rings
+larger than the bound. Error messages and logs never include key material.
+
+The compatible configuration remains:
+
+```text
+HUBUUM_TOKEN_HASH_KEY=<stable-secret>
+```
+
+It is represented internally as the stable key ID `legacy`. Set
+`HUBUUM_REQUIRE_STABLE_TOKEN_HASH_KEY=true` in production to make a missing
+stable key a startup error instead of creating an ephemeral process-local key.
+
+For an environment-backed ring, key ID `old` maps to
+`HUBUUM_TOKEN_HASH_KEY_OLD`; for a file-backed ring it maps to `token/old`
+below `HUBUUM_SECRET_FILE_ROOT`. IDs are non-secret configuration:
+
+```text
+HUBUUM_TOKEN_HASH_ACTIVE_KEY_ID=old
+HUBUUM_TOKEN_HASH_PREVIOUS_KEY_IDS=new
+HUBUUM_TOKEN_HASH_KEY_OLD=<old-secret>
+HUBUUM_TOKEN_HASH_KEY_NEW=<new-secret>
+HUBUUM_REQUIRE_STABLE_TOKEN_HASH_KEY=true
+```
+
+Use this staged multi-replica procedure:
+
+1. Upgrade every replica while retaining the compatible
+   `HUBUUM_TOKEN_HASH_KEY=<old-secret>` setting. During a rolling software
+   upgrade, keep that setting even if ring variables are also staged, because
+   a pre-key-ring binary only reads the compatible setting.
+2. Generate the new independent key. Deploy `old` as active and `new` as a
+   previous key to every replica. Do not advance until every replica's running
+   configuration reports the same ring identity. The compatible old-key
+   variable may be removed after no pre-key-ring binaries remain.
+3. Deploy `new` as active and `old` as previous. During this configuration
+   rollout, replicas still using the old-active ring can verify new tokens
+   because step 2 taught them `new`, and new-active replicas can verify old
+   tokens through `old`.
+4. Wait for the previous-key active count to reach zero. Check
+   `hubuum-admin --token-key-status` for active, revoked, and expired counts,
+   latest validation, and expiry bounds. The runtime configuration exposes
+   active and previous IDs plus a deterministic redacted ring identity.
+   Prometheus exposes the active ID and redacted identity through
+   `hubuum_token_hash_key_info`, plus `hubuum_token_hash_stored` with bounded
+   key-state and lifecycle labels.
+5. Remove `old` from the previous list and remove its secret, then restart all
+   replicas. Confirm the final ring identity is consistent.
+
+New bearer values have the opaque form `hbt1.<key-id>.<secret>`. Verification
+uses only the embedded key ID; an unknown or malformed versioned token never
+falls back across the ring. Unversioned legacy tokens are checked against the
+bounded ring in one storage operation and, after a valid active authentication,
+their unidentified stored digest is migrated atomically to the active key.
+Revoked and expired tokens are never migrated. A versioned token issued under
+a previous key keeps that key ID and ages out through expiry or revocation;
+changing its stored digest would contradict the no-fallback format contract.
+
+To roll back step 3, redeploy `old` as active with `new` previous while both
+secrets are still retained. Tokens issued during the attempted rotation remain
+valid. Never replace the material behind an existing ID in place: that creates
+the same mixed-replica failure as the former single-key configuration.

--- a/docs/storage_boundary.md
+++ b/docs/storage_boundary.md
@@ -223,7 +223,7 @@ The backend-neutral contracts needed by an out-of-tree adapter form the
 experimental public six-crate
 [storage adapter SDK](storage_adapter_sdk.md).
 External-crate integration tests nevertheless implement all 44
-complete-backend traits and their 249 methods, compile every transaction port,
+complete-backend traits and their 250 methods, compile every transaction port,
 exercise representative typed query APIs, and name public construction paths
 for all current adapter-returned values without crate-private access. Backend
 registration remains explicit, exhaustive, and application-owned. Hubuum does

--- a/docs/storage_boundary/method-contracts.toml
+++ b/docs/storage_boundary/method-contracts.toml
@@ -564,6 +564,19 @@ snapshot = "one native read"
 invalid_error = "InvalidInput"
 unsupported_error = "InvalidInput"
 
+[collection_profiles.token_key_usage]
+shape = "complete"
+ordering = "unidentified legacy rows first, then key id ascending"
+duplicate_inputs = "not applicable: one lifecycle observation"
+missing_inputs = "an empty token store yields an empty collection"
+multiplicity = "one aggregate row per distinct optional persisted key id"
+completeness = "all stored token rows classified once as active, revoked, or expired"
+bounds = "bounded by distinct persisted key identifiers; every identifier is at most 32 characters"
+visibility = "administrator aggregate only; token and principal identities are not returned"
+snapshot = "counts, validation timestamp, and expiry bounds share one native read snapshot"
+invalid_error = "InvalidInput"
+unsupported_error = "InvalidInput"
+
 [methods."CollectionStorage::list_collection_children"]
 effect = "complete_read"
 carrier = "CollectionId"
@@ -618,6 +631,11 @@ profile = "token"
 effect = "batch_read"
 carrier = "Vec<TokenId> + StorageTokenObservation"
 profile = "ordered_input_strict"
+
+[methods."TokenStorage::token_key_usage"]
+effect = "complete_read"
+carrier = "StorageTokenObservation"
+profile = "token_key_usage"
 
 [methods."AuthorizationDataStorage::list_authorization_classes"]
 effect = "batch_read"

--- a/docs/storage_boundary/semantic-coverage.toml
+++ b/docs/storage_boundary/semantic-coverage.toml
@@ -140,9 +140,9 @@ shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_back
 
 [traits.TokenStorage]
 source = "crates/hubuum-storage-core/src/identity_tokens.rs"
-methods = ["list_retained_tokens", "create_token", "renew_token", "get_token_metadata", "load_token_metadata_by_ids", "revoke_token", "revoke_token_by_hash", "revoke_all_principal_tokens"]
-effects = { point_read = ["get_token_metadata"], page_read = ["list_retained_tokens"], batch_read = ["load_token_metadata_by_ids"], audited_mutation = ["create_token", "renew_token", "revoke_token", "revoke_token_by_hash", "revoke_all_principal_tokens"] }
-shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_identity_operations"]
+methods = ["list_retained_tokens", "token_key_usage", "create_token", "renew_token", "get_token_metadata", "load_token_metadata_by_ids", "revoke_token", "revoke_token_by_hash", "revoke_all_principal_tokens"]
+effects = { point_read = ["get_token_metadata"], page_read = ["list_retained_tokens"], batch_read = ["load_token_metadata_by_ids"], complete_read = ["token_key_usage"], audited_mutation = ["create_token", "renew_token", "revoke_token", "revoke_token_by_hash", "revoke_all_principal_tokens"] }
+shared_scenarios = ["src/tests/storage_contract.rs::every_available_storage_backend_supplies_complete_identity_operations", "src/tests/storage_contract.rs::every_available_storage_backend_migrates_legacy_token_digests_safely"]
 
 [traits.AuthorizationDataStorage]
 source = "crates/hubuum-storage-core/src/authorization.rs"

--- a/docs/storage_boundary/testing.md
+++ b/docs/storage_boundary/testing.md
@@ -69,7 +69,7 @@ Three `hubuum-storage-core` integration tests compile as external crates.
 representative typed principal and query APIs, plus complete validated event
 administration request construction and access. `complete_external_adapter.rs`
 implements all 44 complete-backend traits and proves that every one of their
-249 method signatures is publicly implementable. `external_adapter_values.rs`
+250 method signatures is publicly implementable. `external_adapter_values.rs`
 exercises public constructors or terminal builders for every value currently
 returned by an adapter, including nested page and protocol values. None of the
 fixtures can reach crate-private fields.

--- a/src/administration.rs
+++ b/src/administration.rs
@@ -1,4 +1,6 @@
 use clap::Parser;
+use serde::Serialize;
+use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
@@ -10,6 +12,7 @@ use crate::config::{
     DEFAULT_DB_POOL_ACQUIRE_TIMEOUT_MS, DEFAULT_DB_STATEMENT_TIMEOUT_MS,
     DEFAULT_EXPORT_TEMPLATE_FUEL, DEFAULT_EXPORT_TEMPLATE_RECURSION_LIMIT,
     DEFAULT_RESTORE_MAX_UPLOAD_BYTES, DEFAULT_RESTORE_STAGE_RETENTION_MINUTES,
+    DEFAULT_TOKEN_LIFETIME_HOURS, token_hash_key_ring,
 };
 #[cfg(feature = "embedded-migrations")]
 use crate::errors::EXIT_CODE_DATABASE_ERROR;
@@ -25,7 +28,8 @@ use crate::services::operational_administration as operational_service;
 #[cfg(feature = "embedded-migrations")]
 use crate::storage::run_storage_migrations;
 use crate::storage::{
-    OperationalStateStorage, StorageBackendKind, StorageHandle, StorageSettings, initialize_storage,
+    OperationalStateStorage, StorageBackendKind, StorageHandle, StorageSettings,
+    StorageTokenKeyUsage, StorageTokenObservation, TokenStorage, initialize_storage,
 };
 use crate::utilities::auth::generate_random_password;
 use crate::utilities::exporting::validate_template_sources_with_limits;
@@ -71,6 +75,10 @@ struct AdminCli {
     #[arg(long, default_value_t = false)]
     database_ready: bool,
 
+    /// Print non-secret token hash key retirement evidence as JSON
+    #[arg(long, default_value_t = false)]
+    token_key_status: bool,
+
     /// Run all pending embedded database migrations
     #[cfg(feature = "embedded-migrations")]
     #[arg(long, default_value_t = false)]
@@ -96,6 +104,14 @@ struct AdminCli {
         default_value_t = DEFAULT_DB_STATEMENT_TIMEOUT_MS
     )]
     db_statement_timeout_ms: u64,
+
+    /// Legacy token lifetime used when classifying rows without explicit expiry
+    #[arg(
+        long,
+        env = "HUBUUM_TOKEN_LIFETIME_HOURS",
+        default_value_t = DEFAULT_TOKEN_LIFETIME_HOURS
+    )]
+    token_lifetime_hours: i64,
 
     /// MiniJinja recursion limit for export template validation
     #[arg(
@@ -183,11 +199,122 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
         load_export_template_health(&storage).await?;
     } else if admin_cli.database_ready {
         storage_ready(&storage).await?;
+    } else if admin_cli.token_key_status {
+        print_token_key_status(&storage, admin_cli.token_lifetime_hours).await?;
     } else {
         println!("No command specified. Use --help for usage information.");
     }
 
     Ok(())
+}
+
+#[derive(Serialize)]
+struct TokenKeyStatusReport {
+    ring_identity: String,
+    stable: bool,
+    require_stable: bool,
+    active_key_id: String,
+    previous_key_ids: Vec<String>,
+    usage: Vec<TokenKeyStatusRow>,
+}
+
+#[derive(Serialize)]
+struct TokenKeyStatusRow {
+    key_id: String,
+    configured_state: &'static str,
+    active: i64,
+    revoked: i64,
+    expired: i64,
+    latest_validation: Option<chrono::DateTime<chrono::Utc>>,
+    earliest_expiry: Option<chrono::DateTime<chrono::Utc>>,
+    latest_expiry: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+async fn print_token_key_status(
+    storage: &StorageHandle,
+    token_lifetime_hours: i64,
+) -> Result<(), ApiError> {
+    let ring =
+        token_hash_key_ring().map_err(|error| ApiError::ValidationError(error.to_string()))?;
+    let observed_at = chrono::Utc::now();
+    let lifetime = chrono::Duration::try_hours(token_lifetime_hours).ok_or_else(|| {
+        ApiError::ValidationError("token lifetime is outside the supported range".to_string())
+    })?;
+    if lifetime <= chrono::Duration::zero() {
+        return Err(ApiError::ValidationError(
+            "token lifetime must be positive".to_string(),
+        ));
+    }
+    let observation = StorageTokenObservation::try_new(observed_at, observed_at - lifetime)
+        .map_err(|error| ApiError::ValidationError(error.to_string()))?;
+    let mut stored = storage
+        .token_key_usage(observation)
+        .await?
+        .into_iter()
+        .map(|usage| (usage.key_id().map(ToString::to_string), usage))
+        .collect::<BTreeMap<_, _>>();
+    let mut usage = Vec::new();
+    usage.push(status_row(
+        ring.active_key_id().to_string(),
+        "active",
+        stored.remove(&Some(ring.active_key_id().to_string())),
+    ));
+    let previous_key_ids = ring
+        .previous_key_ids()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    for key_id in &previous_key_ids {
+        usage.push(status_row(
+            key_id.clone(),
+            "previous",
+            stored.remove(&Some(key_id.clone())),
+        ));
+    }
+    if let Some(legacy) = stored.remove(&None) {
+        usage.push(status_row(
+            "legacy-unidentified".to_string(),
+            "legacy",
+            Some(legacy),
+        ));
+    }
+    for (key_id, unconfigured) in stored {
+        usage.push(status_row(
+            key_id.unwrap_or_else(|| "legacy-unidentified".to_string()),
+            "unconfigured",
+            Some(unconfigured),
+        ));
+    }
+    let report = TokenKeyStatusReport {
+        ring_identity: ring.identity().to_string(),
+        stable: ring.is_stable(),
+        require_stable: ring.requires_stable_key(),
+        active_key_id: ring.active_key_id().to_string(),
+        previous_key_ids,
+        usage,
+    };
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    Ok(())
+}
+
+fn status_row(
+    key_id: String,
+    configured_state: &'static str,
+    usage: Option<StorageTokenKeyUsage>,
+) -> TokenKeyStatusRow {
+    TokenKeyStatusRow {
+        key_id,
+        configured_state,
+        active: usage.as_ref().map_or(0, StorageTokenKeyUsage::active),
+        revoked: usage.as_ref().map_or(0, StorageTokenKeyUsage::revoked),
+        expired: usage.as_ref().map_or(0, StorageTokenKeyUsage::expired),
+        latest_validation: usage
+            .as_ref()
+            .and_then(StorageTokenKeyUsage::latest_validation),
+        earliest_expiry: usage
+            .as_ref()
+            .and_then(StorageTokenKeyUsage::earliest_expiry),
+        latest_expiry: usage.as_ref().and_then(StorageTokenKeyUsage::latest_expiry),
+    }
 }
 
 async fn backup_database(

--- a/src/application.rs
+++ b/src/application.rs
@@ -21,8 +21,9 @@ use crate::config::get_config;
 #[cfg(not(test))]
 use crate::config::initialize_config;
 use crate::config::running::RunningConfig;
-use crate::config::token_hash_key_is_ephemeral;
-use crate::config::{AppConfig, ClientAllowlist, LoginRateLimitBackendKind, MetricsPath};
+use crate::config::{
+    AppConfig, ClientAllowlist, LoginRateLimitBackendKind, MetricsPath, token_hash_key_ring,
+};
 use crate::errors::{
     EXIT_CODE_CONFIG_ERROR, EXIT_CODE_DATABASE_ERROR, EXIT_CODE_INIT_ERROR,
     EXIT_CODE_PERMISSION_BACKEND_ERROR, EXIT_CODE_TLS_ERROR, fatal_error, json_error_handler,
@@ -93,7 +94,13 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
         );
     }
 
-    if token_hash_key_is_ephemeral() {
+    let token_hash_key_ring = token_hash_key_ring().unwrap_or_else(|error| {
+        fatal_error(
+            &format!("Failed to configure token hash keys: {error}"),
+            EXIT_CODE_CONFIG_ERROR,
+        )
+    });
+    if !token_hash_key_ring.is_stable() {
         warn!(
             message = "The token hash key is unavailable; using an ephemeral in-memory key. Existing tokens will be invalid after restart.",
             recommendation = "Configure a stable token key through the selected Hubuum secret source to preserve token validity across restarts"
@@ -108,6 +115,17 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
             );
         }
         observability::metrics::runtime_identity(config.runtime_role);
+        observability::metrics::token_hash_key_ring(
+            if token_hash_key_ring.is_stable() {
+                "stable"
+            } else {
+                "ephemeral"
+            },
+            token_hash_key_ring.active_key_id().as_str(),
+            token_hash_key_ring.identity(),
+            1,
+            u64::try_from(token_hash_key_ring.previous_key_ids().count()).unwrap_or(u64::MAX),
+        );
     }
     if config.storage_backend == StorageBackendKind::Postgres {
         config.database_url = crate::secrets::resolve_database_url(&config.database_url)

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,10 @@ mod token_hash;
 pub use client_network::{ClientAllowlist, ClientNetworkParseError, TrustedProxies};
 pub use defaults::*;
 pub use tls_backend::TlsBackend;
-pub use token_hash::{token_hash_key_bytes, token_hash_key_is_ephemeral};
+pub use token_hash::{
+    TokenHashKeyConfigError, TokenHashKeyRing, token_hash_key_bytes, token_hash_key_is_ephemeral,
+    token_hash_key_ring,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]

--- a/src/config/environment.rs
+++ b/src/config/environment.rs
@@ -177,6 +177,9 @@ pub const APP_CONFIG_ENVIRONMENT: &[EnvironmentVariable] = &[
 /// Exact Hubuum variables resolved outside clap's `AppConfig` adapter.
 pub const PROCESS_ENVIRONMENT: &[EnvironmentVariable] = &[
     option!("HUBUUM_TOKEN_HASH_KEY", Authentication, sensitive),
+    option!("HUBUUM_TOKEN_HASH_ACTIVE_KEY_ID", Authentication),
+    option!("HUBUUM_TOKEN_HASH_PREVIOUS_KEY_IDS", Authentication),
+    option!("HUBUUM_REQUIRE_STABLE_TOKEN_HASH_KEY", Authentication),
     option!("HUBUUM_SECRET_SOURCE", Operations),
     option!("HUBUUM_SECRET_FILE_ROOT", Operations, sensitive),
     option!("HUBUUM_BUILD_GIT_SHA", Operations),
@@ -193,6 +196,7 @@ pub const PROCESS_ENVIRONMENT: &[EnvironmentVariable] = &[
 /// Registered dynamic secret namespaces. The suffix is a consumer-supplied
 /// reference validated by the corresponding secret resolver.
 pub const DYNAMIC_SECRET_PREFIXES: &[(&str, EnvironmentOwner)] = &[
+    ("HUBUUM_TOKEN_HASH_KEY_", EnvironmentOwner::Authentication),
     ("HUBUUM_REMOTE_SECRET_", EnvironmentOwner::RemoteCalls),
     ("HUBUUM_EVENT_SINK_SECRET_", EnvironmentOwner::Events),
     ("HUBUUM_LDAP_SECRET_", EnvironmentOwner::Authentication),

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -6,7 +6,7 @@
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use super::{AppConfig, ClientAllowlist, token_hash_key_is_ephemeral};
+use super::{AppConfig, ClientAllowlist, token_hash_key_ring};
 
 #[derive(Clone, Debug, Serialize, ToSchema)]
 pub struct RunningConfig {
@@ -191,6 +191,11 @@ pub struct AuthenticationConfig {
     #[schema(minimum = 10)]
     pub token_retention_purge_batch_size: usize,
     pub stable_token_hash_key_configured: bool,
+    pub token_hash_key_mode: String,
+    pub active_token_hash_key_id: String,
+    pub previous_token_hash_key_ids: Vec<String>,
+    pub token_hash_key_ring_identity: String,
+    pub require_stable_token_hash_key: bool,
     pub admin_groupname: String,
     pub admin_identity_scope: Option<String>,
     pub provider_config_path: SecretStatus,
@@ -278,6 +283,8 @@ impl RunningConfig {
         let (secret_provider, secret_file_root_configured) =
             crate::secrets::running_source_configuration();
         let secret_cache_policy = hubuum_secrets::CachePolicy::default();
+        let token_hash_keys = token_hash_key_ring()
+            .expect("token hash key-ring configuration must be validated before serving config");
 
         Self {
             server: ServerConfig {
@@ -386,7 +393,19 @@ impl RunningConfig {
                 token_retention_purge_interval_seconds: config
                     .token_retention_purge_interval_seconds,
                 token_retention_purge_batch_size: config.token_retention_purge_batch_size,
-                stable_token_hash_key_configured: !token_hash_key_is_ephemeral(),
+                stable_token_hash_key_configured: token_hash_keys.is_stable(),
+                token_hash_key_mode: if token_hash_keys.is_stable() {
+                    "stable".to_string()
+                } else {
+                    "ephemeral".to_string()
+                },
+                active_token_hash_key_id: token_hash_keys.active_key_id().to_string(),
+                previous_token_hash_key_ids: token_hash_keys
+                    .previous_key_ids()
+                    .map(ToString::to_string)
+                    .collect(),
+                token_hash_key_ring_identity: token_hash_keys.identity().to_string(),
+                require_stable_token_hash_key: token_hash_keys.requires_stable_key(),
                 admin_groupname: config.admin_groupname.clone(),
                 admin_identity_scope: config.admin_identity_scope.clone(),
                 provider_config_path: SecretStatus {

--- a/src/config/token_hash.rs
+++ b/src/config/token_hash.rs
@@ -1,31 +1,390 @@
+use std::fmt;
 use std::sync::LazyLock;
 
+use hubuum_secrets::{SecretError, SecretErrorKind, SecretValue};
+use hubuum_storage_core::{MAX_TOKEN_HASH_KEYS, StorageTokenHashKeyId};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-struct TokenHashKeyConfig {
-    key: Vec<u8>,
-    is_ephemeral: bool,
+const ACTIVE_KEY_ID_ENVIRONMENT: &str = "HUBUUM_TOKEN_HASH_ACTIVE_KEY_ID";
+const PREVIOUS_KEY_IDS_ENVIRONMENT: &str = "HUBUUM_TOKEN_HASH_PREVIOUS_KEY_IDS";
+const REQUIRE_STABLE_KEY_ENVIRONMENT: &str = "HUBUUM_REQUIRE_STABLE_TOKEN_HASH_KEY";
+const LEGACY_KEY_ID: &str = "legacy";
+const EPHEMERAL_KEY_ID: &str = "ephemeral";
+const MINIMUM_KEY_BYTES: usize = 32;
+
+#[derive(Debug, Clone)]
+pub enum TokenHashKeyConfigError {
+    Invalid(&'static str),
+    Secret(SecretError),
 }
 
-static TOKEN_HASH_KEY_CONFIG: LazyLock<TokenHashKeyConfig> = LazyLock::new(|| {
-    if let Ok(key) = crate::secrets::resolve_token_hash_key() {
-        return TokenHashKeyConfig {
-            key,
-            is_ephemeral: false,
+impl fmt::Display for TokenHashKeyConfigError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Invalid(message) => formatter.write_str(message),
+            Self::Secret(error) => write!(formatter, "token hash key resolution failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for TokenHashKeyConfigError {}
+
+impl From<SecretError> for TokenHashKeyConfigError {
+    fn from(error: SecretError) -> Self {
+        Self::Secret(error)
+    }
+}
+
+struct TokenHashKey {
+    id: StorageTokenHashKeyId,
+    material: SecretValue,
+}
+
+/// Validated process-wide token-hash rotation configuration.
+pub struct TokenHashKeyRing {
+    keys: Vec<TokenHashKey>,
+    stable: bool,
+    identity: String,
+    require_stable: bool,
+}
+
+impl fmt::Debug for TokenHashKeyRing {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TokenHashKeyRing")
+            .field("active_key_id", &self.active_key_id())
+            .field("key_count", &self.keys.len())
+            .field("stable", &self.stable)
+            .field("identity", &self.identity)
+            .field("require_stable", &self.require_stable)
+            .finish()
+    }
+}
+
+impl TokenHashKeyRing {
+    fn from_environment() -> Result<Self, TokenHashKeyConfigError> {
+        let require_stable = parse_bool_environment(REQUIRE_STABLE_KEY_ENVIRONMENT)?;
+        let active = environment_value(ACTIVE_KEY_ID_ENVIRONMENT)?;
+        let previous = parse_previous_key_ids()?;
+
+        let Some(active) = active else {
+            if !previous.is_empty() {
+                return Err(TokenHashKeyConfigError::Invalid(
+                    "HUBUUM_TOKEN_HASH_ACTIVE_KEY_ID is required when previous token hash keys are configured",
+                ));
+            }
+            return match crate::secrets::resolve_token_hash_key() {
+                Ok(material) => Self::try_new(
+                    vec![(key_id(LEGACY_KEY_ID)?, material)],
+                    true,
+                    require_stable,
+                ),
+                Err(error) if error.kind() == SecretErrorKind::NotFound && !require_stable => {
+                    let material = format!("{}{}", Uuid::new_v4(), Uuid::new_v4()).into_bytes();
+                    Self::try_new(
+                        vec![(key_id(EPHEMERAL_KEY_ID)?, material)],
+                        false,
+                        require_stable,
+                    )
+                }
+                Err(error) => Err(error.into()),
+            };
         };
+
+        let active = key_id(&active)?;
+        let mut ids = Vec::with_capacity(previous.len() + 1);
+        ids.push(active);
+        for value in previous {
+            ids.push(key_id(&value)?);
+        }
+        validate_ids(&ids)?;
+        let aliases = ids
+            .iter()
+            .map(|id| id.as_str().to_string())
+            .collect::<Vec<_>>();
+        let resolved = crate::secrets::resolve_token_hash_key_group(&aliases)?;
+        let text_source = crate::secrets::token_hash_secrets_are_text()?;
+        let materials = resolved
+            .iter()
+            .map(|secret| {
+                if text_source {
+                    secret
+                        .value()
+                        .expose_utf8()
+                        .map(|value| value.trim().as_bytes().to_vec())
+                } else {
+                    Ok(secret.value().expose().to_vec())
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Self::try_new(
+            ids.into_iter().zip(materials).collect(),
+            true,
+            require_stable,
+        )
     }
 
-    let generated = format!("{}{}", Uuid::new_v4(), Uuid::new_v4());
-    TokenHashKeyConfig {
-        key: generated.into_bytes(),
-        is_ephemeral: true,
+    pub(crate) fn try_new(
+        entries: Vec<(StorageTokenHashKeyId, Vec<u8>)>,
+        stable: bool,
+        require_stable: bool,
+    ) -> Result<Self, TokenHashKeyConfigError> {
+        if entries.is_empty() || entries.len() > MAX_TOKEN_HASH_KEYS {
+            return Err(TokenHashKeyConfigError::Invalid(
+                "the token hash key ring must contain one active key and at most seven previous keys",
+            ));
+        }
+        validate_ids(&entries.iter().map(|(id, _)| id.clone()).collect::<Vec<_>>())?;
+        let keys = entries
+            .into_iter()
+            .map(|(id, material)| {
+                SecretValue::new(material)
+                    .map(|material| TokenHashKey { id, material })
+                    .map_err(TokenHashKeyConfigError::from)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if require_stable && !stable {
+            return Err(TokenHashKeyConfigError::Invalid(
+                "a stable token hash key is required for this deployment",
+            ));
+        }
+        if keys
+            .iter()
+            .any(|key| key.material.len() < MINIMUM_KEY_BYTES)
+        {
+            return Err(TokenHashKeyConfigError::Invalid(
+                "token hash keys must contain at least 32 bytes",
+            ));
+        }
+        if keys.iter().enumerate().any(|(index, key)| {
+            keys[index + 1..]
+                .iter()
+                .any(|other| key.material.expose() == other.material.expose())
+        }) {
+            return Err(TokenHashKeyConfigError::Invalid(
+                "token hash key material must be unique within the key ring",
+            ));
+        }
+        let identity = ring_identity(&keys);
+        Ok(Self {
+            keys,
+            stable,
+            identity,
+            require_stable,
+        })
     }
-});
+
+    #[must_use]
+    pub fn active_key_id(&self) -> &StorageTokenHashKeyId {
+        &self.keys[0].id
+    }
+
+    pub fn previous_key_ids(&self) -> impl Iterator<Item = &StorageTokenHashKeyId> {
+        self.keys[1..].iter().map(|key| &key.id)
+    }
+
+    pub fn key_ids(&self) -> impl Iterator<Item = &StorageTokenHashKeyId> {
+        self.keys.iter().map(|key| &key.id)
+    }
+
+    #[must_use]
+    pub fn is_stable(&self) -> bool {
+        self.stable
+    }
+
+    #[must_use]
+    pub fn identity(&self) -> &str {
+        &self.identity
+    }
+
+    #[must_use]
+    pub fn requires_stable_key(&self) -> bool {
+        self.require_stable
+    }
+
+    #[must_use]
+    pub fn active_key_bytes(&self) -> &[u8] {
+        self.keys[0].material.expose()
+    }
+
+    #[must_use]
+    pub fn key_bytes(&self, id: &StorageTokenHashKeyId) -> Option<&[u8]> {
+        self.keys
+            .iter()
+            .find(|key| &key.id == id)
+            .map(|key| key.material.expose())
+    }
+
+    pub(crate) fn keys(&self) -> impl Iterator<Item = (&StorageTokenHashKeyId, &[u8])> {
+        self.keys.iter().map(|key| (&key.id, key.material.expose()))
+    }
+}
+
+static TOKEN_HASH_KEY_RING: LazyLock<Result<TokenHashKeyRing, TokenHashKeyConfigError>> =
+    LazyLock::new(TokenHashKeyRing::from_environment);
+
+pub fn token_hash_key_ring() -> Result<&'static TokenHashKeyRing, TokenHashKeyConfigError> {
+    TOKEN_HASH_KEY_RING.as_ref().map_err(Clone::clone)
+}
 
 pub fn token_hash_key_bytes() -> &'static [u8] {
-    &TOKEN_HASH_KEY_CONFIG.key
+    token_hash_key_ring()
+        .expect("token hash key-ring configuration must be validated at startup")
+        .active_key_bytes()
 }
 
 pub fn token_hash_key_is_ephemeral() -> bool {
-    TOKEN_HASH_KEY_CONFIG.is_ephemeral
+    token_hash_key_ring()
+        .map(|ring| !ring.is_stable())
+        .unwrap_or(false)
+}
+
+fn key_id(value: &str) -> Result<StorageTokenHashKeyId, TokenHashKeyConfigError> {
+    StorageTokenHashKeyId::try_new(value).map_err(|_| {
+        TokenHashKeyConfigError::Invalid(
+            "token hash key IDs must use 1-32 lowercase ASCII letters, numbers, or interior hyphens",
+        )
+    })
+}
+
+fn validate_ids(ids: &[StorageTokenHashKeyId]) -> Result<(), TokenHashKeyConfigError> {
+    if ids.is_empty() || ids.len() > MAX_TOKEN_HASH_KEYS {
+        return Err(TokenHashKeyConfigError::Invalid(
+            "the token hash key ring must contain one active key and at most seven previous keys",
+        ));
+    }
+    if ids
+        .iter()
+        .enumerate()
+        .any(|(index, id)| ids[index + 1..].contains(id))
+    {
+        return Err(TokenHashKeyConfigError::Invalid(
+            "token hash key IDs must be unique within the key ring",
+        ));
+    }
+    Ok(())
+}
+
+fn environment_value(name: &str) -> Result<Option<String>, TokenHashKeyConfigError> {
+    match std::env::var(name) {
+        Ok(value) if value.trim().is_empty() => Err(TokenHashKeyConfigError::Invalid(
+            "configured token hash key metadata must not be empty",
+        )),
+        Ok(value) => Ok(Some(value.trim().to_string())),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(TokenHashKeyConfigError::Invalid(
+            "token hash key metadata must contain valid Unicode",
+        )),
+    }
+}
+
+fn parse_previous_key_ids() -> Result<Vec<String>, TokenHashKeyConfigError> {
+    let Some(value) = environment_value(PREVIOUS_KEY_IDS_ENVIRONMENT)? else {
+        return Ok(Vec::new());
+    };
+    let ids = value
+        .split(',')
+        .map(str::trim)
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if ids.iter().any(String::is_empty) {
+        return Err(TokenHashKeyConfigError::Invalid(
+            "previous token hash key IDs must not contain empty entries",
+        ));
+    }
+    Ok(ids)
+}
+
+fn parse_bool_environment(name: &str) -> Result<bool, TokenHashKeyConfigError> {
+    match environment_value(name)?.as_deref() {
+        None | Some("false" | "0") => Ok(false),
+        Some("true" | "1") => Ok(true),
+        Some(_) => Err(TokenHashKeyConfigError::Invalid(
+            "HUBUUM_REQUIRE_STABLE_TOKEN_HASH_KEY must be true, false, 1, or 0",
+        )),
+    }
+}
+
+fn ring_identity(keys: &[TokenHashKey]) -> String {
+    let mut hasher = Sha256::new();
+    for key in keys {
+        hasher.update(key.id.as_str().as_bytes());
+        hasher.update([0]);
+        hasher.update(key.material.expose());
+        hasher.update([0xff]);
+    }
+    let digest = hasher.finalize();
+    digest[..12]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(value: &str) -> StorageTokenHashKeyId {
+        StorageTokenHashKeyId::try_new(value).unwrap()
+    }
+
+    #[test]
+    fn key_ring_rejects_duplicate_material() {
+        let result = TokenHashKeyRing::try_new(
+            vec![(id("active"), vec![1; 32]), (id("previous"), vec![1; 32])],
+            true,
+            false,
+        );
+
+        assert!(matches!(result, Err(TokenHashKeyConfigError::Invalid(_))));
+    }
+
+    #[test]
+    fn key_ring_rejects_duplicate_ids() {
+        let result = TokenHashKeyRing::try_new(
+            vec![(id("active"), vec![1; 32]), (id("active"), vec![2; 32])],
+            true,
+            false,
+        );
+
+        assert!(matches!(result, Err(TokenHashKeyConfigError::Invalid(_))));
+    }
+
+    #[test]
+    fn key_ring_rejects_short_material() {
+        let result = TokenHashKeyRing::try_new(vec![(id("active"), vec![1; 31])], true, false);
+
+        assert!(matches!(result, Err(TokenHashKeyConfigError::Invalid(_))));
+    }
+
+    #[test]
+    fn key_ring_rejects_more_than_the_bounded_key_count() {
+        let entries = (0_u8..=8)
+            .map(|index| (id(&format!("key-{index}")), vec![index; 32]))
+            .collect();
+
+        assert!(matches!(
+            TokenHashKeyRing::try_new(entries, true, false),
+            Err(TokenHashKeyConfigError::Invalid(_))
+        ));
+    }
+
+    #[test]
+    fn key_ring_identity_changes_with_material_without_exposing_it() {
+        let first =
+            TokenHashKeyRing::try_new(vec![(id("active"), vec![1; 32])], true, false).unwrap();
+        let second =
+            TokenHashKeyRing::try_new(vec![(id("active"), vec![2; 32])], true, false).unwrap();
+
+        assert_ne!(first.identity(), second.identity());
+        assert!(!format!("{first:?}").contains(&"01".repeat(32)));
+    }
+
+    #[test]
+    fn strict_mode_rejects_ephemeral_material() {
+        let result = TokenHashKeyRing::try_new(vec![(id("ephemeral"), vec![1; 32])], false, true);
+
+        assert!(matches!(result, Err(TokenHashKeyConfigError::Invalid(_))));
+    }
 }

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use utoipa::ToSchema;
 
-use crate::config::{get_config, token_hash_key_bytes};
+use crate::config::{TokenHashKeyRing, get_config, token_hash_key_ring};
 use crate::errors::ApiError;
 use crate::events::EventContext;
 use crate::models::search::{FilterField, SortParam};
@@ -15,7 +15,10 @@ use crate::models::{
     PrincipalID, REDACTED_DEBUG_VALUE, ResourceRevision, TokenIssuancePolicy, TokenLifetime,
     TokenScope, TokenScopeDetails,
 };
-use crate::storage::{StorageAuthenticatedToken, StorageContext};
+use crate::storage::{
+    StorageAuthenticatedToken, StorageAuthenticationCredential, StorageContext, StorageTokenDigest,
+    StorageTokenFormat, StorageTokenHashAlgorithm, StorageTokenHashKeyId,
+};
 use crate::traits::{CursorPaginated, CursorValue};
 
 /// A persisted bearer token, keyed to a principal, with a full lifecycle. The
@@ -332,6 +335,13 @@ impl FromStr for TokenListState {
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Token(pub String);
 
+pub(crate) struct TokenCredentialPlan {
+    pub credentials: Vec<StorageAuthenticationCredential>,
+    pub migration_target: Option<StorageTokenDigest>,
+    pub format: StorageTokenFormat,
+    pub key_state: &'static str,
+}
+
 /// A newly persisted bearer token paired with its authoritative expiry.
 #[derive(Clone)]
 pub struct IssuedToken {
@@ -403,7 +413,7 @@ impl Token {
         crate::services::identity::revoke_token_by_hash(
             backend,
             None,
-            self.storage_hash(),
+            self.credentials()?.credentials,
             &EventContext::system(),
         )
         .await?;
@@ -411,18 +421,166 @@ impl Token {
     }
 
     pub fn storage_hash(&self) -> String {
-        Self::storage_hash_from_raw(&self.0)
+        self.storage_digest()
+            .expect("issued and legacy token values must be hashable")
+            .lookup_value()
+            .to_string()
     }
 
     pub fn storage_hash_from_raw(raw_token: &str) -> String {
-        type HmacSha256 = Hmac<Sha256>;
-
-        let mut mac =
-            HmacSha256::new_from_slice(token_hash_key_bytes()).expect("invalid HMAC key length");
-        mac.update(raw_token.as_bytes());
-        let digest = mac.finalize().into_bytes();
-        digest.iter().map(|b| format!("{b:02x}")).collect()
+        let ring = token_hash_key_ring()
+            .expect("token hash key-ring configuration must be validated at startup");
+        Self::storage_hash_from_raw_with_ring(raw_token, ring)
     }
+
+    fn storage_hash_from_raw_with_ring(raw_token: &str, ring: &TokenHashKeyRing) -> String {
+        let key = raw_token
+            .strip_prefix("hbt1.")
+            .and_then(|value| value.split_once('.'))
+            .and_then(|(key_id, _)| StorageTokenHashKeyId::try_new(key_id).ok())
+            .and_then(|key_id| ring.key_bytes(&key_id))
+            .unwrap_or_else(|| ring.active_key_bytes());
+        hash_with_key(raw_token, key)
+    }
+
+    pub(crate) fn issued(secret: impl AsRef<str>) -> Result<Self, ApiError> {
+        let ring = token_hash_key_ring()
+            .map_err(|error| ApiError::InternalServerError(error.to_string()))?;
+        Self::issued_with_ring(secret, ring)
+    }
+
+    fn issued_with_ring(
+        secret: impl AsRef<str>,
+        ring: &TokenHashKeyRing,
+    ) -> Result<Self, ApiError> {
+        let secret = secret.as_ref();
+        if !is_valid_token_secret(secret) {
+            return Err(ApiError::InternalServerError(
+                "generated token secret has an invalid representation".to_string(),
+            ));
+        }
+        Ok(Self(format!("hbt1.{}.{}", ring.active_key_id(), secret)))
+    }
+
+    pub(crate) fn storage_digest(&self) -> Result<StorageTokenDigest, ApiError> {
+        let plan = self.credentials()?;
+        plan.credentials
+            .into_iter()
+            .next()
+            .map(|credential| credential.digest().clone())
+            .ok_or_else(|| ApiError::InternalServerError("token digest plan was empty".to_string()))
+    }
+
+    pub(crate) fn credentials(&self) -> Result<TokenCredentialPlan, ApiError> {
+        let ring = token_hash_key_ring()
+            .map_err(|error| ApiError::InternalServerError(error.to_string()))?;
+        self.credentials_with_ring(ring)
+    }
+
+    fn credentials_with_ring(
+        &self,
+        ring: &TokenHashKeyRing,
+    ) -> Result<TokenCredentialPlan, ApiError> {
+        if self.0.starts_with("hbt") {
+            let mut parts = self.0.split('.');
+            let version = parts.next();
+            let key_id = parts.next();
+            let secret = parts.next();
+            if version != Some("hbt1")
+                || parts.next().is_some()
+                || secret.is_none_or(|value| !is_valid_token_secret(value))
+            {
+                return Err(invalid_bearer_token());
+            }
+            let key_id = StorageTokenHashKeyId::try_new(key_id.unwrap_or_default())
+                .map_err(|_| invalid_bearer_token())?;
+            let key = ring.key_bytes(&key_id).ok_or_else(invalid_bearer_token)?;
+            let digest =
+                digest_with_key(&self.0, key, StorageTokenFormat::Version1, key_id.clone())?;
+            let key_state = if &key_id == ring.active_key_id() {
+                "active"
+            } else {
+                "previous"
+            };
+            return Ok(TokenCredentialPlan {
+                credentials: vec![StorageAuthenticationCredential::from_digest(digest)],
+                migration_target: None,
+                format: StorageTokenFormat::Version1,
+                key_state,
+            });
+        }
+
+        let credentials = ring
+            .keys()
+            .map(|(key_id, key)| {
+                digest_with_key(&self.0, key, StorageTokenFormat::Legacy, key_id.clone())
+                    .map(StorageAuthenticationCredential::from_digest)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let migration_target = credentials
+            .first()
+            .map(|credential| credential.digest().clone());
+        Ok(TokenCredentialPlan {
+            credentials,
+            migration_target,
+            format: StorageTokenFormat::Legacy,
+            key_state: "legacy",
+        })
+    }
+
+    #[cfg(test)]
+    fn storage_digest_with_ring(
+        &self,
+        ring: &TokenHashKeyRing,
+    ) -> Result<StorageTokenDigest, ApiError> {
+        self.credentials_with_ring(ring)?
+            .credentials
+            .into_iter()
+            .next()
+            .map(|credential| credential.digest().clone())
+            .ok_or_else(|| ApiError::InternalServerError("token digest plan was empty".to_string()))
+    }
+}
+
+fn is_valid_token_secret(value: &str) -> bool {
+    value.len() == 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn digest_with_key(
+    raw_token: &str,
+    key: &[u8],
+    format: StorageTokenFormat,
+    key_id: StorageTokenHashKeyId,
+) -> Result<StorageTokenDigest, ApiError> {
+    StorageTokenDigest::try_new(
+        hash_with_key(raw_token, key),
+        format,
+        StorageTokenHashAlgorithm::HmacSha256V1,
+        Some(key_id),
+    )
+    .map_err(|error| ApiError::InternalServerError(error.to_string()))
+}
+
+fn hash_with_key(raw_token: &str, key: &[u8]) -> String {
+    type HmacSha256 = Hmac<Sha256>;
+
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts keys of any length");
+    mac.update(raw_token.as_bytes());
+    let digest = mac.finalize().into_bytes();
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in digest {
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
+fn invalid_bearer_token() -> ApiError {
+    ApiError::Unauthorized("Invalid token".to_string())
 }
 
 /// Soft-revoke a token by id, scoped to the owning principal. Filtering on BOTH
@@ -594,6 +752,31 @@ impl CursorPaginated for PrincipalToken {
 mod tests {
     use super::*;
 
+    fn rotation_ring(active: &str, previous: &[&str]) -> TokenHashKeyRing {
+        let material = |id: &str| match id {
+            "old" => vec![1; 32],
+            "new" => vec![2; 32],
+            _ => panic!("unexpected rotation-test key ID"),
+        };
+        let entries = std::iter::once(active)
+            .chain(previous.iter().copied())
+            .map(|id| (StorageTokenHashKeyId::try_new(id).unwrap(), material(id)))
+            .collect();
+        TokenHashKeyRing::try_new(entries, true, true).unwrap()
+    }
+
+    fn token_verifies(
+        token: &Token,
+        persisted: &StorageTokenDigest,
+        verifier: &TokenHashKeyRing,
+    ) -> bool {
+        token.credentials_with_ring(verifier).is_ok_and(|plan| {
+            plan.credentials
+                .iter()
+                .any(|candidate| candidate.digest() == persisted)
+        })
+    }
+
     #[test]
     fn principal_token_debug_redacts_stored_digest() {
         let token_digest = "keyed-token-digest";
@@ -618,5 +801,107 @@ mod tests {
 
         assert!(output.contains(REDACTED_DEBUG_VALUE));
         assert!(!output.contains(token_digest));
+    }
+
+    #[test]
+    fn newly_issued_tokens_carry_the_active_key_id() {
+        let token = Token::issued("a".repeat(128)).unwrap();
+        let ring = token_hash_key_ring().unwrap();
+
+        assert!(
+            token
+                .0
+                .starts_with(&format!("hbt1.{}.", ring.active_key_id()))
+        );
+        let plan = token.credentials().unwrap();
+        assert_eq!(plan.format, StorageTokenFormat::Version1);
+        assert_eq!(plan.credentials.len(), 1);
+        assert!(plan.migration_target.is_none());
+    }
+
+    #[test]
+    fn token_issuance_rejects_an_invalid_generated_secret() {
+        let ring = rotation_ring("old", &[]);
+
+        assert!(Token::issued_with_ring("not-hex", &ring).is_err());
+    }
+
+    #[test]
+    fn malformed_versioned_tokens_do_not_fall_back_to_legacy_hashing() {
+        let token = Token("hbt2.legacy.not-a-version-one-secret".to_string());
+
+        assert!(matches!(
+            token.credentials(),
+            Err(ApiError::Unauthorized(_))
+        ));
+    }
+
+    #[test]
+    fn legacy_tokens_generate_one_bounded_candidate_per_configured_key() {
+        let token = Token("legacy-bearer-value".to_string());
+        let ring = token_hash_key_ring().unwrap();
+        let plan = token.credentials().unwrap();
+
+        assert_eq!(plan.format, StorageTokenFormat::Legacy);
+        assert_eq!(plan.credentials.len(), ring.key_ids().count());
+        assert!(plan.migration_target.is_some());
+    }
+
+    #[test]
+    fn supported_replica_ring_combinations_validate_each_others_tokens() {
+        let old_only = rotation_ring("old", &[]);
+        let old_with_future = rotation_ring("old", &["new"]);
+        let new_with_old = rotation_ring("new", &["old"]);
+        let new_only = rotation_ring("new", &[]);
+
+        let old_token = Token::issued_with_ring("a".repeat(128), &old_only).unwrap();
+        let old_digest = old_token.storage_digest_with_ring(&old_only).unwrap();
+        assert!(token_verifies(&old_token, &old_digest, &old_only));
+        assert!(token_verifies(&old_token, &old_digest, &old_with_future));
+        assert!(token_verifies(&old_token, &old_digest, &new_with_old));
+
+        let staged_token = Token::issued_with_ring("b".repeat(128), &old_with_future).unwrap();
+        let staged_digest = staged_token
+            .storage_digest_with_ring(&old_with_future)
+            .unwrap();
+        assert!(token_verifies(&staged_token, &staged_digest, &old_only));
+        assert!(token_verifies(
+            &staged_token,
+            &staged_digest,
+            &old_with_future
+        ));
+        assert!(token_verifies(&staged_token, &staged_digest, &new_with_old));
+
+        let switched_token = Token::issued_with_ring("c".repeat(128), &new_with_old).unwrap();
+        let switched_digest = switched_token
+            .storage_digest_with_ring(&new_with_old)
+            .unwrap();
+        assert!(token_verifies(
+            &switched_token,
+            &switched_digest,
+            &old_with_future
+        ));
+        assert!(token_verifies(
+            &switched_token,
+            &switched_digest,
+            &new_with_old
+        ));
+        assert!(token_verifies(&switched_token, &switched_digest, &new_only));
+
+        let retired_token = Token::issued_with_ring("d".repeat(128), &new_only).unwrap();
+        let retired_digest = retired_token.storage_digest_with_ring(&new_only).unwrap();
+        assert!(token_verifies(
+            &retired_token,
+            &retired_digest,
+            &new_with_old
+        ));
+        assert!(token_verifies(&retired_token, &retired_digest, &new_only));
+
+        assert!(!token_verifies(
+            &switched_token,
+            &switched_digest,
+            &old_only
+        ));
+        assert!(!token_verifies(&old_token, &old_digest, &new_only));
     }
 }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -291,7 +291,7 @@ impl User {
         crate::services::identity::revoke_token_by_hash(
             backend,
             Some(self.id),
-            token_param.storage_hash(),
+            token_param.credentials()?.credentials,
             &EventContext::system(),
         )
         .await

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -16,6 +16,7 @@ mod security;
 mod storage;
 mod task;
 mod timer;
+mod token;
 
 use std::sync::{Mutex, OnceLock};
 
@@ -63,6 +64,7 @@ pub use self::task::{
     task_output_cleanup_deleted, task_output_cleanup_failed, task_output_cleanup_run,
     task_worker_config, task_worker_iteration,
 };
+pub(crate) use self::token::{token_authentication, token_hash_key_ring};
 
 static METRICS: OnceLock<Metrics> = OnceLock::new();
 
@@ -109,6 +111,10 @@ struct Metrics {
     secret_source_info: Gauge<u64>,
     secret_resolution_duration: Histogram<f64>,
     secret_resolutions: Counter<u64>,
+    token_hash_key_info: Gauge<u64>,
+    token_hash_keys: Gauge<u64>,
+    token_authentications: Counter<u64>,
+    token_hash_stored: Gauge<i64>,
     task_worker_iterations: Counter<u64>,
     task_claims: Counter<u64>,
     task_lease_recoveries: Counter<u64>,

--- a/src/observability/metrics/registry.rs
+++ b/src/observability/metrics/registry.rs
@@ -211,6 +211,22 @@ pub fn init() -> Result<(), ApiError> {
             .u64_counter("hubuum_secret_resolutions")
             .with_description("Secret resolution outcomes by bounded provider and consumer")
             .build(),
+        token_hash_key_info: meter
+            .u64_gauge("hubuum_token_hash_key_info")
+            .with_description("Configured token hash key-ring mode")
+            .build(),
+        token_hash_keys: meter
+            .u64_gauge("hubuum_token_hash_keys")
+            .with_description("Configured token hash keys by bounded lifecycle state")
+            .build(),
+        token_authentications: meter
+            .u64_counter("hubuum_token_authentications")
+            .with_description("Bearer-token authentication and migration outcomes")
+            .build(),
+        token_hash_stored: meter
+            .i64_gauge("hubuum_token_hash_stored")
+            .with_description("Stored bearer tokens by bounded key and lifecycle state")
+            .build(),
         task_worker_iterations: meter
             .u64_counter("hubuum_task_worker_iterations")
             .with_description("Task worker loop iterations")

--- a/src/observability/metrics/scrape.rs
+++ b/src/observability/metrics/scrape.rs
@@ -9,7 +9,7 @@ use crate::permissions::AppContext;
 use crate::storage::{StorageCallSite, with_storage_call_site};
 
 use super::Metrics;
-use super::{db, event, get, inventory, login, task};
+use super::{db, event, get, inventory, login, task, token};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum RefreshOutcome {
@@ -25,6 +25,7 @@ pub(super) enum RefreshSource {
     LoginLimiter,
     Process,
     Tasks,
+    TokenKeys,
 }
 
 impl RefreshSource {
@@ -36,6 +37,7 @@ impl RefreshSource {
             Self::LoginLimiter => "login_limiter",
             Self::Process => "process",
             Self::Tasks => "tasks",
+            Self::TokenKeys => "token_keys",
         }
     }
 }
@@ -82,6 +84,7 @@ async fn refresh_scrape_gauges(metrics: &Metrics, backend: &crate::storage::Stor
         inventory::refresh_inventory_gauges(metrics, backend).await;
         task::refresh_task_gauges(metrics, backend).await;
         event::refresh_event_gauges(metrics, backend).await;
+        token::refresh_token_key_gauges(metrics, backend).await;
     } else {
         metrics.refresh_skipped.add(
             1,
@@ -131,6 +134,7 @@ mod tests {
                 RefreshSource::LoginLimiter,
                 RefreshSource::Process,
                 RefreshSource::Tasks,
+                RefreshSource::TokenKeys,
             ]
             .map(RefreshSource::as_str),
             [
@@ -140,6 +144,7 @@ mod tests {
                 "login_limiter",
                 "process",
                 "tasks",
+                "token_keys",
             ]
         );
     }

--- a/src/observability/metrics/token.rs
+++ b/src/observability/metrics/token.rs
@@ -1,0 +1,107 @@
+use opentelemetry::KeyValue;
+
+use super::current;
+use super::scrape::{RefreshOutcome, RefreshSource, record_refresh_attempt};
+use crate::storage::TokenStorage;
+
+pub(crate) fn token_hash_key_ring(
+    mode: &'static str,
+    active_key_id: &str,
+    ring_identity: &str,
+    active: u64,
+    previous: u64,
+) {
+    if let Some(metrics) = current() {
+        metrics.token_hash_key_info.record(
+            1,
+            &[
+                KeyValue::new("mode", mode),
+                KeyValue::new("active_key_id", active_key_id.to_string()),
+                KeyValue::new("ring_identity", ring_identity.to_string()),
+            ],
+        );
+        metrics
+            .token_hash_keys
+            .record(active, &[KeyValue::new("state", "active")]);
+        metrics
+            .token_hash_keys
+            .record(previous, &[KeyValue::new("state", "previous")]);
+    }
+}
+
+pub(crate) fn token_authentication(
+    format: &'static str,
+    key_state: &'static str,
+    outcome: &'static str,
+) {
+    if let Some(metrics) = current() {
+        metrics.token_authentications.add(
+            1,
+            &[
+                KeyValue::new("format", format),
+                KeyValue::new("key_state", key_state),
+                KeyValue::new("outcome", outcome),
+            ],
+        );
+    }
+}
+
+pub(super) async fn refresh_token_key_gauges(
+    metrics: &super::Metrics,
+    backend: &crate::storage::StorageHandle,
+) {
+    let started_at = std::time::Instant::now();
+    let result = async {
+        let observed_at = chrono::Utc::now();
+        let legacy_valid_after = crate::models::configured_token_lifetime()?
+            .cutoff_from(observed_at.naive_utc())?
+            .and_utc();
+        let observation =
+            crate::storage::StorageTokenObservation::try_new(observed_at, legacy_valid_after)
+                .map_err(|error| crate::errors::ApiError::InternalServerError(error.to_string()))?;
+        let usage = backend.token_key_usage(observation).await?;
+        let ring = crate::config::token_hash_key_ring()
+            .map_err(|error| crate::errors::ApiError::InternalServerError(error.to_string()))?;
+        let mut counts = [[0_i64; 3]; 4];
+        for item in usage {
+            let key_state = match item.key_id() {
+                Some(id) if id == ring.active_key_id() => 0,
+                Some(id) if ring.previous_key_ids().any(|previous| previous == id) => 1,
+                Some(_) => 3,
+                None => 2,
+            };
+            counts[key_state][0] += item.active();
+            counts[key_state][1] += item.revoked();
+            counts[key_state][2] += item.expired();
+        }
+        for (key_state, state_counts) in ["active", "previous", "legacy", "unconfigured"]
+            .into_iter()
+            .zip(counts)
+        {
+            for (lifecycle, count) in ["active", "revoked", "expired"]
+                .into_iter()
+                .zip(state_counts)
+            {
+                metrics.token_hash_stored.record(
+                    count,
+                    &[
+                        KeyValue::new("key_state", key_state),
+                        KeyValue::new("lifecycle", lifecycle),
+                    ],
+                );
+            }
+        }
+        Ok::<(), crate::errors::ApiError>(())
+    }
+    .await;
+    record_refresh_attempt(
+        metrics,
+        RefreshSource::TokenKeys,
+        started_at,
+        if result.is_ok() {
+            RefreshOutcome::Succeeded
+        } else {
+            RefreshOutcome::Failed
+        },
+    );
+}

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -3,8 +3,8 @@ use std::sync::LazyLock;
 use std::time::Instant;
 
 use hubuum_secrets::{
-    EnvironmentProvider, FileProvider, FileSymlinkPolicy, ResolvedSecret, SecretError,
-    SecretErrorKind, SecretName, SecretProviderKind, SecretRef, SecretResolver,
+    EnvironmentProvider, FileProvider, FileSymlinkPolicy, ResolvedSecret, ResolvedSecretGroup,
+    SecretError, SecretErrorKind, SecretName, SecretProviderKind, SecretRef, SecretResolver,
 };
 
 const SOURCE_ENVIRONMENT: &str = "HUBUUM_SECRET_SOURCE";
@@ -29,6 +29,31 @@ impl ConsumerSecrets {
                 let reference = SecretRef::new(self.provider_kind, name);
                 self.resolver.resolve(&reference).await
             }
+            Err(error) => Err(error),
+        };
+        crate::observability::metrics::secret_resolution_finished(
+            self.provider_label,
+            self.consumer_label,
+            result
+                .as_ref()
+                .map(|_| "ok")
+                .unwrap_or_else(|error| error_outcome(error.kind())),
+            started.elapsed(),
+        );
+        result
+    }
+
+    async fn resolve_group(&self, aliases: &[String]) -> Result<ResolvedSecretGroup, SecretError> {
+        let started = Instant::now();
+        crate::observability::metrics::secret_source_identity(self.provider_label);
+        let result = aliases
+            .iter()
+            .map(|alias| {
+                SecretName::new(alias).map(|name| SecretRef::new(self.provider_kind, name))
+            })
+            .collect::<Result<Vec<_>, _>>();
+        let result = match result {
+            Ok(references) => self.resolver.resolve_group(&references).await,
             Err(error) => Err(error),
         };
         crate::observability::metrics::secret_resolution_finished(
@@ -133,7 +158,7 @@ impl ApplicationSecrets {
             token: consumer_resolver(
                 source,
                 root,
-                "",
+                "HUBUUM_TOKEN_HASH_KEY_",
                 Some(("key", "HUBUUM_TOKEN_HASH_KEY")),
                 "token",
                 "token_hash",
@@ -254,6 +279,18 @@ pub(crate) fn resolve_token_hash_key() -> Result<Vec<u8>, SecretError> {
         return Ok(trimmed.as_bytes().to_vec());
     }
     Ok(resolved.value().expose().to_vec())
+}
+
+pub(crate) fn resolve_token_hash_key_group(
+    aliases: &[String],
+) -> Result<Vec<ResolvedSecret>, SecretError> {
+    let secrets = configured()?;
+    let resolved = futures::executor::block_on(secrets.token.resolve_group(aliases))?;
+    Ok(resolved.values().to_vec())
+}
+
+pub(crate) fn token_hash_secrets_are_text() -> Result<bool, SecretError> {
+    Ok(configured()?.source == SecretSource::Environment)
 }
 
 pub(crate) fn running_source_configuration() -> (&'static str, bool) {

--- a/src/services/authentication.rs
+++ b/src/services/authentication.rs
@@ -3,8 +3,8 @@ use chrono::SubsecRound;
 use crate::errors::ApiError;
 use crate::models::{Token, configured_token_lifetime};
 use crate::storage::{
-    AuthenticationStorage, StorageAuthenticatedToken, StorageAuthenticationAttempt,
-    StorageAuthenticationCredential, StorageContext, storage_handle,
+    AuthenticationStorage, StorageAuthenticatedToken, StorageAuthenticationAttempt, StorageContext,
+    StorageTokenFormat, StorageTokenMigrationOutcome, storage_handle,
 };
 
 /// Validate one presented bearer token through the selected complete storage
@@ -17,16 +17,51 @@ pub async fn authenticate_bearer_token(
     context: &impl StorageContext,
     token: &Token,
 ) -> Result<StorageAuthenticatedToken, ApiError> {
-    let credential = StorageAuthenticationCredential::new(token.storage_hash());
+    let plan = match token.credentials() {
+        Ok(plan) => plan,
+        Err(error) => {
+            crate::observability::metrics::token_authentication(
+                if token.0.starts_with("hbt") {
+                    "versioned_unknown"
+                } else {
+                    "legacy"
+                },
+                "unknown",
+                "rejected",
+            );
+            return Err(error);
+        }
+    };
+    let format = match plan.format {
+        StorageTokenFormat::Legacy => "legacy",
+        StorageTokenFormat::Version1 => "version1",
+    };
+    let key_state = plan.key_state;
     let observed_at = chrono::Utc::now().naive_utc().trunc_subsecs(6);
     let legacy_valid_after = configured_token_lifetime()?.cutoff_from(observed_at)?;
-    let attempt = StorageAuthenticationAttempt::try_new(
-        credential,
+    let attempt = StorageAuthenticationAttempt::try_candidates(
+        plan.credentials,
+        plan.migration_target,
         observed_at.and_utc(),
         legacy_valid_after.and_utc(),
     )
     .map_err(|error| ApiError::InternalServerError(error.to_string()))?;
-    Ok(storage_handle(context)
+    match storage_handle(context)
         .authenticate_bearer_token(attempt)
-        .await?)
+        .await
+    {
+        Ok(authenticated) => {
+            let outcome = match authenticated.migration_outcome() {
+                StorageTokenMigrationOutcome::NotNeeded => "success",
+                StorageTokenMigrationOutcome::Migrated => "migrated",
+                StorageTokenMigrationOutcome::Conflict => "migration_conflict",
+            };
+            crate::observability::metrics::token_authentication(format, key_state, outcome);
+            Ok(authenticated)
+        }
+        Err(error) => {
+            crate::observability::metrics::token_authentication(format, key_state, "rejected");
+            Err(error.into())
+        }
+    }
 }

--- a/src/services/identity.rs
+++ b/src/services/identity.rs
@@ -436,7 +436,7 @@ pub async fn create_token(
     let raw = crate::utilities::auth::generate_token();
     let storage_request = StorageTokenCreate::new(
         principal_id_to_storage(parts.principal_id.id()),
-        raw.storage_hash(),
+        raw.storage_digest()?,
         token_policy(issuance_policy),
         event_context.clone(),
     )
@@ -471,7 +471,7 @@ pub async fn renew_token(
         hubuum_domain::TokenId::new(source_token_id)
             .expect("validated source token id must be positive"),
         principal_id_to_storage(principal_id),
-        raw.storage_hash(),
+        raw.storage_digest()?,
         expires_at.map(|timestamp| timestamp.and_utc()),
         token_policy(issuance_policy),
         event_context.clone(),
@@ -546,15 +546,17 @@ pub async fn revoke_token(
 pub async fn revoke_token_by_hash(
     context: &impl StorageContext,
     principal_id: Option<i32>,
-    token_hash: String,
+    credentials: Vec<crate::storage::StorageAuthenticationCredential>,
     event_context: &EventContext,
 ) -> Result<usize, ApiError> {
+    let request = StorageTokenHashRevoke::try_candidates(
+        principal_id.map(principal_id_to_storage),
+        credentials,
+        event_context.clone(),
+    )
+    .map_err(|error| ApiError::InternalServerError(error.to_string()))?;
     Ok(storage_handle(context)
-        .revoke_token_by_hash(StorageTokenHashRevoke::new(
-            principal_id.map(principal_id_to_storage),
-            token_hash,
-            event_context.clone(),
-        ))
+        .revoke_token_by_hash(request)
         .await?
         .into_value())
 }

--- a/src/storage/context/identity.rs
+++ b/src/storage/context/identity.rs
@@ -629,6 +629,19 @@ impl TokenStorage for StorageHandle {
         .await
     }
 
+    async fn token_key_usage(
+        &self,
+        observation: StorageTokenObservation,
+    ) -> Result<Vec<StorageTokenKeyUsage>, StorageError> {
+        self.observe_storage_call(
+            self.backend_name(),
+            StorageCapability::Token,
+            "token_key_usage",
+            async { dispatch_backend!(self, |backend| backend.token_key_usage(observation).await) },
+        )
+        .await
+    }
+
     async fn create_token(
         &self,
         request: StorageTokenCreate,

--- a/src/storage/context/mod.rs
+++ b/src/storage/context/mod.rs
@@ -103,13 +103,13 @@ use crate::storage::{
     StorageTaskClaim, StorageTaskCompletion, StorageTaskCreateRequest, StorageTaskEvent,
     StorageTaskEventAppend, StorageTaskFailure, StorageTaskGaugeSnapshot, StorageTaskLease,
     StorageTaskLeaseDuration, StorageTaskListQuery, StorageTaskOutputLookup, StorageTokenCreate,
-    StorageTokenHashRevoke, StorageTokenListQuery, StorageTokenMetadata, StorageTokenObservation,
-    StorageTokenRenew, StorageTokenRevoke, StorageTransaction, StorageTransactionFuture,
-    StorageUnifiedSearchCandidate, StorageUnifiedSearchQuery, StorageUser, StorageUserAnonymize,
-    StorageUserCreate, StorageUserDelete, StorageUserDetails, StorageUserListItem,
-    StorageUserListQuery, StorageUserPasswordUpdate, StorageUserUpdate, TaskExecutionStorage,
-    TaskQueueStorage, TokenRetentionStorage, TokenStorage, TransactionStorage,
-    UnifiedSearchStorage, UserStorage, WorkerNotificationProvider,
+    StorageTokenHashRevoke, StorageTokenKeyUsage, StorageTokenListQuery, StorageTokenMetadata,
+    StorageTokenObservation, StorageTokenRenew, StorageTokenRevoke, StorageTransaction,
+    StorageTransactionFuture, StorageUnifiedSearchCandidate, StorageUnifiedSearchQuery,
+    StorageUser, StorageUserAnonymize, StorageUserCreate, StorageUserDelete, StorageUserDetails,
+    StorageUserListItem, StorageUserListQuery, StorageUserPasswordUpdate, StorageUserUpdate,
+    TaskExecutionStorage, TaskQueueStorage, TokenRetentionStorage, TokenStorage,
+    TransactionStorage, UnifiedSearchStorage, UserStorage, WorkerNotificationProvider,
 };
 use crate::storage::{DatabaseDiagnosticsProvider, DatabasePoolState, DatabaseStorageSnapshot};
 use crate::storage::{StorageClassHistoryRecord, StorageCollectionHistoryRecord};

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -128,14 +128,15 @@ pub(crate) use hubuum_storage_core::{
     StorageTaskEventInput, StorageTaskFailure, StorageTaskKind, StorageTaskLease,
     StorageTaskLeaseDuration, StorageTaskListQuery, StorageTaskOutputLookup,
     StorageTaskResultCounts, StorageTaskScopeSnapshot, StorageTaskStatus,
-    StorageTaskTerminalUpdate, StorageTokenCreate, StorageTokenHashRevoke,
-    StorageTokenIssuancePolicy, StorageTokenListQuery, StorageTokenListState, StorageTokenMetadata,
-    StorageTokenObservation, StorageTokenRenew, StorageTokenRevoke, StorageUnifiedSearchCandidate,
-    StorageUnifiedSearchCursor, StorageUnifiedSearchQuery, StorageUser, StorageUserAnonymize,
-    StorageUserCreate, StorageUserDelete, StorageUserDetails, StorageUserListItem,
-    StorageUserListQuery, StorageUserPasswordUpdate, StorageUserUpdate, StorageVisibility,
-    TaskExecutionStorage, TaskQueueStorage, TokenStorage, UnifiedSearchStorage, UserStorage,
-    WorkerNotificationProvider,
+    StorageTaskTerminalUpdate, StorageTokenCreate, StorageTokenDigest, StorageTokenFormat,
+    StorageTokenHashAlgorithm, StorageTokenHashKeyId, StorageTokenHashRevoke,
+    StorageTokenIssuancePolicy, StorageTokenKeyUsage, StorageTokenListQuery, StorageTokenListState,
+    StorageTokenMetadata, StorageTokenObservation, StorageTokenRenew, StorageTokenRevoke,
+    StorageUnifiedSearchCandidate, StorageUnifiedSearchCursor, StorageUnifiedSearchQuery,
+    StorageUser, StorageUserAnonymize, StorageUserCreate, StorageUserDelete, StorageUserDetails,
+    StorageUserListItem, StorageUserListQuery, StorageUserPasswordUpdate, StorageUserUpdate,
+    StorageVisibility, TaskExecutionStorage, TaskQueueStorage, TokenStorage, UnifiedSearchStorage,
+    UserStorage, WorkerNotificationProvider,
 };
 pub(crate) use hubuum_storage_core::{
     BackupSnapshotStorage, StorageBackupHistorySection, StorageBackupOutput,
@@ -145,8 +146,8 @@ pub(crate) use hubuum_storage_core::{
 };
 pub use hubuum_storage_core::{
     ExecutionStorage, StorageAuthenticatedToken, StorageCallSite, StorageExecutionScope,
-    StorageRevisionPrecondition, StorageRevisionTarget, StorageTransaction,
-    StorageTransactionFuture, TransactionStorage, TransactionalClassRelations,
+    StorageRevisionPrecondition, StorageRevisionTarget, StorageTokenMigrationOutcome,
+    StorageTransaction, StorageTransactionFuture, TransactionStorage, TransactionalClassRelations,
     TransactionalClasses, TransactionalCollections, TransactionalObjectRelations,
     TransactionalObjects, execute_event_retention_batch,
 };

--- a/src/tests/application_boundary.rs
+++ b/src/tests/application_boundary.rs
@@ -3094,6 +3094,7 @@ fn token_resources_are_owned_by_the_postgres_adapter() {
         "revoke_token_by_hash",
         "revoke_all_principal_tokens",
         "list_retained_tokens",
+        "token_key_usage",
     ] {
         let method_body = item_body(token_implementation, "fn", method);
         assert!(

--- a/src/tests/storage_contract.rs
+++ b/src/tests/storage_contract.rs
@@ -130,12 +130,14 @@ use crate::storage::{
     StorageTaskEventAppend, StorageTaskEventInput, StorageTaskFailure, StorageTaskKind,
     StorageTaskLease, StorageTaskLeaseDuration, StorageTaskListQuery, StorageTaskOutputLookup,
     StorageTaskResultCounts, StorageTaskScopeSnapshot, StorageTaskStatus,
-    StorageTaskTerminalUpdate, StorageTokenCreate, StorageTokenHashRevoke,
+    StorageTaskTerminalUpdate, StorageTokenCreate, StorageTokenDigest, StorageTokenFormat,
+    StorageTokenHashAlgorithm, StorageTokenHashKeyId, StorageTokenHashRevoke,
     StorageTokenIssuancePolicy, StorageTokenListQuery, StorageTokenListState,
-    StorageTokenObservation, StorageTokenRenew, StorageTokenRevoke, StorageUnifiedSearchQuery,
-    StorageUserAnonymize, StorageUserCreate, StorageUserDelete, StorageUserListQuery,
-    StorageUserPasswordUpdate, StorageUserUpdate, StorageVisibility, TaskExecutionStorage,
-    TaskQueueStorage, TokenRetentionStorage, TokenStorage, UnifiedSearchStorage, UserStorage,
+    StorageTokenMigrationOutcome, StorageTokenObservation, StorageTokenRenew, StorageTokenRevoke,
+    StorageUnifiedSearchQuery, StorageUserAnonymize, StorageUserCreate, StorageUserDelete,
+    StorageUserListQuery, StorageUserPasswordUpdate, StorageUserUpdate, StorageVisibility,
+    TaskExecutionStorage, TaskQueueStorage, TokenRetentionStorage, TokenStorage,
+    UnifiedSearchStorage, UserStorage,
 };
 use crate::traits::CanSave;
 use hubuum_storage_postgres::PostgresPool;
@@ -285,7 +287,7 @@ async fn create_backend_user(backend: &StorageHandle, name: &str) -> BackendUser
     backend
         .create_token(StorageTokenCreate::new(
             principal_id,
-            &token_hash,
+            StorageTokenDigest::legacy_unidentified(&token_hash),
             StorageTokenIssuancePolicy::try_new(24, 24)
                 .expect("backend-local token policy should be valid"),
             EventContext::system(),
@@ -2459,6 +2461,306 @@ async fn every_available_storage_backend_supplies_authentication_projections() {
 }
 
 #[actix_web::test]
+async fn every_available_storage_backend_migrates_legacy_token_digests_safely() {
+    let _permit = postgres_permit().await;
+    let active_key_id = StorageTokenHashKeyId::try_new("active").unwrap();
+    let previous_key_id = StorageTokenHashKeyId::try_new("previous").unwrap();
+
+    for backend in available_backends() {
+        let user = create_backend_user(&backend, &prefix("token_rotation_user")).await;
+        let old_hash = prefix("legacy_previous_digest");
+        let active_hash = prefix("legacy_active_digest");
+        backend
+            .create_token(StorageTokenCreate::new(
+                user.principal_id,
+                StorageTokenDigest::legacy_unidentified(&old_hash),
+                StorageTokenIssuancePolicy::try_new(24, 24).unwrap(),
+                EventContext::system(),
+            ))
+            .await
+            .expect("certified backend should create a legacy token row")
+            .into_value();
+
+        let observed_at = chrono::Utc::now();
+        let candidate = |hash: &str, key_id: StorageTokenHashKeyId| {
+            StorageAuthenticationCredential::from_digest(
+                StorageTokenDigest::try_new(
+                    hash,
+                    StorageTokenFormat::Legacy,
+                    StorageTokenHashAlgorithm::HmacSha256V1,
+                    Some(key_id),
+                )
+                .unwrap(),
+            )
+        };
+        let migration_target = StorageTokenDigest::try_new(
+            &active_hash,
+            StorageTokenFormat::Legacy,
+            StorageTokenHashAlgorithm::HmacSha256V1,
+            Some(active_key_id.clone()),
+        )
+        .unwrap();
+        let migrated = backend
+            .authenticate_bearer_token(
+                StorageAuthenticationAttempt::try_candidates(
+                    vec![
+                        candidate(&active_hash, active_key_id.clone()),
+                        candidate(&old_hash, previous_key_id.clone()),
+                    ],
+                    Some(migration_target),
+                    observed_at,
+                    observed_at - chrono::Duration::days(1),
+                )
+                .unwrap(),
+            )
+            .await
+            .expect("certified backend should validate and migrate a legacy digest");
+        assert_eq!(
+            migrated.migration_outcome(),
+            StorageTokenMigrationOutcome::Migrated
+        );
+
+        backend
+            .authenticate_bearer_token(
+                StorageAuthenticationAttempt::try_new(
+                    candidate(&active_hash, active_key_id.clone()),
+                    observed_at,
+                    observed_at - chrono::Duration::days(1),
+                )
+                .unwrap(),
+            )
+            .await
+            .expect("the migrated active-key digest should authenticate");
+        backend
+            .authenticate_bearer_token(
+                StorageAuthenticationAttempt::try_new(
+                    candidate(&old_hash, previous_key_id.clone()),
+                    observed_at,
+                    observed_at - chrono::Duration::days(1),
+                )
+                .unwrap(),
+            )
+            .await
+            .expect_err("the retired legacy digest should no longer authenticate");
+
+        let usage = backend
+            .token_key_usage(
+                StorageTokenObservation::try_new(
+                    observed_at,
+                    observed_at - chrono::Duration::days(1),
+                )
+                .unwrap(),
+            )
+            .await
+            .expect("certified backend should report token key retirement evidence");
+        assert!(
+            usage
+                .iter()
+                .any(|item| { item.key_id() == Some(&active_key_id) && item.active() >= 1 })
+        );
+
+        delete_backend_user(&backend, user).await;
+    }
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_prevents_versioned_key_fallback() {
+    let _permit = postgres_permit().await;
+    let active_key_id = StorageTokenHashKeyId::try_new("active").unwrap();
+    let previous_key_id = StorageTokenHashKeyId::try_new("previous").unwrap();
+
+    for backend in available_backends() {
+        let user = create_backend_user(&backend, &prefix("versioned_token_key_user")).await;
+        let versioned_hash = prefix("versioned_previous_digest");
+        backend
+            .create_token(StorageTokenCreate::new(
+                user.principal_id,
+                StorageTokenDigest::try_new(
+                    &versioned_hash,
+                    StorageTokenFormat::Version1,
+                    StorageTokenHashAlgorithm::HmacSha256V1,
+                    Some(previous_key_id.clone()),
+                )
+                .unwrap(),
+                StorageTokenIssuancePolicy::try_new(24, 24).unwrap(),
+                EventContext::system(),
+            ))
+            .await
+            .expect("certified backend should create a versioned token row")
+            .into_value();
+        let observed_at = chrono::Utc::now();
+        let credential = |key_id| {
+            StorageAuthenticationCredential::from_digest(
+                StorageTokenDigest::try_new(
+                    &versioned_hash,
+                    StorageTokenFormat::Version1,
+                    StorageTokenHashAlgorithm::HmacSha256V1,
+                    Some(key_id),
+                )
+                .unwrap(),
+            )
+        };
+
+        backend
+            .authenticate_bearer_token(
+                StorageAuthenticationAttempt::try_new(
+                    credential(active_key_id.clone()),
+                    observed_at,
+                    observed_at - chrono::Duration::days(1),
+                )
+                .unwrap(),
+            )
+            .await
+            .expect_err("versioned credentials must not fall back to another key ID");
+        backend
+            .authenticate_bearer_token(
+                StorageAuthenticationAttempt::try_new(
+                    credential(previous_key_id.clone()),
+                    observed_at,
+                    observed_at - chrono::Duration::days(1),
+                )
+                .unwrap(),
+            )
+            .await
+            .expect("versioned credentials should use exactly their selected key ID");
+
+        delete_backend_user(&backend, user).await;
+    }
+}
+
+#[derive(Clone, Copy)]
+enum InactiveLegacyTokenState {
+    Revoked,
+    Expired,
+}
+
+async fn assert_inactive_legacy_token_is_not_migrated(
+    backend: &StorageHandle,
+    state: InactiveLegacyTokenState,
+) {
+    let (fixture_name, active_key_name, old_hash_name, active_hash_name) = match state {
+        InactiveLegacyTokenState::Revoked => (
+            "revoked_token_rotation_user",
+            "revoked-target",
+            "revoked_legacy_digest",
+            "revoked_active_digest",
+        ),
+        InactiveLegacyTokenState::Expired => (
+            "expired_token_rotation_user",
+            "expired-target",
+            "expired_legacy_digest",
+            "expired_active_digest",
+        ),
+    };
+    let user = create_backend_user(backend, &prefix(fixture_name)).await;
+    let active_key_id = StorageTokenHashKeyId::try_new(active_key_name).unwrap();
+    let previous_key_id = StorageTokenHashKeyId::try_new("inactive-previous").unwrap();
+    let old_hash = prefix(old_hash_name);
+    let active_hash = prefix(active_hash_name);
+    let expires_at = chrono::Utc::now() + chrono::Duration::minutes(1);
+    let create = StorageTokenCreate::new(
+        user.principal_id,
+        StorageTokenDigest::legacy_unidentified(&old_hash),
+        StorageTokenIssuancePolicy::try_new(24, 24).unwrap(),
+        EventContext::system(),
+    );
+    let create = match state {
+        InactiveLegacyTokenState::Revoked => create,
+        InactiveLegacyTokenState::Expired => create.expires_at(Some(expires_at)),
+    };
+    let token = backend
+        .create_token(create)
+        .await
+        .expect("certified backend should create an inactive-token fixture")
+        .into_value();
+    if matches!(state, InactiveLegacyTokenState::Revoked) {
+        backend
+            .revoke_token(StorageTokenRevoke::new(
+                token.id(),
+                user.principal_id,
+                EventContext::system(),
+            ))
+            .await
+            .expect("certified backend should revoke the migration fixture")
+            .into_value();
+    }
+    let observed_at = match state {
+        InactiveLegacyTokenState::Revoked => chrono::Utc::now(),
+        InactiveLegacyTokenState::Expired => expires_at + chrono::Duration::seconds(1),
+    };
+    let candidate = |hash: &str, key_id: StorageTokenHashKeyId| {
+        StorageAuthenticationCredential::from_digest(
+            StorageTokenDigest::try_new(
+                hash,
+                StorageTokenFormat::Legacy,
+                StorageTokenHashAlgorithm::HmacSha256V1,
+                Some(key_id),
+            )
+            .unwrap(),
+        )
+    };
+    let migration_target = StorageTokenDigest::try_new(
+        &active_hash,
+        StorageTokenFormat::Legacy,
+        StorageTokenHashAlgorithm::HmacSha256V1,
+        Some(active_key_id.clone()),
+    )
+    .unwrap();
+
+    backend
+        .authenticate_bearer_token(
+            StorageAuthenticationAttempt::try_candidates(
+                vec![
+                    candidate(&active_hash, active_key_id.clone()),
+                    candidate(&old_hash, previous_key_id),
+                ],
+                Some(migration_target),
+                observed_at,
+                observed_at - chrono::Duration::days(1),
+            )
+            .unwrap(),
+        )
+        .await
+        .expect_err("inactive legacy credentials must not authenticate or migrate");
+
+    let usage = backend
+        .token_key_usage(
+            StorageTokenObservation::try_new(observed_at, observed_at - chrono::Duration::days(1))
+                .unwrap(),
+        )
+        .await
+        .expect("certified backend should report inactive token key usage");
+    assert!(
+        usage
+            .iter()
+            .all(|item| item.key_id() != Some(&active_key_id)),
+        "an inactive token must retain its pre-migration key identity"
+    );
+
+    delete_backend_user(backend, user).await;
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_does_not_migrate_revoked_tokens() {
+    let _permit = postgres_permit().await;
+
+    for backend in available_backends() {
+        assert_inactive_legacy_token_is_not_migrated(&backend, InactiveLegacyTokenState::Revoked)
+            .await;
+    }
+}
+
+#[actix_web::test]
+async fn every_available_storage_backend_does_not_migrate_expired_tokens() {
+    let _permit = postgres_permit().await;
+
+    for backend in available_backends() {
+        assert_inactive_legacy_token_is_not_migrated(&backend, InactiveLegacyTokenState::Expired)
+            .await;
+    }
+}
+
+#[actix_web::test]
 async fn every_available_storage_backend_supplies_complete_identity_operations() {
     let _permit = postgres_permit().await;
 
@@ -2650,7 +2952,7 @@ async fn every_available_storage_backend_supplies_complete_identity_operations()
         let first_token = backend
             .create_token(StorageTokenCreate::new(
                 contract_principal_id,
-                &first_hash,
+                StorageTokenDigest::legacy_unidentified(&first_hash),
                 token_policy,
                 event_context.clone(),
             ))
@@ -2678,7 +2980,7 @@ async fn every_available_storage_backend_supplies_complete_identity_operations()
             .renew_token(StorageTokenRenew::new(
                 first_token_id,
                 contract_principal_id,
-                &second_hash,
+                StorageTokenDigest::legacy_unidentified(&second_hash),
                 None,
                 token_policy,
                 event_context.clone(),
@@ -2715,7 +3017,7 @@ async fn every_available_storage_backend_supplies_complete_identity_operations()
         backend
             .create_token(StorageTokenCreate::new(
                 contract_principal_id,
-                third_hash,
+                StorageTokenDigest::legacy_unidentified(third_hash),
                 token_policy,
                 event_context.clone(),
             ))

--- a/src/utilities/auth.rs
+++ b/src/utilities/auth.rs
@@ -146,7 +146,11 @@ pub fn generate_token() -> Token {
     let mut hasher = Sha512::new();
     hasher.update(raw);
     let result = hasher.finalize();
-    Token(result.iter().map(|byte| format!("{byte:02x}")).collect())
+    let secret = result
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Token::issued(secret).expect("token hash key-ring configuration must be valid at startup")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- add a bounded active/previous token hash key ring with atomic secret resolution, strict startup validation, stable key identifiers, and compatible single-key fallback
- issue versioned `hbt1.<key-id>.<secret>` credentials and authenticate them without legacy fallback
- migrate unidentified legacy digests to the active key after successful authentication using one bounded lookup and race-safe conditional writes
- implement the complete contract in PostgreSQL and memory storage, including aggregate-only key usage reporting and store conformance tests
- expose bounded metrics and administrator status, document the rolling deployment/rollback/retirement sequence, and split the memory adapter into focused import, state, and support modules

## Rollout behavior

Existing deployments can upgrade while retaining `HUBUUM_TOKEN_HASH_KEY`. Operators then configure the current key as active, stage the future key as previous on every replica, switch the active identifier in a second rollout, observe legacy/previous usage, and remove old material only after the configured token-lifetime window. Automatic retirement is intentionally not performed.

Malformed or unknown versioned credentials fail closed and never fall back to legacy key trials. Disabled, revoked, and expired tokens are never migrated. Configuration errors do not expose key material.

## Breaking changes

The experimental `hubuum-storage-core` token capability now uses typed digest/candidate values and requires `token_key_usage`. External storage adapters must persist token format, algorithm, and optional key identifier metadata, implement the aggregate method, and update authentication/create/renew/revoke signatures before upgrading.

The committed PostgreSQL migration performs the required schema upgrade for the built-in adapter. Existing application deployments require no token reset and retain the legacy single-key environment variable during the software-upgrade boundary.

## Performance

`token_storage_hash_callgrind` reports 31,772 instructions after the direct active-key lookup change, down from the approximately 52,000-instruction baseline.

## Verification

- `source .env && ./run_tests.sh`
- `cargo test -p hubuum-storage-core`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- production Docker build with release TLS features
- `cargo bench --bench token_storage_hash_callgrind`
- CI change-classifier regression tests

Closes #254.