### PR TITLE
Separate database migration and runtime roles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 # Local Docker Compose only. Generate a unique value with:
 # openssl rand -hex 32
 POSTGRES_PASSWORD=
+POSTGRES_MIGRATOR_PASSWORD=
+POSTGRES_RUNTIME_PASSWORD=

--- a/.github/openapi-breaking-exceptions.json
+++ b/.github/openapi-breaking-exceptions.json
@@ -181,7 +181,7 @@
       "baseline": "v0.0.11",
       "expires": "2027-08-31",
       "reason": "API confirmation now queues a restore for an isolated migrator-backed executor instead of holding the request open across the destructive transaction.",
-      "migration": "Deploy `hubuum-admin --restore-executor`, accept HTTP 202 from confirmation, and poll the existing capability-authenticated status endpoint to a terminal state.",
+      "migration": "`hubuum-admin --restore-executor`",
       "changelog_entry": "POST /api/v1/restores/{restore_id}/confirm",
       "fingerprints": [
         "ca6ee7172865"

--- a/.github/openapi-breaking-exceptions.json
+++ b/.github/openapi-breaking-exceptions.json
@@ -177,11 +177,11 @@
       ]
     },
     {
-      "id": "v0.0.11-admin-only-destructive-restore",
+      "id": "v0.0.11-asynchronous-destructive-restore",
       "baseline": "v0.0.11",
       "expires": "2027-08-31",
-      "reason": "A bearer-authenticated API process uses the non-owning runtime database role and must not cross the database privilege boundary to perform destructive full-system restore.",
-      "migration": "`hubuum-admin --restore`",
+      "reason": "API confirmation now queues a restore for an isolated migrator-backed executor instead of holding the request open across the destructive transaction.",
+      "migration": "Deploy `hubuum-admin --restore-executor`, accept HTTP 202 from confirmation, and poll the existing capability-authenticated status endpoint to a terminal state.",
       "changelog_entry": "POST /api/v1/restores/{restore_id}/confirm",
       "fingerprints": [
         "ca6ee7172865"

--- a/.github/openapi-breaking-exceptions.json
+++ b/.github/openapi-breaking-exceptions.json
@@ -175,6 +175,17 @@
         "df58eb5e835d",
         "df42b18ec136"
       ]
+    },
+    {
+      "id": "v0.0.11-admin-only-destructive-restore",
+      "baseline": "v0.0.11",
+      "expires": "2027-08-31",
+      "reason": "A bearer-authenticated API process uses the non-owning runtime database role and must not cross the database privilege boundary to perform destructive full-system restore.",
+      "migration": "`hubuum-admin --restore`",
+      "changelog_entry": "POST /api/v1/restores/{restore_id}/confirm",
+      "fingerprints": [
+        "ca6ee7172865"
+      ]
     }
   ]
 }

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -190,7 +190,8 @@ jobs:
         run: |
           git checkout --detach "$HEAD_SHA"
           cargo run --locked --features embedded-migrations --bin hubuum-admin -- \
-            --migrate --database-url "$HEAD_DATABASE_URL"
+            --migrate --legacy-single-role-migration \
+            --database-url "$HEAD_DATABASE_URL"
           cargo build --locked --features runtime-behavior-check --bin hubuum-server
           cargo run --profile dev --locked --features runtime-behavior-check \
             --bin hubuum-runtime-behavior-check -- measure \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ env:
   RUST_BACKTRACE: 1
   DATABASE_URL: postgres://postgres:postgres@localhost:5432/hubuum_rust_test
   HUBUUM_DATABASE_URL: postgres://postgres:postgres@localhost:5432/hubuum_rust_test
+  HUBUUM_MIGRATION_DATABASE_URL: postgres://postgres:postgres@localhost:5432/hubuum_rust_test
   HUBUUM_DB_TEST_PASSWORD: postgres
 
 jobs:
@@ -739,6 +740,7 @@ jobs:
           $dbUrl = "postgres://postgres@127.0.0.1:$pgPort/hubuum_rust_test"
           "DATABASE_URL=$dbUrl" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "HUBUUM_DATABASE_URL=$dbUrl" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "HUBUUM_MIGRATION_DATABASE_URL=$dbUrl" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "PG_TEST_PORT=$pgPort" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "PG_LOG=$pgLog" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
@@ -923,24 +925,42 @@ jobs:
       - name: Test embedded database migrations and readiness
         env:
           IMAGE: hubuum-server:ci
-          DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/hubuum_container_test?sslmode=disable
+          MIGRATION_DATABASE_URL: postgres://hubuum_migrator:migrator-test@127.0.0.1:5432/hubuum_container_test?sslmode=disable
+          RUNTIME_DATABASE_URL: postgres://hubuum_runtime:runtime-test@127.0.0.1:5432/hubuum_container_test?sslmode=disable
         run: |
           docker run --rm --entrypoint hubuum-admin "$IMAGE" --help \
             | grep --quiet -- "--migrate"
+          docker run --rm --entrypoint hubuum-admin "$IMAGE" \
+            --database-role-setup-sql \
+            | docker run --rm --interactive --network host \
+                --env PGPASSWORD=postgres \
+                postgres:18.4@sha256:22c89fe0d0f507606260237fd55e51f6137f58b2d5bcf6152242b96d9fe8f9a4 psql \
+                --host 127.0.0.1 \
+                --username postgres \
+                --dbname hubuum_container_test \
+                --set ON_ERROR_STOP=1
+          docker run --rm --network host \
+            --env PGPASSWORD=postgres \
+            postgres:18.4@sha256:22c89fe0d0f507606260237fd55e51f6137f58b2d5bcf6152242b96d9fe8f9a4 psql \
+            --host 127.0.0.1 \
+            --username postgres \
+            --dbname hubuum_container_test \
+            --set ON_ERROR_STOP=1 \
+            --command "ALTER ROLE hubuum_migrator PASSWORD 'migrator-test'; ALTER ROLE hubuum_runtime PASSWORD 'runtime-test'"
           if docker run --rm --network host \
             --entrypoint hubuum-admin \
-            --env HUBUUM_DATABASE_URL="$DATABASE_URL" \
+            --env HUBUUM_DATABASE_URL="$RUNTIME_DATABASE_URL" \
             "$IMAGE" --database-ready; then
             echo "database readiness unexpectedly accepted an unmigrated schema" >&2
             exit 1
           fi
           docker run --rm --network host \
             --entrypoint hubuum-admin \
-            --env HUBUUM_DATABASE_URL="$DATABASE_URL" \
+            --env HUBUUM_MIGRATION_DATABASE_URL="$MIGRATION_DATABASE_URL" \
             "$IMAGE" --migrate
           docker run --rm --network host \
             --entrypoint hubuum-admin \
-            --env HUBUUM_DATABASE_URL="$DATABASE_URL" \
+            --env HUBUUM_DATABASE_URL="$RUNTIME_DATABASE_URL" \
             "$IMAGE" --database-ready
           test "$(docker run --rm --network host \
             --env PGPASSWORD=postgres \
@@ -952,7 +972,8 @@ jobs:
             --no-align \
             --command "SELECT to_regclass('public.users') IS NOT NULL")" = "t"
           container_id="$(docker run --rm --detach --network host \
-            --env HUBUUM_DATABASE_URL="$DATABASE_URL" \
+            --env HUBUUM_DATABASE_URL="$RUNTIME_DATABASE_URL" \
+            --env HUBUUM_DATABASE_PRIVILEGE_MODE=strict \
             --env HUBUUM_BIND_IP=127.0.0.1 \
             "$IMAGE")"
           trap 'docker stop "$container_id"' EXIT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -930,6 +930,8 @@ jobs:
         run: |
           docker run --rm --entrypoint hubuum-admin "$IMAGE" --help \
             | grep --quiet -- "--migrate"
+          docker run --rm --entrypoint hubuum-admin "$IMAGE" --help \
+            | grep --quiet -- "--restore-executor"
           docker run --rm --entrypoint hubuum-admin "$IMAGE" \
             --database-role-setup-sql \
             | docker run --rm --interactive --network host \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   but must leave old synchronous web confirmation blocked; use the new one-shot
   administrator restore path until the executor-based release is restored. If
   role provisioning must follow schema migration, the new admin binary retains
-  a warned single-role migration bridge when no database-role names are
-  configured; operators must still complete role adoption before enabling
-  strict checks or web restore confirmation.
+  an explicit, warned `--legacy-single-role-migration` bridge that rejects
+  split-role settings; operators must still complete role adoption before
+  enabling strict checks or web restore confirmation. Adoption transfers table
+  ownership before attached sequences so existing serial-backed schemas can be
+  reconciled safely.
 - **Breaking (full restore):** `POST /api/v1/restores/{restore_id}/confirm` now
   returns `202 Accepted` after queuing the validated operation instead of
   completing the replacement synchronously. Deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Added a generated PostgreSQL privilege manifest with distinct non-login
+  owner, one-shot migrator, and non-owning runtime roles; catalog-backed
+  warn/strict startup diagnostics; administrator SQL and JSON reporting; and
+  Compose, single-host, and distributed deployment workflows that keep the
+  migration credential out of long-lived application containers.
 - Added bounded online token hash key-ring rotation with versioned bearer
   tokens, active and previous verification keys, race-safe migration of legacy
   digests, strict stable-key startup enforcement, per-key retirement
@@ -26,6 +31,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Breaking (database deployment):** server container entrypoints no longer
+  apply migrations. Operators must provision the documented owner, migrator,
+  and runtime roles, set `HUBUUM_DATABASE_URL` to the runtime identity, and run
+  `hubuum-admin --migrate` as a one-shot workload with
+  `HUBUUM_MIGRATION_DATABASE_URL` before rolling the server. External
+  single-host installs must add `--migration-database-url` on upgrade.
+- **Breaking (full restore):** `POST /api/v1/restores/{restore_id}/confirm` now
+  returns `501 Not Implemented`; destructive restore requires
+  `hubuum-admin --restore` with the migration database credential. Existing
+  clients may continue staging and validating documents through the API, but
+  must move confirmation into a controlled administrative workload.
+- Temporal history and append-only audit-event triggers now reject forged
+  restore and purge session flags from the runtime role. Event retention uses
+  a bounded, allowlisted security-definer function tied to an existing durable
+  claim instead of granting the runtime role direct event deletion.
 - **Breaking (experimental `hubuum-storage-core` API):** token creation and
   renewal now receive typed `StorageTokenDigest` values, authentication and
   hash-based revocation accept bounded credential candidates, successful

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   serializes with confirmation, refuses an in-flight confirmed restore, and
   preserves validated stages. Rollback keeps the compatibility runtime login
   but must leave old synchronous web confirmation blocked; use the new one-shot
-  administrator restore path until the executor-based release is restored.
+  administrator restore path until the executor-based release is restored. If
+  role provisioning must follow schema migration, the new admin binary retains
+  a warned single-role migration bridge when no database-role names are
+  configured; operators must still complete role adoption before enabling
+  strict checks or web restore confirmation.
 - **Breaking (full restore):** `POST /api/v1/restores/{restore_id}/confirm` now
   returns `202 Accepted` after queuing the validated operation instead of
   completing the replacement synchronously. Deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 
 - Added a generated PostgreSQL privilege manifest with distinct non-login
-  owner, one-shot migrator, and non-owning runtime roles; catalog-backed
+  owner, dedicated migrator, and non-owning runtime roles; catalog-backed
   warn/strict startup diagnostics; administrator SQL and JSON reporting; and
   Compose, single-host, and distributed deployment workflows that keep the
-  migration credential out of long-lived application containers.
+  migration credential out of long-lived application containers. Web restore
+  is preserved through a separate, non-listening restore-executor workload, with
+  document-free terminal receipts for
+  capability-authenticated status polling.
 - Added bounded online token hash key-ring rotation with versioned bearer
   tokens, active and previous verification keys, race-safe migration of legacy
   digests, strict stable-key startup enforcement, per-key retirement
@@ -36,12 +39,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   and runtime roles, set `HUBUUM_DATABASE_URL` to the runtime identity, and run
   `hubuum-admin --migrate` as a one-shot workload with
   `HUBUUM_MIGRATION_DATABASE_URL` before rolling the server. External
-  single-host installs must add `--migration-database-url` on upgrade.
+  single-host installs must add `--migration-database-url` on upgrade. Existing
+  single-role deployments must verify normal maintenance, pause confirmations,
+  adopt the compatibility runtime grants, migrate, start the isolated restore
+  executor, and only then roll runtime-only API and workers; the migration
+  serializes with confirmation, refuses an in-flight confirmed restore, and
+  preserves validated stages. Rollback keeps the compatibility runtime login
+  but must leave old synchronous web confirmation blocked; use the new one-shot
+  administrator restore path until the executor-based release is restored.
 - **Breaking (full restore):** `POST /api/v1/restores/{restore_id}/confirm` now
-  returns `501 Not Implemented`; destructive restore requires
-  `hubuum-admin --restore` with the migration database credential. Existing
-  clients may continue staging and validating documents through the API, but
-  must move confirmation into a controlled administrative workload.
+  returns `202 Accepted` after queuing the validated operation instead of
+  completing the replacement synchronously. Deploy
+  `hubuum-admin --restore-executor` with the migration database credential
+  before allowing confirmations, and update clients to poll the existing
+  capability-authenticated status endpoint until `succeeded` or `failed`.
+  One-shot `hubuum-admin --restore` remains available.
 - Temporal history and append-only audit-event triggers now reject forged
   restore and purge session flags from the runtime role. Event retention uses
   a bounded, allowlisted security-definer function tied to an existing durable

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ curl -H "Authorization: Bearer <token>" http://localhost:8080/api/v1/iam/users
 - Atomic RFC 6902 updates to raw object data are documented in
   [docs/object_data_json_patch.md](docs/object_data_json_patch.md).
 - Full-system disaster-recovery behavior is documented in [docs/backup-restore.md](docs/backup-restore.md).
+- PostgreSQL owner, migrator, and runtime privilege boundaries are documented
+  in [docs/database_roles.md](docs/database_roles.md).
 - Database pool sizing, observability, and load testing are documented in [docs/performance.md](docs/performance.md).
 
 ### Production Behavior

