### PR TITLE
Continuously verify backup recoverability

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -173,7 +173,8 @@ jobs:
         run: |
           git checkout --detach "$BASE_SHA"
           cargo run --locked --features embedded-migrations --bin hubuum-admin -- \
-            --migrate --database-url "$BASE_DATABASE_URL"
+            --migrate --legacy-single-role-migration \
+            --database-url "$BASE_DATABASE_URL"
           cargo build --locked --features runtime-behavior-check --bin hubuum-server
           cargo run --profile dev --locked --features runtime-behavior-check \
             --bin hubuum-runtime-behavior-check -- measure \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1022,6 +1022,17 @@ jobs:
             echo "| Migration seconds | $(jq --raw-output '.migration.seconds' compatibility-report/report.json) |"
             echo "| Maximum API latency | $(jq --raw-output '.migration.max_api_latency_seconds' compatibility-report/report.json) s |"
             echo "| Maximum observed outage | $(jq --raw-output '.migration.max_observed_api_outage_seconds' compatibility-report/report.json) s |"
+            echo ""
+            echo "### Backup recovery"
+            echo ""
+            echo "| Artifact | Result | Generate ms | Restore ms | Logical rows |"
+            echo "| --- | --- | ---: | ---: | ---: |"
+            jq --raw-output '
+              .backup_recovery
+              | to_entries[]
+              | select(.key != "restored_application_smoke")
+              | "| \(.key) | \(.value.result // "not-run") | \(.value.generation_duration_ms // "-") | \(.value.restore_test.restore_duration_ms // "-") | \(.value.total_items // "-") |"
+            ' compatibility-report/report.json
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload adjacent-release compatibility report
         if: always()

