### PR TITLE
Make split PostgreSQL roles optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
 # Local Docker Compose only. Generate a unique value with:
 # openssl rand -hex 32
 POSTGRES_PASSWORD=
+
+# Optional least-privilege topology. Leave the role passwords and URLs unset
+# for the default single-login deployment. Set them when enabling split roles.
+HUBUUM_DATABASE_ROLE_MODE=single
 POSTGRES_MIGRATOR_PASSWORD=
 POSTGRES_RUNTIME_PASSWORD=
+# HUBUUM_DATABASE_URL=postgres://hubuum_runtime:RUNTIME_PASSWORD@db/hubuum
+# HUBUUM_MIGRATION_DATABASE_URL=postgres://hubuum_migrator:MIGRATOR_PASSWORD@db/hubuum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -927,11 +927,33 @@ jobs:
           IMAGE: hubuum-server:ci
           MIGRATION_DATABASE_URL: postgres://hubuum_migrator:migrator-test@127.0.0.1:5432/hubuum_container_test?sslmode=disable
           RUNTIME_DATABASE_URL: postgres://hubuum_runtime:runtime-test@127.0.0.1:5432/hubuum_container_test?sslmode=disable
+          SINGLE_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/hubuum_container_single_test?sslmode=disable
         run: |
           docker run --rm --entrypoint hubuum-admin "$IMAGE" --help \
             | grep --quiet -- "--migrate"
           docker run --rm --entrypoint hubuum-admin "$IMAGE" --help \
             | grep --quiet -- "--restore-executor"
+          docker run --rm --network host \
+            --env PGPASSWORD=postgres \
+            postgres:18.4@sha256:22c89fe0d0f507606260237fd55e51f6137f58b2d5bcf6152242b96d9fe8f9a4 psql \
+            --host 127.0.0.1 \
+            --username postgres \
+            --dbname postgres \
+            --set ON_ERROR_STOP=1 \
+            --command "CREATE DATABASE hubuum_container_single_test"
+          docker run --rm --network host \
+            --entrypoint hubuum-admin \
+            --env HUBUUM_DATABASE_URL="$SINGLE_DATABASE_URL" \
+            "$IMAGE" --migrate
+          test "$(docker run --rm --network host \
+            --env PGPASSWORD=postgres \
+            postgres:18.4@sha256:22c89fe0d0f507606260237fd55e51f6137f58b2d5bcf6152242b96d9fe8f9a4 psql \
+            --host 127.0.0.1 \
+            --username postgres \
+            --dbname hubuum_container_single_test \
+            --tuples-only \
+            --no-align \
+            --command "SELECT to_regclass('public.users') IS NOT NULL")" = "t"
           docker run --rm --entrypoint hubuum-admin "$IMAGE" \
             --database-role-setup-sql \
             | docker run --rm --interactive --network host \
@@ -958,6 +980,7 @@ jobs:
           fi
           docker run --rm --network host \
             --entrypoint hubuum-admin \
+            --env HUBUUM_DATABASE_ROLE_MODE=split \
             --env HUBUUM_MIGRATION_DATABASE_URL="$MIGRATION_DATABASE_URL" \
             "$IMAGE" --migrate
           docker run --rm --network host \
@@ -975,6 +998,7 @@ jobs:
             --command "SELECT to_regclass('public.users') IS NOT NULL")" = "t"
           container_id="$(docker run --rm --detach --network host \
             --env HUBUUM_DATABASE_URL="$RUNTIME_DATABASE_URL" \
+            --env HUBUUM_DATABASE_ROLE_MODE=split \
             --env HUBUUM_DATABASE_PRIVILEGE_MODE=strict \
             --env HUBUUM_BIND_IP=127.0.0.1 \
             "$IMAGE")"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   Existing installations on v0.0.9 or older must first upgrade to v0.0.10 or
   v0.0.11 and create a version 5 backup; version 4-or-older artifacts are not
   converted in place.
-- Added a generated PostgreSQL privilege manifest with distinct non-login
-  owner, dedicated migrator, and non-owning runtime roles; catalog-backed
-  warn/strict startup diagnostics; administrator SQL and JSON reporting; and
-  Compose, single-host, and distributed deployment workflows that keep the
-  migration credential out of long-lived application containers. Web restore
-  is preserved through a separate, non-listening restore-executor workload, with
-  document-free terminal receipts for
+- Added an opt-in split PostgreSQL role topology with a generated privilege
+  manifest, distinct non-login owner, dedicated migrator, and non-owning
+  runtime roles; catalog-backed warn/strict startup diagnostics;
+  administrator SQL and JSON reporting; and Compose, single-host, and
+  distributed deployment workflows that keep the migration credential out of
+  long-lived application containers. The default `single` topology retains one
+  database login for runtime, migrations, and restore execution; set
+  `HUBUUM_DATABASE_ROLE_MODE=split` to enable the least-privilege boundary. Web
+  restore is preserved in either topology through a separate, non-listening
+  restore-executor workload, with document-free terminal receipts for
   capability-authenticated status polling.
 - Added bounded online token hash key-ring rotation with versioned bearer
   tokens, active and previous verification keys, race-safe migration of legacy
@@ -44,24 +47,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Changed
 
 - **Breaking (database deployment):** server container entrypoints no longer
-  apply migrations. Operators must provision the documented owner, migrator,
-  and runtime roles, set `HUBUUM_DATABASE_URL` to the runtime identity, and run
-  `hubuum-admin --migrate` as a one-shot workload with
-  `HUBUUM_MIGRATION_DATABASE_URL` before rolling the server. External
-  single-host installs must add `--migration-database-url` on upgrade. Existing
-  single-role deployments must verify normal maintenance, pause confirmations,
-  adopt the compatibility runtime grants, migrate, start the isolated restore
-  executor, and only then roll runtime-only API and workers; the migration
-  serializes with confirmation, refuses an in-flight confirmed restore, and
-  preserves validated stages. Rollback keeps the compatibility runtime login
-  but must leave old synchronous web confirmation blocked; use the new one-shot
-  administrator restore path until the executor-based release is restored. If
-  role provisioning must follow schema migration, the new admin binary retains
-  an explicit, warned `--legacy-single-role-migration` bridge that rejects
-  split-role settings; operators must still complete role adoption before
-  enabling strict checks or web restore confirmation. Adoption transfers table
-  ownership before attached sequences so existing serial-backed schemas can be
-  reconciled safely.
+  apply migrations. Run `hubuum-admin --migrate` as a one-shot workload before
+  rolling the server and deploy the isolated restore executor. Existing
+  installations may keep one database login: `single` is the default and
+  privileged admin commands fall back to `HUBUUM_DATABASE_URL`.
+  `--legacy-single-role-migration` remains as a deprecated compatibility alias.
+  Deployments choosing `HUBUUM_DATABASE_ROLE_MODE=split` must provision the
+  documented owner, migrator, and runtime roles, set the runtime and migration
+  URLs separately, and complete the adoption sequence before enabling strict
+  checks or web restore confirmation. Existing users of the split-only local
+  Compose example must also retain `POSTGRES_USER=hubuum_bootstrap` when reusing
+  its database volume. Split-role migration serializes with
+  confirmation, refuses an in-flight confirmed restore, preserves validated
+  stages, and transfers table ownership before attached sequences. Rollback
+  must leave old synchronous web confirmation blocked; use the new one-shot
+  administrator restore path until the executor-based release is restored.
 - **Breaking (full restore):** `POST /api/v1/restores/{restore_id}/confirm` now
   returns `202 Accepted` after queuing the validated operation instead of
   completing the replacement synchronously. Deploy

--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ curl -H "Authorization: Bearer <token>" http://localhost:8080/api/v1/iam/users
 - Atomic RFC 6902 updates to raw object data are documented in
   [docs/object_data_json_patch.md](docs/object_data_json_patch.md).
 - Full-system disaster-recovery behavior is documented in [docs/backup-restore.md](docs/backup-restore.md).
-- PostgreSQL owner, migrator, and runtime privilege boundaries are documented
-  in [docs/database_roles.md](docs/database_roles.md).
+- Optional PostgreSQL owner, migrator, and runtime privilege boundaries are
+  documented in [docs/database_roles.md](docs/database_roles.md); the default
+  topology retains one database login.
 - Database pool sizing, observability, and load testing are documented in [docs/performance.md](docs/performance.md).
 
 ### Production Behavior

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,12 @@ services:
     environment:
       HUBUUM_BIND_IP: 0.0.0.0
       HUBUUM_CLIENT_ALLOWLIST: "*"