--- a/crates/hubuum-storage-core/src/restore.rs
+++ b/crates/hubuum-storage-core/src/restore.rs
@@ -534,7 +534,9 @@ impl StorageRestoreJob {
     ) -> Result<Self, StorageValidationError> {
         if matches!(
             summary.status,
-            StorageRestoreJobStatus::Failed | StorageRestoreJobStatus::Expired
+            StorageRestoreJobStatus::Succeeded
+                | StorageRestoreJobStatus::Failed
+                | StorageRestoreJobStatus::Expired
         ) {
             if !document.is_empty() {
                 return Err(StorageValidationError::invalid(
@@ -947,7 +949,8 @@ pub trait RestoreStorage: Send + Sync {
     /// The backend must re-check that the job owns draining maintenance, apply
     /// the snapshot in one rollback-safe transaction, reset backend-owned
     /// derived state and identifiers, write success provenance, return to
-    /// normal operation, and erase restore/coordinator staging records.
+    /// normal operation, erase coordinator staging records, and retain a
+    /// document-free terminal receipt for capability-authenticated polling.
     async fn apply_restore(
         &self,
         request: StorageRestoreApply,

--- a/crates/hubuum-storage-memory/src/workflows.rs
+++ b/crates/hubuum-storage-memory/src/workflows.rs
@@ -1064,7 +1064,7 @@ impl RestoreStorage for MemoryStorage {
             None,
             Some(started_at),
             Some(finished_at),
-            false,
+            true,
         )?;
         state.restore_jobs.insert(job_id.id(), succeeded);
         state.maintenance_state = MaintenanceState::Normal;

--- a/crates/hubuum-storage-postgres/database-privileges.json
+++ b/crates/hubuum-storage-postgres/database-privileges.json
@@ -12,7 +12,7 @@
     "hubuum_complete_event_retention_purge"
   ],
   "runtime_function_policy": "all_security_invoker_plus_allowlisted_security_definer",
-  "restore": "migrator_only",
+  "restore": "isolated_migrator_executor",
   "built_in_capabilities": [
     "advisory_locks",
     "listen_notify",

--- a/crates/hubuum-storage-postgres/database-privileges.json
+++ b/crates/hubuum-storage-postgres/database-privileges.json
@@ -2,6 +2,9 @@
   "schema": "public",
   "migration_table": "__diesel_schema_migrations",
   "history_table_suffix": "_history",
+  "read_only_tables": [
+    "restore_success_receipts"
+  ],
   "events_table": "events",
   "event_update_columns": [
     "dispatched_at",

--- a/crates/hubuum-storage-postgres/database-privileges.json
+++ b/crates/hubuum-storage-postgres/database-privileges.json
@@ -1,0 +1,21 @@
+{
+  "schema": "public",
+  "migration_table": "__diesel_schema_migrations",
+  "history_table_suffix": "_history",
+  "events_table": "events",
+  "event_update_columns": [
+    "dispatched_at",
+    "fanout_locked_until",
+    "fanout_claim_token"
+  ],
+  "runtime_functions": [
+    "hubuum_complete_event_retention_purge"
+  ],
+  "runtime_function_policy": "all_security_invoker_plus_allowlisted_security_definer",
+  "restore": "migrator_only",
+  "built_in_capabilities": [
+    "advisory_locks",
+    "listen_notify",
+    "transaction_local_session_settings"
+  ]
+}

--- a/crates/hubuum-storage-postgres/migrations/2026-08-31-000004_database_role_integrity/down.sql
+++ b/crates/hubuum-storage-postgres/migrations/2026-08-31-000004_database_role_integrity/down.sql
@@ -1,10 +1,6 @@
 DROP FUNCTION IF EXISTS hubuum_complete_event_retention_purge(uuid);
 
-DELETE FROM restore_jobs WHERE status = 'succeeded';
-ALTER TABLE restore_jobs DROP CONSTRAINT restore_jobs_status_check;
-ALTER TABLE restore_jobs
-    ADD CONSTRAINT restore_jobs_status_check
-    CHECK (status IN ('validated', 'confirmed', 'failed', 'expired'));
+DROP TABLE IF EXISTS restore_success_receipts;
 
 -- Downgrades restore the previous invoker security mode. Function bodies are
 -- intentionally retained because the next older migration owns their exact

--- a/crates/hubuum-storage-postgres/migrations/2026-08-31-000004_database_role_integrity/down.sql
+++ b/crates/hubuum-storage-postgres/migrations/2026-08-31-000004_database_role_integrity/down.sql
@@ -1,0 +1,23 @@
+DROP FUNCTION IF EXISTS hubuum_complete_event_retention_purge(uuid);
+
+-- Downgrades restore the previous invoker security mode. Function bodies are
+-- intentionally retained because the next older migration owns their exact
+-- definitions and a subsequent full downgrade will restore them.
+ALTER FUNCTION hubuum_record_history() SECURITY INVOKER;
+ALTER FUNCTION hubuum_record_history() RESET ALL;
+ALTER FUNCTION hubuum_manage_resource_revision() RESET ALL;
+ALTER FUNCTION hubuum_bump_revision_owner() SECURITY INVOKER;
+ALTER FUNCTION hubuum_bump_revision_owner() RESET ALL;
+ALTER FUNCTION hubuum_check_delete_revision() RESET ALL;
+ALTER FUNCTION hubuum_fill_event_revisions() SECURITY INVOKER;
+ALTER FUNCTION hubuum_fill_event_revisions() RESET ALL;
+ALTER FUNCTION notify_events_fanout() SECURITY INVOKER;
+ALTER FUNCTION notify_events_fanout() RESET ALL;
+ALTER FUNCTION enforce_events_append_only() SECURITY INVOKER;
+ALTER FUNCTION enforce_events_append_only() RESET ALL;
+
+GRANT EXECUTE ON FUNCTION hubuum_record_history() TO PUBLIC;
+GRANT EXECUTE ON FUNCTION hubuum_bump_revision_owner() TO PUBLIC;
+GRANT EXECUTE ON FUNCTION hubuum_fill_event_revisions() TO PUBLIC;
+GRANT EXECUTE ON FUNCTION notify_events_fanout() TO PUBLIC;
+GRANT EXECUTE ON FUNCTION enforce_events_append_only() TO PUBLIC;

--- a/crates/hubuum-storage-postgres/migrations/2026-08-31-000004_database_role_integrity/down.sql
+++ b/crates/hubuum-storage-postgres/migrations/2026-08-31-000004_database_role_integrity/down.sql
@@ -1,5 +1,11 @@
 DROP FUNCTION IF EXISTS hubuum_complete_event_retention_purge(uuid);
 
+DELETE FROM restore_jobs WHERE status = 'succeeded';
+ALTER TABLE restore_jobs DROP CONSTRAINT restore_jobs_status_check;
+ALTER TABLE restore_jobs
+    ADD CONSTRAINT restore_jobs_status_check
+    CHECK (status IN ('validated', 'confirmed', 'failed', 'expired'));
+
 -- Downgrades restore the previous invoker security mode. Function bodies are
 -- intentionally retained because the next older migration owns their exact
 -- definitions and a subsequent full downgrade will restore them.

--- a/crates/hubuum-storage-postgres/migrations/2026-08-31-000004_database_role_integrity/up.sql
+++ b/crates/hubuum-storage-postgres/migrations/2026-08-31-000004_database_role_integrity/up.sql
@@ -1,0 +1,428 @@
+-- Make temporal history writes possible without granting the runtime role
+-- direct mutation authority. The trusted restore bypass is available only to
+-- a session whose login role is a member of this function's owning role.
+CREATE OR REPLACE FUNCTION hubuum_record_history()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+  history_relation text := pg_catalog.format('%I.%I', TG_TABLE_SCHEMA, TG_TABLE_NAME || '_history');
+  history_sequence text := pg_catalog.format('%I.%I', TG_TABLE_SCHEMA, TG_TABLE_NAME || '_history_seq');
+  changed_at timestamptz := pg_catalog.clock_timestamp();
+  actor int := nullif(pg_catalog.current_setting('hubuum.actor_id', true), '')::int;
+  actor_kind_value text := nullif(pg_catalog.current_setting('hubuum.actor_kind', true), '');
+  initiator int := nullif(pg_catalog.current_setting('hubuum.initiator_user_id', true), '')::int;
+  provenance_task_id int := nullif(pg_catalog.current_setting('hubuum.task_id', true), '')::int;
+  base_columns text;
+  history_columns text;
+  trusted_restore boolean :=
+    pg_catalog.current_setting('hubuum.restore_history', true) IS NOT DISTINCT FROM 'on'
+    AND pg_catalog.pg_has_role(session_user, current_user, 'MEMBER');
+BEGIN
+  IF actor_kind_value IS NULL AND actor IS NOT NULL THEN
+    actor_kind_value := 'user';
+  END IF;
+
+  IF trusted_restore THEN
+    IF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  SELECT pg_catalog.string_agg(pg_catalog.format('($1).%1$I', attribute.attname), ', ' ORDER BY attribute.attnum),
+         pg_catalog.string_agg(pg_catalog.format('%1$I', attribute.attname), ', ' ORDER BY attribute.attnum)
+    INTO base_columns, history_columns
+  FROM pg_catalog.pg_attribute attribute
+  WHERE attribute.attrelid = TG_RELID
+    AND attribute.attnum > 0
+    AND NOT attribute.attisdropped;
+
+  IF TG_OP = 'INSERT' THEN
+    EXECUTE pg_catalog.format(
+      'INSERT INTO %s (%s, op, valid_from, valid_to, actor_id, history_id,
+                       actor_kind, initiator_user_id, task_id)
+       SELECT %s, %L, $2, NULL, $3, pg_catalog.nextval(%L::pg_catalog.regclass), $4, $5, $6',
+      history_relation, history_columns, base_columns, 'I', history_sequence)
+      USING NEW, changed_at, actor, actor_kind_value, initiator, provenance_task_id;
+    RETURN NEW;
+  ELSIF TG_OP = 'UPDATE' THEN
+    EXECUTE pg_catalog.format(
+      'UPDATE %s SET valid_to=$1 WHERE id=$2 AND valid_to IS NULL',
+      history_relation)
+      USING changed_at, OLD.id;
+    EXECUTE pg_catalog.format(
+      'INSERT INTO %s (%s, op, valid_from, valid_to, actor_id, history_id,
+                       actor_kind, initiator_user_id, task_id)
+       SELECT %s, %L, $2, NULL, $3, pg_catalog.nextval(%L::pg_catalog.regclass), $4, $5, $6',
+      history_relation, history_columns, base_columns, 'U', history_sequence)
+      USING NEW, changed_at, actor, actor_kind_value, initiator, provenance_task_id;
+    RETURN NEW;
+  ELSE
+    EXECUTE pg_catalog.format(
+      'UPDATE %s SET valid_to=$1 WHERE id=$2 AND valid_to IS NULL',
+      history_relation)
+      USING changed_at, OLD.id;
+    EXECUTE pg_catalog.format(
+      'INSERT INTO %s (%s, op, valid_from, valid_to, actor_id, history_id,
+                       actor_kind, initiator_user_id, task_id)
+       SELECT %s, %L, $2, $2, $3, pg_catalog.nextval(%L::pg_catalog.regclass), $4, $5, $6',
+      history_relation, history_columns, base_columns, 'D', history_sequence)
+      USING OLD, changed_at, actor, actor_kind_value, initiator, provenance_task_id;
+    RETURN OLD;
+  END IF;
+END;
+$function$;
+
+-- A caller may opt into restore revisions only when its login role belongs to
+-- the table owner. Internal aggregate bumps run from the owner-controlled
+-- SECURITY DEFINER trigger below and are distinguished by current_user.
+CREATE OR REPLACE FUNCTION hubuum_manage_resource_revision()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    relation_owner oid := (
+        SELECT relation.relowner
+        FROM pg_catalog.pg_class relation
+        WHERE relation.oid = TG_RELID
+    );
+    restoring BOOLEAN :=
+        current_setting('hubuum.restore_revisions', true) IS NOT DISTINCT FROM 'on'
+        AND pg_has_role(session_user, relation_owner, 'MEMBER');
+    internal_bump BOOLEAN :=
+        current_setting('hubuum.internal_revision_bump', true) IS NOT DISTINCT FROM 'on'
+        AND current_user::regrole::oid = relation_owner;
+    has_updated_at BOOLEAN := TG_ARGV[0] = 'updated_at';
+    coalesced BOOLEAN := TG_ARGV[1] = 'coalesce';
+    return_unchanged BOOLEAN := TG_ARGV[1] = 'direct_return_unchanged';
+    ignored_fields TEXT[] := ARRAY['revision', 'created_at', 'updated_at'];
+    domain_old JSONB;
+    domain_new JSONB;
+    operational_old JSONB;
+    operational_new JSONB;
+    owner_key TEXT;
+    first_change BOOLEAN := TRUE;
+    index INT;
+BEGIN
+    IF TG_NARGS > 2 THEN
+        FOR index IN 2..TG_NARGS - 1 LOOP
+            ignored_fields := array_append(ignored_fields, TG_ARGV[index]);
+        END LOOP;
+    END IF;
+
+    IF restoring THEN
+        IF NEW.revision <= 0 THEN
+            RAISE EXCEPTION 'resource revision must be greater than zero';
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    owner_key := public.hubuum_revision_owner_key(TG_TABLE_NAME, to_jsonb(NEW));
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.revision <> 1 THEN
+            RAISE EXCEPTION 'caller-supplied resource revision is not permitted';
+        END IF;
+        IF coalesced THEN
+            PERFORM public.hubuum_revision_owner_first(owner_key);
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    PERFORM public.hubuum_assert_revision_precondition(owner_key, OLD.revision);
+    IF internal_bump THEN
+        IF OLD.revision = 9223372036854775807 OR NEW.revision <> OLD.revision + 1 THEN
+            RAISE EXCEPTION 'invalid internal resource revision advancement';
+        END IF;
+        IF has_updated_at THEN
+            NEW.updated_at := clock_timestamp() AT TIME ZONE 'UTC';
+        END IF;
+        RETURN NEW;
+    END IF;
+    IF NEW.revision IS DISTINCT FROM OLD.revision THEN
+        RAISE EXCEPTION 'caller-supplied resource revision changes are not permitted';
+    END IF;
+
+    domain_old := to_jsonb(OLD) - ignored_fields;
+    domain_new := to_jsonb(NEW) - ignored_fields;
+    IF domain_old = domain_new THEN
+        operational_old := to_jsonb(OLD) - ARRAY['revision', 'created_at', 'updated_at'];
+        operational_new := to_jsonb(NEW) - ARRAY['revision', 'created_at', 'updated_at'];
+        IF operational_old = operational_new THEN
+            IF return_unchanged THEN
+                NEW.revision := OLD.revision;
+                IF has_updated_at THEN
+                    NEW.updated_at := OLD.updated_at;
+                END IF;
+                RETURN NEW;
+            END IF;
+            RETURN NULL;
+        END IF;
+        NEW.revision := OLD.revision;
+        IF has_updated_at THEN
+            NEW.updated_at := OLD.updated_at;
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    IF coalesced THEN
+        first_change := public.hubuum_revision_owner_first(owner_key);
+    END IF;
+    IF first_change THEN
+        IF OLD.revision = 9223372036854775807 THEN
+            RAISE EXCEPTION 'resource revision overflow';
+        END IF;
+        NEW.revision := OLD.revision + 1;
+    ELSE
+        NEW.revision := OLD.revision;
+    END IF;
+    IF has_updated_at
+       AND current_setting('hubuum.preserve_imported_timestamps', true) IS DISTINCT FROM 'on'
+    THEN
+        NEW.updated_at := clock_timestamp() AT TIME ZONE 'UTC';
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION hubuum_bump_revision_owner()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    owner_table TEXT := TG_ARGV[0];
+    owner_id TEXT;
+    owner_key TEXT;
+    trusted_restore BOOLEAN :=
+        pg_catalog.current_setting('hubuum.restore_revisions', true) IS NOT DISTINCT FROM 'on'
+        AND pg_catalog.pg_has_role(session_user, current_user, 'MEMBER');
+BEGIN
+    IF trusted_restore THEN
+        IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+        RETURN NEW;
+    END IF;
+
+    IF TG_ARGV[1] = 'membership' THEN
+        owner_id := coalesce(pg_catalog.to_jsonb(NEW)->>'principal_id', pg_catalog.to_jsonb(OLD)->>'principal_id')
+            || ':' || coalesce(pg_catalog.to_jsonb(NEW)->>'group_id', pg_catalog.to_jsonb(OLD)->>'group_id');
+    ELSE
+        owner_id := coalesce(pg_catalog.to_jsonb(NEW)->>TG_ARGV[1], pg_catalog.to_jsonb(OLD)->>TG_ARGV[1]);
+    END IF;
+    owner_key := owner_table || ':' || owner_id;
+    IF NOT public.hubuum_revision_owner_first(owner_key) THEN
+        IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+        RETURN NEW;
+    END IF;
+
+    PERFORM pg_catalog.set_config('hubuum.internal_revision_bump', 'on', true);
+    IF owner_table = 'principals' THEN
+        UPDATE public.principals SET revision = revision + 1 WHERE id = owner_id::INT;
+    ELSIF owner_table = 'group_memberships' THEN
+        UPDATE public.group_memberships SET revision = revision + 1
+         WHERE principal_id = pg_catalog.split_part(owner_id, ':', 1)::INT
+           AND group_id = pg_catalog.split_part(owner_id, ':', 2)::INT;
+    ELSIF owner_table = 'tokens' THEN
+        UPDATE public.tokens SET revision = revision + 1 WHERE id = owner_id::INT;
+    ELSIF owner_table = 'collection_authorization_state' THEN
+        UPDATE public.collection_authorization_state SET revision = revision + 1
+         WHERE collection_id = owner_id::INT;
+    ELSE
+        RAISE EXCEPTION 'unknown revision owner table %', owner_table;
+    END IF;
+    PERFORM pg_catalog.set_config('hubuum.internal_revision_bump', 'off', true);
+    IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+    RETURN NEW;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION hubuum_check_delete_revision()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    relation_owner oid := (
+        SELECT relation.relowner
+        FROM pg_catalog.pg_class relation
+        WHERE relation.oid = TG_RELID
+    );
+    trusted_restore BOOLEAN :=
+        current_setting('hubuum.restore_revisions', true) IS NOT DISTINCT FROM 'on'
+        AND pg_has_role(session_user, relation_owner, 'MEMBER');
+BEGIN
+    IF NOT trusted_restore THEN
+        PERFORM public.hubuum_assert_revision_precondition(
+            public.hubuum_revision_owner_key(TG_TABLE_NAME, to_jsonb(OLD)),
+            OLD.revision
+        );
+    END IF;
+    RETURN OLD;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION hubuum_fill_event_revisions()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    trusted_restore BOOLEAN :=
+        pg_catalog.current_setting('hubuum.restore_events', true) IS NOT DISTINCT FROM 'on'
+        AND pg_catalog.pg_has_role(session_user, current_user, 'MEMBER');
+BEGIN
+    IF trusted_restore THEN RETURN NEW; END IF;
+    IF NEW.before_revision IS NULL
+       AND pg_catalog.jsonb_typeof((NEW."before"::jsonb)->'revision') = 'number'
+    THEN
+        NEW.before_revision := ((NEW."before"::jsonb)->>'revision')::BIGINT;
+    END IF;
+    IF NEW.after_revision IS NULL
+       AND pg_catalog.jsonb_typeof((NEW."after"::jsonb)->'revision') = 'number'
+    THEN
+        NEW.after_revision := ((NEW."after"::jsonb)->>'revision')::BIGINT;
+    END IF;
+    IF NEW.before_revision IS NOT NULL OR NEW.after_revision IS NOT NULL THEN
+        NEW.schema_version := 2;
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION notify_events_fanout()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    IF pg_catalog.current_setting('hubuum.restore_events', true) IS NOT DISTINCT FROM 'on'
+       AND pg_catalog.pg_has_role(session_user, current_user, 'MEMBER')
+    THEN
+        RETURN NEW;
+    END IF;
+    PERFORM pg_catalog.pg_notify('hubuum_events_fanout', NEW.id::text);
+    RETURN NEW;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION enforce_events_append_only()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        -- Runtime has no direct DELETE grant. Its only path here is the
+        -- allowlisted retention function, which sets this transaction-local
+        -- flag after validating and locking a durable bounded claim.
+        IF pg_catalog.current_setting('events.allow_purge', true) IS DISTINCT FROM 'on' THEN
+            RAISE EXCEPTION 'events table is append-only: DELETE is not permitted';
+        END IF;
+        RETURN OLD;
+    END IF;
+
+    IF NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.event_id IS DISTINCT FROM OLD.event_id
+       OR NEW.occurred_at IS DISTINCT FROM OLD.occurred_at
+       OR NEW.entity_type IS DISTINCT FROM OLD.entity_type
+       OR NEW.entity_id IS DISTINCT FROM OLD.entity_id
+       OR NEW.entity_name IS DISTINCT FROM OLD.entity_name
+       OR NEW.collection_id IS DISTINCT FROM OLD.collection_id
+       OR NEW.action IS DISTINCT FROM OLD.action
+       OR NEW.actor_user_id IS DISTINCT FROM OLD.actor_user_id
+       OR NEW.actor_kind IS DISTINCT FROM OLD.actor_kind
+       OR NEW.initiator_user_id IS DISTINCT FROM OLD.initiator_user_id
+       OR NEW.task_id IS DISTINCT FROM OLD.task_id
+       OR NEW.request_id IS DISTINCT FROM OLD.request_id
+       OR NEW.correlation_id IS DISTINCT FROM OLD.correlation_id
+       OR NEW.summary IS DISTINCT FROM OLD.summary
+       OR NEW.before IS DISTINCT FROM OLD.before
+       OR NEW.after IS DISTINCT FROM OLD.after
+       OR NEW.before_revision IS DISTINCT FROM OLD.before_revision
+       OR NEW.after_revision IS DISTINCT FROM OLD.after_revision
+       OR NEW.metadata IS DISTINCT FROM OLD.metadata
+       OR NEW.schema_version IS DISTINCT FROM OLD.schema_version
+    THEN
+        RAISE EXCEPTION 'events table is append-only: only fan-out claim fields and dispatched_at may be updated';
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+-- Runtime callers can complete only a durable, bounded retention claim. They
+-- cannot supply identifiers, cutoffs, predicates, or SQL fragments directly.
+CREATE OR REPLACE FUNCTION hubuum_complete_event_retention_purge(requested_claim_id uuid)
+RETURNS TABLE (purged_events bigint, purged_terminal_deliveries bigint)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+DECLARE
+    claimed_event_ids bigint[];
+    claimed_delivery_cutoff timestamp;
+    claimed_delivery_batch_size bigint;
+    deleted_events bigint;
+    deleted_deliveries bigint;
+BEGIN
+    SELECT retention.event_ids, retention.delivery_cutoff, retention.delivery_batch_size
+      INTO claimed_event_ids, claimed_delivery_cutoff, claimed_delivery_batch_size
+      FROM public.event_retention_batches retention
+     WHERE retention.claim_id = requested_claim_id
+       AND retention.completed_at IS NULL
+     FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'event retention claim is not pending';
+    END IF;
+    IF pg_catalog.cardinality(claimed_event_ids) > 10000
+       OR claimed_delivery_batch_size < 1
+       OR claimed_delivery_batch_size > 10000
+    THEN
+        RAISE EXCEPTION 'event retention claim exceeds the bounded purge limit';
+    END IF;
+
+    WITH candidates AS (
+        SELECT delivery.id
+          FROM public.event_deliveries delivery
+         WHERE delivery.updated_at < claimed_delivery_cutoff
+           AND delivery.status IN ('succeeded', 'dead')
+         ORDER BY delivery.updated_at ASC, delivery.id ASC
+         LIMIT claimed_delivery_batch_size
+         FOR UPDATE SKIP LOCKED
+    )
+    DELETE FROM public.event_deliveries delivery
+    USING candidates
+    WHERE delivery.id = candidates.id;
+    GET DIAGNOSTICS deleted_deliveries = ROW_COUNT;
+
+    PERFORM pg_catalog.set_config('events.allow_purge', 'on', true);
+    DELETE FROM public.events event
+     WHERE event.id = ANY(claimed_event_ids)
+       AND event.occurred_at < (pg_catalog.clock_timestamp() AT TIME ZONE 'UTC') - INTERVAL '1 day'
+       AND event.dispatched_at IS NOT NULL
+       AND NOT EXISTS (
+           SELECT 1
+             FROM public.event_deliveries delivery
+            WHERE delivery.event_id = event.id
+              AND delivery.status IN ('pending', 'failed', 'in_flight')
+       );
+    GET DIAGNOSTICS deleted_events = ROW_COUNT;
+    IF deleted_events <> pg_catalog.cardinality(claimed_event_ids) THEN
+        RAISE EXCEPTION 'event retention claim no longer matches purgeable events';
+    END IF;
+    RETURN QUERY SELECT deleted_events, deleted_deliveries;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION hubuum_record_history() FROM PUBLIC;
+REVOKE ALL ON FUNCTION hubuum_bump_revision_owner() FROM PUBLIC;
+REVOKE ALL ON FUNCTION hubuum_fill_event_revisions() FROM PUBLIC;
+REVOKE ALL ON FUNCTION notify_events_fanout() FROM PUBLIC;
+REVOKE ALL ON FUNCTION enforce_events_append_only() FROM PUBLIC;
+REVOKE ALL ON FUNCTION hubuum_complete_event_retention_purge(uuid) FROM PUBLIC;

--- a/crates/hubuum-storage-postgres/migrations/2026-08-31-000004_database_role_integrity/up.sql
+++ b/crates/hubuum-storage-postgres/migrations/2026-08-31-000004_database_role_integrity/up.sql
@@ -27,11 +27,24 @@ END;
 $migration_preflight$;
 
 -- Successful asynchronous restores retain a document-free receipt so the web
--- client can poll the terminal result with its one-time capability.
-ALTER TABLE restore_jobs DROP CONSTRAINT restore_jobs_status_check;
-ALTER TABLE restore_jobs
-    ADD CONSTRAINT restore_jobs_status_check
-    CHECK (status IN ('validated', 'confirmed', 'succeeded', 'failed', 'expired'));
+-- client can poll the terminal result with its one-time capability. Keep this
+-- additive: old binaries retain their original restore_jobs status contract
+-- during a rolling upgrade and simply ignore the receipt table.
+CREATE TABLE restore_success_receipts (
+    id BIGINT PRIMARY KEY,
+    requested_by INT NULL,
+    requested_by_identity_scope VARCHAR NOT NULL,
+    requested_by_name VARCHAR NOT NULL,
+    byte_size BIGINT NOT NULL CHECK (byte_size >= 0),
+    sha256 VARCHAR(64) NOT NULL CHECK (length(sha256) = 64),
+    capability_hash VARCHAR(64) NOT NULL CHECK (length(capability_hash) = 64),
+    validation_summary JSONB NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    confirmed_at TIMESTAMP NOT NULL,
+    finished_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
 
 -- Make temporal history writes possible without granting the runtime role
 -- direct mutation authority. The trusted restore bypass is available only to

--- a/crates/hubuum-storage-postgres/migrations/2026-08-31-000004_database_role_integrity/up.sql
+++ b/crates/hubuum-storage-postgres/migrations/2026-08-31-000004_database_role_integrity/up.sql
@@ -1,3 +1,38 @@
+-- Role adoption must never strand a restore between the committed draining
+-- transition and its destructive transaction. Validated stages are preserved
+-- and remain confirmable after the upgrade.
+DO $migration_preflight$
+DECLARE
+    maintenance_state text;
+    active_restore_job_id bigint;
+BEGIN
+    -- Serialize the preflight with both confirmation and destructive restore.
+    -- This closes the boundary between observing normal maintenance and
+    -- committing the role changes during a rolling upgrade.
+    PERFORM pg_advisory_xact_lock(4850188191125217);
+    SELECT state, restore_job_id
+      INTO maintenance_state, active_restore_job_id
+      FROM system_maintenance
+     WHERE id = 1
+     FOR UPDATE;
+    IF maintenance_state IS DISTINCT FROM 'normal'
+       OR active_restore_job_id IS NOT NULL
+       OR EXISTS (SELECT 1 FROM restore_jobs WHERE status = 'confirmed')
+    THEN
+        RAISE EXCEPTION
+            'database-role migration requires normal maintenance with no confirmed restore'
+            USING HINT = 'Allow the existing restore to finish or explicitly recover it before retrying the migration.';
+    END IF;
+END;
+$migration_preflight$;
+
+-- Successful asynchronous restores retain a document-free receipt so the web
+-- client can poll the terminal result with its one-time capability.
+ALTER TABLE restore_jobs DROP CONSTRAINT restore_jobs_status_check;
+ALTER TABLE restore_jobs
+    ADD CONSTRAINT restore_jobs_status_check
+    CHECK (status IN ('validated', 'confirmed', 'succeeded', 'failed', 'expired'));
+
 -- Make temporal history writes possible without granting the runtime role
 -- direct mutation authority. The trusted restore bypass is available only to
 -- a session whose login role is a member of this function's owning role.

--- a/crates/hubuum-storage-postgres/src/database_privileges.rs
+++ b/crates/hubuum-storage-postgres/src/database_privileges.rs
@@ -1,0 +1,735 @@
+//! Generated PostgreSQL role grants and catalog-backed privilege diagnostics.
+
+use std::fmt::Write as _;
+use std::sync::Arc;
+use std::sync::LazyLock;
+
+use diesel::QueryableByName;
+use diesel::sql_types::{Bool, Text};
+use diesel_async::RunQueryDsl;
+use serde::{Deserialize, Serialize};
+
+use crate::{NoopPostgresObserver, PostgresPool, PostgresRuntime, PostgresStorageError};
+
+const MANIFEST_JSON: &str = include_str!("../database-privileges.json");
+
+static MANIFEST: LazyLock<DatabasePrivilegeManifest> = LazyLock::new(|| {
+    serde_json::from_str(MANIFEST_JSON).expect("database privilege manifest must be valid JSON")
+});
+
+#[derive(Debug, Deserialize)]
+struct DatabasePrivilegeManifest {
+    schema: String,
+    migration_table: String,
+    history_table_suffix: String,
+    events_table: String,
+    event_update_columns: Vec<String>,
+    runtime_functions: Vec<String>,
+    runtime_function_policy: String,
+    restore: String,
+    built_in_capabilities: Vec<String>,
+}
+
+/// Validated PostgreSQL identifier used by generated role-management SQL.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatabaseRoleName(String);
+
+impl DatabaseRoleName {
+    pub fn new(value: impl Into<String>) -> Result<Self, PostgresStorageError> {
+        let value = value.into();
+        let mut characters = value.chars();
+        let valid_start = characters
+            .next()
+            .is_some_and(|character| character == '_' || character.is_ascii_alphabetic());
+        let valid_rest = characters.all(|character| {
+            character == '_' || character == '$' || character.is_ascii_alphanumeric()
+        });
+        if value.len() > 63 || !valid_start || !valid_rest {
+            return Err(PostgresStorageError::invalid_input(
+                "database role names must be 1-63 ASCII identifier characters and start with a letter or underscore",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn quoted(&self) -> String {
+        format!("\"{}\"", self.0.replace('"', "\"\""))
+    }
+}
+
+/// Operator-selected names for Hubuum's three supported database roles.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatabaseRoleNames {
+    owner: DatabaseRoleName,
+    migrator: DatabaseRoleName,
+    runtime: DatabaseRoleName,
+}
+
+impl DatabaseRoleNames {
+    pub fn new(
+        owner: impl Into<String>,
+        migrator: impl Into<String>,
+        runtime: impl Into<String>,
+    ) -> Result<Self, PostgresStorageError> {
+        let names = Self {
+            owner: DatabaseRoleName::new(owner)?,
+            migrator: DatabaseRoleName::new(migrator)?,
+            runtime: DatabaseRoleName::new(runtime)?,
+        };
+        if names.owner == names.migrator
+            || names.owner == names.runtime
+            || names.migrator == names.runtime
+        {
+            return Err(PostgresStorageError::invalid_input(
+                "database owner, migrator, and runtime role names must be distinct",
+            ));
+        }
+        Ok(names)
+    }
+
+    #[must_use]
+    pub fn owner(&self) -> &DatabaseRoleName {
+        &self.owner
+    }
+
+    #[must_use]
+    pub fn migrator(&self) -> &DatabaseRoleName {
+        &self.migrator
+    }
+
+    #[must_use]
+    pub fn runtime(&self) -> &DatabaseRoleName {
+        &self.runtime
+    }
+}
+
+/// Finding emitted by the runtime database privilege audit.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct DatabasePrivilegeFinding {
+    code: String,
+    object: String,
+    detail: String,
+}
+
+impl DatabasePrivilegeFinding {
+    fn new(code: &str, object: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            code: code.to_string(),
+            object: object.into(),
+            detail: detail.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
+    #[must_use]
+    pub fn object(&self) -> &str {
+        &self.object
+    }
+
+    #[must_use]
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+}
+
+/// Non-secret result of checking one PostgreSQL role against the manifest.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct DatabasePrivilegeReport {
+    role: String,
+    connected_role: String,
+    safe: bool,
+    dangerous: Vec<DatabasePrivilegeFinding>,
+    missing: Vec<DatabasePrivilegeFinding>,
+}
+
+impl DatabasePrivilegeReport {
+    #[must_use]
+    pub fn role(&self) -> &str {
+        &self.role
+    }
+
+    #[must_use]
+    pub fn connected_role(&self) -> &str {
+        &self.connected_role
+    }
+
+    #[must_use]
+    pub const fn is_safe(&self) -> bool {
+        self.safe
+    }
+
+    #[must_use]
+    pub fn dangerous(&self) -> &[DatabasePrivilegeFinding] {
+        &self.dangerous
+    }
+
+    #[must_use]
+    pub fn missing(&self) -> &[DatabasePrivilegeFinding] {
+        &self.missing
+    }
+}
+
+#[derive(QueryableByName)]
+struct RoleRow {
+    #[diesel(sql_type = Text)]
+    role_name: String,
+    #[diesel(sql_type = Text)]
+    connected_role: String,
+    #[diesel(sql_type = Bool)]
+    superuser: bool,
+    #[diesel(sql_type = Bool)]
+    create_role: bool,
+    #[diesel(sql_type = Bool)]
+    create_database: bool,
+    #[diesel(sql_type = Bool)]
+    bypass_rls: bool,
+    #[diesel(sql_type = Bool)]
+    owns_schema: bool,
+    #[diesel(sql_type = Bool)]
+    creates_in_schema: bool,
+    #[diesel(sql_type = Bool)]
+    owner_member: bool,
+    #[diesel(sql_type = Bool)]
+    migrator_member: bool,
+}
+
+#[derive(QueryableByName)]
+struct ObjectPrivilegeRow {
+    #[diesel(sql_type = Text)]
+    object_kind: String,
+    #[diesel(sql_type = Text)]
+    object_name: String,
+    #[diesel(sql_type = Bool)]
+    owned: bool,
+    #[diesel(sql_type = Bool)]
+    can_select: bool,
+    #[diesel(sql_type = Bool)]
+    can_insert: bool,
+    #[diesel(sql_type = Bool)]
+    can_update: bool,
+    #[diesel(sql_type = Bool)]
+    can_delete: bool,
+    #[diesel(sql_type = Bool)]
+    security_definer: bool,
+}
+
+#[derive(QueryableByName)]
+struct ColumnPrivilegeRow {
+    #[diesel(sql_type = Text)]
+    column_name: String,
+    #[diesel(sql_type = Bool)]
+    can_update: bool,
+}
+
+/// Return the version-controlled manifest verbatim for tooling and docs.
+#[must_use]
+pub const fn database_privilege_manifest_json() -> &'static str {
+    MANIFEST_JSON
+}
+
+/// Generate the idempotent administrator SQL that creates and reconciles all roles.
+#[must_use]
+pub fn database_role_setup_sql(names: &DatabaseRoleNames) -> String {
+    let mut sql = String::new();
+    writeln!(
+        sql,
+        "-- Generated from crates/hubuum-storage-postgres/database-privileges.json."
+    )
+    .unwrap();
+    writeln!(sql, "-- Set passwords or workload-identity mappings separately; this output never contains credentials.").unwrap();
+    writeln!(sql, "BEGIN;").unwrap();
+    for (role, login) in [
+        (names.owner(), false),
+        (names.migrator(), true),
+        (names.runtime(), true),
+    ] {
+        writeln!(
+            sql,
+            "DO $role$ BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '{}') THEN CREATE ROLE {} {}; END IF; END $role$;",
+            role.as_str(),
+            role.quoted(),
+            if login { "LOGIN" } else { "NOLOGIN" },
+        )
+        .unwrap();
+        writeln!(
+            sql,
+            "ALTER ROLE {} {} NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;",
+            role.quoted(),
+            if login { "LOGIN" } else { "NOLOGIN" },
+        )
+        .unwrap();
+    }
+    writeln!(
+        sql,
+        "GRANT {} TO {};",
+        names.owner().quoted(),
+        names.migrator().quoted(),
+    )
+    .unwrap();
+    writeln!(
+        sql,
+        "REVOKE {}, {} FROM {};",
+        names.owner().quoted(),
+        names.migrator().quoted(),
+        names.runtime().quoted(),
+    )
+    .unwrap();
+    sql.push_str(&database_role_reconciliation_sql(names));
+    writeln!(sql, "COMMIT;").unwrap();
+    sql
+}
+
+/// Generate ownership and grants after migrations have created new objects.
+#[must_use]
+pub fn database_role_reconciliation_sql(names: &DatabaseRoleNames) -> String {
+    let manifest = &*MANIFEST;
+    assert_eq!(
+        manifest.runtime_function_policy, "all_security_invoker_plus_allowlisted_security_definer",
+        "unsupported database privilege function policy"
+    );
+    let owner = names.owner().quoted();
+    let runtime = names.runtime().quoted();
+    let update_columns = manifest
+        .event_update_columns
+        .iter()
+        .map(|column| format!("\"{column}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let runtime_functions = manifest
+        .runtime_functions
+        .iter()
+        .map(|function| format!("'{function}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut sql = String::new();
+    writeln!(
+        sql,
+        "REVOKE CREATE ON SCHEMA \"{}\" FROM PUBLIC;",
+        manifest.schema
+    )
+    .unwrap();
+    writeln!(
+        sql,
+        "ALTER SCHEMA \"{}\" OWNER TO {owner};",
+        manifest.schema
+    )
+    .unwrap();
+    writeln!(
+        sql,
+        "REVOKE ALL ON SCHEMA \"{}\" FROM {runtime};",
+        manifest.schema
+    )
+    .unwrap();
+    writeln!(
+        sql,
+        "GRANT USAGE ON SCHEMA \"{}\" TO {runtime};",
+        manifest.schema
+    )
+    .unwrap();
+    writeln!(
+        sql,
+        "DO $grants$ DECLARE object RECORD; BEGIN\n  FOR object IN SELECT c.oid, c.relname, c.relkind FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = '{}' AND c.relkind IN ('r', 'p', 'S') LOOP\n    IF object.relkind = 'S' THEN\n      EXECUTE pg_catalog.format('ALTER SEQUENCE %I.%I OWNER TO %I', '{}', object.relname, '{}');\n      EXECUTE pg_catalog.format('REVOKE ALL ON SEQUENCE %I.%I FROM PUBLIC', '{}', object.relname);\n      EXECUTE pg_catalog.format('REVOKE ALL ON SEQUENCE %I.%I FROM %I', '{}', object.relname, '{}');\n      EXECUTE pg_catalog.format('GRANT USAGE, SELECT ON SEQUENCE %I.%I TO %I', '{}', object.relname, '{}');\n    ELSE\n      EXECUTE pg_catalog.format('ALTER TABLE %I.%I OWNER TO %I', '{}', object.relname, '{}');\n      EXECUTE pg_catalog.format('REVOKE ALL ON TABLE %I.%I FROM PUBLIC', '{}', object.relname);\n      EXECUTE pg_catalog.format('REVOKE ALL ON TABLE %I.%I FROM %I', '{}', object.relname, '{}');\n      IF object.relname = '{}' OR object.relname LIKE '%' || '{}' THEN\n        EXECUTE pg_catalog.format('GRANT SELECT ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n      ELSIF object.relname = '{}' THEN\n        EXECUTE pg_catalog.format('GRANT SELECT, INSERT ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n        EXECUTE pg_catalog.format('GRANT UPDATE ({}) ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n      ELSE\n        EXECUTE pg_catalog.format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n      END IF;\n    END IF;\n  END LOOP;\nEND $grants$;",
+        manifest.schema,
+        manifest.schema,
+        names.owner().as_str(),
+        manifest.schema,
+        manifest.schema,
+        names.runtime().as_str(),
+        manifest.schema,
+        names.runtime().as_str(),
+        manifest.schema,
+        names.owner().as_str(),
+        manifest.schema,
+        manifest.schema,
+        names.runtime().as_str(),
+        manifest.migration_table,
+        manifest.history_table_suffix,
+        manifest.schema,
+        names.runtime().as_str(),
+        manifest.events_table,
+        manifest.schema,
+        names.runtime().as_str(),
+        update_columns,
+        manifest.schema,
+        names.runtime().as_str(),
+        manifest.schema,
+        names.runtime().as_str(),
+    )
+    .unwrap();
+    writeln!(
+        sql,
+        "DO $functions$ DECLARE object RECORD; BEGIN\n  FOR object IN SELECT p.oid, p.proname, p.prosecdef, p.oid::pg_catalog.regprocedure AS identity FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = '{}' LOOP\n    EXECUTE pg_catalog.format('ALTER FUNCTION %s OWNER TO %I', object.identity, '{}');\n    EXECUTE pg_catalog.format('REVOKE ALL ON FUNCTION %s FROM PUBLIC', object.identity);\n    EXECUTE pg_catalog.format('REVOKE ALL ON FUNCTION %s FROM %I', object.identity, '{}');\n    IF NOT object.prosecdef OR object.proname IN ({}) THEN\n      EXECUTE pg_catalog.format('GRANT EXECUTE ON FUNCTION %s TO %I', object.identity, '{}');\n    END IF;\n  END LOOP;\nEND $functions$;",
+        manifest.schema,
+        names.owner().as_str(),
+        names.runtime().as_str(),
+        runtime_functions,
+        names.runtime().as_str(),
+    )
+    .unwrap();
+    writeln!(sql, "ALTER DEFAULT PRIVILEGES FOR ROLE {owner} IN SCHEMA \"{}\" REVOKE ALL ON TABLES FROM PUBLIC;", manifest.schema).unwrap();
+    writeln!(sql, "ALTER DEFAULT PRIVILEGES FOR ROLE {owner} IN SCHEMA \"{}\" GRANT SELECT ON TABLES TO {runtime};", manifest.schema).unwrap();
+    writeln!(sql, "ALTER DEFAULT PRIVILEGES FOR ROLE {owner} IN SCHEMA \"{}\" REVOKE ALL ON SEQUENCES FROM PUBLIC;", manifest.schema).unwrap();
+    writeln!(sql, "ALTER DEFAULT PRIVILEGES FOR ROLE {owner} IN SCHEMA \"{}\" GRANT USAGE, SELECT ON SEQUENCES TO {runtime};", manifest.schema).unwrap();
+    writeln!(sql, "ALTER DEFAULT PRIVILEGES FOR ROLE {owner} IN SCHEMA \"{}\" REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;", manifest.schema).unwrap();
+    sql
+}
+
+/// Inspect a role against all current database objects using manifest rules.
+pub async fn inspect_database_privileges(
+    pool: &PostgresPool,
+    role: &DatabaseRoleName,
+    names: &DatabaseRoleNames,
+) -> Result<DatabasePrivilegeReport, PostgresStorageError> {
+    let manifest = &*MANIFEST;
+    let runtime = PostgresRuntime::new(pool.clone(), Arc::new(NoopPostgresObserver));
+    let role_row = runtime.with_connection(async |connection| {
+        diesel::sql_query(
+            r#"SELECT role.rolname::text AS role_name, current_user::text AS connected_role,
+                      role.rolsuper AS superuser,
+                      role.rolcreaterole AS create_role, role.rolcreatedb AS create_database,
+                      role.rolbypassrls AS bypass_rls,
+                      EXISTS (SELECT FROM pg_catalog.pg_namespace n
+                              WHERE n.nspname = $2 AND n.nspowner = role.oid) AS owns_schema,
+                      pg_catalog.has_schema_privilege(role.oid, $2::text, 'CREATE') AS creates_in_schema,
+                      EXISTS (SELECT FROM pg_catalog.pg_roles expected
+                              WHERE expected.rolname = $3
+                                AND pg_catalog.pg_has_role(role.oid, expected.oid, 'MEMBER')) AS owner_member,
+                      EXISTS (SELECT FROM pg_catalog.pg_roles expected
+                              WHERE expected.rolname = $4
+                                AND pg_catalog.pg_has_role(role.oid, expected.oid, 'MEMBER')) AS migrator_member
+               FROM pg_catalog.pg_roles role
+              WHERE role.rolname = $1"#,
+        )
+        .bind::<Text, _>(role.as_str())
+        .bind::<Text, _>(&manifest.schema)
+        .bind::<Text, _>(names.owner().as_str())
+        .bind::<Text, _>(names.migrator().as_str())
+        .get_result::<RoleRow>(connection)
+        .await
+    })
+    .await
+    .map_err(|error| {
+        PostgresStorageError::database(format!(
+            "failed to inspect database role '{}': {error}",
+            role.as_str()
+        ))
+    })?;
+
+    let objects = runtime.with_connection(async |connection| {
+        diesel::sql_query(
+            r#"SELECT 'table'::text AS object_kind, c.relname::text AS object_name,
+                      pg_catalog.pg_has_role(role.oid, c.relowner, 'MEMBER') AS owned,
+                      pg_catalog.has_table_privilege(role.oid, c.oid, 'SELECT') AS can_select,
+                      pg_catalog.has_table_privilege(role.oid, c.oid, 'INSERT') AS can_insert,
+                      pg_catalog.has_table_privilege(role.oid, c.oid, 'UPDATE') AS can_update,
+                      pg_catalog.has_table_privilege(role.oid, c.oid, 'DELETE') AS can_delete,
+                      false AS security_definer
+               FROM pg_catalog.pg_class c
+               JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+               CROSS JOIN pg_catalog.pg_roles role
+              WHERE role.rolname = $1 AND n.nspname = $2 AND c.relkind IN ('r', 'p')
+              UNION ALL
+             SELECT 'sequence'::text, c.relname::text,
+                    pg_catalog.pg_has_role(role.oid, c.relowner, 'MEMBER'),
+                    pg_catalog.has_sequence_privilege(role.oid, c.oid, 'SELECT'),
+                    pg_catalog.has_sequence_privilege(role.oid, c.oid, 'USAGE'), false, false, false
+               FROM pg_catalog.pg_class c
+               JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+               CROSS JOIN pg_catalog.pg_roles role
+              WHERE role.rolname = $1 AND n.nspname = $2 AND c.relkind = 'S'
+              UNION ALL
+             SELECT 'function'::text, p.oid::pg_catalog.regprocedure::text,
+                    pg_catalog.pg_has_role(role.oid, p.proowner, 'MEMBER'),
+                    pg_catalog.has_function_privilege(role.oid, p.oid, 'EXECUTE'), false, false, false,
+                    p.prosecdef
+               FROM pg_catalog.pg_proc p
+               JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+               CROSS JOIN pg_catalog.pg_roles role
+              WHERE role.rolname = $1 AND n.nspname = $2"#,
+        )
+        .bind::<Text, _>(role.as_str())
+        .bind::<Text, _>(&manifest.schema)
+        .load::<ObjectPrivilegeRow>(connection)
+        .await
+    })
+    .await?;
+
+    let event_columns = runtime
+        .with_connection(async |connection| {
+            diesel::sql_query(
+                r#"SELECT attribute.attname::text AS column_name,
+                          pg_catalog.has_column_privilege(
+                              role.oid, relation.oid, attribute.attnum, 'UPDATE'
+                          ) AS can_update
+                     FROM pg_catalog.pg_class relation
+                     JOIN pg_catalog.pg_namespace namespace ON namespace.oid = relation.relnamespace
+                     JOIN pg_catalog.pg_attribute attribute ON attribute.attrelid = relation.oid
+                     CROSS JOIN pg_catalog.pg_roles role
+                    WHERE role.rolname = $1 AND namespace.nspname = $2
+                      AND relation.relname = $3
+                      AND attribute.attnum > 0 AND NOT attribute.attisdropped"#,
+            )
+            .bind::<Text, _>(role.as_str())
+            .bind::<Text, _>(&manifest.schema)
+            .bind::<Text, _>(&manifest.events_table)
+            .load::<ColumnPrivilegeRow>(connection)
+            .await
+        })
+        .await?;
+
+    let mut dangerous = Vec::new();
+    let mut missing = Vec::new();
+    if role_row.connected_role != role_row.role_name {
+        dangerous.push(DatabasePrivilegeFinding::new(
+            "connected_role_mismatch",
+            &role_row.connected_role,
+            format!(
+                "database connection is authenticated as '{}' instead of the audited runtime role '{}'",
+                role_row.connected_role, role_row.role_name
+            ),
+        ));
+    }
+    for (condition, code, detail) in [
+        (
+            role_row.superuser,
+            "role_superuser",
+            "role is a PostgreSQL superuser",
+        ),
+        (
+            role_row.create_role,
+            "role_create_role",
+            "role can create or alter roles",
+        ),
+        (
+            role_row.create_database,
+            "role_create_database",
+            "role can create databases",
+        ),
+        (
+            role_row.bypass_rls,
+            "role_bypass_rls",
+            "role can bypass row-level security",
+        ),
+        (
+            role_row.owns_schema,
+            "owns_schema",
+            "role owns the application schema",
+        ),
+        (
+            role_row.creates_in_schema,
+            "schema_create",
+            "role can create objects in the application schema",
+        ),
+        (
+            role_row.owner_member,
+            "owner_membership",
+            "role is a member of the schema-owner role",
+        ),
+        (
+            role_row.migrator_member,
+            "migrator_membership",
+            "role is a member of the migrator role",
+        ),
+    ] {
+        if condition {
+            dangerous.push(DatabasePrivilegeFinding::new(
+                code,
+                &manifest.schema,
+                detail,
+            ));
+        }
+    }
+    for object in objects {
+        if object.owned {
+            dangerous.push(DatabasePrivilegeFinding::new(
+                "owns_object",
+                format!("{}:{}", object.object_kind, object.object_name),
+                "runtime role owns or can assume the owner of an application object",
+            ));
+        }
+        match object.object_kind.as_str() {
+            "table" if object.object_name == manifest.migration_table => {
+                if !object.can_select {
+                    missing.push(DatabasePrivilegeFinding::new(
+                        "missing_migration_read",
+                        &object.object_name,
+                        "runtime readiness requires SELECT",
+                    ));
+                }
+                if object.can_insert || object.can_update || object.can_delete {
+                    dangerous.push(DatabasePrivilegeFinding::new(
+                        "migration_table_write",
+                        &object.object_name,
+                        "runtime role can modify migration records",
+                    ));
+                }
+            }
+            "table" if object.object_name.ends_with(&manifest.history_table_suffix) => {
+                if !object.can_select {
+                    missing.push(DatabasePrivilegeFinding::new(
+                        "missing_history_read",
+                        &object.object_name,
+                        "runtime history APIs require SELECT",
+                    ));
+                }
+                if object.can_update || object.can_delete {
+                    dangerous.push(DatabasePrivilegeFinding::new(
+                        "history_mutation",
+                        &object.object_name,
+                        "runtime role can directly update or delete temporal history",
+                    ));
+                }
+            }
+            "table" if object.object_name == manifest.events_table => {
+                if !object.can_select || !object.can_insert {
+                    missing.push(DatabasePrivilegeFinding::new(
+                        "missing_event_access",
+                        &object.object_name,
+                        "runtime requires SELECT and INSERT on audit events",
+                    ));
+                }
+                if object.can_delete || object.can_update {
+                    dangerous.push(DatabasePrivilegeFinding::new(
+                        "event_broad_mutation",
+                        &object.object_name,
+                        "runtime has table-level UPDATE or DELETE on append-only events",
+                    ));
+                }
+            }
+            "table" => {
+                if !(object.can_select
+                    && object.can_insert
+                    && object.can_update
+                    && object.can_delete)
+                {
+                    missing.push(DatabasePrivilegeFinding::new(
+                        "missing_table_dml",
+                        &object.object_name,
+                        "runtime requires SELECT, INSERT, UPDATE, and DELETE",
+                    ));
+                }
+            }
+            "sequence" => {
+                if !(object.can_select && object.can_insert) {
+                    missing.push(DatabasePrivilegeFinding::new(
+                        "missing_sequence_access",
+                        &object.object_name,
+                        "runtime requires SELECT and USAGE",
+                    ));
+                }
+            }
+            "function" => {
+                let base_name = object
+                    .object_name
+                    .split('(')
+                    .next()
+                    .unwrap_or(&object.object_name);
+                let required = !object.security_definer
+                    || manifest
+                        .runtime_functions
+                        .iter()
+                        .any(|name| name == base_name);
+                if required && !object.can_select {
+                    missing.push(DatabasePrivilegeFinding::new(
+                        "missing_function_execute",
+                        &object.object_name,
+                        "runtime requires EXECUTE",
+                    ));
+                } else if !required && object.can_select {
+                    dangerous.push(DatabasePrivilegeFinding::new(
+                        "unexpected_function_execute",
+                        &object.object_name,
+                        "runtime can execute a non-runtime application function directly",
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+    for column in event_columns {
+        let required = manifest
+            .event_update_columns
+            .iter()
+            .any(|required| required == &column.column_name);
+        if required && !column.can_update {
+            missing.push(DatabasePrivilegeFinding::new(
+                "missing_event_column_update",
+                format!("{}.{}", manifest.events_table, column.column_name),
+                "runtime event workers require column-level UPDATE",
+            ));
+        } else if !required && column.can_update {
+            dangerous.push(DatabasePrivilegeFinding::new(
+                "event_immutable_column_update",
+                format!("{}.{}", manifest.events_table, column.column_name),
+                "runtime can update immutable audit event content",
+            ));
+        }
+    }
+    let safe = dangerous.is_empty() && missing.is_empty();
+    Ok(DatabasePrivilegeReport {
+        role: role_row.role_name,
+        connected_role: role_row.connected_role,
+        safe,
+        dangerous,
+        missing,
+    })
+}
+
+/// Machine-readable details that are not expressible as ordinary SQL grants.
+#[must_use]
+pub fn database_privilege_capabilities() -> (&'static str, &'static [String]) {
+    (&MANIFEST.restore, &MANIFEST.built_in_capabilities)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names() -> DatabaseRoleNames {
+        DatabaseRoleNames::new("hubuum_owner", "hubuum_migrator", "hubuum_runtime").unwrap()
+    }
+
+    #[test]
+    fn role_names_reject_unsafe_sql_identifiers() {
+        for value in [
+            "",
+            "1runtime",
+            "runtime; DROP ROLE postgres",
+            "runtime-role",
+        ] {
+            assert!(DatabaseRoleName::new(value).is_err(), "accepted {value:?}");
+        }
+    }
+
+    #[test]
+    fn setup_sql_is_derived_from_the_manifest_and_contains_no_credentials() {
+        let sql = database_role_setup_sql(&names());
+        assert!(sql.contains("hubuum_complete_event_retention_purge"));
+        assert!(sql.contains(
+            "GRANT UPDATE (\"dispatched_at\", \"fanout_locked_until\", \"fanout_claim_token\")"
+        ));
+        assert!(sql.contains("LIKE '%' || '_history'"));
+        assert!(sql.contains("REVOKE ALL ON SCHEMA \"public\" FROM \"hubuum_runtime\""));
+        assert!(!sql.to_ascii_lowercase().contains(" password '"));
+    }
+
+    #[test]
+    fn manifest_declares_privileged_restore_and_builtin_capabilities() {
+        let (restore, capabilities) = database_privilege_capabilities();
+        assert_eq!(restore, "migrator_only");
+        assert!(capabilities.iter().any(|value| value == "listen_notify"));
+        assert_eq!(
+            MANIFEST.runtime_function_policy,
+            "all_security_invoker_plus_allowlisted_security_definer"
+        );
+    }
+}

--- a/crates/hubuum-storage-postgres/src/database_privileges.rs
+++ b/crates/hubuum-storage-postgres/src/database_privileges.rs
@@ -344,33 +344,35 @@ pub fn database_role_reconciliation_sql(names: &DatabaseRoleNames) -> String {
     .unwrap();
     writeln!(
         sql,
-        "DO $grants$ DECLARE object RECORD; BEGIN\n  FOR object IN SELECT c.oid, c.relname, c.relkind FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = '{}' AND c.relkind IN ('r', 'p', 'S') LOOP\n    IF object.relkind = 'S' THEN\n      EXECUTE pg_catalog.format('ALTER SEQUENCE %I.%I OWNER TO %I', '{}', object.relname, '{}');\n      EXECUTE pg_catalog.format('REVOKE ALL ON SEQUENCE %I.%I FROM PUBLIC', '{}', object.relname);\n      EXECUTE pg_catalog.format('REVOKE ALL ON SEQUENCE %I.%I FROM %I', '{}', object.relname, '{}');\n      EXECUTE pg_catalog.format('GRANT USAGE, SELECT ON SEQUENCE %I.%I TO %I', '{}', object.relname, '{}');\n    ELSE\n      EXECUTE pg_catalog.format('ALTER TABLE %I.%I OWNER TO %I', '{}', object.relname, '{}');\n      EXECUTE pg_catalog.format('REVOKE ALL ON TABLE %I.%I FROM PUBLIC', '{}', object.relname);\n      EXECUTE pg_catalog.format('REVOKE ALL ON TABLE %I.%I FROM %I', '{}', object.relname, '{}');\n      IF object.relname = '{}' OR object.relname LIKE '%' || '{}' OR object.relname IN ({}) THEN\n        EXECUTE pg_catalog.format('GRANT SELECT ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n      ELSIF object.relname = '{}' THEN\n        EXECUTE pg_catalog.format('GRANT SELECT, INSERT ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n        EXECUTE pg_catalog.format('GRANT UPDATE ({}) ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n      ELSE\n        EXECUTE pg_catalog.format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n      END IF;\n    END IF;\n  END LOOP;\nEND $grants$;",
-        manifest.schema,
-        manifest.schema,
-        names.owner().as_str(),
-        manifest.schema,
-        manifest.schema,
-        names.runtime().as_str(),
-        manifest.schema,
-        names.runtime().as_str(),
-        manifest.schema,
-        names.owner().as_str(),
-        manifest.schema,
-        manifest.schema,
-        names.runtime().as_str(),
-        manifest.migration_table,
-        manifest.history_table_suffix,
-        read_only_tables,
-        manifest.schema,
-        names.runtime().as_str(),
-        manifest.events_table,
-        manifest.schema,
-        names.runtime().as_str(),
-        update_columns,
-        manifest.schema,
-        names.runtime().as_str(),
-        manifest.schema,
-        names.runtime().as_str(),
+        "DO $grants$ DECLARE object RECORD; BEGIN
+  FOR object IN SELECT c.relname FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = '{schema}' AND c.relkind IN ('r', 'p') LOOP
+    EXECUTE pg_catalog.format('ALTER TABLE %I.%I OWNER TO %I', '{schema}', object.relname, '{owner}');
+    EXECUTE pg_catalog.format('REVOKE ALL ON TABLE %I.%I FROM PUBLIC', '{schema}', object.relname);
+    EXECUTE pg_catalog.format('REVOKE ALL ON TABLE %I.%I FROM %I', '{schema}', object.relname, '{runtime}');
+    IF object.relname = '{migration_table}' OR object.relname LIKE '%' || '{history_suffix}' OR object.relname IN ({read_only_tables}) THEN
+      EXECUTE pg_catalog.format('GRANT SELECT ON TABLE %I.%I TO %I', '{schema}', object.relname, '{runtime}');
+    ELSIF object.relname = '{events_table}' THEN
+      EXECUTE pg_catalog.format('GRANT SELECT, INSERT ON TABLE %I.%I TO %I', '{schema}', object.relname, '{runtime}');
+      EXECUTE pg_catalog.format('GRANT UPDATE ({update_columns}) ON TABLE %I.%I TO %I', '{schema}', object.relname, '{runtime}');
+    ELSE
+      EXECUTE pg_catalog.format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %I.%I TO %I', '{schema}', object.relname, '{runtime}');
+    END IF;
+  END LOOP;
+  FOR object IN SELECT c.relname FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = '{schema}' AND c.relkind = 'S' LOOP
+    EXECUTE pg_catalog.format('ALTER SEQUENCE %I.%I OWNER TO %I', '{schema}', object.relname, '{owner}');
+    EXECUTE pg_catalog.format('REVOKE ALL ON SEQUENCE %I.%I FROM PUBLIC', '{schema}', object.relname);
+    EXECUTE pg_catalog.format('REVOKE ALL ON SEQUENCE %I.%I FROM %I', '{schema}', object.relname, '{runtime}');
+    EXECUTE pg_catalog.format('GRANT USAGE, SELECT ON SEQUENCE %I.%I TO %I', '{schema}', object.relname, '{runtime}');
+  END LOOP;
+END $grants$;",
+        schema = manifest.schema,
+        owner = names.owner().as_str(),
+        runtime = names.runtime().as_str(),
+        migration_table = manifest.migration_table,
+        history_suffix = manifest.history_table_suffix,
+        read_only_tables = read_only_tables,
+        events_table = manifest.events_table,
+        update_columns = update_columns,
     )
     .unwrap();
     writeln!(

--- a/crates/hubuum-storage-postgres/src/database_privileges.rs
+++ b/crates/hubuum-storage-postgres/src/database_privileges.rs
@@ -22,6 +22,7 @@ struct DatabasePrivilegeManifest {
     schema: String,
     migration_table: String,
     history_table_suffix: String,
+    read_only_tables: Vec<String>,
     events_table: String,
     event_update_columns: Vec<String>,
     runtime_functions: Vec<String>,
@@ -310,6 +311,12 @@ pub fn database_role_reconciliation_sql(names: &DatabaseRoleNames) -> String {
         .map(|function| format!("'{function}'"))
         .collect::<Vec<_>>()
         .join(", ");
+    let read_only_tables = manifest
+        .read_only_tables
+        .iter()
+        .map(|table| format!("'{}'", table.replace('\'', "''")))
+        .collect::<Vec<_>>()
+        .join(", ");
     let mut sql = String::new();
     writeln!(
         sql,
@@ -337,7 +344,7 @@ pub fn database_role_reconciliation_sql(names: &DatabaseRoleNames) -> String {
     .unwrap();
     writeln!(
         sql,
-        "DO $grants$ DECLARE object RECORD; BEGIN\n  FOR object IN SELECT c.oid, c.relname, c.relkind FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = '{}' AND c.relkind IN ('r', 'p', 'S') LOOP\n    IF object.relkind = 'S' THEN\n      EXECUTE pg_catalog.format('ALTER SEQUENCE %I.%I OWNER TO %I', '{}', object.relname, '{}');\n      EXECUTE pg_catalog.format('REVOKE ALL ON SEQUENCE %I.%I FROM PUBLIC', '{}', object.relname);\n      EXECUTE pg_catalog.format('REVOKE ALL ON SEQUENCE %I.%I FROM %I', '{}', object.relname, '{}');\n      EXECUTE pg_catalog.format('GRANT USAGE, SELECT ON SEQUENCE %I.%I TO %I', '{}', object.relname, '{}');\n    ELSE\n      EXECUTE pg_catalog.format('ALTER TABLE %I.%I OWNER TO %I', '{}', object.relname, '{}');\n      EXECUTE pg_catalog.format('REVOKE ALL ON TABLE %I.%I FROM PUBLIC', '{}', object.relname);\n      EXECUTE pg_catalog.format('REVOKE ALL ON TABLE %I.%I FROM %I', '{}', object.relname, '{}');\n      IF object.relname = '{}' OR object.relname LIKE '%' || '{}' THEN\n        EXECUTE pg_catalog.format('GRANT SELECT ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n      ELSIF object.relname = '{}' THEN\n        EXECUTE pg_catalog.format('GRANT SELECT, INSERT ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n        EXECUTE pg_catalog.format('GRANT UPDATE ({}) ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n      ELSE\n        EXECUTE pg_catalog.format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n      END IF;\n    END IF;\n  END LOOP;\nEND $grants$;",
+        "DO $grants$ DECLARE object RECORD; BEGIN\n  FOR object IN SELECT c.oid, c.relname, c.relkind FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = '{}' AND c.relkind IN ('r', 'p', 'S') LOOP\n    IF object.relkind = 'S' THEN\n      EXECUTE pg_catalog.format('ALTER SEQUENCE %I.%I OWNER TO %I', '{}', object.relname, '{}');\n      EXECUTE pg_catalog.format('REVOKE ALL ON SEQUENCE %I.%I FROM PUBLIC', '{}', object.relname);\n      EXECUTE pg_catalog.format('REVOKE ALL ON SEQUENCE %I.%I FROM %I', '{}', object.relname, '{}');\n      EXECUTE pg_catalog.format('GRANT USAGE, SELECT ON SEQUENCE %I.%I TO %I', '{}', object.relname, '{}');\n    ELSE\n      EXECUTE pg_catalog.format('ALTER TABLE %I.%I OWNER TO %I', '{}', object.relname, '{}');\n      EXECUTE pg_catalog.format('REVOKE ALL ON TABLE %I.%I FROM PUBLIC', '{}', object.relname);\n      EXECUTE pg_catalog.format('REVOKE ALL ON TABLE %I.%I FROM %I', '{}', object.relname, '{}');\n      IF object.relname = '{}' OR object.relname LIKE '%' || '{}' OR object.relname IN ({}) THEN\n        EXECUTE pg_catalog.format('GRANT SELECT ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n      ELSIF object.relname = '{}' THEN\n        EXECUTE pg_catalog.format('GRANT SELECT, INSERT ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n        EXECUTE pg_catalog.format('GRANT UPDATE ({}) ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n      ELSE\n        EXECUTE pg_catalog.format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %I.%I TO %I', '{}', object.relname, '{}');\n      END IF;\n    END IF;\n  END LOOP;\nEND $grants$;",
         manifest.schema,
         manifest.schema,
         names.owner().as_str(),
@@ -353,6 +360,7 @@ pub fn database_role_reconciliation_sql(names: &DatabaseRoleNames) -> String {
         names.runtime().as_str(),
         manifest.migration_table,
         manifest.history_table_suffix,
+        read_only_tables,
         manifest.schema,
         names.runtime().as_str(),
         manifest.events_table,
@@ -589,6 +597,22 @@ pub async fn inspect_database_privileges(
                     ));
                 }
             }
+            "table" if manifest.read_only_tables.contains(&object.object_name) => {
+                if !object.can_select {
+                    missing.push(DatabasePrivilegeFinding::new(
+                        "missing_read_only_table_read",
+                        &object.object_name,
+                        "runtime status APIs require SELECT",
+                    ));
+                }
+                if object.can_insert || object.can_update || object.can_delete {
+                    dangerous.push(DatabasePrivilegeFinding::new(
+                        "read_only_table_write",
+                        &object.object_name,
+                        "runtime role can modify an integrity-bearing receipt",
+                    ));
+                }
+            }
             "table" if object.object_name == manifest.events_table => {
                 if !object.can_select || !object.can_insert {
                     missing.push(DatabasePrivilegeFinding::new(
@@ -718,6 +742,7 @@ mod tests {
             "GRANT UPDATE (\"dispatched_at\", \"fanout_locked_until\", \"fanout_claim_token\")"
         ));
         assert!(sql.contains("LIKE '%' || '_history'"));
+        assert!(sql.contains("object.relname IN ('restore_success_receipts')"));
         assert!(sql.contains("REVOKE ALL ON SCHEMA \"public\" FROM \"hubuum_runtime\""));
         assert!(!sql.to_ascii_lowercase().contains(" password '"));
     }

--- a/crates/hubuum-storage-postgres/src/database_privileges.rs
+++ b/crates/hubuum-storage-postgres/src/database_privileges.rs
@@ -725,7 +725,7 @@ mod tests {
     #[test]
     fn manifest_declares_privileged_restore_and_builtin_capabilities() {
         let (restore, capabilities) = database_privilege_capabilities();
-        assert_eq!(restore, "migrator_only");
+        assert_eq!(restore, "isolated_migrator_executor");
         assert!(capabilities.iter().any(|value| value == "listen_notify"));
         assert_eq!(
             MANIFEST.runtime_function_policy,

--- a/crates/hubuum-storage-postgres/src/lib.rs
+++ b/crates/hubuum-storage-postgres/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod backend;
 mod cursor;
+mod database_privileges;
 mod diagnostics;
 mod error;
 mod failpoints;
@@ -64,6 +65,11 @@ pub mod diesel_async_prelude {
 
 pub use backend::PostgresStorage;
 pub(crate) use cursor::{apply_cursor_ordering_fields, apply_query_options_with_fields};
+pub use database_privileges::{
+    DatabasePrivilegeFinding, DatabasePrivilegeReport, DatabaseRoleName, DatabaseRoleNames,
+    database_privilege_capabilities, database_privilege_manifest_json,
+    database_role_reconciliation_sql, database_role_setup_sql, inspect_database_privileges,
+};
 pub(crate) use diagnostics::{
     PostgresPoolAcquisitionState, PostgresPoolCapacity, PostgresPoolConnectionState,
 };
@@ -82,7 +88,7 @@ pub(crate) use filters::{
     postgres_is_null_filter, postgres_revision_filter, postgres_string_filter,
 };
 #[cfg(feature = "embedded-migrations")]
-pub use migrations::run_embedded_migrations;
+pub use migrations::{run_embedded_migrations, run_embedded_migrations_as};
 #[cfg(any(feature = "integration-test-support", feature = "benchmark-support"))]
 #[doc(hidden)]
 pub use operations::computed_materialization::source_data_sha256;

--- a/crates/hubuum-storage-postgres/src/migrations.rs
+++ b/crates/hubuum-storage-postgres/src/migrations.rs
@@ -1,24 +1,60 @@
+use diesel::connection::SimpleConnection;
 use diesel::{Connection, PgConnection};
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use hubuum_storage_core::StorageError;
 
-use crate::PostgresStorageError;
+use crate::{DatabaseRoleNames, PostgresStorageError, database_role_reconciliation_sql};
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 
 /// Apply every embedded PostgreSQL migration not yet recorded by Diesel.
 pub fn run_embedded_migrations(connection_url: &str) -> Result<usize, StorageError> {
+    run_embedded_migrations_with_roles(connection_url, None)
+}
+
+/// Apply migrations as the schema-owner role and reconcile runtime grants.
+pub fn run_embedded_migrations_as(
+    connection_url: &str,
+    roles: &DatabaseRoleNames,
+) -> Result<usize, StorageError> {
+    run_embedded_migrations_with_roles(connection_url, Some(roles))
+}
+
+fn run_embedded_migrations_with_roles(
+    connection_url: &str,
+    roles: Option<&DatabaseRoleNames>,
+) -> Result<usize, StorageError> {
     let mut connection = PgConnection::establish(connection_url).map_err(|error| {
         StorageError::from(PostgresStorageError::database(format!(
             "failed to connect for storage migrations: {error}"
         )))
     })?;
-    let applied = connection
+    if let Some(roles) = roles {
+        connection
+            .batch_execute(&format!("SET ROLE {};", roles.owner().quoted()))
+            .map_err(|error| {
+                StorageError::from(PostgresStorageError::database(format!(
+                    "failed to assume database schema-owner role '{}': {error}",
+                    roles.owner().as_str()
+                )))
+            })?;
+    }
+    let applied_count = connection
         .run_pending_migrations(MIGRATIONS)
         .map_err(|error| {
             StorageError::from(PostgresStorageError::database(format!(
                 "failed to run storage migrations: {error}"
             )))
-        })?;
-    Ok(applied.len())
+        })?
+        .len();
+    if let Some(roles) = roles {
+        connection
+            .batch_execute(&database_role_reconciliation_sql(roles))
+            .map_err(|error| {
+                StorageError::from(PostgresStorageError::database(format!(
+                    "failed to reconcile database ownership and runtime grants: {error}"
+                )))
+            })?;
+    }
+    Ok(applied_count)
 }

--- a/crates/hubuum-storage-postgres/src/operations/event_retention.rs
+++ b/crates/hubuum-storage-postgres/src/operations/event_retention.rs
@@ -31,6 +31,14 @@ struct EventIdRow {
 }
 
 #[derive(QueryableByName)]
+struct PurgeSummaryRow {
+    #[diesel(sql_type = BigInt)]
+    purged_events: i64,
+    #[diesel(sql_type = BigInt)]
+    purged_terminal_deliveries: i64,
+}
+
+#[derive(QueryableByName)]
 struct RetentionBatchRow {
     #[diesel(sql_type = SqlUuid)]
     claim_id: Uuid,
@@ -38,10 +46,6 @@ struct RetentionBatchRow {
     event_ids: Vec<i64>,
     #[diesel(sql_type = Jsonb)]
     event_documents: Value,
-    #[diesel(sql_type = Timestamp)]
-    delivery_cutoff: NaiveDateTime,
-    #[diesel(sql_type = BigInt)]
-    delivery_batch_size: i64,
     #[diesel(sql_type = Nullable<Timestamp>)]
     completed_at: Option<NaiveDateTime>,
     #[diesel(sql_type = Nullable<BigInt>)]
@@ -164,8 +168,6 @@ pub async fn claim_event_retention_batch(
                 claim_id,
                 event_ids,
                 event_documents,
-                delivery_cutoff,
-                delivery_batch_size: settings.query_batch_size(),
                 completed_at: None,
                 purged_events: None,
                 purged_terminal_deliveries: None,
@@ -199,13 +201,7 @@ pub async fn complete_event_retention_batch(
             if claim.completed_at.is_some() {
                 return completed_summary(&claim);
             }
-            let summary = purge_event_retention_batch(
-                connection,
-                claim.delivery_cutoff,
-                claim.delivery_batch_size,
-                &claim.event_ids,
-            )
-            .await?;
+            let summary = purge_event_retention_batch(connection, batch_id).await?;
             diesel::sql_query(
                 "UPDATE event_retention_batches
                  SET completed_at = clock_timestamp() AT TIME ZONE 'UTC',
@@ -239,8 +235,7 @@ async fn load_pending_claim(
     connection: &mut PostgresConnection,
 ) -> Result<Option<RetentionBatchRow>, PostgresStorageError> {
     diesel::sql_query(
-        "SELECT claim_id, event_ids, event_documents, delivery_cutoff,
-                delivery_batch_size, completed_at, purged_events,
+        "SELECT claim_id, event_ids, event_documents, completed_at, purged_events,
                 purged_terminal_deliveries
          FROM event_retention_batches
          WHERE completed_at IS NULL
@@ -258,8 +253,7 @@ async fn load_claim_for_update(
     batch_id: StorageEventRetentionBatchId,
 ) -> Result<RetentionBatchRow, PostgresStorageError> {
     diesel::sql_query(
-        "SELECT claim_id, event_ids, event_documents, delivery_cutoff,
-                delivery_batch_size, completed_at, purged_events,
+        "SELECT claim_id, event_ids, event_documents, completed_at, purged_events,
                 purged_terminal_deliveries
          FROM event_retention_batches
          WHERE claim_id = $1
@@ -355,22 +349,22 @@ async fn select_events_for_retention_purge(
 
 async fn purge_event_retention_batch(
     connection: &mut PostgresConnection,
-    delivery_cutoff: NaiveDateTime,
-    delivery_batch_size: i64,
-    event_ids: &[i64],
+    batch_id: StorageEventRetentionBatchId,
 ) -> Result<StorageEventRetentionSummary, PostgresStorageError> {
-    let purged_terminal_deliveries =
-        purge_terminal_event_deliveries(connection, delivery_cutoff, delivery_batch_size).await?;
-    let purged_events = purge_events_by_id(connection, event_ids).await?;
-    if purged_events != event_ids.len() {
-        return Err(PostgresStorageError::conflict(format!(
-            "Event retention claim expected to purge {} events but purged {purged_events}",
-            event_ids.len(),
-        )));
-    }
+    let row = diesel::sql_query(
+        "SELECT purged_events, purged_terminal_deliveries \
+         FROM hubuum_complete_event_retention_purge($1)",
+    )
+    .bind::<SqlUuid, _>(batch_id.as_uuid())
+    .get_result::<PurgeSummaryRow>(connection)
+    .await?;
     Ok(StorageEventRetentionSummary::new(
-        purged_events,
-        purged_terminal_deliveries,
+        usize::try_from(row.purged_events).map_err(|_| {
+            PostgresStorageError::database("Retention event count does not fit usize")
+        })?,
+        usize::try_from(row.purged_terminal_deliveries).map_err(|_| {
+            PostgresStorageError::database("Retention delivery count does not fit usize")
+        })?,
     ))
 }
 
@@ -399,59 +393,5 @@ async fn select_event_ids_for_retention_purge(
     .load::<EventIdRow>(connection)
     .await
     .map(|rows| rows.into_iter().map(|row| row.id).collect())
-    .map_err(PostgresStorageError::from)
-}
-
-async fn purge_terminal_event_deliveries(
-    connection: &mut PostgresConnection,
-    cutoff: NaiveDateTime,
-    batch_size: i64,
-) -> Result<usize, PostgresStorageError> {
-    diesel::sql_query(
-        "WITH candidates AS (
-             SELECT id
-             FROM event_deliveries
-             WHERE updated_at < $1
-               AND status IN ('succeeded', 'dead')
-             ORDER BY updated_at ASC, id ASC
-             LIMIT $2
-             FOR UPDATE SKIP LOCKED
-         )
-         DELETE FROM event_deliveries AS delivery
-         USING candidates
-         WHERE delivery.id = candidates.id",
-    )
-    .bind::<Timestamp, _>(cutoff)
-    .bind::<BigInt, _>(batch_size)
-    .execute(connection)
-    .await
-    .map_err(PostgresStorageError::from)
-}
-
-async fn purge_events_by_id(
-    connection: &mut PostgresConnection,
-    event_ids: &[i64],
-) -> Result<usize, PostgresStorageError> {
-    if event_ids.is_empty() {
-        return Ok(0);
-    }
-
-    diesel::sql_query("SELECT set_config('events.allow_purge', 'on', true)")
-        .execute(&mut *connection)
-        .await?;
-    diesel::sql_query(
-        "DELETE FROM events e
-         WHERE e.id = ANY($1)
-           AND e.dispatched_at IS NOT NULL
-           AND NOT EXISTS (
-             SELECT 1
-             FROM event_deliveries d
-             WHERE d.event_id = e.id
-               AND d.status IN ('pending', 'failed', 'in_flight')
-           )",
-    )
-    .bind::<Array<BigInt>, _>(event_ids)
-    .execute(connection)
-    .await
     .map_err(PostgresStorageError::from)
 }

--- a/crates/hubuum-storage-postgres/src/operations/restore_lifecycle.rs
+++ b/crates/hubuum-storage-postgres/src/operations/restore_lifecycle.rs
@@ -3,7 +3,7 @@
 use chrono::{DateTime, NaiveDateTime, Utc};
 use diesel::dsl::sql;
 use diesel::prelude::{ExpressionMethods, OptionalExtension, QueryDsl};
-use diesel::sql_types::{Jsonb, Timestamp};
+use diesel::sql_types::{BigInt, Jsonb, Timestamp};
 use diesel::{Insertable, Queryable, Selectable, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use hubuum_domain::{MaintenanceState, PrincipalId, RestoreJobId};
@@ -158,6 +158,24 @@ struct RestoreJobStatusRow {
 }
 
 #[derive(Queryable, Selectable)]
+#[diesel(table_name = crate::schema::restore_success_receipts)]
+struct RestoreSuccessReceiptRow {
+    id: i64,
+    requested_by: Option<i32>,
+    requested_by_identity_scope: String,
+    requested_by_name: String,
+    byte_size: i64,
+    sha256: String,
+    capability_hash: String,
+    validation_summary: serde_json::Value,
+    expires_at: NaiveDateTime,
+    confirmed_at: NaiveDateTime,
+    finished_at: NaiveDateTime,
+    created_at: NaiveDateTime,
+    updated_at: NaiveDateTime,
+}
+
+#[derive(Queryable, Selectable)]
 #[diesel(table_name = crate::schema::restore_jobs)]
 struct RestoreApplyRow {
     id: i64,
@@ -276,6 +294,30 @@ fn status_to_storage(
     )
 }
 
+fn success_receipt_to_storage(
+    row: RestoreSuccessReceiptRow,
+) -> Result<StorageRestoreStatus, PostgresStorageError> {
+    let summary = summary_from_parts(RestoreSummaryParts {
+        id: row.id,
+        status: StorageRestoreJobStatus::Succeeded.as_str().to_owned(),
+        requested_by: row.requested_by,
+        requested_by_identity_scope: row.requested_by_identity_scope,
+        requested_by_name: row.requested_by_name,
+        byte_size: row.byte_size,
+        sha256: row.sha256,
+        error: None,
+        expires_at: row.expires_at,
+        confirmed_at: Some(row.confirmed_at),
+        finished_at: Some(row.finished_at),
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    })?;
+    crate::validate_persisted(
+        "restore status",
+        StorageRestoreStatus::try_new(summary, row.capability_hash, row.validation_summary),
+    )
+}
+
 fn instance_to_storage(
     instance: ServerInstanceRow,
 ) -> Result<StorageRestoreInstance, PostgresStorageError> {
@@ -362,11 +404,25 @@ pub async fn get_restore_status(
                 .await
                 .optional()
         })
+        .await?;
+    if let Some(row) = row {
+        return status_to_storage(row);
+    }
+
+    let receipt = runtime
+        .with_connection(async |connection| {
+            crate::schema::restore_success_receipts::table
+                .filter(crate::schema::restore_success_receipts::id.eq(job_id))
+                .select(RestoreSuccessReceiptRow::as_select())
+                .first::<RestoreSuccessReceiptRow>(connection)
+                .await
+                .optional()
+        })
         .await?
         .ok_or_else(|| {
             PostgresStorageError::not_found(format!("Restore stage {job_id} was not found"))
         })?;
-    status_to_storage(row)
+    success_receipt_to_storage(receipt)
 }
 
 /// Expire a still-valid staged restore and erase its document.
@@ -714,17 +770,22 @@ async fn finish_restore(
     .bind::<Timestamp, _>(finished_at)
     .execute(connection)
     .await?;
-    diesel::sql_query("DELETE FROM restore_jobs WHERE id <> $1")
-        .bind::<diesel::sql_types::BigInt, _>(job_id)
+    diesel::sql_query("DELETE FROM restore_success_receipts")
         .execute(connection)
         .await?;
     let completed = diesel::sql_query(
-        "UPDATE restore_jobs \
-         SET status='succeeded', document=''::bytea, error=NULL, \
-             finished_at=$2, updated_at=$2 \
-         WHERE id=$1 AND status='confirmed'",
+        "INSERT INTO restore_success_receipts (\
+             id, requested_by, requested_by_identity_scope, requested_by_name, \
+             byte_size, sha256, capability_hash, validation_summary, expires_at, \
+             confirmed_at, finished_at, created_at, updated_at\
+         ) \
+         SELECT id, requested_by, requested_by_identity_scope, requested_by_name, \
+                byte_size, sha256, capability_hash, validation_summary, expires_at, \
+                confirmed_at, $2, created_at, $2 \
+         FROM restore_jobs \
+         WHERE id=$1 AND status='confirmed' AND confirmed_at IS NOT NULL",
     )
-    .bind::<diesel::sql_types::BigInt, _>(job_id)
+    .bind::<BigInt, _>(job_id)
     .bind::<Timestamp, _>(finished_at)
     .execute(connection)
     .await?;
@@ -733,6 +794,9 @@ async fn finish_restore(
             "Confirmed restore receipt changed concurrently",
         ));
     }
+    diesel::sql_query("DELETE FROM restore_jobs")
+        .execute(connection)
+        .await?;
     diesel::sql_query("DELETE FROM server_instances")
         .execute(connection)
         .await?;
@@ -986,7 +1050,7 @@ mod tests {
     use diesel::prelude::{ExpressionMethods, QueryDsl};
     use rstest::rstest;
 
-    use super::{RestoreJobStatusRow, validate_restore_identifier};
+    use super::{RestoreJobStatusRow, RestoreSuccessReceiptRow, validate_restore_identifier};
 
     #[test]
     fn restore_status_projection_excludes_document() {
@@ -997,6 +1061,17 @@ mod tests {
 
         assert!(!sql.contains("\"restore_jobs\".\"document\""));
         assert!(sql.contains("\"restore_jobs\".\"capability_hash\""));
+    }
+
+    #[test]
+    fn successful_restore_projection_is_document_free() {
+        let query = crate::schema::restore_success_receipts::table
+            .filter(crate::schema::restore_success_receipts::id.eq(42_i64))
+            .select(RestoreSuccessReceiptRow::as_select());
+        let sql = diesel::debug_query::<diesel::pg::Pg, _>(&query).to_string();
+
+        assert!(!sql.contains("document"));
+        assert!(sql.contains("\"restore_success_receipts\".\"capability_hash\""));
     }
 
     #[rstest]

--- a/crates/hubuum-storage-postgres/src/operations/restore_lifecycle.rs
+++ b/crates/hubuum-storage-postgres/src/operations/restore_lifecycle.rs
@@ -1,7 +1,6 @@
 //! PostgreSQL-owned restore staging and coordinator lifecycle.
 
 use chrono::{DateTime, NaiveDateTime, Utc};
-use diesel::NullableExpressionMethods;
 use diesel::dsl::sql;
 use diesel::prelude::{ExpressionMethods, OptionalExtension, QueryDsl};
 use diesel::sql_types::{Jsonb, Timestamp};
@@ -406,6 +405,10 @@ pub async fn start_restore_draining(
             diesel::sql_query("SELECT pg_advisory_xact_lock(4850188191125217)")
                 .execute(connection)
                 .await?;
+            let confirmation_time = diesel::select(sql::<Timestamp>(DATABASE_UTC_NOW_SQL))
+                .get_result::<NaiveDateTime>(connection)
+                .await?;
+            preserve_explicit_timestamps(connection).await?;
             let confirmation_time = diesel::update(
                 crate::schema::restore_jobs::table
                     .filter(crate::schema::restore_jobs::id.eq(job_id))
@@ -416,9 +419,9 @@ pub async fn start_restore_draining(
             )
             .set((
                 crate::schema::restore_jobs::status.eq(StorageRestoreJobStatus::Confirmed.as_str()),
-                crate::schema::restore_jobs::confirmed_at
-                    .eq(sql::<Timestamp>(DATABASE_UTC_NOW_SQL).nullable()),
+                crate::schema::restore_jobs::confirmed_at.eq(Some(confirmation_time)),
                 crate::schema::restore_jobs::error.eq::<Option<String>>(None),
+                crate::schema::restore_jobs::updated_at.eq(confirmation_time),
             ))
             .returning(crate::schema::restore_jobs::confirmed_at)
             .get_result::<Option<NaiveDateTime>>(connection)
@@ -547,7 +550,7 @@ pub async fn apply_restore(
                 append_event(connection, &provenance).await?;
 
                 let finished_at = Utc::now().naive_utc();
-                finish_restore(connection, finished_at).await?;
+                finish_restore(connection, job.id, finished_at).await?;
                 crate::validate_persisted(
                     "restore completion",
                     StorageRestoreCompletion::try_new(started_at.and_utc(), finished_at.and_utc()),
@@ -695,8 +698,13 @@ fn validate_restore_identifier(
 
 async fn finish_restore(
     connection: &mut PostgresConnection,
+    job_id: i64,
     finished_at: NaiveDateTime,
 ) -> Result<(), PostgresStorageError> {
+    // The shared updated-at trigger uses transaction-start time. Preserve the
+    // explicit completion clock so the terminal receipt cannot appear to have
+    // finished after its own updated_at value.
+    preserve_explicit_timestamps(connection).await?;
     diesel::sql_query(
         "UPDATE system_maintenance \
          SET generation=0, state='normal', restore_job_id=NULL, \
@@ -706,13 +714,38 @@ async fn finish_restore(
     .bind::<Timestamp, _>(finished_at)
     .execute(connection)
     .await?;
-    diesel::sql_query("DELETE FROM restore_jobs")
+    diesel::sql_query("DELETE FROM restore_jobs WHERE id <> $1")
+        .bind::<diesel::sql_types::BigInt, _>(job_id)
         .execute(connection)
         .await?;
+    let completed = diesel::sql_query(
+        "UPDATE restore_jobs \
+         SET status='succeeded', document=''::bytea, error=NULL, \
+             finished_at=$2, updated_at=$2 \
+         WHERE id=$1 AND status='confirmed'",
+    )
+    .bind::<diesel::sql_types::BigInt, _>(job_id)
+    .bind::<Timestamp, _>(finished_at)
+    .execute(connection)
+    .await?;
+    if completed != 1 {
+        return Err(PostgresStorageError::conflict(
+            "Confirmed restore receipt changed concurrently",
+        ));
+    }
     diesel::sql_query("DELETE FROM server_instances")
         .execute(connection)
         .await?;
     diesel::sql_query("SELECT pg_notify('hubuum_maintenance', 'normal')")
+        .execute(connection)
+        .await?;
+    Ok(())
+}
+
+async fn preserve_explicit_timestamps(
+    connection: &mut PostgresConnection,
+) -> Result<(), PostgresStorageError> {
+    diesel::sql_query("SELECT set_config('hubuum.preserve_imported_timestamps', 'on', true)")
         .execute(connection)
         .await?;
     Ok(())

--- a/crates/hubuum-storage-postgres/src/runtime.rs
+++ b/crates/hubuum-storage-postgres/src/runtime.rs
@@ -20,7 +20,7 @@ use crate::revision::revision_owner_key;
 use crate::{PostgresConnection, PostgresPool, PostgresPooledConnection, PostgresStorageError};
 
 /// Latest migration required by this adapter.
-pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260831000003";
+pub const REQUIRED_DATABASE_MIGRATION_VERSION: &str = "20260831000004";
 pub const DEFAULT_COMPUTED_REINDEX_BATCH_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
 
 /// Adapter-level observation hook supplied by the application composition root.

--- a/crates/hubuum-storage-postgres/src/schema.rs
+++ b/crates/hubuum-storage-postgres/src/schema.rs
@@ -645,6 +645,26 @@ diesel::table! {
 }
 
 diesel::table! {
+    restore_success_receipts (id) {
+        id -> Int8,
+        requested_by -> Nullable<Int4>,
+        requested_by_identity_scope -> Varchar,
+        requested_by_name -> Varchar,
+        byte_size -> Int8,
+        #[max_length = 64]
+        sha256 -> Varchar,
+        #[max_length = 64]
+        capability_hash -> Varchar,
+        validation_summary -> Jsonb,
+        expires_at -> Timestamp,
+        confirmed_at -> Timestamp,
+        finished_at -> Timestamp,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     server_instances (instance_id) {
         instance_id -> Uuid,
         maintenance_generation -> Int8,
@@ -855,6 +875,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     remote_targets,
     remote_targets_history,
     restore_jobs,
+    restore_success_receipts,
     server_instances,
     service_accounts,
     system_maintenance,

--- a/crates/hubuum-storage-postgres/src/test_support.rs
+++ b/crates/hubuum-storage-postgres/src/test_support.rs
@@ -25,8 +25,8 @@ use hubuum_storage_core::{
 use tokio::time::{Duration, Instant, sleep};
 
 use crate::{
-    PostgresConnection, PostgresPool, PostgresPoolSettings, PostgresStorageError,
-    build_postgres_pool,
+    DatabaseRoleNames, PostgresConnection, PostgresPool, PostgresPoolSettings,
+    PostgresStorageError, build_postgres_pool,
 };
 
 /// Build a pool for an adapter integration test against the migrated database
@@ -45,6 +45,37 @@ pub fn integration_test_pool(max_size: u32) -> PostgresPool {
         .build()
         .expect("integration-test PostgreSQL settings must be valid");
     build_postgres_pool(&settings).expect("integration-test PostgreSQL pool must be constructed")
+}
+
+/// Whether the repository runner provisioned the dedicated database-role fixture.
+#[must_use]
+pub fn database_role_tests_enabled() -> bool {
+    std::env::var("HUBUUM_DATABASE_ROLE_TESTS").as_deref() == Ok("true")
+}
+
+/// Role names provisioned by the repository integration-test runner.
+#[must_use]
+pub fn integration_test_database_roles() -> DatabaseRoleNames {
+    DatabaseRoleNames::new(
+        std::env::var("HUBUUM_DATABASE_OWNER_ROLE").expect("test owner role"),
+        std::env::var("HUBUUM_DATABASE_MIGRATOR_ROLE").expect("test migrator role"),
+        std::env::var("HUBUUM_DATABASE_RUNTIME_ROLE").expect("test runtime role"),
+    )
+    .expect("test role names")
+}
+
+/// Build a pool authenticated as the repository test migrator.
+#[must_use]
+pub fn integration_test_migration_pool(max_size: u32) -> PostgresPool {
+    let database_url = std::env::var("HUBUUM_MIGRATION_DATABASE_URL")
+        .expect("HUBUUM_MIGRATION_DATABASE_URL must identify the migrated test database");
+    let settings = PostgresPoolSettings::builder(database_url)
+        .max_size(max_size)
+        .statement_timeout_ms(0)
+        .acquire_timeout_ms(5_000)
+        .build()
+        .expect("integration-test migration settings must be valid");
+    build_postgres_pool(&settings).expect("integration-test migration pool must be constructed")
 }
 
 /// Persisted credential evidence needed by request-level authentication tests.

--- a/crates/hubuum-storage-postgres/tests/database_privileges.rs
+++ b/crates/hubuum-storage-postgres/tests/database_privileges.rs
@@ -100,6 +100,9 @@ async fn runtime_cannot_change_application_schema(#[case] statement: &str) {
 #[case(
     "INSERT INTO public.__diesel_schema_migrations(version, run_on) VALUES ('99999999999999', now())"
 )]
+#[case(
+    "INSERT INTO public.restore_success_receipts(id, requested_by_identity_scope, requested_by_name, byte_size, sha256, capability_hash, validation_summary, expires_at, confirmed_at, finished_at, created_at, updated_at) VALUES (999999, 'local', 'forged', 0, repeat('0', 64), repeat('0', 64), '{}'::jsonb, now(), now(), now(), now(), now())"
+)]
 #[tokio::test]
 async fn runtime_cannot_rewrite_integrity_records(#[case] statement: &str) {
     require_database_role_fixture!();

--- a/crates/hubuum-storage-postgres/tests/database_privileges.rs
+++ b/crates/hubuum-storage-postgres/tests/database_privileges.rs
@@ -188,7 +188,7 @@ async fn split_role_reconciliation_adopts_existing_single_role_objects() {
         connection
             .transaction::<_, diesel::result::Error, _>(async |connection| {
                 diesel::sql_query(format!(
-                    "CREATE TABLE public.\"{table_name}\" (id integer PRIMARY KEY)"
+                    "CREATE TABLE public.\"{table_name}\" (id serial PRIMARY KEY)"
                 ))
                 .execute(&mut *connection)
                 .await?;

--- a/crates/hubuum-storage-postgres/tests/database_privileges.rs
+++ b/crates/hubuum-storage-postgres/tests/database_privileges.rs
@@ -1,0 +1,373 @@
+#![cfg(feature = "integration-test-support")]
+
+use diesel::QueryableByName;
+use diesel::sql_types::{BigInt, Bool, Integer, Text};
+use diesel_async::{AsyncConnection, RunQueryDsl, SimpleAsyncConnection};
+use hubuum_storage_postgres::test_support::{
+    database_role_tests_enabled, integration_test_database_roles, integration_test_migration_pool,
+    integration_test_pool,
+};
+use hubuum_storage_postgres::{
+    DatabaseRoleNames, database_role_reconciliation_sql, inspect_database_privileges,
+    with_connection,
+};
+use rstest::rstest;
+use uuid::Uuid;
+
+macro_rules! require_database_role_fixture {
+    () => {
+        if !database_role_tests_enabled() {
+            return;
+        }
+    };
+}
+
+fn role_names() -> DatabaseRoleNames {
+    integration_test_database_roles()
+}
+
+async fn assert_runtime_rejects(statement: String) {
+    let pool = integration_test_pool(2);
+    let result = with_connection(&pool, async |connection| {
+        diesel::sql_query("BEGIN").execute(&mut *connection).await?;
+        let result = diesel::sql_query(statement).execute(&mut *connection).await;
+        diesel::sql_query("ROLLBACK")
+            .execute(&mut *connection)
+            .await?;
+        Ok::<_, diesel::result::Error>(result)
+    })
+    .await
+    .expect("privilege probe transaction");
+    assert!(
+        result.is_err(),
+        "runtime unexpectedly executed privileged SQL"
+    );
+}
+
+#[tokio::test]
+async fn generated_runtime_grants_pass_the_catalog_audit() {
+    require_database_role_fixture!();
+    let pool = integration_test_pool(2);
+    let roles = role_names();
+    let report = inspect_database_privileges(&pool, roles.runtime(), &roles)
+        .await
+        .expect("privilege report");
+
+    assert!(
+        report.is_safe(),
+        "dangerous={:?}, missing={:?}",
+        report.dangerous(),
+        report.missing()
+    );
+}
+
+#[tokio::test]
+async fn audit_rejects_a_connection_authenticated_as_a_different_role() {
+    require_database_role_fixture!();
+    let pool = integration_test_migration_pool(1);
+    let roles = role_names();
+    let report = inspect_database_privileges(&pool, roles.runtime(), &roles)
+        .await
+        .expect("privilege report");
+
+    assert_eq!(report.connected_role(), roles.migrator().as_str());
+    assert!(
+        report
+            .dangerous()
+            .iter()
+            .any(|finding| finding.code() == "connected_role_mismatch")
+    );
+    assert!(!report.is_safe());
+}
+
+#[rstest]
+#[case("CREATE TABLE public.runtime_must_not_create_objects (id integer)")]
+#[case("ALTER TABLE public.groups ADD COLUMN runtime_must_not_alter integer")]
+#[case("ALTER TABLE public.groups OWNER TO CURRENT_USER")]
+#[case("DROP TABLE public.groups")]
+#[case("ALTER TABLE public.groups DISABLE TRIGGER ALL")]
+#[tokio::test]
+async fn runtime_cannot_change_application_schema(#[case] statement: &str) {
+    require_database_role_fixture!();
+    assert_runtime_rejects(statement.to_string()).await;
+}
+
+#[rstest]
+#[case("UPDATE public.collections_history SET valid_to = now()")]
+#[case("DELETE FROM public.collections_history")]
+#[case("UPDATE public.events SET summary = 'forged'")]
+#[case("DELETE FROM public.events")]
+#[case(
+    "INSERT INTO public.__diesel_schema_migrations(version, run_on) VALUES ('99999999999999', now())"
+)]
+#[tokio::test]
+async fn runtime_cannot_rewrite_integrity_records(#[case] statement: &str) {
+    require_database_role_fixture!();
+    assert_runtime_rejects(statement.to_string()).await;
+}
+
+#[rstest]
+#[case::owner(true)]
+#[case::migrator(false)]
+#[tokio::test]
+async fn runtime_cannot_assume_privileged_roles(#[case] owner: bool) {
+    require_database_role_fixture!();
+    let roles = role_names();
+    let role = if owner {
+        roles.owner()
+    } else {
+        roles.migrator()
+    };
+    assert_runtime_rejects(format!("SET ROLE \"{}\"", role.as_str())).await;
+}
+
+#[tokio::test]
+async fn runtime_cannot_grant_itself_owner_membership() {
+    require_database_role_fixture!();
+    let roles = role_names();
+    assert_runtime_rejects(format!(
+        "GRANT \"{}\" TO \"{}\"",
+        roles.owner().as_str(),
+        roles.runtime().as_str()
+    ))
+    .await;
+}
+
+#[tokio::test]
+async fn runtime_cannot_grant_itself_table_privileges() {
+    require_database_role_fixture!();
+    let pool = integration_test_pool(1);
+    let roles = role_names();
+    let _grant_result = with_connection(&pool, async |connection| {
+        diesel::sql_query(format!(
+            "GRANT TRUNCATE ON TABLE public.groups TO \"{}\"",
+            roles.runtime().as_str()
+        ))
+        .execute(connection)
+        .await
+    })
+    .await;
+    let privilege = with_connection(&pool, async |connection| {
+        diesel::sql_query(
+            "SELECT pg_catalog.has_table_privilege(\
+                current_user, 'public.groups', 'TRUNCATE'\
+             ) AS allowed",
+        )
+        .get_result::<PrivilegeRow>(connection)
+        .await
+    })
+    .await
+    .expect("runtime table privilege probe");
+    assert!(!privilege.allowed, "runtime granted itself TRUNCATE");
+}
+
+#[derive(QueryableByName)]
+struct PrivilegeRow {
+    #[diesel(sql_type = Bool)]
+    allowed: bool,
+}
+
+#[derive(QueryableByName)]
+struct OwnerRow {
+    #[diesel(sql_type = Text)]
+    owner_name: String,
+}
+
+#[tokio::test]
+#[ignore = "run serially by run_tests.sh because reconciliation locks every application table"]
+async fn split_role_reconciliation_adopts_existing_single_role_objects() {
+    require_database_role_fixture!();
+    let roles = role_names();
+    let migration_pool = integration_test_migration_pool(1);
+    let table_name = format!("single_role_adoption_{}", Uuid::new_v4().simple());
+
+    let (owner_before, owner_after) = with_connection(&migration_pool, async |connection| {
+        connection
+            .transaction::<_, diesel::result::Error, _>(async |connection| {
+                diesel::sql_query(format!(
+                    "CREATE TABLE public.\"{table_name}\" (id integer PRIMARY KEY)"
+                ))
+                .execute(&mut *connection)
+                .await?;
+                let owner_before = diesel::sql_query(
+                    "SELECT pg_catalog.pg_get_userbyid(relation.relowner)::text AS owner_name \
+                     FROM pg_catalog.pg_class relation \
+                     JOIN pg_catalog.pg_namespace namespace ON namespace.oid = relation.relnamespace \
+                     WHERE namespace.nspname = 'public' AND relation.relname = $1",
+                )
+                .bind::<Text, _>(&table_name)
+                .get_result::<OwnerRow>(&mut *connection)
+                .await?
+                .owner_name;
+                connection
+                    .batch_execute(&database_role_reconciliation_sql(&roles))
+                    .await?;
+                let owner_after = diesel::sql_query(
+                    "SELECT pg_catalog.pg_get_userbyid(relation.relowner)::text AS owner_name \
+                     FROM pg_catalog.pg_class relation \
+                     JOIN pg_catalog.pg_namespace namespace ON namespace.oid = relation.relnamespace \
+                     WHERE namespace.nspname = 'public' AND relation.relname = $1",
+                )
+                .bind::<Text, _>(&table_name)
+                .get_result::<OwnerRow>(&mut *connection)
+                .await?
+                .owner_name;
+                Ok((owner_before, owner_after))
+            })
+            .await
+    })
+    .await
+    .expect("single-role adoption transaction");
+
+    assert_eq!(owner_before, roles.migrator().as_str());
+    assert_eq!(owner_after, roles.owner().as_str());
+
+    let runtime_pool = integration_test_pool(1);
+    with_connection(&runtime_pool, async |connection| {
+        diesel::sql_query(format!(
+            "INSERT INTO public.\"{table_name}\" (id) VALUES (1)"
+        ))
+        .execute(&mut *connection)
+        .await?;
+        diesel::sql_query(format!(
+            "UPDATE public.\"{table_name}\" SET id = 2 WHERE id = 1"
+        ))
+        .execute(&mut *connection)
+        .await?;
+        diesel::sql_query(format!("DELETE FROM public.\"{table_name}\" WHERE id = 2"))
+            .execute(&mut *connection)
+            .await
+    })
+    .await
+    .expect("adopted table runtime DML");
+
+    with_connection(&migration_pool, async |connection| {
+        connection
+            .transaction::<_, diesel::result::Error, _>(async |connection| {
+                diesel::sql_query("SELECT set_config('role', $1, true)")
+                    .bind::<Text, _>(roles.owner().as_str())
+                    .execute(&mut *connection)
+                    .await?;
+                diesel::sql_query(format!("DROP TABLE public.\"{table_name}\""))
+                    .execute(&mut *connection)
+                    .await?;
+                Ok(())
+            })
+            .await
+    })
+    .await
+    .expect("adoption fixture cleanup");
+}
+
+#[derive(QueryableByName)]
+struct SecurityDefinerRow {
+    #[diesel(sql_type = Text)]
+    function_name: String,
+    #[diesel(sql_type = Bool)]
+    owner_can_login: bool,
+    #[diesel(sql_type = Text)]
+    settings: String,
+}
+
+#[tokio::test]
+async fn privileged_functions_have_non_login_owners_and_fixed_search_paths() {
+    require_database_role_fixture!();
+    let pool = integration_test_pool(2);
+    let rows = with_connection(&pool, async |connection| {
+        diesel::sql_query(
+            r#"SELECT procedure.proname::text AS function_name,
+                      owner.rolcanlogin AS owner_can_login,
+                      array_to_string(procedure.proconfig, ',') AS settings
+                 FROM pg_catalog.pg_proc procedure
+                 JOIN pg_catalog.pg_namespace namespace ON namespace.oid = procedure.pronamespace
+                 JOIN pg_catalog.pg_roles owner ON owner.oid = procedure.proowner
+                WHERE namespace.nspname = 'public' AND procedure.prosecdef
+                ORDER BY procedure.proname"#,
+        )
+        .load::<SecurityDefinerRow>(connection)
+        .await
+    })
+    .await
+    .expect("security-definer catalog rows");
+
+    assert!(
+        !rows.is_empty(),
+        "expected hardened security-definer functions"
+    );
+    for row in rows {
+        assert!(
+            !row.owner_can_login,
+            "{} has a login owner",
+            row.function_name
+        );
+        assert_eq!(
+            row.settings, "search_path=pg_catalog",
+            "{} does not fix its search path",
+            row.function_name
+        );
+    }
+}
+
+#[derive(QueryableByName)]
+struct InsertedCollection {
+    #[diesel(sql_type = Integer)]
+    id: i32,
+}
+
+#[derive(QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = BigInt)]
+    count: i64,
+}
+
+#[tokio::test]
+async fn runtime_restore_flag_cannot_suppress_temporal_history() {
+    require_database_role_fixture!();
+    let pool = integration_test_pool(2);
+    let name = format!("runtime-history-guard-{}", Uuid::new_v4());
+    let collection_id = with_connection(&pool, async |connection| {
+        diesel::sql_query("BEGIN").execute(&mut *connection).await?;
+        diesel::sql_query("SELECT set_config('hubuum.restore_history', 'on', true)")
+            .execute(&mut *connection)
+            .await?;
+        let inserted = diesel::sql_query(
+            "INSERT INTO public.collections (name, description, parent_collection_id) \
+             VALUES (
+                 $1,
+                 'privilege test',
+                 (SELECT id FROM public.collections WHERE parent_collection_id IS NULL LIMIT 1)
+             ) RETURNING id",
+        )
+        .bind::<Text, _>(&name)
+        .get_result::<InsertedCollection>(&mut *connection)
+        .await?;
+        diesel::sql_query("COMMIT")
+            .execute(&mut *connection)
+            .await?;
+        Ok::<_, diesel::result::Error>(inserted.id)
+    })
+    .await
+    .expect("runtime collection insert");
+
+    let count = with_connection(&pool, async |connection| {
+        diesel::sql_query(
+            "SELECT count(*)::bigint AS count FROM public.collections_history WHERE id = $1",
+        )
+        .bind::<Integer, _>(collection_id)
+        .get_result::<CountRow>(connection)
+        .await
+    })
+    .await
+    .expect("history count")
+    .count;
+    assert_eq!(count, 1);
+
+    with_connection(&pool, async |connection| {
+        diesel::sql_query("DELETE FROM public.collections WHERE id = $1")
+            .bind::<Integer, _>(collection_id)
+            .execute(connection)
+            .await
+    })
+    .await
+    .expect("collection cleanup");
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,34 @@ services:
     environment:
       HUBUUM_BIND_IP: 0.0.0.0
       HUBUUM_CLIENT_ALLOWLIST: "*"
-      HUBUUM_DATABASE_URL: postgres://hubuum:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db/hubuum
+      HUBUUM_DATABASE_URL: postgres://hubuum_runtime:${POSTGRES_RUNTIME_PASSWORD:?Set POSTGRES_RUNTIME_PASSWORD in .env}@db/hubuum
+      HUBUUM_DATABASE_OWNER_ROLE: hubuum_owner
+      HUBUUM_DATABASE_MIGRATOR_ROLE: hubuum_migrator
+      HUBUUM_DATABASE_RUNTIME_ROLE: hubuum_runtime
+      HUBUUM_DATABASE_PRIVILEGE_MODE: strict
       HUBUUM_LOG_LEVEL: debug
       HUBUUM_DEFAULT_PAGE_LIMIT: ${HUBUUM_DEFAULT_PAGE_LIMIT:-100}
       HUBUUM_MAX_PAGE_LIMIT: ${HUBUUM_MAX_PAGE_LIMIT:-250}
-      DATABASE_URL: postgres://hubuum:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db/hubuum
+    depends_on:
+      db:
+        condition: service_healthy
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+
+  hubuum-migrate:
+    build: .
+    profiles: ["administration"]
+    entrypoint: /usr/local/bin/hubuum-admin
+    environment:
+      HUBUUM_MIGRATION_DATABASE_URL: postgres://hubuum_migrator:${POSTGRES_MIGRATOR_PASSWORD:?Set POSTGRES_MIGRATOR_PASSWORD in .env}@db/hubuum
+      HUBUUM_DATABASE_OWNER_ROLE: hubuum_owner
+      HUBUUM_DATABASE_MIGRATOR_ROLE: hubuum_migrator
+      HUBUUM_DATABASE_RUNTIME_ROLE: hubuum_runtime
     depends_on:
       db:
         condition: service_healthy
@@ -29,14 +52,16 @@ services:
     ports:
       - "127.0.0.1:9998:5432"
     environment:
-      POSTGRES_USER: hubuum
+      POSTGRES_USER: hubuum_bootstrap
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_MIGRATOR_PASSWORD: ${POSTGRES_MIGRATOR_PASSWORD:?Set POSTGRES_MIGRATOR_PASSWORD in .env}
+      POSTGRES_RUNTIME_PASSWORD: ${POSTGRES_RUNTIME_PASSWORD:?Set POSTGRES_RUNTIME_PASSWORD in .env}
       POSTGRES_DB: hubuum
-      PGUSER: hubuum
+      PGUSER: hubuum_bootstrap
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U hubuum -d hubuum" ]
+      test: [ "CMD-SHELL", "pg_isready -U hubuum_bootstrap -d hubuum" ]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,27 @@ services:
     security_opt:
       - no-new-privileges:true
 
+  hubuum-restore-executor:
+    build: .
+    entrypoint: /usr/local/bin/hubuum-admin
+    command: ["--restore-executor"]
+    restart: unless-stopped
+    environment:
+      HUBUUM_MIGRATION_DATABASE_URL: postgres://hubuum_migrator:${POSTGRES_MIGRATOR_PASSWORD:?Set POSTGRES_MIGRATOR_PASSWORD in .env}@db/hubuum
+      HUBUUM_DATABASE_OWNER_ROLE: hubuum_owner
+      HUBUUM_DATABASE_MIGRATOR_ROLE: hubuum_migrator
+      HUBUUM_DATABASE_RUNTIME_ROLE: hubuum_runtime
+    depends_on:
+      db:
+        condition: service_healthy
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+
   db:
     build:
       context: .

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,1 +1,3 @@
 FROM docker.io/library/postgres:18.4@sha256:22c89fe0d0f507606260237fd55e51f6137f58b2d5bcf6152242b96d9fe8f9a4
+
+COPY docker/postgres/init-database-roles.sh /docker-entrypoint-initdb.d/20-hubuum-database-roles.sh

--- a/docker/postgres/init-database-roles.sh
+++ b/docker/postgres/init-database-roles.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+require_identifier() {
+    case "$2" in
+        ''|[!A-Za-z_]*|*[!A-Za-z0-9_$]*)
+            echo "invalid PostgreSQL identifier in $1" >&2
+            exit 1
+            ;;
+    esac
+}
+
+: "${POSTGRES_DB:?POSTGRES_DB is required}"
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${POSTGRES_MIGRATOR_PASSWORD:?POSTGRES_MIGRATOR_PASSWORD is required}"
+: "${POSTGRES_RUNTIME_PASSWORD:?POSTGRES_RUNTIME_PASSWORD is required}"
+
+owner_role="${HUBUUM_DATABASE_OWNER_ROLE:-hubuum_owner}"
+migrator_role="${HUBUUM_DATABASE_MIGRATOR_ROLE:-hubuum_migrator}"
+runtime_role="${HUBUUM_DATABASE_RUNTIME_ROLE:-hubuum_runtime}"
+require_identifier HUBUUM_DATABASE_OWNER_ROLE "$owner_role"
+require_identifier HUBUUM_DATABASE_MIGRATOR_ROLE "$migrator_role"
+require_identifier HUBUUM_DATABASE_RUNTIME_ROLE "$runtime_role"
+
+psql --set ON_ERROR_STOP=1 \
+    --username "$POSTGRES_USER" \
+    --dbname "$POSTGRES_DB" \
+    --set database_name="$POSTGRES_DB" \
+    --set owner_role="$owner_role" \
+    --set migrator_role="$migrator_role" \
+    --set runtime_role="$runtime_role" \
+    --set migrator_password="$POSTGRES_MIGRATOR_PASSWORD" \
+    --set runtime_password="$POSTGRES_RUNTIME_PASSWORD" <<'SQL'
+CREATE ROLE :"owner_role" NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+CREATE ROLE :"migrator_role" LOGIN PASSWORD :'migrator_password' NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+CREATE ROLE :"runtime_role" LOGIN PASSWORD :'runtime_password' NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+GRANT :"owner_role" TO :"migrator_role";
+ALTER DATABASE :"database_name" OWNER TO :"owner_role";
+ALTER SCHEMA public OWNER TO :"owner_role";
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+SQL

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -93,7 +93,8 @@ capability or restore metadata.
 
 Staging and validation do not enter maintenance mode or lock application data.
 
-Confirm with the exact SHA-256, capability, and destructive phrase:
+API confirmation is intentionally disabled. A valid request to the confirmation
+endpoint returns `501 Not Implemented` and leaves the validated stage intact:
 
 ```http
 POST /api/v1/restores/{restore_id}/confirm
@@ -107,29 +108,11 @@ Content-Type: application/json
 }
 ```
 
-During confirmation, Hubuum first commits a global `draining` maintenance
-state. All instances reject ordinary API work, background workers stop starting
-work, and readiness returns `503`; liveness and capability-authenticated restore
-status remain available. Every runtime role, including API-only replicas,
-registers a heartbeat and participates in this drain barrier. After every live
-instance reports drained, the restore takes PostgreSQL `ACCESS EXCLUSIVE` locks
-on every replaced table and performs truncation plus all inserts in one database
-transaction. If draining, an insert, or a constraint check fails, Hubuum rolls
-back the replacement and returns to normal mode with the old application data
-intact.
-
-The restore coordinator waits for a 60-second confirmation grace period before
-treating a confirmed drain as interrupted. This keeps a live API or CLI
-confirmation authoritative through the bounded drain window while still
-allowing another replica to resume a restore after the confirming process exits.
-
-On success, Hubuum deletes all restore staging records and server-heartbeat
-records. The restored backup is the sole source of application data, with one
-intentional exception: Hubuum appends a `restore.succeeded` system audit event
-in the same transaction. Its metadata records the backup SHA-256 and the
-initiating administrator's immutable identity snapshot. This event is the
-logical-restore provenance marker; an administrator performing a physical
-database restore can, by definition, replace it as well.
+This boundary is deliberate: API and worker processes use the non-owning
+runtime database role, which cannot truncate application tables or suppress
+temporal and audit integrity controls. Run destructive restore through the
+admin CLI in a tightly controlled one-shot workload with the migrator
+credential instead.
 
 Inspect validation, draining, or failure status by sending the capability in a
 header:
@@ -140,10 +123,8 @@ X-Hubuum-Restore-Capability: <capability>
 ```
 
 Do not put the capability in a query string, where access logs could retain it.
-Stored stages can report `validated`, `confirmed`, `failed`, or `expired`.
-The successful confirmation response reports `succeeded` directly, but that
-status is never persisted. Subsequent status lookups return `404` because a
-successful restore removes all staging records.
+Without an administrative CLI restore, stored stages report `validated` or
+`expired`. A successful CLI restore removes all staging records.
 
 ## Admin CLI
 
@@ -161,14 +142,21 @@ History is included by default. Add `--backup-without-history` only to create a
 backup whose eventual restore resets terminal task, audit, delivery, and
 temporal history.
 
-Restore requires the same explicit destructive phrase as the API:
+Restore requires the explicit destructive phrase and the separate migration
+credential:
 
 ```text
 hubuum-admin \
-  --database-url "$HUBUUM_DATABASE_URL" \
+  --migration-database-url "$HUBUUM_MIGRATION_DATABASE_URL" \
   --restore backup.json \
   --restore-confirmation "REPLACE ALL HUBUUM DATA"
 ```
+
+The CLI coordinates maintenance and performs replacement in one database
+transaction. It appends the `restore.succeeded` provenance event on success and
+rolls back to the old application data if validation, insertion, or constraint
+checks fail. See [PostgreSQL Database Roles](database_roles.md) for credential
+handling and workload isolation.
 
 ## Configuration ownership
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -93,8 +93,8 @@ capability or restore metadata.
 
 Staging and validation do not enter maintenance mode or lock application data.
 
-API confirmation is intentionally disabled. A valid request to the confirmation
-endpoint returns `501 Not Implemented` and leaves the validated stage intact:
+Confirm the validated stage with the administrator token, one-time capability,
+exact SHA-256, and destructive phrase:
 
 ```http
 POST /api/v1/restores/{restore_id}/confirm
@@ -108,11 +108,11 @@ Content-Type: application/json
 }
 ```
 
-This boundary is deliberate: API and worker processes use the non-owning
-runtime database role, which cannot truncate application tables or suppress
-temporal and audit integrity controls. Run destructive restore through the
-admin CLI in a tightly controlled one-shot workload with the migrator
-credential instead.
+The endpoint commits draining maintenance and returns `202 Accepted` with
+status `confirmed`. It does not perform privileged SQL. A separately deployed
+`hubuum-admin --restore-executor` process, holding only the migration database
+URL, re-loads and revalidates the staged bytes, waits for API and worker
+instances to drain, and applies the replacement transaction.
 
 Inspect validation, draining, or failure status by sending the capability in a
 header:
@@ -123,8 +123,18 @@ X-Hubuum-Restore-Capability: <capability>
 ```
 
 Do not put the capability in a query string, where access logs could retain it.
-Without an administrative CLI restore, stored stages report `validated` or
-`expired`. A successful CLI restore removes all staging records.
+Continue polling after confirmation. The status changes from `confirmed` to
+`succeeded` or `failed`; successful and failed terminal rows contain no backup
+document. A successful restore keeps its document-free receipt and capability
+hash so the client whose administrator token was replaced can observe the
+result. A later successful restore removes older receipts.
+
+Deploy exactly one executor replica in ordinary operation. It exposes no HTTP
+listener and accepts no request-provided SQL, identifier, or file path. Multiple
+replicas are protected by the same database advisory lock, but a single replica
+avoids redundant conflict logs. See
+[PostgreSQL Database Roles](database_roles.md) for deployment isolation, threat
+model, and the existing single-role migration order.
 
 ## Admin CLI
 
@@ -152,11 +162,12 @@ hubuum-admin \
   --restore-confirmation "REPLACE ALL HUBUUM DATA"
 ```
 
-The CLI coordinates maintenance and performs replacement in one database
-transaction. It appends the `restore.succeeded` provenance event on success and
-rolls back to the old application data if validation, insertion, or constraint
-checks fail. See [PostgreSQL Database Roles](database_roles.md) for credential
-handling and workload isolation.
+The CLI stages and confirms the document, then runs one executor iteration in
+the same process. It appends the `restore.succeeded` provenance event on
+success and rolls back to the old application data if validation, insertion,
+or constraint checks fail. See
+[PostgreSQL Database Roles](database_roles.md) for credential handling and
+workload isolation.
 
 ## Configuration ownership
 

--- a/docs/database_roles.md
+++ b/docs/database_roles.md
@@ -1,0 +1,261 @@
+# PostgreSQL Database Roles
+
+Hubuum uses three distinct PostgreSQL roles. Long-lived API and worker
+processes must use only the runtime role. Schema changes and destructive
+restore use a separate one-shot migrator credential, while a non-login owner
+holds application objects.
+
+| Role | Login | Purpose | Must not have |
+| --- | --- | --- | --- |
+| Owner | No | Owns the application schema, tables, sequences, and functions | A password or workload identity |
+| Migrator | Yes | Assumes the owner role for embedded migrations, grant reconciliation, and destructive restore | Superuser, `CREATEROLE`, or `BYPASSRLS` |
+| Runtime | Yes | Serves API requests and runs background workers | Ownership, DDL, migration writes, direct history mutation, or broad audit-event mutation |
+
+The default names are `hubuum_owner`, `hubuum_migrator`, and
+`hubuum_runtime`. Override all workloads consistently with
+`HUBUUM_DATABASE_OWNER_ROLE`, `HUBUUM_DATABASE_MIGRATOR_ROLE`, and
+`HUBUUM_DATABASE_RUNTIME_ROLE`.
+
+## Privilege Manifest
+
+The version-controlled
+`crates/hubuum-storage-postgres/database-privileges.json` manifest is the
+machine-readable source for generated grants and diagnostics. After every
+embedded migration, Hubuum transfers application-object ownership to the
+owner and reconciles runtime privileges for every table, sequence, and
+function in the application schema. This catalog-driven step prevents a new
+object from silently being omitted from a handwritten grant list.
+
+Runtime access is intentionally narrower for integrity-bearing objects:
+
+- migration and `*_history` tables are read-only;
+- audit events allow `SELECT`, `INSERT`, and updates only to the delivery claim
+  columns listed in the manifest;
+- application security-invoker functions are executable because PostgreSQL
+  still checks the caller's underlying privileges;
+- security-definer functions are denied unless explicitly allowlisted; and
+- direct destructive restore is migrator-only.
+
+The hardened security-definer functions use a fixed `pg_catalog` search path,
+qualified application objects, closed identifier inputs, and non-login owners.
+Setting Hubuum's transaction-local restore flags from a runtime session does
+not grant restore authority or suppress temporal history.
+
+## Initial Provisioning
+
+Run the full setup SQL through an identity that may create roles and change
+object ownership. The output is idempotent and contains no credentials:
+
+```bash
+hubuum-admin --database-role-setup-sql > hubuum-database-roles.sql
+psql "$POSTGRES_BOOTSTRAP_URL" --set ON_ERROR_STOP=1 \
+  --file hubuum-database-roles.sql
+```
+
+Set the migrator and runtime passwords, certificates, or workload-identity
+mappings through the database provider's secret-management interface. Do not
+put credentials into the generated SQL file. Then migrate with the migrator
+URL:
+
+```bash
+export HUBUUM_MIGRATION_DATABASE_URL='postgres://hubuum_migrator:.../hubuum'
+hubuum-admin --migrate
+```
+
+The migrator must be a member of the owner role. It connects under its own
+login and Hubuum explicitly runs `SET ROLE hubuum_owner` before applying
+migrations. The runtime login must not be a member of either privileged role.
+
+### Restricted Managed PostgreSQL
+
+Some managed control planes create identities outside SQL or do not allow the
+application operator to run `CREATE ROLE` and `ALTER ROLE`. Create the three
+identities and the owner-to-migrator membership through that control plane,
+then generate only the database-local ownership and grants:
+
+```bash
+hubuum-admin --database-role-grants-sql > hubuum-database-grants.sql
+psql "$MANAGED_DATABASE_ADMIN_URL" --set ON_ERROR_STOP=1 \
+  --file hubuum-database-grants.sql
+```
+
+The provider-created identities must still match the role matrix above. Use a
+dedicated Hubuum database: reconciliation intentionally owns and protects all
+application objects in its `public` schema.
+
+### Adopting An Existing Single-Role Database
+
+Take a verified backup first. For a no-downtime first adoption, use the
+existing application login as the configured runtime role and introduce new
+owner and migrator roles around it. Applying the generated setup SQL transfers
+ownership and grants runtime DML in one transaction, so existing API and worker
+connections keep the access they need after the commit while losing DDL and
+direct integrity-table mutation authority:
+
+```bash
+hubuum-admin \
+  --database-owner-role hubuum_owner \
+  --database-migrator-role hubuum_migrator \
+  --database-runtime-role EXISTING_APPLICATION_ROLE \
+  --database-role-setup-sql > hubuum-database-role-adoption.sql
+psql "$EXISTING_OWNER_DATABASE_URL" --set ON_ERROR_STOP=1 \
+  --file hubuum-database-role-adoption.sql
+```
+
+Set `HUBUUM_DATABASE_RUNTIME_ROLE=EXISTING_APPLICATION_ROLE` on the old and new
+server versions during that rollout. Create the separate migrator credential,
+run `hubuum-admin --migrate`, verify the runtime report, and only then enable
+strict mode. A later credential-rotation rollout may replace the compatibility
+runtime login with `hubuum_runtime`; keep both runtime grants only for that
+bounded overlap and revoke the old login afterward.
+
+The managed single-host updater automates this transition. It retains the
+existing volume's bootstrap password, creates and reconciles the three new
+roles, updates their passwords through the local PostgreSQL container, runs the
+one-shot migration, and then replaces long-lived containers with runtime-only
+credentials. The bootstrap secret remains infrastructure-only and is never
+injected into an API or worker container.
+
+Grant reconciliation is safe to repeat after a partial rollout. It moves any
+objects owned by the former migration/application role to the non-login owner,
+removes pre-existing direct runtime grants before rebuilding the manifest, and
+does not fall back to making the runtime role an owner if migration fails.
+
+## Runtime Diagnostics
+
+Audit the runtime connection and current catalog grants before rollout:
+
+```bash
+hubuum-admin \
+  --database-url "$HUBUUM_DATABASE_URL" \
+  --check-database-privileges \
+  --role runtime
+```
+
+Add `--json` for machine-readable output. The audit checks the role named in
+the manifest and also requires PostgreSQL `current_user` to be that role; an
+overprivileged connection cannot pass by auditing a different safe identity.
+
+Server startup repeats this audit. `HUBUUM_DATABASE_PRIVILEGE_MODE=warn` is the
+compatibility default and emits findings without stopping the process. New
+production deployments should use `strict`, which fails startup when the role
+is dangerous, incomplete, different from the connected identity, or cannot be
+inspected. Runtime configuration reports the mode and role names but never a
+database URL or credential.
+
+## Container And Single-Host Deployments
+
+The server image entrypoint checks schema readiness only. It never runs
+migrations. For the repository Compose example, initialize the database and
+run the one-shot service before starting the application:
+
+```bash
+docker compose --profile administration run --rm hubuum-migrate --migrate
+docker compose up -d hubuum
+```
+
+Set unique `POSTGRES_PASSWORD`, `POSTGRES_MIGRATOR_PASSWORD`, and
+`POSTGRES_RUNTIME_PASSWORD` values in `.env`. The long-lived `hubuum` service
+receives only the runtime URL. The `hubuum-migrate` service receives only the
+migration URL.
+
+The single-host installer implements the same boundary automatically. For an
+external PostgreSQL server, both URLs are required:
+
+```bash
+sudo ./scripts/install-single-host.sh \
+  --api hubuum-api.example.com \
+  --email admin@example.com \
+  --database-url 'postgres://hubuum_runtime:.../hubuum?sslmode=require' \
+  --migration-database-url 'postgres://hubuum_migrator:.../hubuum?sslmode=require'
+```
+
+The migration URL is stored in the owner-only deployment environment file and
+injected only into the transient `hubuum-migrate` service. It is not present in
+the primary or standby API container environment.
+
+## Distributed Orchestration
+
+Store runtime and migration URLs in different secret objects and reference the
+migration secret only from the one-shot job. The application Deployment should
+also enable strict diagnostics:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hubuum-runtime-database
+stringData:
+  database-url: postgres://hubuum_runtime:REPLACE@postgres/hubuum
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hubuum-migration-database
+stringData:
+  database-url: postgres://hubuum_migrator:REPLACE@postgres/hubuum
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hubuum-migrate
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: ghcr.io/hubuum/hubuum-server:VERSION
+          command: ["/usr/local/bin/hubuum-admin", "--migrate"]
+          env:
+            - name: HUBUUM_MIGRATION_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hubuum-migration-database
+                  key: database-url
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hubuum-api
+spec:
+  template:
+    spec:
+      containers:
+        - name: hubuum-api
+          image: ghcr.io/hubuum/hubuum-server:VERSION
+          args: ["--runtime-role", "api"]
+          env:
+            - name: HUBUUM_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hubuum-runtime-database
+                  key: database-url
+            - name: HUBUUM_DATABASE_PRIVILEGE_MODE
+              value: strict
+```
+
+Apply and await the Job before updating API or worker Deployments. Never mount
+the migration Secret into those Deployments, including as an unused projected
+volume or broad `envFrom` source. Secret rotation should update the applicable
+workload only: restart API and workers for a runtime-credential rotation, and
+create a new migration Job for a migrator-credential rotation.
+
+## Destructive Restore
+
+Destructive restore requires `HUBUUM_MIGRATION_DATABASE_URL` and is available
+only through `hubuum-admin`. API staging and status remain available for backup
+validation, but API confirmation returns `501 Not Implemented`; a bearer-token
+request running under the runtime database role cannot cross the privilege
+boundary.
+
+```bash
+hubuum-admin \
+  --migration-database-url "$HUBUUM_MIGRATION_DATABASE_URL" \
+  --restore backup.json \
+  --restore-confirmation "REPLACE ALL HUBUUM DATA"
+```
+
+Treat this URL as a disaster-recovery credential. Supply it only to a tightly
+controlled administrative workload, audit its use, and remove that workload
+after completion.

--- a/docs/database_roles.md
+++ b/docs/database_roles.md
@@ -1,14 +1,14 @@
 # PostgreSQL Database Roles
 
 Hubuum uses three distinct PostgreSQL roles. Long-lived API and worker
-processes must use only the runtime role. Schema changes and destructive
-restore use a separate one-shot migrator credential, while a non-login owner
+processes must use only the runtime role. Schema changes and the isolated
+restore executor use a separate migrator credential, while a non-login owner
 holds application objects.
 
 | Role | Login | Purpose | Must not have |
 | --- | --- | --- | --- |
 | Owner | No | Owns the application schema, tables, sequences, and functions | A password or workload identity |
-| Migrator | Yes | Assumes the owner role for embedded migrations, grant reconciliation, and destructive restore | Superuser, `CREATEROLE`, or `BYPASSRLS` |
+| Migrator | Yes | Assumes the owner role for embedded migrations, grant reconciliation, and the isolated restore executor | Superuser, `CREATEROLE`, or `BYPASSRLS` |
 | Runtime | Yes | Serves API requests and runs background workers | Ownership, DDL, migration writes, direct history mutation, or broad audit-event mutation |
 
 The default names are `hubuum_owner`, `hubuum_migrator`, and
@@ -34,7 +34,8 @@ Runtime access is intentionally narrower for integrity-bearing objects:
 - application security-invoker functions are executable because PostgreSQL
   still checks the caller's underlying privileges;
 - security-definer functions are denied unless explicitly allowlisted; and
-- direct destructive restore is migrator-only.
+- destructive snapshot replacement is available only to the isolated
+  migrator-backed restore executor.
 
 The hardened security-definer functions use a fixed `pg_catalog` search path,
 qualified application objects, closed identifier inputs, and non-login owners.
@@ -103,11 +104,44 @@ psql "$EXISTING_OWNER_DATABASE_URL" --set ON_ERROR_STOP=1 \
 ```
 
 Set `HUBUUM_DATABASE_RUNTIME_ROLE=EXISTING_APPLICATION_ROLE` on the old and new
-server versions during that rollout. Create the separate migrator credential,
-run `hubuum-admin --migrate`, verify the runtime report, and only then enable
-strict mode. A later credential-rotation rollout may replace the compatibility
-runtime login with `hubuum_runtime`; keep both runtime grants only for that
-bounded overlap and revoke the old login afterward.
+server versions during that rollout. Then use this order:
+
+1. Verify the backup and inspect the restore control plane:
+
+   ```sql
+   SELECT state, restore_job_id,
+          EXISTS (SELECT 1 FROM restore_jobs WHERE status = 'confirmed')
+            AS has_confirmed_restore
+     FROM system_maintenance
+    WHERE id = 1;
+   ```
+
+   Continue only when the state is `normal`, `restore_job_id` is null, and
+   `has_confirmed_restore` is false. Finish or explicitly recover any confirmed
+   restore first. If a pre-upgrade confirmation was interrupted, keep or restart
+   the previous release with its existing credential and let its reconciliation
+   loop return maintenance to `normal` before changing roles. Do not run the new
+   migration or revoke the old authority first. Validated, unconfirmed stages
+   may remain in the database.
+2. Pause `POST /api/v1/restores/*/confirm` at the ingress for the bounded
+   migration window. If the ingress cannot block one route and method, briefly
+   stop all old API replicas; workers do not need the migration credential.
+   Ordinary API traffic may otherwise continue while the existing login keeps
+   compatibility runtime grants.
+3. Create the separate migrator credential and run `hubuum-admin --migrate`.
+   The database-role migration refuses to run while maintenance is draining or
+   a confirmed restore exists; it serializes this check with restore
+   confirmation and preserves validated stages.
+4. Start `hubuum-admin --restore-executor` with only
+   `HUBUUM_MIGRATION_DATABASE_URL`, then roll API and worker processes with only
+   the runtime URL. Verify the executor stays running before unpausing the
+   confirmation route. Existing validated stages remain confirmable through
+   the new API and are claimed by the executor.
+5. Run the runtime privilege report, enable strict mode, and perform a staged
+   web restore drill against a disposable backup if operational policy permits.
+6. In a later credential-rotation rollout, replace the compatibility login
+   with `hubuum_runtime`. Keep both runtime grants only for that bounded overlap
+   and revoke or disable the old login afterward.
 
 The managed single-host updater automates this transition. It retains the
 existing volume's bootstrap password, creates and reconciles the three new
@@ -119,7 +153,19 @@ injected into an API or worker container.
 Grant reconciliation is safe to repeat after a partial rollout. It moves any
 objects owned by the former migration/application role to the non-login owner,
 removes pre-existing direct runtime grants before rebuilding the manifest, and
-does not fall back to making the runtime role an owner if migration fails.
+does not fall back to making the runtime role an owner if migration fails. A
+failed restore preflight leaves the prior roles and data in place; recover the
+active restore and repeat the same reconciliation and migration commands.
+
+Keep the existing login configured as the compatibility runtime identity until
+the new API and executor have both passed their health checks. If application
+rollback is required after the role migration, the old binary can continue
+ordinary service with that compatibility runtime login, but its synchronous
+web-restore implementation no longer has destructive database authority. Keep
+confirmation blocked during that rollback and use the new one-shot
+`hubuum-admin --restore` path for disaster recovery. Database migration rollback
+removes any `succeeded` polling receipt before restoring the older status
+constraint; it does not re-grant broad ownership to the runtime login.
 
 ## Runtime Diagnostics
 
@@ -151,13 +197,15 @@ run the one-shot service before starting the application:
 
 ```bash
 docker compose --profile administration run --rm hubuum-migrate --migrate
-docker compose up -d hubuum
+docker compose up -d hubuum-restore-executor hubuum
 ```
 
 Set unique `POSTGRES_PASSWORD`, `POSTGRES_MIGRATOR_PASSWORD`, and
 `POSTGRES_RUNTIME_PASSWORD` values in `.env`. The long-lived `hubuum` service
-receives only the runtime URL. The `hubuum-migrate` service receives only the
-migration URL.
+receives only the runtime URL. The isolated
+`hubuum-restore-executor` receives only the migration URL, exposes no network
+port, and runs read-only with all Linux capabilities dropped. The transient
+`hubuum-migrate` service uses the same privileged URL for schema changes.
 
 The single-host installer implements the same boundary automatically. For an
 external PostgreSQL server, both URLs are required:
@@ -171,14 +219,16 @@ sudo ./scripts/install-single-host.sh \
 ```
 
 The migration URL is stored in the owner-only deployment environment file and
-injected only into the transient `hubuum-migrate` service. It is not present in
-the primary or standby API container environment.
+injected only into `hubuum-migrate` and the isolated restore executor. It is not
+present in primary or standby API or worker container environments. Managed
+updates run migrations, recreate the executor, and only then replace API
+replicas.
 
 ## Distributed Orchestration
 
 Store runtime and migration URLs in different secret objects and reference the
-migration secret only from the one-shot job. The application Deployment should
-also enable strict diagnostics:
+migration secret only from the one-shot job and isolated restore executor. The
+application Deployment should also enable strict diagnostics:
 
 ```yaml
 apiVersion: v1
@@ -237,17 +287,72 @@ spec:
 
 Apply and await the Job before updating API or worker Deployments. Never mount
 the migration Secret into those Deployments, including as an unused projected
-volume or broad `envFrom` source. Secret rotation should update the applicable
-workload only: restart API and workers for a runtime-credential rotation, and
-create a new migration Job for a migrator-credential rotation.
+volume or broad `envFrom` source. Add a separate one-replica Deployment for the
+executor:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hubuum-restore-executor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hubuum-restore-executor
+  template:
+    metadata:
+      labels:
+        app: hubuum-restore-executor
+    spec:
+      containers:
+        - name: restore-executor
+          image: ghcr.io/hubuum/hubuum-server:VERSION
+          command: ["/usr/local/bin/hubuum-admin", "--restore-executor"]
+          env:
+            - name: HUBUUM_MIGRATION_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hubuum-migration-database
+                  key: database-url
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+```
+
+The executor needs database connectivity but no Service or inbound network
+path. Secret rotation should update the applicable workload only: restart API
+and workers for a runtime-credential rotation, and recreate both the migration
+Job and restore executor for a migrator-credential rotation.
 
 ## Destructive Restore
 
-Destructive restore requires `HUBUUM_MIGRATION_DATABASE_URL` and is available
-only through `hubuum-admin`. API staging and status remain available for backup
-validation, but API confirmation returns `501 Not Implemented`; a bearer-token
-request running under the runtime database role cannot cross the privilege
-boundary.
+Web restore remains available without putting a migration credential in an API
+process. The administrator stages and confirms the exact document through the
+API. Confirmation enters draining maintenance and returns `202 Accepted`; the
+isolated `hubuum-admin --restore-executor` process re-loads and validates the
+stored document, waits for runtime instances to drain, and performs the
+replacement with `HUBUUM_MIGRATION_DATABASE_URL`. The capability-authenticated
+status endpoint reports `confirmed`, then `succeeded` or `failed`.
+
+The executor accepts no SQL, identifiers, or document path from the network.
+It reads only the typed staged artifact referenced by the committed maintenance
+row; the adapter rechecks lifecycle ownership, uses closed table and column
+lists, and applies replacement and provenance in one transaction. A compromised
+administrator session can intentionally request destructive data replacement,
+which is inherent in the restore feature.
+
+This boundary protects the migration credential and schema-owner authority; it
+does not claim that a compromised runtime database identity cannot damage
+application data. The runtime role owns the restore control-plane DML required
+to stage and confirm through the backend contract, so direct database compromise
+can fabricate a validated request for the executor and replace data, including
+restored history. It still cannot obtain schema ownership, execute DDL, mutate
+history tables directly, or set trusted restore flags in its own session.
+
+Direct disaster-recovery restore remains available as a one-shot command:
 
 ```bash
 hubuum-admin \
@@ -256,6 +361,6 @@ hubuum-admin \
   --restore-confirmation "REPLACE ALL HUBUUM DATA"
 ```
 
-Treat this URL as a disaster-recovery credential. Supply it only to a tightly
-controlled administrative workload, audit its use, and remove that workload
-after completion.
+Treat this URL as a disaster-recovery credential. Supply it only to the
+migration job, isolated executor, or a tightly controlled one-shot restore;
+audit every use.

--- a/docs/database_roles.md
+++ b/docs/database_roles.md
@@ -28,7 +28,7 @@ object from silently being omitted from a handwritten grant list.
 
 Runtime access is intentionally narrower for integrity-bearing objects:
 
-- migration and `*_history` tables are read-only;
+- migration, `*_history`, and successful-restore receipt tables are read-only;
 - audit events allow `SELECT`, `INSERT`, and updates only to the delivery claim
   columns listed in the manifest;
 - application security-invoker functions are executable because PostgreSQL
@@ -93,14 +93,15 @@ ownership and grants runtime DML in one transaction, so existing API and worker
 connections keep the access they need after the commit while losing DDL and
 direct integrity-table mutation authority:
 
+Generate the adoption SQL now, but do not apply it until the confirmation route
+has been paused in step 2:
+
 ```bash
 hubuum-admin \
   --database-owner-role hubuum_owner \
   --database-migrator-role hubuum_migrator \
   --database-runtime-role EXISTING_APPLICATION_ROLE \
   --database-role-setup-sql > hubuum-database-role-adoption.sql
-psql "$EXISTING_OWNER_DATABASE_URL" --set ON_ERROR_STOP=1 \
-  --file hubuum-database-role-adoption.sql
 ```
 
 The new admin binary also retains an explicit legacy bridge for deployments
@@ -139,7 +140,20 @@ server versions during that rollout. Then use this order:
    stop all old API replicas; workers do not need the migration credential.
    Ordinary API traffic may otherwise continue while the existing login keeps
    compatibility runtime grants.
-3. Create the separate migrator credential and run `hubuum-admin --migrate`.
+3. Create the owner and migrator identities, apply the generated adoption SQL
+   through the existing owner connection, configure the migrator credential,
+   and run the migration with the same three role names:
+
+   ```bash
+   psql "$EXISTING_OWNER_DATABASE_URL" --set ON_ERROR_STOP=1 \
+     --file hubuum-database-role-adoption.sql
+   export HUBUUM_MIGRATION_DATABASE_URL='postgres://hubuum_migrator:.../hubuum'
+   export HUBUUM_DATABASE_OWNER_ROLE=hubuum_owner
+   export HUBUUM_DATABASE_MIGRATOR_ROLE=hubuum_migrator
+   export HUBUUM_DATABASE_RUNTIME_ROLE=EXISTING_APPLICATION_ROLE
+   hubuum-admin --migrate
+   ```
+
    The database-role migration refuses to run while maintenance is draining or
    a confirmed restore exists; it serializes this check with restore
    confirmation and preserves validated stages.
@@ -153,6 +167,15 @@ server versions during that rollout. Then use this order:
 6. In a later credential-rotation rollout, replace the compatibility login
    with `hubuum_runtime`. Keep both runtime grants only for that bounded overlap
    and revoke or disable the old login afterward.
+
+If role provisioning cannot precede schema migration, use the bridge only for
+step 3: with all three database-role settings absent, run
+`hubuum-admin --migrate --database-url "$EXISTING_OWNER_DATABASE_URL"`, confirm
+the compatibility warning, then provision the roles and apply the adoption SQL.
+Run `hubuum-admin --migrate` again with the migrator URL and all three role names
+set; this second invocation has no schema work but performs ownership and grant
+reconciliation. Do not proceed to step 4, enable strict privilege checks, or
+unpause confirmation until that reconciliation and its privilege report pass.
 
 The managed single-host updater automates this transition. It retains the
 existing volume's bootstrap password, creates and reconciles the three new
@@ -175,8 +198,8 @@ ordinary service with that compatibility runtime login, but its synchronous
 web-restore implementation no longer has destructive database authority. Keep
 confirmation blocked during that rollback and use the new one-shot
 `hubuum-admin --restore` path for disaster recovery. Database migration rollback
-removes any `succeeded` polling receipt before restoring the older status
-constraint; it does not re-grant broad ownership to the runtime login.
+drops the additive successful-restore receipt table; it does not re-grant broad
+ownership to the runtime login.
 
 ## Runtime Diagnostics
 

--- a/docs/database_roles.md
+++ b/docs/database_roles.md
@@ -103,6 +103,17 @@ psql "$EXISTING_OWNER_DATABASE_URL" --set ON_ERROR_STOP=1 \
   --file hubuum-database-role-adoption.sql
 ```
 
+The new admin binary also retains an explicit legacy bridge for deployments
+that must upgrade the schema before they can provision roles. When none of the
+three database-role flags or environment variables is configured,
+`hubuum-admin --migrate` applies migrations as the connected existing owner and
+prints a compatibility-mode warning. It does not transfer ownership or
+reconcile runtime grants. Keep restore confirmation blocked and privilege mode
+at `warn`, then complete the role-adoption procedure below before starting the
+restore executor, enabling strict mode, or unblocking web restore confirmation.
+Supplying any database-role name selects split-role migration and retains the
+documented defaults for names not overridden.
+
 Set `HUBUUM_DATABASE_RUNTIME_ROLE=EXISTING_APPLICATION_ROLE` on the old and new
 server versions during that rollout. Then use this order:
 

--- a/docs/database_roles.md
+++ b/docs/database_roles.md
@@ -105,14 +105,15 @@ hubuum-admin \
 ```
 
 The new admin binary also retains an explicit legacy bridge for deployments
-that must upgrade the schema before they can provision roles. When none of the
-three database-role flags or environment variables is configured,
-`hubuum-admin --migrate` applies migrations as the connected existing owner and
-prints a compatibility-mode warning. It does not transfer ownership or
-reconcile runtime grants. Keep restore confirmation blocked and privilege mode
-at `warn`, then complete the role-adoption procedure below before starting the
-restore executor, enabling strict mode, or unblocking web restore confirmation.
-Supplying any database-role name selects split-role migration and retains the
+that must upgrade the schema before they can provision roles.
+`hubuum-admin --migrate --legacy-single-role-migration` applies migrations as
+the connected existing owner and prints a compatibility-mode warning. It does
+not transfer ownership or reconcile runtime grants. The flag rejects all three
+database-role settings so the bridge cannot be confused with split-role
+migration. Keep restore confirmation blocked and privilege mode at `warn`, then
+complete the role-adoption procedure below before starting the restore
+executor, enabling strict mode, or unblocking web restore confirmation. Without
+the legacy flag, migration always reconciles the split roles, using the
 documented defaults for names not overridden.
 
 Set `HUBUUM_DATABASE_RUNTIME_ROLE=EXISTING_APPLICATION_ROLE` on the old and new
@@ -140,12 +141,15 @@ server versions during that rollout. Then use this order:
    stop all old API replicas; workers do not need the migration credential.
    Ordinary API traffic may otherwise continue while the existing login keeps
    compatibility runtime grants.
-3. Create the owner and migrator identities, apply the generated adoption SQL
-   through the existing owner connection, configure the migrator credential,
-   and run the migration with the same three role names:
+3. Create the owner and migrator identities, then apply the generated adoption
+   SQL through a bootstrap or provider-administrator connection that can manage
+   role membership and reassign objects owned by the existing application
+   login. The application login alone is usually not sufficiently privileged.
+   Configure the migrator credential and run the migration with the same three
+   role names:
 
    ```bash
-   psql "$EXISTING_OWNER_DATABASE_URL" --set ON_ERROR_STOP=1 \
+   psql "$ROLE_ADMIN_DATABASE_URL" --set ON_ERROR_STOP=1 \
      --file hubuum-database-role-adoption.sql
    export HUBUUM_MIGRATION_DATABASE_URL='postgres://hubuum_migrator:.../hubuum'
    export HUBUUM_DATABASE_OWNER_ROLE=hubuum_owner
@@ -169,13 +173,19 @@ server versions during that rollout. Then use this order:
    and revoke or disable the old login afterward.
 
 If role provisioning cannot precede schema migration, use the bridge only for
-step 3: with all three database-role settings absent, run
-`hubuum-admin --migrate --database-url "$EXISTING_OWNER_DATABASE_URL"`, confirm
-the compatibility warning, then provision the roles and apply the adoption SQL.
-Run `hubuum-admin --migrate` again with the migrator URL and all three role names
-set; this second invocation has no schema work but performs ownership and grant
-reconciliation. Do not proceed to step 4, enable strict privilege checks, or
-unpause confirmation until that reconciliation and its privilege report pass.
+step 3 with all three database-role settings absent:
+
+```bash
+hubuum-admin --migrate --legacy-single-role-migration \
+  --database-url "$EXISTING_OWNER_DATABASE_URL"
+```
+
+Confirm the compatibility warning, then provision the roles and apply the
+adoption SQL. Run `hubuum-admin --migrate` again with the migrator URL and all
+three role names set; this second invocation has no schema work but performs
+ownership and grant reconciliation. Do not proceed to step 4, enable strict
+privilege checks, or unpause confirmation until that reconciliation and its
+privilege report pass.
 
 The managed single-host updater automates this transition. It retains the
 existing volume's bootstrap password, creates and reconciles the three new

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -209,8 +209,9 @@ sudo ./scripts/install-single-host.sh \
 ```
 
 The runtime and migration identities must be provisioned before installation.
-The migration URL is injected only into a transient administration container;
-API containers receive only the runtime URL. See
+The migration URL is injected only into the transient migration container and
+the isolated restore executor; API and worker containers receive only the
+runtime URL. See
 [PostgreSQL Database Roles](database_roles.md) for the required grants,
 managed-service workflow, and upgrade diagnostics.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -204,8 +204,15 @@ sudo ./scripts/install-single-host.sh \
   --web hubuum.example.com \
   --api hubuum-api.example.com \
   --email admin@example.com \
-  --database-url 'postgres://hubuum:secret@postgres.example.com:5432/hubuum?sslmode=require'
+  --database-url 'postgres://hubuum_runtime:runtime-secret@postgres.example.com:5432/hubuum?sslmode=require' \
+  --migration-database-url 'postgres://hubuum_migrator:migration-secret@postgres.example.com:5432/hubuum?sslmode=require'
 ```
+
+The runtime and migration identities must be provisioned before installation.
+The migration URL is injected only into a transient administration container;
+API containers receive only the runtime URL. See
+[PostgreSQL Database Roles](database_roles.md) for the required grants,
+managed-service workflow, and upgrade diagnostics.
 
 Database TLS behavior follows the URL's `sslmode`:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -301,7 +301,8 @@ release-link overhead:
 ```bash
 export HUBUUM_BENCH_DATABASE_URL=postgres://postgres:postgres@localhost/hubuum_runtime
 cargo run --features embedded-migrations --bin hubuum-admin -- \
-  --migrate --database-url "$HUBUUM_BENCH_DATABASE_URL"
+  --migrate --legacy-single-role-migration \
+  --database-url "$HUBUUM_BENCH_DATABASE_URL"
 cargo build --features runtime-behavior-check --bin hubuum-server
 cargo run --profile dev --features runtime-behavior-check \
   --bin hubuum-runtime-behavior-check -- measure \

--- a/docs/distributed_deployment.md
+++ b/docs/distributed_deployment.md
@@ -101,6 +101,57 @@ migration required by the binary. API `/readyz` performs the same schema check.
 This prevents a missed or incomplete migration job from making a replica appear
 ready, while keeping migration ownership in the one-shot job.
 
+For the database-role migration, first verify maintenance is `normal` and block
+`POST /api/v1/restores/*/confirm` at the ingress. The migration shares the
+restore advisory lock and refuses to run if a confirmed restore is draining;
+validated stages are preserved. After the Job succeeds, deploy and verify the
+restore executor before rolling API and worker replicas or unblocking that
+route. Existing single-role databases should follow the complete adoption and
+rollback sequence in
+[PostgreSQL Database Roles](database_roles.md).
+
+## Isolated Restore Executor
+
+API confirmation queues a restore but never performs privileged SQL. Run one
+long-lived executor replica from the same image:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hubuum-restore-executor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hubuum-restore-executor
+  template:
+    metadata:
+      labels:
+        app: hubuum-restore-executor
+    spec:
+      containers:
+        - name: restore-executor
+          image: ghcr.io/hubuum/hubuum-server:VERSION
+          command: ["/usr/local/bin/hubuum-admin", "--restore-executor"]
+          env:
+            - name: HUBUUM_MIGRATION_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hubuum-migration-database
+                  key: database-url
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+```
+
+Do not add a Service or mount the migration secret into API or worker pods.
+The executor polls database control state, revalidates the staged document, and
+uses the migrator role only for the closed, transaction-protected restore
+operation.
+
 ## Kubernetes And Helm HTTP Availability
 
 This repository does not currently publish a Helm chart. Direct Kubernetes

--- a/docs/distributed_deployment.md
+++ b/docs/distributed_deployment.md
@@ -44,16 +44,12 @@ to behave as before.
 
 ## One-Shot Migrations
 
-The `api` and `worker` container roles always skip migrations. Setting the
-following value as well makes that ownership explicit in deployment manifests:
-
-```env
-HUBUUM_SKIP_MIGRATIONS=true
-```
-
-Run exactly one migration job before rolling out the new application version.
-The production image contains `hubuum-admin` and embedded migrations; it does
-not require the Diesel CLI or `psql`.
+Every server container role checks schema readiness without applying
+migrations. Run exactly one migration job before rolling out the new
+application version. The production image contains `hubuum-admin` and embedded
+migrations; it does not require the Diesel CLI or `psql`. See
+[PostgreSQL Database Roles](database_roles.md) for initial provisioning and the
+complete least-privilege contract.
 
 ```yaml
 apiVersion: batch/v1
@@ -69,10 +65,10 @@ spec:
           image: ghcr.io/hubuum/hubuum-server:VERSION
           command: ["/usr/local/bin/hubuum-admin", "--migrate"]
           env:
-            - name: HUBUUM_DATABASE_URL
+            - name: HUBUUM_MIGRATION_DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: hubuum
+                  name: hubuum-migration-database
                   key: database-url
 ```
 
@@ -149,8 +145,13 @@ spec:
           env:
             - name: HUBUUM_RUNTIME_ROLE
               value: api
-            - name: HUBUUM_SKIP_MIGRATIONS
-              value: "true"
+            - name: HUBUUM_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hubuum-runtime-database
+                  key: database-url
+            - name: HUBUUM_DATABASE_PRIVILEGE_MODE
+              value: strict
           ports:
             - name: http
               containerPort: 8080
@@ -190,11 +191,11 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ```
 
-The migration Job must use the new application image and the same database
-credentials as the Deployments. If the chart creates those credentials, make
-them available before the hook runs or keep migration ownership in the release
-pipeline. A failed migration must stop the rollout while the old API replicas
-remain online.
+The migration Job must use the new application image and a distinct migrator
+credential that is not mounted into any Deployment. If the chart creates that
+credential, make it available before the hook runs or keep migration ownership
+in the release pipeline. A failed migration must stop the rollout while the old
+API replicas remain online.
 
 Every migration used in this sequence must be compatible with both the old and
 new API versions. Use expand/backfill/switch/contract changes across releases;

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -18410,34 +18410,6 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Restore completed",
-            "headers": {
-              "Cache-Control": {
-                "schema": {
-                  "type": "string"
-                },
-                "description": "Always no-store for restore metadata"
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RestoreStageResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Confirmation phrase is invalid",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -18449,7 +18421,7 @@
             }
           },
           "403": {
-            "description": "Administrator or capability rejected",
+            "description": "Administrator access required",
             "content": {
               "application/json": {
                 "schema": {
@@ -18458,18 +18430,8 @@
               }
             }
           },
-          "409": {
-            "description": "Stage state or SHA-256 mismatch",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "410": {
-            "description": "Restore stage expired",
+          "501": {
+            "description": "Destructive restore requires hubuum-admin and a migration credential",
             "content": {
               "application/json": {
                 "schema": {
@@ -20463,12 +20425,22 @@
           "url",
           "pool_size",
           "pool_acquire_timeout_ms",
-          "statement_timeout_ms"
+          "statement_timeout_ms",
+          "privilege_mode",
+          "owner_role",
+          "migrator_role",
+          "runtime_role"
         ],
         "properties": {
           "backend": {
             "type": "string",
             "description": "Complete storage backend selected by the application composition root."
+          },
+          "migrator_role": {
+            "type": "string"
+          },
+          "owner_role": {
+            "type": "string"
           },
           "pool_acquire_timeout_ms": {
             "type": "integer",
@@ -20479,6 +20451,12 @@
             "type": "integer",
             "format": "int32",
             "minimum": 0
+          },
+          "privilege_mode": {
+            "type": "string"
+          },
+          "runtime_role": {
+            "type": "string"
           },
           "statement_timeout_ms": {
             "type": "integer",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -28397,7 +28397,7 @@
               "string",
               "null"
             ],
-            "description": "Returned only when a stage is created. It is stored only as a hash and\nmust be supplied to confirm or inspect the restore while its staging\nrecord exists. A successful restore deletes every staging record."
+            "description": "Returned only when a stage is created. It is stored only as a hash and\nmust be supplied to confirm or inspect the restore while its staging\nrecord exists. Success retains only a document-free terminal receipt."
           },
           "sha256": {
             "type": "string"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -18410,6 +18410,34 @@
           "required": true
         },
         "responses": {
+          "202": {
+            "description": "Restore confirmed and queued for the isolated executor",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Always no-store for restore metadata"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreStageResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid confirmation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -18421,7 +18449,7 @@
             }
           },
           "403": {
-            "description": "Administrator access required",
+            "description": "Administrator access required or restore capability rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -18430,8 +18458,18 @@
               }
             }
           },
-          "501": {
-            "description": "Destructive restore requires hubuum-admin and a migration credential",
+          "409": {
+            "description": "Restore stage cannot be confirmed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Restore stage expired",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -21,8 +21,11 @@ The development Compose stack requires a local, untracked `.env` file instead
 of using a password committed to the repository:
 
 ```bash
-printf 'POSTGRES_PASSWORD=%s\n' "$(openssl rand -hex 32)" > .env
-docker compose up --build
+for variable in POSTGRES_PASSWORD POSTGRES_MIGRATOR_PASSWORD POSTGRES_RUNTIME_PASSWORD; do
+  printf '%s=%s\n' "$variable" "$(openssl rand -hex 32)"
+done > .env
+docker compose --profile administration run --rm hubuum-migrate --migrate
+docker compose up --build -d hubuum
 ```
 
 The API is published on `127.0.0.1:9999` and PostgreSQL on
@@ -31,10 +34,10 @@ The Hubuum container runs as the unprivileged `hubuum` user with a read-only
 root filesystem, all Linux capabilities dropped, and only a small temporary
 filesystem at `/tmp`.
 
-The production image includes a `/healthz` health check and runs pending
-embedded migrations during startup. PostgreSQL client administration tools and
-the standalone Diesel CLI are not installed. Set
-`HUBUUM_SKIP_MIGRATIONS=true` only when migrations are coordinated externally.
+The production image includes a `/healthz` health check, but long-lived server
+containers never run migrations. PostgreSQL client administration tools and
+the standalone Diesel CLI are not installed; use the image's `hubuum-admin`
+binary in a one-shot migration workload.
 
 ### Server Configuration
 
@@ -71,14 +74,20 @@ examples.
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
 | `HUBUUM_STORAGE_BACKEND` | `postgresql` | Storage adapter selected from those registered in this application build; empty selects the default, while other unknown values are rejected at startup |
-| `HUBUUM_DATABASE_URL` | `postgres://localhost` | PostgreSQL connection URL |
+| `HUBUUM_DATABASE_URL` | `postgres://localhost` | Runtime-role PostgreSQL connection URL |
+| `HUBUUM_MIGRATION_DATABASE_URL` | *(none)* | Migrator-role URL accepted by `hubuum-admin --migrate` and destructive restore; never configure this on a server process |
+| `HUBUUM_DATABASE_OWNER_ROLE` | `hubuum_owner` | Non-login schema-owner role |
+| `HUBUUM_DATABASE_MIGRATOR_ROLE` | `hubuum_migrator` | One-shot migration and restore role |
+| `HUBUUM_DATABASE_RUNTIME_ROLE` | `hubuum_runtime` | Non-owning API and worker role |
+| `HUBUUM_DATABASE_PRIVILEGE_MODE` | `warn` | Runtime privilege audit behavior: `warn` or startup-failing `strict` |
 | `HUBUUM_DB_POOL_SIZE` | `10` | Maximum number of database connections in the pool |
 | `HUBUUM_DB_POOL_ACQUIRE_TIMEOUT_MS` | `2000` | Maximum wait for a free pooled connection before failing the request |
-| `HUBUUM_SKIP_MIGRATIONS` | `false` | If true, the container waits for the database but does not run migrations; `api` and `worker` roles always skip them |
 | `HUBUUM_DB_STATEMENT_TIMEOUT_MS` | `30000` | Pool-global Postgres `statement_timeout` in ms (`0` disables). Cancels any query exceeding it server-side; applies to **all** DB work, not just exports |
 
 See [Database Pool Tuning and Load Testing](performance.md) for connection
 budgeting, pool observability, and a repeatable k6 scenario.
+See [PostgreSQL Database Roles](database_roles.md) for provisioning, grant
+diagnostics, and one-shot workload examples.
 
 Administrators can inspect the selected storage backend and these effective
 pool settings at `GET /api/v1/admin/config`. The endpoint reports only whether
@@ -159,11 +168,11 @@ delivery semantics, operational health, and retention behavior.
 | `HUBUUM_RESTORE_STAGE_RETENTION_MINUTES` | `60` | How long a validated restore stage remains confirmable |
 | `HUBUUM_RESTORE_MAX_UPLOAD_BYTES` | `268435456` | Maximum full-system restore document size accepted by the API |
 
-Backups and restores are unscoped administrator-only disaster-recovery
-operations. A confirmed restore puts every instance into maintenance mode and
-replaces all application data. See [Backup and Restore](backup-restore.md) for
-the destructive confirmation flow, locking behavior, and export/import
-alternative for selective transfers.
+Backups and restore staging are unscoped administrator-only disaster-recovery
+operations. Destructive confirmation is disabled through the API and must run
+through `hubuum-admin` with the migrator credential. See
+[Backup and Restore](backup-restore.md) for the destructive confirmation flow,
+locking behavior, and export/import alternative for selective transfers.
 
 ### Pagination Configuration
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -75,9 +75,9 @@ examples.
 | -------- | ------- | ----------- |
 | `HUBUUM_STORAGE_BACKEND` | `postgresql` | Storage adapter selected from those registered in this application build; empty selects the default, while other unknown values are rejected at startup |
 | `HUBUUM_DATABASE_URL` | `postgres://localhost` | Runtime-role PostgreSQL connection URL |
-| `HUBUUM_MIGRATION_DATABASE_URL` | *(none)* | Migrator-role URL accepted by `hubuum-admin --migrate` and destructive restore; never configure this on a server process |
+| `HUBUUM_MIGRATION_DATABASE_URL` | *(none)* | Migrator-role URL accepted by `hubuum-admin --migrate`, `--restore`, and `--restore-executor`; never configure this on an API or worker process |
 | `HUBUUM_DATABASE_OWNER_ROLE` | `hubuum_owner` | Non-login schema-owner role |
-| `HUBUUM_DATABASE_MIGRATOR_ROLE` | `hubuum_migrator` | One-shot migration and restore role |
+| `HUBUUM_DATABASE_MIGRATOR_ROLE` | `hubuum_migrator` | Migration and isolated restore-executor role |
 | `HUBUUM_DATABASE_RUNTIME_ROLE` | `hubuum_runtime` | Non-owning API and worker role |
 | `HUBUUM_DATABASE_PRIVILEGE_MODE` | `warn` | Runtime privilege audit behavior: `warn` or startup-failing `strict` |
 | `HUBUUM_DB_POOL_SIZE` | `10` | Maximum number of database connections in the pool |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -189,9 +189,10 @@ backends:
 
 The full image also gets explicit aliases ending in `-full`.
 
-The image runs pending embedded Diesel migrations during startup unless
-`HUBUUM_SKIP_MIGRATIONS` is enabled. The image does not need the standalone Diesel CLI or `psql`;
-operators can run migrations explicitly with `hubuum-admin --migrate`.
+The image never runs embedded Diesel migrations from a long-lived server
+entrypoint. It does not need the standalone Diesel CLI or `psql`; operators run
+migrations with `hubuum-admin --migrate` in a one-shot workload using the
+separate migration database credential.
 
 Publishing from `main` happens in the same workflow run and depends directly on the CI jobs passing.
 Documentation-only and repository-metadata pushes do not rebuild or replace

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,44 +46,13 @@ if [ "${1:-}" = --container-healthcheck ]; then
     exit $?
 fi
 
-RUNTIME_ROLE="$(runtime_role "$@")"
-
-should_skip_migrations() {
-    case "$RUNTIME_ROLE" in
-        api|worker)
-            # Distributed long-running roles never own schema changes. Run
-            # hubuum-admin --migrate as a one-shot job before rollout.
-            return 0
-            ;;
-    esac
-
-    case "${HUBUUM_SKIP_MIGRATIONS:-false}" in
-        1|yes|y|true|on)
-            return 0
-            ;;
-        *)
-            return 1
-            ;;
-    esac
-}
-
 echo "Waiting for database to be ready..."
-until {
-    if should_skip_migrations; then
-        hubuum-admin --database-ready
-    else
-        hubuum-admin --migrate
-    fi
-}; do
+until hubuum-admin --database-ready; do
     echo "Database is unavailable - sleeping"
     sleep 1
 done
 
-if should_skip_migrations; then
-    echo "Database is ready; migrations were skipped."
-else
-    echo "Database is ready; all pending migrations were applied."
-fi
+echo "Database is ready. Schema migrations are owned by a separate one-shot administrative workload."
 
 # Start the application
 echo "Starting the application..."

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -31,6 +31,10 @@ fi
 # Generate a collision-resistant database name. Keep it identifier-safe.
 UNIQUE_SUFFIX="$(date +%s)_$$_${RANDOM}${RANDOM}"
 TEST_DB_NAME="${TEST_DB_PREFIX}${UNIQUE_SUFFIX}"
+OWNER_ROLE="hubuum_test_owner_${UNIQUE_SUFFIX}"
+MIGRATOR_ROLE="hubuum_test_migrator_${UNIQUE_SUFFIX}"
+RUNTIME_ROLE="hubuum_test_runtime_${UNIQUE_SUFFIX}"
+ADMIN_TEST_URL="postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$TEST_DB_NAME$SSL_MODE"
 
 cleanup() {
     if [ -n "${TEST_DB_NAME:-}" ]; then
@@ -42,18 +46,37 @@ cleanup() {
             -v ON_ERROR_STOP=1 \
             -c "DROP DATABASE IF EXISTS $TEST_DB_NAME;" \
             > /dev/null 2>&1 || true
+        PGPASSWORD=$DB_PASSWORD psql "$ROOT_URL" \
+            -v ON_ERROR_STOP=1 \
+            -c "REVOKE $OWNER_ROLE FROM $MIGRATOR_ROLE; DROP ROLE IF EXISTS $RUNTIME_ROLE; DROP ROLE IF EXISTS $MIGRATOR_ROLE; DROP ROLE IF EXISTS $OWNER_ROLE;" \
+            > /dev/null 2>&1 || true
     fi
 }
 
 trap cleanup EXIT
 
-# Create a new database
-PGPASSWORD=$DB_PASSWORD psql "$ROOT_URL" -v ON_ERROR_STOP=1 -c "CREATE DATABASE $TEST_DB_NAME;" > /dev/null
+# Create distinct cluster roles and a database owned by the non-login schema
+# owner. Password interpolation is handled by psql, not by SQL string assembly.
+PGPASSWORD=$DB_PASSWORD psql "$ROOT_URL" -v ON_ERROR_STOP=1 \
+    -v owner_role="$OWNER_ROLE" \
+    -v migrator_role="$MIGRATOR_ROLE" \
+    -v runtime_role="$RUNTIME_ROLE" \
+    -v role_password="$DB_PASSWORD" \
+    -f scripts/create-test-database-roles.sql \
+    > /dev/null
+PGPASSWORD=$DB_PASSWORD psql "$ROOT_URL" -v ON_ERROR_STOP=1 \
+    -c "CREATE DATABASE $TEST_DB_NAME OWNER $OWNER_ROLE;" > /dev/null
 
 echo "Created test database: $TEST_DB_NAME"
 
 
-export HUBUUM_DATABASE_URL="postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$TEST_DB_NAME$SSL_MODE"
+export HUBUUM_MIGRATION_DATABASE_URL="postgres://$MIGRATOR_ROLE:$DB_PASSWORD@$DB_HOST:$DB_PORT/$TEST_DB_NAME$SSL_MODE"
+export HUBUUM_DATABASE_URL="postgres://$RUNTIME_ROLE:$DB_PASSWORD@$DB_HOST:$DB_PORT/$TEST_DB_NAME$SSL_MODE"
+export HUBUUM_DATABASE_OWNER_ROLE="$OWNER_ROLE"
+export HUBUUM_DATABASE_MIGRATOR_ROLE="$MIGRATOR_ROLE"
+export HUBUUM_DATABASE_RUNTIME_ROLE="$RUNTIME_ROLE"
+export HUBUUM_DATABASE_PRIVILEGE_MODE="strict"
+export HUBUUM_DATABASE_ROLE_TESTS="true"
 # Every integration test owns a small connection pool. Bound parallelism so a
 # high-core test host cannot exhaust PostgreSQL while retaining parallel tests.
 export RUST_TEST_THREADS="$TEST_THREADS"
@@ -61,10 +84,29 @@ export RUST_TEST_THREADS="$TEST_THREADS"
 
 # Run migrations, lock the schema as we define views in the sql and those go bye-bye with print-schema.
 # See https://github.com/diesel-rs/diesel/issues/1482.
-diesel migration run --migration-dir "$MIGRATIONS_DIR" --database-url "$HUBUUM_DATABASE_URL" --locked-schema
+PGOPTIONS="-c role=$OWNER_ROLE" diesel migration run \
+    --migration-dir "$MIGRATIONS_DIR" \
+    --database-url "$HUBUUM_MIGRATION_DATABASE_URL" \
+    --locked-schema
+
+# Apply the same generated manifest used by production migration tooling.
+ROLE_SETUP_SQL="$(cargo run --quiet --bin hubuum-admin -- \
+    --database-role-setup-sql \
+    --database-owner-role "$OWNER_ROLE" \
+    --database-migrator-role "$MIGRATOR_ROLE" \
+    --database-runtime-role "$RUNTIME_ROLE")"
+PGPASSWORD=$DB_PASSWORD psql "$ADMIN_TEST_URL" \
+    -v ON_ERROR_STOP=1 -c "$ROLE_SETUP_SQL" > /dev/null
 
 # Run adapter-native tests before the application suite while the isolated,
 # migrated database is available.
+if [ "$#" -eq 0 ]; then
+    cargo test -p hubuum-storage-postgres \
+        --features integration-test-support \
+        --test database_privileges \
+        split_role_reconciliation_adopts_existing_single_role_objects \
+        -- --exact --ignored
+fi
 cargo test -p hubuum-storage-postgres --features integration-test-support "$@"
 
 # Run the application and request-level suites.

--- a/scripts/create-test-database-roles.sql
+++ b/scripts/create-test-database-roles.sql
@@ -1,0 +1,16 @@
+SELECT pg_catalog.format('CREATE ROLE %I NOLOGIN', :'owner_role') \gexec
+SELECT pg_catalog.format(
+    'CREATE ROLE %I LOGIN PASSWORD %L',
+    :'migrator_role',
+    :'role_password'
+) \gexec
+SELECT pg_catalog.format(
+    'CREATE ROLE %I LOGIN PASSWORD %L',
+    :'runtime_role',
+    :'role_password'
+) \gexec
+SELECT pg_catalog.format(
+    'GRANT %I TO %I',
+    :'owner_role',
+    :'migrator_role'
+) \gexec

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -846,6 +846,44 @@ cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
 EOF
 
 cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+  hubuum-restore-executor:
+EOF
+
+if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
+  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    build:
+      context: ./src/hubuum
+    image: local/hubuum-api:single-host
+EOF
+else
+  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    image: ${BACKEND_IMAGE}
+EOF
+fi
+
+cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    container_name: hubuum-restore-executor
+    restart: unless-stopped
+    entrypoint: /usr/local/bin/hubuum-admin
+    command: ["--restore-executor"]
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      HUBUUM_MIGRATION_DATABASE_URL: ${HUBUUM_MIGRATION_DATABASE_URL}
+      HUBUUM_DATABASE_OWNER_ROLE: ${HUBUUM_DATABASE_OWNER_ROLE}
+      HUBUUM_DATABASE_MIGRATOR_ROLE: ${HUBUUM_DATABASE_MIGRATOR_ROLE}
+      HUBUUM_DATABASE_RUNTIME_ROLE: ${HUBUUM_DATABASE_RUNTIME_ROLE}
+    networks:
+      - hubuum_net
+
+EOF
+
+cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
   hubuum-api: &hubuum-api
 EOF
 

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -22,6 +22,7 @@ POSTGRES_IMAGE="docker.io/library/postgres:18.4-alpine3.24@sha256:9a8afca54e7861
 VALKEY_IMAGE="docker.io/valkey/valkey:9-alpine"
 CADDY_IMAGE="docker.io/library/caddy:2-alpine"
 EXTERNAL_DATABASE_URL=""
+EXTERNAL_MIGRATION_DATABASE_URL=""
 AUTH_CONFIG_HOST_PATH=""
 AUTH_CONFIG_CONTAINER_PATH="/etc/hubuum/auth.toml"
 NETWORK_SUBNET="172.30.42.0/24"
@@ -66,6 +67,8 @@ Options:
   --backend-image IMAGE   Backend image. Default: ghcr.io/hubuum/hubuum-server:main
   --frontend-image IMAGE  Frontend image. Default: ghcr.io/hubuum/hubuum-frontend:main
   --database-url URL      Existing Postgres URL. If set, no Postgres container is created
+  --migration-database-url URL
+                          Migrator Postgres URL required with --database-url
   --auth-config PATH      Host auth-provider TOML file to mount read-only in the API container
   --engine ENGINE         Container engine: auto, docker, or podman. Default: auto
   --postgres-image IMAGE  Postgres image. Default: PostgreSQL 18.4 on Alpine 3.24 (digest-pinned)
@@ -150,7 +153,8 @@ while [[ $# -gt 0 ]]; do
     --frontend-ref) FRONTEND_REF="$2"; ARG_SET+=" FRONTEND_REF"; shift 2 ;;
     --backend-repo) BACKEND_REPO="$2"; ARG_SET+=" BACKEND_REPO"; shift 2 ;;
     --frontend-repo) FRONTEND_REPO="$2"; ARG_SET+=" FRONTEND_REPO"; shift 2 ;;
-    --database-url) EXTERNAL_DATABASE_URL="$2"; shift 2 ;;
+    --database-url) EXTERNAL_DATABASE_URL="$2"; ARG_SET+=" EXTERNAL_DATABASE_URL"; shift 2 ;;
+    --migration-database-url) EXTERNAL_MIGRATION_DATABASE_URL="$2"; ARG_SET+=" EXTERNAL_MIGRATION_DATABASE_URL"; shift 2 ;;
     --auth-config) AUTH_CONFIG_HOST_PATH="$2"; ARG_SET+=" AUTH_CONFIG_HOST_PATH"; shift 2 ;;
     --engine) ENGINE="$2"; shift 2 ;;
     --postgres-image) POSTGRES_IMAGE="$2"; ARG_SET+=" POSTGRES_IMAGE"; shift 2 ;;
@@ -452,13 +456,20 @@ fi
 ENV_FILE="$INSTALL_DIR/.env"
 
 POSTGRES_PASSWORD=""
+POSTGRES_MIGRATOR_PASSWORD=""
+POSTGRES_RUNTIME_PASSWORD=""
 HUBUUM_TOKEN_HASH_KEY=""
 EXISTING_POSTGRES_PASSWORD="$(read_env_value POSTGRES_PASSWORD || true)"
+EXISTING_POSTGRES_MIGRATOR_PASSWORD="$(read_env_value POSTGRES_MIGRATOR_PASSWORD || true)"
+EXISTING_POSTGRES_RUNTIME_PASSWORD="$(read_env_value POSTGRES_RUNTIME_PASSWORD || true)"
 if [[ "$RECREATE" != "true" ]]; then
   if [[ -z "$EXTERNAL_DATABASE_URL" && "$(read_env_value DATABASE_MANAGED || true)" == "false" ]]; then
     EXTERNAL_DATABASE_URL="$(read_env_value HUBUUM_DATABASE_URL || true)"
+    EXTERNAL_MIGRATION_DATABASE_URL="$(read_env_value HUBUUM_MIGRATION_DATABASE_URL || true)"
   fi
   POSTGRES_PASSWORD="$EXISTING_POSTGRES_PASSWORD"
+  POSTGRES_MIGRATOR_PASSWORD="$EXISTING_POSTGRES_MIGRATOR_PASSWORD"
+  POSTGRES_RUNTIME_PASSWORD="$EXISTING_POSTGRES_RUNTIME_PASSWORD"
   HUBUUM_TOKEN_HASH_KEY="$(read_env_value HUBUUM_TOKEN_HASH_KEY || true)"
 fi
 
@@ -469,16 +480,23 @@ fi
 if [[ "$RECREATE" == "true" && -z "$EXTERNAL_DATABASE_URL" && -n "$EXISTING_POSTGRES_PASSWORD" ]]; then
   echo "WARNING: --recreate does not rotate the managed Postgres password, because the existing database volume was initialized with it. Rotating it would break authentication. To reset the database, uninstall with --purge first, then reinstall." >&2
   POSTGRES_PASSWORD="$EXISTING_POSTGRES_PASSWORD"
+  POSTGRES_MIGRATOR_PASSWORD="$EXISTING_POSTGRES_MIGRATOR_PASSWORD"
+  POSTGRES_RUNTIME_PASSWORD="$EXISTING_POSTGRES_RUNTIME_PASSWORD"
 fi
 
 [[ -n "$POSTGRES_PASSWORD" ]] || POSTGRES_PASSWORD="$(random_hex 32)"
+[[ -n "$POSTGRES_MIGRATOR_PASSWORD" ]] || POSTGRES_MIGRATOR_PASSWORD="$(random_hex 32)"
+[[ -n "$POSTGRES_RUNTIME_PASSWORD" ]] || POSTGRES_RUNTIME_PASSWORD="$(random_hex 32)"
 [[ -n "$HUBUUM_TOKEN_HASH_KEY" ]] || HUBUUM_TOKEN_HASH_KEY="$(random_hex 32)"
 
 DATABASE_MANAGED="true"
-HUBUUM_DATABASE_URL="postgres://hubuum:${POSTGRES_PASSWORD}@postgres:5432/hubuum"
+HUBUUM_DATABASE_URL="postgres://hubuum_runtime:${POSTGRES_RUNTIME_PASSWORD}@postgres:5432/hubuum"
+HUBUUM_MIGRATION_DATABASE_URL="postgres://hubuum_migrator:${POSTGRES_MIGRATOR_PASSWORD}@postgres:5432/hubuum"
 if [[ -n "$EXTERNAL_DATABASE_URL" ]]; then
+  [[ -n "$EXTERNAL_MIGRATION_DATABASE_URL" ]] || die "--migration-database-url is required with --database-url (or set HUBUUM_MIGRATION_DATABASE_URL in the existing .env)"
   DATABASE_MANAGED="false"
   HUBUUM_DATABASE_URL="$EXTERNAL_DATABASE_URL"
+  HUBUUM_MIGRATION_DATABASE_URL="$EXTERNAL_MIGRATION_DATABASE_URL"
 fi
 
 LOGIN_RATE_LIMIT_BACKEND="memory"
@@ -510,9 +528,15 @@ write_deployment_env() {
   printf 'POSTGRES_DB=hubuum\n'
   printf 'POSTGRES_USER=hubuum\n'
   printf 'POSTGRES_PASSWORD=%s\n' "$POSTGRES_PASSWORD"
+  printf 'POSTGRES_MIGRATOR_PASSWORD=%s\n' "$POSTGRES_MIGRATOR_PASSWORD"
+  printf 'POSTGRES_RUNTIME_PASSWORD=%s\n' "$POSTGRES_RUNTIME_PASSWORD"
   printf '\n'
   printf 'HUBUUM_DATABASE_URL=%s\n' "$(quote_env "$HUBUUM_DATABASE_URL")"
-  printf 'DATABASE_URL=%s\n' "$(quote_env "$HUBUUM_DATABASE_URL")"
+  printf 'HUBUUM_MIGRATION_DATABASE_URL=%s\n' "$(quote_env "$HUBUUM_MIGRATION_DATABASE_URL")"
+  printf 'HUBUUM_DATABASE_OWNER_ROLE=hubuum_owner\n'
+  printf 'HUBUUM_DATABASE_MIGRATOR_ROLE=hubuum_migrator\n'
+  printf 'HUBUUM_DATABASE_RUNTIME_ROLE=hubuum_runtime\n'
+  printf 'HUBUUM_DATABASE_PRIVILEGE_MODE=strict\n'
   printf 'HUBUUM_BIND_IP=0.0.0.0\n'
   printf 'HUBUUM_BIND_PORT=%s\n' "$API_PORT"
   printf 'HUBUUM_LOG_LEVEL=info\n'
@@ -570,6 +594,28 @@ else
 fi
 
 chmod 0600 "$ENV_FILE"
+
+DATABASE_ROLE_PASSWORD_SCRIPT="$INSTALL_DIR/set-database-role-passwords.sh"
+cat > "$DATABASE_ROLE_PASSWORD_SCRIPT" <<'EOF'
+#!/bin/sh
+set -eu
+
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${POSTGRES_DB:?POSTGRES_DB is required}"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
+: "${POSTGRES_MIGRATOR_PASSWORD:?POSTGRES_MIGRATOR_PASSWORD is required}"
+: "${POSTGRES_RUNTIME_PASSWORD:?POSTGRES_RUNTIME_PASSWORD is required}"
+
+PGHOST=postgres PGPASSWORD="$POSTGRES_PASSWORD" psql --set ON_ERROR_STOP=1 \
+  --username "$POSTGRES_USER" \
+  --dbname "$POSTGRES_DB" \
+  --set migrator_password="$POSTGRES_MIGRATOR_PASSWORD" \
+  --set runtime_password="$POSTGRES_RUNTIME_PASSWORD" <<'SQL'
+ALTER ROLE hubuum_migrator PASSWORD :'migrator_password';
+ALTER ROLE hubuum_runtime PASSWORD :'runtime_password';
+SQL
+EOF
+chmod 0755 "$DATABASE_ROLE_PASSWORD_SCRIPT"
 
 CADDYFILE_TEMP="$(mktemp "$INSTALL_DIR/.Caddyfile.XXXXXX")"
 cat > "$CADDYFILE_TEMP" <<EOF
@@ -746,9 +792,12 @@ if [[ "$DATABASE_MANAGED" == "true" ]]; then
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_MIGRATOR_PASSWORD: ${POSTGRES_MIGRATOR_PASSWORD}
+      POSTGRES_RUNTIME_PASSWORD: ${POSTGRES_RUNTIME_PASSWORD}
       PGUSER: ${POSTGRES_USER}
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./set-database-role-passwords.sh:/usr/local/bin/hubuum-set-database-role-passwords:ro
     networks:
       - hubuum_net
     healthcheck:
@@ -759,6 +808,42 @@ if [[ "$DATABASE_MANAGED" == "true" ]]; then
 
 EOF
 fi
+
+cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+  hubuum-migrate:
+    profiles: ["administration"]
+EOF
+
+if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
+  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    build:
+      context: ./src/hubuum
+    image: local/hubuum-api:single-host
+EOF
+else
+  cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    image: ${BACKEND_IMAGE}
+EOF
+fi
+
+cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
+    entrypoint: /usr/local/bin/hubuum-admin
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      HUBUUM_MIGRATION_DATABASE_URL: ${HUBUUM_MIGRATION_DATABASE_URL}
+      HUBUUM_DATABASE_OWNER_ROLE: ${HUBUUM_DATABASE_OWNER_ROLE}
+      HUBUUM_DATABASE_MIGRATOR_ROLE: ${HUBUUM_DATABASE_MIGRATOR_ROLE}
+      HUBUUM_DATABASE_RUNTIME_ROLE: ${HUBUUM_DATABASE_RUNTIME_ROLE}
+    networks:
+      - hubuum_net
+
+EOF
 
 cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
   hubuum-api: &hubuum-api
@@ -792,7 +877,10 @@ cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
       HUBUUM_BIND_IP: ${HUBUUM_BIND_IP}
       HUBUUM_BIND_PORT: ${HUBUUM_BIND_PORT}
       HUBUUM_DATABASE_URL: ${HUBUUM_DATABASE_URL}
-      DATABASE_URL: ${DATABASE_URL}
+      HUBUUM_DATABASE_OWNER_ROLE: ${HUBUUM_DATABASE_OWNER_ROLE}
+      HUBUUM_DATABASE_MIGRATOR_ROLE: ${HUBUUM_DATABASE_MIGRATOR_ROLE}
+      HUBUUM_DATABASE_RUNTIME_ROLE: ${HUBUUM_DATABASE_RUNTIME_ROLE}
+      HUBUUM_DATABASE_PRIVILEGE_MODE: ${HUBUUM_DATABASE_PRIVILEGE_MODE}
       HUBUUM_LOG_LEVEL: ${HUBUUM_LOG_LEVEL}
       HUBUUM_TOKEN_HASH_KEY: ${HUBUUM_TOKEN_HASH_KEY}
       HUBUUM_CLIENT_ALLOWLIST: ${HUBUUM_CLIENT_ALLOWLIST}

--- a/scripts/single-host-rollout.sh
+++ b/scripts/single-host-rollout.sh
@@ -299,6 +299,8 @@ hubuum_start_stack() {
   hubuum_ensure_infrastructure
   hubuum_run_migrations
 
+  "${COMPOSE_CMD[@]}" up -d --no-deps --force-recreate hubuum-restore-executor
+
   "${COMPOSE_CMD[@]}" up -d hubuum-api
   hubuum_wait_for_rollout_health hubuum-api
 
@@ -348,6 +350,7 @@ hubuum_rollout() {
     fi
     return 1
   fi
+  "${COMPOSE_CMD[@]}" up -d --no-deps --force-recreate hubuum-restore-executor
   if [[ "$primary_workers_drained" == "true" ]]; then
     hubuum_roll_service hubuum-api
     api_primary_recovered="true"

--- a/scripts/single-host-rollout.sh
+++ b/scripts/single-host-rollout.sh
@@ -244,9 +244,17 @@ hubuum_reload_caddy_and_wait_for_upstreams() {
 }
 
 hubuum_run_migrations() {
+  if [[ "${DATABASE_MANAGED:-true}" == "true" ]]; then
+    echo "Reconciling managed database roles..."
+    "${COMPOSE_CMD[@]}" run --rm --no-deps -T hubuum-migrate \
+      --database-role-setup-sql | \
+      "${COMPOSE_CMD[@]}" exec -T postgres \
+        psql --set ON_ERROR_STOP=1 --username hubuum --dbname hubuum
+    "${COMPOSE_CMD[@]}" run --rm --no-deps -T \
+      --entrypoint /usr/local/bin/hubuum-set-database-role-passwords postgres
+  fi
   echo "Running one-shot database migrations..."
-  "${COMPOSE_CMD[@]}" run --rm --no-deps -T \
-    --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+  "${COMPOSE_CMD[@]}" run --rm --no-deps -T hubuum-migrate --migrate
 }
 
 hubuum_drain_primary_workers_for_migrations() {
@@ -288,8 +296,9 @@ hubuum_restart_primary_after_failed_migration() {
 hubuum_start_stack() {
   echo "Starting the initial Hubuum stack..."
 
-  # Start the migration-owning primary first. Starting both API containers at
-  # once could make two fresh containers race to apply the same migrations.
+  hubuum_ensure_infrastructure
+  hubuum_run_migrations
+
   "${COMPOSE_CMD[@]}" up -d hubuum-api
   hubuum_wait_for_rollout_health hubuum-api
 

--- a/scripts/test-adjacent-release-upgrade.sh
+++ b/scripts/test-adjacent-release-upgrade.sh
@@ -465,7 +465,7 @@ probe_previous_api &
 probe_pid=$!
 migration_started=$SECONDS
 "${compose[@]}" run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin \
-  candidate-api --migrate > "$migration_log" 2>&1
+  candidate-api --migrate --legacy-single-role-migration > "$migration_log" 2>&1
 migration_seconds=$((SECONDS - migration_started))
 stop_probe
 analyze_probes

--- a/scripts/test-single-host-rollout.sh
+++ b/scripts/test-single-host-rollout.sh
@@ -201,6 +201,7 @@ compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
 compose --env-file .env -f compose.yml stop hubuum-api
 compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-restore-executor
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
 compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
@@ -222,6 +223,7 @@ cat > "$TEST_ROOT/expected-reload.log" <<EOF
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
 compose --env-file .env -f compose.yml stop hubuum-api
 compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-restore-executor
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
 compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
@@ -267,6 +269,7 @@ rm -f "$TEST_ROOT/started-hubuum-api"
 hubuum_rollout
 cat > "$TEST_ROOT/expected-recovery.log" <<EOF
 compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-restore-executor
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
 compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
@@ -290,6 +293,7 @@ compose --env-file .env -f compose.yml up -d --no-deps --no-recreate valkey
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
 compose --env-file .env -f compose.yml stop hubuum-api
 compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-restore-executor
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
 compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
@@ -311,6 +315,7 @@ rm -f "$TEST_ROOT/started-caddy"
 hubuum_rollout
 cat > "$TEST_ROOT/expected-initial.log" <<EOF
 compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
+compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-restore-executor
 compose --env-file .env -f compose.yml up -d hubuum-api
 compose --env-file .env -f compose.yml up -d --no-deps hubuum-api-standby
 compose --env-file .env -f compose.yml up -d --no-deps caddy

--- a/scripts/test-single-host-rollout.sh
+++ b/scripts/test-single-host-rollout.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 
 printf '%s\n' "$*" >> "$COMMAND_LOG"
 
-if [[ "$*" == *" run "* && "$*" == *" hubuum-api --migrate" &&
+if [[ "$*" == *" run "* && "$*" == *" hubuum-migrate --migrate" &&
   "${FAKE_MIGRATION_FAIL:-false}" == "true" ]]; then
   exit 1
 fi
@@ -115,6 +115,7 @@ export FAKE_UNHEALTHY_SERVICES=""
 ENGINE_PATH="$FAKE_ENGINE"
 COMPOSE_CMD=("$FAKE_ENGINE" compose --env-file .env -f compose.yml)
 API_PORT=8080
+DATABASE_MANAGED="false"
 
 # shellcheck source=scripts/single-host-rollout.sh
 source "$REPOSITORY_ROOT/scripts/single-host-rollout.sh"
@@ -199,7 +200,7 @@ compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
 compose --env-file .env -f compose.yml stop hubuum-api
-compose --env-file .env -f compose.yml run --rm --no-deps -T --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
 compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
@@ -220,7 +221,7 @@ hubuum_rollout
 cat > "$TEST_ROOT/expected-reload.log" <<EOF
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
 compose --env-file .env -f compose.yml stop hubuum-api
-compose --env-file .env -f compose.yml run --rm --no-deps -T --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
 compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
@@ -239,7 +240,7 @@ fi
 cat > "$TEST_ROOT/expected-migration-failure.log" <<EOF
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
 compose --env-file .env -f compose.yml stop hubuum-api
-compose --env-file .env -f compose.yml run --rm --no-deps -T --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
 compose --env-file .env -f compose.yml start hubuum-api
 EOF
 assert_commands "$TEST_ROOT/expected-migration-failure.log"
@@ -265,7 +266,7 @@ rm -f "$TEST_ROOT/started-hubuum-api"
 : > "$COMMAND_LOG"
 hubuum_rollout
 cat > "$TEST_ROOT/expected-recovery.log" <<EOF
-compose --env-file .env -f compose.yml run --rm --no-deps -T --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
 compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
@@ -288,7 +289,7 @@ cat > "$TEST_ROOT/expected-missing-infrastructure.log" <<EOF
 compose --env-file .env -f compose.yml up -d --no-deps --no-recreate valkey
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
 compose --env-file .env -f compose.yml stop hubuum-api
-compose --env-file .env -f compose.yml run --rm --no-deps -T --entrypoint /usr/local/bin/hubuum-admin hubuum-api --migrate
+compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
 compose --env-file .env -f compose.yml up -d --no-deps --force-recreate hubuum-api
 compose --env-file .env -f compose.yml exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
 compose --env-file .env -f compose.yml exec -T caddy wget -qO- http://127.0.0.1:2019/reverse_proxy/upstreams
@@ -309,6 +310,7 @@ rm -f "$TEST_ROOT/started-caddy"
 : > "$COMMAND_LOG"
 hubuum_rollout
 cat > "$TEST_ROOT/expected-initial.log" <<EOF
+compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
 compose --env-file .env -f compose.yml up -d hubuum-api
 compose --env-file .env -f compose.yml up -d --no-deps hubuum-api-standby
 compose --env-file .env -f compose.yml up -d --no-deps caddy
@@ -360,5 +362,16 @@ if reload_output="$(hubuum_reload_caddy 2>&1)"; then
 fi
 [[ "$reload_output" == *"ERROR: Caddy reload failed"* ]]
 [[ "$reload_output" == *'fake reload diagnostic'* ]]
+
+DATABASE_MANAGED="true"
+: > "$COMMAND_LOG"
+hubuum_run_migrations
+cat > "$TEST_ROOT/expected-managed-migration.log" <<EOF
+compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --database-role-setup-sql
+compose --env-file .env -f compose.yml exec -T postgres psql --set ON_ERROR_STOP=1 --username hubuum --dbname hubuum
+compose --env-file .env -f compose.yml run --rm --no-deps -T --entrypoint /usr/local/bin/hubuum-set-database-role-passwords postgres
+compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
+EOF
+assert_commands "$TEST_ROOT/expected-managed-migration.log"
 
 echo "Single-host rolling update test passed"

--- a/scripts/test-single-host-zero-downtime.sh
+++ b/scripts/test-single-host-zero-downtime.sh
@@ -16,6 +16,7 @@ HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS="${HUBUUM_ROLLOUT_HEALTH_TIMEOUT_SECONDS:-
 HUBUUM_ROLLOUT_CADDY_TIMEOUT_SECONDS="${HUBUUM_ROLLOUT_CADDY_TIMEOUT_SECONDS:-45}"
 HUBUUM_ZERO_DOWNTIME_PROBE_TIMEOUT_SECONDS="${HUBUUM_ZERO_DOWNTIME_PROBE_TIMEOUT_SECONDS:-7}"
 INSTALL_MODE="backend"
+DATABASE_MANAGED="false"
 
 docker image inspect "$HUBUUM_TEST_IMAGE" >/dev/null 2>&1 || {
   echo "ERROR: missing test image $HUBUUM_TEST_IMAGE" >&2
@@ -63,6 +64,7 @@ trap cleanup EXIT
 
 write_environment() {
   local database_url="$1"
+  local migration_database_url="${2:-$1}"
 
   cat > "$TEST_ROOT/.env" <<EOF
 HUBUUM_TEST_IMAGE=$HUBUUM_TEST_IMAGE
@@ -70,11 +72,14 @@ HUBUUM_OLD_TEST_IMAGE=$HUBUUM_OLD_TEST_IMAGE
 POSTGRES_TEST_IMAGE=$POSTGRES_TEST_IMAGE
 CADDY_TEST_IMAGE=$CADDY_TEST_IMAGE
 HUBUUM_ZERO_DOWNTIME_DATABASE_URL=$database_url
+HUBUUM_ZERO_DOWNTIME_MIGRATION_DATABASE_URL=$migration_database_url
 EOF
 }
 
-DATABASE_URL="postgres://hubuum:zero-downtime-test@postgres/hubuum?sslmode=disable"
-write_environment "$DATABASE_URL"
+BOOTSTRAP_DATABASE_URL="postgres://hubuum:zero-downtime-test@postgres/hubuum?sslmode=disable"
+RUNTIME_DATABASE_URL="postgres://hubuum_runtime:runtime-test@postgres/hubuum?sslmode=disable"
+MIGRATION_DATABASE_URL="postgres://hubuum_migrator:migrator-test@postgres/hubuum?sslmode=disable"
+write_environment "$BOOTSTRAP_DATABASE_URL"
 
 write_old_caddyfile() {
   cat > "$TEST_ROOT/Caddyfile" <<'EOF'
@@ -143,6 +148,13 @@ services:
       timeout: 2s
       retries: 30
 
+  hubuum-migrate:
+    image: ${HUBUUM_TEST_IMAGE}
+    profiles: ["administration"]
+    entrypoint: /usr/local/bin/hubuum-admin
+    environment:
+      HUBUUM_MIGRATION_DATABASE_URL: ${HUBUUM_ZERO_DOWNTIME_MIGRATION_DATABASE_URL}
+
   hubuum-api: &hubuum-api
     image: ${HUBUUM_TEST_IMAGE}
     stop_grace_period: 75s
@@ -157,6 +169,7 @@ services:
       HUBUUM_BIND_IP: 0.0.0.0
       HUBUUM_BIND_PORT: 8080
       HUBUUM_DATABASE_URL: ${HUBUUM_ZERO_DOWNTIME_DATABASE_URL}
+      HUBUUM_DATABASE_PRIVILEGE_MODE: strict
       HUBUUM_CLIENT_ALLOWLIST: "*"
       HUBUUM_LOG_LEVEL: info
     depends_on:
@@ -388,6 +401,14 @@ expected_migration_version="$(find "$REPOSITORY_ROOT/crates/hubuum-storage-postg
 start_probes
 
 echo "Migrating the v0.0.1 database and rolling to the candidate image..."
+"${BASE_COMPOSE_CMD[@]}" run --rm --no-deps -T hubuum-migrate \
+  --database-role-setup-sql | \
+  "${BASE_COMPOSE_CMD[@]}" exec -T postgres \
+    psql --set ON_ERROR_STOP=1 --username hubuum --dbname hubuum
+"${BASE_COMPOSE_CMD[@]}" exec -T postgres \
+  psql --set ON_ERROR_STOP=1 --username hubuum --dbname hubuum \
+  --command "ALTER ROLE hubuum_migrator PASSWORD 'migrator-test'; ALTER ROLE hubuum_runtime PASSWORD 'runtime-test'"
+write_environment "$RUNTIME_DATABASE_URL" "$MIGRATION_DATABASE_URL"
 write_candidate_caddyfile
 hubuum_rollout
 touch "$READY_PROBES_FILE"
@@ -419,9 +440,9 @@ initial_primary_id="$(service_id hubuum-api)"
 initial_standby_id="$(service_id hubuum-api-standby)"
 
 echo "Verifying that a failed migration leaves both API replicas untouched..."
-write_environment "postgres://hubuum:zero-downtime-test@127.0.0.1:1/hubuum"
+write_environment "$RUNTIME_DATABASE_URL" "postgres://hubuum_migrator:migrator-test@127.0.0.1:1/hubuum"
 expect_rollout_failure migration-failure
-write_environment "$DATABASE_URL"
+write_environment "$RUNTIME_DATABASE_URL" "$MIGRATION_DATABASE_URL"
 assert_same_id "primary API after migration failure" "$initial_primary_id" "$(service_id hubuum-api)"
 assert_same_id "standby API after migration failure" "$initial_standby_id" "$(service_id hubuum-api-standby)"
 

--- a/scripts/test-single-host-zero-downtime.sh
+++ b/scripts/test-single-host-zero-downtime.sh
@@ -155,6 +155,13 @@ services:
     environment:
       HUBUUM_MIGRATION_DATABASE_URL: ${HUBUUM_ZERO_DOWNTIME_MIGRATION_DATABASE_URL}
 
+  hubuum-restore-executor:
+    image: ${HUBUUM_TEST_IMAGE}
+    entrypoint: /usr/local/bin/hubuum-admin
+    command: ["--restore-executor"]
+    environment:
+      HUBUUM_MIGRATION_DATABASE_URL: ${HUBUUM_ZERO_DOWNTIME_MIGRATION_DATABASE_URL}
+
   hubuum-api: &hubuum-api
     image: ${HUBUUM_TEST_IMAGE}
     stop_grace_period: 75s

--- a/scripts/update-single-host.sh
+++ b/scripts/update-single-host.sh
@@ -208,6 +208,7 @@ refresh_deployment_files
 
 [[ -f "$INSTALL_DIR/single-host-rollout.sh" ]] || die "configuration refresh did not install single-host-rollout.sh"
 grep -q '^  hubuum-api-standby:' "$INSTALL_DIR/compose.yml" || die "refreshed compose.yml does not support rolling updates"
+grep -q '^  hubuum-restore-executor:' "$INSTALL_DIR/compose.yml" || die "refreshed compose.yml does not provide the isolated restore executor"
 if grep -q 'HUBUUM_AUTH_CONFIG_PATH' "$INSTALL_DIR/compose.yml"; then
   AUTH_CONFIG_HOST_PATH="$(read_env_value HUBUUM_AUTH_CONFIG_HOST_PATH || true)"
   [[ -n "$AUTH_CONFIG_HOST_PATH" ]] || die "HUBUUM_AUTH_CONFIG_HOST_PATH is missing from $ENV_FILE"

--- a/src/administration.rs
+++ b/src/administration.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::ffi::OsString;
@@ -28,8 +28,11 @@ use crate::services::operational_administration as operational_service;
 #[cfg(feature = "embedded-migrations")]
 use crate::storage::run_storage_migrations;
 use crate::storage::{
-    OperationalStateStorage, StorageBackendKind, StorageHandle, StorageSettings,
+    OperationalStateStorage, StorageBackendKind, StorageDatabasePrivilegeReport,
+    StorageDatabaseRole, StorageDatabaseRoleNames, StorageHandle, StorageSettings,
     StorageTokenKeyUsage, StorageTokenObservation, TokenStorage, initialize_storage,
+    inspect_storage_database_privileges, storage_database_role_grants_sql,
+    storage_database_role_setup_sql,
 };
 use crate::utilities::auth::generate_random_password;
 use crate::utilities::exporting::validate_template_sources_with_limits;
@@ -84,6 +87,35 @@ struct AdminCli {
     #[arg(long, default_value_t = false)]
     migrate: bool,
 
+    /// Print idempotent SQL for the configured owner, migrator, and runtime roles
+    #[arg(long, default_value_t = false)]
+    database_role_setup_sql: bool,
+
+    /// Print grant/ownership SQL for roles pre-created by a managed database provider
+    #[arg(
+        long,
+        default_value_t = false,
+        conflicts_with = "database_role_setup_sql"
+    )]
+    database_role_grants_sql: bool,
+
+    /// Check a logical database role against the generated privilege manifest
+    #[arg(long, default_value_t = false)]
+    check_database_privileges: bool,
+
+    /// Logical role inspected by --check-database-privileges
+    #[arg(
+        long,
+        value_enum,
+        default_value = "runtime",
+        requires = "check_database_privileges"
+    )]
+    role: DatabasePrivilegeRole,
+
+    /// Emit machine-readable JSON for supported report commands
+    #[arg(long, default_value_t = false)]
+    json: bool,
+
     /// Storage adapter compiled into this application build.
     #[arg(
         long,
@@ -96,6 +128,34 @@ struct AdminCli {
     /// Database URL
     #[arg(long, env = "HUBUUM_DATABASE_URL")]
     database_url: Option<String>,
+
+    /// One-shot migration and destructive-restore database URL
+    #[arg(long, env = "HUBUUM_MIGRATION_DATABASE_URL")]
+    migration_database_url: Option<String>,
+
+    /// Non-login role that owns Hubuum database objects
+    #[arg(
+        long,
+        env = "HUBUUM_DATABASE_OWNER_ROLE",
+        default_value = "hubuum_owner"
+    )]
+    database_owner_role: String,
+
+    /// Login/workload role used only by migrations and destructive restore
+    #[arg(
+        long,
+        env = "HUBUUM_DATABASE_MIGRATOR_ROLE",
+        default_value = "hubuum_migrator"
+    )]
+    database_migrator_role: String,
+
+    /// Non-owning login role used by API and worker processes
+    #[arg(
+        long,
+        env = "HUBUUM_DATABASE_RUNTIME_ROLE",
+        default_value = "hubuum_runtime"
+    )]
+    database_runtime_role: String,
 
     /// Pool-global storage query timeout in milliseconds (0 disables it)
     #[arg(
@@ -135,6 +195,13 @@ struct AdminCli {
     log_level: String,
 }
 
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum DatabasePrivilegeRole {
+    Owner,
+    Migrator,
+    Runtime,
+}
+
 /// Parse and execute one Hubuum administration command.
 ///
 /// This is the workspace-internal boundary used by `hubuum-admin`; callers
@@ -143,21 +210,52 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
     let admin_cli = AdminCli::parse();
     init_logging(&admin_cli.log_level);
 
+    let database_roles = StorageDatabaseRoleNames::new(
+        admin_cli.database_owner_role.clone(),
+        admin_cli.database_migrator_role.clone(),
+        admin_cli.database_runtime_role.clone(),
+    )
+    .map_err(|error| ApiError::BadRequest(error.to_string()))?;
+
+    if admin_cli.database_role_setup_sql {
+        print!("{}", storage_database_role_setup_sql(&database_roles)?);
+        return Ok(());
+    }
+    if admin_cli.database_role_grants_sql {
+        println!("BEGIN;");
+        print!("{}", storage_database_role_grants_sql(&database_roles)?);
+        println!("COMMIT;");
+        return Ok(());
+    }
+
     if admin_cli.restore.is_some()
         && admin_cli.restore_confirmation.as_deref() != Some(RESTORE_CONFIRMATION_PHRASE)
     {
         return Err(destructive_confirmation_error());
     }
 
+    #[cfg(feature = "embedded-migrations")]
+    let migration_requested = admin_cli.migrate;
+    #[cfg(not(feature = "embedded-migrations"))]
+    let migration_requested = false;
+    let privileged_database_operation = migration_requested || admin_cli.restore.is_some();
+    let database_url = if privileged_database_operation {
+        admin_cli.migration_database_url.or(admin_cli.database_url)
+    } else {
+        admin_cli.database_url
+    };
     let storage_settings = match admin_cli.storage_backend {
         StorageBackendKind::Postgres => {
-            let database_url = admin_cli.database_url.unwrap_or_else(|| {
-                std::env::var("HUBUUM_DATABASE_URL").unwrap_or_else(|_| {
-                    fatal_error(
-                        "HUBUUM_DATABASE_URL must be set if not provided as an argument",
-                        EXIT_CODE_CONFIG_ERROR,
-                    )
-                })
+            let database_url = database_url.unwrap_or_else(|| {
+                let variable = if privileged_database_operation {
+                    "HUBUUM_MIGRATION_DATABASE_URL (or the compatibility fallback HUBUUM_DATABASE_URL)"
+                } else {
+                    "HUBUUM_DATABASE_URL"
+                };
+                fatal_error(
+                    &format!("{variable} must be set if not provided as an argument"),
+                    EXIT_CODE_CONFIG_ERROR,
+                )
             });
             StorageSettings::postgres(database_url)
                 .max_connections(1)
@@ -170,13 +268,37 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
 
     #[cfg(feature = "embedded-migrations")]
     if admin_cli.migrate {
-        let applied = run_storage_migrations(&storage_settings).unwrap_or_else(|error| {
-            fatal_error(
-                &format!("Failed to run storage migrations: {error}"),
-                EXIT_CODE_DATABASE_ERROR,
-            )
-        });
+        let applied = run_storage_migrations(&storage_settings, Some(&database_roles))
+            .unwrap_or_else(|error| {
+                fatal_error(
+                    &format!("Failed to run storage migrations: {error}"),
+                    EXIT_CODE_DATABASE_ERROR,
+                )
+            });
         println!("Applied {applied} storage migration(s).");
+        return Ok(());
+    }
+
+    if admin_cli.check_database_privileges {
+        let role = match admin_cli.role {
+            DatabasePrivilegeRole::Owner => StorageDatabaseRole::Owner,
+            DatabasePrivilegeRole::Migrator => StorageDatabaseRole::Migrator,
+            DatabasePrivilegeRole::Runtime => StorageDatabaseRole::Runtime,
+        };
+        let report = inspect_storage_database_privileges(&storage_settings, role, &database_roles)
+            .await?
+            .ok_or_else(|| {
+                ApiError::BadRequest(
+                    "Database privilege checks require the PostgreSQL storage backend".to_string(),
+                )
+            })?;
+        print_database_privilege_report(&report, admin_cli.json)?;
+        if !report.is_safe() {
+            return Err(ApiError::BadRequest(format!(
+                "Database role '{}' does not satisfy the Hubuum privilege manifest",
+                report.role(),
+            )));
+        }
         return Ok(());
     }
 
@@ -205,6 +327,46 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
         println!("No command specified. Use --help for usage information.");
     }
 
+    Ok(())
+}
+
+fn print_database_privilege_report(
+    report: &StorageDatabasePrivilegeReport,
+    json: bool,
+) -> Result<(), ApiError> {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(report).map_err(|error| {
+                ApiError::InternalServerError(format!(
+                    "Failed to serialize database privilege report: {error}"
+                ))
+            })?
+        );
+        return Ok(());
+    }
+    println!(
+        "Database role '{}' (connected as '{}'): {}",
+        report.role(),
+        report.connected_role(),
+        if report.is_safe() { "safe" } else { "unsafe" }
+    );
+    for finding in report.dangerous() {
+        println!(
+            "DANGEROUS {} {}: {}",
+            finding.code(),
+            finding.object(),
+            finding.detail()
+        );
+    }
+    for finding in report.missing() {
+        println!(
+            "MISSING {} {}: {}",
+            finding.code(),
+            finding.object(),
+            finding.detail()
+        );
+    }
     Ok(())
 }
 

--- a/src/administration.rs
+++ b/src/administration.rs
@@ -40,6 +40,10 @@ use crate::utilities::auth::generate_random_password;
 use crate::utilities::exporting::validate_template_sources_with_limits;
 use crate::utilities::is_valid_log_level;
 
+const DEFAULT_DATABASE_OWNER_ROLE: &str = "hubuum_owner";
+const DEFAULT_DATABASE_MIGRATOR_ROLE: &str = "hubuum_migrator";
+const DEFAULT_DATABASE_RUNTIME_ROLE: &str = "hubuum_runtime";
+
 #[derive(Parser)]
 #[command(
     author = "Terje Kvernes <terje@kvernes.no>",
@@ -140,28 +144,16 @@ struct AdminCli {
     migration_database_url: Option<String>,
 
     /// Non-login role that owns Hubuum database objects
-    #[arg(
-        long,
-        env = "HUBUUM_DATABASE_OWNER_ROLE",
-        default_value = "hubuum_owner"
-    )]
-    database_owner_role: String,
+    #[arg(long, env = "HUBUUM_DATABASE_OWNER_ROLE")]
+    database_owner_role: Option<String>,
 
     /// Login/workload role used only by migrations and destructive restore
-    #[arg(
-        long,
-        env = "HUBUUM_DATABASE_MIGRATOR_ROLE",
-        default_value = "hubuum_migrator"
-    )]
-    database_migrator_role: String,
+    #[arg(long, env = "HUBUUM_DATABASE_MIGRATOR_ROLE")]
+    database_migrator_role: Option<String>,
 
     /// Non-owning login role used by API and worker processes
-    #[arg(
-        long,
-        env = "HUBUUM_DATABASE_RUNTIME_ROLE",
-        default_value = "hubuum_runtime"
-    )]
-    database_runtime_role: String,
+    #[arg(long, env = "HUBUUM_DATABASE_RUNTIME_ROLE")]
+    database_runtime_role: Option<String>,
 
     /// Pool-global storage query timeout in milliseconds (0 disables it)
     #[arg(
@@ -216,12 +208,13 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
     let admin_cli = AdminCli::parse();
     init_logging(&admin_cli.log_level);
 
-    let database_roles = StorageDatabaseRoleNames::new(
-        admin_cli.database_owner_role.clone(),
-        admin_cli.database_migrator_role.clone(),
-        admin_cli.database_runtime_role.clone(),
-    )
-    .map_err(|error| ApiError::BadRequest(error.to_string()))?;
+    let (database_roles, database_roles_configured) = resolve_database_roles(
+        admin_cli.database_owner_role.as_deref(),
+        admin_cli.database_migrator_role.as_deref(),
+        admin_cli.database_runtime_role.as_deref(),
+    )?;
+    #[cfg(not(feature = "embedded-migrations"))]
+    let _ = database_roles_configured;
 
     if admin_cli.database_role_setup_sql {
         print!("{}", storage_database_role_setup_sql(&database_roles)?);
@@ -279,13 +272,22 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
 
     #[cfg(feature = "embedded-migrations")]
     if admin_cli.migrate {
-        let applied = run_storage_migrations(&storage_settings, Some(&database_roles))
-            .unwrap_or_else(|error| {
+        let migration_roles = database_roles_configured.then_some(&database_roles);
+        let applied =
+            run_storage_migrations(&storage_settings, migration_roles).unwrap_or_else(|error| {
                 fatal_error(
                     &format!("Failed to run storage migrations: {error}"),
                     EXIT_CODE_DATABASE_ERROR,
                 )
             });
+        if !database_roles_configured {
+            eprintln!(
+                "WARNING: no database role names were configured; migrations ran in legacy \
+                 single-role compatibility mode without privilege reconciliation. Complete the \
+                 database-role adoption procedure before enabling strict privilege checks or web \
+                 restore confirmations."
+            );
+        }
         println!("Applied {applied} storage migration(s).");
         return Ok(());
     }
@@ -346,6 +348,21 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
     }
 
     Ok(())
+}
+
+fn resolve_database_roles(
+    owner: Option<&str>,
+    migrator: Option<&str>,
+    runtime: Option<&str>,
+) -> Result<(StorageDatabaseRoleNames, bool), ApiError> {
+    let configured = owner.is_some() || migrator.is_some() || runtime.is_some();
+    let roles = StorageDatabaseRoleNames::new(
+        owner.unwrap_or(DEFAULT_DATABASE_OWNER_ROLE),
+        migrator.unwrap_or(DEFAULT_DATABASE_MIGRATOR_ROLE),
+        runtime.unwrap_or(DEFAULT_DATABASE_RUNTIME_ROLE),
+    )
+    .map_err(|error| ApiError::BadRequest(error.to_string()))?;
+    Ok((roles, configured))
 }
 
 fn print_database_privilege_report(
@@ -950,7 +967,11 @@ fn init_logging(log_level: &str) {
 mod tests {
     use clap::Parser;
 
-    use super::{AdminCli, StorageBackendKind};
+    use super::{
+        AdminCli, DEFAULT_DATABASE_MIGRATOR_ROLE, DEFAULT_DATABASE_OWNER_ROLE,
+        DEFAULT_DATABASE_RUNTIME_ROLE, StorageBackendKind, StorageDatabaseRoleNames,
+        resolve_database_roles,
+    };
 
     #[test]
     fn storage_backend_selection_defaults_only_for_an_empty_value() {
@@ -964,5 +985,30 @@ mod tests {
 
         assert_eq!(empty.storage_backend, StorageBackendKind::Postgres);
         assert_eq!(unsupported.kind(), clap::error::ErrorKind::InvalidValue);
+    }
+
+    #[test]
+    fn absent_database_role_configuration_selects_legacy_migration_mode() {
+        let (roles, configured) = resolve_database_roles(None, None, None).unwrap();
+
+        assert!(!configured);
+        assert_eq!(
+            roles,
+            StorageDatabaseRoleNames::new(
+                DEFAULT_DATABASE_OWNER_ROLE,
+                DEFAULT_DATABASE_MIGRATOR_ROLE,
+                DEFAULT_DATABASE_RUNTIME_ROLE,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn any_database_role_configuration_selects_split_role_migration_mode() {
+        let (roles, configured) =
+            resolve_database_roles(None, None, Some("existing_hubuum_login")).unwrap();
+
+        assert!(configured);
+        assert_eq!(roles.runtime(), "existing_hubuum_login");
     }
 }

--- a/src/administration.rs
+++ b/src/administration.rs
@@ -22,7 +22,9 @@ use crate::models::{
     BackupRequest, ExportContentType, RESTORE_CONFIRMATION_PHRASE, RestoreConfirmRequest,
     RestoreInitiator, RestoreJobID, RestoreStageRequest,
 };
-use crate::restores::{RestoreSettings, confirm_restore, stage_restore};
+use crate::restores::{
+    RestoreSettings, confirm_restore, execute_confirmed_restore, restore_status, stage_restore,
+};
 use crate::services::identity as identity_service;
 use crate::services::operational_administration as operational_service;
 #[cfg(feature = "embedded-migrations")]
@@ -61,6 +63,10 @@ struct AdminCli {
     /// Exact destructive confirmation phrase required with --restore
     #[arg(long, value_name = "PHRASE", requires = "restore")]
     restore_confirmation: Option<String>,
+
+    /// Run the isolated long-lived executor for confirmed web restores
+    #[arg(long, default_value_t = false)]
+    restore_executor: bool,
 
     /// Reset the password for the specified username
     #[arg(long)]
@@ -129,7 +135,7 @@ struct AdminCli {
     #[arg(long, env = "HUBUUM_DATABASE_URL")]
     database_url: Option<String>,
 
-    /// One-shot migration and destructive-restore database URL
+    /// Privileged migration and restore-executor database URL
     #[arg(long, env = "HUBUUM_MIGRATION_DATABASE_URL")]
     migration_database_url: Option<String>,
 
@@ -238,8 +244,11 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
     let migration_requested = admin_cli.migrate;
     #[cfg(not(feature = "embedded-migrations"))]
     let migration_requested = false;
-    let privileged_database_operation = migration_requested || admin_cli.restore.is_some();
-    let database_url = if privileged_database_operation {
+    let privileged_database_operation =
+        migration_requested || admin_cli.restore.is_some() || admin_cli.restore_executor;
+    let database_url = if admin_cli.restore_executor {
+        admin_cli.migration_database_url
+    } else if privileged_database_operation {
         admin_cli.migration_database_url.or(admin_cli.database_url)
     } else {
         admin_cli.database_url
@@ -247,7 +256,9 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
     let storage_settings = match admin_cli.storage_backend {
         StorageBackendKind::Postgres => {
             let database_url = database_url.unwrap_or_else(|| {
-                let variable = if privileged_database_operation {
+                let variable = if admin_cli.restore_executor {
+                    "HUBUUM_MIGRATION_DATABASE_URL"
+                } else if privileged_database_operation {
                     "HUBUUM_MIGRATION_DATABASE_URL (or the compatibility fallback HUBUUM_DATABASE_URL)"
                 } else {
                     "HUBUUM_DATABASE_URL"
@@ -304,7 +315,14 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
 
     let storage = initialize_storage(&storage_settings)?;
 
-    if let Some(path) = admin_cli.backup {
+    if admin_cli.restore_executor {
+        if !matches!(admin_cli.storage_backend, StorageBackendKind::Postgres) {
+            return Err(ApiError::BadRequest(
+                "The restore executor requires the PostgreSQL storage backend".to_string(),
+            ));
+        }
+        run_restore_executor(&storage).await?;
+    } else if let Some(path) = admin_cli.backup {
         backup_database(&storage, &path, !admin_cli.backup_without_history).await?;
     } else if let Some(path) = admin_cli.restore {
         restore_database(&storage, &path, admin_cli.restore_confirmation.as_deref()).await?;
@@ -719,25 +737,76 @@ async fn restore_database(
     let initiator = RestoreInitiator::new(None, "system", "hubuum-admin")?;
     let request = RestoreStageRequest::new(initiator, bytes)?;
     let staged = stage_restore(storage, &settings, request).await?;
-    let capability = staged.restore_capability.ok_or_else(|| {
+    let capability = staged.restore_capability.clone().ok_or_else(|| {
         ApiError::InternalServerError("Restore stage did not return a capability".to_string())
     })?;
-    let restored = confirm_restore(
+    let confirmed = confirm_restore(
         storage,
         RestoreJobID::new(staged.id)?,
         &RestoreConfirmRequest {
-            restore_capability: capability,
+            restore_capability: capability.clone(),
             sha256: staged.sha256,
             confirmation: RESTORE_CONFIRMATION_PHRASE.to_string(),
         },
     )
     .await?;
+    if !execute_confirmed_restore(storage).await? {
+        return Err(ApiError::Conflict(format!(
+            "Restore {} was confirmed but no longer owns draining maintenance",
+            confirmed.id
+        )));
+    }
+    let restored = restore_status(storage, RestoreJobID::new(confirmed.id)?, &capability).await?;
     println!(
         "Restore {} completed with status '{}'.",
         restored.id,
         restored.status.as_str()
     );
     Ok(())
+}
+
+async fn run_restore_executor(storage: &StorageHandle) -> Result<(), ApiError> {
+    println!("Restore executor is ready for confirmed web restores.");
+    loop {
+        match execute_confirmed_restore(storage).await {
+            Ok(true) => tracing::info!(message = "Confirmed restore completed"),
+            Ok(false) => {}
+            Err(error) => {
+                tracing::error!(message = "Restore executor iteration failed", error = %error)
+            }
+        }
+        tokio::select! {
+            result = wait_for_restore_executor_shutdown() => {
+                result?;
+                println!("Restore executor stopped.");
+                return Ok(());
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn wait_for_restore_executor_shutdown() -> Result<(), ApiError> {
+    let mut terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .map_err(|error| {
+        ApiError::InternalServerError(format!(
+            "Failed to install restore executor signal handler: {error}"
+        ))
+    })?;
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => result.map_err(|error| {
+            ApiError::InternalServerError(format!("Restore executor signal error: {error}"))
+        }),
+        _ = terminate.recv() => Ok(()),
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_restore_executor_shutdown() -> Result<(), ApiError> {
+    tokio::signal::ctrl_c().await.map_err(|error| {
+        ApiError::InternalServerError(format!("Restore executor signal error: {error}"))
+    })
 }
 
 fn destructive_confirmation_error() -> ApiError {

--- a/src/administration.rs
+++ b/src/administration.rs
@@ -97,6 +97,20 @@ struct AdminCli {
     #[arg(long, default_value_t = false)]
     migrate: bool,
 
+    /// Migrate an existing single-role database without reconciling split-role grants
+    #[cfg(feature = "embedded-migrations")]
+    #[arg(
+        long,
+        default_value_t = false,
+        requires = "migrate",
+        conflicts_with_all = [
+            "database_owner_role",
+            "database_migrator_role",
+            "database_runtime_role"
+        ]
+    )]
+    legacy_single_role_migration: bool,
+
     /// Print idempotent SQL for the configured owner, migrator, and runtime roles
     #[arg(long, default_value_t = false)]
     database_role_setup_sql: bool,
@@ -208,13 +222,11 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
     let admin_cli = AdminCli::parse();
     init_logging(&admin_cli.log_level);
 
-    let (database_roles, database_roles_configured) = resolve_database_roles(
+    let database_roles = resolve_database_roles(
         admin_cli.database_owner_role.as_deref(),
         admin_cli.database_migrator_role.as_deref(),
         admin_cli.database_runtime_role.as_deref(),
     )?;
-    #[cfg(not(feature = "embedded-migrations"))]
-    let _ = database_roles_configured;
 
     if admin_cli.database_role_setup_sql {
         print!("{}", storage_database_role_setup_sql(&database_roles)?);
@@ -272,7 +284,7 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
 
     #[cfg(feature = "embedded-migrations")]
     if admin_cli.migrate {
-        let migration_roles = database_roles_configured.then_some(&database_roles);
+        let migration_roles = (!admin_cli.legacy_single_role_migration).then_some(&database_roles);
         let applied =
             run_storage_migrations(&storage_settings, migration_roles).unwrap_or_else(|error| {
                 fatal_error(
@@ -280,10 +292,10 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
                     EXIT_CODE_DATABASE_ERROR,
                 )
             });
-        if !database_roles_configured {
+        if admin_cli.legacy_single_role_migration {
             eprintln!(
-                "WARNING: no database role names were configured; migrations ran in legacy \
-                 single-role compatibility mode without privilege reconciliation. Complete the \
+                "WARNING: --legacy-single-role-migration was requested; migrations ran as the \
+                 connected existing owner without privilege reconciliation. Complete the \
                  database-role adoption procedure before enabling strict privilege checks or web \
                  restore confirmations."
             );
@@ -354,15 +366,13 @@ fn resolve_database_roles(
     owner: Option<&str>,
     migrator: Option<&str>,
     runtime: Option<&str>,
-) -> Result<(StorageDatabaseRoleNames, bool), ApiError> {
-    let configured = owner.is_some() || migrator.is_some() || runtime.is_some();
-    let roles = StorageDatabaseRoleNames::new(
+) -> Result<StorageDatabaseRoleNames, ApiError> {
+    StorageDatabaseRoleNames::new(
         owner.unwrap_or(DEFAULT_DATABASE_OWNER_ROLE),
         migrator.unwrap_or(DEFAULT_DATABASE_MIGRATOR_ROLE),
         runtime.unwrap_or(DEFAULT_DATABASE_RUNTIME_ROLE),
     )
-    .map_err(|error| ApiError::BadRequest(error.to_string()))?;
-    Ok((roles, configured))
+    .map_err(|error| ApiError::BadRequest(error.to_string()))
 }
 
 fn print_database_privilege_report(
@@ -988,10 +998,9 @@ mod tests {
     }
 
     #[test]
-    fn absent_database_role_configuration_selects_legacy_migration_mode() {
-        let (roles, configured) = resolve_database_roles(None, None, None).unwrap();
+    fn absent_database_role_configuration_uses_documented_defaults() {
+        let roles = resolve_database_roles(None, None, None).unwrap();
 
-        assert!(!configured);
         assert_eq!(
             roles,
             StorageDatabaseRoleNames::new(
@@ -1004,11 +1013,41 @@ mod tests {
     }
 
     #[test]
-    fn any_database_role_configuration_selects_split_role_migration_mode() {
-        let (roles, configured) =
-            resolve_database_roles(None, None, Some("existing_hubuum_login")).unwrap();
+    fn database_role_configuration_overrides_individual_defaults() {
+        let roles = resolve_database_roles(None, None, Some("existing_hubuum_login")).unwrap();
 
-        assert!(configured);
         assert_eq!(roles.runtime(), "existing_hubuum_login");
+    }
+
+    #[cfg(feature = "embedded-migrations")]
+    #[test]
+    fn legacy_single_role_migration_requires_migrate() {
+        let error =
+            match AdminCli::try_parse_from(["hubuum-admin", "--legacy-single-role-migration"]) {
+                Ok(_) => panic!("the compatibility bridge must require --migrate"),
+                Err(error) => error,
+            };
+
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+    }
+
+    #[cfg(feature = "embedded-migrations")]
+    #[test]
+    fn legacy_single_role_migration_rejects_split_role_names() {
+        let error = match AdminCli::try_parse_from([
+            "hubuum-admin",
+            "--migrate",
+            "--legacy-single-role-migration",
+            "--database-runtime-role",
+            "existing_hubuum_login",
+        ]) {
+            Ok(_) => panic!("legacy migration must not accept split-role configuration"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 }

--- a/src/api/v1/handlers/restores.rs
+++ b/src/api/v1/handlers/restores.rs
@@ -13,7 +13,7 @@ use crate::models::{
 };
 use crate::permissions::AppContext;
 use crate::restores::{
-    RestoreSettings, resolve_identity_scope_name, restore_status, stage_restore,
+    RestoreSettings, confirm_restore, resolve_identity_scope_name, restore_status, stage_restore,
 };
 
 const RESTORE_CAPABILITY_HEADER: &str = "X-Hubuum-Restore-Capability";
@@ -75,22 +75,27 @@ pub async fn create_restore_stage(
     params(("restore_id" = i64, Path, description = "Restore stage ID", minimum = 1)),
     request_body = RestoreConfirmRequest,
     responses(
-        (status = 501, description = "Destructive restore requires hubuum-admin and a migration credential", body = ApiErrorResponse),
+        (status = 202, description = "Restore confirmed and queued for the isolated executor", body = RestoreStageResponse,
+            headers(("Cache-Control" = String, description = "Always no-store for restore metadata"))
+        ),
+        (status = 400, description = "Invalid confirmation", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
-        (status = 403, description = "Administrator access required", body = ApiErrorResponse)
+        (status = 403, description = "Administrator access required or restore capability rejected", body = ApiErrorResponse),
+        (status = 409, description = "Restore stage cannot be confirmed", body = ApiErrorResponse),
+        (status = 410, description = "Restore stage expired", body = ApiErrorResponse)
     )
 )]
 #[post("/{restore_id}/confirm")]
 pub async fn confirm_restore_stage(
-    _context: AppContext,
+    context: AppContext,
     _admin: AdminAccess,
-    _restore_id: web::Path<RestoreJobID>,
-    _confirmation: web::Json<RestoreConfirmRequest>,
+    restore_id: web::Path<RestoreJobID>,
+    confirmation: web::Json<RestoreConfirmRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    Err(ApiError::NotImplemented(
-        "API-driven destructive restore is disabled; run hubuum-admin --restore with HUBUUM_MIGRATION_DATABASE_URL"
-            .to_string(),
-    ))
+    let response = confirm_restore(&context, restore_id.into_inner(), &confirmation).await?;
+    Ok(HttpResponse::Accepted()
+        .insert_header(("Cache-Control", "no-store"))
+        .json(response))
 }
 
 #[utoipa::path(

--- a/src/api/v1/handlers/restores.rs
+++ b/src/api/v1/handlers/restores.rs
@@ -13,7 +13,7 @@ use crate::models::{
 };
 use crate::permissions::AppContext;
 use crate::restores::{
-    RestoreSettings, confirm_restore, resolve_identity_scope_name, restore_status, stage_restore,
+    RestoreSettings, resolve_identity_scope_name, restore_status, stage_restore,
 };
 
 const RESTORE_CAPABILITY_HEADER: &str = "X-Hubuum-Restore-Capability";
@@ -75,25 +75,22 @@ pub async fn create_restore_stage(
     params(("restore_id" = i64, Path, description = "Restore stage ID", minimum = 1)),
     request_body = RestoreConfirmRequest,
     responses(
-        (status = 200, description = "Restore completed", body = RestoreStageResponse,
-            headers(("Cache-Control" = String, description = "Always no-store for restore metadata"))
-        ),
-        (status = 400, description = "Confirmation phrase is invalid", body = ApiErrorResponse),
+        (status = 501, description = "Destructive restore requires hubuum-admin and a migration credential", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
-        (status = 403, description = "Administrator or capability rejected", body = ApiErrorResponse),
-        (status = 409, description = "Stage state or SHA-256 mismatch", body = ApiErrorResponse),
-        (status = 410, description = "Restore stage expired", body = ApiErrorResponse)
+        (status = 403, description = "Administrator access required", body = ApiErrorResponse)
     )
 )]
 #[post("/{restore_id}/confirm")]
 pub async fn confirm_restore_stage(
-    context: AppContext,
+    _context: AppContext,
     _admin: AdminAccess,
-    restore_id: web::Path<RestoreJobID>,
-    confirmation: web::Json<RestoreConfirmRequest>,
-) -> Result<impl Responder, ApiError> {
-    let response = confirm_restore(&context, restore_id.into_inner(), &confirmation).await?;
-    Ok(ApiResponse::new_no_store(response, StatusCode::OK))
+    _restore_id: web::Path<RestoreJobID>,
+    _confirmation: web::Json<RestoreConfirmRequest>,
+) -> Result<HttpResponse, ApiError> {
+    Err(ApiError::NotImplemented(
+        "API-driven destructive restore is disabled; run hubuum-admin --restore with HUBUUM_MIGRATION_DATABASE_URL"
+            .to_string(),
+    ))
 }
 
 #[utoipa::path(

--- a/src/application.rs
+++ b/src/application.rs
@@ -22,7 +22,8 @@ use crate::config::get_config;
 use crate::config::initialize_config;
 use crate::config::running::RunningConfig;
 use crate::config::{
-    AppConfig, ClientAllowlist, LoginRateLimitBackendKind, MetricsPath, token_hash_key_ring,
+    AppConfig, ClientAllowlist, DatabasePrivilegeMode, LoginRateLimitBackendKind, MetricsPath,
+    token_hash_key_ring,
 };
 use crate::errors::{
     EXIT_CODE_CONFIG_ERROR, EXIT_CODE_DATABASE_ERROR, EXIT_CODE_INIT_ERROR,
@@ -42,7 +43,8 @@ use crate::permissions::{AppContext, build_permission_backend};
 use crate::restores::{RestoreSettings, ensure_restore_coordinator_running};
 use crate::services::event_administration::count_enabled_event_sinks;
 use crate::storage::{
-    OperationalStateStorage, StorageBackendKind, StorageSettings, initialize_storage,
+    OperationalStateStorage, StorageBackendKind, StorageDatabaseRole, StorageDatabaseRoleNames,
+    StorageSettings, initialize_storage, inspect_storage_database_privileges,
 };
 use crate::tasks::{ensure_task_worker_running_with_settings, initialize_task_worker_settings};
 use crate::token_retention::ensure_token_retention_worker_running;
@@ -163,6 +165,69 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
             "Storage backend schema is not ready",
             EXIT_CODE_DATABASE_ERROR,
         );
+    }
+    if config.storage_backend == StorageBackendKind::Postgres {
+        let database_roles = StorageDatabaseRoleNames::new(
+            config.database_owner_role.clone(),
+            config.database_migrator_role.clone(),
+            config.database_runtime_role.clone(),
+        )
+        .unwrap_or_else(|error| fatal_error(&error.to_string(), EXIT_CODE_CONFIG_ERROR));
+        let privilege_report = inspect_storage_database_privileges(
+            &storage_settings,
+            StorageDatabaseRole::Runtime,
+            &database_roles,
+        )
+        .await;
+        match privilege_report {
+            Ok(Some(report)) if report.is_safe() => {
+                info!(
+                    message = "Database runtime privileges satisfy the generated manifest",
+                    role = report.role(),
+                    privilege_mode = config.database_privilege_mode.as_str(),
+                );
+            }
+            Ok(Some(report)) => {
+                for finding in report.dangerous() {
+                    warn!(
+                        message = "Dangerous database runtime privilege detected",
+                        role = report.role(),
+                        code = finding.code(),
+                        object = finding.object(),
+                        detail = finding.detail(),
+                    );
+                }
+                for finding in report.missing() {
+                    warn!(
+                        message = "Required database runtime privilege is missing",
+                        role = report.role(),
+                        code = finding.code(),
+                        object = finding.object(),
+                        detail = finding.detail(),
+                    );
+                }
+                if config.database_privilege_mode == DatabasePrivilegeMode::Strict {
+                    fatal_error(
+                        "Database runtime privileges do not satisfy the generated manifest",
+                        EXIT_CODE_DATABASE_ERROR,
+                    );
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                warn!(
+                    message = "Database runtime privilege inspection failed",
+                    role = database_roles.runtime(),
+                    error = %error,
+                );
+                if config.database_privilege_mode == DatabasePrivilegeMode::Strict {
+                    fatal_error(
+                        "Database runtime privilege inspection failed in strict mode",
+                        EXIT_CODE_DATABASE_ERROR,
+                    );
+                }
+            }
+        }
     }
 
     let backup_settings = BackupSettings::new(

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,6 +125,23 @@ pub enum RuntimeRole {
     Worker,
 }
 
+#[derive(ValueEnum, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum DatabasePrivilegeMode {
+    #[default]
+    Warn,
+    Strict,
+}
+
+impl DatabasePrivilegeMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Warn => "warn",
+            Self::Strict => "strict",
+        }
+    }
+}
+
 impl RuntimeRole {
     pub const fn serves_http(self) -> bool {
         matches!(self, Self::All | Self::Api)
@@ -203,6 +220,39 @@ pub struct AppConfig {
         default_value = "postgres://localhost"
     )]
     pub database_url: String,
+
+    /// Whether unsafe or incomplete PostgreSQL runtime grants warn or fail startup
+    #[clap(
+        long,
+        env = "HUBUUM_DATABASE_PRIVILEGE_MODE",
+        value_enum,
+        default_value = "warn"
+    )]
+    pub database_privilege_mode: DatabasePrivilegeMode,
+
+    /// Non-login PostgreSQL role that owns Hubuum database objects
+    #[clap(
+        long,
+        env = "HUBUUM_DATABASE_OWNER_ROLE",
+        default_value = "hubuum_owner"
+    )]
+    pub database_owner_role: String,
+
+    /// PostgreSQL role used by one-shot migrations and destructive restore
+    #[clap(
+        long,
+        env = "HUBUUM_DATABASE_MIGRATOR_ROLE",
+        default_value = "hubuum_migrator"
+    )]
+    pub database_migrator_role: String,
+
+    /// Non-owning PostgreSQL role used by API and worker processes
+    #[clap(
+        long,
+        env = "HUBUUM_DATABASE_RUNTIME_ROLE",
+        default_value = "hubuum_runtime"
+    )]
+    pub database_runtime_role: String,
 
     /// Number of Actix workers
     #[clap(
@@ -1524,6 +1574,13 @@ fn get_config_from_env() -> Result<AppConfig, ApiError> {
             .unwrap_or(8080),
         log_level: env_or_default("HUBUUM_LOG_LEVEL", "debug"),
         database_url: env_or_default("HUBUUM_DATABASE_URL", "postgres://test"),
+        database_privilege_mode: env::var("HUBUUM_DATABASE_PRIVILEGE_MODE")
+            .ok()
+            .and_then(|value| DatabasePrivilegeMode::from_str(&value, true).ok())
+            .unwrap_or_default(),
+        database_owner_role: env_or_default("HUBUUM_DATABASE_OWNER_ROLE", "hubuum_owner"),
+        database_migrator_role: env_or_default("HUBUUM_DATABASE_MIGRATOR_ROLE", "hubuum_migrator"),
+        database_runtime_role: env_or_default("HUBUUM_DATABASE_RUNTIME_ROLE", "hubuum_runtime"),
         actix_workers: env::var("HUBUUM_ACTIX_WORKERS")
             .ok()
             .and_then(|value| value.parse().ok())

--- a/src/config/environment.rs
+++ b/src/config/environment.rs
@@ -62,6 +62,10 @@ pub const APP_CONFIG_ENVIRONMENT: &[EnvironmentVariable] = &[
     option!("HUBUUM_RUNTIME_ROLE", Server),
     option!("HUBUUM_STORAGE_BACKEND", Database),
     option!("HUBUUM_DATABASE_URL", Database, sensitive),
+    option!("HUBUUM_DATABASE_PRIVILEGE_MODE", Database),
+    option!("HUBUUM_DATABASE_OWNER_ROLE", Database),
+    option!("HUBUUM_DATABASE_MIGRATOR_ROLE", Database),
+    option!("HUBUUM_DATABASE_RUNTIME_ROLE", Database),
     option!("HUBUUM_DB_POOL_SIZE", Database),
     option!("HUBUUM_DB_POOL_ACQUIRE_TIMEOUT_MS", Database),
     option!("HUBUUM_DB_STATEMENT_TIMEOUT_MS", Database),
@@ -176,6 +180,8 @@ pub const APP_CONFIG_ENVIRONMENT: &[EnvironmentVariable] = &[
 
 /// Exact Hubuum variables resolved outside clap's `AppConfig` adapter.
 pub const PROCESS_ENVIRONMENT: &[EnvironmentVariable] = &[
+    option!("HUBUUM_MIGRATION_DATABASE_URL", Database, sensitive),
+    option!("HUBUUM_DATABASE_ROLE_TESTS", Operations),
     option!("HUBUUM_TOKEN_HASH_KEY", Authentication, sensitive),
     option!("HUBUUM_TOKEN_HASH_ACTIVE_KEY_ID", Authentication),
     option!("HUBUUM_TOKEN_HASH_PREVIOUS_KEY_IDS", Authentication),
@@ -183,7 +189,6 @@ pub const PROCESS_ENVIRONMENT: &[EnvironmentVariable] = &[
     option!("HUBUUM_SECRET_SOURCE", Operations),
     option!("HUBUUM_SECRET_FILE_ROOT", Operations, sensitive),
     option!("HUBUUM_BUILD_GIT_SHA", Operations),
-    option!("HUBUUM_SKIP_MIGRATIONS", Operations),
     option!("HUBUUM_AUTH_CONFIG_HOST_PATH", Operations, sensitive),
     option!("HUBUUM_TREETOP_TEST_URL", Permissions, sensitive),
     option!("HUBUUM_TREETOP_TEST_CONTAINER_NAME", Permissions),
@@ -211,6 +216,8 @@ pub const ENVIRONMENT_ADAPTER_PATHS: &[&str] = &[
     "src/administration.rs",
     "src/logger.rs",
     "src/secrets.rs",
+    "src/test_support.rs",
+    "src/tests/temporal/mod.rs",
     "src/tests/permissions/live_treetop_parity.rs",
     "crates/hubuum-storage-postgres/src/test_support.rs",
 ];

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -105,6 +105,10 @@ pub struct DatabaseConfig {
     pub pool_size: u32,
     pub pool_acquire_timeout_ms: u64,
     pub statement_timeout_ms: u64,
+    pub privilege_mode: String,
+    pub owner_role: String,
+    pub migrator_role: String,
+    pub runtime_role: String,
 }
 
 #[derive(Clone, Debug, Serialize, ToSchema)]
@@ -318,6 +322,10 @@ impl RunningConfig {
                 pool_size: config.db_pool_size,
                 pool_acquire_timeout_ms: config.db_pool_acquire_timeout_ms,
                 statement_timeout_ms: config.db_statement_timeout_ms,
+                privilege_mode: config.database_privilege_mode.as_str().to_string(),
+                owner_role: config.database_owner_role.clone(),
+                migrator_role: config.database_migrator_role.clone(),
+                runtime_role: config.database_runtime_role.clone(),
             },
             tasks: TaskConfig {
                 workers: config.task_workers,

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -77,7 +77,6 @@ fn run_entrypoint(runtime_role: &str, arguments: &[&str]) -> Output {
         .args(arguments)
         .env("PATH", &commands)
         .env("HUBUUM_RUNTIME_ROLE", runtime_role)
-        .env_remove("HUBUUM_SKIP_MIGRATIONS")
         .output()
         .expect("entrypoint should run");
     fs::remove_dir_all(commands).expect("fake command directory should be removed");
@@ -180,12 +179,11 @@ fn production_container_has_a_healthcheck() {
 
 #[cfg(unix)]
 #[rstest]
-#[case("all", "worker", "admin:--database-ready")]
-#[case("worker", "all", "admin:--migrate")]
-fn entrypoint_cli_runtime_role_overrides_environment_for_migrations(
+#[case("all", "worker")]
+#[case("worker", "all")]
+fn entrypoint_uses_only_the_readiness_probe_before_starting_the_server(
     #[case] environment_role: &str,
     #[case] cli_role: &str,
-    #[case] expected_admin_command: &str,
 ) {
     let output = run_entrypoint(
         environment_role,
@@ -194,7 +192,8 @@ fn entrypoint_cli_runtime_role_overrides_environment_for_migrations(
     let stdout = String::from_utf8(output.stdout).unwrap();
 
     assert!(output.status.success(), "entrypoint failed: {stdout}");
-    assert!(stdout.contains(expected_admin_command));
+    assert!(stdout.contains("admin:--database-ready"));
+    assert!(!stdout.contains("admin:--migrate"));
     assert!(stdout.contains(&format!(
         "server:--runtime-role {cli_role} --log-level debug"
     )));

--- a/src/models/backup.rs
+++ b/src/models/backup.rs
@@ -332,7 +332,7 @@ pub struct RestoreStageResponse {
     pub validation: RestoreValidationSummary,
     /// Returned only when a stage is created. It is stored only as a hash and
     /// must be supplied to confirm or inspect the restore while its staging
-    /// record exists. A successful restore deletes every staging record.
+    /// record exists. Success retains only a document-free terminal receipt.
     pub restore_capability: Option<String>,
 }
 

--- a/src/restores/mod.rs
+++ b/src/restores/mod.rs
@@ -36,8 +36,9 @@ const RESTORE_DRAIN_TIMEOUT_SECONDS: u64 = 30;
 const RESTORE_STAGE_EXPIRY_INTERVAL_SECONDS: u64 = 60;
 const MISSING_RESTORE_CAPABILITY_HASH: &str =
     "0000000000000000000000000000000000000000000000000000000000000000";
-// Keep this longer than the bounded drain so normal confirmations enter the
-// advisory-lock-protected restore transaction before recovery is eligible.
+// Compatibility recovery for confirmations created by older in-process
+// coordinators retains their original grace period. The dedicated executor
+// does not wait for this threshold.
 const RESTORE_RECONCILIATION_GRACE_SECONDS: i64 = 60;
 
 struct RestoreJobSummaryData {
@@ -955,30 +956,14 @@ pub async fn confirm_restore(
         ApiError::InternalServerError(format!("Staged restore document became invalid: {error}"))
     })?;
     let validation = validation_summary(&document)?;
-    // The maintenance transition commits before the destructive transaction,
-    // allowing every instance to reject new work. ACCESS EXCLUSIVE table locks
-    // in `apply_restore` are the final drain barrier for requests already in
-    // flight. A failed restore rolls the data transaction back intact.
+    // Confirmation commits only the maintenance transition. A separately
+    // deployed executor owns the privileged destructive transaction, so the
+    // API and worker processes never need a migration credential.
     let job_id = restore_job_id_to_storage(job.id);
     let confirmed_at = storage_handle(pool).start_restore_draining(job_id).await?;
-
-    if let Err(error) = wait_for_instances_drained(pool).await {
-        fail_restore_and_resume(pool, job_id, &error).await?;
-        return Err(error);
-    }
-
-    let completion = match apply_restore(pool, job_id, document).await {
-        Ok(completion) => completion,
-        Err(error) => {
-            fail_restore_and_resume(pool, job_id, &error).await?;
-            return Err(error);
-        }
-    };
-
-    let (started_at, finished_at) = completion.into_parts();
     Ok(RestoreStageResponse {
         id: job.id,
-        status: RestoreJobStatus::Succeeded,
+        status: RestoreJobStatus::Confirmed,
         requested_by: job.requested_by,
         requested_by_identity_scope: job.requested_by_identity_scope,
         requested_by_name: job.requested_by_name,
@@ -987,10 +972,10 @@ pub async fn confirm_restore(
         expires_at: job.expires_at,
         error: None,
         confirmed_at: Some(confirmed_at.naive_utc()),
-        started_at: Some(started_at.naive_utc()),
-        finished_at: Some(finished_at.naive_utc()),
+        started_at: None,
+        finished_at: None,
         created_at: job.created_at,
-        updated_at: finished_at.naive_utc(),
+        updated_at: confirmed_at.naive_utc(),
         validation,
         restore_capability: None,
     })
@@ -998,24 +983,39 @@ pub async fn confirm_restore(
 
 /// Resume a restore whose committed maintenance transition survived a process
 /// restart. The destructive transaction is guarded by an advisory lock and
-/// re-checks the job/maintenance state. Once one coordinator commits, the
-/// maintenance row is normal and every restore staging row has been removed.
+/// re-checks the job/maintenance state. This compatibility recovery entrypoint
+/// retains the grace period used by older in-process coordinators.
 pub async fn reconcile_interrupted_restore(
     pool: &impl crate::storage::StorageContext,
 ) -> Result<(), ApiError> {
     let snapshot = storage_handle(pool)
         .get_restore_coordinator_snapshot()
         .await?;
-    reconcile_interrupted_restore_from_snapshot(pool, snapshot).await
+    reconcile_restore_from_snapshot(pool, snapshot, true)
+        .await
+        .map(|_| ())
 }
 
-async fn reconcile_interrupted_restore_from_snapshot(
+/// Apply one confirmed restore, if present, using an isolated privileged
+/// storage handle. The caller is expected to poll this operation from the
+/// dedicated restore-executor workload.
+pub async fn execute_confirmed_restore(
+    pool: &impl crate::storage::StorageContext,
+) -> Result<bool, ApiError> {
+    let snapshot = storage_handle(pool)
+        .get_restore_coordinator_snapshot()
+        .await?;
+    reconcile_restore_from_snapshot(pool, snapshot, false).await
+}
+
+async fn reconcile_restore_from_snapshot(
     pool: &impl crate::storage::StorageContext,
     snapshot: StorageRestoreCoordinatorSnapshot,
-) -> Result<(), ApiError> {
+    require_stale_confirmation: bool,
+) -> Result<bool, ApiError> {
     let maintenance_state = snapshot.maintenance_state();
     if maintenance_state.is_normal() {
-        return Ok(());
+        return Ok(false);
     }
     if maintenance_state != MaintenanceState::Draining {
         return Err(ApiError::InternalServerError(format!(
@@ -1049,7 +1049,7 @@ async fn reconcile_interrupted_restore_from_snapshot(
         RestoreJobStatus::Failed | RestoreJobStatus::Expired
     ) {
         storage_handle(pool).resume_terminal_restore(job_id).await?;
-        return Ok(());
+        return Ok(false);
     }
     if job.status != RestoreJobStatus::Confirmed {
         let error = ApiError::Conflict(format!(
@@ -1066,8 +1066,10 @@ async fn reconcile_interrupted_restore_from_snapshot(
         fail_restore_and_resume(pool, job_id, &error).await?;
         return Err(error);
     };
-    if !confirmation_is_stale(confirmed_at, snapshot.backend_now().naive_utc()) {
-        return Ok(());
+    if require_stale_confirmation
+        && !confirmation_is_stale(confirmed_at, snapshot.backend_now().naive_utc())
+    {
+        return Ok(false);
     }
 
     let document: BackupDocument = match serde_json::from_slice(&document_bytes) {
@@ -1092,7 +1094,7 @@ async fn reconcile_interrupted_restore_from_snapshot(
         fail_restore_and_resume(pool, job_id, &error).await?;
         return Err(error);
     }
-    Ok(())
+    Ok(true)
 }
 
 async fn heartbeat_instance(
@@ -1139,23 +1141,6 @@ async fn wait_for_instances_drained(
     }
 }
 
-async fn reconcile_interrupted_restore_with_heartbeat(
-    pool: &impl crate::storage::StorageContext,
-    instance_id: Uuid,
-    snapshot: StorageRestoreCoordinatorSnapshot,
-) -> Result<(), ApiError> {
-    let reconciliation = reconcile_interrupted_restore_from_snapshot(pool, snapshot);
-    tokio::pin!(reconciliation);
-    loop {
-        tokio::select! {
-            result = &mut reconciliation => return result,
-            _ = actix_rt::time::sleep(StdDuration::from_secs(1)) => {
-                heartbeat_instance(pool, instance_id, false).await?;
-            }
-        }
-    }
-}
-
 pub fn ensure_restore_coordinator_running<C>(backend: C)
 where
     C: StorageContext,
@@ -1172,25 +1157,10 @@ where
                         last_run.elapsed()
                             >= StdDuration::from_secs(RESTORE_STAGE_EXPIRY_INTERVAL_SECONDS)
                     });
-                    let snapshot =
-                        heartbeat_instance(&pool, instance_id, expire_validated_jobs).await;
-                    match snapshot {
-                        Ok(snapshot) => {
+                    match heartbeat_instance(&pool, instance_id, expire_validated_jobs).await {
+                        Ok(_) => {
                             if expire_validated_jobs {
                                 last_expiry_run = Some(Instant::now());
-                            }
-                            if let Err(error) = reconcile_interrupted_restore_with_heartbeat(
-                                &pool,
-                                instance_id,
-                                snapshot,
-                            )
-                            .await
-                            {
-                                tracing::error!(
-                                    message = "Interrupted restore reconciliation failed",
-                                    instance_id = %instance_id,
-                                    error = %error,
-                                );
                             }
                         }
                         Err(error) => {

--- a/src/storage/factory.rs
+++ b/src/storage/factory.rs
@@ -11,9 +11,13 @@ use std::time::Duration;
 
 use hubuum_storage_core::{StorageCallSite, StorageNotification};
 use hubuum_storage_postgres::{
-    PostgresObserver, PostgresPool, PostgresPoolBuildError, PostgresPoolSettings, PostgresStorage,
-    build_postgres_pool,
+    DatabasePrivilegeFinding as PostgresDatabasePrivilegeFinding,
+    DatabasePrivilegeReport as PostgresDatabasePrivilegeReport,
+    DatabaseRoleNames as PostgresDatabaseRoleNames, PostgresObserver, PostgresPool,
+    PostgresPoolBuildError, PostgresPoolSettings, PostgresStorage, build_postgres_pool,
+    inspect_database_privileges,
 };
+use serde::Serialize;
 use tracing::{error, info};
 
 use super::{
@@ -21,6 +25,124 @@ use super::{
     DatabasePoolConnections, DatabasePoolState, DatabaseStorageSnapshot, StorageBackendKind,
     StorageError, StorageErrorKind, StorageHandle,
 };
+
+/// Validated names for the database roles used by application composition.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct StorageDatabaseRoleNames {
+    owner: String,
+    migrator: String,
+    runtime: String,
+}
+
+impl StorageDatabaseRoleNames {
+    pub(crate) fn new(
+        owner: impl Into<String>,
+        migrator: impl Into<String>,
+        runtime: impl Into<String>,
+    ) -> Result<Self, StorageError> {
+        let names = Self {
+            owner: owner.into(),
+            migrator: migrator.into(),
+            runtime: runtime.into(),
+        };
+        names.postgres_names()?;
+        Ok(names)
+    }
+
+    pub(crate) fn runtime(&self) -> &str {
+        &self.runtime
+    }
+
+    fn postgres_names(&self) -> Result<PostgresDatabaseRoleNames, StorageError> {
+        PostgresDatabaseRoleNames::new(
+            self.owner.clone(),
+            self.migrator.clone(),
+            self.runtime.clone(),
+        )
+        .map_err(StorageError::from)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum StorageDatabaseRole {
+    Owner,
+    Migrator,
+    Runtime,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct StorageDatabasePrivilegeFinding {
+    code: String,
+    object: String,
+    detail: String,
+}
+
+impl StorageDatabasePrivilegeFinding {
+    pub(crate) fn code(&self) -> &str {
+        &self.code
+    }
+
+    pub(crate) fn object(&self) -> &str {
+        &self.object
+    }
+
+    pub(crate) fn detail(&self) -> &str {
+        &self.detail
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct StorageDatabasePrivilegeReport {
+    role: String,
+    connected_role: String,
+    safe: bool,
+    dangerous: Vec<StorageDatabasePrivilegeFinding>,
+    missing: Vec<StorageDatabasePrivilegeFinding>,
+}
+
+impl StorageDatabasePrivilegeReport {
+    pub(crate) fn role(&self) -> &str {
+        &self.role
+    }
+
+    pub(crate) fn connected_role(&self) -> &str {
+        &self.connected_role
+    }
+
+    pub(crate) const fn is_safe(&self) -> bool {
+        self.safe
+    }
+
+    pub(crate) fn dangerous(&self) -> &[StorageDatabasePrivilegeFinding] {
+        &self.dangerous
+    }
+
+    pub(crate) fn missing(&self) -> &[StorageDatabasePrivilegeFinding] {
+        &self.missing
+    }
+}
+
+impl From<PostgresDatabasePrivilegeReport> for StorageDatabasePrivilegeReport {
+    fn from(report: PostgresDatabasePrivilegeReport) -> Self {
+        let findings = |source: &[PostgresDatabasePrivilegeFinding]| {
+            source
+                .iter()
+                .map(|finding| StorageDatabasePrivilegeFinding {
+                    code: finding.code().to_string(),
+                    object: finding.object().to_string(),
+                    detail: finding.detail().to_string(),
+                })
+                .collect::<Vec<_>>()
+        };
+        Self {
+            role: report.role().to_string(),
+            connected_role: report.connected_role().to_string(),
+            safe: report.is_safe(),
+            dangerous: findings(report.dangerous()),
+            missing: findings(report.missing()),
+        }
+    }
+}
 
 #[derive(Debug)]
 struct ApplicationPostgresObserver;
@@ -294,8 +416,36 @@ impl PostgresAdapterFactory {
     }
 
     #[cfg(feature = "embedded-migrations")]
-    fn run_migrations(settings: &PostgresPoolSettings) -> Result<usize, StorageError> {
-        hubuum_storage_postgres::run_embedded_migrations(settings.connection_url())
+    fn run_migrations(
+        settings: &PostgresPoolSettings,
+        roles: Option<&PostgresDatabaseRoleNames>,
+    ) -> Result<usize, StorageError> {
+        match roles {
+            Some(roles) => hubuum_storage_postgres::run_embedded_migrations_as(
+                settings.connection_url(),
+                roles,
+            ),
+            None => hubuum_storage_postgres::run_embedded_migrations(settings.connection_url()),
+        }
+    }
+
+    async fn inspect_privileges(
+        settings: &PostgresPoolSettings,
+        role: StorageDatabaseRole,
+        roles: &PostgresDatabaseRoleNames,
+    ) -> Result<StorageDatabasePrivilegeReport, StorageError> {
+        let pool_settings =
+            operational_pool_settings(settings, 1).map_err(Self::initialization_error)?;
+        let pool = build_postgres_pool(&pool_settings).map_err(Self::initialization_error)?;
+        let role = match role {
+            StorageDatabaseRole::Owner => roles.owner(),
+            StorageDatabaseRole::Migrator => roles.migrator(),
+            StorageDatabaseRole::Runtime => roles.runtime(),
+        };
+        inspect_database_privileges(&pool, role, roles)
+            .await
+            .map_err(StorageError::from)
+            .map(StorageDatabasePrivilegeReport::from)
     }
 }
 
@@ -328,12 +478,51 @@ pub(crate) fn initialize_storage(
 }
 
 #[cfg(feature = "embedded-migrations")]
-pub(crate) fn run_storage_migrations(settings: &StorageSettings) -> Result<usize, StorageError> {
+pub(crate) fn run_storage_migrations(
+    settings: &StorageSettings,
+    roles: Option<&StorageDatabaseRoleNames>,
+) -> Result<usize, StorageError> {
+    match &settings.adapter {
+        StorageAdapterSettings::Postgres(settings) => match roles {
+            Some(roles) => {
+                let roles = roles.postgres_names()?;
+                PostgresAdapterFactory::run_migrations(settings, Some(&roles))
+            }
+            None => PostgresAdapterFactory::run_migrations(settings, None),
+        },
+        StorageAdapterSettings::Memory => Ok(0),
+    }
+}
+
+pub(crate) fn storage_database_role_setup_sql(
+    roles: &StorageDatabaseRoleNames,
+) -> Result<String, StorageError> {
+    Ok(hubuum_storage_postgres::database_role_setup_sql(
+        &roles.postgres_names()?,
+    ))
+}
+
+pub(crate) fn storage_database_role_grants_sql(
+    roles: &StorageDatabaseRoleNames,
+) -> Result<String, StorageError> {
+    Ok(hubuum_storage_postgres::database_role_reconciliation_sql(
+        &roles.postgres_names()?,
+    ))
+}
+
+pub(crate) async fn inspect_storage_database_privileges(
+    settings: &StorageSettings,
+    role: StorageDatabaseRole,
+    roles: &StorageDatabaseRoleNames,
+) -> Result<Option<StorageDatabasePrivilegeReport>, StorageError> {
     match &settings.adapter {
         StorageAdapterSettings::Postgres(settings) => {
-            PostgresAdapterFactory::run_migrations(settings)
+            let roles = roles.postgres_names()?;
+            PostgresAdapterFactory::inspect_privileges(settings, role, &roles)
+                .await
+                .map(Some)
         }
-        StorageAdapterSettings::Memory => Ok(0),
+        StorageAdapterSettings::Memory => Ok(None),
     }
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -27,7 +27,11 @@ pub use execution::{
 };
 #[cfg(feature = "embedded-migrations")]
 pub(crate) use factory::run_storage_migrations;
-pub(crate) use factory::{StorageSettings, initialize_storage};
+pub(crate) use factory::{
+    StorageDatabasePrivilegeReport, StorageDatabaseRole, StorageDatabaseRoleNames, StorageSettings,
+    initialize_storage, inspect_storage_database_privileges, storage_database_role_grants_sql,
+    storage_database_role_setup_sql,
+};
 pub(crate) use hubuum_storage_core::{
     AuditEventStorage, AuthenticationStorage, AuthorizationDataStorage, CatalogStorage,
     ClassRelationStorage, ClassStorage, CollectionAuthorizationQueryStorage, CollectionStorage,

--- a/src/tests/temporal/mod.rs
+++ b/src/tests/temporal/mod.rs
@@ -5,6 +5,9 @@ use chrono::{DateTime, Utc};
 use diesel::sql_types::{Integer, Text, Timestamp, Timestamptz};
 use hubuum_domain::{PrincipalId, TaskId};
 use hubuum_storage_postgres::diesel_async_prelude::*;
+use hubuum_storage_postgres::test_support::{
+    database_role_tests_enabled, integration_test_database_roles, integration_test_migration_pool,
+};
 use hubuum_storage_postgres::with_connection;
 
 /// Driving INSERT/UPDATE/DELETE on a base table through raw SQL with only the
@@ -127,11 +130,17 @@ async fn trigger_records_ops_and_actor() {
 /// should not silently shift base values into the wrong history fields.
 #[actix_rt::test]
 async fn trigger_inserts_history_by_column_name() {
-    let scope = TestScope::new();
-    let pool = scope.pool.clone();
+    let pool = integration_test_migration_pool(1);
 
     let row: ColumnOrderHistoryRow = with_connection(&pool, async |conn| {
         conn.transaction::<_, diesel::result::Error, _>(async |conn| {
+            if database_role_tests_enabled() {
+                let roles = integration_test_database_roles();
+                diesel::sql_query("SELECT set_config('role', $1, true)")
+                    .bind::<Text, _>(roles.owner().as_str())
+                    .execute(conn)
+                    .await?;
+            }
             diesel::sql_query(
                 "CREATE TEMP TABLE temporal_column_order (
                     id int PRIMARY KEY,

--- a/tests/admin_cli.rs
+++ b/tests/admin_cli.rs
@@ -62,6 +62,7 @@ fn admin_help_exposes_reset_password() {
     assert!(stdout.contains("--reset-password"));
     assert!(stdout.contains("--backup"));
     assert!(stdout.contains("--restore"));
+    assert!(stdout.contains("--restore-executor"));
     assert!(stdout.contains("--database-role-setup-sql"));
     assert!(stdout.contains("--database-role-grants-sql"));
     assert!(stdout.contains("--check-database-privileges"));

--- a/tests/admin_cli.rs
+++ b/tests/admin_cli.rs
@@ -63,6 +63,8 @@ fn admin_help_exposes_reset_password() {
     assert!(stdout.contains("--backup"));
     assert!(stdout.contains("--restore"));
     assert!(stdout.contains("--restore-executor"));
+    #[cfg(feature = "embedded-migrations")]
+    assert!(stdout.contains("--legacy-single-role-migration"));
     assert!(stdout.contains("--database-role-setup-sql"));
     assert!(stdout.contains("--database-role-grants-sql"));
     assert!(stdout.contains("--check-database-privileges"));

--- a/tests/admin_cli.rs
+++ b/tests/admin_cli.rs
@@ -62,12 +62,16 @@ fn admin_help_exposes_reset_password() {
     assert!(stdout.contains("--reset-password"));
     assert!(stdout.contains("--backup"));
     assert!(stdout.contains("--restore"));
+    assert!(stdout.contains("--database-role-setup-sql"));
+    assert!(stdout.contains("--database-role-grants-sql"));
+    assert!(stdout.contains("--check-database-privileges"));
 }
 
 #[cfg(feature = "embedded-migrations")]
 #[test]
 fn migration_connection_failures_use_the_database_exit_code() {
     let output = Command::new(admin_binary())
+        .env_remove("HUBUUM_MIGRATION_DATABASE_URL")
         .args([
             "--migrate",
             "--database-url",

--- a/tests/api_core_data_suite/objects.rs
+++ b/tests/api_core_data_suite/objects.rs
@@ -5,7 +5,8 @@ mod tests {
     use diesel::sql_types::{Bool, Integer, Text};
     use hubuum_storage_postgres::diesel_async_prelude::*;
     use hubuum_storage_postgres::test_support::{
-        integration_test_database_roles, integration_test_migration_pool,
+        database_role_tests_enabled, integration_test_database_roles,
+        integration_test_migration_pool,
     };
     use rstest::rstest;
 
@@ -1176,13 +1177,20 @@ mod tests {
         }
 
         let migration_pool = integration_test_migration_pool(1);
-        let database_roles = integration_test_database_roles();
+        let owner_role = database_role_tests_enabled().then(|| {
+            integration_test_database_roles()
+                .owner()
+                .as_str()
+                .to_owned()
+        });
         let plan_rows = with_connection(&migration_pool, async |conn| {
             conn.transaction::<_, diesel::result::Error, _>(async |conn| {
-                diesel::sql_query("SELECT set_config('role', $1, true)")
-                    .bind::<Text, _>(database_roles.owner().as_str())
-                    .execute(conn)
-                    .await?;
+                if let Some(owner_role) = owner_role.as_deref() {
+                    diesel::sql_query("SELECT set_config('role', $1, true)")
+                        .bind::<Text, _>(owner_role)
+                        .execute(conn)
+                        .await?;
+                }
                 let create_index_sql = format!(
                     "CREATE INDEX IF NOT EXISTS idx_test_json_ip_expression \
                  ON hubuumobject USING GIST ((try_inet(data #>> '{{network,address}}')) inet_ops) \

--- a/tests/api_core_data_suite/objects.rs
+++ b/tests/api_core_data_suite/objects.rs
@@ -4,6 +4,9 @@ mod tests {
 
     use diesel::sql_types::{Bool, Integer, Text};
     use hubuum_storage_postgres::diesel_async_prelude::*;
+    use hubuum_storage_postgres::test_support::{
+        integration_test_database_roles, integration_test_migration_pool,
+    };
     use rstest::rstest;
 
     use crate::events::EventContext;
@@ -1172,8 +1175,14 @@ mod tests {
             .unwrap();
         }
 
-        let plan_rows = with_connection(&context.pool, async |conn| {
+        let migration_pool = integration_test_migration_pool(1);
+        let database_roles = integration_test_database_roles();
+        let plan_rows = with_connection(&migration_pool, async |conn| {
             conn.transaction::<_, diesel::result::Error, _>(async |conn| {
+                diesel::sql_query("SELECT set_config('role', $1, true)")
+                    .bind::<Text, _>(database_roles.owner().as_str())
+                    .execute(conn)
+                    .await?;
                 let create_index_sql = format!(
                     "CREATE INDEX IF NOT EXISTS idx_test_json_ip_expression \
                  ON hubuumobject USING GIST ((try_inet(data #>> '{{network,address}}')) inet_ops) \

--- a/tests/api_core_data_suite/querying.rs
+++ b/tests/api_core_data_suite/querying.rs
@@ -2,7 +2,11 @@
 mod tests {
     use actix_web::{http::StatusCode, test as actix_test};
     use chrono::{NaiveDate, NaiveDateTime};
+    use diesel::sql_types::Text;
     use hubuum_storage_postgres::diesel_async_prelude::*;
+    use hubuum_storage_postgres::test_support::{
+        integration_test_database_roles, integration_test_migration_pool,
+    };
     use rstest::rstest;
 
     use crate::models::search::{DataType, SearchOperator};
@@ -19,7 +23,7 @@ mod tests {
     use crate::tests::asserts::assert_response_status;
     use crate::tests::{CollectionFixture, TestContext, ensure_admin_group, test_context};
     use crate::traits::{CanDelete, CanSave};
-    use hubuum_storage_postgres::with_transaction;
+    use hubuum_storage_postgres::{PostgresPool, with_transaction};
 
     const STRING_OPERATORS: &[&str] = &[
         "equals",
@@ -122,11 +126,16 @@ mod tests {
     }
 
     async fn set_object_created_at(
-        context: &TestContext,
+        migration_pool: &PostgresPool,
+        owner_role: &str,
         object: &HubuumObject,
         created_at: NaiveDateTime,
     ) {
-        with_transaction(&context.pool, async |conn| {
+        with_transaction(migration_pool, async |conn| {
+            diesel::sql_query("SELECT set_config('role', $1, true)")
+                .bind::<Text, _>(owner_role)
+                .execute(conn)
+                .await?;
             diesel::sql_query("SELECT set_config('hubuum.restore_revisions', 'on', true)")
                 .execute(conn)
                 .await?;
@@ -488,6 +497,8 @@ mod tests {
         );
         let (collection, class, objects) =
             create_objects_fixture(&context, &label, &["dated-0", "dated-1", "dated-2"]).await;
+        let migration_pool = integration_test_migration_pool(1);
+        let database_roles = integration_test_database_roles();
 
         for (object, (year, month, day)) in
             objects
@@ -498,7 +509,13 @@ mod tests {
                 .unwrap()
                 .and_hms_opt(0, 0, 0)
                 .unwrap();
-            set_object_created_at(&context, object, created_at).await;
+            set_object_created_at(
+                &migration_pool,
+                database_roles.owner().as_str(),
+                object,
+                created_at,
+            )
+            .await;
         }
 
         let resp = get_request(

--- a/tests/api_core_data_suite/querying.rs
+++ b/tests/api_core_data_suite/querying.rs
@@ -5,7 +5,8 @@ mod tests {
     use diesel::sql_types::Text;
     use hubuum_storage_postgres::diesel_async_prelude::*;
     use hubuum_storage_postgres::test_support::{
-        integration_test_database_roles, integration_test_migration_pool,
+        database_role_tests_enabled, integration_test_database_roles,
+        integration_test_migration_pool,
     };
     use rstest::rstest;
 
@@ -127,15 +128,17 @@ mod tests {
 
     async fn set_object_created_at(
         migration_pool: &PostgresPool,
-        owner_role: &str,
+        owner_role: Option<&str>,
         object: &HubuumObject,
         created_at: NaiveDateTime,
     ) {
         with_transaction(migration_pool, async |conn| {
-            diesel::sql_query("SELECT set_config('role', $1, true)")
-                .bind::<Text, _>(owner_role)
-                .execute(conn)
-                .await?;
+            if let Some(owner_role) = owner_role {
+                diesel::sql_query("SELECT set_config('role', $1, true)")
+                    .bind::<Text, _>(owner_role)
+                    .execute(conn)
+                    .await?;
+            }
             diesel::sql_query("SELECT set_config('hubuum.restore_revisions', 'on', true)")
                 .execute(conn)
                 .await?;
@@ -498,7 +501,12 @@ mod tests {
         let (collection, class, objects) =
             create_objects_fixture(&context, &label, &["dated-0", "dated-1", "dated-2"]).await;
         let migration_pool = integration_test_migration_pool(1);
-        let database_roles = integration_test_database_roles();
+        let owner_role = database_role_tests_enabled().then(|| {
+            integration_test_database_roles()
+                .owner()
+                .as_str()
+                .to_owned()
+        });
 
         for (object, (year, month, day)) in
             objects
@@ -509,13 +517,7 @@ mod tests {
                 .unwrap()
                 .and_hms_opt(0, 0, 0)
                 .unwrap();
-            set_object_created_at(
-                &migration_pool,
-                database_roles.owner().as_str(),
-                object,
-                created_at,
-            )
-            .await;
+            set_object_created_at(&migration_pool, owner_role.as_deref(), object, created_at).await;
         }
 
         let resp = get_request(

--- a/tests/api_jobs_suite/restores.rs
+++ b/tests/api_jobs_suite/restores.rs
@@ -232,7 +232,7 @@ mod tests {
     #[case::existing_stage(true)]
     #[case::missing_stage(false)]
     #[actix_web::test]
-    async fn invalid_confirmation_capability_does_not_disclose_stage_existence(
+    async fn api_restore_confirmation_is_disabled_for_privilege_separation(
         #[future(awt)] test_context: TestContext,
         #[case] stage_exists: bool,
     ) {
@@ -263,14 +263,14 @@ mod tests {
             },
         )
         .await;
-        let response = assert_response_status(response, StatusCode::FORBIDDEN).await;
+        let response = assert_response_status(response, StatusCode::NOT_IMPLEMENTED).await;
         let body = test::read_body_json::<serde_json::Value, _>(response).await;
 
         assert_eq!(
             body,
             serde_json::json!({
-                "error": "Forbidden",
-                "message": "Restore capability is invalid"
+                "error": "Not Implemented",
+                "message": "API-driven destructive restore is disabled; run hubuum-admin --restore with HUBUUM_MIGRATION_DATABASE_URL"
             })
         );
 
@@ -374,7 +374,7 @@ mod tests {
 
     #[rstest]
     #[actix_web::test]
-    async fn expired_confirmation_expires_the_validated_stage(
+    async fn disabled_api_confirmation_does_not_change_an_expired_stage(
         #[future(awt)] test_context: TestContext,
     ) {
         let context = test_context;
@@ -413,7 +413,7 @@ mod tests {
             },
         )
         .await;
-        assert_response_status(response, StatusCode::GONE).await;
+        assert_response_status(response, StatusCode::NOT_IMPLEMENTED).await;
 
         let (status, document) = with_connection(&context.pool, async |conn| {
             use crate::schema::restore_jobs::dsl::{document, id, restore_jobs, status};
@@ -426,8 +426,8 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            (status.as_str(), document.as_slice()),
-            (RestoreJobStatus::Expired.as_str(), b"".as_slice())
+            (status.as_str(), document.is_empty()),
+            (RestoreJobStatus::Validated.as_str(), false)
         );
 
         with_connection(&context.pool, async |conn| {

--- a/tests/api_jobs_suite/restores.rs
+++ b/tests/api_jobs_suite/restores.rs
@@ -232,7 +232,7 @@ mod tests {
     #[case::existing_stage(true)]
     #[case::missing_stage(false)]
     #[actix_web::test]
-    async fn api_restore_confirmation_is_disabled_for_privilege_separation(
+    async fn invalid_restore_confirmation_capability_does_not_disclose_stage_existence(
         #[future(awt)] test_context: TestContext,
         #[case] stage_exists: bool,
     ) {
@@ -263,14 +263,14 @@ mod tests {
             },
         )
         .await;
-        let response = assert_response_status(response, StatusCode::NOT_IMPLEMENTED).await;
+        let response = assert_response_status(response, StatusCode::FORBIDDEN).await;
         let body = test::read_body_json::<serde_json::Value, _>(response).await;
 
         assert_eq!(
             body,
             serde_json::json!({
-                "error": "Not Implemented",
-                "message": "API-driven destructive restore is disabled; run hubuum-admin --restore with HUBUUM_MIGRATION_DATABASE_URL"
+                "error": "Forbidden",
+                "message": "Restore capability is invalid"
             })
         );
 
@@ -374,7 +374,7 @@ mod tests {
 
     #[rstest]
     #[actix_web::test]
-    async fn disabled_api_confirmation_does_not_change_an_expired_stage(
+    async fn api_confirmation_expires_and_erases_an_expired_stage(
         #[future(awt)] test_context: TestContext,
     ) {
         let context = test_context;
@@ -413,7 +413,7 @@ mod tests {
             },
         )
         .await;
-        assert_response_status(response, StatusCode::NOT_IMPLEMENTED).await;
+        assert_response_status(response, StatusCode::GONE).await;
 
         let (status, document) = with_connection(&context.pool, async |conn| {
             use crate::schema::restore_jobs::dsl::{document, id, restore_jobs, status};
@@ -427,7 +427,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             (status.as_str(), document.is_empty()),
-            (RestoreJobStatus::Validated.as_str(), false)
+            (RestoreJobStatus::Expired.as_str(), true)
         );
 
         with_connection(&context.pool, async |conn| {

--- a/tests/restore_roundtrip.rs
+++ b/tests/restore_roundtrip.rs
@@ -16,7 +16,7 @@ use hubuum::restores::{
 };
 use hubuum::schema::{
     collections, events, hubuumclass_history, hubuumclass_reachability, hubuumclass_relation,
-    restore_jobs, system_maintenance, tasks,
+    restore_jobs, restore_success_receipts, system_maintenance, tasks,
 };
 use hubuum::storage::with_mutation_provenance;
 use hubuum::test_support::{create_audit_event, postgres_test_pool_with_timeout};
@@ -179,16 +179,16 @@ async fn interrupted_restore_is_reconciled_after_the_drain_transition() {
         .expect("reconcile interrupted restore");
 
     let (
-        restore_job_exists,
+        success_receipt_exists,
         marker_exists,
         historical_task,
         historical_task_event,
         class_history_provenance,
         restore_event,
     ) = with_connection(&pool, async |conn| {
-        let restore_job = restore_jobs::table
-            .filter(restore_jobs::id.eq(staged.id))
-            .select(restore_jobs::id)
+        let success_receipt = restore_success_receipts::table
+            .filter(restore_success_receipts::id.eq(staged.id))
+            .select(restore_success_receipts::id)
             .first::<i64>(conn)
             .await
             .optional()?;
@@ -230,7 +230,7 @@ async fn interrupted_restore_is_reconciled_after_the_drain_transition() {
             .await
             .optional()?;
         Ok::<_, diesel::result::Error>((
-            restore_job,
+            success_receipt,
             marker,
             history,
             historical_task_event,
@@ -242,7 +242,7 @@ async fn interrupted_restore_is_reconciled_after_the_drain_transition() {
     .expect("restored data lookup");
     assert_eq!(
         (
-            restore_job_exists,
+            success_receipt_exists,
             marker_exists,
             historical_task,
             restore_event.as_ref().map(|event| event.0.as_str()),
@@ -346,8 +346,16 @@ async fn interrupted_restore_is_reconciled_after_the_drain_transition() {
     })
     .await
     .expect("remaining restore jobs");
+    let success_receipts = with_connection(&pool, async |conn| {
+        restore_success_receipts::table
+            .count()
+            .get_result::<i64>(conn)
+            .await
+    })
+    .await
+    .expect("successful restore receipts");
     assert_eq!(
-        (completed.status, remaining_restore_jobs),
-        (RestoreJobStatus::Succeeded, 1)
+        (completed.status, remaining_restore_jobs, success_receipts),
+        (RestoreJobStatus::Succeeded, 0, 1)
     );
 }

--- a/tests/restore_roundtrip.rs
+++ b/tests/restore_roundtrip.rs
@@ -11,8 +11,8 @@ use hubuum::models::{
     RestoreJobStatus, RestoreStageRequest, TaskStatus,
 };
 use hubuum::restores::{
-    RestoreSettings, confirm_restore, get_maintenance_state, reconcile_interrupted_restore,
-    stage_restore,
+    RestoreSettings, confirm_restore, execute_confirmed_restore, get_maintenance_state,
+    reconcile_interrupted_restore, restore_status, stage_restore,
 };
 use hubuum::schema::{
     collections, events, hubuumclass_history, hubuumclass_reachability, hubuumclass_relation,
@@ -29,9 +29,19 @@ fn database_url() -> String {
         .expect("HUBUUM_MIGRATION_DATABASE_URL must provide destructive restore authority")
 }
 
+fn runtime_database_url() -> String {
+    std::env::var("HUBUUM_DATABASE_URL")
+        .expect("HUBUUM_DATABASE_URL must provide runtime restore-coordination authority")
+}
+
 #[tokio::test]
 async fn interrupted_restore_is_reconciled_after_the_drain_transition() {
     let pool = postgres_test_pool_with_timeout(&database_url(), 2, DEFAULT_DB_STATEMENT_TIMEOUT_MS);
+    let runtime_pool = postgres_test_pool_with_timeout(
+        &runtime_database_url(),
+        2,
+        DEFAULT_DB_STATEMENT_TIMEOUT_MS,
+    );
     let root_collection_id = with_connection(&pool, async |conn| {
         collections::table
             .filter(collections::parent_collection_id.is_null())
@@ -242,7 +252,7 @@ async fn interrupted_restore_is_reconciled_after_the_drain_transition() {
                 .and_then(serde_json::Value::as_str),
         ),
         (
-            None,
+            Some(staged.id),
             None,
             Some((historical_task_id, None, Some(provenance_initiator_id))),
             Some("system"),
@@ -299,23 +309,38 @@ async fn interrupted_restore_is_reconciled_after_the_drain_transition() {
     let initiator = RestoreInitiator::new(None, "test", "restore-confirmation")
         .expect("restore confirmation initiator");
     let request = RestoreStageRequest::new(initiator, document).expect("restore request");
-    let confirmed_stage = stage_restore(&pool, &settings, request)
+    let confirmed_stage = stage_restore(&runtime_pool, &settings, request)
         .await
         .expect("stage confirmation-path restore");
-    let completed = confirm_restore(
-        &pool,
+    let capability = confirmed_stage
+        .restore_capability
+        .clone()
+        .expect("restore capability");
+    let confirmed = confirm_restore(
+        &runtime_pool,
         RestoreJobID::new(confirmed_stage.id).expect("positive staged restore id"),
         &RestoreConfirmRequest {
-            restore_capability: confirmed_stage
-                .restore_capability
-                .clone()
-                .expect("restore capability"),
+            restore_capability: capability.clone(),
             sha256: confirmed_stage.sha256,
             confirmation: RESTORE_CONFIRMATION_PHRASE.to_string(),
         },
     )
     .await
-    .expect("confirm restore");
+    .expect("queue restore through runtime storage");
+    assert_eq!(confirmed.status, RestoreJobStatus::Confirmed);
+
+    assert!(
+        execute_confirmed_restore(&pool)
+            .await
+            .expect("apply restore through migration storage")
+    );
+    let completed = restore_status(
+        &runtime_pool,
+        RestoreJobID::new(confirmed_stage.id).expect("positive staged restore id"),
+        &capability,
+    )
+    .await
+    .expect("poll completed restore through runtime storage");
     let remaining_restore_jobs = with_connection(&pool, async |conn| {
         restore_jobs::table.count().get_result::<i64>(conn).await
     })
@@ -323,6 +348,6 @@ async fn interrupted_restore_is_reconciled_after_the_drain_transition() {
     .expect("remaining restore jobs");
     assert_eq!(
         (completed.status, remaining_restore_jobs),
-        (RestoreJobStatus::Succeeded, 0)
+        (RestoreJobStatus::Succeeded, 1)
     );
 }

--- a/tests/restore_roundtrip.rs
+++ b/tests/restore_roundtrip.rs
@@ -25,8 +25,8 @@ use hubuum_storage_postgres::diesel_async_prelude::*;
 use hubuum_storage_postgres::{with_connection, with_transaction};
 
 fn database_url() -> String {
-    std::env::var("HUBUUM_DATABASE_URL")
-        .expect("HUBUUM_DATABASE_URL must point to the isolated migrated test database")
+    std::env::var("HUBUUM_MIGRATION_DATABASE_URL")
+        .expect("HUBUUM_MIGRATION_DATABASE_URL must provide destructive restore authority")
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- define a machine-readable PostgreSQL privilege manifest and generate role setup, grant reconciliation, and catalog diagnostics from it
- separate non-login owner, migrator, and runtime credentials across application configuration, administration commands, tests, Compose, CI, and single-host deployment
- harden temporal-history and event-retention functions so the runtime role cannot bypass integrity controls or acquire schema authority
- preserve web restore through an isolated, migrator-backed executor while API and worker processes retain only the runtime credential
- retain document-free terminal restore receipts in an additive read-only table
  for capability-authenticated polling, without changing the adjacent release's
  `restore_jobs` constraint, and keep one-shot administrator restore available

## Restore behavior

`POST /api/v1/restores/{restore_id}/confirm` validates the administrator request and one-time capability, commits draining maintenance, and returns `202 Accepted` with status `confirmed`. It never performs privileged SQL. A separately deployed `hubuum-admin --restore-executor` process reads the durable request, revalidates it, waits for instances to drain, and applies the replacement transaction with `HUBUUM_MIGRATION_DATABASE_URL`. Clients poll the existing capability-authenticated status endpoint until `succeeded` or `failed`.

The executor has no HTTP listener or request-controlled SQL/file input. Compose and single-host deployments run one read-only, capability-dropped executor container with no published port. Distributed deployments use a one-replica workload and a separately mounted migration secret.

## Breaking changes and upgrade action

The server container entrypoint no longer runs database migrations. Deployments must provision the documented owner, migrator, and runtime roles, configure API and workers with the runtime URL, and run migrations as a separate one-shot operation with the migration URL before rolling application workloads.

Restore confirmation is now asynchronous: it returns HTTP 202 instead of completing synchronously. Deploy the restore executor before allowing confirmations and update clients to poll status. `hubuum-admin --restore` remains a synchronous administrative workflow from the operator's perspective.

Existing single-role installations have an ordered compatibility path:

1. take and verify a backup; require normal maintenance and no confirmed restore
2. block the confirmation route for the bounded migration window
3. through a role-administrator connection, temporarily name the existing application login as the runtime role, create the owner and migrator identities, and apply generated ownership/grant reconciliation
4. run the migration with the migrator URL; its preflight shares the restore advisory lock, rejects an in-flight restore, and preserves validated stages
5. start and verify the executor, roll runtime-only API/workers, then unblock confirmation
6. enable strict privilege checks and rotate from the compatibility login to the dedicated runtime login in a later rollout

If role provisioning cannot happen before the schema step, the explicit
`--legacy-single-role-migration` flag makes the new admin binary migrate with
the connected legacy owner, emit a compatibility warning, and skip privilege
reconciliation. The flag rejects split-role settings, while ordinary
`--migrate` always reconciles the documented role names. This is a bounded
bridge only: keep confirmation blocked and privilege mode at `warn`, then
complete role adoption and rerun migration with the split-role names so
ownership and grants are reconciled before starting the executor or enabling
strict checks. Reconciliation transfers table ownership before attached
sequences, allowing existing serial-backed schemas to be adopted atomically.

The migration is retry-safe after restore recovery. An application rollback may keep the compatibility runtime login for ordinary service, but old synchronous web confirmation must remain blocked because it no longer has destructive authority; use the new one-shot administrator restore until this release is restored. Full commands, managed-service variants, and rollback details are in `docs/database_roles.md`.

## Security behavior

- runtime credentials cannot alter schema, own database objects directly or through role membership, write migration/history/restore-receipt tables directly, set trusted restore flags for their own sessions, or call non-allowlisted security-definer functions
- the event-retention path uses a bounded allowlisted function, while temporal and event functions use qualified objects and a fixed `search_path`
- privilege diagnostics detect unsafe role attributes, inherited ownership, schema creation, direct integrity writes, missing grants, and an unexpected connected role
- isolating the executor protects the migration/schema-owner credential, but does not make a compromised runtime database identity harmless: runtime restore-control DML can fabricate a staged request and cause replacement, as documented in the threat model

## Verification

- full `./run_tests.sh` suite against a fresh split-role PostgreSQL database
- end-to-end runtime confirmation, migrator execution, retained receipt, and capability polling
- migration against the real previous schema; confirmed/draining refusal and successful retry after recovery
- adjacent-release migration compatibility policy and preservation of an existing validated restore without changing the prior status constraint
- empty-schema embedded migration and the complete API core-data suite with all role variables absent
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --features embedded-migrations --bins -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `bash scripts/test-classify-ci-changes.sh`
- `bash scripts/test-single-host-rollout.sh`
- `bash scripts/test-install-script-refresh.sh`
- OpenAPI regeneration and compatibility validation
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- production Docker image with `tls-rustls`, `tls-openssl`, `--locked`, and `--release`

Closes #255