--- a/.github/workflows/restore-drill.yml
+++ b/.github/workflows/restore-drill.yml
@@ -1,0 +1,82 @@
+name: Scheduled backup recovery drill
+
+on:
+  schedule:
+    - cron: "41 04 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: scheduled-backup-recovery
+  cancel-in-progress: false
+
+jobs:
+  backup-recovery:
+    name: Backup recovery
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build candidate production image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          push: false
+          tags: hubuum-server:restore-drill
+          build-args: |
+            CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release
+            HUBUUM_BUILD_GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Resolve adjacent stable release
+        id: adjacent_release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HUBUUM_COMPATIBILITY_REPORT: backup-recovery-report/release-metadata.json
+        run: bash scripts/resolve-adjacent-release.sh
+      - name: Run isolated backup recovery drill
+        env:
+          HUBUUM_TEST_IMAGE: hubuum-server:restore-drill
+          HUBUUM_PREVIOUS_IMAGE: ${{ steps.adjacent_release.outputs.previous_image }}
+          HUBUUM_PREVIOUS_RELEASE_TAG: ${{ steps.adjacent_release.outputs.previous_tag }}
+          HUBUUM_COMPATIBILITY_REPORT_DIR: backup-recovery-report
+        run: bash scripts/test-adjacent-release-upgrade.sh
+      - name: Summarize backup recovery
+        if: always() && hashFiles('backup-recovery-report/report.json') != ''
+        run: |
+          {
+            echo "### Backup recovery drill"
+            echo ""
+            echo "| Artifact | Result | Restore ms | Logical rows |"
+            echo "| --- | --- | ---: | ---: |"
+            jq --raw-output '
+              .backup_recovery
+              | to_entries[]
+              | select(.key != "restored_application_smoke")
+              | "| \(.key) | \(.value.result // "not-run") | \(.value.restore_test.restore_duration_ms // "-") | \(.value.total_items // "-") |"
+            ' backup-recovery-report/report.json
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload sanitized recovery evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scheduled-backup-recovery-${{ github.run_id }}
+          path: backup-recovery-report
+          if-no-files-found: error
+          retention-days: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Added `hubuum-admin --verify-backup` for bounded offline validation and an
+  opt-in isolated PostgreSQL restore drill with empty-target and production-
+  endpoint safeguards, sanitized JSON evidence, readiness checks, and explicit
+  cleanup ownership. Release and scheduled CI now restore current, adjacent-
+  release, and history-free artifacts and smoke-test the restored API, worker,
+  authentication recovery, history, token exclusion, and computed rebuilding.
+  Existing installations on v0.0.9 or older must first upgrade to v0.0.10 or
+  v0.0.11 and create a version 5 backup; version 4-or-older artifacts are not
+  converted in place.
 - Added a generated PostgreSQL privilege manifest with distinct non-login
   owner, dedicated migrator, and non-owning runtime roles; catalog-backed
   warn/strict startup diagnostics; administrator SQL and JSON reporting; and
@@ -86,6 +95,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   Kubernetes projected-secret symlinks. LDAP, event, and remote integrations
   observe rotation after cache refresh; PostgreSQL pools and token hashing
   explicitly require restart rather than claiming unsafe live rotation.
+
+### Fixed
+
+- Production container builds now normalize `/entrypoint.sh` to mode `0755`
+  so the non-root runtime user can read it even when the source checkout uses
+  restrictive group-oriented permissions.
+- PostgreSQL endpoint diagnostics and disposable-restore target comparisons now
+  preserve explicit non-default ports instead of reporting and comparing every
+  endpoint as port 5432.
 
 ## [0.0.11] - 2026-08-30
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN apk upgrade --no-cache && \
 COPY --from=builder /tmp/hubuum-server /usr/local/bin/hubuum-server
 COPY --from=builder /tmp/hubuum-admin /usr/local/bin/hubuum-admin
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN chmod 0755 /entrypoint.sh
 
 EXPOSE 8080
 

--- a/crates/hubuum-storage-postgres/src/lib.rs
+++ b/crates/hubuum-storage-postgres/src/lib.rs
@@ -88,7 +88,10 @@ pub(crate) use filters::{
     postgres_is_null_filter, postgres_revision_filter, postgres_string_filter,
 };
 #[cfg(feature = "embedded-migrations")]
-pub use migrations::{run_embedded_migrations, run_embedded_migrations_as};
+pub use migrations::{
+    prepare_disposable_restore_database, reset_disposable_restore_database,
+    run_embedded_migrations, run_embedded_migrations_as,
+};
 #[cfg(any(feature = "integration-test-support", feature = "benchmark-support"))]
 #[doc(hidden)]
 pub use operations::computed_materialization::source_data_sha256;

--- a/crates/hubuum-storage-postgres/src/migrations.rs
+++ b/crates/hubuum-storage-postgres/src/migrations.rs
@@ -1,4 +1,7 @@
+use diesel::RunQueryDsl;
 use diesel::connection::SimpleConnection;
+use diesel::deserialize::QueryableByName;
+use diesel::sql_types::{BigInt, Text};
 use diesel::{Connection, PgConnection};
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use hubuum_storage_core::StorageError;
@@ -6,6 +9,22 @@ use hubuum_storage_core::StorageError;
 use crate::{DatabaseRoleNames, PostgresStorageError, database_role_reconciliation_sql};
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
+
+#[derive(QueryableByName)]
+struct DisposableDatabaseState {
+    #[diesel(sql_type = Text)]
+    database_name: String,
+    #[diesel(sql_type = BigInt)]
+    user_object_count: i64,
+}
+
+#[derive(QueryableByName)]
+struct DisposableRestoreMarkers {
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    has_migrations: bool,
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    has_collections: bool,
+}
 
 /// Apply every embedded PostgreSQL migration not yet recorded by Diesel.
 pub fn run_embedded_migrations(connection_url: &str) -> Result<usize, StorageError> {
@@ -18,6 +37,109 @@ pub fn run_embedded_migrations_as(
     roles: &DatabaseRoleNames,
 ) -> Result<usize, StorageError> {
     run_embedded_migrations_with_roles(connection_url, Some(roles))
+}
+
+/// Require a genuinely empty, non-maintenance database and migrate it for an
+/// isolated restore verification. The emptiness check and migrations share
+/// one connection so a caller cannot accidentally point this path at an
+/// already initialized Hubuum database.
+pub fn prepare_disposable_restore_database(connection_url: &str) -> Result<usize, StorageError> {
+    let mut connection = PgConnection::establish(connection_url).map_err(|error| {
+        StorageError::from(PostgresStorageError::database(format!(
+            "failed to connect to the disposable restore-test database: {error}"
+        )))
+    })?;
+    let state = diesel::sql_query(
+        "SELECT current_database()::text AS database_name, COUNT(*)::bigint AS user_object_count \
+         FROM ( \
+           SELECT relation.oid \
+           FROM pg_catalog.pg_class AS relation \
+           JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace \
+           WHERE namespace.nspname <> 'information_schema' \
+             AND namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\' \
+             AND relation.relkind IN ('r', 'p', 'v', 'm', 'S', 'f', 'c') \
+           UNION ALL \
+           SELECT routine.oid \
+           FROM pg_catalog.pg_proc AS routine \
+           JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = routine.pronamespace \
+           WHERE namespace.nspname <> 'information_schema' \
+             AND namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\' \
+           UNION ALL \
+           SELECT type.oid \
+           FROM pg_catalog.pg_type AS type \
+           JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = type.typnamespace \
+           WHERE namespace.nspname <> 'information_schema' \
+             AND namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\' \
+             AND type.typtype IN ('c', 'd', 'e', 'm', 'r') \
+             AND type.typrelid = 0 \
+           UNION ALL \
+           SELECT namespace.oid \
+           FROM pg_catalog.pg_namespace AS namespace \
+           WHERE namespace.nspname NOT IN ('information_schema', 'public') \
+             AND namespace.nspname NOT LIKE 'pg\\_%' ESCAPE '\\' \
+         ) AS user_objects",
+    )
+    .get_result::<DisposableDatabaseState>(&mut connection)
+    .map_err(|error| {
+        StorageError::from(PostgresStorageError::database(format!(
+            "failed to inspect the disposable restore-test database: {error}"
+        )))
+    })?;
+    if matches!(
+        state.database_name.as_str(),
+        "postgres" | "template0" | "template1"
+    ) {
+        return Err(StorageError::invalid_input(
+            "Refused to use a PostgreSQL maintenance database for restore verification",
+        ));
+    }
+    if state.user_object_count != 0 {
+        return Err(StorageError::invalid_input(format!(
+            "Refused restore verification because the target database contains {} user object(s); provide a newly created empty disposable database",
+            state.user_object_count
+        )));
+    }
+    connection
+        .run_pending_migrations(MIGRATIONS)
+        .map_err(|error| {
+            StorageError::from(PostgresStorageError::database(format!(
+                "failed to migrate the disposable restore-test database: {error}"
+            )))
+        })
+        .map(|migrations| migrations.len())
+}
+
+/// Remove the Hubuum schema created by [`prepare_disposable_restore_database`]
+/// after an isolated restore test. This deliberately refuses databases that
+/// do not contain both expected Hubuum marker tables.
+pub fn reset_disposable_restore_database(connection_url: &str) -> Result<(), StorageError> {
+    let mut connection = PgConnection::establish(connection_url).map_err(|error| {
+        StorageError::from(PostgresStorageError::database(format!(
+            "failed to connect for disposable restore-test cleanup: {error}"
+        )))
+    })?;
+    let markers = diesel::sql_query(
+        "SELECT to_regclass('public.__diesel_schema_migrations') IS NOT NULL AS has_migrations, \
+                to_regclass('public.collections') IS NOT NULL AS has_collections",
+    )
+    .get_result::<DisposableRestoreMarkers>(&mut connection)
+    .map_err(|error| {
+        StorageError::from(PostgresStorageError::database(format!(
+            "failed to inspect disposable restore-test cleanup markers: {error}"
+        )))
+    })?;
+    if !markers.has_migrations || !markers.has_collections {
+        return Err(StorageError::invalid_input(
+            "Refused disposable restore-test cleanup because Hubuum schema markers are missing",
+        ));
+    }
+    connection
+        .batch_execute("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
+        .map_err(|error| {
+            StorageError::from(PostgresStorageError::database(format!(
+                "failed to reset the disposable restore-test database: {error}"
+            )))
+        })
 }
 
 fn run_embedded_migrations_with_roles(

--- a/crates/hubuum-storage-postgres/src/pool.rs
+++ b/crates/hubuum-storage-postgres/src/pool.rs
@@ -254,7 +254,7 @@ fn parse_postgres_endpoint(database_url: &str) -> Result<PostgresEndpoint, Postg
     Ok(PostgresEndpoint {
         username: parsed.username.unwrap_or_default().to_string(),
         host: host.to_string(),
-        port: 5432,
+        port: parsed.port.unwrap_or(5432),
         database: parsed.path.trim_start_matches('/').to_string(),
     })
 }
@@ -437,10 +437,11 @@ mod tests {
 
     #[test]
     fn endpoint_metadata_excludes_credentials() {
-        let settings = settings("postgres://admin:secret@db.example.com/hubuum").unwrap();
+        let settings = settings("postgres://admin:secret@db.example.com:55432/hubuum").unwrap();
 
         assert_eq!(settings.endpoint().username(), "admin");
         assert_eq!(settings.endpoint().host(), "db.example.com");
+        assert_eq!(settings.endpoint().port(), 55432);
         assert_eq!(settings.endpoint().database(), "hubuum");
         assert!(!format!("{:?}", settings.endpoint()).contains("secret"));
     }

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -152,6 +152,85 @@ History is included by default. Add `--backup-without-history` only to create a
 backup whose eventual restore resets terminal task, audit, delivery, and
 temporal history.
 
+Verify the artifact without a database connection before moving or archiving
+it:
+
+```text
+hubuum-admin --verify-backup backup.json --json
+```
+
+This bounded, non-destructive check verifies the document version, SHA-256,
+manifest counts and exclusions, required sections and seed rows, timestamp and
+revision invariants, logical references, computed-field definitions, and JSON
+Schema. Its versioned report contains only artifact metadata, counts, timings,
+and results; it never includes backup rows, database URLs, tokens, or
+credentials. A format-only success proves that the bytes are internally valid,
+not that PostgreSQL can restore them.
+
+For a real recovery rehearsal, create a new empty disposable PostgreSQL
+database and let the candidate binary migrate, restore, and check it:
+
+```text
+createdb --maintenance-db="$POSTGRES_ADMIN_URL" hubuum_restore_drill
+hubuum-admin \
+  --verify-backup backup.json \
+  --restore-test-database-url \
+    'postgres://hubuum_restore_drill:.../hubuum_restore_drill' \
+  --json
+dropdb --maintenance-db="$POSTGRES_ADMIN_URL" hubuum_restore_drill
+```
+
+The restore-test login must be able to migrate and replace data in that one
+database. The command refuses PostgreSQL maintenance databases, a database
+containing any user object, and a target matching either configured Hubuum
+database URL even when the usernames differ. It uses the production restore
+validation and transaction path, checks storage readiness, and takes a second
+logical snapshot. Authoritative state and retained history must match the
+source, apart from the one documented `restore.succeeded` provenance event.
+The JSON report includes the canonical state digest and comparison results. By
+default the command resets the disposable database's `public` schema after
+both successful and failed verification. The database itself remains the
+caller's responsibility and should be dropped afterward.
+
+Add `--keep-restore-test-database` when the restored API and worker must be
+started for application-level smoke tests. That option deliberately leaves the
+restored schema intact; delete the database after inspection. Password hashes,
+tokens, and token scopes are excluded from backups, so reset an administrator
+password and issue a new token before exercising authenticated endpoints.
+
+## Existing deployment upgrade path
+
+Treat a restorable backup as an upgrade prerequisite, especially when adopting
+the split database roles described in
+[PostgreSQL Database Roles](database_roles.md). Use this sequence:
+
+1. While the existing release is healthy, stop new backup, restore, and import
+   operations and create a version 5 backup with history. Keep the old release,
+   its database credential, and this artifact until the upgrade is accepted.
+2. Run the candidate `hubuum-admin --verify-backup` against those exact bytes.
+   If the installed release is v0.0.9 or older, first upgrade normally to
+   v0.0.10 or v0.0.11, create a version 5 backup there, and only then continue;
+   converting a version 4-or-older document in place is not supported.
+3. Restore the artifact into a newly created empty disposable database using
+   `--restore-test-database-url` and
+   `--keep-restore-test-database`. Start the candidate API and worker against
+   only that database, reset an administrator password, and verify login,
+   representative reads, background work, audit history, and computed-field
+   rebuilding. Then delete the disposable database.
+4. Confirm production maintenance is `normal` and no confirmed restore is in
+   flight. Follow the single-role adoption procedure, run the one-shot schema
+   migration, start the isolated restore executor, and roll runtime-only API
+   and worker processes.
+5. Keep restore confirmation blocked until the executor and runtime privilege
+   report pass. Retain the pre-upgrade deployment and backup through the
+   observation window. Application rollback after role adoption uses the
+   compatibility runtime login; web restore stays blocked and the candidate
+   one-shot admin restore remains the recovery path.
+
+This is an application migration path, not an automatic database downgrade.
+Older application releases are only certified against the adjacent migrated
+schema as documented in [Releasing Hubuum](releasing.md).
+
 Restore requires the explicit destructive phrase and the separate migration
 credential:
 

--- a/docs/database_roles.md
+++ b/docs/database_roles.md
@@ -119,7 +119,10 @@ documented defaults for names not overridden.
 Set `HUBUUM_DATABASE_RUNTIME_ROLE=EXISTING_APPLICATION_ROLE` on the old and new
 server versions during that rollout. Then use this order:
 
-1. Verify the backup and inspect the restore control plane:
+1. Create and rehearse a version 5 backup with the candidate verifier and an
+   empty disposable database, following the
+   [existing deployment upgrade path](backup-restore.md#existing-deployment-upgrade-path).
+   Then inspect the production restore control plane:
 
    ```sql
    SELECT state, restore_job_id,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,6 +13,9 @@ This repository uses the CI workflow in
   immediately preceding stable release.
 - The candidate must pass the adjacent stable release upgrade and application
   rollback harness against an immutable release-image digest.
+- The candidate must restore current, adjacent-release, and history-free backup
+  artifacts into isolated databases and pass restored API and worker smoke
+  checks.
 - Every Rust package must retain an explicit support classification; internal
   packages cannot be published, and any supported package must pass rustdoc,
   clean packaging, and semantic compatibility checks.
@@ -59,8 +62,9 @@ Once the tag is pushed, the CI workflow will:
 - verify the tagged commit already passed CI on `main`
 - regenerate OpenAPI and compare it with the immediately preceding stable tag
 - resolve the latest stable release, migrate its representative data under live
-  API probes, exercise a mixed-version interval, and restore its application
-  image against the migrated database before publishing
+  API probes, exercise a mixed-version interval, restore its application image
+  against the migrated database, and prove the candidate can recover both
+  adjacent-release and current backup artifacts before publishing
 - verify that the tag, `Cargo.toml`, changelog, and OpenAPI versions match
 - validate Rust API classifications and any supported crate compatibility
 - publish GitHub release archives and SHA-256 checksums for Linux x86_64, Linux ARM64,
@@ -159,10 +163,23 @@ restarts the `N-1` API against the migrated schema. That last step is an
 application rollback only. Hubuum does not automatically downgrade the
 database, and releases older than `N-1` are outside this compatibility promise.
 
-Backup, restore, and import document formats may change at a release boundary.
-Quiesce those operations while versions overlap and use the document format
-accepted by the application version that will process it. A successful API
-rollback does not make a newer backup or import document readable by `N-1`.
+The harness also creates an `N-1` backup with history, an `N-1` history-free
+backup, and an `N` backup. The candidate restores each into a separately
+created empty database, records bounded sanitized evidence, and starts its API
+and worker against the retained `N-1` restore. Smoke checks cover authentication
+recovery, representative resource and history reads, excluded bearer tokens,
+and computed-field rebuilding. A scheduled workflow repeats the same drill so
+recoverability is checked between release events rather than inferred from
+backup creation alone.
+
+Backup, restore, and import document formats may still change at a release
+boundary. Quiesce those operations while versions overlap and use the document
+format accepted by the application version that will process it. CI guarantees
+candidate restore compatibility only for the immediately adjacent stable
+release. A successful API rollback does not make a newer backup or import
+document readable by `N-1`; follow the
+[existing deployment upgrade path](backup-restore.md#existing-deployment-upgrade-path)
+when an older installation must cross a format boundary.
 
 ## Native archives
 

--- a/scripts/classify-ci-changes.sh
+++ b/scripts/classify-ci-changes.sh
@@ -96,6 +96,10 @@ for path in "$@"; do
       benchmarks=true
       runtime_benchmark=true
       ;;
+    .github/workflows/restore-drill.yml)
+      code=true
+      container=true
+      ;;
     .github/workflows/ci.yml)
       code=true
       openapi=true

--- a/scripts/test-adjacent-release-upgrade.sh
+++ b/scripts/test-adjacent-release-upgrade.sh
@@ -17,14 +17,40 @@ migration_log="$report_root/migration.log"
 compose_log="$report_root/compose.log"
 report_file="$report_root/report.json"
 database_url="postgres://hubuum:adjacent-release@postgres/hubuum?sslmode=disable"
+restore_database_url="postgres://hubuum:adjacent-release@postgres/hubuum_restore?sslmode=disable"
+history_free_restore_database_url="postgres://hubuum:adjacent-release@postgres/hubuum_restore_no_history?sslmode=disable"
+current_restore_database_url="postgres://hubuum:adjacent-release@postgres/hubuum_restore_current?sslmode=disable"
+adjacent_backup_file="$test_root/adjacent-backup.json"
+history_free_backup_file="$test_root/adjacent-backup-no-history.json"
+current_backup_file="$test_root/current-backup.json"
+adjacent_restore_report="$report_root/adjacent-backup-restore.json"
+history_free_restore_report="$report_root/history-free-backup-restore.json"
+current_restore_report="$report_root/current-backup-restore.json"
 admin_token=""
 collection_id=""
 class_id=""
 object_id=""
 probe_task_id=""
+group_id=""
+user_id=""
+related_class_id=""
+related_object_id=""
+class_relation_id=""
+template_id=""
 migration_seconds=0
 max_probe_latency_seconds=0
 max_probe_outage_seconds=0
+adjacent_backup_generation_ms=0
+history_free_backup_generation_ms=0
+current_backup_generation_ms=0
+rebuild_duration_ms=0
+restored_readiness=false
+restored_authentication=false
+restored_state_reads=false
+restored_history_read=false
+restored_task_read=false
+restored_computed_rebuild=false
+restored_token_exclusion=false
 api_body=""
 api_headers=""
 
@@ -51,7 +77,8 @@ applied_migrations() {
   local migration_table
   local versions
 
-  if ! "${compose[@]}" ps postgres >/dev/null 2>&1; then
+  if ! "${compose[@]}" exec -T postgres pg_isready \
+    --host 127.0.0.1 --username hubuum --dbname hubuum >/dev/null 2>&1; then
     printf '[]'
     return
   fi
@@ -80,10 +107,28 @@ write_report() {
   local previous_digest
   local candidate_id
   local migrations
+  local adjacent_restore
+  local history_free_restore
+  local current_restore
 
   previous_digest="${previous_image##*@}"
   candidate_id="$(docker image inspect "$candidate_image" --format '{{.Id}}' 2>/dev/null || true)"
   migrations="$(applied_migrations)"
+  adjacent_restore="null"
+  history_free_restore="null"
+  current_restore="null"
+  if [[ -s "$adjacent_restore_report" ]] && \
+    jq --exit-status '.' "$adjacent_restore_report" >/dev/null 2>&1; then
+    adjacent_restore="$(jq '.' "$adjacent_restore_report")"
+  fi
+  if [[ -s "$history_free_restore_report" ]] && \
+    jq --exit-status '.' "$history_free_restore_report" >/dev/null 2>&1; then
+    history_free_restore="$(jq '.' "$history_free_restore_report")"
+  fi
+  if [[ -s "$current_restore_report" ]] && \
+    jq --exit-status '.' "$current_restore_report" >/dev/null 2>&1; then
+    current_restore="$(jq '.' "$current_restore_report")"
+  fi
 
   jq --null-input \
     --arg result "$result" \
@@ -98,6 +143,20 @@ write_report() {
     --argjson max_probe_latency_seconds "$max_probe_latency_seconds" \
     --argjson max_probe_outage_seconds "$max_probe_outage_seconds" \
     --argjson migrations "$migrations" \
+    --argjson adjacent_restore "$adjacent_restore" \
+    --argjson history_free_restore "$history_free_restore" \
+    --argjson current_restore "$current_restore" \
+    --argjson adjacent_backup_generation_ms "$adjacent_backup_generation_ms" \
+    --argjson history_free_backup_generation_ms "$history_free_backup_generation_ms" \
+    --argjson current_backup_generation_ms "$current_backup_generation_ms" \
+    --argjson rebuild_duration_ms "$rebuild_duration_ms" \
+    --argjson restored_readiness "$restored_readiness" \
+    --argjson restored_authentication "$restored_authentication" \
+    --argjson restored_state_reads "$restored_state_reads" \
+    --argjson restored_history_read "$restored_history_read" \
+    --argjson restored_task_read "$restored_task_read" \
+    --argjson restored_computed_rebuild "$restored_computed_rebuild" \
+    --argjson restored_token_exclusion "$restored_token_exclusion" \
     '{
       result: $result,
       phase: $phase,
@@ -108,6 +167,33 @@ write_report() {
         max_api_latency_seconds: $max_probe_latency_seconds,
         max_observed_api_outage_seconds: $max_probe_outage_seconds,
         applied_versions: $migrations
+      },
+      backup_recovery: {
+        adjacent_release_with_history: (
+          if $adjacent_restore == null then null else $adjacent_restore + {
+            generation_duration_ms: $adjacent_backup_generation_ms
+          } end
+        ),
+        adjacent_release_without_history: (
+          if $history_free_restore == null then null else $history_free_restore + {
+            generation_duration_ms: $history_free_backup_generation_ms
+          } end
+        ),
+        current_release_with_history: (
+          if $current_restore == null then null else $current_restore + {
+            generation_duration_ms: $current_backup_generation_ms
+          } end
+        ),
+        restored_application_smoke: {
+          readiness: $restored_readiness,
+          authentication_reestablished: $restored_authentication,
+          authoritative_state_reads: $restored_state_reads,
+          history_read: $restored_history_read,
+          terminal_task_read: $restored_task_read,
+          computed_rebuild: $restored_computed_rebuild,
+          excluded_token_rejected: $restored_token_exclusion,
+          rebuild_duration_ms: $rebuild_duration_ms
+        }
       }
     }' > "$report_file"
 }
@@ -125,7 +211,9 @@ cleanup() {
   trap - EXIT
   set +e
   stop_probe
-  "${compose[@]}" logs --no-color --timestamps > "$compose_log" 2>&1
+  if ! "${compose[@]}" logs --no-color --timestamps > "$compose_log" 2>&1; then
+    "${compose[@]}" logs --timestamps > "$compose_log" 2>&1
+  fi
   if [[ "$status" -eq 0 ]]; then
     write_report passed
   else
@@ -145,6 +233,7 @@ HUBUUM_CANDIDATE_IMAGE=$candidate_image
 HUBUUM_PREVIOUS_IMAGE=$previous_image
 POSTGRES_TEST_IMAGE=$postgres_image
 HUBUUM_COMPATIBILITY_DATABASE_URL=$database_url
+HUBUUM_RESTORE_DATABASE_URL=$restore_database_url
 EOF
 
 cat > "$test_root/compose.yml" <<'EOF'
@@ -212,6 +301,31 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+
+  restored-api:
+    image: ${HUBUUM_CANDIDATE_IMAGE}
+    command: ["--runtime-role", "api"]
+    ports:
+      - "127.0.0.1::8080"
+    environment:
+      <<: *hubuum-environment
+      DATABASE_URL: ${HUBUUM_RESTORE_DATABASE_URL}
+      HUBUUM_DATABASE_URL: ${HUBUUM_RESTORE_DATABASE_URL}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck: *hubuum-healthcheck
+
+  restored-worker:
+    image: ${HUBUUM_CANDIDATE_IMAGE}
+    command: ["--runtime-role", "worker"]
+    environment:
+      <<: *hubuum-environment
+      DATABASE_URL: ${HUBUUM_RESTORE_DATABASE_URL}
+      HUBUUM_DATABASE_URL: ${HUBUUM_RESTORE_DATABASE_URL}
+    depends_on:
+      postgres:
+        condition: service_healthy
 EOF
 
 service_url() {
@@ -219,6 +333,11 @@ service_url() {
   local address
 
   address="$("${compose[@]}" port "$service" 8080)"
+  if [[ "$address" =~ ^[0-9]+$ ]]; then
+    address="127.0.0.1:$address"
+  elif [[ "$address" == 0.0.0.0:* || "$address" == \[::\]:* ]]; then
+    address="127.0.0.1:${address##*:}"
+  fi
   printf 'http://%s' "$address"
 }
 
@@ -281,16 +400,100 @@ json_id() {
   jq --exit-status --raw-output '.id' <<< "$api_body"
 }
 
+create_backup_artifact() {
+  local service="$1"
+  local include_history="$2"
+  local output_path="$3"
+  local duration_variable="$4"
+  local task_id
+  local status
+  local headers_path="$output_path.headers"
+  local expected_digest
+  local actual_digest
+  local started_ms
+  local finished_ms
+
+  started_ms="$(date +%s%3N)"
+  api_request "$service" POST /api/v1/backups \
+    "{\"include_history\":$include_history}"
+  task_id="$(json_id)"
+  for _ in $(seq 1 200); do
+    api_request "$service" GET "/api/v1/tasks/$task_id"
+    status="$(jq --raw-output '.status' <<< "$api_body")"
+    case "$status" in
+      succeeded)
+        break
+        ;;
+      failed|cancelled)
+        echo "ERROR: backup task $task_id ended as $status" >&2
+        return 1
+        ;;
+    esac
+    sleep 0.1
+  done
+  [[ "$status" == "succeeded" ]] || {
+    echo "ERROR: backup task $task_id did not complete" >&2
+    return 1
+  }
+
+  status="$(
+    curl --silent --show-error \
+      --output "$output_path" \
+      --dump-header "$headers_path" \
+      --write-out '%{http_code}' \
+      --header "Authorization: Bearer $admin_token" \
+      "$(service_url "$service")/api/v1/backups/$task_id/output"
+  )"
+  [[ "$status" == "200" ]] || {
+    echo "ERROR: backup output $task_id returned HTTP $status" >&2
+    return 1
+  }
+  expected_digest="$(
+    awk 'BEGIN {IGNORECASE=1} /^x-hubuum-backup-sha256:/ {sub(/\r$/, "", $2); print $2}' \
+      "$headers_path"
+  )"
+  actual_digest="$(sha256sum "$output_path" | awk '{print $1}')"
+  [[ -n "$expected_digest" && "$expected_digest" == "$actual_digest" ]] || {
+    echo "ERROR: downloaded backup digest does not match its response header" >&2
+    return 1
+  }
+  finished_ms="$(date +%s%3N)"
+  printf -v "$duration_variable" '%d' "$((finished_ms - started_ms))"
+  rm -f "$headers_path"
+}
+
+verify_restore_artifact() {
+  local backup_path="$1"
+  local target_database_url="$2"
+  local report_path="$3"
+  local retention="$4"
+  local backup_name
+  local args
+
+  backup_name="$(basename -- "$backup_path")"
+  args=(
+    --verify-backup "/verification/$backup_name"
+    --restore-test-database-url "$target_database_url"
+    --log-level error
+    --json
+  )
+  if [[ "$retention" == "keep" ]]; then
+    args+=(--keep-restore-test-database)
+  fi
+  "${compose[@]}" run --rm --no-deps -T \
+    --user 0:0 \
+    --volume "$test_root:/verification:ro,Z" \
+    --entrypoint /usr/local/bin/hubuum-admin \
+    candidate-api "${args[@]}" > "$report_path"
+  jq --exit-status \
+    '.result == "passed" and .mode == "isolated_restore" and .restore_test.storage_ready == true' \
+    "$report_path" >/dev/null
+}
+
 seed_previous_release() {
-  local group_id
-  local user_id
   local service_account_id
   local child_collection_id
-  local related_class_id
-  local related_object_id
-  local class_relation_id
   local sink_id
-  local template_id
   local task_id
 
   api_request previous-api POST /api/v1/iam/groups \
@@ -437,13 +640,14 @@ for _ in $(seq 1 60); do
 done
 "${compose[@]}" exec -T postgres pg_isready \
   --host 127.0.0.1 --username hubuum --dbname hubuum >/dev/null
-"${compose[@]}" run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin previous-api --migrate
+"${compose[@]}" run --rm --no-deps -T \
+  --entrypoint /usr/local/bin/hubuum-admin previous-api --migrate
 "${compose[@]}" up -d previous-api previous-worker
 wait_for_ready previous-api
 
 phase="authenticate-previous-release"
 password_output="$(
-  "${compose[@]}" run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin \
+  "${compose[@]}" run --rm --no-deps -T --entrypoint /usr/local/bin/hubuum-admin \
     previous-api --reset-password admin
 )"
 admin_password="${password_output##*reset to: }"
@@ -455,16 +659,25 @@ admin_token="$(jq --exit-status --raw-output '.token' <<< "$api_body")"
 phase="seed-previous-release"
 seed_previous_release
 
+phase="backup-previous-release"
+create_backup_artifact \
+  previous-api true "$adjacent_backup_file" adjacent_backup_generation_ms
+create_backup_artifact \
+  previous-api false "$history_free_backup_file" history_free_backup_generation_ms
+
 phase="drain-previous-worker"
 "${compose[@]}" stop --timeout 75 previous-worker
-[[ -z "$("${compose[@]}" ps --status running -q previous-worker)" ]]
+if "${compose[@]}" exec -T previous-worker true >/dev/null 2>&1; then
+  echo "ERROR: previous worker remained available after drain" >&2
+  exit 1
+fi
 
 phase="candidate-migration"
 rm -f "$probe_stop_file"
 probe_previous_api &
 probe_pid=$!
 migration_started=$SECONDS
-"${compose[@]}" run --rm --no-deps --entrypoint /usr/local/bin/hubuum-admin \
+"${compose[@]}" run --rm --no-deps -T --entrypoint /usr/local/bin/hubuum-admin \
   candidate-api --migrate --legacy-single-role-migration > "$migration_log" 2>&1
 migration_seconds=$((SECONDS - migration_started))
 stop_probe
@@ -490,7 +703,7 @@ phase="candidate-rollout"
 "${compose[@]}" stop --timeout 75 previous-api
 "${compose[@]}" up -d candidate-worker
 sleep 2
-[[ -n "$("${compose[@]}" ps --status running -q candidate-worker)" ]]
+"${compose[@]}" exec -T candidate-worker true
 
 phase="application-rollback"
 "${compose[@]}" stop --timeout 75 candidate-api candidate-worker
@@ -508,6 +721,94 @@ wait_for_ready candidate-api
 api_request candidate-api GET "/api/v1/collections/$collection_id"
 [[ "$(jq --raw-output '.description' <<< "$api_body")" == "verified by previous release rollback" ]]
 api_request candidate-api GET /readyz
+
+phase="backup-current-release"
+create_backup_artifact candidate-api true "$current_backup_file" current_backup_generation_ms
+
+phase="isolated-backup-restores"
+"${compose[@]}" exec -T postgres createdb --username hubuum hubuum_restore
+"${compose[@]}" exec -T postgres createdb --username hubuum hubuum_restore_no_history
+"${compose[@]}" exec -T postgres createdb --username hubuum hubuum_restore_current
+verify_restore_artifact \
+  "$adjacent_backup_file" "$restore_database_url" "$adjacent_restore_report" keep
+verify_restore_artifact \
+  "$history_free_backup_file" "$history_free_restore_database_url" \
+  "$history_free_restore_report" reset
+verify_restore_artifact \
+  "$current_backup_file" "$current_restore_database_url" "$current_restore_report" reset
+jq --exit-status '.includes_history == true and .source_version != ""' \
+  "$adjacent_restore_report" >/dev/null
+jq --exit-status '.includes_history == false and .restore_test.target_cleanup == "schema_reset"' \
+  "$history_free_restore_report" >/dev/null
+jq --exit-status '.includes_history == true and .restore_test.target_cleanup == "schema_reset"' \
+  "$current_restore_report" >/dev/null
+
+phase="restored-api-smoke"
+source_admin_token="$admin_token"
+"${compose[@]}" up -d restored-api restored-worker
+wait_for_ready restored-api
+restored_readiness=true
+password_output="$(
+  "${compose[@]}" run --rm --no-deps -T --entrypoint /usr/local/bin/hubuum-admin \
+    restored-api --reset-password admin
+)"
+restored_admin_password="${password_output##*reset to: }"
+[[ -n "$restored_admin_password" && "$restored_admin_password" != "$password_output" ]]
+admin_token=""
+api_request restored-api POST /api/v0/auth/login \
+  "{\"name\":\"admin\",\"password\":\"$restored_admin_password\"}"
+admin_token="$(jq --exit-status --raw-output '.token' <<< "$api_body")"
+restored_authentication=true
+
+api_request restored-api GET "/api/v1/collections/$collection_id"
+[[ "$(jq --raw-output '.description' <<< "$api_body")" == "adjacent release root" ]]
+api_request restored-api GET "/api/v1/classes/$class_id/$object_id"
+[[ "$(jq --raw-output '.data.owner' <<< "$api_body")" == "previous" ]]
+api_request restored-api GET "/api/v1/iam/groups/$group_id/members/$user_id"
+api_request restored-api GET "/api/v1/collections/$collection_id/permissions/group/$group_id"
+[[ "$(jq '.permissions | length' <<< "$api_body")" -gt 0 ]]
+api_request restored-api GET \
+  "/api/v1/classes/$class_id/$object_id/relations/$related_class_id/$related_object_id"
+[[ "$(jq --raw-output '.class_relation_id' <<< "$api_body")" == "$class_relation_id" ]]
+api_request restored-api GET "/api/v1/export-templates/$template_id"
+restored_state_reads=true
+api_request restored-api GET "/api/v1/tasks/$probe_task_id"
+[[ "$(jq --raw-output '.status' <<< "$api_body")" == "succeeded" ]]
+restored_task_read=true
+api_request restored-api GET "/api/v1/collections/$collection_id/events?limit=50"
+[[ "$(jq 'length' <<< "$api_body")" -gt 0 ]]
+restored_history_read=true
+
+computed_ready=false
+rebuild_started_ms="$(date +%s%3N)"
+for _ in $(seq 1 100); do
+  api_request restored-api GET "/api/v1/classes/$class_id/$object_id?include=computed"
+  if jq --exit-status \
+    '.computed.shared.materialization_stale == false and .computed.shared.values.owner_copy == "previous"' \
+    <<< "$api_body" >/dev/null; then
+    computed_ready=true
+    break
+  fi
+  sleep 0.1
+done
+rebuild_finished_ms="$(date +%s%3N)"
+rebuild_duration_ms="$((rebuild_finished_ms - rebuild_started_ms))"
+[[ "$computed_ready" == "true" ]] || {
+  echo "ERROR: restored computed-field materialization did not become current" >&2
+  exit 1
+}
+restored_computed_rebuild=true
+
+old_token_status="$(
+  curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+    --header "Authorization: Bearer $source_admin_token" \
+    "$(service_url restored-api)/api/v1/collections/$collection_id"
+)"
+[[ "$old_token_status" == "401" ]] || {
+  echo "ERROR: a bearer token excluded from backup remained usable after restore" >&2
+  exit 1
+}
+restored_token_exclusion=true
 
 phase="complete"
 echo "Adjacent release compatibility passed: $previous_tag -> ${GITHUB_SHA:-local candidate}."

--- a/scripts/test-classify-ci-changes.sh
+++ b/scripts/test-classify-ci-changes.sh
@@ -251,6 +251,12 @@ assert_flag "$compatibility_output" code true
 assert_flag "$compatibility_output" container true
 assert_flag "$compatibility_output" artifacts false
 
+restore_drill_output="$(bash "$classifier" .github/workflows/restore-drill.yml)"
+assert_flag "$restore_drill_output" code true
+assert_flag "$restore_drill_output" container true
+assert_flag "$restore_drill_output" artifacts false
+assert_flag "$restore_drill_output" benchmarks false
+
 unknown_output="$(bash "$classifier" future-build-input.conf)"
 assert_flag "$unknown_output" code true
 assert_flag "$unknown_output" container true

--- a/src/administration.rs
+++ b/src/administration.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fs::{File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
@@ -18,17 +18,22 @@ use crate::config::{
 use crate::errors::EXIT_CODE_DATABASE_ERROR;
 use crate::errors::{ApiError, EXIT_CODE_CONFIG_ERROR, fatal_error};
 use crate::logger;
+#[cfg(feature = "embedded-migrations")]
+use crate::models::BackupDocument;
 use crate::models::{
     BackupRequest, ExportContentType, RESTORE_CONFIRMATION_PHRASE, RestoreConfirmRequest,
     RestoreInitiator, RestoreJobID, RestoreStageRequest,
 };
+#[cfg(feature = "embedded-migrations")]
+use crate::restores::verify_restored_backup_matches;
 use crate::restores::{
-    RestoreSettings, confirm_restore, execute_confirmed_restore, restore_status, stage_restore,
+    BackupVerificationReport, RestoreSettings, confirm_restore, execute_confirmed_restore,
+    restore_status, stage_restore, verify_backup_document,
 };
 use crate::services::identity as identity_service;
 use crate::services::operational_administration as operational_service;
 #[cfg(feature = "embedded-migrations")]
-use crate::storage::run_storage_migrations;
+use crate::storage::reset_disposable_restore_database;
 use crate::storage::{
     OperationalStateStorage, StorageBackendKind, StorageDatabasePrivilegeReport,
     StorageDatabaseRole, StorageDatabaseRoleNames, StorageHandle, StorageSettings,
@@ -36,6 +41,8 @@ use crate::storage::{
     inspect_storage_database_privileges, storage_database_role_grants_sql,
     storage_database_role_setup_sql,
 };
+#[cfg(feature = "embedded-migrations")]
+use crate::storage::{prepare_disposable_restore_database, run_storage_migrations};
 use crate::utilities::auth::generate_random_password;
 use crate::utilities::exporting::validate_template_sources_with_limits;
 use crate::utilities::is_valid_log_level;
@@ -59,6 +66,22 @@ struct AdminCli {
     /// Omit audit, task, delivery, and temporal history from --backup
     #[arg(long, default_value_t = false, requires = "backup")]
     backup_without_history: bool,
+
+    /// Verify a backup document without connecting to a database
+    #[arg(
+        long,
+        value_name = "PATH",
+        conflicts_with_all = ["backup", "restore", "restore_executor"]
+    )]
+    verify_backup: Option<PathBuf>,
+
+    /// Restore a verified backup into this newly created empty disposable database
+    #[arg(long, value_name = "URL", requires = "verify_backup")]
+    restore_test_database_url: Option<String>,
+
+    /// Leave the restored disposable database intact for manual inspection
+    #[arg(long, default_value_t = false, requires = "restore_test_database_url")]
+    keep_restore_test_database: bool,
 
     /// Destructively replace all application data from this backup document
     #[arg(long, value_name = "PATH", conflicts_with = "backup")]
@@ -221,6 +244,21 @@ enum DatabasePrivilegeRole {
 pub async fn run_admin_from_environment() -> Result<(), ApiError> {
     let admin_cli = AdminCli::parse();
     init_logging(&admin_cli.log_level);
+
+    if let Some(path) = admin_cli.verify_backup.as_deref() {
+        verify_backup_file(BackupVerificationOptions {
+            path,
+            restore_test_database_url: admin_cli.restore_test_database_url.as_deref(),
+            configured_database_url: admin_cli.database_url.as_deref(),
+            configured_migration_database_url: admin_cli.migration_database_url.as_deref(),
+            storage_backend: admin_cli.storage_backend,
+            statement_timeout_ms: admin_cli.db_statement_timeout_ms,
+            keep_restore_test_database: admin_cli.keep_restore_test_database,
+            json: admin_cli.json,
+        })
+        .await?;
+        return Ok(());
+    }
 
     let database_roles = resolve_database_roles(
         admin_cli.database_owner_role.as_deref(),
@@ -545,6 +583,221 @@ async fn backup_database(
     Ok(())
 }
 
+fn read_backup_file(path: &Path, max_bytes: usize) -> Result<Vec<u8>, ApiError> {
+    let file = File::open(path).map_err(|error| {
+        ApiError::BadRequest(format!(
+            "Failed to open backup document '{}': {error}",
+            path.display()
+        ))
+    })?;
+    let metadata = file.metadata().map_err(|error| {
+        ApiError::BadRequest(format!(
+            "Failed to inspect backup document '{}': {error}",
+            path.display()
+        ))
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(ApiError::BadRequest(format!(
+            "Backup document '{}' must be an ordinary file",
+            path.display()
+        )));
+    }
+    if metadata.len() > u64::try_from(max_bytes).unwrap_or(u64::MAX) {
+        return Err(ApiError::PayloadTooLarge(format!(
+            "Backup document is {} bytes, exceeding the configured {} byte limit",
+            metadata.len(),
+            max_bytes
+        )));
+    }
+    let read_limit = u64::try_from(max_bytes)
+        .unwrap_or(u64::MAX - 1)
+        .saturating_add(1);
+    let mut bytes = Vec::with_capacity(
+        usize::try_from(metadata.len())
+            .unwrap_or(max_bytes)
+            .min(max_bytes),
+    );
+    file.take(read_limit)
+        .read_to_end(&mut bytes)
+        .map_err(|error| {
+            ApiError::BadRequest(format!(
+                "Failed to read backup document '{}': {error}",
+                path.display()
+            ))
+        })?;
+    if bytes.len() > max_bytes {
+        return Err(ApiError::PayloadTooLarge(format!(
+            "Backup document exceeds the configured {max_bytes} byte limit"
+        )));
+    }
+    Ok(bytes)
+}
+
+fn admin_storage_settings(
+    database_url: impl Into<String>,
+    statement_timeout_ms: u64,
+) -> Result<StorageSettings, ApiError> {
+    StorageSettings::postgres(database_url)
+        .max_connections(1)
+        .statement_timeout_ms(statement_timeout_ms)
+        .acquire_timeout_ms(DEFAULT_DB_POOL_ACQUIRE_TIMEOUT_MS)
+        .build()
+        .map_err(Into::into)
+}
+
+fn reject_configured_database_target(
+    target: &StorageSettings,
+    configured_url: Option<&str>,
+    statement_timeout_ms: u64,
+) -> Result<(), ApiError> {
+    let Some(configured_url) = configured_url.filter(|value| !value.trim().is_empty()) else {
+        return Ok(());
+    };
+    let configured = admin_storage_settings(configured_url, statement_timeout_ms)?;
+    if target.same_database_endpoint(&configured) {
+        return Err(ApiError::BadRequest(
+            "Refused restore verification because the disposable target matches a configured Hubuum database"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+struct BackupVerificationOptions<'a> {
+    path: &'a Path,
+    restore_test_database_url: Option<&'a str>,
+    configured_database_url: Option<&'a str>,
+    configured_migration_database_url: Option<&'a str>,
+    storage_backend: StorageBackendKind,
+    statement_timeout_ms: u64,
+    keep_restore_test_database: bool,
+    json: bool,
+}
+
+async fn verify_backup_file(
+    options: BackupVerificationOptions<'_>,
+) -> Result<BackupVerificationReport, ApiError> {
+    let bytes = read_backup_file(options.path, DEFAULT_RESTORE_MAX_UPLOAD_BYTES)?;
+    let report = verify_backup_document(&bytes, DEFAULT_RESTORE_MAX_UPLOAD_BYTES)?;
+    let report = if let Some(database_url) = options.restore_test_database_url {
+        if !matches!(options.storage_backend, StorageBackendKind::Postgres) {
+            return Err(ApiError::BadRequest(
+                "Isolated restore verification requires the PostgreSQL storage backend".to_string(),
+            ));
+        }
+        let target = admin_storage_settings(database_url, options.statement_timeout_ms)?;
+        reject_configured_database_target(
+            &target,
+            options.configured_database_url,
+            options.statement_timeout_ms,
+        )?;
+        reject_configured_database_target(
+            &target,
+            options.configured_migration_database_url,
+            options.statement_timeout_ms,
+        )?;
+        verify_backup_restore(report, bytes, target, options.keep_restore_test_database).await?
+    } else {
+        report
+    };
+    if options.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else if options.restore_test_database_url.is_some() {
+        println!(
+            "Backup verification passed, including restore into an isolated disposable database."
+        );
+        if options.keep_restore_test_database {
+            println!("The caller remains responsible for deleting the disposable database.");
+        } else {
+            println!("The disposable database schema was reset after verification.");
+        }
+        print_backup_verification_summary(&report);
+    } else {
+        println!("Backup verification passed (format only; no restore was attempted).");
+        print_backup_verification_summary(&report);
+    }
+    Ok(report)
+}
+
+#[cfg(feature = "embedded-migrations")]
+async fn verify_backup_restore(
+    mut report: BackupVerificationReport,
+    bytes: Vec<u8>,
+    target: StorageSettings,
+    keep_restore_test_database: bool,
+) -> Result<BackupVerificationReport, ApiError> {
+    let migrations_applied = prepare_disposable_restore_database(&target)?;
+    let verification = async {
+        let storage = initialize_storage(&target)?;
+        let source: BackupDocument = serde_json::from_slice(&bytes)?;
+        let started_at = std::time::Instant::now();
+        restore_database_bytes(&storage, bytes).await?;
+        let restore_duration = started_at.elapsed();
+        let readiness = storage.get_readiness_snapshot().await?;
+        if !readiness.storage_is_ready() {
+            return Err(ApiError::ServiceUnavailable(
+                "Restored disposable database did not pass storage readiness".to_string(),
+            ));
+        }
+        let restored = create_backup_document(
+            &storage,
+            &BackupRequest {
+                include_history: source.history.is_some(),
+            },
+        )
+        .await?;
+        verify_restored_backup_matches(&source, &restored)?;
+        Ok::<_, ApiError>(restore_duration)
+    }
+    .await;
+    let target_cleanup = if keep_restore_test_database {
+        "caller_managed"
+    } else {
+        if let Err(cleanup_error) = reset_disposable_restore_database(&target) {
+            if verification.is_err() {
+                return Err(ApiError::InternalServerError(
+                    "Restore verification failed and the disposable database could not be reset; delete it explicitly"
+                        .to_string(),
+                ));
+            }
+            return Err(cleanup_error.into());
+        }
+        "schema_reset"
+    };
+    let restore_duration = verification?;
+    report.record_isolated_restore(migrations_applied, restore_duration, target_cleanup);
+    Ok(report)
+}
+
+#[cfg(not(feature = "embedded-migrations"))]
+async fn verify_backup_restore(
+    _report: BackupVerificationReport,
+    _bytes: Vec<u8>,
+    _target: StorageSettings,
+    _keep_restore_test_database: bool,
+) -> Result<BackupVerificationReport, ApiError> {
+    Err(ApiError::NotImplemented(
+        "This hubuum-admin build does not include embedded migrations required for isolated restore verification"
+            .to_string(),
+    ))
+}
+
+fn print_backup_verification_summary(report: &BackupVerificationReport) {
+    println!("Backup version: {}", report.backup_version());
+    println!("Source version: {}", report.source_version());
+    println!("SHA-256: {}", report.sha256());
+    println!("Bytes: {}", report.byte_size());
+    println!("Logical rows: {}", report.total_items());
+    println!(
+        "History: {}",
+        if report.includes_history() {
+            "included"
+        } else {
+            "excluded"
+        }
+    );
+}
+
 fn write_backup_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let (temporary_path, mut file) = create_backup_temporary_file(path)?;
     let write_result = file.write_all(bytes).and_then(|_| file.sync_all());
@@ -750,12 +1003,20 @@ async fn restore_database(
     if confirmation != Some(RESTORE_CONFIRMATION_PHRASE) {
         return Err(destructive_confirmation_error());
     }
-    let bytes = std::fs::read(path).map_err(|error| {
-        ApiError::BadRequest(format!(
-            "Failed to read restore document '{}': {error}",
-            path.display()
-        ))
-    })?;
+    let bytes = read_backup_file(path, usize::MAX)?;
+    let restored = restore_database_bytes(storage, bytes).await?;
+    println!(
+        "Restore {} completed with status '{}'.",
+        restored.id,
+        restored.status.as_str()
+    );
+    Ok(())
+}
+
+async fn restore_database_bytes(
+    storage: &StorageHandle,
+    bytes: Vec<u8>,
+) -> Result<crate::models::RestoreStageResponse, ApiError> {
     let settings = RestoreSettings::new(
         DEFAULT_RESTORE_STAGE_RETENTION_MINUTES,
         DEFAULT_RESTORE_MAX_UPLOAD_BYTES.max(bytes.len()),
@@ -784,12 +1045,7 @@ async fn restore_database(
         )));
     }
     let restored = restore_status(storage, RestoreJobID::new(confirmed.id)?, &capability).await?;
-    println!(
-        "Restore {} completed with status '{}'.",
-        restored.id,
-        restored.status.as_str()
-    );
-    Ok(())
+    Ok(restored)
 }
 
 async fn run_restore_executor(storage: &StorageHandle) -> Result<(), ApiError> {

--- a/src/backups/mod.rs
+++ b/src/backups/mod.rs
@@ -1,6 +1,4 @@
 use crate::models::token_scope::TokenScope;
-use std::collections::BTreeMap;
-
 use chrono::Utc;
 use sha2::{Digest, Sha256};
 
@@ -67,29 +65,7 @@ impl BackupSettings {
 }
 
 fn build_manifest(state: &BackupState, history: Option<&BackupHistory>) -> BackupManifest {
-    let mut item_counts = BTreeMap::new();
-    for (name, rows) in &state.sections {
-        item_counts.insert(name.as_str().to_string(), rows.len() as i64);
-    }
-    if let Some(history) = history {
-        for (name, rows) in &history.sections {
-            item_counts.insert(format!("history.{}", name.as_str()), rows.len() as i64);
-        }
-    }
-    BackupManifest {
-        item_counts,
-        exclusions: vec![
-            "backup_task_outputs (backup artifacts never recursively contain prior backups)"
-                .to_string(),
-            "authentication tokens and token scopes (credentials must be reissued after restore)"
-                .to_string(),
-            "class reachability cache (rebuilt by database triggers during restore)".to_string(),
-            "computed-field class state and materialized object cache (rebuilt after restore)"
-                .to_string(),
-            "active tasks and non-terminal event deliveries".to_string(),
-            "restore control-plane tables and server instance heartbeats".to_string(),
-        ],
-    }
+    BackupManifest::from_sections(state, history)
 }
 
 pub async fn create_backup_document(

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -155,6 +155,12 @@ fn production_container_runs_as_non_root() {
             .any(|line| line.trim() == "USER hubuum:hubuum"),
         "production Dockerfile must select the dedicated hubuum user"
     );
+    assert!(
+        dockerfile
+            .lines()
+            .any(|line| line.trim() == "RUN chmod 0755 /entrypoint.sh"),
+        "production entrypoint must be readable by the dedicated hubuum user"
+    );
 }
 
 #[test]

--- a/src/models/backup.rs
+++ b/src/models/backup.rs
@@ -13,6 +13,14 @@ use crate::models::{REDACTED_DEBUG_VALUE, redacted_debug_option};
 use super::principal::Principal;
 
 pub const CURRENT_BACKUP_VERSION: i32 = 5;
+pub(crate) const BACKUP_MANIFEST_EXCLUSIONS: &[&str] = &[
+    "backup_task_outputs (backup artifacts never recursively contain prior backups)",
+    "authentication tokens and token scopes (credentials must be reissued after restore)",
+    "class reachability cache (rebuilt by database triggers during restore)",
+    "computed-field class state and materialized object cache (rebuilt after restore)",
+    "active tasks and non-terminal event deliveries",
+    "restore control-plane tables and server instance heartbeats",
+];
 
 /// Immutable identity snapshot recorded with a restore stage and its provenance event.
 pub struct RestoreInitiator {
@@ -110,6 +118,28 @@ pub struct BackupManifest {
     #[schema(value_type = Object)]
     pub item_counts: BTreeMap<String, i64>,
     pub exclusions: Vec<String>,
+}
+
+impl BackupManifest {
+    #[must_use]
+    pub fn from_sections(state: &BackupState, history: Option<&BackupHistory>) -> Self {
+        let mut item_counts = BTreeMap::new();
+        for (name, rows) in &state.sections {
+            item_counts.insert(name.as_str().to_string(), rows.len() as i64);
+        }
+        if let Some(history) = history {
+            for (name, rows) in &history.sections {
+                item_counts.insert(format!("history.{}", name.as_str()), rows.len() as i64);
+            }
+        }
+        Self {
+            item_counts,
+            exclusions: BACKUP_MANIFEST_EXCLUSIONS
+                .iter()
+                .map(|value| (*value).to_string())
+                .collect(),
+        }
+    }
 }
 
 /// Privileged, restore-only logical snapshots. Backup version 5 identifies

--- a/src/restores/mod.rs
+++ b/src/restores/mod.rs
@@ -1,10 +1,11 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Once;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration as StdDuration, Instant};
 
-use chrono::{Duration, NaiveDateTime, Utc};
+use chrono::{DateTime, Duration, NaiveDateTime, Utc};
 use hubuum_computed_fields::{MAX_PERSONAL_DEFINITIONS, MAX_SHARED_DEFINITIONS, SEMANTICS_VERSION};
+use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -14,10 +15,10 @@ use crate::lifecycle::spawn_background_worker;
 use crate::models::identity::{LOCAL_IDENTITY_SCOPE, LOCAL_PROVIDER_KIND};
 use crate::models::retention::FutureRetention;
 use crate::models::{
-    BackupDocument, COMPUTED_FIELD_VISIBILITY_PERSONAL, COMPUTED_FIELD_VISIBILITY_SHARED,
-    ComputedFieldDefinitionRequest, ComputedResultType, MaintenanceState,
-    RESTORE_CONFIRMATION_PHRASE, RestoreConfirmRequest, RestoreJobID, RestoreJobStatus,
-    RestoreStageRequest, RestoreStageResponse, RestoreValidationSummary,
+    BACKUP_MANIFEST_EXCLUSIONS, BackupDocument, COMPUTED_FIELD_VISIBILITY_PERSONAL,
+    COMPUTED_FIELD_VISIBILITY_SHARED, ComputedFieldDefinitionRequest, ComputedResultType,
+    MaintenanceState, RESTORE_CONFIRMATION_PHRASE, RestoreConfirmRequest, RestoreJobID,
+    RestoreJobStatus, RestoreStageRequest, RestoreStageResponse, RestoreValidationSummary,
 };
 use crate::services::identity::resolve_identity_scope_name as load_identity_scope_name;
 use crate::storage::storage_handle;
@@ -40,6 +41,91 @@ const MISSING_RESTORE_CAPABILITY_HASH: &str =
 // coordinators retains their original grace period. The dedicated executor
 // does not wait for this threshold.
 const RESTORE_RECONCILIATION_GRACE_SECONDS: i64 = 60;
+const BACKUP_VERIFICATION_REPORT_VERSION: i32 = 1;
+const MAX_BACKUP_SOURCE_VERSION_BYTES: usize = 128;
+
+/// Sanitized, versioned evidence produced by offline backup verification.
+#[derive(Clone, Debug, Serialize)]
+pub struct BackupVerificationReport {
+    report_version: i32,
+    result: &'static str,
+    mode: &'static str,
+    verified_at: DateTime<Utc>,
+    verifier_version: &'static str,
+    backup_version: i32,
+    source_version: String,
+    created_at: DateTime<Utc>,
+    sha256: String,
+    byte_size: u64,
+    includes_history: bool,
+    total_items: i64,
+    canonical_state_sha256: String,
+    section_counts: BTreeMap<String, i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    restore_test: Option<BackupRestoreTestReport>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct BackupRestoreTestReport {
+    target_version: &'static str,
+    migrations_applied: usize,
+    restore_duration_ms: u64,
+    storage_ready: bool,
+    state_matches_source: bool,
+    history_matches_source: bool,
+    target_cleanup: &'static str,
+}
+
+impl BackupVerificationReport {
+    #[must_use]
+    pub fn sha256(&self) -> &str {
+        &self.sha256
+    }
+
+    #[must_use]
+    pub const fn byte_size(&self) -> u64 {
+        self.byte_size
+    }
+
+    #[must_use]
+    pub const fn total_items(&self) -> i64 {
+        self.total_items
+    }
+
+    #[must_use]
+    pub fn source_version(&self) -> &str {
+        &self.source_version
+    }
+
+    #[must_use]
+    pub const fn backup_version(&self) -> i32 {
+        self.backup_version
+    }
+
+    #[must_use]
+    pub const fn includes_history(&self) -> bool {
+        self.includes_history
+    }
+
+    pub fn record_isolated_restore(
+        &mut self,
+        migrations_applied: usize,
+        restore_duration: StdDuration,
+        target_cleanup: &'static str,
+    ) {
+        self.mode = "isolated_restore";
+        self.verified_at = Utc::now();
+        self.restore_test = Some(BackupRestoreTestReport {
+            target_version: env!("CARGO_PKG_VERSION"),
+            migrations_applied,
+            restore_duration_ms: u64::try_from(restore_duration.as_millis()).unwrap_or(u64::MAX),
+            storage_ready: true,
+            state_matches_source: true,
+            history_matches_source: true,
+            target_cleanup,
+        });
+    }
+}
 
 struct RestoreJobSummaryData {
     id: i64,
@@ -200,6 +286,485 @@ fn sha256(bytes: &[u8]) -> String {
         .collect()
 }
 
+fn backup_section_counts(document: &BackupDocument) -> Result<BTreeMap<String, i64>, ApiError> {
+    let mut counts = BTreeMap::new();
+    for (section, rows) in &document.state.sections {
+        counts.insert(
+            section.as_str().to_string(),
+            i64::try_from(rows.len()).map_err(|_| {
+                ApiError::PayloadTooLarge(format!(
+                    "Full backup section '{section}' exceeds the supported row-count range"
+                ))
+            })?,
+        );
+    }
+    if let Some(history) = &document.history {
+        for (section, rows) in &history.sections {
+            counts.insert(
+                format!("history.{}", section.as_str()),
+                i64::try_from(rows.len()).map_err(|_| {
+                    ApiError::PayloadTooLarge(format!(
+                        "Full backup history section '{section}' exceeds the supported row-count range"
+                    ))
+                })?,
+            );
+        }
+    }
+    Ok(counts)
+}
+
+fn validate_backup_manifest(document: &BackupDocument) -> Result<BTreeMap<String, i64>, ApiError> {
+    let counts = backup_section_counts(document)?;
+    if document.manifest.item_counts != counts {
+        let mismatched_section = counts
+            .keys()
+            .chain(document.manifest.item_counts.keys())
+            .find(|section| counts.get(*section) != document.manifest.item_counts.get(*section))
+            .map(String::as_str)
+            .unwrap_or("unknown");
+        return Err(ApiError::BadRequest(format!(
+            "Full backup manifest count for section '{mismatched_section}' does not match the document"
+        )));
+    }
+    let exclusions = BACKUP_MANIFEST_EXCLUSIONS
+        .iter()
+        .map(|value| (*value).to_string())
+        .collect::<Vec<_>>();
+    if document.manifest.exclusions != exclusions {
+        return Err(ApiError::BadRequest(
+            "Full backup manifest exclusions do not match backup version 5".to_string(),
+        ));
+    }
+    Ok(counts)
+}
+
+fn validate_backup_metadata(document: &BackupDocument) -> Result<(), ApiError> {
+    if document.source_version.trim().is_empty()
+        || document.source_version.len() > MAX_BACKUP_SOURCE_VERSION_BYTES
+    {
+        return Err(ApiError::BadRequest(format!(
+            "Full backup source_version must contain between 1 and {MAX_BACKUP_SOURCE_VERSION_BYTES} bytes"
+        )));
+    }
+    if document.created_at > Utc::now() + Duration::minutes(5) {
+        return Err(ApiError::BadRequest(
+            "Full backup creation timestamp is unreasonably far in the future".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_row_timestamps(section: &str, rows: &[StorageBackupRow]) -> Result<(), ApiError> {
+    for row in rows {
+        for (field, value) in row.fields() {
+            if !(field.ends_with("_at")
+                || matches!(field.as_str(), "issued" | "valid_from" | "valid_to"))
+                || value.is_null()
+            {
+                continue;
+            }
+            let timestamp = value.as_str().ok_or_else(|| {
+                ApiError::BadRequest(format!(
+                    "Full backup section '{section}' contains a non-string timestamp in '{field}'"
+                ))
+            })?;
+            DateTime::parse_from_rfc3339(timestamp).map_err(|_| {
+                ApiError::BadRequest(format!(
+                    "Full backup section '{section}' contains an invalid RFC 3339 timestamp in '{field}'"
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_backup_timestamps(document: &BackupDocument) -> Result<(), ApiError> {
+    for (section, rows) in &document.state.sections {
+        validate_row_timestamps(section.as_str(), rows)?;
+    }
+    if let Some(history) = &document.history {
+        for (section, rows) in &history.sections {
+            validate_row_timestamps(&format!("history.{}", section.as_str()), rows)?;
+        }
+    }
+    Ok(())
+}
+
+fn required_positive_id(
+    section: &str,
+    row: &StorageBackupRow,
+    field: &str,
+) -> Result<i64, ApiError> {
+    row.get(field)
+        .and_then(Value::as_i64)
+        .filter(|value| *value > 0)
+        .ok_or_else(|| {
+            ApiError::BadRequest(format!(
+                "Full backup section '{section}' contains an invalid {field}"
+            ))
+        })
+}
+
+fn optional_positive_id(
+    section: &str,
+    row: &StorageBackupRow,
+    field: &str,
+) -> Result<Option<i64>, ApiError> {
+    match row.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(_) => required_positive_id(section, row, field).map(Some),
+    }
+}
+
+fn section_ids(
+    document: &BackupDocument,
+    section: StorageBackupStateSection,
+) -> Result<HashSet<i64>, ApiError> {
+    let rows = required_state_section(document, section)?;
+    let ids = rows
+        .iter()
+        .map(|row| required_positive_id(section.as_str(), row, "id"))
+        .collect::<Result<HashSet<_>, _>>()?;
+    if ids.len() != rows.len() {
+        return Err(ApiError::BadRequest(format!(
+            "Full backup section '{section}' contains duplicate identifiers"
+        )));
+    }
+    Ok(ids)
+}
+
+fn require_reference(
+    section: &str,
+    field: &str,
+    value: i64,
+    targets: &HashSet<i64>,
+) -> Result<(), ApiError> {
+    if targets.contains(&value) {
+        Ok(())
+    } else {
+        Err(ApiError::BadRequest(format!(
+            "Full backup section '{section}' contains a {field} that does not reference a retained row"
+        )))
+    }
+}
+
+fn validate_required_reference(
+    section: &str,
+    row: &StorageBackupRow,
+    field: &str,
+    targets: &HashSet<i64>,
+) -> Result<i64, ApiError> {
+    let value = required_positive_id(section, row, field)?;
+    require_reference(section, field, value, targets)?;
+    Ok(value)
+}
+
+fn validate_optional_reference(
+    section: &str,
+    row: &StorageBackupRow,
+    field: &str,
+    targets: &HashSet<i64>,
+) -> Result<Option<i64>, ApiError> {
+    let value = optional_positive_id(section, row, field)?;
+    if let Some(value) = value {
+        require_reference(section, field, value, targets)?;
+    }
+    Ok(value)
+}
+
+fn validate_backup_state_references(document: &BackupDocument) -> Result<(), ApiError> {
+    let identity_scopes = section_ids(document, StorageBackupStateSection::IdentityScopes)?;
+    let groups = section_ids(document, StorageBackupStateSection::Groups)?;
+    let principals = section_ids(document, StorageBackupStateSection::Principals)?;
+    let collections = section_ids(document, StorageBackupStateSection::Collections)?;
+    let classes = section_ids(document, StorageBackupStateSection::Classes)?;
+    let class_relations = section_ids(document, StorageBackupStateSection::ClassRelations)?;
+    let objects = section_ids(document, StorageBackupStateSection::Objects)?;
+    let sinks = section_ids(document, StorageBackupStateSection::EventSinks)?;
+
+    for row in required_state_section(document, StorageBackupStateSection::Groups)? {
+        validate_required_reference("groups", row, "identity_scope_id", &identity_scopes)?;
+    }
+    for row in required_state_section(document, StorageBackupStateSection::Principals)? {
+        validate_required_reference("principals", row, "identity_scope_id", &identity_scopes)?;
+    }
+    for section in [
+        StorageBackupStateSection::Users,
+        StorageBackupStateSection::ServiceAccounts,
+    ] {
+        for row in required_state_section(document, section)? {
+            validate_required_reference(section.as_str(), row, "id", &principals)?;
+        }
+    }
+    for row in required_state_section(document, StorageBackupStateSection::ServiceAccounts)? {
+        validate_required_reference("service_accounts", row, "owner_group_id", &groups)?;
+        validate_optional_reference("service_accounts", row, "created_by", &principals)?;
+    }
+    for row in required_state_section(document, StorageBackupStateSection::GroupMemberships)? {
+        validate_required_reference("group_memberships", row, "principal_id", &principals)?;
+        validate_required_reference("group_memberships", row, "group_id", &groups)?;
+    }
+    for row in required_state_section(document, StorageBackupStateSection::GroupMembershipSources)?
+    {
+        validate_required_reference("group_membership_sources", row, "principal_id", &principals)?;
+        validate_required_reference("group_membership_sources", row, "group_id", &groups)?;
+        validate_required_reference(
+            "group_membership_sources",
+            row,
+            "source_scope_id",
+            &identity_scopes,
+        )?;
+    }
+    for row in required_state_section(document, StorageBackupStateSection::Collections)? {
+        validate_optional_reference("collections", row, "parent_collection_id", &collections)?;
+    }
+    for row in required_state_section(document, StorageBackupStateSection::CollectionAuthorization)?
+    {
+        validate_required_reference(
+            "collection_authorization",
+            row,
+            "collection_id",
+            &collections,
+        )?;
+    }
+    for row in required_state_section(document, StorageBackupStateSection::CollectionHierarchy)? {
+        validate_required_reference(
+            "collection_hierarchy",
+            row,
+            "ancestor_collection_id",
+            &collections,
+        )?;
+        validate_required_reference(
+            "collection_hierarchy",
+            row,
+            "descendant_collection_id",
+            &collections,
+        )?;
+    }
+    for row in required_state_section(
+        document,
+        StorageBackupStateSection::CollectionPermissionGrants,
+    )? {
+        validate_required_reference(
+            "collection_permission_grants",
+            row,
+            "collection_id",
+            &collections,
+        )?;
+        validate_required_reference("collection_permission_grants", row, "group_id", &groups)?;
+    }
+
+    let class_collections = required_state_section(document, StorageBackupStateSection::Classes)?
+        .iter()
+        .map(|row| {
+            let id = required_positive_id("classes", row, "id")?;
+            let collection_id =
+                validate_required_reference("classes", row, "collection_id", &collections)?;
+            Ok((id, collection_id))
+        })
+        .collect::<Result<HashMap<_, _>, ApiError>>()?;
+    for row in required_state_section(
+        document,
+        StorageBackupStateSection::ComputedFieldDefinitions,
+    )? {
+        validate_required_reference("computed_field_definitions", row, "class_id", &classes)?;
+        validate_optional_reference(
+            "computed_field_definitions",
+            row,
+            "owner_principal_id",
+            &principals,
+        )?;
+        validate_optional_reference("computed_field_definitions", row, "created_by", &principals)?;
+        validate_optional_reference("computed_field_definitions", row, "updated_by", &principals)?;
+    }
+
+    let relation_classes =
+        required_state_section(document, StorageBackupStateSection::ClassRelations)?
+            .iter()
+            .map(|row| {
+                let id = required_positive_id("class_relations", row, "id")?;
+                let from =
+                    validate_required_reference("class_relations", row, "from_class_id", &classes)?;
+                let to =
+                    validate_required_reference("class_relations", row, "to_class_id", &classes)?;
+                Ok((id, (from, to)))
+            })
+            .collect::<Result<HashMap<_, _>, ApiError>>()?;
+
+    let object_classes = required_state_section(document, StorageBackupStateSection::Objects)?
+        .iter()
+        .map(|row| {
+            let id = required_positive_id("objects", row, "id")?;
+            let class_id = validate_required_reference("objects", row, "class_id", &classes)?;
+            let collection_id =
+                validate_required_reference("objects", row, "collection_id", &collections)?;
+            if class_collections.get(&class_id) != Some(&collection_id) {
+                return Err(ApiError::BadRequest(
+                    "Full backup object collection does not match its class collection".to_string(),
+                ));
+            }
+            Ok((id, class_id))
+        })
+        .collect::<Result<HashMap<_, _>, ApiError>>()?;
+
+    for row in required_state_section(document, StorageBackupStateSection::ObjectRelations)? {
+        let from_object =
+            validate_required_reference("object_relations", row, "from_object_id", &objects)?;
+        let to_object =
+            validate_required_reference("object_relations", row, "to_object_id", &objects)?;
+        let relation_id = validate_required_reference(
+            "object_relations",
+            row,
+            "class_relation_id",
+            &class_relations,
+        )?;
+        let endpoints = (
+            object_classes.get(&from_object).copied(),
+            object_classes.get(&to_object).copied(),
+        );
+        let expected = relation_classes.get(&relation_id).copied();
+        if expected.is_none_or(|expected| {
+            endpoints != (Some(expected.0), Some(expected.1))
+                && endpoints != (Some(expected.1), Some(expected.0))
+        }) {
+            return Err(ApiError::BadRequest(
+                "Full backup object relation endpoints do not match its class relation".to_string(),
+            ));
+        }
+    }
+
+    for row in required_state_section(document, StorageBackupStateSection::ExportTemplates)? {
+        validate_required_reference("export_templates", row, "collection_id", &collections)?;
+        validate_optional_reference("export_templates", row, "class_id", &classes)?;
+    }
+    for row in required_state_section(document, StorageBackupStateSection::RemoteTargets)? {
+        validate_required_reference("remote_targets", row, "collection_id", &collections)?;
+        validate_optional_reference("remote_targets", row, "class_id", &classes)?;
+    }
+    for row in required_state_section(document, StorageBackupStateSection::EventSubscriptions)? {
+        validate_required_reference("event_subscriptions", row, "collection_id", &collections)?;
+        validate_required_reference("event_subscriptions", row, "sink_id", &sinks)?;
+    }
+    Ok(())
+}
+
+/// Validate backup bytes without connecting to or mutating a database.
+pub fn verify_backup_document(
+    document_bytes: &[u8],
+    max_document_bytes: usize,
+) -> Result<BackupVerificationReport, ApiError> {
+    if document_bytes.is_empty() {
+        return Err(ApiError::BadRequest(
+            "Backup document must not be empty".to_string(),
+        ));
+    }
+    if document_bytes.len() > max_document_bytes {
+        return Err(ApiError::PayloadTooLarge(format!(
+            "Backup document is {} bytes, exceeding the configured {} byte limit",
+            document_bytes.len(),
+            max_document_bytes
+        )));
+    }
+    let document: BackupDocument = serde_json::from_slice(document_bytes).map_err(|error| {
+        ApiError::BadRequest(format!("Backup document is not valid backup JSON: {error}"))
+    })?;
+    let summary = validation_summary(&document)?;
+    let section_counts = backup_section_counts(&document)?;
+    Ok(BackupVerificationReport {
+        report_version: BACKUP_VERIFICATION_REPORT_VERSION,
+        result: "passed",
+        mode: "format_only",
+        verified_at: Utc::now(),
+        verifier_version: env!("CARGO_PKG_VERSION"),
+        backup_version: summary.backup_version,
+        source_version: summary.source_version,
+        created_at: document.created_at,
+        sha256: sha256(document_bytes),
+        byte_size: u64::try_from(document_bytes.len()).unwrap_or(u64::MAX),
+        includes_history: summary.includes_history,
+        total_items: summary.total_items,
+        canonical_state_sha256: sha256(&serde_json::to_vec(&document.state)?),
+        section_counts,
+        restore_test: None,
+    })
+}
+
+/// Compare a post-restore logical snapshot with the source artifact. The
+/// destructive restore deliberately appends exactly one provenance event; all
+/// authoritative state and every other requested history section must remain
+/// byte-for-byte equivalent at the logical storage boundary.
+#[cfg(feature = "embedded-migrations")]
+pub(crate) fn verify_restored_backup_matches(
+    source: &BackupDocument,
+    restored: &BackupDocument,
+) -> Result<(), ApiError> {
+    if source.state != restored.state {
+        return Err(ApiError::InternalServerError(
+            "Restored logical state does not match the verified backup".to_string(),
+        ));
+    }
+    match (&source.history, &restored.history) {
+        (None, None) => Ok(()),
+        (Some(source_history), Some(restored_history)) => {
+            for section in StorageBackupHistorySection::ALL {
+                let source_rows = source_history.sections.get(section).ok_or_else(|| {
+                    ApiError::InternalServerError(format!(
+                        "Verified backup comparison is missing history section '{section}'"
+                    ))
+                })?;
+                let restored_rows = restored_history.sections.get(section).ok_or_else(|| {
+                    ApiError::InternalServerError(format!(
+                        "Restored snapshot comparison is missing history section '{section}'"
+                    ))
+                })?;
+                if *section == StorageBackupHistorySection::AuditEvents {
+                    verify_restore_provenance_delta(source_rows, restored_rows)?;
+                } else if source_rows != restored_rows {
+                    return Err(ApiError::InternalServerError(format!(
+                        "Restored history section '{section}' does not match the verified backup"
+                    )));
+                }
+            }
+            Ok(())
+        }
+        _ => Err(ApiError::InternalServerError(
+            "Restored history inclusion does not match the verified backup".to_string(),
+        )),
+    }
+}
+
+#[cfg(feature = "embedded-migrations")]
+fn verify_restore_provenance_delta(
+    source_rows: &[StorageBackupRow],
+    restored_rows: &[StorageBackupRow],
+) -> Result<(), ApiError> {
+    if restored_rows.len() != source_rows.len().saturating_add(1)
+        || source_rows
+            .iter()
+            .any(|source_row| !restored_rows.contains(source_row))
+    {
+        return Err(ApiError::InternalServerError(
+            "Restored audit history differs by more than its provenance event".to_string(),
+        ));
+    }
+    let added = restored_rows
+        .iter()
+        .find(|row| !source_rows.contains(row))
+        .ok_or_else(|| {
+            ApiError::InternalServerError(
+                "Restored audit history is missing its provenance event".to_string(),
+            )
+        })?;
+    if added.get("entity_type").and_then(Value::as_str) != Some("restore")
+        || added.get("action").and_then(Value::as_str) != Some("succeeded")
+    {
+        return Err(ApiError::InternalServerError(
+            "Restored audit history contains an unexpected additional event".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn capability_matches(capability_hash: &str, capability: &str) -> bool {
     let supplied = sha256(capability.as_bytes());
     let expected = capability_hash.as_bytes();
@@ -227,6 +792,7 @@ fn invalid_restore_capability() -> ApiError {
 
 fn validation_summary(document: &BackupDocument) -> Result<RestoreValidationSummary, ApiError> {
     document.validate_version()?;
+    validate_backup_metadata(document)?;
     StorageBackupSnapshot::try_new(
         document.state.sections.clone(),
         document
@@ -235,27 +801,20 @@ fn validation_summary(document: &BackupDocument) -> Result<RestoreValidationSumm
             .map(|history| history.sections.clone()),
     )
     .map_err(|error| ApiError::from(error.into_request_error()))?;
+    let item_counts = validate_backup_manifest(document)?;
+    validate_backup_timestamps(document)?;
     validate_required_seed_rows(document)?;
+    validate_backup_state_references(document)?;
     validate_backup_revisions(document)?;
     validate_backup_class_schemas(document)?;
     validate_computed_field_definitions(document)?;
-    let total_items = document
-        .state
-        .sections
-        .values()
-        .map(|rows| rows.len() as i64)
-        .sum::<i64>()
-        + document
-            .history
-            .as_ref()
-            .map(|history| {
-                history
-                    .sections
-                    .values()
-                    .map(|rows| rows.len() as i64)
-                    .sum::<i64>()
-            })
-            .unwrap_or(0);
+    let total_items = item_counts.values().try_fold(0_i64, |total, count| {
+        total.checked_add(*count).ok_or_else(|| {
+            ApiError::PayloadTooLarge(
+                "Full backup total row count exceeds the supported range".to_string(),
+            )
+        })
+    })?;
     Ok(RestoreValidationSummary {
         backup_version: document.backup_version,
         source_version: document.source_version.clone(),
@@ -1210,11 +1769,13 @@ mod tests {
     use rstest::rstest;
     use serde_json::json;
 
+    #[cfg(feature = "embedded-migrations")]
+    use super::verify_restored_backup_matches;
     use super::{
         MAX_PERSONAL_DEFINITIONS, MAX_SHARED_DEFINITIONS, RESTORE_RECONCILIATION_GRACE_SECONDS,
         RestoreSettings, confirmation_is_stale, restore_capability_matches,
         restore_error_for_storage, sha256, validate_computed_field_definitions,
-        validate_event_revisions,
+        validate_event_revisions, verify_backup_document,
     };
     use crate::errors::ApiError;
     use crate::models::{
@@ -1282,6 +1843,224 @@ mod tests {
             }),
             manifest: BackupManifest::default(),
         }
+    }
+
+    fn minimally_valid_document() -> BackupDocument {
+        let mut sections = StorageBackupStateSection::ALL
+            .iter()
+            .copied()
+            .map(|section| (section, Vec::new()))
+            .collect::<BTreeMap<_, _>>();
+        sections
+            .get_mut(&StorageBackupStateSection::IdentityScopes)
+            .unwrap()
+            .push(
+                StorageBackupRow::try_from_value(json!({
+                    "id": 1,
+                    "name": "local",
+                    "provider_kind": "local",
+                    "created_at": "2026-07-16T00:00:00Z",
+                    "updated_at": "2026-07-16T00:00:00Z",
+                    "revision": 1
+                }))
+                .unwrap(),
+            );
+        sections
+            .get_mut(&StorageBackupStateSection::Collections)
+            .unwrap()
+            .push(
+                StorageBackupRow::try_from_value(json!({
+                    "id": 1,
+                    "name": "root",
+                    "parent_collection_id": null,
+                    "created_at": "2026-07-16T00:00:00Z",
+                    "updated_at": "2026-07-16T00:00:00Z",
+                    "revision": 1
+                }))
+                .unwrap(),
+            );
+        sections
+            .get_mut(&StorageBackupStateSection::CollectionAuthorization)
+            .unwrap()
+            .push(
+                StorageBackupRow::try_from_value(json!({
+                    "collection_id": 1,
+                    "revision": 1
+                }))
+                .unwrap(),
+            );
+        sections
+            .get_mut(&StorageBackupStateSection::CollectionHierarchy)
+            .unwrap()
+            .push(
+                StorageBackupRow::try_from_value(json!({
+                    "ancestor_collection_id": 1,
+                    "descendant_collection_id": 1,
+                    "depth": 0
+                }))
+                .unwrap(),
+            );
+        let state = BackupState { sections };
+        let manifest = BackupManifest::from_sections(&state, None);
+        BackupDocument {
+            backup_version: CURRENT_BACKUP_VERSION,
+            created_at: backup_instant(),
+            source_version: "0.0.11".to_string(),
+            state,
+            history: None,
+            manifest,
+        }
+    }
+
+    #[test]
+    fn offline_backup_verification_returns_only_sanitized_artifact_evidence() {
+        let mut document = minimally_valid_document();
+        document
+            .state
+            .sections
+            .get_mut(&StorageBackupStateSection::Collections)
+            .unwrap()[0] = StorageBackupRow::try_from_value(json!({
+            "id": 1,
+            "name": "verification-canary",
+            "parent_collection_id": null,
+            "created_at": "2026-07-16T00:00:00Z",
+            "updated_at": "2026-07-16T00:00:00Z",
+            "revision": 1
+        }))
+        .unwrap();
+        let bytes = serde_json::to_vec(&document).unwrap();
+
+        let report = verify_backup_document(&bytes, bytes.len()).unwrap();
+        let report = serde_json::to_string(&report).unwrap();
+
+        assert!(report.contains("\"result\":\"passed\""));
+        assert!(report.contains("\"mode\":\"format_only\""));
+        assert!(!report.contains("verification-canary"));
+    }
+
+    #[test]
+    fn offline_backup_verification_rejects_manifest_count_drift() {
+        let mut document = minimally_valid_document();
+        document
+            .manifest
+            .item_counts
+            .insert("collections".to_string(), 99);
+        let bytes = serde_json::to_vec(&document).unwrap();
+
+        let error = verify_backup_document(&bytes, bytes.len()).unwrap_err();
+
+        assert!(error.to_string().contains("manifest count"));
+        assert!(error.to_string().contains("collections"));
+    }
+
+    #[test]
+    fn offline_backup_verification_rejects_future_versions() {
+        let mut document = minimally_valid_document();
+        document.backup_version = CURRENT_BACKUP_VERSION + 1;
+        let bytes = serde_json::to_vec(&document).unwrap();
+
+        let error = verify_backup_document(&bytes, bytes.len()).unwrap_err();
+
+        assert!(error.to_string().contains("Unsupported backup version"));
+    }
+
+    #[test]
+    fn offline_backup_verification_rejects_dangling_references() {
+        let mut document = minimally_valid_document();
+        document
+            .state
+            .sections
+            .get_mut(&StorageBackupStateSection::Groups)
+            .unwrap()
+            .push(
+                StorageBackupRow::try_from_value(json!({
+                    "id": 2,
+                    "identity_scope_id": 999,
+                    "revision": 1
+                }))
+                .unwrap(),
+            );
+        document.manifest = BackupManifest::from_sections(&document.state, None);
+        let bytes = serde_json::to_vec(&document).unwrap();
+
+        let error = verify_backup_document(&bytes, bytes.len()).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("does not reference a retained row")
+        );
+    }
+
+    #[test]
+    fn offline_backup_verification_rejects_invalid_row_timestamps() {
+        let mut document = minimally_valid_document();
+        document
+            .state
+            .sections
+            .get_mut(&StorageBackupStateSection::Collections)
+            .unwrap()[0] = StorageBackupRow::try_from_value(json!({
+            "id": 1,
+            "name": "root",
+            "parent_collection_id": null,
+            "created_at": "not-a-timestamp",
+            "updated_at": "2026-07-16T00:00:00Z",
+            "revision": 1
+        }))
+        .unwrap();
+        let bytes = serde_json::to_vec(&document).unwrap();
+
+        let error = verify_backup_document(&bytes, bytes.len()).unwrap_err();
+
+        assert!(error.to_string().contains("invalid RFC 3339 timestamp"));
+    }
+
+    #[cfg(feature = "embedded-migrations")]
+    #[test]
+    fn restored_backup_comparison_accepts_only_the_provenance_event() {
+        let mut source = minimally_valid_document();
+        source.history = Some(BackupHistory {
+            sections: StorageBackupHistorySection::ALL
+                .iter()
+                .copied()
+                .map(|section| (section, Vec::new()))
+                .collect(),
+        });
+        let mut restored = source.clone();
+        restored
+            .history
+            .as_mut()
+            .unwrap()
+            .sections
+            .get_mut(&StorageBackupHistorySection::AuditEvents)
+            .unwrap()
+            .push(
+                StorageBackupRow::try_from_value(json!({
+                    "id": 1,
+                    "entity_type": "restore",
+                    "action": "succeeded"
+                }))
+                .unwrap(),
+            );
+
+        assert!(verify_restored_backup_matches(&source, &restored).is_ok());
+    }
+
+    #[cfg(feature = "embedded-migrations")]
+    #[test]
+    fn restored_backup_comparison_rejects_state_drift() {
+        let source = minimally_valid_document();
+        let mut restored = source.clone();
+        restored
+            .state
+            .sections
+            .get_mut(&StorageBackupStateSection::Collections)
+            .unwrap()
+            .clear();
+
+        let error = verify_restored_backup_matches(&source, &restored).unwrap_err();
+
+        assert!(error.to_string().contains("logical state"));
     }
 
     #[rstest]

--- a/src/storage/factory.rs
+++ b/src/storage/factory.rs
@@ -287,6 +287,20 @@ impl StorageSettings {
             acquire_timeout_ms: None,
         }
     }
+
+    pub(crate) fn same_database_endpoint(&self, other: &Self) -> bool {
+        match (&self.adapter, &other.adapter) {
+            (StorageAdapterSettings::Postgres(left), StorageAdapterSettings::Postgres(right)) => {
+                let left = left.endpoint();
+                let right = right.endpoint();
+                left.host() == right.host()
+                    && left.port() == right.port()
+                    && left.database() == right.database()
+            }
+            (StorageAdapterSettings::Memory, StorageAdapterSettings::Memory) => true,
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Debug for StorageSettings {
@@ -494,6 +508,34 @@ pub(crate) fn run_storage_migrations(
     }
 }
 
+#[cfg(feature = "embedded-migrations")]
+pub(crate) fn prepare_disposable_restore_database(
+    settings: &StorageSettings,
+) -> Result<usize, StorageError> {
+    match &settings.adapter {
+        StorageAdapterSettings::Postgres(settings) => {
+            hubuum_storage_postgres::prepare_disposable_restore_database(settings.connection_url())
+        }
+        StorageAdapterSettings::Memory => Err(StorageError::invalid_input(
+            "Isolated restore verification requires the PostgreSQL storage backend",
+        )),
+    }
+}
+
+#[cfg(feature = "embedded-migrations")]
+pub(crate) fn reset_disposable_restore_database(
+    settings: &StorageSettings,
+) -> Result<(), StorageError> {
+    match &settings.adapter {
+        StorageAdapterSettings::Postgres(settings) => {
+            hubuum_storage_postgres::reset_disposable_restore_database(settings.connection_url())
+        }
+        StorageAdapterSettings::Memory => Err(StorageError::invalid_input(
+            "Isolated restore verification requires the PostgreSQL storage backend",
+        )),
+    }
+}
+
 pub(crate) fn storage_database_role_setup_sql(
     roles: &StorageDatabaseRoleNames,
 ) -> Result<String, StorageError> {
@@ -528,7 +570,45 @@ pub(crate) async fn inspect_storage_database_privileges(
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
+
+    fn postgres_settings(url: &str) -> StorageSettings {
+        StorageSettings::postgres(url)
+            .max_connections(1)
+            .statement_timeout_ms(500)
+            .acquire_timeout_ms(1_000)
+            .build()
+            .expect("settings should be valid")
+    }
+
+    #[rstest]
+    #[case::different_credentials(
+        "postgres://runtime:one@database.example:5432/hubuum?sslmode=require",
+        "postgres://restore:two@database.example:5432/hubuum?sslmode=disable",
+        true
+    )]
+    #[case::different_database(
+        "postgres://runtime:one@database.example:5432/hubuum",
+        "postgres://runtime:one@database.example:5432/hubuum_restore",
+        false
+    )]
+    #[case::different_port(
+        "postgres://runtime:one@database.example:5432/hubuum",
+        "postgres://runtime:one@database.example:5433/hubuum",
+        false
+    )]
+    fn database_endpoint_comparison_ignores_credentials_only(
+        #[case] left: &str,
+        #[case] right: &str,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(
+            postgres_settings(left).same_database_endpoint(&postgres_settings(right)),
+            expected
+        );
+    }
 
     #[test]
     fn settings_debug_redacts_the_connection_url() {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -25,12 +25,14 @@ pub use execution::{
     with_mutation_provenance, with_revision_precondition, with_storage_call_site,
     with_storage_call_site_send, with_storage_execution_scope, with_storage_execution_scope_send,
 };
-#[cfg(feature = "embedded-migrations")]
-pub(crate) use factory::run_storage_migrations;
 pub(crate) use factory::{
     StorageDatabasePrivilegeReport, StorageDatabaseRole, StorageDatabaseRoleNames, StorageSettings,
     initialize_storage, inspect_storage_database_privileges, storage_database_role_grants_sql,
     storage_database_role_setup_sql,
+};
+#[cfg(feature = "embedded-migrations")]
+pub(crate) use factory::{
+    prepare_disposable_restore_database, reset_disposable_restore_database, run_storage_migrations,
 };
 pub(crate) use hubuum_storage_core::{
     AuditEventStorage, AuthenticationStorage, AuthorizationDataStorage, CatalogStorage,

--- a/tests/admin_cli.rs
+++ b/tests/admin_cli.rs
@@ -61,6 +61,7 @@ fn admin_help_exposes_reset_password() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("--reset-password"));
     assert!(stdout.contains("--backup"));
+    assert!(stdout.contains("--verify-backup"));
     assert!(stdout.contains("--restore"));
     assert!(stdout.contains("--restore-executor"));
     #[cfg(feature = "embedded-migrations")]
@@ -107,6 +108,38 @@ fn backup_files_are_owner_only_and_atomically_replaced() {
     );
     let original_inode = std::fs::metadata(&path).unwrap().ino();
 
+    let verification = Command::new(admin_binary())
+        .env_remove("HUBUUM_DATABASE_URL")
+        .env_remove("HUBUUM_MIGRATION_DATABASE_URL")
+        .args([
+            "--verify-backup",
+            path.to_str().expect("UTF-8 backup path"),
+            "--json",
+        ])
+        .output()
+        .expect("hubuum-admin --verify-backup should run without a database");
+    assert_command_succeeded(&verification);
+    let report: serde_json::Value = serde_json::from_slice(&verification.stdout).unwrap();
+    assert_eq!(report["result"], "passed");
+    assert_eq!(report["mode"], "format_only");
+    assert_eq!(report["backup_version"], 5);
+    assert!(report["total_items"].as_i64().unwrap() > 0);
+
+    let unsafe_restore_test = admin_command(&database_url)
+        .args([
+            "--verify-backup",
+            path.to_str().expect("UTF-8 backup path"),
+            "--restore-test-database-url",
+            &database_url,
+        ])
+        .output()
+        .expect("hubuum-admin should reject the configured database as a restore-test target");
+    assert!(!unsafe_restore_test.status.success());
+    assert!(
+        String::from_utf8_lossy(&unsafe_restore_test.stderr)
+            .contains("target matches a configured Hubuum database")
+    );
+
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
     let output = admin_command(&database_url)
         .args(["--backup", path.to_str().expect("UTF-8 backup path")])
@@ -117,6 +150,30 @@ fn backup_files_are_owner_only_and_atomically_replaced() {
     assert_eq!(replaced_metadata.permissions().mode() & 0o777, 0o600);
     assert_ne!(replaced_metadata.ino(), original_inode);
 
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn backup_verification_rejects_malformed_input_before_database_configuration() {
+    let path = std::env::temp_dir().join(format!("{}.json", unique_name("invalid_backup")));
+    std::fs::write(
+        &path,
+        br#"{"backup_version":5,"secret":"verification-canary"}"#,
+    )
+    .unwrap();
+
+    let output = Command::new(admin_binary())
+        .env_remove("HUBUUM_DATABASE_URL")
+        .env_remove("HUBUUM_MIGRATION_DATABASE_URL")
+        .args(["--verify-backup", path.to_str().unwrap(), "--json"])
+        .output()
+        .expect("hubuum-admin --verify-backup should reject malformed input");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not valid backup JSON"));
+    assert!(!stderr.contains("verification-canary"));
+    assert!(!stderr.contains("must be set"));
     std::fs::remove_file(path).unwrap();
 }
 

--- a/tests/api_jobs_suite/restores.rs
+++ b/tests/api_jobs_suite/restores.rs
@@ -104,6 +104,7 @@ mod tests {
                 }))
                 .unwrap(),
             );
+        document.manifest = BackupManifest::from_sections(&document.state, None);
         document
     }
 


### PR DESCRIPTION
## Summary

- add bounded `hubuum-admin --verify-backup` validation that runs without a database and emits sanitized, versioned JSON evidence
- optionally migrate and restore into a caller-created empty PostgreSQL database, then compare exact logical state and retained history through the production restore path
- extend adjacent-release CI and a weekly scheduled drill to recover v0.0.11/current and history/history-free artifacts, then smoke-test the restored API, worker, authentication, history, terminal tasks, token exclusion, and computed rebuilding

## Safety and behavior

- refuse maintenance databases, non-empty targets, and targets matching either configured Hubuum database endpoint even when credentials differ
- reset the disposable `public` schema after success or failure unless the caller explicitly keeps it for application smoke tests
- validate manifest counts/exclusions, required sections and seeds, timestamps, revisions, references, JSON Schema, and computed definitions before database access
- compare the post-restore logical snapshot byte-for-byte, allowing only the expected `restore.succeeded` provenance event
- retain the existing one-shot `--restore` artifact-size behavior; the new format-only verifier remains bounded at the documented default

## Existing-user migration

This does not change the supported version 5 backup format. Installations on v0.0.9 or older must first upgrade normally to v0.0.10 or v0.0.11, create a version 5 backup with history, and rehearse those exact bytes with the candidate before adopting the split database roles. Version 4-or-older artifacts are not converted in place. The deployment guide now covers the full rehearsal, rollout, rollback, and restore-executor sequence.

## Additional fixes found by the drill

- preserve explicit non-default PostgreSQL ports in endpoint diagnostics and disposable-target comparisons
- set the production image entrypoint to mode `0755`, ensuring the non-root runtime user can read it even from a restrictive checkout
- normalize Docker/Podman Compose port, TTY, status, log, and SELinux bind-mount behavior in the compatibility harness
- keep runtime-behavior base measurements compatible with split database roles by using the documented single-role migration mode for their isolated CI database

## Changelog

The `[Unreleased]` section documents the verifier, recovery automation, existing-user migration action, explicit-port fix, and container entrypoint fix. There are no new API endpoint or OpenAPI schema changes.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `bash scripts/test-classify-ci-changes.sh`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- production container build with `-F tls-rustls -F tls-openssl --locked --release`
- local v0.0.11-to-candidate recovery matrix: 48 migrations, all three restore comparisons passed, and all restored-application smoke checks passed

Closes #253