-      HUBUUM_DATABASE_URL: postgres://hubuum_runtime:${POSTGRES_RUNTIME_PASSWORD:?Set POSTGRES_RUNTIME_PASSWORD in .env}@db/hubuum
+      HUBUUM_DATABASE_ROLE_MODE: ${HUBUUM_DATABASE_ROLE_MODE:-single}
+      HUBUUM_DATABASE_URL: ${HUBUUM_DATABASE_URL:-postgres://${POSTGRES_USER:-hubuum}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db/hubuum}
       HUBUUM_DATABASE_OWNER_ROLE: hubuum_owner
       HUBUUM_DATABASE_MIGRATOR_ROLE: hubuum_migrator
       HUBUUM_DATABASE_RUNTIME_ROLE: hubuum_runtime
-      HUBUUM_DATABASE_PRIVILEGE_MODE: strict
+      HUBUUM_DATABASE_PRIVILEGE_MODE: ${HUBUUM_DATABASE_PRIVILEGE_MODE:-warn}
       HUBUUM_LOG_LEVEL: debug
       HUBUUM_DEFAULT_PAGE_LIMIT: ${HUBUUM_DEFAULT_PAGE_LIMIT:-100}
       HUBUUM_MAX_PAGE_LIMIT: ${HUBUUM_MAX_PAGE_LIMIT:-250}
@@ -30,7 +31,9 @@ services:
     profiles: ["administration"]
     entrypoint: /usr/local/bin/hubuum-admin
     environment:
-      HUBUUM_MIGRATION_DATABASE_URL: postgres://hubuum_migrator:${POSTGRES_MIGRATOR_PASSWORD:?Set POSTGRES_MIGRATOR_PASSWORD in .env}@db/hubuum
+      HUBUUM_DATABASE_ROLE_MODE: ${HUBUUM_DATABASE_ROLE_MODE:-single}
+      HUBUUM_DATABASE_URL: ${HUBUUM_DATABASE_URL:-postgres://${POSTGRES_USER:-hubuum}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db/hubuum}
+      HUBUUM_MIGRATION_DATABASE_URL: ${HUBUUM_MIGRATION_DATABASE_URL:-${HUBUUM_DATABASE_URL:-postgres://${POSTGRES_USER:-hubuum}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db/hubuum}}
       HUBUUM_DATABASE_OWNER_ROLE: hubuum_owner
       HUBUUM_DATABASE_MIGRATOR_ROLE: hubuum_migrator
       HUBUUM_DATABASE_RUNTIME_ROLE: hubuum_runtime
@@ -51,7 +54,9 @@ services:
     command: ["--restore-executor"]
     restart: unless-stopped
     environment:
-      HUBUUM_MIGRATION_DATABASE_URL: postgres://hubuum_migrator:${POSTGRES_MIGRATOR_PASSWORD:?Set POSTGRES_MIGRATOR_PASSWORD in .env}@db/hubuum
+      HUBUUM_DATABASE_ROLE_MODE: ${HUBUUM_DATABASE_ROLE_MODE:-single}
+      HUBUUM_DATABASE_URL: ${HUBUUM_DATABASE_URL:-postgres://${POSTGRES_USER:-hubuum}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db/hubuum}
+      HUBUUM_MIGRATION_DATABASE_URL: ${HUBUUM_MIGRATION_DATABASE_URL:-${HUBUUM_DATABASE_URL:-postgres://${POSTGRES_USER:-hubuum}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db/hubuum}}
       HUBUUM_DATABASE_OWNER_ROLE: hubuum_owner
       HUBUUM_DATABASE_MIGRATOR_ROLE: hubuum_migrator
       HUBUUM_DATABASE_RUNTIME_ROLE: hubuum_runtime
@@ -73,16 +78,17 @@ services:
     ports:
       - "127.0.0.1:9998:5432"
     environment:
-      POSTGRES_USER: hubuum_bootstrap
+      POSTGRES_USER: ${POSTGRES_USER:-hubuum}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
-      POSTGRES_MIGRATOR_PASSWORD: ${POSTGRES_MIGRATOR_PASSWORD:?Set POSTGRES_MIGRATOR_PASSWORD in .env}
-      POSTGRES_RUNTIME_PASSWORD: ${POSTGRES_RUNTIME_PASSWORD:?Set POSTGRES_RUNTIME_PASSWORD in .env}
+      HUBUUM_DATABASE_ROLE_MODE: ${HUBUUM_DATABASE_ROLE_MODE:-single}
+      POSTGRES_MIGRATOR_PASSWORD: ${POSTGRES_MIGRATOR_PASSWORD:-}
+      POSTGRES_RUNTIME_PASSWORD: ${POSTGRES_RUNTIME_PASSWORD:-}
       POSTGRES_DB: hubuum
-      PGUSER: hubuum_bootstrap
+      PGUSER: ${POSTGRES_USER:-hubuum}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U hubuum_bootstrap -d hubuum" ]
+      test: [ "CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d hubuum" ]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker/postgres/init-database-roles.sh
+++ b/docker/postgres/init-database-roles.sh
@@ -12,6 +12,20 @@ require_identifier() {
 
 : "${POSTGRES_DB:?POSTGRES_DB is required}"
 : "${POSTGRES_USER:?POSTGRES_USER is required}"
+
+role_mode="${HUBUUM_DATABASE_ROLE_MODE:-single}"
+case "$role_mode" in
+    single)
+        exit 0
+        ;;
+    split)
+        ;;
+    *)
+        echo "HUBUUM_DATABASE_ROLE_MODE must be single or split" >&2
+        exit 1
+        ;;
+esac
+
 : "${POSTGRES_MIGRATOR_PASSWORD:?POSTGRES_MIGRATOR_PASSWORD is required}"
 : "${POSTGRES_RUNTIME_PASSWORD:?POSTGRES_RUNTIME_PASSWORD is required}"
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -110,9 +110,10 @@ Content-Type: application/json
 
 The endpoint commits draining maintenance and returns `202 Accepted` with
 status `confirmed`. It does not perform privileged SQL. A separately deployed
-`hubuum-admin --restore-executor` process, holding only the migration database
-URL, re-loads and revalidates the staged bytes, waits for API and worker
-instances to drain, and applies the replacement transaction.
+`hubuum-admin --restore-executor` process, holding the database URL selected
+for its single- or split-role topology, re-loads and revalidates the staged
+bytes, waits for API and worker instances to drain, and applies the replacement
+transaction.
 
 Inspect validation, draining, or failure status by sending the capability in a
 header:
@@ -134,7 +135,7 @@ listener and accepts no request-provided SQL, identifier, or file path. Multiple
 replicas are protected by the same database advisory lock, but a single replica
 avoids redundant conflict logs. See
 [PostgreSQL Database Roles](database_roles.md) for deployment isolation, threat
-model, and the existing single-role migration order.
+model, and role-topology choices.
 
 ## Admin CLI
 
@@ -218,21 +219,22 @@ the split database roles described in
    representative reads, background work, audit history, and computed-field
    rebuilding. Then delete the disposable database.
 4. Confirm production maintenance is `normal` and no confirmed restore is in
-   flight. Follow the single-role adoption procedure, run the one-shot schema
-   migration, start the isolated restore executor, and roll runtime-only API
-   and worker processes.
-5. Keep restore confirmation blocked until the executor and runtime privilege
-   report pass. Retain the pre-upgrade deployment and backup through the
-   observation window. Application rollback after role adoption uses the
-   compatibility runtime login; web restore stays blocked and the candidate
-   one-shot admin restore remains the recovery path.
+   flight. Run the one-shot schema migration, start the isolated restore
+   executor, and roll runtime-only API and worker processes. If opting into
+   split roles, complete the documented adoption before those workloads start.
+5. Keep restore confirmation blocked until the executor is healthy. In split
+   mode, also require the runtime privilege report to pass. Retain the
+   pre-upgrade deployment and backup through the observation window. After a
+   split-role adoption, application rollback uses the compatibility runtime
+   login; web restore stays blocked and the candidate one-shot admin restore
+   remains the recovery path.
 
 This is an application migration path, not an automatic database downgrade.
 Older application releases are only certified against the adjacent migrated
 schema as documented in [Releasing Hubuum](releasing.md).
 
-Restore requires the explicit destructive phrase and the separate migration
-credential:
+Restore always requires the explicit destructive phrase. Split mode also uses
+the separate migration credential:
 
 ```text
 hubuum-admin \
@@ -240,6 +242,10 @@ hubuum-admin \
   --restore backup.json \
   --restore-confirmation "REPLACE ALL HUBUUM DATA"
 ```
+
+In the default single-role mode, omit `--migration-database-url`; the command
+uses `HUBUUM_DATABASE_URL`. Split-role deployments use the privileged URL shown
+above.
 
 The CLI stages and confirms the document, then runs one executor iteration in
 the same process. It appends the `restore.succeeded` provenance event on

--- a/docs/database_roles.md
+++ b/docs/database_roles.md
@@ -1,9 +1,14 @@
 # PostgreSQL Database Roles
 
-Hubuum uses three distinct PostgreSQL roles. Long-lived API and worker
-processes must use only the runtime role. Schema changes and the isolated
-restore executor use a separate migrator credential, while a non-login owner
-holds application objects.
+Hubuum defaults to `HUBUUM_DATABASE_ROLE_MODE=single`, in which the server,
+one-shot migration job, and isolated restore executor all use
+`HUBUUM_DATABASE_URL`. This preserves the original one-login deployment model
+while keeping schema migration and restore execution in separate processes.
+
+Set `HUBUUM_DATABASE_ROLE_MODE=split` to opt into three distinct PostgreSQL
+roles. Long-lived API and worker processes then use only the runtime role.
+Schema changes and the isolated restore executor use a separate migrator
+credential, while a non-login owner holds application objects.
 
 | Role | Login | Purpose | Must not have |
 | --- | --- | --- | --- |
@@ -14,7 +19,26 @@ holds application objects.
 The default names are `hubuum_owner`, `hubuum_migrator`, and
 `hubuum_runtime`. Override all workloads consistently with
 `HUBUUM_DATABASE_OWNER_ROLE`, `HUBUUM_DATABASE_MIGRATOR_ROLE`, and
-`HUBUUM_DATABASE_RUNTIME_ROLE`.
+`HUBUUM_DATABASE_RUNTIME_ROLE`. These names and the generated privilege
+manifest are ignored by normal server startup in `single` mode.
+
+## Choosing A Topology
+
+Use `single` when the database provider supplies one application identity or
+operational simplicity is more important than limiting the impact of a leaked
+runtime credential. Run migrations and the restore executor with the same URL:
+
+```bash
+export HUBUUM_DATABASE_ROLE_MODE=single
+export HUBUUM_DATABASE_URL='postgres://hubuum:.../hubuum'
+hubuum-admin --migrate
+hubuum-admin --restore-executor
+```
+
+Use `split` when the provider can express role membership and separate
+workload credentials. Set the mode on the server, migration job, and restore
+executor. The remaining sections describe provisioning and operating that
+topology.
 
 ## Privilege Manifest
 
@@ -48,6 +72,7 @@ Run the full setup SQL through an identity that may create roles and change
 object ownership. The output is idempotent and contains no credentials:
 
 ```bash
+export HUBUUM_DATABASE_ROLE_MODE=split
 hubuum-admin --database-role-setup-sql > hubuum-database-roles.sql
 psql "$POSTGRES_BOOTSTRAP_URL" --set ON_ERROR_STOP=1 \
   --file hubuum-database-roles.sql
@@ -104,17 +129,14 @@ hubuum-admin \
   --database-role-setup-sql > hubuum-database-role-adoption.sql
 ```
 
-The new admin binary also retains an explicit legacy bridge for deployments
-that must upgrade the schema before they can provision roles.
-`hubuum-admin --migrate --legacy-single-role-migration` applies migrations as
-the connected existing owner and prints a compatibility-mode warning. It does
-not transfer ownership or reconcile runtime grants. The flag rejects all three
-database-role settings so the bridge cannot be confused with split-role
-migration. Keep restore confirmation blocked and privilege mode at `warn`, then
-complete the role-adoption procedure below before starting the restore
-executor, enabling strict mode, or unblocking web restore confirmation. Without
-the legacy flag, migration always reconciles the split roles, using the
-documented defaults for names not overridden.
+An existing installation can remain in `single` mode indefinitely. To adopt
+split roles, keep restore confirmation blocked and privilege mode at `warn`,
+then complete the role-adoption procedure below before setting
+`HUBUUM_DATABASE_ROLE_MODE=split`, starting the migrator-backed restore
+executor, enabling strict mode, or unblocking web restore confirmation.
+`hubuum-admin --migrate --legacy-single-role-migration` remains as a deprecated
+alias for an ordinary single-role migration; new automation should use the
+role-mode setting instead.
 
 Set `HUBUUM_DATABASE_RUNTIME_ROLE=EXISTING_APPLICATION_ROLE` on the old and new
 server versions during that rollout. Then use this order:
@@ -229,12 +251,12 @@ Add `--json` for machine-readable output. The audit checks the role named in
 the manifest and also requires PostgreSQL `current_user` to be that role; an
 overprivileged connection cannot pass by auditing a different safe identity.
 
-Server startup repeats this audit. `HUBUUM_DATABASE_PRIVILEGE_MODE=warn` is the
-compatibility default and emits findings without stopping the process. New
-production deployments should use `strict`, which fails startup when the role
-is dangerous, incomplete, different from the connected identity, or cannot be
-inspected. Runtime configuration reports the mode and role names but never a
-database URL or credential.
+Server startup repeats this audit only in `split` mode.
+`HUBUUM_DATABASE_PRIVILEGE_MODE=warn` emits findings without stopping the
+process. Split-role production deployments should use `strict`, which fails
+startup when the role is dangerous, incomplete, different from the connected
+identity, or cannot be inspected. Runtime configuration reports the topology,
+audit mode, and role names but never a database URL or credential.
 
 ## Container And Single-Host Deployments
 
@@ -247,20 +269,31 @@ docker compose --profile administration run --rm hubuum-migrate --migrate
 docker compose up -d hubuum-restore-executor hubuum
 ```
 
-Set unique `POSTGRES_PASSWORD`, `POSTGRES_MIGRATOR_PASSWORD`, and
-`POSTGRES_RUNTIME_PASSWORD` values in `.env`. The long-lived `hubuum` service
-receives only the runtime URL. The isolated
-`hubuum-restore-executor` receives only the migration URL, exposes no network
-port, and runs read-only with all Linux capabilities dropped. The transient
+The default repository Compose configuration requires only
+`POSTGRES_PASSWORD`; every workload connects as `hubuum`. To enable split
+roles on a fresh volume, set `HUBUUM_DATABASE_ROLE_MODE=split`, unique
+`POSTGRES_MIGRATOR_PASSWORD` and `POSTGRES_RUNTIME_PASSWORD` values, and the
+matching runtime and migration URLs shown in `.env.example`. The long-lived
+`hubuum` service then receives only the runtime URL. The isolated
+`hubuum-restore-executor` receives the migration URL, exposes no network port,
+and runs read-only with all Linux capabilities dropped. The transient
 `hubuum-migrate` service uses the same privileged URL for schema changes.
 
-The single-host installer implements the same boundary automatically. For an
-external PostgreSQL server, both URLs are required:
+If reusing a volume initialized by the earlier split-only Compose example, set
+`HUBUUM_DATABASE_ROLE_MODE=split`, `POSTGRES_USER=hubuum_bootstrap`, and the
+existing runtime and migration URLs before starting it with this Compose file.
+Those values preserve the bootstrap login and established role topology.
+
+The single-host installer defaults to one generated database login. Pass
+`--database-role-mode split` to generate and deploy the separated identities.
+For an external PostgreSQL server, the migration URL is required only with
+split mode:
 
 ```bash
 sudo ./scripts/install-single-host.sh \
   --api hubuum-api.example.com \
   --email admin@example.com \
+  --database-role-mode split \
   --database-url 'postgres://hubuum_runtime:.../hubuum?sslmode=require' \
   --migration-database-url 'postgres://hubuum_migrator:.../hubuum?sslmode=require'
 ```
@@ -305,6 +338,8 @@ spec:
           image: ghcr.io/hubuum/hubuum-server:VERSION
           command: ["/usr/local/bin/hubuum-admin", "--migrate"]
           env:
+            - name: HUBUUM_DATABASE_ROLE_MODE
+              value: split
             - name: HUBUUM_MIGRATION_DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -323,6 +358,8 @@ spec:
           image: ghcr.io/hubuum/hubuum-server:VERSION
           args: ["--runtime-role", "api"]
           env:
+            - name: HUBUUM_DATABASE_ROLE_MODE
+              value: split
             - name: HUBUUM_DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -357,6 +394,8 @@ spec:
           image: ghcr.io/hubuum/hubuum-server:VERSION
           command: ["/usr/local/bin/hubuum-admin", "--restore-executor"]
           env:
+            - name: HUBUUM_DATABASE_ROLE_MODE
+              value: split
             - name: HUBUUM_MIGRATION_DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -381,7 +420,8 @@ process. The administrator stages and confirms the exact document through the
 API. Confirmation enters draining maintenance and returns `202 Accepted`; the
 isolated `hubuum-admin --restore-executor` process re-loads and validates the
 stored document, waits for runtime instances to drain, and performs the
-replacement with `HUBUUM_MIGRATION_DATABASE_URL`. The capability-authenticated
+replacement with `HUBUUM_DATABASE_URL` in single mode or
+`HUBUUM_MIGRATION_DATABASE_URL` in split mode. The capability-authenticated
 status endpoint reports `confirmed`, then `succeeded` or `failed`.
 
 The executor accepts no SQL, identifiers, or document path from the network.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -204,14 +204,26 @@ sudo ./scripts/install-single-host.sh \
   --web hubuum.example.com \
   --api hubuum-api.example.com \
   --email admin@example.com \
+  --database-url 'postgres://hubuum:secret@postgres.example.com:5432/hubuum?sslmode=require'
+```
+
+This uses the default single-role topology. To isolate the runtime credential,
+opt into split roles and provide both URLs:
+
+```bash
+sudo ./scripts/install-single-host.sh \
+  --web hubuum.example.com \
+  --api hubuum-api.example.com \
+  --email admin@example.com \
+  --database-role-mode split \
   --database-url 'postgres://hubuum_runtime:runtime-secret@postgres.example.com:5432/hubuum?sslmode=require' \
   --migration-database-url 'postgres://hubuum_migrator:migration-secret@postgres.example.com:5432/hubuum?sslmode=require'
 ```
 
-The runtime and migration identities must be provisioned before installation.
-The migration URL is injected only into the transient migration container and
-the isolated restore executor; API and worker containers receive only the
-runtime URL. See
+For split mode, the runtime and migration identities must be provisioned before
+installation. The migration URL is injected only into the transient migration
+container and the isolated restore executor; API and worker containers receive
+only the runtime URL. See
 [PostgreSQL Database Roles](database_roles.md) for the required grants,
 managed-service workflow, and upgrade diagnostics.
 
@@ -455,6 +467,8 @@ Common optional parameters:
 - `--dir`: install directory. Default: `/opt/hubuum`.
 - `--mode`: `all` or `backend`. Default: `all`.
 - `--database-url`: existing Postgres URL. If omitted, the installer creates a managed Postgres container.
+- `--database-role-mode`: `single` (default) or `split`.
+- `--migration-database-url`: privileged Postgres URL required with an external database only in split mode.
 - `--auth-config`: absolute path to a host auth-provider TOML file. The API container mounts it read-only at `/etc/hubuum/auth.toml`.
 - `--engine`: `auto`, `docker`, or `podman`. Default: `auto`.
 - `--backend-image`: backend image. Default: `ghcr.io/hubuum/hubuum-server:main`.

--- a/docs/distributed_deployment.md
+++ b/docs/distributed_deployment.md
@@ -51,6 +51,11 @@ migrations; it does not require the Diesel CLI or `psql`. See
 [PostgreSQL Database Roles](database_roles.md) for initial provisioning and the
 complete least-privilege contract.
 
+With the default `HUBUUM_DATABASE_ROLE_MODE=single`, give the Job
+`HUBUUM_DATABASE_URL`, using the same Secret as the application. The example
+below shows the opt-in split topology; set the mode on every workload and keep
+the migration Secret out of API and worker Deployments.
+
 ```yaml
 apiVersion: batch/v1
 kind: Job
@@ -65,6 +70,8 @@ spec:
           image: ghcr.io/hubuum/hubuum-server:VERSION
           command: ["/usr/local/bin/hubuum-admin", "--migrate"]
           env:
+            - name: HUBUUM_DATABASE_ROLE_MODE
+              value: split
             - name: HUBUUM_MIGRATION_DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -101,7 +108,7 @@ migration required by the binary. API `/readyz` performs the same schema check.
 This prevents a missed or incomplete migration job from making a replica appear
 ready, while keeping migration ownership in the one-shot job.
 
-For the database-role migration, first verify maintenance is `normal` and block
+When adopting split database roles, first verify maintenance is `normal` and block
 `POST /api/v1/restores/*/confirm` at the ingress. The migration shares the
 restore advisory lock and refuses to run if a confirmed restore is draining;
 validated stages are preserved. After the Job succeeds, deploy and verify the
@@ -135,6 +142,8 @@ spec:
           image: ghcr.io/hubuum/hubuum-server:VERSION
           command: ["/usr/local/bin/hubuum-admin", "--restore-executor"]
           env:
+            - name: HUBUUM_DATABASE_ROLE_MODE
+              value: split
             - name: HUBUUM_MIGRATION_DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -147,10 +156,10 @@ spec:
               drop: ["ALL"]
 ```
 
-Do not add a Service or mount the migration secret into API or worker pods.
-The executor polls database control state, revalidates the staged document, and
-uses the migrator role only for the closed, transaction-protected restore
-operation.
+Do not add a Service. In split mode, do not mount the migration secret into API
+or worker pods. The executor polls database control state, revalidates the
+staged document, and uses the configured single or migrator identity only for
+the closed, transaction-protected restore operation.
 
 ## Kubernetes And Helm HTTP Availability
 
@@ -242,11 +251,12 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ```
 
-The migration Job must use the new application image and a distinct migrator
-credential that is not mounted into any Deployment. If the chart creates that
-credential, make it available before the hook runs or keep migration ownership
-in the release pipeline. A failed migration must stop the rollout while the old
-API replicas remain online.
+The migration Job must use the new application image. In single mode it may use
+the application database Secret. In split mode it must use a distinct migrator
+credential that is not mounted into any application Deployment. If the chart
+creates that credential, make it available before the hook runs or keep
+migration ownership in the release pipeline. A failed migration must stop the
+rollout while the old API replicas remain online.
 
 Every migration used in this sequence must be compatible with both the old and
 new API versions. Use expand/backfill/switch/contract changes across releases;

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -20464,6 +20464,7 @@
           "pool_size",
           "pool_acquire_timeout_ms",
           "statement_timeout_ms",
+          "role_mode",
           "privilege_mode",
           "owner_role",
           "migrator_role",
@@ -20491,6 +20492,9 @@
             "minimum": 0
           },
           "privilege_mode": {
+            "type": "string"
+          },
+          "role_mode": {
             "type": "string"
           },
           "runtime_role": {

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -21,12 +21,16 @@ The development Compose stack requires a local, untracked `.env` file instead
 of using a password committed to the repository:
 
 ```bash
-for variable in POSTGRES_PASSWORD POSTGRES_MIGRATOR_PASSWORD POSTGRES_RUNTIME_PASSWORD; do
-  printf '%s=%s\n' "$variable" "$(openssl rand -hex 32)"
-done > .env
+printf 'POSTGRES_PASSWORD=%s\n' "$(openssl rand -hex 32)" > .env
 docker compose --profile administration run --rm hubuum-migrate --migrate
 docker compose up --build -d hubuum
 ```
+
+This default uses one PostgreSQL login for the server, one-shot migrations,
+and the isolated restore executor. To opt into separate least-privilege roles,
+set `HUBUUM_DATABASE_ROLE_MODE=split`, provide unique migrator and runtime
+passwords and URLs as shown in `.env.example`, and initialize a fresh Compose
+database volume.
 
 The API is published on `127.0.0.1:9999` and PostgreSQL on
 `127.0.0.1:9998`; neither service listens on all host interfaces by default.
@@ -74,12 +78,13 @@ examples.
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
 | `HUBUUM_STORAGE_BACKEND` | `postgresql` | Storage adapter selected from those registered in this application build; empty selects the default, while other unknown values are rejected at startup |
-| `HUBUUM_DATABASE_URL` | `postgres://localhost` | Runtime-role PostgreSQL connection URL |
-| `HUBUUM_MIGRATION_DATABASE_URL` | *(none)* | Migrator-role URL accepted by `hubuum-admin --migrate`, `--restore`, and `--restore-executor`; never configure this on an API or worker process |
-| `HUBUUM_DATABASE_OWNER_ROLE` | `hubuum_owner` | Non-login schema-owner role |
-| `HUBUUM_DATABASE_MIGRATOR_ROLE` | `hubuum_migrator` | Migration and isolated restore-executor role |
-| `HUBUUM_DATABASE_RUNTIME_ROLE` | `hubuum_runtime` | Non-owning API and worker role |
-| `HUBUUM_DATABASE_PRIVILEGE_MODE` | `warn` | Runtime privilege audit behavior: `warn` or startup-failing `strict` |
+| `HUBUUM_DATABASE_URL` | `postgres://localhost` | PostgreSQL connection URL; used by all workloads in `single` mode and only runtime workloads in `split` mode |
+| `HUBUUM_DATABASE_ROLE_MODE` | `single` | Credential topology: one shared login (`single`) or separate owner, migrator, and runtime roles (`split`) |
+| `HUBUUM_MIGRATION_DATABASE_URL` | *(none)* | Optional privileged URL for admin migrations and restore execution in `single` mode; required for those workloads in `split` mode and never configured on an API or worker process |
+| `HUBUUM_DATABASE_OWNER_ROLE` | `hubuum_owner` | Non-login schema-owner role used in `split` mode |
+| `HUBUUM_DATABASE_MIGRATOR_ROLE` | `hubuum_migrator` | Migration and isolated restore-executor role used in `split` mode |
+| `HUBUUM_DATABASE_RUNTIME_ROLE` | `hubuum_runtime` | Non-owning API and worker role used in `split` mode |
+| `HUBUUM_DATABASE_PRIVILEGE_MODE` | `warn` | Split-role runtime privilege audit behavior: `warn` or startup-failing `strict`; ignored in `single` mode |
 | `HUBUUM_DB_POOL_SIZE` | `10` | Maximum number of database connections in the pool |
 | `HUBUUM_DB_POOL_ACQUIRE_TIMEOUT_MS` | `2000` | Maximum wait for a free pooled connection before failing the request |
 | `HUBUUM_DB_STATEMENT_TIMEOUT_MS` | `30000` | Pool-global Postgres `statement_timeout` in ms (`0` disables). Cancels any query exceeding it server-side; applies to **all** DB work, not just exports |

--- a/docs/temporal_history.md
+++ b/docs/temporal_history.md
@@ -346,7 +346,11 @@ This column is NULL until anonymization occurs. It serves as:
 
 ### Database Role Privilege Model
 
-Run the Hubuum application under a **non-owning, unprivileged PostgreSQL role**:
+For database-enforced separation, opt into
+`HUBUUM_DATABASE_ROLE_MODE=split` and run the application under a
+**non-owning, unprivileged PostgreSQL role**. Hubuum's generated privilege
+manifest supplies the exact grants; this simplified example illustrates the
+boundary:
 
 ```sql
 CREATE ROLE hubuum_app NOINHERIT;
@@ -357,9 +361,15 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO hubuum_ap
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO hubuum_app;
 ```
 
+The default `single` topology intentionally uses one login for runtime and
+schema management. It remains supported, but that login can alter or own
+database objects, so it does not provide this defense against direct database
+credential compromise. See [PostgreSQL Database Roles](database_roles.md).
+
 ### History Table Protections
 
-**DEPLOYMENT CHECKLIST REQUIREMENT**: History integrity depends on database-level enforcement. In production:
+In split-role production deployments, history integrity depends on
+database-level enforcement:
 
 - **MUST NOT grant** `UPDATE` or `DELETE` on `_history` tables to the application role.
 - Triggers insert into history tables; the application role should only have **SELECT** grants.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -31,12 +31,23 @@ fi
 # Generate a collision-resistant database name. Keep it identifier-safe.
 UNIQUE_SUFFIX="$(date +%s)_$$_${RANDOM}${RANDOM}"
 TEST_DB_NAME="${TEST_DB_PREFIX}${UNIQUE_SUFFIX}"
+SINGLE_TEST_DB_NAME="${TEST_DB_NAME}_single"
 OWNER_ROLE="hubuum_test_owner_${UNIQUE_SUFFIX}"
 MIGRATOR_ROLE="hubuum_test_migrator_${UNIQUE_SUFFIX}"
 RUNTIME_ROLE="hubuum_test_runtime_${UNIQUE_SUFFIX}"
 ADMIN_TEST_URL="postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$TEST_DB_NAME$SSL_MODE"
 
 cleanup() {
+    if [ -n "${SINGLE_TEST_DB_NAME:-}" ]; then
+        PGPASSWORD=$DB_PASSWORD psql "$ROOT_URL" \
+            -v ON_ERROR_STOP=1 \
+            -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$SINGLE_TEST_DB_NAME' AND pid <> pg_backend_pid();" \
+            > /dev/null 2>&1 || true
+        PGPASSWORD=$DB_PASSWORD psql "$ROOT_URL" \
+            -v ON_ERROR_STOP=1 \
+            -c "DROP DATABASE IF EXISTS $SINGLE_TEST_DB_NAME;" \
+            > /dev/null 2>&1 || true
+    fi
     if [ -n "${TEST_DB_NAME:-}" ]; then
         PGPASSWORD=$DB_PASSWORD psql "$ROOT_URL" \
             -v ON_ERROR_STOP=1 \
@@ -55,6 +66,25 @@ cleanup() {
 
 trap cleanup EXIT
 
+# Prove the default topology can migrate a database owned by the connected
+# login without creating or reconciling any cluster roles.
+PGPASSWORD=$DB_PASSWORD psql "$ROOT_URL" -v ON_ERROR_STOP=1 \
+    -c "CREATE DATABASE $SINGLE_TEST_DB_NAME;" > /dev/null
+SINGLE_TEST_URL="postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$SINGLE_TEST_DB_NAME$SSL_MODE"
+env -u HUBUUM_MIGRATION_DATABASE_URL \
+    -u HUBUUM_DATABASE_ROLE_MODE \
+    -u HUBUUM_DATABASE_OWNER_ROLE \
+    -u HUBUUM_DATABASE_MIGRATOR_ROLE \
+    -u HUBUUM_DATABASE_RUNTIME_ROLE \
+    cargo run --quiet --features embedded-migrations --bin hubuum-admin -- \
+        --migrate \
+        --database-url "$SINGLE_TEST_URL" > /dev/null
+PGPASSWORD=$DB_PASSWORD psql "$SINGLE_TEST_URL" -v ON_ERROR_STOP=1 \
+    -c "SELECT 1 FROM users LIMIT 1;" > /dev/null
+PGPASSWORD=$DB_PASSWORD psql "$ROOT_URL" -v ON_ERROR_STOP=1 \
+    -c "DROP DATABASE $SINGLE_TEST_DB_NAME;" > /dev/null
+SINGLE_TEST_DB_NAME=""
+
 # Create distinct cluster roles and a database owned by the non-login schema
 # owner. Password interpolation is handled by psql, not by SQL string assembly.
 PGPASSWORD=$DB_PASSWORD psql "$ROOT_URL" -v ON_ERROR_STOP=1 \
@@ -72,6 +102,7 @@ echo "Created test database: $TEST_DB_NAME"
 
 export HUBUUM_MIGRATION_DATABASE_URL="postgres://$MIGRATOR_ROLE:$DB_PASSWORD@$DB_HOST:$DB_PORT/$TEST_DB_NAME$SSL_MODE"
 export HUBUUM_DATABASE_URL="postgres://$RUNTIME_ROLE:$DB_PASSWORD@$DB_HOST:$DB_PORT/$TEST_DB_NAME$SSL_MODE"
+export HUBUUM_DATABASE_ROLE_MODE="split"
 export HUBUUM_DATABASE_OWNER_ROLE="$OWNER_ROLE"
 export HUBUUM_DATABASE_MIGRATOR_ROLE="$MIGRATOR_ROLE"
 export HUBUUM_DATABASE_RUNTIME_ROLE="$RUNTIME_ROLE"

--- a/scripts/install-single-host.sh
+++ b/scripts/install-single-host.sh
@@ -23,6 +23,7 @@ VALKEY_IMAGE="docker.io/valkey/valkey:9-alpine"
 CADDY_IMAGE="docker.io/library/caddy:2-alpine"
 EXTERNAL_DATABASE_URL=""
 EXTERNAL_MIGRATION_DATABASE_URL=""
+DATABASE_ROLE_MODE="single"
 AUTH_CONFIG_HOST_PATH=""
 AUTH_CONFIG_CONTAINER_PATH="/etc/hubuum/auth.toml"
 NETWORK_SUBNET="172.30.42.0/24"
@@ -68,7 +69,9 @@ Options:
   --frontend-image IMAGE  Frontend image. Default: ghcr.io/hubuum/hubuum-frontend:main
   --database-url URL      Existing Postgres URL. If set, no Postgres container is created
   --migration-database-url URL
-                          Migrator Postgres URL required with --database-url
+                          Migrator Postgres URL required for split database roles
+  --database-role-mode MODE
+                          Database roles: single or split. Default: single
   --auth-config PATH      Host auth-provider TOML file to mount read-only in the API container
   --engine ENGINE         Container engine: auto, docker, or podman. Default: auto
   --postgres-image IMAGE  Postgres image. Default: PostgreSQL 18.4 on Alpine 3.24 (digest-pinned)
@@ -155,6 +158,7 @@ while [[ $# -gt 0 ]]; do
     --frontend-repo) FRONTEND_REPO="$2"; ARG_SET+=" FRONTEND_REPO"; shift 2 ;;
     --database-url) EXTERNAL_DATABASE_URL="$2"; ARG_SET+=" EXTERNAL_DATABASE_URL"; shift 2 ;;
     --migration-database-url) EXTERNAL_MIGRATION_DATABASE_URL="$2"; ARG_SET+=" EXTERNAL_MIGRATION_DATABASE_URL"; shift 2 ;;
+    --database-role-mode) DATABASE_ROLE_MODE="$2"; ARG_SET+=" DATABASE_ROLE_MODE"; shift 2 ;;
     --auth-config) AUTH_CONFIG_HOST_PATH="$2"; ARG_SET+=" AUTH_CONFIG_HOST_PATH"; shift 2 ;;
     --engine) ENGINE="$2"; shift 2 ;;
     --postgres-image) POSTGRES_IMAGE="$2"; ARG_SET+=" POSTGRES_IMAGE"; shift 2 ;;
@@ -219,11 +223,21 @@ if generates_deployment_files && [[ -f "$ENV_FILE" ]]; then
   reuse_from_env FRONTEND_REPO FRONTEND_REPO
   reuse_from_env BUILD_FROM_SOURCE BUILD_FROM_SOURCE
   reuse_from_env NETWORK_SUBNET HUBUUM_CLIENT_ALLOWLIST
+  reuse_from_env DATABASE_ROLE_MODE HUBUUM_DATABASE_ROLE_MODE
   reuse_from_env AUTH_CONFIG_HOST_PATH HUBUUM_AUTH_CONFIG_HOST_PATH
   reuse_from_env SCRIPT_BASE_URL MANAGEMENT_SCRIPT_BASE_URL
+  if ! arg_was_set DATABASE_ROLE_MODE \
+    && [[ -z "$(read_env_value HUBUUM_DATABASE_ROLE_MODE || true)" ]] \
+    && [[ -n "$(read_env_value POSTGRES_MIGRATOR_PASSWORD || true)" ]] \
+    && [[ -n "$(read_env_value POSTGRES_RUNTIME_PASSWORD || true)" ]]; then
+    # Installations generated while split roles were mandatory predate the
+    # topology setting. Preserve their established credential boundary.
+    DATABASE_ROLE_MODE="split"
+  fi
 fi
 
 [[ "$MODE" == "all" || "$MODE" == "backend" ]] || die "--mode must be all or backend"
+[[ "$DATABASE_ROLE_MODE" == "single" || "$DATABASE_ROLE_MODE" == "split" ]] || die "--database-role-mode must be single or split"
 [[ "$ENGINE" == "auto" || "$ENGINE" == "docker" || "$ENGINE" == "podman" ]] || die "--engine must be auto, docker, or podman"
 [[ "$API_PORT" =~ ^[0-9]+$ && "$API_PORT" -ge 1 && "$API_PORT" -le 65535 ]] || die "--api-port must be an integer between 1 and 65535"
 if [[ -n "$SHARED_HOST_ROUTING" && "$SHARED_HOST_ROUTING" != "bff" && "$SHARED_HOST_ROUTING" != "direct" && "$SHARED_HOST_ROUTING" != "prefixed" ]]; then
@@ -485,18 +499,29 @@ if [[ "$RECREATE" == "true" && -z "$EXTERNAL_DATABASE_URL" && -n "$EXISTING_POST
 fi
 
 [[ -n "$POSTGRES_PASSWORD" ]] || POSTGRES_PASSWORD="$(random_hex 32)"
-[[ -n "$POSTGRES_MIGRATOR_PASSWORD" ]] || POSTGRES_MIGRATOR_PASSWORD="$(random_hex 32)"
-[[ -n "$POSTGRES_RUNTIME_PASSWORD" ]] || POSTGRES_RUNTIME_PASSWORD="$(random_hex 32)"
+if [[ "$DATABASE_ROLE_MODE" == "split" ]]; then
+  [[ -n "$POSTGRES_MIGRATOR_PASSWORD" ]] || POSTGRES_MIGRATOR_PASSWORD="$(random_hex 32)"
+  [[ -n "$POSTGRES_RUNTIME_PASSWORD" ]] || POSTGRES_RUNTIME_PASSWORD="$(random_hex 32)"
+fi
 [[ -n "$HUBUUM_TOKEN_HASH_KEY" ]] || HUBUUM_TOKEN_HASH_KEY="$(random_hex 32)"
 
 DATABASE_MANAGED="true"
-HUBUUM_DATABASE_URL="postgres://hubuum_runtime:${POSTGRES_RUNTIME_PASSWORD}@postgres:5432/hubuum"
-HUBUUM_MIGRATION_DATABASE_URL="postgres://hubuum_migrator:${POSTGRES_MIGRATOR_PASSWORD}@postgres:5432/hubuum"
+if [[ "$DATABASE_ROLE_MODE" == "split" ]]; then
+  HUBUUM_DATABASE_URL="postgres://hubuum_runtime:${POSTGRES_RUNTIME_PASSWORD}@postgres:5432/hubuum"
+  HUBUUM_MIGRATION_DATABASE_URL="postgres://hubuum_migrator:${POSTGRES_MIGRATOR_PASSWORD}@postgres:5432/hubuum"
+  HUBUUM_DATABASE_PRIVILEGE_MODE="strict"
+else
+  HUBUUM_DATABASE_URL="postgres://hubuum:${POSTGRES_PASSWORD}@postgres:5432/hubuum"
+  HUBUUM_MIGRATION_DATABASE_URL="$HUBUUM_DATABASE_URL"
+  HUBUUM_DATABASE_PRIVILEGE_MODE="warn"
+fi
 if [[ -n "$EXTERNAL_DATABASE_URL" ]]; then
-  [[ -n "$EXTERNAL_MIGRATION_DATABASE_URL" ]] || die "--migration-database-url is required with --database-url (or set HUBUUM_MIGRATION_DATABASE_URL in the existing .env)"
+  if [[ "$DATABASE_ROLE_MODE" == "split" && -z "$EXTERNAL_MIGRATION_DATABASE_URL" ]]; then
+    die "--migration-database-url is required with --database-role-mode split"
+  fi
   DATABASE_MANAGED="false"
   HUBUUM_DATABASE_URL="$EXTERNAL_DATABASE_URL"
-  HUBUUM_MIGRATION_DATABASE_URL="$EXTERNAL_MIGRATION_DATABASE_URL"
+  HUBUUM_MIGRATION_DATABASE_URL="${EXTERNAL_MIGRATION_DATABASE_URL:-$EXTERNAL_DATABASE_URL}"
 fi
 
 LOGIN_RATE_LIMIT_BACKEND="memory"
@@ -531,12 +556,13 @@ write_deployment_env() {
   printf 'POSTGRES_MIGRATOR_PASSWORD=%s\n' "$POSTGRES_MIGRATOR_PASSWORD"
   printf 'POSTGRES_RUNTIME_PASSWORD=%s\n' "$POSTGRES_RUNTIME_PASSWORD"
   printf '\n'
+  printf 'HUBUUM_DATABASE_ROLE_MODE=%s\n' "$DATABASE_ROLE_MODE"
   printf 'HUBUUM_DATABASE_URL=%s\n' "$(quote_env "$HUBUUM_DATABASE_URL")"
   printf 'HUBUUM_MIGRATION_DATABASE_URL=%s\n' "$(quote_env "$HUBUUM_MIGRATION_DATABASE_URL")"
   printf 'HUBUUM_DATABASE_OWNER_ROLE=hubuum_owner\n'
   printf 'HUBUUM_DATABASE_MIGRATOR_ROLE=hubuum_migrator\n'
   printf 'HUBUUM_DATABASE_RUNTIME_ROLE=hubuum_runtime\n'
-  printf 'HUBUUM_DATABASE_PRIVILEGE_MODE=strict\n'
+  printf 'HUBUUM_DATABASE_PRIVILEGE_MODE=%s\n' "$HUBUUM_DATABASE_PRIVILEGE_MODE"
   printf 'HUBUUM_BIND_IP=0.0.0.0\n'
   printf 'HUBUUM_BIND_PORT=%s\n' "$API_PORT"
   printf 'HUBUUM_LOG_LEVEL=info\n'
@@ -603,6 +629,13 @@ set -eu
 : "${POSTGRES_USER:?POSTGRES_USER is required}"
 : "${POSTGRES_DB:?POSTGRES_DB is required}"
 : "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
+
+case "${HUBUUM_DATABASE_ROLE_MODE:-single}" in
+  single) exit 0 ;;
+  split) ;;
+  *) echo "HUBUUM_DATABASE_ROLE_MODE must be single or split" >&2; exit 1 ;;
+esac
+
 : "${POSTGRES_MIGRATOR_PASSWORD:?POSTGRES_MIGRATOR_PASSWORD is required}"
 : "${POSTGRES_RUNTIME_PASSWORD:?POSTGRES_RUNTIME_PASSWORD is required}"
 
@@ -792,6 +825,7 @@ if [[ "$DATABASE_MANAGED" == "true" ]]; then
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      HUBUUM_DATABASE_ROLE_MODE: ${HUBUUM_DATABASE_ROLE_MODE}
       POSTGRES_MIGRATOR_PASSWORD: ${POSTGRES_MIGRATOR_PASSWORD}
       POSTGRES_RUNTIME_PASSWORD: ${POSTGRES_RUNTIME_PASSWORD}
       PGUSER: ${POSTGRES_USER}
@@ -836,6 +870,8 @@ cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
     security_opt:
       - no-new-privileges:true
     environment:
+      HUBUUM_DATABASE_ROLE_MODE: ${HUBUUM_DATABASE_ROLE_MODE}
+      HUBUUM_DATABASE_URL: ${HUBUUM_DATABASE_URL}
       HUBUUM_MIGRATION_DATABASE_URL: ${HUBUUM_MIGRATION_DATABASE_URL}
       HUBUUM_DATABASE_OWNER_ROLE: ${HUBUUM_DATABASE_OWNER_ROLE}
       HUBUUM_DATABASE_MIGRATOR_ROLE: ${HUBUUM_DATABASE_MIGRATOR_ROLE}
@@ -874,6 +910,8 @@ cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
     security_opt:
       - no-new-privileges:true
     environment:
+      HUBUUM_DATABASE_ROLE_MODE: ${HUBUUM_DATABASE_ROLE_MODE}
+      HUBUUM_DATABASE_URL: ${HUBUUM_DATABASE_URL}
       HUBUUM_MIGRATION_DATABASE_URL: ${HUBUUM_MIGRATION_DATABASE_URL}
       HUBUUM_DATABASE_OWNER_ROLE: ${HUBUUM_DATABASE_OWNER_ROLE}
       HUBUUM_DATABASE_MIGRATOR_ROLE: ${HUBUUM_DATABASE_MIGRATOR_ROLE}
@@ -914,6 +952,7 @@ cat >> "$INSTALL_DIR/compose.yml" <<'EOF'
     environment:
       HUBUUM_BIND_IP: ${HUBUUM_BIND_IP}
       HUBUUM_BIND_PORT: ${HUBUUM_BIND_PORT}
+      HUBUUM_DATABASE_ROLE_MODE: ${HUBUUM_DATABASE_ROLE_MODE}
       HUBUUM_DATABASE_URL: ${HUBUUM_DATABASE_URL}
       HUBUUM_DATABASE_OWNER_ROLE: ${HUBUUM_DATABASE_OWNER_ROLE}
       HUBUUM_DATABASE_MIGRATOR_ROLE: ${HUBUUM_DATABASE_MIGRATOR_ROLE}

--- a/scripts/single-host-rollout.sh
+++ b/scripts/single-host-rollout.sh
@@ -244,7 +244,7 @@ hubuum_reload_caddy_and_wait_for_upstreams() {
 }
 
 hubuum_run_migrations() {
-  if [[ "${DATABASE_MANAGED:-true}" == "true" ]]; then
+  if [[ "${DATABASE_MANAGED:-true}" == "true" && "${DATABASE_ROLE_MODE:-${HUBUUM_DATABASE_ROLE_MODE:-single}}" == "split" ]]; then
     echo "Reconciling managed database roles..."
     "${COMPOSE_CMD[@]}" run --rm --no-deps -T hubuum-migrate \
       --database-role-setup-sql | \

--- a/scripts/test-single-host-rollout.sh
+++ b/scripts/test-single-host-rollout.sh
@@ -369,6 +369,7 @@ fi
 [[ "$reload_output" == *'fake reload diagnostic'* ]]
 
 DATABASE_MANAGED="true"
+DATABASE_ROLE_MODE="split"
 : > "$COMMAND_LOG"
 hubuum_run_migrations
 cat > "$TEST_ROOT/expected-managed-migration.log" <<EOF
@@ -378,5 +379,13 @@ compose --env-file .env -f compose.yml run --rm --no-deps -T --entrypoint /usr/l
 compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
 EOF
 assert_commands "$TEST_ROOT/expected-managed-migration.log"
+
+DATABASE_ROLE_MODE="single"
+: > "$COMMAND_LOG"
+hubuum_run_migrations
+cat > "$TEST_ROOT/expected-managed-single-role-migration.log" <<EOF
+compose --env-file .env -f compose.yml run --rm --no-deps -T hubuum-migrate --migrate
+EOF
+assert_commands "$TEST_ROOT/expected-managed-single-role-migration.log"
 
 echo "Single-host rolling update test passed"

--- a/scripts/test-single-host-zero-downtime.sh
+++ b/scripts/test-single-host-zero-downtime.sh
@@ -153,6 +153,7 @@ services:
     profiles: ["administration"]
     entrypoint: /usr/local/bin/hubuum-admin
     environment:
+      HUBUUM_DATABASE_ROLE_MODE: split
       HUBUUM_MIGRATION_DATABASE_URL: ${HUBUUM_ZERO_DOWNTIME_MIGRATION_DATABASE_URL}
 
   hubuum-restore-executor:
@@ -160,6 +161,7 @@ services:
     entrypoint: /usr/local/bin/hubuum-admin
     command: ["--restore-executor"]
     environment:
+      HUBUUM_DATABASE_ROLE_MODE: split
       HUBUUM_MIGRATION_DATABASE_URL: ${HUBUUM_ZERO_DOWNTIME_MIGRATION_DATABASE_URL}
 
   hubuum-api: &hubuum-api
@@ -175,6 +177,7 @@ services:
     environment:
       HUBUUM_BIND_IP: 0.0.0.0
       HUBUUM_BIND_PORT: 8080
+      HUBUUM_DATABASE_ROLE_MODE: split
       HUBUUM_DATABASE_URL: ${HUBUUM_ZERO_DOWNTIME_DATABASE_URL}
       HUBUUM_DATABASE_PRIVILEGE_MODE: strict
       HUBUUM_CLIENT_ALLOWLIST: "*"

--- a/scripts/update-single-host.sh
+++ b/scripts/update-single-host.sh
@@ -112,6 +112,7 @@ fi
 BUILD_FROM_SOURCE="$(read_env_value BUILD_FROM_SOURCE || printf 'false')"
 INSTALL_MODE="$(read_env_value INSTALL_MODE || printf 'all')"
 DATABASE_MANAGED="$(read_env_value DATABASE_MANAGED || printf 'true')"
+DATABASE_ROLE_MODE="$(read_env_value HUBUUM_DATABASE_ROLE_MODE || printf 'single')"
 API_PORT="$(read_env_value HUBUUM_BIND_PORT || printf '8080')"
 MANAGEMENT_SCRIPT_BASE_URL="$(
   read_env_value MANAGEMENT_SCRIPT_BASE_URL || printf '%s' "$DEFAULT_MANAGEMENT_SCRIPT_BASE_URL"
@@ -214,6 +215,7 @@ if grep -q 'HUBUUM_AUTH_CONFIG_PATH' "$INSTALL_DIR/compose.yml"; then
   [[ -n "$AUTH_CONFIG_HOST_PATH" ]] || die "HUBUUM_AUTH_CONFIG_HOST_PATH is missing from $ENV_FILE"
   absolute_config_path "$AUTH_CONFIG_HOST_PATH" >/dev/null
 fi
+DATABASE_ROLE_MODE="$(read_env_value HUBUUM_DATABASE_ROLE_MODE || printf 'single')"
 
 if [[ "$BUILD_FROM_SOURCE" == "true" ]]; then
   PULL_SERVICES=(caddy)

--- a/src/administration.rs
+++ b/src/administration.rs
@@ -12,7 +12,7 @@ use crate::config::{
     DEFAULT_DB_POOL_ACQUIRE_TIMEOUT_MS, DEFAULT_DB_STATEMENT_TIMEOUT_MS,
     DEFAULT_EXPORT_TEMPLATE_FUEL, DEFAULT_EXPORT_TEMPLATE_RECURSION_LIMIT,
     DEFAULT_RESTORE_MAX_UPLOAD_BYTES, DEFAULT_RESTORE_STAGE_RETENTION_MINUTES,
-    DEFAULT_TOKEN_LIFETIME_HOURS, token_hash_key_ring,
+    DEFAULT_TOKEN_LIFETIME_HOURS, DatabaseRoleMode, token_hash_key_ring,
 };
 #[cfg(feature = "embedded-migrations")]
 use crate::errors::EXIT_CODE_DATABASE_ERROR;
@@ -120,7 +120,7 @@ struct AdminCli {
     #[arg(long, default_value_t = false)]
     migrate: bool,
 
-    /// Migrate an existing single-role database without reconciling split-role grants
+    /// Compatibility alias for --database-role-mode single during migration
     #[cfg(feature = "embedded-migrations")]
     #[arg(
         long,
@@ -171,6 +171,15 @@ struct AdminCli {
         default_value = "postgresql"
     )]
     storage_backend: StorageBackendKind,
+
+    /// Database credential topology: one shared login or split owner/migrator/runtime roles
+    #[arg(
+        long,
+        env = "HUBUUM_DATABASE_ROLE_MODE",
+        value_enum,
+        default_value = "single"
+    )]
+    database_role_mode: DatabaseRoleMode,
 
     /// Database URL
     #[arg(long, env = "HUBUUM_DATABASE_URL")]
@@ -260,17 +269,13 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
         return Ok(());
     }
 
-    let database_roles = resolve_database_roles(
-        admin_cli.database_owner_role.as_deref(),
-        admin_cli.database_migrator_role.as_deref(),
-        admin_cli.database_runtime_role.as_deref(),
-    )?;
-
     if admin_cli.database_role_setup_sql {
+        let database_roles = configured_database_roles(&admin_cli)?;
         print!("{}", storage_database_role_setup_sql(&database_roles)?);
         return Ok(());
     }
     if admin_cli.database_role_grants_sql {
+        let database_roles = configured_database_roles(&admin_cli)?;
         println!("BEGIN;");
         print!("{}", storage_database_role_grants_sql(&database_roles)?);
         println!("COMMIT;");
@@ -287,22 +292,31 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
     let migration_requested = admin_cli.migrate;
     #[cfg(not(feature = "embedded-migrations"))]
     let migration_requested = false;
+    #[cfg(feature = "embedded-migrations")]
+    let database_role_mode = effective_database_role_mode(&admin_cli)?;
+    #[cfg(not(feature = "embedded-migrations"))]
+    let database_role_mode = admin_cli.database_role_mode;
     let privileged_database_operation =
         migration_requested || admin_cli.restore.is_some() || admin_cli.restore_executor;
-    let database_url = if admin_cli.restore_executor {
-        admin_cli.migration_database_url
+    let database_url = if privileged_database_operation && database_role_mode.uses_split_roles() {
+        admin_cli.migration_database_url.clone()
     } else if privileged_database_operation {
-        admin_cli.migration_database_url.or(admin_cli.database_url)
+        admin_cli
+            .migration_database_url
+            .clone()
+            .or_else(|| admin_cli.database_url.clone())
     } else {
-        admin_cli.database_url
+        admin_cli.database_url.clone()
     };
     let storage_settings = match admin_cli.storage_backend {
         StorageBackendKind::Postgres => {
             let database_url = database_url.unwrap_or_else(|| {
-                let variable = if admin_cli.restore_executor {
+                let variable = if privileged_database_operation
+                    && database_role_mode.uses_split_roles()
+                {
                     "HUBUUM_MIGRATION_DATABASE_URL"
                 } else if privileged_database_operation {
-                    "HUBUUM_MIGRATION_DATABASE_URL (or the compatibility fallback HUBUUM_DATABASE_URL)"
+                    "HUBUUM_DATABASE_URL (or the optional HUBUUM_MIGRATION_DATABASE_URL override)"
                 } else {
                     "HUBUUM_DATABASE_URL"
                 };
@@ -322,9 +336,12 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
 
     #[cfg(feature = "embedded-migrations")]
     if admin_cli.migrate {
-        let migration_roles = (!admin_cli.legacy_single_role_migration).then_some(&database_roles);
-        let applied =
-            run_storage_migrations(&storage_settings, migration_roles).unwrap_or_else(|error| {
+        let database_roles = database_role_mode
+            .uses_split_roles()
+            .then(|| configured_database_roles(&admin_cli))
+            .transpose()?;
+        let applied = run_storage_migrations(&storage_settings, database_roles.as_ref())
+            .unwrap_or_else(|error| {
                 fatal_error(
                     &format!("Failed to run storage migrations: {error}"),
                     EXIT_CODE_DATABASE_ERROR,
@@ -332,10 +349,8 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
             });
         if admin_cli.legacy_single_role_migration {
             eprintln!(
-                "WARNING: --legacy-single-role-migration was requested; migrations ran as the \
-                 connected existing owner without privilege reconciliation. Complete the \
-                 database-role adoption procedure before enabling strict privilege checks or web \
-                 restore confirmations."
+                "WARNING: --legacy-single-role-migration is deprecated; single-role migration is \
+                 now the default. Use --database-role-mode single explicitly if desired."
             );
         }
         println!("Applied {applied} storage migration(s).");
@@ -343,6 +358,7 @@ pub async fn run_admin_from_environment() -> Result<(), ApiError> {
     }
 
     if admin_cli.check_database_privileges {
+        let database_roles = configured_database_roles(&admin_cli)?;
         let role = match admin_cli.role {
             DatabasePrivilegeRole::Owner => StorageDatabaseRole::Owner,
             DatabasePrivilegeRole::Migrator => StorageDatabaseRole::Migrator,
@@ -411,6 +427,29 @@ fn resolve_database_roles(
         runtime.unwrap_or(DEFAULT_DATABASE_RUNTIME_ROLE),
     )
     .map_err(|error| ApiError::BadRequest(error.to_string()))
+}
+
+fn configured_database_roles(admin_cli: &AdminCli) -> Result<StorageDatabaseRoleNames, ApiError> {
+    resolve_database_roles(
+        admin_cli.database_owner_role.as_deref(),
+        admin_cli.database_migrator_role.as_deref(),
+        admin_cli.database_runtime_role.as_deref(),
+    )
+}
+
+#[cfg(feature = "embedded-migrations")]
+fn effective_database_role_mode(admin_cli: &AdminCli) -> Result<DatabaseRoleMode, ApiError> {
+    if admin_cli.legacy_single_role_migration && admin_cli.database_role_mode.uses_split_roles() {
+        return Err(ApiError::BadRequest(
+            "--legacy-single-role-migration cannot be combined with --database-role-mode split"
+                .to_string(),
+        ));
+    }
+    if admin_cli.legacy_single_role_migration {
+        Ok(DatabaseRoleMode::Single)
+    } else {
+        Ok(admin_cli.database_role_mode)
+    }
 }
 
 fn print_database_privilege_report(
@@ -1233,10 +1272,12 @@ fn init_logging(log_level: &str) {
 mod tests {
     use clap::Parser;
 
+    #[cfg(feature = "embedded-migrations")]
+    use super::effective_database_role_mode;
     use super::{
         AdminCli, DEFAULT_DATABASE_MIGRATOR_ROLE, DEFAULT_DATABASE_OWNER_ROLE,
-        DEFAULT_DATABASE_RUNTIME_ROLE, StorageBackendKind, StorageDatabaseRoleNames,
-        resolve_database_roles,
+        DEFAULT_DATABASE_RUNTIME_ROLE, DatabaseRoleMode, StorageBackendKind,
+        StorageDatabaseRoleNames, resolve_database_roles,
     };
 
     #[test]
@@ -1305,5 +1346,35 @@ mod tests {
         };
 
         assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[cfg(feature = "embedded-migrations")]
+    #[test]
+    fn legacy_single_role_migration_rejects_split_mode() {
+        let cli = AdminCli::try_parse_from([
+            "hubuum-admin",
+            "--migrate",
+            "--legacy-single-role-migration",
+            "--database-role-mode",
+            "split",
+        ])
+        .unwrap();
+
+        let error = effective_database_role_mode(&cli).unwrap_err();
+
+        assert!(error.to_string().contains("cannot be combined"));
+    }
+
+    #[test]
+    fn database_role_mode_accepts_explicit_single_and_split_values() {
+        for (value, expected) in [
+            ("single", DatabaseRoleMode::Single),
+            ("split", DatabaseRoleMode::Split),
+        ] {
+            let cli =
+                AdminCli::try_parse_from(["hubuum-admin", "--database-role-mode", value]).unwrap();
+
+            assert_eq!(cli.database_role_mode, expected);
+        }
     }
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -166,7 +166,9 @@ pub async fn run_runtime_from_environment() -> std::io::Result<()> {
             EXIT_CODE_DATABASE_ERROR,
         );
     }
-    if config.storage_backend == StorageBackendKind::Postgres {
+    if config.storage_backend == StorageBackendKind::Postgres
+        && config.database_role_mode.uses_split_roles()
+    {
         let database_roles = StorageDatabaseRoleNames::new(
             config.database_owner_role.clone(),
             config.database_migrator_role.clone(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,27 @@ pub enum DatabasePrivilegeMode {
     Strict,
 }
 
+#[derive(ValueEnum, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum DatabaseRoleMode {
+    #[default]
+    Single,
+    Split,
+}
+
+impl DatabaseRoleMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Single => "single",
+            Self::Split => "split",
+        }
+    }
+
+    pub const fn uses_split_roles(self) -> bool {
+        matches!(self, Self::Split)
+    }
+}
+
 impl DatabasePrivilegeMode {
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -220,6 +241,15 @@ pub struct AppConfig {
         default_value = "postgres://localhost"
     )]
     pub database_url: String,
+
+    /// Database credential topology: one shared login or split owner/migrator/runtime roles
+    #[clap(
+        long,
+        env = "HUBUUM_DATABASE_ROLE_MODE",
+        value_enum,
+        default_value = "single"
+    )]
+    pub database_role_mode: DatabaseRoleMode,
 
     /// Whether unsafe or incomplete PostgreSQL runtime grants warn or fail startup
     #[clap(
@@ -1574,6 +1604,10 @@ fn get_config_from_env() -> Result<AppConfig, ApiError> {
             .unwrap_or(8080),
         log_level: env_or_default("HUBUUM_LOG_LEVEL", "debug"),
         database_url: env_or_default("HUBUUM_DATABASE_URL", "postgres://test"),
+        database_role_mode: env::var("HUBUUM_DATABASE_ROLE_MODE")
+            .ok()
+            .and_then(|value| DatabaseRoleMode::from_str(&value, true).ok())
+            .unwrap_or_default(),
         database_privilege_mode: env::var("HUBUUM_DATABASE_PRIVILEGE_MODE")
             .ok()
             .and_then(|value| DatabasePrivilegeMode::from_str(&value, true).ok())
@@ -1956,9 +1990,10 @@ mod tests {
         DEFAULT_REMOTE_CALL_MAX_ACTIVE_TASKS_PER_USER, DEFAULT_TASK_POLL_INTERVAL_MS,
         DEFAULT_TOKEN_LIFETIME_HOURS, DEFAULT_TOKEN_RETENTION_DAYS,
         DEFAULT_TOKEN_RETENTION_PURGE_BATCH_SIZE, DEFAULT_TOKEN_RETENTION_PURGE_ENABLED,
-        DEFAULT_TOKEN_RETENTION_PURGE_INTERVAL_SECONDS, MAX_PAGE_LIMIT, RuntimeRole,
-        StorageBackendKind, TEST_ENV_LOCK, TlsBackend, default_actix_workers, default_task_workers,
-        get_config_from_env, token_hash_key_bytes, token_hash_key_is_ephemeral,
+        DEFAULT_TOKEN_RETENTION_PURGE_INTERVAL_SECONDS, DatabaseRoleMode, MAX_PAGE_LIMIT,
+        RuntimeRole, StorageBackendKind, TEST_ENV_LOCK, TlsBackend, default_actix_workers,
+        default_task_workers, get_config_from_env, token_hash_key_bytes,
+        token_hash_key_is_ephemeral,
     };
 
     struct EnvVarGuard {
@@ -2096,6 +2131,24 @@ mod tests {
         assert_eq!(loaded.runtime_role, RuntimeRole::Worker);
         assert!(!loaded.runtime_role.serves_http());
         assert!(loaded.runtime_role.runs_background_workers());
+    }
+
+    #[test]
+    fn database_role_mode_defaults_to_single_and_accepts_split_opt_in() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _role_mode_guard = EnvVarGuard::set("HUBUUM_DATABASE_ROLE_MODE", None);
+
+        let default = AppConfig::try_parse_from(["hubuum-server"]).unwrap();
+        let split =
+            AppConfig::try_parse_from(["hubuum-server", "--database-role-mode", "split"]).unwrap();
+        let loaded = {
+            let _split_guard = EnvVarGuard::set("HUBUUM_DATABASE_ROLE_MODE", Some("split"));
+            get_config_from_env().unwrap()
+        };
+
+        assert_eq!(default.database_role_mode, DatabaseRoleMode::Single);
+        assert_eq!(split.database_role_mode, DatabaseRoleMode::Split);
+        assert_eq!(loaded.database_role_mode, DatabaseRoleMode::Split);
     }
 
     #[test]

--- a/src/config/environment.rs
+++ b/src/config/environment.rs
@@ -62,6 +62,7 @@ pub const APP_CONFIG_ENVIRONMENT: &[EnvironmentVariable] = &[
     option!("HUBUUM_RUNTIME_ROLE", Server),
     option!("HUBUUM_STORAGE_BACKEND", Database),
     option!("HUBUUM_DATABASE_URL", Database, sensitive),
+    option!("HUBUUM_DATABASE_ROLE_MODE", Database),
     option!("HUBUUM_DATABASE_PRIVILEGE_MODE", Database),
     option!("HUBUUM_DATABASE_OWNER_ROLE", Database),
     option!("HUBUUM_DATABASE_MIGRATOR_ROLE", Database),

--- a/src/config/running.rs
+++ b/src/config/running.rs
@@ -105,6 +105,7 @@ pub struct DatabaseConfig {
     pub pool_size: u32,
     pub pool_acquire_timeout_ms: u64,
     pub statement_timeout_ms: u64,
+    pub role_mode: String,
     pub privilege_mode: String,
     pub owner_role: String,
     pub migrator_role: String,
@@ -322,6 +323,7 @@ impl RunningConfig {
                 pool_size: config.db_pool_size,
                 pool_acquire_timeout_ms: config.db_pool_acquire_timeout_ms,
                 statement_timeout_ms: config.db_statement_timeout_ms,
+                role_mode: config.database_role_mode.as_str().to_string(),
                 privilege_mode: config.database_privilege_mode.as_str().to_string(),
                 owner_role: config.database_owner_role.clone(),
                 migrator_role: config.database_migrator_role.clone(),
@@ -503,6 +505,10 @@ mod tests {
         assert!(!json.contains("treetop-token"));
         assert!(json.contains("\"configured\":true"));
         assert!(json.contains("\"backend\":\"postgresql\""));
+        assert!(json.contains(&format!(
+            "\"role_mode\":\"{}\"",
+            config.database_role_mode.as_str()
+        )));
         assert!(json.contains("\"secrets\":{\"provider\":\"environment\""));
         assert!(json.contains("\"stale_values_allowed\":false"));
         assert!(!json.contains("contract_version"));

--- a/src/container_build.rs
+++ b/src/container_build.rs
@@ -364,6 +364,18 @@ fn development_compose_requires_a_local_password() {
 }
 
 #[test]
+fn compose_database_roles_default_to_single_with_split_opt_in() {
+    let compose = read_repository_text("docker-compose.yml");
+    let initializer = read_repository_text("docker/postgres/init-database-roles.sh");
+
+    assert!(compose.contains("HUBUUM_DATABASE_ROLE_MODE: ${HUBUUM_DATABASE_ROLE_MODE:-single}"));
+    assert!(compose.contains("POSTGRES_MIGRATOR_PASSWORD: ${POSTGRES_MIGRATOR_PASSWORD:-}"));
+    assert!(compose.contains("POSTGRES_RUNTIME_PASSWORD: ${POSTGRES_RUNTIME_PASSWORD:-}"));
+    assert!(initializer.contains("role_mode=\"${HUBUUM_DATABASE_ROLE_MODE:-single}\""));
+    assert!(initializer.contains("split)"));
+}
+
+#[test]
 fn development_compose_limits_container_privileges() {
     let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let compose = fs::read_to_string(repository.join("docker-compose.yml"))

--- a/tests/admin_cli.rs
+++ b/tests/admin_cli.rs
@@ -5,7 +5,7 @@ use chrono::{Duration, Utc};
 use diesel::insert_into;
 use hubuum::config::DEFAULT_DB_STATEMENT_TIMEOUT_MS;
 #[cfg(feature = "embedded-migrations")]
-use hubuum::errors::EXIT_CODE_DATABASE_ERROR;
+use hubuum::errors::{EXIT_CODE_CONFIG_ERROR, EXIT_CODE_DATABASE_ERROR};
 use hubuum::models::NewUser;
 use hubuum::models::identity::{LOCAL_IDENTITY_SCOPE, LOCAL_PROVIDER_KIND};
 use hubuum::schema::{collections, export_templates, identity_scopes, principals, users};
@@ -69,6 +69,7 @@ fn admin_help_exposes_reset_password() {
     assert!(stdout.contains("--database-role-setup-sql"));
     assert!(stdout.contains("--database-role-grants-sql"));
     assert!(stdout.contains("--check-database-privileges"));
+    assert!(stdout.contains("--database-role-mode"));
 }
 
 #[cfg(feature = "embedded-migrations")]
@@ -87,6 +88,27 @@ fn migration_connection_failures_use_the_database_exit_code() {
     assert_eq!(output.status.code(), Some(EXIT_CODE_DATABASE_ERROR));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Failed to run storage migrations"));
+}
+
+#[cfg(feature = "embedded-migrations")]
+#[test]
+fn split_role_migration_requires_the_privileged_database_url() {
+    let output = Command::new(admin_binary())
+        .env_remove("HUBUUM_DATABASE_URL")
+        .env_remove("HUBUUM_MIGRATION_DATABASE_URL")
+        .args([
+            "--migrate",
+            "--database-role-mode",
+            "split",
+            "--database-url",
+            "postgres://hubuum@127.0.0.1:1/unreachable",
+        ])
+        .output()
+        .expect("hubuum-admin --migrate should validate split-role configuration");
+
+    assert_eq!(output.status.code(), Some(EXIT_CODE_CONFIG_ERROR));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("HUBUUM_MIGRATION_DATABASE_URL must be set"));
 }
 
 #[cfg(unix)]

--- a/tests/api_platform_suite/runtime_config.rs
+++ b/tests/api_platform_suite/runtime_config.rs
@@ -37,6 +37,10 @@ mod tests {
         let serialized = serde_json::to_string(&body).unwrap();
 
         assert_eq!(body["database"]["backend"], "postgresql");
+        assert!(matches!(
+            body["database"]["role_mode"].as_str(),
+            Some("single" | "split")
+        ));
         assert!(body["database"].get("contract_version").is_none());
         assert!(body["database"].get("capabilities").is_none());
         assert_eq!(body["database"]["url"]["configured"], true);


### PR DESCRIPTION
## Summary

- add `HUBUUM_DATABASE_ROLE_MODE=single|split`, defaulting to the original one-login topology
- keep migrations and restore execution isolated from the server entrypoint in both modes
- retain the #361 owner, migrator, and runtime privilege boundary as an explicit split-mode opt-in
- update Compose, single-host automation, distributed examples, administrator configuration, OpenAPI, and tests

## Behavior

In `single` mode, the server, one-shot migration job, and isolated restore executor may all use `HUBUUM_DATABASE_URL`. Runtime privilege reconciliation and startup auditing are skipped because no split-role contract is selected.

In `split` mode, privileged operations require `HUBUUM_MIGRATION_DATABASE_URL`, migrations reconcile the configured owner, migrator, and runtime roles, and server startup applies the configured privilege audit. This preserves the behavior introduced by #361.

`--legacy-single-role-migration` remains as a deprecated compatibility alias. It rejects an explicit split mode.

## Compatibility

The role mode defaults to `single`. Existing split-role deployments should set `HUBUUM_DATABASE_ROLE_MODE=split` on server, migration, and restore-executor workloads. The single-host installer detects its older generated split-role environment and preserves that topology. Existing volumes from the former split-only local Compose setup must also retain `POSTGRES_USER=hubuum_bootstrap`, as documented.

This does not restore entrypoint migrations or synchronous web restore. Migration and restore remain separate operational workloads.

## Verification

- `source .env && ./run_tests.sh`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npx markdownlint-cli2 --config .markdownlint.json "**/*.md" "!target"`
- `cargo run --quiet --bin hubuum-openapi` matches `docs/openapi.json`
- `bash scripts/test-classify-ci-changes.sh`
- `bash scripts/test-install-script-refresh.sh`
- `bash scripts/test-single-host-rollout.sh`
- default and split `docker compose config --quiet`
- `cargo test --bin hubuum-server dockerfile_copies_every_workspace_manifest --locked`
- `docker build --build-arg "CARGO_BUILD_FLAGS=-F tls-rustls -F tls-openssl --locked --release" --tag hubuum-server:verify .`

Follow-up to #361.